### PR TITLE
Pin cgroupDriver to systemd for k8s >= 1.21 for capv

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.38.40
-	github.com/aws/eks-distro-build-tooling/release v0.0.0-20210810165539-7d41d9b36b74
 	github.com/aws/eks-anywhere/release v0.0.0-20210629184439-aded106d7d59
+	github.com/aws/eks-distro-build-tooling/release v0.0.0-20210810165539-7d41d9b36b74
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.4.0

--- a/internal/test/testdata/bundles.yaml
+++ b/internal/test/testdata/bundles.yaml
@@ -389,4 +389,359 @@ spec:
       syncer:
         uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-7c2690c880c6521afdd9ffa8d90443a11c6b817b
       version: v0.7.8
+  - aws:
+      clusterTemplate:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
+      components:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
+      controller:
+        arch:
+          - amd64
+        description: Container image for cluster-api-aws-controller image
+        imageDigest: sha256:78e0c0aba2fb31bec327fd2f941d338ebc2b670457e2ec4257984bd3d22275e5
+        name: cluster-api-aws-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-build.158
+      kubeProxy:
+        arch:
+          - amd64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:7e38d182d7b9a6b8ef428e026a4c83daa4719e066f82b552bed72f482ecfc74c
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.158
+      metadata:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
+      version: v0.6.4
+    bootstrap:
+      components:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api/manifests/bootstrap-kubeadm/v0.3.23/bootstrap-components.yaml
+      controller:
+        arch:
+          - amd64
+        description: Container image for kubeadm-bootstrap-controller image
+        imageDigest: sha256:781b3141be11ecf523c57797905bef3edac76403905248baf87e23262afa7a41
+        name: kubeadm-bootstrap-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v0.3.23-eks-a-v0.0.0-dev-build.158
+      kubeProxy:
+        arch:
+          - amd64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:7e38d182d7b9a6b8ef428e026a4c83daa4719e066f82b552bed72f482ecfc74c
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.158
+      metadata:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api/manifests/bootstrap-kubeadm/v0.3.23/metadata.yaml
+      version: v0.3.23
+    bottlerocketBootstrap:
+      bootstrap:
+        arch:
+          - amd64
+        description: Container image for bottlerocket-bootstrap image
+        imageDigest: sha256:96082fc950fc798e78698eaa8f135749792c72ad9affc5a6c1e8f490695a5ead
+        name: bottlerocket-bootstrap
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap:v1-21-4-eks-a-v0.0.0-dev-build.158
+    certManager:
+      acmesolver:
+        arch:
+          - amd64
+        description: Container image for cert-manager-acmesolver image
+        imageDigest: sha256:711a5ebd903a62707398a5a914daab5226a3416a4def36877dca8a3937c9b2e8
+        name: cert-manager-acmesolver
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-acmesolver:v1.1.0-eks-a-v0.0.0-dev-build.158
+      cainjector:
+        arch:
+          - amd64
+        description: Container image for cert-manager-cainjector image
+        imageDigest: sha256:7213acfc690ccef077c72d84d01c9b85e9e4eaa9065313681ab23ed849b4d0b7
+        name: cert-manager-cainjector
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-cainjector:v1.1.0-eks-a-v0.0.0-dev-build.158
+      controller:
+        arch:
+          - amd64
+        description: Container image for cert-manager-controller image
+        imageDigest: sha256:ff95f4449c25e58405223ae7d1b6a9d8fa7528910277464d938badeec1f8d26d
+        name: cert-manager-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-controller:v1.1.0-eks-a-v0.0.0-dev-build.158
+      webhook:
+        arch:
+          - amd64
+        description: Container image for cert-manager-webhook image
+        imageDigest: sha256:e6fbc2a1f498d5fc5c590e65e4c15ed0cdf6545426c0a9e3476d9f1510e2a11d
+        name: cert-manager-webhook
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-webhook:v1.1.0-eks-a-v0.0.0-dev-build.158
+    cilium:
+      cilium:
+        arch:
+          - amd64
+        description: Container image for cilium image
+        imageDigest: sha256:fe31ed6950c4fcfa5eb2a93dc389e72b1b6563a58dc2665d1085afd0bb5fee8f
+        name: cilium
+        os: linux
+        uri: public.ecr.aws/isovalent/cilium-eksa:v1.9.9-beta2
+      manifest:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cilium/manifests/cilium/v1.9.9-beta2/cilium.yaml
+      operator:
+        arch:
+          - amd64
+        description: Container image for operator-generic image
+        imageDigest: sha256:3726a965cd960295ca3c5e7f2b543c02096c0912c6652eb8bbb9ce54bcaa99d8
+        name: operator-generic
+        os: linux
+        uri: public.ecr.aws/isovalent/operator-generic-eksa:v1.9.9-beta1
+    clusterAPI:
+      components:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api/manifests/cluster-api/v0.3.23/core-components.yaml
+      controller:
+        arch:
+          - amd64
+        description: Container image for cluster-api-controller image
+        imageDigest: sha256:f1952369e76a28e657a6689a7c026ab812c26b056d7eb039d022f74030412728
+        name: cluster-api-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/cluster-api-controller:v0.3.23-eks-a-v0.0.0-dev-build.158
+      kubeProxy:
+        arch:
+          - amd64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:7e38d182d7b9a6b8ef428e026a4c83daa4719e066f82b552bed72f482ecfc74c
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.158
+      metadata:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api/manifests/control-plane-kubeadm/v0.3.23/metadata.yaml
+      version: v0.3.23
+    controlPlane:
+      components:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api/manifests/control-plane-kubeadm/v0.3.23/control-plane-components.yaml
+      controller:
+        arch:
+          - amd64
+        description: Container image for kubeadm-control-plane-controller image
+        imageDigest: sha256:f10d48da533285f5765a9408bcaa760d99b37d402a5f5ce68c583add5f6c67d2
+        name: kubeadm-control-plane-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v0.3.23-eks-a-v0.0.0-dev-build.158
+      kubeProxy:
+        arch:
+          - amd64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:7e38d182d7b9a6b8ef428e026a4c83daa4719e066f82b552bed72f482ecfc74c
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.158
+      metadata:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api/manifests/control-plane-kubeadm/v0.3.23/metadata.yaml
+      version: v0.3.23
+    docker:
+      clusterTemplate:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api/manifests/infrastructure-docker/v0.3.23/cluster-template-development.yaml
+      components:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api/manifests/infrastructure-docker/v0.3.23/infrastructure-components-development.yaml
+      kubeProxy:
+        arch:
+          - amd64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:7e38d182d7b9a6b8ef428e026a4c83daa4719e066f82b552bed72f482ecfc74c
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.158
+      manager:
+        arch:
+          - amd64
+        description: Container image for capd-manager image
+        imageDigest: sha256:6f2db3827be766010b395f01c622433bb3ac6b5e86619a54cc9d04a56dc5248a
+        name: capd-manager
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/capd-manager:v0.3.23-eks-a-v0.0.0-dev-build.158
+      metadata:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api/manifests/infrastructure-docker/v0.3.23/metadata.yaml
+      version: v0.3.23
+    eksD:
+      channel: 1-21
+      gitCommit: f7b4e40dbc04809428e70f6f0a8c6254b74bf049
+      kindNode:
+        arch:
+          - amd64
+        description: Container image for kind-node image
+        imageDigest: sha256:94b12eacfe24db0a38877fc39f6e3d214871e174ad9b1e23f041e8e3070faebd
+        name: kind-node
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind/node:v1.21.2-eks-d-1-21-4-eks-a-v0.0.0-dev-build.158
+      kubeVersion: v1.21.2
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-4.yaml
+      name: kubernetes-1-21-eks-4
+      ova:
+        bottlerocket:
+          arch:
+            - amd64
+          description: Bottlerocket OVA for EKS-D 1-21-4 release
+          name: bottlerocket-v1.21.2-eks-d-1-21-4-eks-a-v0.0.0-dev-build.158-amd64.ova
+          os: linux
+          osName: bottlerocket
+          sha256: a4400640c958dbb883500ad2a0214e515275e47b41af903c4148601c01b3688d
+          sha512: 5542af26e45a653276b3d1bc27eefea37b54a34412692be29fd7fda008d799b25ec9ec31a8df43bdcd4fbe28612b1d845ceb0517a10db736423821c0860d28af
+          uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/eks-distro/ova/1-21/1-21-4/bottlerocket-v1.21.2-eks-d-1-21-4-eks-a-v0.0.0-dev-build.158-amd64.ova
+        ubuntu:
+          arch:
+            - amd64
+          description: Ubuntu OVA for EKS-D 1-21-4 release
+          name: ubuntu-v1.21.2-eks-d-1-21-4-eks-a-v0.0.0-dev-build.158-amd64.ova
+          os: linux
+          osName: ubuntu
+          sha256: 1f9294eb576765ccdbba0bfe72ae091aaa2d1abb44c6ac369d203fbfb9f231a6
+          sha512: 3657be5002ada079d309193e3545e03666672675a699fb08ce152a15fd8fc589a78f1dbfc28b20143d56251be28b82715b8114a34935249a00bb33eb3099e4e3
+          uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/eks-distro/ova/1-21/1-21-4/ubuntu-v1.21.2-eks-d-1-21-4-eks-a-v0.0.0-dev-build.158-amd64.ova
+    eksa:
+      cliTools:
+        arch:
+          - amd64
+        description: Container image for eks-anywhere-cli-tools image
+        imageDigest: sha256:7cdd7fc26f3c4afd998df06c3da504229c5ea9df45f759537064a3ac714e97a6
+        name: eks-anywhere-cli-tools
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:eks-a-v0.0.0-dev-build.158
+      components:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/eks-anywhere/manifests/cluster-controller/e8aa98e09a30d56e3e1de7c81e4ae1e436333aeb/eksa-components.yaml
+    etcdadmBootstrap:
+      components:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v0.1.0-beta-3.3/bootstrap-components.yaml
+      controller:
+        arch:
+          - amd64
+        description: Container image for etcdadm-bootstrap-provider image
+        imageDigest: sha256:302c04641b659668a990d4bb8a12d25a0bf464632ed108ef714ee2bbefa4e908
+        name: etcdadm-bootstrap-provider
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/mrajashree/etcdadm-bootstrap-provider:v0.1.0-beta-3.3-eks-a-v0.0.0-dev-build.158
+      kubeProxy:
+        arch:
+          - amd64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:7e38d182d7b9a6b8ef428e026a4c83daa4719e066f82b552bed72f482ecfc74c
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.158
+      metadata:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v0.1.0-beta-3.3/metadata.yaml
+      version: v0.1.0-beta-3.3
+    etcdadmController:
+      components:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v0.1.0-beta-3.5/bootstrap-components.yaml
+      controller:
+        arch:
+          - amd64
+        description: Container image for etcdadm-controller image
+        imageDigest: sha256:8b8b7dff53076c8d70ae5295dee7af22f659f959940dd053fab73216c1eb4be4
+        name: etcdadm-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/mrajashree/etcdadm-controller:v0.1.0-beta-3.5-eks-a-v0.0.0-dev-build.158
+      kubeProxy:
+        arch:
+          - amd64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:7e38d182d7b9a6b8ef428e026a4c83daa4719e066f82b552bed72f482ecfc74c
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.158
+      metadata:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v0.1.0-beta-3.5/metadata.yaml
+      version: v0.1.0-beta-3.5
+    flux:
+      helmController:
+        arch:
+          - amd64
+        description: Container image for helm-controller image
+        imageDigest: sha256:72df37775123993b255dd7af5580f6f510df61bda6773698cba7f2369e00713b
+        name: helm-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/fluxcd/helm-controller:v0.10.0-eks-a-v0.0.0-dev-build.158
+      kustomizeController:
+        arch:
+          - amd64
+        description: Container image for kustomize-controller image
+        imageDigest: sha256:9f5670c6d9292b78cc275a86d485e7e5e93234a10326bb121bdc4b961ad83fb7
+        name: kustomize-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/fluxcd/kustomize-controller:v0.11.1-eks-a-v0.0.0-dev-build.158
+      notificationController:
+        arch:
+          - amd64
+        description: Container image for notification-controller image
+        imageDigest: sha256:8eef63281ea5f144b14da5ee4372ccf1abb51521bcf46274721c0456e31747b2
+        name: notification-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/fluxcd/notification-controller:v0.13.0-eks-a-v0.0.0-dev-build.158
+      sourceController:
+        arch:
+          - amd64
+        description: Container image for source-controller image
+        imageDigest: sha256:056564ce2682831c799dc1fb788b6d53aa1fc3011c78b96a5443ec43b47a9cab
+        name: source-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/fluxcd/source-controller:v0.12.1-eks-a-v0.0.0-dev-build.158
+    kubeVersion: "1.21"
+    vSphere:
+      clusterAPIController:
+        arch:
+          - amd64
+        description: Container image for cluster-api-vsphere-controller image
+        imageDigest: sha256:b7390a5be95e823bb3f5e38a9120786d8c657e7b7530105bee9dec3df86892ce
+        name: cluster-api-vsphere-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v0.7.10-eks-a-v0.0.0-dev-build.158
+      clusterTemplate:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v0.7.10/cluster-template.yaml
+      components:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v0.7.10/infrastructure-components.yaml
+      driver:
+        arch:
+          - amd64
+        description: Container image for vsphere-csi-driver image
+        imageDigest: sha256:5455fb516bc854fb17c287b23b644ca9b1a7e6efe331208f0c0bd92854f6c301
+        name: vsphere-csi-driver
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.158
+      kubeProxy:
+        arch:
+          - amd64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:7e38d182d7b9a6b8ef428e026a4c83daa4719e066f82b552bed72f482ecfc74c
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.158
+      kubeVip:
+        arch:
+          - amd64
+        description: Container image for kube-vip image
+        imageDigest: sha256:204c63f246bd6eccc330be2875805cae0a1f6867ecac16c07732103429d312b7
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+      manager:
+        arch:
+          - amd64
+        description: Container image for cloud-provider-vsphere image
+        imageDigest: sha256:d883d89d1fce34f5a8971943f8526a1451a9deeec1771882d01284bcff1766c1
+        name: cloud-provider-vsphere
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.21.0-eks-d-1-21-eks-a-v0.0.0-dev-build.158
+      metadata:
+        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.158/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v0.7.10/metadata.yaml
+      syncer:
+        arch:
+          - amd64
+        description: Container image for vsphere-csi-syncer image
+        imageDigest: sha256:08cc37d5e661a786ad7ac580831f11c2633e50bf1d05cbea464e504178feedf0
+        name: vsphere-csi-syncer
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.158
+      version: v0.7.10
 status: {}

