### PR TITLE
Adding releasesManifestURL flag and fix error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ eks-a-e2e:
 
 .PHONY: e2e-tests-binary
 e2e-tests-binary:
-	go test ./test/e2e -c -o bin/e2e.test -tags "$(E2E_TAGS)" -ldflags "-X github.com/aws/eks-anywhere/pkg/version.gitVersion=$(DEV_GIT_VERSION)"
+	go test ./test/e2e -c -o bin/e2e.test -tags "$(E2E_TAGS)" -ldflags "-X github.com/aws/eks-anywhere/pkg/version.gitVersion=$(DEV_GIT_VERSION) -X github.com/aws/eks-anywhere/pkg/cluster.releasesManifestURL=$(RELEASE_MANIFEST_URL)"
 
 .PHONY: integration-test-binary
 integration-test-binary:

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -401,6 +401,8 @@ func GetEksdRelease(cliVersion version.Info, clusterConfig *eksav1alpha1.Cluster
 	s := &Spec{
 		releasesManifestURL: releasesManifestURL,
 		configFS:            configFS,
+		httpClient:          &http.Client{},
+		userAgent:           userAgent("cli", cliVersion.GitVersion),
 	}
 
 	bundles, err := s.getBundles(cliVersion)

--- a/test/framework/conformance.go
+++ b/test/framework/conformance.go
@@ -24,6 +24,7 @@ func (e *E2ETest) RunConformanceTests() {
 	kubeVersion, err := e.getEksdReleaseKubeVersion()
 	if err != nil {
 		e.T.Errorf("Error getting EKS-D release KubeVersion from bundle: %v", err)
+		return
 	}
 	e.T.Log("Downloading Sonobuoy binary for testing")
 	err = conformance.Download()


### PR DESCRIPTION
*Description of changes:*
The conformance e2e tests were failing to read the release manifest for getting EKS-D version. Also, fixed error handling issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
