### PR TITLE
Add retries for send ssm command and check for throttling error

### DIFF
--- a/internal/pkg/ssm/command.go
+++ b/internal/pkg/ssm/command.go
@@ -51,8 +51,8 @@ func Run(session *session.Session, instanceId string, command string, opts ...Co
 		opt(c)
 	}
 	var result *ssm.SendCommandOutput
-	r := retrier.New(180*time.Minute, retrier.WithMaxRetries(50, 10*time.Second), retrier.WithRetryPolicy(func(totalRetries int, err error) (retry bool, wait time.Duration) {
-		if request.IsErrorThrottle(err) {
+	r := retrier.New(180*time.Minute, retrier.WithRetryPolicy(func(totalRetries int, err error) (retry bool, wait time.Duration) {
+		if request.IsErrorThrottle(err) && totalRetries < 50 {
 			return true, 10 * time.Second
 		}
 		return false, 0


### PR DESCRIPTION
This commit adds retries around send ssm command. For ssm command errors
it also checks if it was a throttling error in which case it is retried
with backoff, and for other errors retries are aborted.

The throttling errors we've been seeing in e2e runs match the throttling error codes
`error sending ssm command: ThrottlingException: Rate exceeded\n\tstatus code: 400`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
