### PR TITLE
Copy attribution file instead of moving

### DIFF
--- a/cmd/integration_test/build/script/upload_artifacts.sh
+++ b/cmd/integration_test/build/script/upload_artifacts.sh
@@ -19,7 +19,7 @@ function build::cli::move_artifacts() {
   local -r cli_artifacts_path=$2
 
   mv ${BINARY_PATH}/${os}/eksctl-anywhere ${cli_artifacts_path}
-  mv ATTRIBUTION.txt ${cli_artifacts_path}
+  cp ATTRIBUTION.txt ${cli_artifacts_path}
 }
 
 function build::cli::create_tarball() {


### PR DESCRIPTION
Copying the attribution file instead of moving so it's still available at repo root. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
