### PR TITLE
Adding OSFamily flag to vSphere ubuntu e2e tests

### DIFF
--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -111,25 +111,37 @@ func NewVSphere(t *testing.T, opts ...VSphereOpt) *VSphere {
 
 func WithUbuntu121() VSphereOpt {
 	return func(v *VSphere) {
-		v.fillers = append(v.fillers, api.WithStringFromEnvVar(vsphereTemplateUbuntu121Var, api.WithTemplate))
+		v.fillers = append(v.fillers,
+			api.WithStringFromEnvVar(vsphereTemplateUbuntu121Var, api.WithTemplate),
+			api.WithOsFamily(v1alpha1.Ubuntu),
+		)
 	}
 }
 
 func WithUbuntu120() VSphereOpt {
 	return func(v *VSphere) {
-		v.fillers = append(v.fillers, api.WithStringFromEnvVar(vsphereTemplateUbuntu120Var, api.WithTemplate))
+		v.fillers = append(v.fillers,
+			api.WithStringFromEnvVar(vsphereTemplateUbuntu120Var, api.WithTemplate),
+			api.WithOsFamily(v1alpha1.Ubuntu),
+		)
 	}
 }
 
 func WithUbuntu119() VSphereOpt {
 	return func(v *VSphere) {
-		v.fillers = append(v.fillers, api.WithStringFromEnvVar(vsphereTemplateUbuntu119Var, api.WithTemplate))
+		v.fillers = append(v.fillers,
+			api.WithStringFromEnvVar(vsphereTemplateUbuntu119Var, api.WithTemplate),
+			api.WithOsFamily(v1alpha1.Ubuntu),
+		)
 	}
 }
 
 func WithUbuntu118() VSphereOpt {
 	return func(v *VSphere) {
-		v.fillers = append(v.fillers, api.WithStringFromEnvVar(vsphereTemplateUbuntu118Var, api.WithTemplate))
+		v.fillers = append(v.fillers,
+			api.WithStringFromEnvVar(vsphereTemplateUbuntu118Var, api.WithTemplate),
+			api.WithOsFamily(v1alpha1.Ubuntu),
+		)
 	}
 }
 


### PR DESCRIPTION
*Description of changes:*
The default OS family moved from Ubuntu -> BottleRocket. So we need to set the OSFamily explicitly for Ubuntu template tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
