### PR TITLE
Ensure env variables get unset before upload

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -43,9 +43,9 @@ phases:
       -m 40
       -r 'Test'
       --skip 'TestDockerKubernetes119Flux,TestDockerKubernetes119ThreeReplicasFlux,TestVSphereKubernetes119Flux,TestVSphereKubernetes119ThreeReplicasFlux,TestDockerKubernetes118Flux,TestDockerKubernetes12OFlux,TestDockerKubernetes121Flux,TestVSphereKubernetes118Flux,TestVSphereKubernetes120Flux,TestVSphereKubernetes121Flux,TestDockerKubernetes119GitopsOptionsFlux,TestVSphereKubernetes119GitopsOptionsFlux,TestVSphereKubernetes120UbuntuTo121WithFluxUpgrade,TestVSphereKubernetes120BottlerocketTo121WithFluxUpgrade'
-    - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE
   post_build:
     commands:
+    - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE
     - export GIT_HASH=$(cat bin/githash)
     - >
       ./cmd/integration_test/build/script/upload_artifacts.sh


### PR DESCRIPTION
Ensure env variables get unset before CLI tarballs upload.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