--- a/internal/test/testdata/kubernetes-1-21-eks-4.yaml
+++ b/internal/test/testdata/kubernetes-1-21-eks-4.yaml
@@ -1,0 +1,649 @@
+apiVersion: distro.eks.amazonaws.com/v1alpha1
+kind: Release
+metadata:
+  creationTimestamp: null
+  name: kubernetes-1-21-eks-4
+spec:
+  channel: 1-21
+  number: 4
+status:
+  components:
+    - assets:
+        - arch:
+            - amd64
+            - arm64
+          description: livenessprobe container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-21-4
+          name: livenessprobe-image
+          os: linux
+          type: Image
+      gitTag: v2.2.0
+      name: livenessprobe
+    - assets:
+        - arch:
+            - amd64
+            - arm64
+          description: node-driver-registrar container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-21-4
+          name: node-driver-registrar-image
+          os: linux
+          type: Image
+      gitTag: v2.1.0
+      name: node-driver-registrar
+    - assets:
+        - arch:
+            - amd64
+            - arm64
+          description: metrics-server container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes-sigs/metrics-server:v0.5.0-eks-1-21-4
+          name: metrics-server-image
+          os: linux
+          type: Image
+      gitTag: v0.5.0
+      name: metrics-server
+    - assets:
+        - arch:
+            - arm64
+          archive:
+            sha256: 01b694df8ac776cf5424c4ea98a2558a692cc47304c8f3f6b6f1112fc878350e
+            sha512: 0c6a9d63dca470530b39922aaaecdcd5a8e33a1f3ac9a38772ef92e0849837344583838540929c30f170d51e15f0cd120eb7d554cdedac3c3910a8fe4063fa29
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/plugins/v0.8.7/cni-plugins-linux-arm64-v0.8.7.tar.gz
+          description: cni-plugins tarball for linux/arm64
+          name: cni-plugins-linux-arm64-v0.8.7.tar.gz
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 5319a01aacc622c3870eb76f6d9c77cd988179dfb56e8d2dc438c339c77a156c
+            sha512: ec9823fcff5964ec50cb47f1b188e3c870cc5008bd216684e3e7d4c9eac1b5702ed132343edeaee5be9e743909cc5f151f620ebf7499e784c9585f2178b24dee
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/plugins/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tar.gz
+          description: cni-plugins tarball for linux/amd64
+          name: cni-plugins-linux-amd64-v0.8.7.tar.gz
+          os: linux
+          type: Archive
+      gitTag: v0.8.7
+      name: cni-plugins
+    - assets:
+        - arch:
+            - amd64
+            - arm64
+          description: coredns container image
+          image:
+            uri: public.ecr.aws/eks-distro/coredns/coredns:v1.8.3-eks-1-21-4
+          name: coredns-image
+          os: linux
+          type: Image
+      gitTag: v1.8.3
+      name: coredns
+    - assets:
+        - arch:
+            - arm64
+          archive:
+            sha256: 966903341836d9fd7bb102402f1bc435138e9fd53f20572004665d4b30b776b8
+            sha512: 39d9768f44ef82edf3778d397b58efc71ce6df8a601a50f7bef063021345e0e9c7c56f881e92afd729d4b881c14d0012f8e3d057a5c8a93456b379cb5e3ce77e
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/kubernetes-client-linux-arm64.tar.gz
+          description: Kubernetes client tarball for linux/arm64
+          name: kubernetes-client-linux-arm64.tar.gz
+          os: linux
+          type: Archive
+        - arch:
+            - arm64
+          archive:
+            sha256: 3c78780affefb3802aa45672554c1d8d1e90696b6a0ae8c17a32612ceefb1630
+            sha512: 6018e0dccd5aa60ca2bb9442e842cbb69577e82b94ffcb78580c2bf3986ea473e5753ca8fdb5ebed2e20043b3318003e38930ffc460d9c4f390e9f73126ea5de
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/kubernetes-server-linux-arm64.tar.gz
+          description: Kubernetes server tarball for linux/arm64
+          name: kubernetes-server-linux-arm64.tar.gz
+          os: linux
+          type: Archive
+        - arch:
+            - arm64
+          archive:
+            sha256: af8603efb3a70266c8674fd52935b2b5adfd2cd83ecc6383a90d0e766da980ea
+            sha512: e429525f0d9d7de3949ae2964a3e6255ba9b69e9a44b8a9215cc224d7b8e0730003c803ac2cc0303c5dcc71349dffc6f0b99e5db48ce1ea3f2429281bf7acd3a
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/kubernetes-node-linux-arm64.tar.gz
+          description: Kubernetes node tarball for linux/arm64
+          name: kubernetes-node-linux-arm64.tar.gz
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 61a61c22b9197ac7c34b9bf54195a6f9d263d5cf4995f69fa284c06f26e22934
+            sha512: 4a2cdacb22c8a581db2e83d7939e16e89a5931ffd92ce9f514ec20ed9a3e955573bfc9493ca5bc8050ae35dbf980db86ff6e20edb25e5234146cbffca14f8a93
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/kubernetes-client-linux-amd64.tar.gz
+          description: Kubernetes client tarball for linux/amd64
+          name: kubernetes-client-linux-amd64.tar.gz
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: c0374bba401b973b7f224ac2777d8d30281acf79f865c73da4c36b6f5f6de9c5
+            sha512: 956a47dae2dc0c841686d2bdb0545717dbd74c4490bd7112cc65e5caacfa4fbd6172ba8b8f760bc2785bbcd06e579c1ef21efa5ef04b6f8dec220a8a5a809ce5
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/kubernetes-server-linux-amd64.tar.gz
+          description: Kubernetes server tarball for linux/amd64
+          name: kubernetes-server-linux-amd64.tar.gz
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: f906bdcc982627fe7c9645a505f8e79383b34edd20149f5488cecffcf8a18008
+            sha512: b0e6b307fb9104eb3bd7f932e76d34de06ff6a735fe90868abf24d63cc5edbdeb6f249e633dee3baff84e0f8e5b8d646c19878004bb769b4c6d71863103e73dd
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/kubernetes-node-linux-amd64.tar.gz
+          description: Kubernetes node tarball for linux/amd64
+          name: kubernetes-node-linux-amd64.tar.gz
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: d2c49607c79b3daa8b36a359d87b69257fd0f82da5ad22bd38627a40076fac92
+            sha512: 7d17ab07e4eb606c9f22c5de7a4382df69778c87ef5dd26c28a5f4ea3fa4a72e90df34537d8302f80f875002a14f80ccec3431b0e395c9bc355cc7956947e8c0
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/kubernetes-client-windows-amd64.tar.gz
+          description: Kubernetes client tarball for windows/amd64
+          name: kubernetes-client-windows-amd64.tar.gz
+          os: windows
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: e4da84235f3cdc3ffeaa1d24d924e1971126733bf429dbd7710e9fd00c65de7d
+            sha512: 5ba45e832f1820f126eb2df3d8cdddfecfbaab2b438e2bf6a9b61463ff4b828b8419d25e90b68d5d83aad1ab61e1478bf0e2d25bdbd4d95aef9c0dbc3922e2c3
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/kubernetes-node-windows-amd64.tar.gz
+          description: Kubernetes node tarball for windows/amd64
+          name: kubernetes-node-windows-amd64.tar.gz
+          os: windows
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 5c4c31b9cb1348eaf802a7a885546fec85a0d849d3d7896ef979584210e22182
+            sha512: 50c624b906715245a58f91095743f0d1ce5c9e799a3ce58f4a49a524ca2075d4dc5bf311fba9e813a3893cb939701237c9566b5b7e7861b35a7399e75cac6e4e
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/kubernetes-client-darwin-amd64.tar.gz
+          description: Kubernetes client tarball for darwin/amd64
+          name: kubernetes-client-darwin-amd64.tar.gz
+          os: darwin
+          type: Archive
+        - arch:
+            - amd64
+            - arm64
+          description: kube-apiserver container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.21.2-eks-1-21-4
+          name: kube-apiserver-image
+          os: linux
+          type: Image
+        - arch:
+            - amd64
+            - arm64
+          description: kube-controller-manager container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.21.2-eks-1-21-4
+          name: kube-controller-manager-image
+          os: linux
+          type: Image
+        - arch:
+            - amd64
+            - arm64
+          description: kube-scheduler container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes/kube-scheduler:v1.21.2-eks-1-21-4
+          name: kube-scheduler-image
+          os: linux
+          type: Image
+        - arch:
+            - amd64
+            - arm64
+          description: kube-proxy container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.21.2-eks-1-21-4
+          name: kube-proxy-image
+          os: linux
+          type: Image
+        - arch:
+            - amd64
+            - arm64
+          description: pause container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes/pause:v1.21.2-eks-1-21-4
+          name: pause-image
+          os: linux
+          type: Image
+        - arch:
+            - arm64
+          archive:
+            sha256: e6f984e59aacc011e960f113a954828c5cdeb5cd466574632b6534d50068c78d
+            sha512: 4796b18a2f649f0618698e29828349b73aa3e6f02cae47146cfb8fb83764ce2abe17c7df3192228e0cb517ee18af1e9a69793e41f8e4a6212fbadc2a0742b925
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/arm64/kube-apiserver
+          description: kube-apiserver binary for linux/arm64
+          name: bin/linux/arm64/kube-apiserver
+          os: linux
+          type: Archive
+        - arch:
+            - arm64
+          archive:
+            sha256: 4eb3343efaf153ca5b4d87b55e3f3c42888b768d29d4957212d7f48b1846c774
+            sha512: ed2e229270e9628c6eb539491557b944cf0f7c19155db61bd93513393d8951153e7d16bd80450a4b1a986c900372a20a896c92c19cbde66c8603861bd7f75238
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/arm64/kube-controller-manager
+          description: kube-controller-manager binary for linux/arm64
+          name: bin/linux/arm64/kube-controller-manager
+          os: linux
+          type: Archive
+        - arch:
+            - arm64
+          archive:
+            sha256: 0e291b4794d8f9efe4ca2a6a27da2796517893a1a09d9d72ae9c25b92c046f94
+            sha512: f03db8447fd5263df188016d3ed4f01a52038eb8b2483ce79cb26e16bd625236d31180bd5b0f48fe67410bc521983abdb9ba55dc643d3cfb6d074d3cd4d91618
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/arm64/kube-proxy
+          description: kube-proxy binary for linux/arm64
+          name: bin/linux/arm64/kube-proxy
+          os: linux
+          type: Archive
+        - arch:
+            - arm64
+          archive:
+            sha256: 0b69258abbf4028a6a167b09737ff084d3a55c21de3ec8bdd18211ddcd50b444
+            sha512: d757fca9a5a38d916439e9f3134a1486b35af15c27067ffce2012ea5db3e3055131cee71485177be4efbd25aab2f65ef243a7ac85e1e0a600a94d1b439d300cb
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/arm64/kube-scheduler
+          description: kube-scheduler binary for linux/arm64
+          name: bin/linux/arm64/kube-scheduler
+          os: linux
+          type: Archive
+        - arch:
+            - arm64
+          archive:
+            sha256: afef1e678181cea1c243b6ceac5216a4c5b18e409b85bbeef18b2bf784690971
+            sha512: 6d339d26f98092b2764aa40d2c4bed92eaa58fa0e13861263993708a82df9aa475b2d108228b961e170271282260474a12b87da47587b848d168c86621620fa1
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/arm64/kubectl
+          description: kubectl binary for linux/arm64
+          name: bin/linux/arm64/kubectl
+          os: linux
+          type: Archive
+        - arch:
+            - arm64
+          archive:
+            sha256: 946173e0d960d04e935b1e3b6fa2ef1b7a9987e9354e92866faf1e02461385a0
+            sha512: 2dcd81c045d206005a7288fdff98289bfbc166c2d70223720fe5a6d7d3724e578b05910859e942180d64ba66d07fbab24775324bf13f128701e61313850c5d9f
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/arm64/kubelet
+          description: kubelet binary for linux/arm64
+          name: bin/linux/arm64/kubelet
+          os: linux
+          type: Archive
+        - arch:
+            - arm64
+          archive:
+            sha256: 9d252f1a256f27102cbf72ccc3f98558e28d6a5abd44180319d0baf8b0904ff5
+            sha512: de2638eeed5c622155a567a59e0f2e79937e3e767d95352cff76972b64a32f8d2301a5619ec93f6c337ba4291879bd5088944df73eef8d5cfccf48ebecac5c44
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/arm64/kubeadm
+          description: kubeadm binary for linux/arm64
+          name: bin/linux/arm64/kubeadm
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: d92494a0e211fe37eb6b9f0bfb1b5003d1136e8e4254dead1858e4068f2925fe
+            sha512: 6fcd583d2fb74fc2bf99dffb29f897f2490d5d331ff71beaedd16ace0f949f268885b77d8943f21cebd7bc00da6971e72fa2efce1026f4b47e62e30e9f612ee4
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/amd64/kube-apiserver
+          description: kube-apiserver binary for linux/amd64
+          name: bin/linux/amd64/kube-apiserver
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: ac9ac45822fce5c9c85b327fcc2f884b400f383c82b9fe5d6b757274a25d2ebb
+            sha512: fbf05bcebf50ad9d90669cf9de53bc511b439f35eeba51016c95c63d23e4e767a2b728160d599f8ab9c30244034ff9b9e9c9f744dc0ac9414c297ea28f50b076
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/amd64/kube-controller-manager
+          description: kube-controller-manager binary for linux/amd64
+          name: bin/linux/amd64/kube-controller-manager
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: b4ee924d9be73713a7a112805f89a17a09859cb2c91be5902a0ca14865703946
+            sha512: f56bfdcbf40d9db1a0fac9175a69a6ea3cc841f6febe1fed33a5d70586a55906d7c5c0b111c4a68dd79324a28dfe40b0182cb278db7a0a116be48dc0f89d54ce
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/amd64/kube-proxy
+          description: kube-proxy binary for linux/amd64
+          name: bin/linux/amd64/kube-proxy
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 6fb48dc6f3987c3e82cb0fb2240c0802972467fc0c873d5c30c68c2c9e463043
+            sha512: 69528755f3ae7b6999b96f32eef211b55decd35b252fddfaf50c9636a821772fedbcd8a11b3aa27589021fe423cf98ef6759a10b9c66ed8cd9d46dfb647c3f08
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/amd64/kube-scheduler
+          description: kube-scheduler binary for linux/amd64
+          name: bin/linux/amd64/kube-scheduler
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 72823ffea2321d389ae3e26d5a2cc97e311695e0a72329b299ffbdc6745edf42
+            sha512: 2278d1dcb2e0204d4cf1cf5933d820a69f47a20b07780287a4287e7973534eeaf042a27b8d444b188d938a2ccbd7360b572152056b01c926db8ee343671c0285
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/amd64/kubectl
+          description: kubectl binary for linux/amd64
+          name: bin/linux/amd64/kubectl
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 6bc6a526555f92b740cf11e490a1011680bdc037b2827faa2936066a12326388
+            sha512: 2ec83efd1f9c566495b1f9e11f5076a632c2eed80ce09df2da7a9cc70129ebc5340e267b5212501535d05371842ee30df0141e385397a4d6a4b433639a993984
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/amd64/kubelet
+          description: kubelet binary for linux/amd64
+          name: bin/linux/amd64/kubelet
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: b52f00aeaa04627a7f049b4378e47a6ae7275de819f5f9d724eafdaed4698345
+            sha512: c21cf84451651692fc54258a3b0722b2a3e14443bf7c48b9e1a25986faa152882047ab4060bf8ec9101d0a734a58ae1595af0f76e57d0bee44d3b3df5d392f9a
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/amd64/kubeadm
+          description: kubeadm binary for linux/amd64
+          name: bin/linux/amd64/kubeadm
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 3858a83bb84ce815b2de3891b3c5656b072a6abd023b4c58cae544e92203a35a
+            sha512: 6e7646f1a8eb734af704ee3846a1ec46671200bf501174adc5b740e0b7169c512ea33c945b7697beff429806b1ef10b86e7ff0d3f064caf9f7ca3de44c44c205
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/windows/amd64/kube-proxy.exe
+          description: kube-proxy.exe binary for windows/amd64
+          name: bin/windows/amd64/kube-proxy.exe
+          os: windows
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 9a2f3f55bc6aeeb82bde6969a611ee6c443355b97458a8829ea963fbce267f98
+            sha512: 16222b21b4358e915637a7cf29ed932ce3f06c099f068e96503352c4637d515ef7aaf1df384922e80c60bbcb1300a2cef99ccaacd5dd324f7dff73b690ec7fb1
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/windows/amd64/kubeadm.exe
+          description: kubeadm.exe binary for windows/amd64
+          name: bin/windows/amd64/kubeadm.exe
+          os: windows
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 44442bd5ee742d6239b6a2a8703f136623b60cc3b46ada67c7ccd8d722e6ff79
+            sha512: b0cc2850f5495e0875bcd53a42af04f31386c576f21976b391d9a90d1225c01cbf8ce9f1dfadb21fc0735983856c2b632947b3b7af0cf7f7d5622b19d2ab76ce
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/windows/amd64/kubectl.exe
+          description: kubectl.exe binary for windows/amd64
+          name: bin/windows/amd64/kubectl.exe
+          os: windows
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 52993cdaa91f806323eefd2e2d0f3a0f52501f9abc4d4d02dcec1513b53c04a7
+            sha512: 342c88a808eabd935e1e576b06332234d8b4ac64e09c785b23281c7ba873a690a07bf60774c76d97fbe5ed5f5bb370cce1785c8ae6645f13fe75ebce05c3532a
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/windows/amd64/kubelet.exe
+          description: kubelet.exe binary for windows/amd64
+          name: bin/windows/amd64/kubelet.exe
+          os: windows
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: b78911eb453a100bc4ef32d6a0fc3ff27fb80ce562bc741f8d460d27ffeb97fc
+            sha512: 3fb1259d29f4ced143ccc961491d034793082c9d447f002a42cdc7dd3ae0f2123241105f1d1a64ac72555e9f317ac7fbaaca157b4c01790a63d91adc76eca91d
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/darwin/amd64/kubectl
+          description: kubectl binary for darwin/amd64
+          name: bin/darwin/amd64/kubectl
+          os: darwin
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: d77822777885536fc410d0eb1bdbe19b85d15745f6e474dd5dc6253a4d57d760
+            sha512: eab15dc57578f947a199c1d43aa453c2a625d1d4b34843347dab6d55ac60648a856c7a0d795035b9d703675cabedac7835f870eb9823388aadc3cfe9c4112186
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/amd64/kube-apiserver.tar
+          description: kube-apiserver linux/amd64 OCI image tar
+          name: bin/linux/amd64/kube-apiserver.tar
+          os: linux
+          type: Archive
+        - arch:
+            - arm64
+          archive:
+            sha256: 0d45910c70997d58e640cb4c5a96d8f0adeaf1f6b145a46df9083cfe842517f6
+            sha512: 89c0b3a51f4f02b69879ed99fe0cd73efcc93dd9a5691cabd8e3722e300b01d45a0e5779a96c84b9887d129b5440f3db8806af1687c5c727ec11e22e9d5218e0
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/arm64/kube-apiserver.tar
+          description: kube-apiserver linux/arm64 OCI image tar
+          name: bin/linux/arm64/kube-apiserver.tar
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 9ade10b01d3ec253f9b21810f87c5aed368fac142e4d905ddfceec3db55ed693
+            sha512: 88d10e89b363fc0f138bada2579296bf803958a7511afa40a299110d5edfb079cac75a2ec50912e953bf831086788bba299e815fb1533ace7adf6e0a2ea3a406
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/amd64/kube-controller-manager.tar
+          description: kube-controller-manager linux/amd64 OCI image tar
+          name: bin/linux/amd64/kube-controller-manager.tar
+          os: linux
+          type: Archive
+        - arch:
+            - arm64
+          archive:
+            sha256: 55a2b28c0de67acabf7b42a72b3c48fb56fbc4ebc7c1e38d0991541168de33a0
+            sha512: b87d8ca76f84613ec6a49ea551064bdc3015ad3c2aa4ee1d4b609dbd20f7154af00939cf40583b45958dbf2f3364adb461d8275e7f8637418e7198515f850a70
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/arm64/kube-controller-manager.tar
+          description: kube-controller-manager linux/arm64 OCI image tar
+          name: bin/linux/arm64/kube-controller-manager.tar
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: e731a5b4f59dff6982bc9146a11b3b98382c3cceb35c7aa06728fa1e4a031aac
+            sha512: fb4a3a73c35d874910d60e8fc1ea47163eff71d68b2aaf36115346e069defb9ce1095f771c605e1aee99910fb71f95c20ac9a17eb4bcbcdcbb5f780d3bba0f8b
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/amd64/kube-scheduler.tar
+          description: kube-scheduler linux/amd64 OCI image tar
+          name: bin/linux/amd64/kube-scheduler.tar
+          os: linux
+          type: Archive
+        - arch:
+            - arm64
+          archive:
+            sha256: 21a4db4b90022e033e5494a9ef40a006ed9868bcdc56bee72c500092b42f983d
+            sha512: 6ca272eeddc80515438ca5c3045829b3a2d7a84a310d6d73eae4da96294710fa2f24d2745a6162dadaff3dfff06aa36105b2abdbbed6ea3570092070c62bf369
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/arm64/kube-scheduler.tar
+          description: kube-scheduler linux/arm64 OCI image tar
+          name: bin/linux/arm64/kube-scheduler.tar
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 5b00770666cce8c51a53f9b00dd4269bf07a052ddd4d43e7ccf4733116b2d429
+            sha512: ceb27539221f65984e57e9c4f325309faca87b25991c1ed1c4164f0964146825c2d5a41fcdb4f5b8e19bda325a217e0de9154f601f2abc1b55d0eb0fa2b367db
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/amd64/kube-proxy.tar
+          description: kube-proxy linux/amd64 OCI image tar
+          name: bin/linux/amd64/kube-proxy.tar
+          os: linux
+          type: Archive
+        - arch:
+            - arm64
+          archive:
+            sha256: 5cbfaac112f2d717cc3fef2395adc12f8e292dbc45663025ca05ee79020a02e3
+            sha512: c0200c7d64270a84cec304059dcca61b19ab518de79e842b4785b19ebe8aec54f83dc0256b51f13b49d013419ebc0f8f092c1f66c06d76a3b03d65e00fb826e1
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/bin/linux/arm64/kube-proxy.tar
+          description: kube-proxy linux/arm64 OCI image tar
+          name: bin/linux/arm64/kube-proxy.tar
+          os: linux
+          type: Archive
+        - archive:
+            sha256: 4edc9f9718c91b8aa0edc00154c54b19728644328286ca2801173e2e67cea83d
+            sha512: 81a91081900b0113f20c0b76eafa0a40bae0b776a20450de665844cace41f2375d28e48ffdc6ef1ddd2714dcc946bc6659544761d971aff30f9029738f986e7f
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/kubernetes/v1.21.2/kubernetes-src.tar.gz
+          description: Kubernetes source tarball
+          name: kubernetes-src.tar.gz
+          type: Archive
+      gitCommit: 092fbfbf53427de67cac1e9fa54aaa09a28371d7
+      gitTag: v1.21.2
+      name: kubernetes
+    - assets:
+        - arch:
+            - amd64
+            - arm64
+          description: external-attacher container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v3.1.0-eks-1-21-4
+          name: external-attacher-image
+          os: linux
+          type: Image
+      gitTag: v3.1.0
+      name: external-attacher
+    - assets:
+        - arch:
+            - amd64
+            - arm64
+          description: external-provisioner container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-21-4
+          name: external-provisioner-image
+          os: linux
+          type: Image
+      gitTag: v2.1.1
+      name: external-provisioner
+    - assets:
+        - arch:
+            - amd64
+            - arm64
+          description: external-resizer container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.1.0-eks-1-21-4
+          name: external-resizer-image
+          os: linux
+          type: Image
+      gitTag: v1.1.0
+      name: external-resizer
+    - assets:
+        - arch:
+            - amd64
+            - arm64
+          description: csi-snapshotter container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter:v3.0.3-eks-1-21-4
+          name: csi-snapshotter-image
+          os: linux
+          type: Image
+        - arch:
+            - amd64
+            - arm64
+          description: snapshot-controller container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/snapshot-controller:v3.0.3-eks-1-21-4
+          name: snapshot-controller-image
+          os: linux
+          type: Image
+        - arch:
+            - amd64
+            - arm64
+          description: snapshot-validation-webhook container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/snapshot-validation-webhook:v3.0.3-eks-1-21-4
+          name: snapshot-validation-webhook-image
+          os: linux
+          type: Image
+      gitTag: v3.0.3
+      name: external-snapshotter
+    - assets:
+        - arch:
+            - arm64
+          archive:
+            sha256: a4041862485ca6a257754d317c6c4e415556f8e113d27418f8997ebc4add81f4
+            sha512: 4516b03122ae8d2907fc7e4e1aafa0048be1cfa6355835bb142268cca2e3136e97b89bd21d4ae041b64715ca236e0507c5098ea13119b933329629996e77a49e
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-arm64-v3.4.16.tar.gz
+          description: etcd tarball for linux/arm64
+          name: etcd-linux-arm64-v3.4.16.tar.gz
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 80f9fc0227c5d62ee4371ce986ebab342ae8e0b156f2cd7240ecea475120a01e
+            sha512: fe253b56efb85e74a211dc242a50e9d3d959c83501bc60983509f9e43b99fb936dd3373b7835b08231e620237dcbb4f753ea2439169854bed84965d83faa0a90
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
+          description: etcd tarball for linux/amd64
+          name: etcd-linux-amd64-v3.4.16.tar.gz
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+            - arm64
+          description: etcd container image
+          image:
+            uri: public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.16-eks-1-21-4
+          name: etcd-image
+          os: linux
+          type: Image
+      gitTag: v3.4.16
+      name: etcd
+    - assets:
+        - arch:
+            - amd64
+          archive:
+            sha256: 9ccecc672c2153fbc0eb7380262befbf7d0d3aa7dda84579cacd2ae4609b81d1
+            sha512: 1514123d5cff65c48f1d244469a59bf92c823d7952be02dc7f317bbeb44c7d4608bb3e91d9a8672c34866246f6bf47c9253474a7b873435aa668736f2ee2d9bc
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/aws-iam-authenticator/v0.5.2/aws-iam-authenticator-windows-amd64-v0.5.2.tar.gz
+          description: aws-iam-authenticator tarball for windows/amd64
+          name: aws-iam-authenticator-windows-amd64-v0.5.2.tar.gz
+          os: windows
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 3bfd1c2012d154cdf34055c792b99b67b35d60e888701ef9c5415e7edff01893
+            sha512: b3b25c10054dddd1f49feb11282e4b6a54c3071a2608c5cf32d6a1fdee4e590cb8c7f53d3f4507bd107712f274e5c33300a5ac7ecb2afb7333f8c20ff8e3082b
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/aws-iam-authenticator/v0.5.2/aws-iam-authenticator-darwin-amd64-v0.5.2.tar.gz
+          description: aws-iam-authenticator tarball for darwin/amd64
+          name: aws-iam-authenticator-darwin-amd64-v0.5.2.tar.gz
+          os: darwin
+          type: Archive
+        - arch:
+            - arm64
+          archive:
+            sha256: 3084dc06b3c0a7f4295a712a3a80ab6014e666c92c57459145ec91f624951537
+            sha512: 7533a1f4ee7612bf1c3e38c319b57fb88136bacb0bce41a455d4c169c0a9c5e7b4182ed20664378569c15b83b21a093826da522542f31cb0cb56901de5e9e5f3
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/aws-iam-authenticator/v0.5.2/aws-iam-authenticator-linux-arm64-v0.5.2.tar.gz
+          description: aws-iam-authenticator tarball for linux/arm64
+          name: aws-iam-authenticator-linux-arm64-v0.5.2.tar.gz
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+          archive:
+            sha256: 5433763474f9caf324b9db659289e6292d688f60f383a2ae67052ee84dcf5e20
+            sha512: f90f153ac1ec491c2c4450f7617adc65e665492ae453b7783710171f07930bdca0d3ac4c1abe1cdd6b1abcfe5c36ddaf86bf53987ff464c9c3cc227bf3e6f292
+            uri: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/aws-iam-authenticator/v0.5.2/aws-iam-authenticator-linux-amd64-v0.5.2.tar.gz
+          description: aws-iam-authenticator tarball for linux/amd64
+          name: aws-iam-authenticator-linux-amd64-v0.5.2.tar.gz
+          os: linux
+          type: Archive
+        - arch:
+            - amd64
+            - arm64
+          description: aws-iam-authenticator container image
+          image:
+            uri: public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.5.2-eks-1-21-4
+          name: aws-iam-authenticator-image
+          os: linux
+          type: Image
+      gitTag: v0.5.2
+      name: aws-iam-authenticator
+  date: "2021-08-19T20:14:48Z"
+

