### PR TITLE
Prefix env vars eith EKSA_

### DIFF
--- a/pkg/executables/flux.go
+++ b/pkg/executables/flux.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	fluxPath       = "flux"
-	githubTokenEnv = "GITHUB_TOKEN"
+	githubTokenEnv = "EKSA_GITHUB_TOKEN"
 	gitProvider    = "github"
 )
 

--- a/pkg/executables/flux_test.go
+++ b/pkg/executables/flux_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	githubToken   = "GITHUB_TOKEN"
+	githubToken   = "EKSA_GITHUB_TOKEN"
 	validPATValue = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	gitProvider   = "github"
 )

--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -30,8 +30,8 @@ const (
 	govcInsecure         = "GOVC_INSECURE"
 	govcTlsHostsFile     = "govc_known_hosts"
 	govcTlsKnownHostsKey = "GOVC_TLS_KNOWN_HOSTS"
-	vSphereUsernameKey   = "VSPHERE_USERNAME"
-	vSpherePasswordKey   = "VSPHERE_PASSWORD"
+	vSphereUsernameKey   = "EKSA_VSPHERE_USERNAME"
+	vSpherePasswordKey   = "EKSA_VSPHERE_PASSWORD"
 	vSphereServerKey     = "VSPHERE_SERVER"
 	byteToGiB            = 1073741824.0
 	deployOptsFile       = "deploy-opts.json"

--- a/pkg/git/providers/github/github.go
+++ b/pkg/git/providers/github/github.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	GitProviderName   = "github"
-	GithubTokenEnv    = "GITHUB_TOKEN"
+	GithubTokenEnv    = "EKSA_GITHUB_TOKEN"
 	githubUrlTemplate = "https://github.com/%v/%v.git"
 	patRegex          = "^[A-Za-z0-9_]{40}$"
 	repoPermissions   = "repo"
@@ -162,16 +162,11 @@ func (g *githubProvider) Validate(ctx context.Context) error {
 
 func validateGithubAccessToken() error {
 	r := regexp.MustCompile(patRegex)
-
-	logger.V(4).Info("Checking validity of Github Access Token")
-
 	logger.V(4).Info("Checking validity of Github Access Token environment variable", "env var", GithubTokenEnv)
 	val, ok := os.LookupEnv(GithubTokenEnv)
 	if !ok {
-		fmt.Printf("Val %v, \nok %v", val, ok)
 		return fmt.Errorf("github access token environment variable %s is invalid; could not get var from environment", GithubTokenEnv)
 	}
-
 	if !r.MatchString(val) {
 		return fmt.Errorf("github access token environment variable %s is invalid; must match format %s", GithubTokenEnv, patRegex)
 	}

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -43,6 +43,8 @@ const (
 	eksaLicense              = "EKSA_LICENSE"
 	vSphereUsernameKey       = "VSPHERE_USERNAME"
 	vSpherePasswordKey       = "VSPHERE_PASSWORD"
+	eksavSphereUsernameKey   = "EKSA_VSPHERE_USERNAME"
+	eksavSpherePasswordKey   = "EKSA_VSPHERE_PASSWORD"
 	vSphereServerKey         = "VSPHERE_SERVER"
 	govcInsecure             = "GOVC_INSECURE"
 	expClusterResourceSetKey = "EXP_CLUSTER_RESOURCE_SET"
@@ -357,11 +359,19 @@ func (p *vsphereProvider) validateControlPlaneIpUniqueness(ip string) error {
 }
 
 func (p *vsphereProvider) validateEnv(ctx context.Context) error {
-	if vSphereUsername, ok := os.LookupEnv(vSphereUsernameKey); !ok || len(vSphereUsername) <= 0 {
-		return fmt.Errorf("%s is not set or is empty", vSphereUsernameKey)
+	if vSphereUsername, ok := os.LookupEnv(eksavSphereUsernameKey); ok && len(vSphereUsername) > 0 {
+		if err := os.Setenv(vSphereUsernameKey, vSphereUsername); err != nil {
+			return fmt.Errorf("unable to set %s: %v", eksavSphereUsernameKey, err)
+		}
+	} else {
+		return fmt.Errorf("%s is not set or is empty", eksavSphereUsernameKey)
 	}
-	if vSpherePassword, ok := os.LookupEnv(vSpherePasswordKey); !ok || len(vSpherePassword) <= 0 {
-		return fmt.Errorf("%s is not set or is empty", vSpherePasswordKey)
+	if vSpherePassword, ok := os.LookupEnv(eksavSpherePasswordKey); ok && len(vSpherePassword) > 0 {
+		if err := os.Setenv(vSpherePasswordKey, vSpherePassword); err != nil {
+			return fmt.Errorf("unable to set %s: %v", eksavSpherePasswordKey, err)
+		}
+	} else {
+		return fmt.Errorf("%s is not set or is empty", eksavSpherePasswordKey)
 	}
 	if len(p.datacenterConfig.Spec.Server) <= 0 {
 		return errors.New("VSphereDatacenterConfig server is not set or is empty")

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -197,26 +197,28 @@ type testContext struct {
 }
 
 func (tctx *testContext) SaveContext() {
-	tctx.oldUsername, tctx.isUsernameSet = os.LookupEnv(vSphereUsernameKey)
-	tctx.oldPassword, tctx.isPasswordSet = os.LookupEnv(vSpherePasswordKey)
+	tctx.oldUsername, tctx.isUsernameSet = os.LookupEnv(eksavSphereUsernameKey)
+	tctx.oldPassword, tctx.isPasswordSet = os.LookupEnv(eksavSpherePasswordKey)
 	tctx.oldServername, tctx.isServernameSet = os.LookupEnv(vSpherePasswordKey)
 	tctx.oldExpClusterResourceSet, tctx.isExpClusterResourceSetSet = os.LookupEnv(vSpherePasswordKey)
-	os.Setenv(vSphereUsernameKey, expectedVSphereUsername)
-	os.Setenv(vSpherePasswordKey, expectedVSpherePassword)
+	os.Setenv(eksavSphereUsernameKey, expectedVSphereUsername)
+	os.Setenv(vSphereUsernameKey, os.Getenv(eksavSphereUsernameKey))
+	os.Setenv(eksavSpherePasswordKey, expectedVSpherePassword)
+	os.Setenv(vSpherePasswordKey, os.Getenv(eksavSpherePasswordKey))
 	os.Setenv(vSphereServerKey, expectedVSphereServer)
 	os.Setenv(expClusterResourceSetKey, expectedExpClusterResourceSet)
 }
 
 func (tctx *testContext) RestoreContext() {
 	if tctx.isUsernameSet {
-		os.Setenv(vSphereUsernameKey, tctx.oldUsername)
+		os.Setenv(eksavSphereUsernameKey, tctx.oldUsername)
 	} else {
-		os.Unsetenv(vSphereUsernameKey)
+		os.Unsetenv(eksavSphereUsernameKey)
 	}
 	if tctx.isPasswordSet {
-		os.Setenv(vSpherePasswordKey, tctx.oldPassword)
+		os.Setenv(eksavSpherePasswordKey, tctx.oldPassword)
 	} else {
-		os.Unsetenv(vSpherePasswordKey)
+		os.Unsetenv(eksavSpherePasswordKey)
 	}
 }
 
@@ -606,11 +608,11 @@ func TestSetupAndValidateCreateClusterNoUsername(t *testing.T) {
 	var tctx testContext
 	tctx.SaveContext()
 	defer tctx.RestoreContext()
-	os.Unsetenv(vSphereUsernameKey)
+	os.Unsetenv(eksavSphereUsernameKey)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 
-	thenErrorExpected(t, "failed setup and validations: VSPHERE_USERNAME is not set or is empty", err)
+	thenErrorExpected(t, "failed setup and validations: EKSA_VSPHERE_USERNAME is not set or is empty", err)
 }
 
 func TestSetupAndValidateCreateClusterNoPassword(t *testing.T) {
@@ -620,11 +622,11 @@ func TestSetupAndValidateCreateClusterNoPassword(t *testing.T) {
 	var tctx testContext
 	tctx.SaveContext()
 	defer tctx.RestoreContext()
-	os.Unsetenv(vSpherePasswordKey)
+	os.Unsetenv(eksavSpherePasswordKey)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 
-	thenErrorExpected(t, "failed setup and validations: VSPHERE_PASSWORD is not set or is empty", err)
+	thenErrorExpected(t, "failed setup and validations: EKSA_VSPHERE_PASSWORD is not set or is empty", err)
 }
 
 func TestSetupAndValidateDeleteCluster(t *testing.T) {
@@ -646,11 +648,11 @@ func TestSetupAndValidateDeleteClusterNoPassword(t *testing.T) {
 	var tctx testContext
 	tctx.SaveContext()
 	defer tctx.RestoreContext()
-	os.Unsetenv(vSpherePasswordKey)
+	os.Unsetenv(eksavSpherePasswordKey)
 
 	err := provider.SetupAndValidateDeleteCluster(ctx)
 
-	thenErrorExpected(t, "failed setup and validations: VSPHERE_PASSWORD is not set or is empty", err)
+	thenErrorExpected(t, "failed setup and validations: EKSA_VSPHERE_PASSWORD is not set or is empty", err)
 }
 
 func TestSetupAndValidateUpgradeCluster(t *testing.T) {
@@ -675,11 +677,11 @@ func TestSetupAndValidateUpgradeClusterNoUsername(t *testing.T) {
 	var tctx testContext
 	tctx.SaveContext()
 	defer tctx.RestoreContext()
-	os.Unsetenv(vSphereUsernameKey)
+	os.Unsetenv(eksavSphereUsernameKey)
 
 	err := provider.SetupAndValidateUpgradeCluster(ctx, clusterSpec)
 
-	thenErrorExpected(t, "failed setup and validations: VSPHERE_USERNAME is not set or is empty", err)
+	thenErrorExpected(t, "failed setup and validations: EKSA_VSPHERE_USERNAME is not set or is empty", err)
 }
 
 func TestSetupAndValidateUpgradeClusterNoPassword(t *testing.T) {
@@ -689,11 +691,11 @@ func TestSetupAndValidateUpgradeClusterNoPassword(t *testing.T) {
 	var tctx testContext
 	tctx.SaveContext()
 	defer tctx.RestoreContext()
-	os.Unsetenv(vSpherePasswordKey)
+	os.Unsetenv(eksavSpherePasswordKey)
 
 	err := provider.SetupAndValidateUpgradeCluster(ctx, clusterSpec)
 
-	thenErrorExpected(t, "failed setup and validations: VSPHERE_PASSWORD is not set or is empty", err)
+	thenErrorExpected(t, "failed setup and validations: EKSA_VSPHERE_PASSWORD is not set or is empty", err)
 }
 
 func TestSetupAndValidateUpgradeClusterIpExists(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changing required environment variables to start with EKSA_.

Previously used env vars like VSPHERE_USERNAME will now be configured as EKSA_VSPHERE_USERNAME.
This only applies to variables that are configured by the user, not the ones that the cli code sets like GOVC_URL and so.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
