### PR TITLE
Wait for etcdadm controllers after clusterctl init

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clustermanager/internal"
 	"github.com/aws/eks-anywhere/pkg/clustermarshaller"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
@@ -35,37 +36,6 @@ const (
 	etcdWaitStr       = "60m"
 	deploymentWaitStr = "30m"
 )
-
-// map where key = namespace and value is a capi deployment
-var capiDeployments = map[string][]string{
-	"capi-kubeadm-bootstrap-system":     {"capi-kubeadm-bootstrap-controller-manager"},
-	"capi-kubeadm-control-plane-system": {"capi-kubeadm-control-plane-controller-manager"},
-	"capi-system":                       {"capi-controller-manager"},
-	"capi-webhook-system":               {"capi-controller-manager", "capi-kubeadm-bootstrap-controller-manager", "capi-kubeadm-control-plane-controller-manager"},
-	"cert-manager":                      {"cert-manager", "cert-manager-cainjector", "cert-manager-webhook"},
-}
-
-var externalEtcdDeployments = map[string][]string{
-	"etcdadm-controller-system":         {"etcdadm-controller-controller-manager"},
-	"etcdadm-bootstrap-provider-system": {"etcdadm-bootstrap-provider-controller-manager"},
-}
-
-// map between file name and the capi/v deployments
-var clusterDeployments = map[string]*types.Deployment{
-	"kubeadm-bootstrap-controller-manager.log":         {Name: "capi-kubeadm-bootstrap-controller-manager", Namespace: "capi-kubeadm-bootstrap-system", Container: "manager"},
-	"kubeadm-control-plane-controller-manager.log":     {Name: "capi-kubeadm-control-plane-controller-manager", Namespace: "capi-kubeadm-control-plane-system", Container: "manager"},
-	"capi-controller-manager.log":                      {Name: "capi-controller-manager", Namespace: "capi-system", Container: "manager"},
-	"wh-capi-controller-manager.log":                   {Name: "capi-controller-manager", Namespace: "capi-webhook-system", Container: "manager"},
-	"wh-capi-kubeadm-bootstrap-controller-manager.log": {Name: "capi-kubeadm-bootstrap-controller-manager", Namespace: "capi-webhook-system", Container: "manager"},
-	"wh-kubeadm-control-plane-controller-manager.log":  {Name: "capi-kubeadm-control-plane-controller-manager", Namespace: "capi-webhook-system", Container: "manager"},
-	"cert-manager.log":                                 {Name: "cert-manager", Namespace: "cert-manager"},
-	"cert-manager-cainjector.log":                      {Name: "cert-manager-cainjector", Namespace: "cert-manager"},
-	"cert-manager-webhook.log":                         {Name: "cert-manager-webhook", Namespace: "cert-manager"},
-	"coredns.log":                                      {Name: "coredns", Namespace: "kube-system"},
-	"local-path-provisioner.log":                       {Name: "local-path-provisioner", Namespace: "local-path-storage"},
-	"capv-controller-manager.log":                      {Name: "capv-controller-manager", Namespace: "capv-system", Container: "manager"},
-	"wh-capv-controller-manager.log":                   {Name: "capv-controller-manager", Namespace: "capi-webhook-system", Container: "manager"},
-}
 
 type ClusterManager struct {
 	clusterClient   ClusterClient
@@ -378,13 +348,13 @@ func (c *ClusterManager) InstallCapi(ctx context.Context, clusterSpec *cluster.S
 }
 
 func (c *ClusterManager) waitForCapi(ctx context.Context, cluster *types.Cluster, provider providers.Provider, externalEtcdTopology bool) error {
-	err := c.waitForDeployments(ctx, capiDeployments, cluster)
+	err := c.waitForDeployments(ctx, internal.CapiDeployments, cluster)
 	if err != nil {
 		return err
 	}
 
 	if externalEtcdTopology {
-		err := c.waitForDeployments(ctx, externalEtcdDeployments, cluster)
+		err := c.waitForDeployments(ctx, internal.ExternalEtcdDeployments, cluster)
 		if err != nil {
 			return err
 		}
@@ -456,13 +426,13 @@ func (c *ClusterManager) SaveLogs(ctx context.Context, cluster *types.Cluster) e
 		return nil
 	}
 	var wg sync.WaitGroup
-	wg.Add(len(clusterDeployments))
+	wg.Add(len(internal.ClusterDeployments))
 
 	w, err := c.writer.WithDir(logDir)
 	if err != nil {
 		return err
 	}
-	for fileName, deployment := range clusterDeployments {
+	for fileName, deployment := range internal.ClusterDeployments {
 		go func(dep *types.Deployment, f string) {
 			// Ignoring error for now
 			defer wg.Done()

--- a/pkg/clustermanager/internal/deployments.go
+++ b/pkg/clustermanager/internal/deployments.go
@@ -1,0 +1,34 @@
+package internal
+
+import "github.com/aws/eks-anywhere/pkg/types"
+
+// map where key = namespace and value is a capi deployment
+var CapiDeployments = map[string][]string{
+	"capi-kubeadm-bootstrap-system":     {"capi-kubeadm-bootstrap-controller-manager"},
+	"capi-kubeadm-control-plane-system": {"capi-kubeadm-control-plane-controller-manager"},
+	"capi-system":                       {"capi-controller-manager"},
+	"capi-webhook-system":               {"capi-controller-manager", "capi-kubeadm-bootstrap-controller-manager", "capi-kubeadm-control-plane-controller-manager"},
+	"cert-manager":                      {"cert-manager", "cert-manager-cainjector", "cert-manager-webhook"},
+}
+
+var ExternalEtcdDeployments = map[string][]string{
+	"etcdadm-controller-system":         {"etcdadm-controller-controller-manager"},
+	"etcdadm-bootstrap-provider-system": {"etcdadm-bootstrap-provider-controller-manager"},
+}
+
+// map between file name and the capi/v deployments
+var ClusterDeployments = map[string]*types.Deployment{
+	"kubeadm-bootstrap-controller-manager.log":         {Name: "capi-kubeadm-bootstrap-controller-manager", Namespace: "capi-kubeadm-bootstrap-system", Container: "manager"},
+	"kubeadm-control-plane-controller-manager.log":     {Name: "capi-kubeadm-control-plane-controller-manager", Namespace: "capi-kubeadm-control-plane-system", Container: "manager"},
+	"capi-controller-manager.log":                      {Name: "capi-controller-manager", Namespace: "capi-system", Container: "manager"},
+	"wh-capi-controller-manager.log":                   {Name: "capi-controller-manager", Namespace: "capi-webhook-system", Container: "manager"},
+	"wh-capi-kubeadm-bootstrap-controller-manager.log": {Name: "capi-kubeadm-bootstrap-controller-manager", Namespace: "capi-webhook-system", Container: "manager"},
+	"wh-kubeadm-control-plane-controller-manager.log":  {Name: "capi-kubeadm-control-plane-controller-manager", Namespace: "capi-webhook-system", Container: "manager"},
+	"cert-manager.log":                                 {Name: "cert-manager", Namespace: "cert-manager"},
+	"cert-manager-cainjector.log":                      {Name: "cert-manager-cainjector", Namespace: "cert-manager"},
+	"cert-manager-webhook.log":                         {Name: "cert-manager-webhook", Namespace: "cert-manager"},
+	"coredns.log":                                      {Name: "coredns", Namespace: "kube-system"},
+	"local-path-provisioner.log":                       {Name: "local-path-provisioner", Namespace: "local-path-storage"},
+	"capv-controller-manager.log":                      {Name: "capv-controller-manager", Namespace: "capv-system", Container: "manager"},
+	"wh-capv-controller-manager.log":                   {Name: "capv-controller-manager", Namespace: "capi-webhook-system", Container: "manager"},
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
After clusterctl init, cli waits for capi deployments to be available. This wait wasn't implemented for etcdadm controllers when external etcd is enabled. This commit adds wait for etcdadm controller deployments

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
