### PR TITLE
Don't log warning about recommended etcd cluster size for capd

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -287,7 +287,10 @@ func validateEtcdReplicas(clusterConfig *Cluster) error {
 		return errors.New("external etcd count cannot be an even number")
 	}
 	if clusterConfig.Spec.ExternalEtcdConfiguration.Count != 3 && clusterConfig.Spec.ExternalEtcdConfiguration.Count != 5 {
-		logger.Info("Warning: The recommended size of an external etcd cluster is 3 or 5")
+		if clusterConfig.Spec.DatacenterRef.Name != DockerDatacenterKind {
+			// only log warning about recommended etcd cluster size for providers other than docker
+			logger.Info("Warning: The recommended size of an external etcd cluster is 3 or 5")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This commit removes the recommended etcd cluster size warning when using docker provider with single etcd member since it should be allowed without warnings when using docker for testing purposes:
`Warning: The recommended size of an external etcd cluster is 3 or 5`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
