### PR TITLE
MODELROCKET-1752 - Set docker provider defaults to be 1:1:1

### DIFF
--- a/cmd/eks-a/cmd/generateclusterconfig.go
+++ b/cmd/eks-a/cmd/generateclusterconfig.go
@@ -62,6 +62,11 @@ func generateClusterConfig(clusterName string) error {
 	case docker.ProviderName:
 		datacenterConfig := v1alpha1.NewDockerDatacenterConfigGenerate(clusterName)
 		clusterConfigOpts = append(clusterConfigOpts, v1alpha1.WithDatacenterRef(datacenterConfig))
+		clusterConfigOpts = append(clusterConfigOpts,
+			v1alpha1.ControlPlaneConfigCount(1),
+			v1alpha1.ExternalETCDConfigCount(1),
+			v1alpha1.WorkerNodeConfigCount(1),
+		)
 		dcyaml, err := yaml.Marshal(datacenterConfig)
 		if err != nil {
 			return fmt.Errorf("error outputting yaml: %v", err)
@@ -71,6 +76,11 @@ func generateClusterConfig(clusterName string) error {
 		clusterConfigOpts = append(clusterConfigOpts, v1alpha1.WithClusterEndpoint())
 		datacenterConfig := v1alpha1.NewVSphereDatacenterConfigGenerate(clusterName)
 		clusterConfigOpts = append(clusterConfigOpts, v1alpha1.WithDatacenterRef(datacenterConfig))
+		clusterConfigOpts = append(clusterConfigOpts,
+			v1alpha1.ControlPlaneConfigCount(2),
+			v1alpha1.ExternalETCDConfigCount(3),
+			v1alpha1.WorkerNodeConfigCount(2),
+		)
 		dcyaml, err := yaml.Marshal(datacenterConfig)
 		if err != nil {
 			return fmt.Errorf("error outputting yaml: %v", err)

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -34,12 +34,7 @@ func NewClusterGenerate(clusterName string, opts ...ClusterGenerateOpt) *Cluster
 			Name: clusterName,
 		},
 		Spec: ClusterSpec{
-			KubernetesVersion:             Kube121,
-			ControlPlaneConfiguration:     ControlPlaneConfiguration{Count: 2},
-			WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{Count: 2}},
-			ExternalEtcdConfiguration: &ExternalEtcdConfiguration{
-				Count: 3,
-			},
+			KubernetesVersion: Kube121,
 			ClusterNetwork: ClusterNetwork{
 				Pods: Pods{
 					CidrBlocks: []string{"192.168.0.0/16"},
@@ -55,6 +50,26 @@ func NewClusterGenerate(clusterName string, opts ...ClusterGenerateOpt) *Cluster
 		opt(config)
 	}
 	return config
+}
+
+func ControlPlaneConfigCount(count int) ClusterGenerateOpt {
+	return func(c *ClusterGenerate) {
+		c.Spec.ControlPlaneConfiguration.Count = count
+	}
+}
+
+func ExternalETCDConfigCount(count int) ClusterGenerateOpt {
+	return func(c *ClusterGenerate) {
+		c.Spec.ExternalEtcdConfiguration = &ExternalEtcdConfiguration{
+			Count: count,
+		}
+	}
+}
+
+func WorkerNodeConfigCount(count int) ClusterGenerateOpt {
+	return func(c *ClusterGenerate) {
+		c.Spec.WorkerNodeGroupConfigurations = []WorkerNodeGroupConfiguration{{Count: count}}
+	}
 }
 
 func WithClusterEndpoint() ClusterGenerateOpt {


### PR DESCRIPTION
*Issue #, if available:* MODELROCKET-1752

*Description of changes:*
Set docker provider defaults to be 1:1:1 and set vsphere provider to 2:3:2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
