### PR TITLE
Flux e2e tests delete repo

### DIFF
--- a/internal/pkg/api/gitops.go
+++ b/internal/pkg/api/gitops.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +37,13 @@ func WithFluxOwner(username string) GitOpsConfigOpt {
 func WithFluxRepository(repository string) GitOpsConfigOpt {
 	return func(c *v1alpha1.GitOpsConfig) {
 		c.Spec.Flux.Github.Repository = repository
+	}
+}
+
+func WithFluxRepositorySuffix(suffix string) GitOpsConfigOpt {
+	return func(c *v1alpha1.GitOpsConfig) {
+		repository := c.Spec.Flux.Github.Repository
+		c.Spec.Flux.Github.Repository = fmt.Sprintf("%s-%s", repository, suffix)
 	}
 }
 

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/pkg/ec2"
 	"github.com/aws/eks-anywhere/internal/pkg/ssm"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	e2etests "github.com/aws/eks-anywhere/test/framework"
 )
 
 type ParallelRunConf struct {
@@ -127,12 +128,12 @@ func (e *E2ESession) runTests(regex string) error {
 }
 
 func (e *E2ESession) commandWithEnvVars(command string) string {
-	fullCommand := make([]string, 0, len(e.testEnvVars)+1)
-
+	fullCommand := make([]string, 0, len(e.testEnvVars)+2)
+	jobIdCommand := fmt.Sprintf("export %s=%s", e2etests.JobIdVar, e.jobId)
 	for k, v := range e.testEnvVars {
 		fullCommand = append(fullCommand, fmt.Sprintf("export %s=%s", k, v))
 	}
-	fullCommand = append(fullCommand, command)
+	fullCommand = append(fullCommand, jobIdCommand, command)
 
 	return strings.Join(fullCommand, "; ")
 }

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -239,8 +239,8 @@ func (k *Kubectl) ValidateWorkerNodes(ctx context.Context, cluster *types.Cluste
 	return nil
 }
 
-func (k *Kubectl) VsphereWorkerNodesMachineTemplate(ctx context.Context, clusterName string, kubeconfig string) (*vspherev3.VSphereMachineTemplate, error) {
-	machineTemplateName, err := k.MachineTemplateName(ctx, clusterName, kubeconfig)
+func (k *Kubectl) VsphereWorkerNodesMachineTemplate(ctx context.Context, clusterName string, kubeconfig string, namespace string) (*vspherev3.VSphereMachineTemplate, error) {
+	machineTemplateName, err := k.MachineTemplateName(ctx, clusterName, kubeconfig, WithNamespace(namespace))
 	if err != nil {
 		return nil, err
 	}
@@ -257,10 +257,10 @@ func (k *Kubectl) VsphereWorkerNodesMachineTemplate(ctx context.Context, cluster
 	return machineTemplateSpec, nil
 }
 
-func (k *Kubectl) MachineTemplateName(ctx context.Context, clusterName string, kubeconfig string) (string, error) {
+func (k *Kubectl) MachineTemplateName(ctx context.Context, clusterName string, kubeconfig string, opts ...KubectlOpt) (string, error) {
 	template := "{{.spec.template.spec.infrastructureRef.name}}"
 	params := []string{"get", "MachineDeployment", fmt.Sprintf("%s-md-0", clusterName), "-o", "go-template", "--template", template, "--kubeconfig", kubeconfig}
-
+	applyOpts(&params, opts...)
 	buffer, err := k.executable.Execute(ctx, params...)
 	if err != nil {
 		return "", err

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -19,6 +19,7 @@ type Provider interface {
 	Branch(name string) error
 	GetRepo(ctx context.Context) (repo *Repository, err error)
 	CreateRepo(ctx context.Context, opts CreateRepoOpts) (repo *Repository, err error)
+	DeleteRepo(ctx context.Context, opts DeleteRepoOpts) error
 	Validate(ctx context.Context) error
 	PathExists(ctx context.Context, owner, repo, branch, path string) (bool, error)
 }
@@ -32,6 +33,11 @@ type CreateRepoOpts struct {
 }
 
 type GetRepoOpts struct {
+	Owner      string
+	Repository string
+}
+
+type DeleteRepoOpts struct {
 	Owner      string
 	Repository string
 }

--- a/pkg/git/gogithub/gogithub.go
+++ b/pkg/git/gogithub/gogithub.go
@@ -44,6 +44,7 @@ type Client interface {
 	GetContents(ctx context.Context, owner, repo, path string, opt *goGithub.RepositoryContentGetOptions) (
 		fileContent *goGithub.RepositoryContent, directoryContent []*goGithub.RepositoryContent, resp *goGithub.Response, err error,
 	)
+	DeleteRepo(ctx context.Context, owner, repo string) (*goGithub.Response, error)
 }
 
 type githubClient struct {
@@ -74,6 +75,10 @@ func (ggc *githubClient) Organization(ctx context.Context, org string) (*goGithu
 
 func (ggc *githubClient) GetContents(ctx context.Context, owner, repo, path string, opt *goGithub.RepositoryContentGetOptions) (fileContent *goGithub.RepositoryContent, directoryContent []*goGithub.RepositoryContent, resp *goGithub.Response, err error) {
 	return ggc.client.Repositories.GetContents(ctx, owner, repo, path, opt)
+}
+
+func (ggc *githubClient) DeleteRepo(ctx context.Context, owner, repo string) (*goGithub.Response, error) {
+	return ggc.client.Repositories.Delete(ctx, owner, repo)
 }
 
 // CreateRepo creates an empty Github Repository. The repository must be initialized locally or
@@ -193,6 +198,18 @@ func (g *GoGithub) PathExists(ctx context.Context, owner, repo, branch, path str
 	}
 
 	return true, nil
+}
+
+// DeleteRepo deletes a Github repository.
+func (g *GoGithub) DeleteRepo(ctx context.Context, opts git.DeleteRepoOpts) error {
+	r := opts.Repository
+	o := opts.Owner
+	logger.V(3).Info("Deleting Github repository", "name", r, "owner", o)
+	_, err := g.Client.DeleteRepo(ctx, o, r)
+	if err != nil {
+		return fmt.Errorf("error when deleting repository %s: %v", r, err)
+	}
+	return nil
 }
 
 func newClient(ctx context.Context, opts Options) Client {

--- a/pkg/git/gogithub/mocks/client.go
+++ b/pkg/git/gogithub/mocks/client.go
@@ -51,6 +51,21 @@ func (mr *MockClientMockRecorder) CreateRepo(arg0, arg1, arg2 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRepo", reflect.TypeOf((*MockClient)(nil).CreateRepo), arg0, arg1, arg2)
 }
 
+// DeleteRepo mocks base method.
+func (m *MockClient) DeleteRepo(arg0 context.Context, arg1, arg2 string) (*github.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRepo", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*github.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteRepo indicates an expected call of DeleteRepo.
+func (mr *MockClientMockRecorder) DeleteRepo(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRepo", reflect.TypeOf((*MockClient)(nil).DeleteRepo), arg0, arg1, arg2)
+}
+
 // GetContents mocks base method.
 func (m *MockClient) GetContents(arg0 context.Context, arg1, arg2, arg3 string, arg4 *github.RepositoryContentGetOptions) (*github.RepositoryContent, []*github.RepositoryContent, *github.Response, error) {
 	m.ctrl.T.Helper()

--- a/pkg/git/mocks/git.go
+++ b/pkg/git/mocks/git.go
@@ -106,6 +106,20 @@ func (mr *MockProviderMockRecorder) CreateRepo(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRepo", reflect.TypeOf((*MockProvider)(nil).CreateRepo), arg0, arg1)
 }
 
+// DeleteRepo mocks base method.
+func (m *MockProvider) DeleteRepo(arg0 context.Context, arg1 git.DeleteRepoOpts) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRepo", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRepo indicates an expected call of DeleteRepo.
+func (mr *MockProviderMockRecorder) DeleteRepo(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRepo", reflect.TypeOf((*MockProvider)(nil).DeleteRepo), arg0, arg1)
+}
+
 // GetRepo mocks base method.
 func (m *MockProvider) GetRepo(arg0 context.Context) (*git.Repository, error) {
 	m.ctrl.T.Helper()

--- a/pkg/git/providers/github/github.go
+++ b/pkg/git/providers/github/github.go
@@ -59,6 +59,7 @@ type GithubProviderClient interface {
 	GetAccessTokenPermissions(accessToken string) (string, error)
 	CheckAccessTokenPermissions(checkPATPermission string, allPermissionScopes string) error
 	PathExists(ctx context.Context, owner, repo, branch, path string) (bool, error)
+	DeleteRepo(ctx context.Context, opts git.DeleteRepoOpts) error
 }
 
 func New(gitProviderClient GitProviderClient, githubProviderClient GithubProviderClient, opts Options, auth git.TokenAuth) (git.Provider, error) {
@@ -196,6 +197,10 @@ func (g *githubProvider) RepoUrl() string {
 
 func (g *githubProvider) PathExists(ctx context.Context, owner, repo, branch, path string) (bool, error) {
 	return g.githubProviderClient.PathExists(ctx, owner, repo, branch, path)
+}
+
+func (g *githubProvider) DeleteRepo(ctx context.Context, opts git.DeleteRepoOpts) error {
+	return g.githubProviderClient.DeleteRepo(ctx, opts)
 }
 
 type GitProviderNotFoundError struct {

--- a/pkg/git/providers/github/mocks/github.go
+++ b/pkg/git/providers/github/mocks/github.go
@@ -227,6 +227,20 @@ func (mr *MockGithubProviderClientMockRecorder) CreateRepo(arg0, arg1 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRepo", reflect.TypeOf((*MockGithubProviderClient)(nil).CreateRepo), arg0, arg1)
 }
 
+// DeleteRepo mocks base method.
+func (m *MockGithubProviderClient) DeleteRepo(arg0 context.Context, arg1 git.DeleteRepoOpts) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRepo", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRepo indicates an expected call of DeleteRepo.
+func (mr *MockGithubProviderClientMockRecorder) DeleteRepo(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRepo", reflect.TypeOf((*MockGithubProviderClient)(nil).DeleteRepo), arg0, arg1)
+}
+
 // GetAccessTokenPermissions mocks base method.
 func (m *MockGithubProviderClient) GetAccessTokenPermissions(arg0 string) (string, error) {
 	m.ctrl.T.Helper()

--- a/test/framework/e2e.go
+++ b/test/framework/e2e.go
@@ -26,6 +26,7 @@ import (
 const (
 	defaultClusterConfigFile = "cluster.yaml"
 	defaultClusterName       = "eksa-test"
+	JobIdVar                 = "T_JOB_ID"
 )
 
 //go:embed testdata/oidc-roles.yaml
@@ -107,6 +108,10 @@ func (e *E2ETest) CreateCluster() {
 	e.cleanup(func() {
 		os.RemoveAll(e.ClusterName)
 	})
+	// Setting GitRepo cleanup if the test has GitOps configured
+	if e.GitOpsConfig != nil {
+		e.T.Cleanup(e.CleanUpGithubRepo)
+	}
 }
 
 func (e *E2ETest) ValidateCluster(kubeVersion v1alpha1.KubernetesVersion) {
@@ -283,4 +288,8 @@ func (e *E2ETest) clusterConfig() *v1alpha1.Cluster {
 	e.ClusterConfig = c
 
 	return e.ClusterConfig
+}
+
+func (e *E2ETest) getJobIdFromEnv() string {
+	return os.Getenv(JobIdVar)
 }


### PR DESCRIPTION
*Description of changes:*
As part of enabling Flux e2e tests we wanted to delete the repos that we auto create.

- Added DELETE_REPO api support to git provider.
- Modified the flux e2e tests to call delete repo as a final step

I have not enabled running these tests in this PR. Will do in a follow up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