--- a/pkg/providers/vsphere/testdata/cluster_main_121.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_main_121.yaml
@@ -1,0 +1,102 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: test
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: 1.2.3.4
+    machineGroupRef:
+      name: test-cp
+      kind: VSphereMachineConfig
+  kubernetesVersion: "1.21"
+  workerNodeGroupConfigurations:
+    - count: 3
+      machineGroupRef:
+        name: test-wn
+        kind: VSphereMachineConfig
+  externalEtcdConfiguration:
+    count: 3
+    machineGroupRef:
+      name: test-etcd
+      kind: VSphereMachineConfig
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-cp
+spec:
+  diskGiB: 25
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: ubuntu
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.21.2"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-wn
+spec:
+  diskGiB: 25
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 4096
+  numCPUs: 3
+  osFamily: ubuntu
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.21.2"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-etcd
+spec:
+  diskGiB: 25
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 4096
+  numCPUs: 3
+  osFamily: ubuntu
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.21.2"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: test
+spec:
+  datacenter: "SDDC-Datacenter"
+  network: "/SDDC-Datacenter/network/sddc-cgw-network-1"
+  server: "vsphere_server"
+  thumbprint: "ABCDEFG"
+  insecure: false

--- a/pkg/providers/vsphere/testdata/expected_results_121.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_121.yaml
@@ -2,177 +2,137 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: {{.clusterName}}
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+    cluster.x-k8s.io/cluster-name: test
+  name: test
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks: {{.podCidrs}}
+      cidrBlocks: [192.168.0.0/16]
     services:
