### PR TITLE
Revert "Don't provide ssh key for e2e tests"

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -16,6 +16,7 @@ env:
     T_VSPHERE_NETWORK: "vsphere_ci_beta_connection:network"
     T_VSPHERE_RESOURCE_POOL: "vsphere_ci_beta_connection:resource_pool"
     T_VSPHERE_SERVER: "vsphere_ci_beta_connection:server"
+    T_VSPHERE_SSH_AUTHORIZED_KEY: "vsphere_ci_beta_connection:ssh_authorized_key"
     T_VSPHERE_TEMPLATE_UBUNTU_1_18: "vsphere_ci_beta_connection:template_18"
     T_VSPHERE_TEMPLATE_UBUNTU_1_19: "vsphere_ci_beta_connection:template_19"
     T_VSPHERE_TEMPLATE_UBUNTU_1_20: "vsphere_ci_beta_connection:template_20"

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -41,6 +41,7 @@ var requiredEnvVars = []string{
 	vsphereNetworkVar,
 	vsphereResourcePoolVar,
 	vsphereServerVar,
+	vsphereSshAuthorizedKeyVar,
 	vsphereTemplateUbuntu118Var,
 	vsphereTemplateUbuntu119Var,
 	vsphereTemplateUbuntu120Var,


### PR DESCRIPTION
Reverts aws/eks-anywhere#72

e2e upgrade tests where cluster.yml is created without ssh keys fail because original cluster.yml gets used for upgrade instead of the updated one. Reverting this fix for now till e2e tests can use the updated cluster.yml for upgrade