### PR TITLE
Fix release manifest URL

### DIFF
--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -212,7 +212,7 @@ var releaseCmd = &cobra.Command{
 			} else {
 				eksAReleaseManifestKey = "/releases/eks-a/manifest.yaml"
 			}
-			eksAReleaseManifestUrl := fmt.Sprintf("%s/%s", releaseConfig.CDN, eksAReleaseManifestKey)
+			eksAReleaseManifestUrl := fmt.Sprintf("%s%s", releaseConfig.CDN, eksAReleaseManifestKey)
 
 			exists, err := pkg.ExistsInS3(releaseClients, releaseConfig.ReleaseBucket, eksAReleaseManifestKey)
 			if err != nil {


### PR DESCRIPTION
The key already has a preceding slash.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