-      cidrBlocks: {{.serviceCidrs}}
+      cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
-    name: {{.clusterName}}
+    name: test
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
-    name: {{.clusterName}}
-{{- if .externalEtcd }}
+    name: test
   managedExternalEtcdRef:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
-    name: {{.clusterName}}-etcd
-{{- end }}
+    name: test-etcd
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test
+  namespace: eksa-system
 spec:
   cloudProviderConfiguration:
     global:
       secretName: cloud-provider-vsphere-credentials
       secretNamespace: kube-system
-      thumbprint: '{{.thumbprint}}'
-      insecure: {{.insecure}}
+      thumbprint: 'ABCDEFG'
+      insecure: false
     network:
-      name: {{.vsphereNetwork}}
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
     providerConfig:
       cloud:
-        controllerImage: {{.managerImage}}
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.21.0-eks-d-1-21-eks-a-v0.0.0-dev-build.158
     virtualCenter:
-      {{.vsphereServer}}:
-        datacenters: {{.vsphereDatacenter}}
-        thumbprint: '{{.thumbprint}}'
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
     workspace:
-      datacenter: {{.vsphereDatacenter}}
-      datastore: {{.controlPlaneVsphereDatastore}}
-      folder: '{{.controlPlaneVsphereFolder}}'
-      resourcePool: '{{.controlPlaneVsphereResourcePool}}'
-      server: {{.vsphereServer}}
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
-    host: {{.controlPlaneEndpointIp}}
+    host: 1.2.3.4
     port: 6443
