### PR TITLE
Don't provide ssh key for e2e tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -16,7 +16,6 @@ env:
     T_VSPHERE_NETWORK: "vsphere_ci_beta_connection:network"
     T_VSPHERE_RESOURCE_POOL: "vsphere_ci_beta_connection:resource_pool"
     T_VSPHERE_SERVER: "vsphere_ci_beta_connection:server"
-    T_VSPHERE_SSH_AUTHORIZED_KEY: "vsphere_ci_beta_connection:ssh_authorized_key"
     T_VSPHERE_TEMPLATE_UBUNTU_1_18: "vsphere_ci_beta_connection:template_18"
     T_VSPHERE_TEMPLATE_UBUNTU_1_19: "vsphere_ci_beta_connection:template_19"
     T_VSPHERE_TEMPLATE_UBUNTU_1_20: "vsphere_ci_beta_connection:template_20"

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -41,7 +41,6 @@ var requiredEnvVars = []string{
 	vsphereNetworkVar,
 	vsphereResourcePoolVar,
 	vsphereServerVar,
-	vsphereSshAuthorizedKeyVar,
 	vsphereTemplateUbuntu118Var,
 	vsphereTemplateUbuntu119Var,
 	vsphereTemplateUbuntu120Var,


### PR DESCRIPTION
If ssh key env var is not set, cluster.yaml will be generated without
the ssh key. This way the cli will generate the ssh key for each test and it
will get saved in the ec2 instance so it's available for debugging

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
