### PR TITLE
Adding EC2 instance Id to error logs

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -110,7 +110,7 @@ func (e *E2ESession) runTests(regex string) error {
 		command,
 	)
 	if err != nil {
-		return fmt.Errorf("error running e2e tests: %v", err)
+		return fmt.Errorf("error running e2e tests on instance %s: %v", e.instanceId, err)
 	}
 
 	key := "Integration-Test-Done"


### PR DESCRIPTION
*Description of changes:*
Added EC2 instance Id to e2e test failure logs. This enables easier debugging of test failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
