### PR TITLE
Add latest changes for moving namespaces, OVA size fixes, vsphere machine configuration

### DIFF
--- a/cmd/eks-a/cmd/create.go
+++ b/cmd/eks-a/cmd/create.go
@@ -7,7 +7,7 @@ import (
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create resources",
-	Long:  "Use eks-a create to create resources, such as clusters",
+	Long:  "Use eksctl anywhere create to create resources, such as clusters",
 }
 
 func init() {

--- a/cmd/eks-a/cmd/delete.go
+++ b/cmd/eks-a/cmd/delete.go
@@ -7,7 +7,7 @@ import (
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete resources",
-	Long:  "Use eks-a delete to delete clusters",
+	Long:  "Use eksctl anywhere delete to delete clusters",
 }
 
 func init() {

--- a/cmd/eks-a/cmd/deletecluster.go
+++ b/cmd/eks-a/cmd/deletecluster.go
@@ -42,7 +42,7 @@ var dc = &deleteClusterOptions{}
 var deleteClusterCmd = &cobra.Command{
 	Use:          "cluster (<cluster-name>|-f <config-file>)",
 	Short:        "Workload cluster",
-	Long:         "This command is used to delete workload clusters created by eks-a",
+	Long:         "This command is used to delete workload clusters created by eksctl anywhere",
 	PreRunE:      preRunDeleteCluster,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/eks-a/cmd/generate.go
+++ b/cmd/eks-a/cmd/generate.go
@@ -7,7 +7,7 @@ import (
 var generateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "Generate resources",
-	Long:  "Use eks-a generate to generate resources, such as clusterconfig yaml",
+	Long:  "Use eksctl anywhere generate to generate resources, such as clusterconfig yaml",
 }
 
 func init() {

--- a/cmd/eks-a/cmd/generateclusterconfig.go
+++ b/cmd/eks-a/cmd/generateclusterconfig.go
@@ -80,9 +80,12 @@ func generateClusterConfig(clusterName string) error {
 		// in controller code
 		cpMachineConfig := v1alpha1.NewVSphereMachineConfigGenerate(clusterName + "-cp")
 		workerMachineConfig := v1alpha1.NewVSphereMachineConfigGenerate(clusterName)
+		etcdMachineConfig := v1alpha1.NewVSphereMachineConfigGenerate(fmt.Sprintf("%s-etcd", clusterName))
 		clusterConfigOpts = append(clusterConfigOpts,
 			v1alpha1.WithCPMachineGroupRef(cpMachineConfig),
-			v1alpha1.WithWorkerMachineGroupRef(workerMachineConfig))
+			v1alpha1.WithWorkerMachineGroupRef(workerMachineConfig),
+			v1alpha1.WithEtcdMachineGroupRef(etcdMachineConfig),
+		)
 		cpMcYaml, err := yaml.Marshal(cpMachineConfig)
 		if err != nil {
 			return fmt.Errorf("error outputting yaml: %v", err)
@@ -91,7 +94,11 @@ func generateClusterConfig(clusterName string) error {
 		if err != nil {
 			return fmt.Errorf("error outputting yaml: %v", err)
 		}
-		machineGroupYaml = append(machineGroupYaml, cpMcYaml, workerMcYaml)
+		etcdMcYaml, err := yaml.Marshal(etcdMachineConfig)
+		if err != nil {
+			return fmt.Errorf("error outputting yaml: %v", err)
+		}
+		machineGroupYaml = append(machineGroupYaml, cpMcYaml, workerMcYaml, etcdMcYaml)
 	default:
 		return fmt.Errorf("not a valid provider")
 	}

--- a/cmd/eks-a/cmd/root.go
+++ b/cmd/eks-a/cmd/root.go
@@ -12,9 +12,9 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:              "eks-a",
+	Use:              "anywhere",
 	Short:            "Amazon EKS Anywhere",
-	Long:             `Use eks-a to build your own self-managing cluster on your hardware with the best of Amazon EKS`,
+	Long:             `Use eksctl anywhere to build your own self-managing cluster on your hardware with the best of Amazon EKS`,
 	PersistentPreRun: rootPersistentPreRun,
 }
 

--- a/cmd/eks-a/cmd/upgrade.go
+++ b/cmd/eks-a/cmd/upgrade.go
@@ -7,7 +7,7 @@ import (
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Upgrade resources",
-	Long:  "Use eks-a upgrade to upgrade resources, such as clusters",
+	Long:  "Use eksctl anywhere upgrade to upgrade resources, such as clusters",
 }
 
 func init() {

--- a/cmd/eks-a/cmd/version.go
+++ b/cmd/eks-a/cmd/version.go
@@ -10,8 +10,8 @@ import (
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Get the eks-a version",
-	Long:  "This command prints the version of eks-a",
+	Short: "Get the eksctl anywhere version",
+	Long:  "This command prints the version of eksctl anywhere",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return printVersion()
 	},

--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -99,6 +99,15 @@ spec:
                 properties:
                   count:
                     type: integer
+                  machineGroupRef:
+                    description: MachineGroupRef defines the machine group configuration
+                      for the etcd machines.
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                    type: object
                 type: object
               gitOpsRef:
                 properties:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -2205,6 +2205,8 @@ rules:
   - secrets/status
   - configmaps
   - configmaps/status
+  - namespaces
+  - namespaces/status
   verbs:
   - get
   - list

--- a/config/rbac/manager_extraroles_patch.yaml
+++ b/config/rbac/manager_extraroles_patch.yaml
@@ -112,6 +112,8 @@
       - secrets/status
       - configmaps
       - configmaps/status
+      - namespaces
+      - namespaces/status
     verbs:
       - get
       - list

--- a/controllers/controllers/resource/fetcher.go
+++ b/controllers/controllers/resource/fetcher.go
@@ -18,6 +18,7 @@ import (
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
@@ -119,7 +120,7 @@ func (r *capiResourceFetcher) fetchClusterForRef(ctx context.Context, refId type
 	for _, c := range clusters.Items {
 		if kind == anywherev1.VSphereDatacenterKind || kind == anywherev1.DockerDatacenterKind {
 			if c.Spec.DatacenterRef.Name == refId.Name {
-				if _, err := r.clusterByName(ctx, refId.Namespace, c.Name); err == nil { // further validates a capi cluster exists
+				if _, err := r.clusterByName(ctx, constants.EksaSystemNamespace, c.Name); err == nil { // further validates a capi cluster exists
 					return &c, nil
 				}
 			}
@@ -127,13 +128,13 @@ func (r *capiResourceFetcher) fetchClusterForRef(ctx context.Context, refId type
 		if kind == anywherev1.VSphereMachineConfigKind {
 			for _, machineRef := range c.Spec.WorkerNodeGroupConfigurations {
 				if machineRef.MachineGroupRef != nil && machineRef.MachineGroupRef.Name == refId.Name {
-					if _, err := r.clusterByName(ctx, refId.Namespace, c.Name); err == nil { // further validates a capi cluster exists
+					if _, err := r.clusterByName(ctx, constants.EksaSystemNamespace, c.Name); err == nil { // further validates a capi cluster exists
 						return &c, nil
 					}
 				}
 			}
 			if c.Spec.ControlPlaneConfiguration.MachineGroupRef != nil && c.Spec.ControlPlaneConfiguration.MachineGroupRef.Name == refId.Name {
-				if _, err := r.clusterByName(ctx, refId.Namespace, c.Name); err == nil { // further validates a capi cluster exists
+				if _, err := r.clusterByName(ctx, constants.EksaSystemNamespace, c.Name); err == nil { // further validates a capi cluster exists
 					return &c, nil
 				}
 			}
@@ -148,7 +149,7 @@ func (r *capiResourceFetcher) machineDeployments(ctx context.Context, c *anywher
 	if err != nil {
 		return nil, err
 	}
-	o := &client.ListOptions{LabelSelector: labels.NewSelector().Add(*req), Namespace: c.Namespace}
+	o := &client.ListOptions{LabelSelector: labels.NewSelector().Add(*req), Namespace: constants.EksaSystemNamespace}
 	err = r.client.List(ctx, machineDeployments, o)
 	if err != nil {
 		return nil, err
@@ -190,7 +191,7 @@ func (r *capiResourceFetcher) VSphereMachineTemplate(ctx context.Context, cs *an
 		return nil, err
 	}
 	vsphereMachineTemplate := &vspherev3.VSphereMachineTemplate{}
-	err = r.FetchObjectByName(ctx, md.Spec.Template.Spec.InfrastructureRef.Name, md.GetNamespace(), vsphereMachineTemplate)
+	err = r.FetchObjectByName(ctx, md.Spec.Template.Spec.InfrastructureRef.Name, constants.EksaSystemNamespace, vsphereMachineTemplate)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +210,7 @@ func (r *capiResourceFetcher) clusterBundle(ctx context.Context, cs *anywherev1.
 func (r *capiResourceFetcher) ControlPlane(ctx context.Context, cs *anywherev1.Cluster) (*kubeadmnv1alpha3.KubeadmControlPlane, error) {
 	// Fetch capi cluster
 	capiCluster := &clusterv1.Cluster{}
-	err := r.FetchObjectByName(ctx, cs.Name, cs.Namespace, capiCluster)
+	err := r.FetchObjectByName(ctx, cs.Name, constants.EksaSystemNamespace, capiCluster)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/controllers/resource/template.go
+++ b/controllers/controllers/resource/template.go
@@ -27,7 +27,7 @@ type VsphereTemplate struct {
 
 func (r *VsphereTemplate) TemplateResources(ctx context.Context, eksaCluster *anywherev1.Cluster, clusterSpec *cluster.Spec, vdcSpec anywherev1.VSphereDatacenterConfig, vmcSpec anywherev1.VSphereMachineConfig) ([]*unstructured.Unstructured, error) {
 	// passing the same vspheremachineconfig for worker and cp as control plane updates are prohibited in controller
-	templateBuilder := vsphere.NewVsphereTemplateBuilder(&vdcSpec.Spec, &vmcSpec.Spec, &vmcSpec.Spec, r.now)
+	templateBuilder := vsphere.NewVsphereTemplateBuilder(&vdcSpec.Spec, &vmcSpec.Spec, &vmcSpec.Spec, &vmcSpec.Spec, r.now)
 	clusterName := clusterSpec.ObjectMeta.Name
 	kubeadmControlPlane, err := r.ControlPlane(ctx, eksaCluster)
 	if err != nil {

--- a/controllers/controllers/resource/testdata/expectedMachineDeployment.yaml
+++ b/controllers/controllers/resource/testdata/expectedMachineDeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test_cluster
   name: test_cluster-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterName: test_cluster
   replicas: 4

--- a/controllers/controllers/resource/testdata/expectedMachineDeploymentOnlyReplica.yaml
+++ b/controllers/controllers/resource/testdata/expectedMachineDeploymentOnlyReplica.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test_cluster
   name: test_cluster-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterName: test_cluster
   replicas: 3

--- a/controllers/controllers/resource/testdata/machineDeployment.yaml
+++ b/controllers/controllers/resource/testdata/machineDeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test_cluster
   name: test_cluster-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterName: test_cluster
   replicas: 1

--- a/controllers/controllers/resource/testdata/vsphereMachineTemplate.yaml
+++ b/controllers/controllers/resource/testdata/vsphereMachineTemplate.yaml
@@ -2,7 +2,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test_cluster-worker-node-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -177,8 +177,8 @@ enable = false
         desc = "Development takes place here!"
 
 [[params.versions]]
-fullversion = "main"
-version = "main"
-githubbranch = "main"
+fullversion = "v0.5.0"
+version = "v0.5.0"
+githubbranch = "v0.5.0"
 docsbranch = "main"
 url = "/docs"

--- a/docs/content/en/docs/overview/_index.md
+++ b/docs/content/en/docs/overview/_index.md
@@ -6,15 +6,16 @@ description: >
   Provides an overview of EKS Anywhere
 ---
 
-EKS Anywhere will use the `eksctl` executable to create a Kubernetes cluster in your environment.
+EKS Anywhere uses the `eksctl` executable to create a Kubernetes cluster in your environment.
 Currently it allows you to create and delete clusters in a vSphere environment.
 You can run cluster create and delete commands from an Ubuntu or Mac administrative machine.
 
-To create a cluster you will need to create a specification file which includes all of your vSphere details and information about your EKS cluster.
-The `eksctl anywhere create cluster` command will create a temporary bootstrap cluster on your admin machine which will be used to create a workload cluster in vSphere.
-Once the workload cluster is created the cluster management resources will be moved to your workload cluster and the local bootstrap cluster will be deleted.
+To create a cluster, you need to create a specification file that includes all of your vSphere details and information about your EKS cluster.
+Running the `eksctl anywhere create cluster` command from your admin machine creates the workload cluster in vSphere.
+It does this by first creating a temporary bootstrap cluster to direct the workload cluster creation.
+Once the workload cluster is created, the cluster management resources are moved to your workload cluster and the local bootstrap cluster is deleted.
 
-Once your workload cluster is created a KUBECONFIG file will be stored on your admin machine with RBAC admin permissions for the workload cluster.
+Once your workload cluster is created, a KUBECONFIG file is stored on your admin machine with RBAC admin permissions for the workload cluster.
 You’ll be able to use that file with `kubectl` to set up and deploy workloads.
 Here’s a diagram that explains the process visually.
 
@@ -27,5 +28,3 @@ The delete process is similar to the create process.
 
 Next steps:
 * [Getting Started](/docs/getting-started/)
-* [Examples](/docs/examples/)
-

--- a/docs/content/en/docs/reference/faq/_index.md
+++ b/docs/content/en/docs/reference/faq/_index.md
@@ -43,9 +43,9 @@ However, you can look into the [Dex LDAP Connector](https://dexidp.io/docs/conne
 Yes, you can install the [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator) on your EKS-A cluster to achieve this.
 
 
-## EKS-A add-on recommendations
+## EKS-A integrations recommendations
 
-### Which add-ons are recommended with EKS-A?
+### Which integrations are recommended with EKS-A?
 
 EKS Anywhere offers AWS support for certain third-party vendor components,
 namely Ubuntu TLS, Cilium, and Flux.

--- a/docs/deploy-docs.sh
+++ b/docs/deploy-docs.sh
@@ -15,7 +15,7 @@
 #
 # To deploy to a development environment make sure you have
 # ${AWS_PROFILE} set to your account
-# ${AMPLIFY_APP_ID} (optional) set to your Amplify app or a stack named modelrocket-docs-devstack
+# ${AMPLIFY_APP_ID} (optional) set to your Amplify app or a stack named eks-anywhere-docs-devstack
 # ${AMPLIFY_APP_BRANCH} (optional) set to Amplify branch you want to deploy to [default: main]
 
 set -euo pipefail
@@ -49,7 +49,7 @@ cancel_job() {
 GIT_COMMIT=$(git rev-parse --short HEAD)
 FILE=${1:-public.zip}
 APP=${AMPLIFY_APP_ID:-$(aws cloudformation describe-stacks \
-    --stack-name modelrocket-docs-devstack \
+    --stack-name eks-anywhere-docs-devstack \
     --query 'Stacks[].Outputs[?OutputKey==`EksAnywhereDocsappId`].OutputValue' \
     --output text)}
 BRANCH=${AMPLIFY_APP_BRANCH:-main}

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -103,6 +103,17 @@ func WithWorkerMachineGroupRef(ref ProviderRefAccessor) ClusterGenerateOpt {
 	}
 }
 
+func WithEtcdMachineGroupRef(ref ProviderRefAccessor) ClusterGenerateOpt {
+	return func(c *ClusterGenerate) {
+		if c.Spec.ExternalEtcdConfiguration != nil {
+			c.Spec.ExternalEtcdConfiguration.MachineGroupRef = &Ref{
+				Kind: ref.Kind(),
+				Name: ref.Name(),
+			}
+		}
+	}
+}
+
 func NewCluster(clusterName string) *Cluster {
 	c := &Cluster{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -12,6 +12,11 @@ const (
 	// ControlPlaneAnnotation is an annotation that can be applied to EKS-A machineconfig
 	// object to prevent a controller from making changes to that resource.
 	controlPlaneAnnotation = "anywhere.eks.amazonaws.com/control-plane"
+
+	clusterResourceType = "clusters.anywhere.eks.amazonaws.com"
+
+	// etcdAnnotation can be applied to EKS-A machineconfig CR for etcd, to prevent controller from making changes to it
+	etcdAnnotation = "anywhere.eks.amazonaws.com/etcd"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -204,6 +209,8 @@ type KindAccessor interface {
 // ExternalEtcdConfiguration defines the configuration options for using unstacked etcd topology
 type ExternalEtcdConfiguration struct {
 	Count int `json:"count,omitempty"`
+	// MachineGroupRef defines the machine group configuration for the etcd machines.
+	MachineGroupRef *Ref `json:"machineGroupRef,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -239,6 +246,14 @@ func (c *Cluster) PausedAnnotation() string {
 
 func (c *Cluster) ControlPlaneAnnotation() string {
 	return controlPlaneAnnotation
+}
+
+func (c *Cluster) ResourceType() string {
+	return clusterResourceType
+}
+
+func (c *Cluster) EtcdAnnotation() string {
+	return etcdAnnotation
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/api/v1alpha1/vspheremachineconfig_types.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_types.go
@@ -42,6 +42,13 @@ func (c *VSphereMachineConfig) IsControlPlane() bool {
 	return false
 }
 
+func (c *VSphereMachineConfig) IsEtcd() bool {
+	if s, ok := c.Annotations[etcdAnnotation]; ok {
+		return s == "true"
+	}
+	return false
+}
+
 type OSFamily string
 
 const (

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
@@ -112,11 +112,11 @@ func validateImmutableFieldsVSphereMachineConfig(new, old *VSphereMachineConfig)
 		)
 	}
 
-	if !old.IsControlPlane() {
-		vspheremachineconfiglog.Info("Machine config is not associated with control plane")
+	if !old.IsControlPlane() && !old.IsEtcd() {
+		vspheremachineconfiglog.Info("Machine config is not associated with control plane or etcd")
 		return allErrs
 	}
-	vspheremachineconfiglog.Info("Machine config is associated with control plane")
+	vspheremachineconfiglog.Info("Machine config is associated with control plane or etcd")
 
 	if old.Spec.MemoryMiB != new.Spec.MemoryMiB {
 		allErrs = append(

--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/types"
 )
@@ -25,6 +26,7 @@ type ClusterClient interface {
 	GetKubeconfig(ctx context.Context, clusterName string) (string, error)
 	ClusterExists(ctx context.Context, clusterName string) (bool, error)
 	ValidateClustersCRD(ctx context.Context, cluster *types.Cluster) error
+	CreateNamespace(ctx context.Context, kubeconfig string, namespace string) error
 }
 
 type (
@@ -47,6 +49,10 @@ func (b *Bootstrapper) CreateBootstrapCluster(ctx context.Context, clusterSpec *
 	c := &types.Cluster{
 		Name:           clusterSpec.Name,
 		KubeconfigFile: kubeconfigFile,
+	}
+
+	if err := b.clusterClient.CreateNamespace(ctx, c.KubeconfigFile, constants.EksaSystemNamespace); err != nil {
+		return nil, err
 	}
 
 	err = cluster.ApplyExtraObjects(ctx, b.clusterClient, c, clusterSpec)

--- a/pkg/bootstrapper/bootstrapper_test.go
+++ b/pkg/bootstrapper/bootstrapper_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/bootstrapper"
 	"github.com/aws/eks-anywhere/pkg/bootstrapper/mocks"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 
@@ -35,6 +36,7 @@ func TestBootstrapperCreateBootstrapClusterSuccessNoExtraObjects(t *testing.T) {
 			ctx := context.Background()
 			b, client := newBootstrapper(t)
 			client.EXPECT().CreateBootstrapCluster(ctx, clusterSpec).Return(kubeconfigFile, nil)
+			client.EXPECT().CreateNamespace(ctx, kubeconfigFile, constants.EksaSystemNamespace)
 
 			got, err := b.CreateBootstrapCluster(ctx, clusterSpec, tt.opts...)
 			if err != nil {
@@ -58,6 +60,7 @@ func TestBootstrapperCreateBootstrapClusterSuccessExtraObjects(t *testing.T) {
 	ctx := context.Background()
 	b, client := newBootstrapper(t)
 	client.EXPECT().CreateBootstrapCluster(ctx, clusterSpec).Return(kubeconfigFile, nil)
+	client.EXPECT().CreateNamespace(ctx, kubeconfigFile, constants.EksaSystemNamespace)
 	client.EXPECT().ApplyKubeSpecFromBytes(ctx, wantCluster, gomock.Any())
 
 	got, err := b.CreateBootstrapCluster(ctx, clusterSpec)

--- a/pkg/bootstrapper/mocks/client.go
+++ b/pkg/bootstrapper/mocks/client.go
@@ -86,6 +86,20 @@ func (mr *MockClusterClientMockRecorder) CreateBootstrapCluster(arg0, arg1 inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBootstrapCluster", reflect.TypeOf((*MockClusterClient)(nil).CreateBootstrapCluster), varargs...)
 }
 
+// CreateNamespace mocks base method.
+func (m *MockClusterClient) CreateNamespace(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNamespace", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateNamespace indicates an expected call of CreateNamespace.
+func (mr *MockClusterClientMockRecorder) CreateNamespace(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockClusterClient)(nil).CreateNamespace), arg0, arg1, arg2)
+}
+
 // DeleteBootstrapCluster mocks base method.
 func (m *MockClusterClient) DeleteBootstrapCluster(arg0 context.Context, arg1 *types.Cluster) error {
 	m.ctrl.T.Helper()

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -81,6 +81,20 @@ func (mr *MockClusterClientMockRecorder) ApplyKubeSpecFromBytesForce(arg0, arg1,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyKubeSpecFromBytesForce", reflect.TypeOf((*MockClusterClient)(nil).ApplyKubeSpecFromBytesForce), arg0, arg1, arg2)
 }
 
+// ApplyKubeSpecWithNamespace mocks base method.
+func (m *MockClusterClient) ApplyKubeSpecWithNamespace(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyKubeSpecWithNamespace", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyKubeSpecWithNamespace indicates an expected call of ApplyKubeSpecWithNamespace.
+func (mr *MockClusterClientMockRecorder) ApplyKubeSpecWithNamespace(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyKubeSpecWithNamespace", reflect.TypeOf((*MockClusterClient)(nil).ApplyKubeSpecWithNamespace), arg0, arg1, arg2, arg3)
+}
+
 // DeleteCluster mocks base method.
 func (m *MockClusterClient) DeleteCluster(arg0 context.Context, arg1, arg2 *types.Cluster) error {
 	m.ctrl.T.Helper()
@@ -213,6 +227,20 @@ func (mr *MockClusterClientMockRecorder) MoveManagement(arg0, arg1, arg2 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveManagement", reflect.TypeOf((*MockClusterClient)(nil).MoveManagement), arg0, arg1, arg2)
 }
 
+// RemoveAnnotationInNamespace mocks base method.
+func (m *MockClusterClient) RemoveAnnotationInNamespace(arg0 context.Context, arg1, arg2, arg3 string, arg4 *types.Cluster, arg5 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveAnnotationInNamespace", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveAnnotationInNamespace indicates an expected call of RemoveAnnotationInNamespace.
+func (mr *MockClusterClientMockRecorder) RemoveAnnotationInNamespace(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAnnotationInNamespace", reflect.TypeOf((*MockClusterClient)(nil).RemoveAnnotationInNamespace), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
 // SaveLog mocks base method.
 func (m *MockClusterClient) SaveLog(arg0 context.Context, arg1 *types.Cluster, arg2 *types.Deployment, arg3 string, arg4 filewriter.FileWriter) error {
 	m.ctrl.T.Helper()
@@ -239,20 +267,6 @@ func (m *MockClusterClient) UpdateAnnotationInNamespace(arg0 context.Context, ar
 func (mr *MockClusterClientMockRecorder) UpdateAnnotationInNamespace(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAnnotationInNamespace", reflect.TypeOf((*MockClusterClient)(nil).UpdateAnnotationInNamespace), arg0, arg1, arg2, arg3, arg4, arg5)
-}
-
-// UpdateEksaClusterAnnotations mocks base method.
-func (m *MockClusterClient) UpdateEksaClusterAnnotations(arg0 context.Context, arg1 map[string]string, arg2 *types.Cluster) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateEksaClusterAnnotations", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateEksaClusterAnnotations indicates an expected call of UpdateEksaClusterAnnotations.
-func (mr *MockClusterClientMockRecorder) UpdateEksaClusterAnnotations(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEksaClusterAnnotations", reflect.TypeOf((*MockClusterClient)(nil).UpdateEksaClusterAnnotations), arg0, arg1, arg2)
 }
 
 // WaitForControlPlaneReady mocks base method.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	EksaSystemNamespace = "eksa-system"
+)

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/templater"
@@ -143,7 +144,7 @@ func writeInfrastructureBundle(clusterSpec *cluster.Spec, rootFolder string, bun
 }
 
 func (c *Clusterctl) MoveManagement(ctx context.Context, from, to *types.Cluster) error {
-	params := []string{"move", "--to-kubeconfig", to.KubeconfigFile}
+	params := []string{"move", "--to-kubeconfig", to.KubeconfigFile, "--namespace", constants.EksaSystemNamespace}
 	if from.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", from.KubeconfigFile)
 	}
@@ -158,6 +159,7 @@ func (c *Clusterctl) GetWorkloadKubeconfig(ctx context.Context, clusterName stri
 	stdOut, err := c.executable.Execute(
 		ctx, "get", "kubeconfig", clusterName,
 		"--kubeconfig", cluster.KubeconfigFile,
+		"--namespace", constants.EksaSystemNamespace,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error executing get kubeconfig: %v", err)

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	specv1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	mockexecutables "github.com/aws/eks-anywhere/pkg/executables/mocks"
 	mockswriter "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
@@ -295,7 +296,7 @@ func TestClusterctlMoveManagement(t *testing.T) {
 			testName:     "no kubeconfig",
 			from:         &types.Cluster{},
 			to:           &types.Cluster{},
-			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", ""},
+			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "", "--namespace", constants.EksaSystemNamespace},
 		},
 		{
 			testName: "no kubeconfig in 'from' cluster",
@@ -303,7 +304,7 @@ func TestClusterctlMoveManagement(t *testing.T) {
 			to: &types.Cluster{
 				KubeconfigFile: "to.kubeconfig",
 			},
-			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig"},
+			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig", "--namespace", constants.EksaSystemNamespace},
 		},
 		{
 			testName: "with both kubeconfigs",
@@ -313,7 +314,7 @@ func TestClusterctlMoveManagement(t *testing.T) {
 			to: &types.Cluster{
 				KubeconfigFile: "to.kubeconfig",
 			},
-			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig", "--kubeconfig", "from.kubeconfig"},
+			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--kubeconfig", "from.kubeconfig"},
 		},
 	}
 
@@ -435,7 +436,7 @@ var versionBundle = &cluster.VersionsBundle{
 		},
 		Eksa: v1alpha1.EksaBundle{
 			CliTools: v1alpha1.Image{
-				URI: "public.ecr.aws/l0g8r8j6/modelrocket/base:v1-19-1-75ac0bf61974d7ea5d83c17a1c629f26c142cca7",
+				URI: "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v1-19-1-75ac0bf61974d7ea5d83c17a1c629f26c142cca7",
 			},
 		},
 		ExternalEtcdBootstrap: v1alpha1.EtcdadmBootstrapBundle{

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -38,7 +38,7 @@ var requiredEnvVars = []string{
 	"AWS_SSH_KEY_NAME", "AWS_CONTROL_PLANE_MACHINE_TYPE", "AWS_NODE_MACHINE_TYPE", "AWS_SESSION_TOKEN", "GITHUB_TOKEN",
 }
 
-var eksaAwsResourceName = fmt.Sprintf("awsdatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
+var eksaAwsResourceType = fmt.Sprintf("awsdatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 
 type provider struct {
 	clusterName           string
@@ -115,11 +115,11 @@ func (p *provider) Name() string {
 	return ProviderName
 }
 
-func (p *provider) DatacenterResourceName() string {
-	return eksaAwsResourceName
+func (p *provider) DatacenterResourceType() string {
+	return eksaAwsResourceType
 }
 
-func (p *provider) MachineResourceName() string {
+func (p *provider) MachineResourceType() string {
 	return ""
 }
 

--- a/pkg/providers/docker/config/template.yaml
+++ b/pkg/providers/docker/config/template.yaml
@@ -2,7 +2,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: {{.clusterName}}
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   clusterNetwork:
     pods:
@@ -16,32 +16,32 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: {{.clusterName}}
-    namespace: default
+    namespace: {{.eksaSystemNamespace}}
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerCluster
     name: {{.clusterName}}
-    namespace: default
+    namespace: {{.eksaSystemNamespace}}
 {{- if .externalEtcd }}
   managedExternalEtcdRef:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
     name: {{.clusterName}}-etcd
-    namespace: default
+    namespace: {{.eksaSystemNamespace}}
 {{- end }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerCluster
 metadata:
   name: {{.clusterName}}
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 ---
 {{- if .needsNewControlPlaneTemplate }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerMachineTemplate
 metadata:
   name: {{.controlPlaneTemplateName}}
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   template:
     spec:
@@ -55,13 +55,13 @@ apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: {{.clusterName}}
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate
     name: {{.controlPlaneTemplateName}}
-    namespace: default
+    namespace: {{.eksaSystemNamespace}}
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: {{.kubernetesRepository}}
@@ -112,7 +112,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerMachineTemplate
 metadata:
   name: {{.workloadTemplateName}}
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   template:
     spec:
@@ -126,7 +126,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: {{.clusterName}}-md-0
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   template:
     spec:
@@ -141,7 +141,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: {{.clusterName}}-md-0
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   clusterName: {{.clusterName}}
   replicas: {{.worker_replicas}}
@@ -154,13 +154,13 @@ spec:
           apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: {{.clusterName}}-md-0
-          namespace: default
+          namespace: {{.eksaSystemNamespace}}
       clusterName: {{.clusterName}}
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: DockerMachineTemplate
         name: {{.workloadTemplateName}}
-        namespace: default
+        namespace: {{.eksaSystemNamespace}}
       version: {{.kubernetesVersion}}
 {{- if .externalEtcd }}
 ---
@@ -168,7 +168,7 @@ kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: {{.clusterName}}-etcd
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   replicas: {{.externalEtcdReplicas}}
   etcdadmConfigSpec:
@@ -179,14 +179,14 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate
     name: {{.etcdTemplateName}}
-    namespace: default
+    namespace: {{.eksaSystemNamespace}}
 ---
 {{- if .needsNewEtcdTemplate }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerMachineTemplate
 metadata:
   name: {{.etcdTemplateName}}
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   template:
     spec:

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_expected.yaml
@@ -2,7 +2,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: test-cluster
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
@@ -16,24 +16,24 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test-cluster
-    namespace: default
+    namespace: eksa-system
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerCluster
     name: test-cluster
-    namespace: default
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerCluster
 metadata:
   name: test-cluster
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-control-plane-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -46,13 +46,13 @@ apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test-cluster
-  namespace: default
+  namespace: eksa-system
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate
     name: test-cluster-control-plane-template-1234567890000
-    namespace: default
+    namespace: eksa-system
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -98,7 +98,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-worker-node-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -111,7 +111,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-cluster-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -126,7 +126,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: test-cluster-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterName: test-cluster
   replicas: 3
@@ -139,11 +139,11 @@ spec:
           apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test-cluster-md-0
-          namespace: default
+          namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: DockerMachineTemplate
         name: test-cluster-worker-node-template-1234567890000
-        namespace: default
+        namespace: eksa-system
       version: v1.19.6-eks-1-19-2

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_expected.yaml
@@ -2,7 +2,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: test-cluster
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
@@ -16,24 +16,24 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test-cluster
-    namespace: default
+    namespace: eksa-system
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerCluster
     name: test-cluster
-    namespace: default
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerCluster
 metadata:
   name: test-cluster
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-control-plane-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -46,13 +46,13 @@ apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test-cluster
-  namespace: default
+  namespace: eksa-system
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate
     name: test-cluster-control-plane-template-1234567890000
-    namespace: default
+    namespace: eksa-system
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -93,7 +93,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-worker-node-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -106,7 +106,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-cluster-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -121,7 +121,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: test-cluster-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterName: test-cluster
   replicas: 3
@@ -134,11 +134,11 @@ spec:
           apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test-cluster-md-0
-          namespace: default
+          namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: DockerMachineTemplate
         name: test-cluster-worker-node-template-1234567890000
-        namespace: default
+        namespace: eksa-system
       version: v1.19.6-eks-1-19-2

--- a/pkg/providers/docker/testdata/no_machinetemplate_update_expected.yaml
+++ b/pkg/providers/docker/testdata/no_machinetemplate_update_expected.yaml
@@ -2,7 +2,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: fluxAddonTestCluster
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
@@ -16,31 +16,31 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: fluxAddonTestCluster
-    namespace: default
+    namespace: eksa-system
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerCluster
     name: fluxAddonTestCluster
-    namespace: default
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerCluster
 metadata:
   name: fluxAddonTestCluster
-  namespace: default
+  namespace: eksa-system
 ---
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: fluxAddonTestCluster
-  namespace: default
+  namespace: eksa-system
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate
     name: test-control-plane-template-original
-    namespace: default
+    namespace: eksa-system
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: 
@@ -79,7 +79,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: fluxAddonTestCluster-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -94,7 +94,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: fluxAddonTestCluster-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterName: fluxAddonTestCluster
   replicas: 0
@@ -107,11 +107,11 @@ spec:
           apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: fluxAddonTestCluster-md-0
-          namespace: default
+          namespace: eksa-system
       clusterName: fluxAddonTestCluster
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: DockerMachineTemplate
         name: test-worker-node-template-original
-        namespace: default
+        namespace: eksa-system
       version: 

--- a/pkg/providers/docker/testdata/valid_deployment_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_expected.yaml
@@ -2,7 +2,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: test-cluster
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
@@ -16,24 +16,24 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test-cluster
-    namespace: default
+    namespace: eksa-system
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerCluster
     name: test-cluster
-    namespace: default
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerCluster
 metadata:
   name: test-cluster
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-control-plane-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -46,13 +46,13 @@ apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test-cluster
-  namespace: default
+  namespace: eksa-system
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate
     name: test-cluster-control-plane-template-1234567890000
-    namespace: default
+    namespace: eksa-system
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -90,7 +90,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-worker-node-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -103,7 +103,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-cluster-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -118,7 +118,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: test-cluster-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterName: test-cluster
   replicas: 3
@@ -131,11 +131,11 @@ spec:
           apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test-cluster-md-0
-          namespace: default
+          namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: DockerMachineTemplate
         name: test-cluster-worker-node-template-1234567890000
-        namespace: default
+        namespace: eksa-system
       version: v1.19.6-eks-1-19-2

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -96,18 +96,18 @@ func (mr *MockProviderMockRecorder) DatacenterConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatacenterConfig", reflect.TypeOf((*MockProvider)(nil).DatacenterConfig))
 }
 
-// DatacenterResourceName mocks base method.
-func (m *MockProvider) DatacenterResourceName() string {
+// DatacenterResourceType mocks base method.
+func (m *MockProvider) DatacenterResourceType() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DatacenterResourceName")
+	ret := m.ctrl.Call(m, "DatacenterResourceType")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// DatacenterResourceName indicates an expected call of DatacenterResourceName.
-func (mr *MockProviderMockRecorder) DatacenterResourceName() *gomock.Call {
+// DatacenterResourceType indicates an expected call of DatacenterResourceType.
+func (mr *MockProviderMockRecorder) DatacenterResourceType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatacenterResourceName", reflect.TypeOf((*MockProvider)(nil).DatacenterResourceName))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatacenterResourceType", reflect.TypeOf((*MockProvider)(nil).DatacenterResourceType))
 }
 
 // EnvMap mocks base method.
@@ -226,18 +226,18 @@ func (mr *MockProviderMockRecorder) MachineConfigs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineConfigs", reflect.TypeOf((*MockProvider)(nil).MachineConfigs))
 }
 
-// MachineResourceName mocks base method.
-func (m *MockProvider) MachineResourceName() string {
+// MachineResourceType mocks base method.
+func (m *MockProvider) MachineResourceType() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MachineResourceName")
+	ret := m.ctrl.Call(m, "MachineResourceType")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// MachineResourceName indicates an expected call of MachineResourceName.
-func (mr *MockProviderMockRecorder) MachineResourceName() *gomock.Call {
+// MachineResourceType indicates an expected call of MachineResourceType.
+func (mr *MockProviderMockRecorder) MachineResourceType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineResourceName", reflect.TypeOf((*MockProvider)(nil).MachineResourceName))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineResourceType", reflect.TypeOf((*MockProvider)(nil).MachineResourceType))
 }
 
 // Name mocks base method.

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -27,8 +27,8 @@ type Provider interface {
 	GetDeployments() map[string][]string
 	GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle
 	DatacenterConfig() DatacenterConfig
-	DatacenterResourceName() string
-	MachineResourceName() string
+	DatacenterResourceType() string
+	MachineResourceType() string
 	MachineConfigs() []MachineConfig
 	ValidateNewSpec(ctx context.Context, cluster *types.Cluster) error
 	GenerateMHC() ([]byte, error)

--- a/pkg/providers/vsphere/config/template.yaml
+++ b/pkg/providers/vsphere/config/template.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: {{.clusterName}}
   name: {{.clusterName}}
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   clusterNetwork:
     pods:
@@ -30,7 +30,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: {{.clusterName}}
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   cloudProviderConfiguration:
     global:
@@ -64,7 +64,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: {{.controlPlaneTemplateName}}
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   template:
     spec:
@@ -93,7 +93,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: {{.workloadTemplateName}}
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   template:
     spec:
@@ -121,7 +121,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: {{.clusterName}}
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
@@ -284,7 +284,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: {{.clusterName}}-md-0
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   template:
     spec:
@@ -342,7 +342,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: {{.clusterName}}
   name: {{.clusterName}}-md-0
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   clusterName: {{.clusterName}}
   replicas: {{.workerReplicas}}
@@ -371,7 +371,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: {{.clusterName}}
   name: {{.clusterName}}-crs-0
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   clusterSelector:
     matchLabels:
@@ -397,7 +397,7 @@ kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: {{.clusterName}}-etcd
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 spec:
   replicas: {{.externalEtcdReplicas}}
   etcdadmConfigSpec:
@@ -411,6 +411,7 @@ spec:
 {{- else}}
     cloudInitConfig:
       version: {{.externalEtcdVersion}}
+      installDir: "/usr/bin"
     preEtcdadmCommands:
       - hostname "{{`{{ ds.meta_data.hostname }}`}}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
@@ -419,9 +420,9 @@ spec:
       - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
 {{- end }}
     users:
-      - name: {{.controlPlaneSshUsername}}
+      - name: {{.etcdSshUsername}}
         sshAuthorizedKeys:
-          - '{{.vsphereControlPlaneSshAuthorizedKey}}'
+          - '{{.vsphereEtcdSshAuthorizedKey}}'
         sudo: ALL=(ALL) NOPASSWD:ALL
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
@@ -433,25 +434,25 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: {{.etcdTemplateName}}
-  namespace: 'default'
+  namespace: '{{.eksaSystemNamespace}}'
 spec:
   template:
     spec:
       cloneMode: linkedClone
       datacenter: {{.vsphereDatacenter}}
-      datastore: {{.controlPlaneVsphereDatastore}}
-      diskGiB: {{.controlPlaneDiskGiB}}
-      folder: '{{.controlPlaneVsphereFolder}}'
-      memoryMiB: {{.controlPlaneVMsMemoryMiB}}
+      datastore: {{.etcdVsphereDatastore}}
+      diskGiB: {{.etcdDiskGiB}}
+      folder: '{{.etcdVsphereFolder}}'
+      memoryMiB: {{.etcdVMsMemoryMiB}}
       network:
         devices:
           - dhcp4: true
             networkName: {{.vsphereNetwork}}
-      numCPUs: {{.controlPlaneVMsNumCPUs}}
-      resourcePool: '{{.controlPlaneVsphereResourcePool}}'
+      numCPUs: {{.etcdVMsNumCPUs}}
+      resourcePool: '{{.etcdVsphereResourcePool}}'
       server: {{.vsphereServer}}
-{{- if (ne .controlPlaneVsphereStoragePolicyName "") }}
-      storagePolicyName: "{{.controlPlaneVsphereStoragePolicyName}}"
+{{- if (ne .etcdVsphereStoragePolicyName "") }}
+      storagePolicyName: "{{.etcdVsphereStoragePolicyName}}"
 {{- end }}
       template: {{.vsphereTemplate}}
       thumbprint: '{{.thumbprint}}'
@@ -462,7 +463,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-csi-controller
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 stringData:
   data: |
     apiVersion: v1
@@ -582,7 +583,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-role
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 ---
 apiVersion: v1
 data:
@@ -602,7 +603,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-binding
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 ---
 apiVersion: v1
 data:
@@ -616,7 +617,7 @@ data:
 kind: ConfigMap
 metadata:
   name: csi.vsphere.vmware.com
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 ---
 apiVersion: v1
 data:
@@ -749,7 +750,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-node
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 ---
 apiVersion: v1
 data:
@@ -874,7 +875,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}
 ---
 apiVersion: v1
 data:
@@ -889,4 +890,4 @@ data:
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
-  namespace: default
+  namespace: {{.eksaSystemNamespace}}

--- a/pkg/providers/vsphere/internal/templates/factory_test.go
+++ b/pkg/providers/vsphere/internal/templates/factory_test.go
@@ -18,6 +18,7 @@ type test struct {
 	datastore       string
 	resourcePool    string
 	templateLibrary string
+	resizeDisk2     bool
 	govc            *mocks.MockGovcClient
 	factory         *templates.Factory
 	ctx             context.Context
@@ -43,6 +44,7 @@ func newTest(t *testing.T) *test {
 		datastore:       "datastore",
 		resourcePool:    "*/pool/",
 		templateLibrary: "library",
+		resizeDisk2:     false,
 		govc:            mocks.NewMockGovcClient(ctrl),
 		ctx:             context.Background(),
 		dummyError:      errors.New("error from govc"),
@@ -67,6 +69,7 @@ func newMachineConfig(t *testing.T) *v1alpha1.VSphereMachineConfig {
 		},
 		Spec: v1alpha1.VSphereMachineConfigSpec{
 			Template: "/SDDC-Datacenter/vm/Templates/ubuntu-v1.19.8-eks-d-1-19-4-eks-a-0.0.1.build.38-amd64",
+			OSFamily: "ubuntu",
 		},
 	}
 }
@@ -161,7 +164,7 @@ func TestFactoryCreateIfMissingErrorDeploy(t *testing.T) {
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateInLibrary).Return(false, nil)
 	ct.govc.EXPECT().ImportTemplate(ct.ctx, ct.templateLibrary, ct.ovaURL, ct.templateName).Return(nil)
 	ct.govc.EXPECT().DeployTemplateFromLibrary(
-		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool,
+		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool, ct.resizeDisk2,
 	).Return(ct.dummyError)
 
 	ct.assertErrorFromCreateIfMissing()
@@ -175,7 +178,7 @@ func TestFactoryCreateIfMissingErrorFromTagFactory(t *testing.T) {
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateInLibrary).Return(false, nil)
 	ct.govc.EXPECT().ImportTemplate(ct.ctx, ct.templateLibrary, ct.ovaURL, ct.templateName).Return(nil)
 	ct.govc.EXPECT().DeployTemplateFromLibrary(
-		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool,
+		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool, ct.resizeDisk2,
 	).Return(nil)
 
 	// expects for tagging
@@ -192,7 +195,7 @@ func TestFactoryCreateIfMissingSuccessLibraryDoesNotExist(t *testing.T) {
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateInLibrary).Return(false, nil)
 	ct.govc.EXPECT().ImportTemplate(ct.ctx, ct.templateLibrary, ct.ovaURL, ct.templateName).Return(nil)
 	ct.govc.EXPECT().DeployTemplateFromLibrary(
-		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool,
+		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool, ct.resizeDisk2,
 	).Return(nil)
 
 	// expects for tagging
@@ -209,7 +212,7 @@ func TestFactoryCreateIfMissingSuccessLibraryExists(t *testing.T) {
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateInLibrary).Return(false, nil)
 	ct.govc.EXPECT().ImportTemplate(ct.ctx, ct.templateLibrary, ct.ovaURL, ct.templateName).Return(nil)
 	ct.govc.EXPECT().DeployTemplateFromLibrary(
-		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool,
+		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool, ct.resizeDisk2,
 	).Return(nil)
 
 	// expects for tagging
@@ -225,7 +228,7 @@ func TestFactoryCreateIfMissingSuccessTemplateInLibrarytExists(t *testing.T) {
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateLibrary).Return(true, nil)
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateInLibrary).Return(true, nil)
 	ct.govc.EXPECT().DeployTemplateFromLibrary(
-		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool,
+		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool, ct.resizeDisk2,
 	).Return(nil)
 
 	// expects for tagging

--- a/pkg/providers/vsphere/internal/templates/mocks/govc.go
+++ b/pkg/providers/vsphere/internal/templates/mocks/govc.go
@@ -92,17 +92,17 @@ func (mr *MockGovcClientMockRecorder) CreateTag(ctx, tag, category interface{}) 
 }
 
 // DeployTemplateFromLibrary mocks base method.
-func (m *MockGovcClient) DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, resourcePool string) error {
+func (m *MockGovcClient) DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, resourcePool string, resizeDisk2 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeployTemplateFromLibrary", ctx, templateDir, templateName, library, resourcePool)
+	ret := m.ctrl.Call(m, "DeployTemplateFromLibrary", ctx, templateDir, templateName, library, resourcePool, resizeDisk2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeployTemplateFromLibrary indicates an expected call of DeployTemplateFromLibrary.
-func (mr *MockGovcClientMockRecorder) DeployTemplateFromLibrary(ctx, templateDir, templateName, library, resourcePool interface{}) *gomock.Call {
+func (mr *MockGovcClientMockRecorder) DeployTemplateFromLibrary(ctx, templateDir, templateName, library, resourcePool, resizeDisk2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTemplateFromLibrary", reflect.TypeOf((*MockGovcClient)(nil).DeployTemplateFromLibrary), ctx, templateDir, templateName, library, resourcePool)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTemplateFromLibrary", reflect.TypeOf((*MockGovcClient)(nil).DeployTemplateFromLibrary), ctx, templateDir, templateName, library, resourcePool, resizeDisk2)
 }
 
 // ImportTemplate mocks base method.

--- a/pkg/providers/vsphere/mocks/client.go
+++ b/pkg/providers/vsphere/mocks/client.go
@@ -98,17 +98,17 @@ func (mr *MockProviderGovcClientMockRecorder) CreateTag(arg0, arg1, arg2 interfa
 }
 
 // DeployTemplateFromLibrary mocks base method.
-func (m *MockProviderGovcClient) DeployTemplateFromLibrary(arg0 context.Context, arg1, arg2, arg3, arg4 string) error {
+func (m *MockProviderGovcClient) DeployTemplateFromLibrary(arg0 context.Context, arg1, arg2, arg3, arg4 string, arg5 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeployTemplateFromLibrary", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "DeployTemplateFromLibrary", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeployTemplateFromLibrary indicates an expected call of DeployTemplateFromLibrary.
-func (mr *MockProviderGovcClientMockRecorder) DeployTemplateFromLibrary(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockProviderGovcClientMockRecorder) DeployTemplateFromLibrary(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTemplateFromLibrary", reflect.TypeOf((*MockProviderGovcClient)(nil).DeployTemplateFromLibrary), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTemplateFromLibrary", reflect.TypeOf((*MockProviderGovcClient)(nil).DeployTemplateFromLibrary), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // GetTags mocks base method.
@@ -293,6 +293,20 @@ func (m *MockProviderKubectlClient) ApplyKubeSpecFromBytes(arg0 context.Context,
 func (mr *MockProviderKubectlClientMockRecorder) ApplyKubeSpecFromBytes(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyKubeSpecFromBytes", reflect.TypeOf((*MockProviderKubectlClient)(nil).ApplyKubeSpecFromBytes), arg0, arg1, arg2)
+}
+
+// CreateNamespace mocks base method.
+func (m *MockProviderKubectlClient) CreateNamespace(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNamespace", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateNamespace indicates an expected call of CreateNamespace.
+func (mr *MockProviderKubectlClientMockRecorder) CreateNamespace(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockProviderKubectlClient)(nil).CreateNamespace), arg0, arg1, arg2)
 }
 
 // GetEksaCluster mocks base method.

--- a/pkg/providers/vsphere/testdata/cluster_bottlerocket_external_etcd.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_bottlerocket_external_etcd.yaml
@@ -32,6 +32,9 @@ spec:
         - 10.96.0.0/16
   externalEtcdConfiguration:
     count: 3
+    machineGroupRef:
+      name: test-etcd
+      kind: VSphereMachineConfig
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: VSphereMachineConfig
@@ -54,6 +57,23 @@ apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: VSphereMachineConfig
 metadata:
   name: test-wn
+spec:
+  diskGiB: 25
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  osFamily: bottlerocket
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/bottlerocket-1804-kube-v1.19.6"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-etcd
 spec:
   diskGiB: 25
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"

--- a/pkg/providers/vsphere/testdata/cluster_main.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_main.yaml
@@ -16,6 +16,11 @@ spec:
       machineGroupRef:
         name: test-wn
         kind: VSphereMachineConfig
+  externalEtcdConfiguration:
+    count: 3
+    machineGroupRef:
+      name: test-etcd
+      kind: VSphereMachineConfig
   datacenterRef:
     kind: VSphereDatacenterConfig
     name: test
@@ -65,6 +70,25 @@ spec:
     - name: capv
       sshAuthorizedKeys:
         - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-etcd
+spec:
+  diskGiB: 25
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 4096
+  numCPUs: 3
+  osFamily: ubuntu
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+       - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: VSphereDatacenterConfig

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
@@ -28,7 +28,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   cloudProviderConfiguration:
     global:
@@ -61,7 +61,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -86,7 +86,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-worker-node-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -111,7 +111,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
@@ -235,7 +235,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -270,7 +270,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterName: test
   replicas: 3
@@ -299,7 +299,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test-crs-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterSelector:
     matchLabels:
@@ -324,7 +324,7 @@ kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: test-etcd
-  namespace: default
+  namespace: eksa-system
 spec:
   replicas: 3
   etcdadmConfigSpec:
@@ -348,7 +348,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000
-  namespace: 'default'
+  namespace: 'eksa-system'
 spec:
   template:
     spec:
@@ -373,7 +373,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-csi-controller
-  namespace: default
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -493,7 +493,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-role
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -513,7 +513,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-binding
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -527,7 +527,7 @@ data:
 kind: ConfigMap
 metadata:
   name: csi.vsphere.vmware.com
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -660,7 +660,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-node
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -785,7 +785,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -800,4 +800,4 @@ data:
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
-  namespace: default
+  namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_full_oidc.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_full_oidc.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
@@ -24,7 +24,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   cloudProviderConfiguration:
     global:
@@ -57,7 +57,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -82,7 +82,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-worker-node-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -107,7 +107,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
@@ -217,7 +217,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -246,7 +246,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterName: test
   replicas: 3
@@ -275,7 +275,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test-crs-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterSelector:
     matchLabels:
@@ -300,7 +300,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-csi-controller
-  namespace: default
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -420,7 +420,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-role
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -440,7 +440,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-binding
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -454,7 +454,7 @@ data:
 kind: ConfigMap
 metadata:
   name: csi.vsphere.vmware.com
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -587,7 +587,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-node
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -712,7 +712,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -727,4 +727,4 @@ data:
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
-  namespace: default
+  namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_main.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
@@ -19,12 +19,16 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
+  managedExternalEtcdRef:
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
+    kind: EtcdadmCluster
+    name: test-etcd
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   cloudProviderConfiguration:
     global:
@@ -57,7 +61,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -82,7 +86,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-worker-node-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -107,7 +111,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
@@ -117,9 +121,11 @@ spec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
-        local:
-          imageRepository: public.ecr.aws/eks-distro/etcd-io
-          imageTag: v3.4.14-eks-1-19-4
+        external:
+          endpoints: []
+          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
+          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
+          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
       dns:
         type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
@@ -210,7 +216,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -239,7 +245,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterName: test
   replicas: 3
@@ -268,7 +274,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test-crs-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterSelector:
     matchLabels:
@@ -289,11 +295,65 @@ spec:
   - kind: ConfigMap
     name: vsphere-csi-controller
 ---
+kind: EtcdadmCluster
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
+metadata:
+  name: test-etcd
+  namespace: eksa-system
+spec:
+  replicas: 3
+  etcdadmConfigSpec:
+    etcdadmBuiltin: true
+    format: cloud-config
+    cloudInitConfig:
+      version: 3.4.14
+      installDir: "/usr/bin"
+    preEtcdadmCommands:
+      - hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    users:
+      - name: capv
+        sshAuthorizedKeys:
+          - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
+        sudo: ALL=(ALL) NOPASSWD:ALL
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-etcd-template-1234567890000
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: VSphereMachineTemplate
+metadata:
+  name: test-etcd-template-1234567890000
+  namespace: 'eksa-system'
+spec:
+  template:
+    spec:
+      cloneMode: linkedClone
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 8192
+      network:
+        devices:
+          - dhcp4: true
+            networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 3
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
+      thumbprint: 'ABCDEFG'
+---
 apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-csi-controller
-  namespace: default
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -413,7 +473,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-role
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -433,7 +493,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-binding
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -447,7 +507,7 @@ data:
 kind: ConfigMap
 metadata:
   name: csi.vsphere.vmware.com
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -580,7 +640,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-node
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -705,7 +765,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -720,4 +780,4 @@ data:
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
-  namespace: default
+  namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
@@ -19,12 +19,16 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
+  managedExternalEtcdRef:
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
+    kind: EtcdadmCluster
+    name: test-etcd
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   cloudProviderConfiguration:
     global:
@@ -59,7 +63,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
@@ -69,9 +73,11 @@ spec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
-        local:
-          imageRepository: public.ecr.aws/eks-distro/etcd-io
-          imageTag: v3.4.14-eks-1-19-4
+        external:
+          endpoints: []
+          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
+          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
+          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
       dns:
         type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
@@ -162,7 +168,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -191,7 +197,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterName: test
   replicas: 3
@@ -220,7 +226,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test-crs-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterSelector:
     matchLabels:
@@ -241,11 +247,40 @@ spec:
   - kind: ConfigMap
     name: vsphere-csi-controller
 ---
+kind: EtcdadmCluster
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
+metadata:
+  name: test-etcd
+  namespace: eksa-system
+spec:
+  replicas: 3
+  etcdadmConfigSpec:
+    etcdadmBuiltin: true
+    format: cloud-config
+    cloudInitConfig:
+      version: 3.4.14
+      installDir: "/usr/bin"
+    preEtcdadmCommands:
+      - hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    users:
+      - name: capv
+        sshAuthorizedKeys:
+          - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
+        sudo: ALL=(ALL) NOPASSWD:ALL
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-etcd-template-original
+---
 apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-csi-controller
-  namespace: default
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -365,7 +400,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-role
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -385,7 +420,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-binding
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -399,7 +434,7 @@ data:
 kind: ConfigMap
 metadata:
   name: csi.vsphere.vmware.com
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -532,7 +567,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-node
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -657,7 +692,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -672,4 +707,4 @@ data:
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
-  namespace: default
+  namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_minimal.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
@@ -24,7 +24,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   cloudProviderConfiguration:
     global:
@@ -57,7 +57,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -81,7 +81,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-worker-node-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -105,7 +105,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
@@ -208,7 +208,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -237,7 +237,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterName: test
   replicas: 3
@@ -266,7 +266,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test-crs-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterSelector:
     matchLabels:
@@ -291,7 +291,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-csi-controller
-  namespace: default
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -411,7 +411,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-role
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -431,7 +431,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-binding
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -445,7 +445,7 @@ data:
 kind: ConfigMap
 metadata:
   name: csi.vsphere.vmware.com
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -578,7 +578,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-node
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -703,7 +703,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -718,4 +718,4 @@ data:
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
-  namespace: default
+  namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_oidc.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_oidc.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
@@ -24,7 +24,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   cloudProviderConfiguration:
     global:
@@ -57,7 +57,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -82,7 +82,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-worker-node-template-1234567890000
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -107,7 +107,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
-  namespace: default
+  namespace: eksa-system
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
@@ -212,7 +212,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   template:
     spec:
@@ -241,7 +241,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test-md-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterName: test
   replicas: 3
@@ -270,7 +270,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test
   name: test-crs-0
-  namespace: default
+  namespace: eksa-system
 spec:
   clusterSelector:
     matchLabels:
@@ -295,7 +295,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-csi-controller
-  namespace: default
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -415,7 +415,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-role
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -435,7 +435,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-binding
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -449,7 +449,7 @@ data:
 kind: ConfigMap
 metadata:
   name: csi.vsphere.vmware.com
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -582,7 +582,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-node
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -707,7 +707,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller
-  namespace: default
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -722,4 +722,4 @@ data:
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
-  namespace: default
+  namespace: eksa-system

--- a/pkg/validations/upgradevalidations/cluster_test.go
+++ b/pkg/validations/upgradevalidations/cluster_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/validations/upgradevalidations"
 )
 
@@ -45,7 +46,7 @@ func TestValidateClusterPresent(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(tt *testing.T) {
 			fileContent := test.ReadFile(t, tc.getClusterResponse)
-			e.EXPECT().Execute(ctx, []string{"get", capiClustersResourceName, "-o", "json", "--kubeconfig", cluster.KubeconfigFile}).Return(*bytes.NewBufferString(fileContent), nil)
+			e.EXPECT().Execute(ctx, []string{"get", capiClustersResourceType, "-o", "json", "--kubeconfig", cluster.KubeconfigFile, "--namespace", constants.EksaSystemNamespace}).Return(*bytes.NewBufferString(fileContent), nil)
 			err := upgradevalidations.ValidateClusterObjectExists(ctx, k, cluster)
 			if !reflect.DeepEqual(err, tc.wantErr) {
 				t.Errorf("%v got = %v, \nwant %v", tc.name, err, tc.wantErr)
@@ -54,4 +55,4 @@ func TestValidateClusterPresent(t *testing.T) {
 	}
 }
 
-var capiClustersResourceName = fmt.Sprintf("clusters.%s", v1alpha3.GroupVersion.Group)
+var capiClustersResourceType = fmt.Sprintf("clusters.%s", v1alpha3.GroupVersion.Group)

--- a/pkg/validations/upgradevalidations/eksasystem.go
+++ b/pkg/validations/upgradevalidations/eksasystem.go
@@ -4,32 +4,32 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 
 const (
-	eksaSystemNamespace          = "eksa-system"
 	eksaControllerDeploymentName = "eksa-controller-manager"
 )
 
 func ValidateEksaSystemComponents(ctx context.Context, k *executables.Kubectl, cluster *types.Cluster) error {
-	deployments, err := k.GetDeployments(ctx, executables.WithCluster(cluster), executables.WithNamespace(eksaSystemNamespace))
+	deployments, err := k.GetDeployments(ctx, executables.WithCluster(cluster), executables.WithNamespace(constants.EksaSystemNamespace))
 	if err != nil {
-		return fmt.Errorf("error getting deployments in namespace %s: %v", eksaSystemNamespace, err)
+		return fmt.Errorf("error getting deployments in namespace %s: %v", constants.EksaSystemNamespace, err)
 	}
 	for _, d := range deployments {
 		if d.Name == eksaControllerDeploymentName {
 			ready := d.Status.ReadyReplicas
 			actual := d.Status.Replicas
 			if actual == 0 {
-				return fmt.Errorf("EKS-A controller deployment %s in namespace %s is scaled to 0 replicas; should be at least one replcias", eksaControllerDeploymentName, eksaSystemNamespace)
+				return fmt.Errorf("EKS-A controller deployment %s in namespace %s is scaled to 0 replicas; should be at least one replcias", eksaControllerDeploymentName, constants.EksaSystemNamespace)
 			}
 			if ready != actual {
-				return fmt.Errorf("EKS-A controller deployment %s replicas in namespace %s are not ready; ready=%d, want=%d", eksaControllerDeploymentName, eksaSystemNamespace, ready, actual)
+				return fmt.Errorf("EKS-A controller deployment %s replicas in namespace %s are not ready; ready=%d, want=%d", eksaControllerDeploymentName, constants.EksaSystemNamespace, ready, actual)
 			}
 			return nil
 		}
 	}
-	return fmt.Errorf("failed to find EKS-A controller deployment %s in namespace %s", eksaControllerDeploymentName, eksaSystemNamespace)
+	return fmt.Errorf("failed to find EKS-A controller deployment %s in namespace %s", eksaControllerDeploymentName, constants.EksaSystemNamespace)
 }

--- a/pkg/validations/upgradevalidations/eksasystem_test.go
+++ b/pkg/validations/upgradevalidations/eksasystem_test.go
@@ -8,11 +8,8 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/validations/upgradevalidations"
-)
-
-const (
-	eksaSystemNamespace = "eksa-system"
 )
 
 func TestValidateEksaControllerReady(t *testing.T) {
@@ -49,7 +46,7 @@ func TestValidateEksaControllerReady(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(tt *testing.T) {
 			fileContent := test.ReadFile(t, tc.getDeploymentsResponse)
-			e.EXPECT().Execute(ctx, []string{"get", "deployments", "-o", "json", "--kubeconfig", cluster.KubeconfigFile, "--namespace", eksaSystemNamespace}).Return(*bytes.NewBufferString(fileContent), nil)
+			e.EXPECT().Execute(ctx, []string{"get", "deployments", "-o", "json", "--kubeconfig", cluster.KubeconfigFile, "--namespace", constants.EksaSystemNamespace}).Return(*bytes.NewBufferString(fileContent), nil)
 			err := upgradevalidations.ValidateEksaSystemComponents(ctx, k, cluster)
 			if !reflect.DeepEqual(err, tc.wantErr) {
 				t.Errorf("%v got = %v, \nwant %v", tc.name, err, tc.wantErr)

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/providers"
@@ -22,7 +23,6 @@ import (
 )
 
 const (
-	eksaSystemNamespace = "eksa-system"
 	eksaConfigFileName  = "eksa-cluster.yaml"
 	fluxSystemNamespace = "flux-system"
 	gitRepositoryVar    = "T_GIT_REPOSITORY"
@@ -275,7 +275,7 @@ func (e *E2ETest) validateFluxDeployments(ctx context.Context) error {
 
 func (e *E2ETest) validateEksaSystemDeployments(ctx context.Context) error {
 	expectedDeployments := map[string]int{"eksa-controller-manager": 1}
-	return e.validateDeployments(ctx, eksaSystemNamespace, expectedDeployments)
+	return e.validateDeployments(ctx, constants.EksaSystemNamespace, expectedDeployments)
 }
 
 func (e *E2ETest) validateDeployments(ctx context.Context, namespace string, expectedeployments map[string]int) error {
@@ -544,7 +544,7 @@ func (e *E2ETest) clusterConfGitPath() string {
 	if len(p) == 0 {
 		p = path.Join("clusters", e.ClusterName)
 	}
-	return path.Join(p, eksaSystemNamespace, eksaConfigFileName)
+	return path.Join(p, constants.EksaSystemNamespace, eksaConfigFileName)
 }
 
 func (e *E2ETest) clusterConfigGitPath() string {


### PR DESCRIPTION
Add code for:
* Adding vsphereMachineConfig for etcd machines
* Resizing bottlerocket 2nd disk to 20G post auto-import
* Moving all capi resources to eksa-system namespace
* Reconciling on eksa-system namespace
* Allowing datacenter, network, template, and folder names with spaces during vsphere validations 
* Patches and fixes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
