### PR TITLE
Add wait for eksa-controller-manager deployment

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -624,7 +624,7 @@ func (c *ClusterManager) InstallCustomComponents(ctx context.Context, clusterSpe
 	if err != nil {
 		return fmt.Errorf("error applying eks-a components spec: %v", err)
 	}
-	return nil
+	return c.waitForDeployments(ctx, internal.EksaDeployments, cluster)
 }
 
 func (c *ClusterManager) CreateEKSAResources(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec,

--- a/pkg/clustermanager/internal/deployments.go
+++ b/pkg/clustermanager/internal/deployments.go
@@ -32,3 +32,7 @@ var ClusterDeployments = map[string]*types.Deployment{
 	"capv-controller-manager.log":                      {Name: "capv-controller-manager", Namespace: "capv-system", Container: "manager"},
 	"wh-capv-controller-manager.log":                   {Name: "capv-controller-manager", Namespace: "capi-webhook-system", Container: "manager"},
 }
+
+var EksaDeployments = map[string][]string{
+	"eksa-system": {"eksa-controller-manager"},
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a wait for the eksa-controller-manager deployment to be available before creating EKS-A CRDs
The retry around applying the spec for eksa-components retries the `kubectl apply` command if it fails. This does not include a wait for the deployment.

The logs from the test failure:
```
2021-09-03T14:33:35.503Z    V0  Installing EKS-A custom components (CRD and controller) on workload cluster
787 | 2021-09-03T14:33:37.412Z    V0  Creating EKS-A CRDs instances on workload cluster
788 | 2021-09-03T14:33:37.413Z    V4  Applying eksa yaml resources to cluster
789 | 2021-09-03T14:36:38.081Z    V4  Task finished   {"task_name": "eksa-components-install", "duration": "3m2.578810335s"}
790 | 2021-09-03T14:36:38.081Z    V4  ----------------------------------
791 | 2021-09-03T14:36:38.081Z    V4  Tasks completed {"duration": "14m53.929762311s"}
792 | Error: failed to create cluster: error applying eks-a spec: error executing apply --force: Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "validation.cluster.anywhere.amazonaws.com": Post "https://eksa-webhook-service.eksa-system.svc:443/validate-anywhere-eks-amazonaws-com-v1alpha1-cluster?timeout=10s": dial tcp 10.96.110.159:443: connect: connection refused
793 | Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "validation.vspheredatacenterconfig.anywhere.amazonaws.com": Post "https://eksa-webhook-service.eksa-system.svc:443/validate-anywhere-eks-amazonaws-com-v1alpha1-vspheredatacenterconfig?timeout=10s": dial tcp 10.96.110.159:443: connect: connection refused
794 | Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "validation.vspheremachineconfig.anywhere.amazonaws.com": Post "https://eksa-webhook-service.eksa-system.svc:443/validate-anywhere-eks-amazonaws-com-v1alpha1-vspheremachineconfig?timeout=10s": dial tcp 10.96.110.159:443: connect: connection refused
795 | Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "validation.vspheremachineconfig.anywhere.amazonaws.com": Post "https://eksa-webhook-service.eksa-system.svc:443/validate-anywhere-eks-amazonaws-com-v1alpha1-vspheremachineconfig?timeout=10s": dial tcp 10.96.110.159:443: connect: connection refused
796 | Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "validation.vspheremachineconfig.anywhere.amazonaws.com": Post "https://eksa-webhook-service.eksa-system.svc:443/validate-anywhere-eks-amazonaws-com-v1alpha1-vspheremachineconfig?timeout=10s": dial tcp 10.96.110.159:443: connect: connection refused
797
```
However the controller got deployed within some time without errors because if we login to that test instance and create an eks-a crd it works now. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
