### PR TITLE
Use public ECR regex for replacing manifest image

### DIFF
--- a/release/pkg/prepare_release.go
+++ b/release/pkg/prepare_release.go
@@ -159,7 +159,7 @@ func (r *ReleaseConfig) renameArtifacts(sourceClients *SourceClients, artifacts 
 					if err != nil {
 						return errors.Cause(err)
 					}
-					regex := fmt.Sprintf("%s/%s.*", r.SourceContainerRegistry, imageTagOverride.Repository)
+					regex := fmt.Sprintf("public.ecr.aws.*%s.*", imageTagOverride.Repository)
 					compiledRegex, err := regexp.Compile(regex)
 					if err != nil {
 						return errors.Cause(err)


### PR DESCRIPTION
Using public ECR regex in release tooling to replace images in clusterctl override manifests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