-  server: {{.vsphereServer}}
-  thumbprint: '{{.thumbprint}}'
+  server: vsphere_server
+  thumbprint: 'ABCDEFG'
 ---
-{{- if .needsNewControlPlaneTemplate }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
-  name: {{.controlPlaneTemplateName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test-control-plane-template-1234567890000
+  namespace: eksa-system
 spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{.vsphereDatacenter}}
-      datastore: {{.controlPlaneVsphereDatastore}}
-      diskGiB: {{.controlPlaneDiskGiB}}
-      folder: '{{.controlPlaneVsphereFolder}}'
-      memoryMiB: {{.controlPlaneVMsMemoryMiB}}
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 8192
       network:
         devices:
         - dhcp4: true
-          networkName: {{.vsphereNetwork}}
-      numCPUs: {{.controlPlaneVMsNumCPUs}}
-      resourcePool: '{{.controlPlaneVsphereResourcePool}}'
-      server: {{.vsphereServer}}
-{{- if (ne .controlPlaneVsphereStoragePolicyName "") }}
-      storagePolicyName: "{{.controlPlaneVsphereStoragePolicyName}}"
-{{- end }}
-      template: {{.vsphereTemplate}}
-      thumbprint: '{{.thumbprint}}'
-{{- end }}
+          networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 2
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.21.2
+      thumbprint: 'ABCDEFG'
 ---
-{{- if .needsNewWorkloadTemplate }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
-  name: {{.workloadTemplateName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test-worker-node-template-1234567890000
+  namespace: eksa-system
 spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{.vsphereDatacenter}}
-      datastore: {{.workerVsphereDatastore}}
-      diskGiB: {{.workloadDiskGiB}}
-      folder: '{{.workerVsphereFolder}}'
-      memoryMiB: {{.workloadVMsMemoryMiB}}
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 4096
       network:
         devices:
         - dhcp4: true
-          networkName: {{.vsphereNetwork}}
-      numCPUs: {{.workloadVMsNumCPUs}}
-      resourcePool: '{{.workerVsphereResourcePool}}'
-      server: {{.vsphereServer}}
-{{- if (ne .workerVsphereStoragePolicyName "") }}
-      storagePolicyName: "{{.workerVsphereStoragePolicyName}}"
-{{- end }}
-      template: {{.vsphereTemplate}}
-      thumbprint: '{{.thumbprint}}'
-{{- end }}
+          networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 3
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.21.2
+      thumbprint: 'ABCDEFG'
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test
+  namespace: eksa-system
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
-    name: {{.controlPlaneTemplateName}}
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: {{.kubernetesRepository}}
+      imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
-{{- if .externalEtcd }}
         external:
           endpoints: []
-{{- if (eq .format "bottlerocket") }}
-          caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
-          certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
-          keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"
-{{- else }}
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
-{{- end }}
-{{- else }}
-        local:
-          imageRepository: {{.etcdRepository}}
-          imageTag: {{.etcdImageTag}}
-{{- end }}
       dns:
         type: CoreDNS
-        imageRepository: {{.corednsRepository}}
-        imageTag: {{.corednsVersion}}
-{{- if (eq .format "bottlerocket") }}
-      pause:
-        imageRepository: {{.pauseRepository}}
-        imageTag: {{.pauseVersion}}
-      bottlerocketBootstrap:
-        imageRepository: {{.bottlerocketBootstrapRepository}}
-        imageTag: {{.bottlerocketBootstrapVersion}}
-{{- end }}
-{{- if and .proxyConfig (eq .format "bottlerocket")}}
-        proxy:
-          httpsProxy: {{.httpsProxy}}
-          noProxy: {{ range .noProxy }}
-            - {{ . }}
-          {{- end }}
-{{- end }}
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.8.3-eks-1-21-4
       apiServer:
         extraArgs:
           cloud-provider: external
-{{- if .extraArgs }}
-{{ .extraArgs.ToYaml | indent 10 }}
-{{- end }}
       controllerManager:
         extraArgs:
           cloud-provider: external
@@ -194,7 +154,7 @@ spec:
             - name: vip_leaderelection
               value: "true"
             - name: vip_address
-              value: {{.controlPlaneEndpointIp}}
+              value: 1.2.3.4
             - name: vip_interface
               value: eth0
             - name: vip_leaseduration
@@ -203,7 +163,7 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: {{.kubeVipImage}}
+            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}
@@ -224,161 +184,102 @@ spec:
         status: {}
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
-{{- if and .proxyConfig (ne .format "bottlerocket")}}
-    - content: |
-        [Service]
-        Environment="HTTP_PROXY={{.httpProxy}}"
-        Environment="HTTPS_PROXY={{.httpsProxy}}"
-        Environment="NO_PROXY={{ stringsJoin .noProxy "," }}"
-      owner: root:root
-      path: /etc/systemd/system/containerd.service.d/http-proxy.conf
-{{- end }}
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
-        name: '{{`{{ ds.meta_data.hostname }}`}}'
+        name: '{{ ds.meta_data.hostname }}'
     joinConfiguration:
-{{- if (eq .format "bottlerocket") }}
-      pause:
-        imageRepository: {{.pauseRepository}}
-        imageTag: {{.pauseVersion}}
-      bottlerocketBootstrap:
-        imageRepository: {{.bottlerocketBootstrapRepository}}
-        imageTag: {{.bottlerocketBootstrapVersion}}
-{{- end }}
-{{- if and .proxyConfig (eq .format "bottlerocket")}}
-      proxy:
-        httpsProxy: {{.httpsProxy}}
-        noProxy: {{ range .noProxy }}
-        - {{ . }}
-        {{- end }}
-{{- end }}
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
-        name: '{{`{{ ds.meta_data.hostname }}`}}'
+        name: '{{ ds.meta_data.hostname }}'
     preKubeadmCommands:
-{{- if and .proxyConfig (ne .format "bottlerocket")}}
-    - sudo systemctl daemon-reload
-    - sudo systemctl restart containerd
-{{- end }}
-    - hostname "{{`{{ ds.meta_data.hostname }}`}}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
-    - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     useExperimentalRetryJoin: true
     users:
-    - name: {{.controlPlaneSshUsername}}
+    - name: capv
       sshAuthorizedKeys:
-      - '{{.vsphereControlPlaneSshAuthorizedKey}}'
+      - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
       sudo: ALL=(ALL) NOPASSWD:ALL
-    format: {{.format}}
-  replicas: {{.controlPlaneReplicas}}
-  version: {{.kubernetesVersion}}
+    format: cloud-config
+  replicas: 3
+  version: v1.21.2-eks-1-21-4
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
-  name: {{.clusterName}}-md-0
-  namespace: {{.eksaSystemNamespace}}
+  name: test-md-0
+  namespace: eksa-system
 spec:
   template:
     spec:
       joinConfiguration:
-{{- if (eq .format "bottlerocket") }}
-        pause:
-          imageRepository: {{.pauseRepository}}
-          imageTag: {{.pauseVersion}}
-        bottlerocketBootstrap:
-          imageRepository: {{.bottlerocketBootstrapRepository}}
-          imageTag: {{.bottlerocketBootstrapVersion}}
-{{- end }}
-{{- if and .proxyConfig (eq .format "bottlerocket")}}
-        proxy:
-          httpsProxy: {{.httpsProxy}}
-          noProxy: {{ range .noProxy }}
-            - {{ . }}
-          {{- end }}
-{{- end }}
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-provider: external
-{{- if .cgroupDriverSystemd}}
             cgroup-driver: systemd
-{{- end }}
-          name: '{{"{{"}} ds.meta_data.hostname {{"}}"}}'
-{{- if and .proxyConfig (ne .format "bottlerocket")}}
-      files:
-      - content: |
-          [Service]
-          Environment="HTTP_PROXY={{.httpProxy}}"
-          Environment="HTTPS_PROXY={{.httpsProxy}}"
-          Environment="NO_PROXY={{ stringsJoin .noProxy "," }}"
-        owner: root:root
-        path: /etc/systemd/system/containerd.service.d/http-proxy.conf
-{{- end }}
+          name: '{{ ds.meta_data.hostname }}'
       preKubeadmCommands:
-{{- if and .proxyConfig (ne .format "bottlerocket")}}
-      - sudo systemctl daemon-reload
-      - sudo systemctl restart containerd
-{{- end }}
-      - hostname "{{`{{ ds.meta_data.hostname }}`}}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
-      - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
-      - name: {{.workerSshUsername}}
+      - name: capv
         sshAuthorizedKeys:
-        - '{{.vsphereWorkerSshAuthorizedKey}}'
+        - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
-      format: {{.format}}
+      format: cloud-config
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: {{.clusterName}}
-  name: {{.clusterName}}-md-0
-  namespace: {{.eksaSystemNamespace}}
+    cluster.x-k8s.io/cluster-name: test
+  name: test-md-0
+  namespace: eksa-system
 spec:
-  clusterName: {{.clusterName}}
-  replicas: {{.workerReplicas}}
+  clusterName: test
+  replicas: 3
   selector:
     matchLabels: {}
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: {{.clusterName}}
+        cluster.x-k8s.io/cluster-name: test
     spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
-          name: {{.clusterName}}-md-0
-      clusterName: {{.clusterName}}
+          name: test-md-0
+      clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
-        name: {{.workloadTemplateName}}
-      version: {{.kubernetesVersion}}
+        name: test-worker-node-template-1234567890000
+      version: v1.21.2-eks-1-21-4
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: {{.clusterName}}
-  name: {{.clusterName}}-crs-0
-  namespace: {{.eksaSystemNamespace}}
+    cluster.x-k8s.io/cluster-name: test
+  name: test-crs-0
+  namespace: eksa-system
 spec:
   clusterSelector:
     matchLabels:
-      cluster.x-k8s.io/cluster-name: {{.clusterName}}
+      cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
     name: vsphere-csi-controller
@@ -395,78 +296,65 @@ spec:
   - kind: ConfigMap
     name: vsphere-csi-controller
 ---
-{{- if .externalEtcd }}
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
-  name: {{.clusterName}}-etcd
-  namespace: {{.eksaSystemNamespace}}
+  name: test-etcd
+  namespace: eksa-system
 spec:
-  replicas: {{.externalEtcdReplicas}}
+  replicas: 3
   etcdadmConfigSpec:
     etcdadmBuiltin: true
-    format: {{.format}}
-{{- if (eq .format "bottlerocket") }}
-    bottlerocketConfig:
-      etcdImage: {{.etcdImage}}
-      bootstrapImage: {{.bottlerocketBootstrapRepository}}:{{.bottlerocketBootstrapVersion}}
-      pauseImage: {{.pauseRepository}}:{{.pauseVersion}}
-{{- else}}
+    format: cloud-config
     cloudInitConfig:
-      version: {{.externalEtcdVersion}}
+      version: 3.4.16
       installDir: "/usr/bin"
     preEtcdadmCommands:
-      - hostname "{{`{{ ds.meta_data.hostname }}`}}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
-      - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
-{{- end }}
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     users:
-      - name: {{.etcdSshUsername}}
+      - name: capv
         sshAuthorizedKeys:
-          - '{{.vsphereEtcdSshAuthorizedKey}}'
+          - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
-    name: {{.etcdTemplateName}}
+    name: test-etcd-template-1234567890000
 ---
-{{- if .needsNewEtcdTemplate }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
-  name: {{.etcdTemplateName}}
-  namespace: '{{.eksaSystemNamespace}}'
+  name: test-etcd-template-1234567890000
+  namespace: 'eksa-system'
 spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{.vsphereDatacenter}}
-      datastore: {{.etcdVsphereDatastore}}
-      diskGiB: {{.etcdDiskGiB}}
-      folder: '{{.etcdVsphereFolder}}'
-      memoryMiB: {{.etcdVMsMemoryMiB}}
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 8192
       network:
         devices:
           - dhcp4: true
-            networkName: {{.vsphereNetwork}}
-      numCPUs: {{.etcdVMsNumCPUs}}
-      resourcePool: '{{.etcdVsphereResourcePool}}'
-      server: {{.vsphereServer}}
-{{- if (ne .etcdVsphereStoragePolicyName "") }}
-      storagePolicyName: "{{.etcdVsphereStoragePolicyName}}"
-{{- end }}
-      template: {{.vsphereTemplate}}
-      thumbprint: '{{.thumbprint}}'
+            networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 3
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.21.2
+      thumbprint: 'ABCDEFG'
 ---
-{{- end }}
-{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-csi-controller
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -586,7 +474,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-role
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -606,7 +494,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-binding
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -620,7 +508,7 @@ data:
 kind: ConfigMap
 metadata:
   name: csi.vsphere.vmware.com
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -650,7 +538,7 @@ data:
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-            image: {{.nodeDriverRegistrarImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-21-4
             lifecycle:
               preStop:
                 exec:
@@ -684,7 +572,7 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            image: {{.driverImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.158
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -717,7 +605,7 @@ data:
               name: device-dir
           - args:
             - --csi-address=/csi/csi.sock
-            image: {{.livenessProbeImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-21-4
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -753,7 +641,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-node
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -783,7 +671,7 @@ data:
             env:
             - name: ADDRESS
               value: /csi/csi.sock
-            image: {{.externalAttacherImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v3.1.0-eks-1-21-4
             name: csi-attacher
             resources: {}
             volumeMounts:
@@ -800,7 +688,7 @@ data:
               value: PRODUCTION
             - name: X_CSI_LOG_LEVEL
               value: INFO
-            image: {{.driverImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.158
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -826,7 +714,7 @@ data:
             env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            image: {{.livenessProbeImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-21-4
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -841,7 +729,7 @@ data:
               value: PRODUCTION
             - name: VSPHERE_CSI_CONFIG
               value: /etc/cloud/csi-vsphere.conf
-            image: {{.syncerImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.158
             name: vsphere-syncer
             resources: {}
             volumeMounts:
@@ -857,7 +745,7 @@ data:
             env:
             - name: ADDRESS
               value: /csi/csi.sock
-            image: {{.externalProvisionerImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-21-4
             name: csi-provisioner
             resources: {}
             volumeMounts:
@@ -878,7 +766,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -893,4 +781,4 @@ data:
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/networkutils"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/providers/vsphere/internal/templates"
+	"github.com/aws/eks-anywhere/pkg/semver"
 	"github.com/aws/eks-anywhere/pkg/templater"
 	"github.com/aws/eks-anywhere/pkg/types"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -985,7 +986,10 @@ func (vs *VsphereTemplateBuilder) GenerateDeploymentFile(clusterSpec *cluster.Sp
 	if clusterSpec.Spec.ExternalEtcdConfiguration != nil {
 		etcdMachineSpec = *vs.etcdMachineSpec
 	}
-	values := BuildTemplateMap(clusterSpec, *vs.datacenterSpec, *vs.controlPlaneMachineSpec, *vs.workerNodeGroupMachineSpec, etcdMachineSpec)
+	values, err := BuildTemplateMap(clusterSpec, *vs.datacenterSpec, *vs.controlPlaneMachineSpec, *vs.workerNodeGroupMachineSpec, etcdMachineSpec)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, buildOption := range buildOptions {
 		buildOption(values)
@@ -999,7 +1003,7 @@ func (vs *VsphereTemplateBuilder) GenerateDeploymentFile(clusterSpec *cluster.Sp
 	return bytes, nil
 }
 
-func BuildTemplateMap(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphereDatacenterConfigSpec, controlPlaneMachineSpec, workerNodeGroupMachineSpec, etcdMachineSpec v1alpha1.VSphereMachineConfigSpec) map[string]interface{} {
+func BuildTemplateMap(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphereDatacenterConfigSpec, controlPlaneMachineSpec, workerNodeGroupMachineSpec, etcdMachineSpec v1alpha1.VSphereMachineConfigSpec) (map[string]interface{}, error) {
 	bundle := clusterSpec.VersionsBundle
 	format := "cloud-config"
 
@@ -1058,6 +1062,14 @@ func BuildTemplateMap(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphere
 		"eksaSystemNamespace":                  constants.EksaSystemNamespace,
 	}
 
+	k8sVersion, err := semver.New(bundle.KubeDistro.Kubernetes.Tag)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing kubernetes version %v: %v", bundle.KubeDistro.Kubernetes.Tag, err)
+	}
+	if k8sVersion.Major == 1 && k8sVersion.Minor >= 21 {
+		values["cgroupDriverSystemd"] = true
+	}
+
 	if clusterSpec.Spec.ProxyConfiguration != nil {
 		values["proxyConfig"] = true
 		var noProxyList []string
@@ -1099,7 +1111,7 @@ func BuildTemplateMap(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphere
 		values["bottlerocketBootstrapVersion"] = bundle.BottleRocketBootstrap.Bootstrap.Tag()
 	}
 
-	return values
+	return values, nil
 }
 
 func (p *vsphereProvider) generateTemplateValuesForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec) ([]byte, error) {

--- a/pkg/templater/templater.go
+++ b/pkg/templater/templater.go
@@ -49,7 +49,6 @@ func Execute(templateContent string, data interface{}) ([]byte, error) {
 			return pad + strings.Replace(v, "\n", "\n"+pad, -1)
 		},
 		"stringsJoin": strings.Join,
-		"hasPrefix":   strings.HasPrefix,
 	}
 	temp = temp.Funcs(funcMap)
 


### PR DESCRIPTION
K8s 1.21 defaults to systemd for cgroupDriver. K8s 1.20 nodes are started
with cgroupfs as the cgroupDriver. On upgrade from 1.20 to 1.21, KCP
controller updates the kubelet config cm to pin cgroup to systemd.
Since CLI applies the updated spec for all objects (KCP/MD/etcdadmcluster) at the same time
the worker nodes rollout starts at the same as controlplane/etcd. CAPI pauses
KCP when etcd is undergoing upgrade, due to which KCP controller does not upgrade
kubelet configmap till KCP is unpaused. However the MD rollout starts and uses the
older kubelet configmap which does not have th cgroup change.
So this commit pins cgroup driver to systemd if k8s version >= 1.21 for now.

Opened a ticket to change the order post GA: https://sim.amazon.com/issues/MODELROCKET-1763

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
