### PR TITLE
Implement retry for EC2 instance creation

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -43,6 +43,7 @@ phases:
       -n ${INTEGRATION_TEST_SUBNET_ID}
       -m 40
       -r 'Test'
+      -v 4
       --skip 'TestDockerKubernetes119Flux,TestDockerKubernetes119ThreeReplicasFlux,TestVSphereKubernetes119Flux,TestVSphereKubernetes119ThreeReplicasFlux,TestDockerKubernetes118Flux,TestDockerKubernetes12OFlux,TestDockerKubernetes121Flux,TestVSphereKubernetes118Flux,TestVSphereKubernetes120Flux,TestVSphereKubernetes121Flux,TestDockerKubernetes119GitopsOptionsFlux,TestVSphereKubernetes119GitopsOptionsFlux,TestVSphereKubernetes120UbuntuTo121WithFluxUpgrade,TestVSphereKubernetes120BottlerocketTo121WithFluxUpgrade'
   post_build:
     commands:

--- a/internal/pkg/ec2/create.go
+++ b/internal/pkg/ec2/create.go
@@ -2,53 +2,74 @@ package ec2
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/retrier"
 )
 
 func CreateInstance(session *session.Session, amiId, key, tag, instanceProfileName, subnetId, name string) (string, error) {
-	service := ec2.New(session)
+	r := retrier.New(180*time.Minute, retrier.WithRetryPolicy(func(totalRetries int, err error) (retry bool, wait time.Duration) {
+		// EC2 Request token bucket has a refill rate of 2 request tokens
+		// per second, so 10 seconds wait per retry should be sufficient
+		if request.IsErrorThrottle(err) && totalRetries < 50 {
+			return true, 10 * time.Second
+		}
+		return false, 0
+	}))
 
-	logger.V(2).Info("Creating instance", "name", name)
-	result, err := service.RunInstances(&ec2.RunInstancesInput{
-		ImageId:      aws.String(amiId),
-		InstanceType: aws.String("t3.2xlarge"),
-		MinCount:     aws.Int64(1),
-		MaxCount:     aws.Int64(1),
-		BlockDeviceMappings: []*ec2.BlockDeviceMapping{
-			{
-				DeviceName: aws.String("/dev/xvda"),
-				Ebs: &ec2.EbsBlockDevice{
-					VolumeSize: aws.Int64(100),
-				},
-			},
-		},
-		IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
-			Name: aws.String(instanceProfileName),
-		},
-		SubnetId: aws.String(subnetId),
-		TagSpecifications: []*ec2.TagSpecification{
-			{
-				ResourceType: aws.String("instance"),
-				Tags: []*ec2.Tag{
-					{
-						Key:   aws.String(key),
-						Value: aws.String(tag),
-					},
-					{
-						Key:   aws.String("Name"),
-						Value: aws.String(name),
+	service := ec2.New(session)
+	var result *ec2.Reservation
+
+	err := r.Retry(func() error {
+		var err error
+		logger.V(2).Info("Creating instance", "name", name)
+		result, err = service.RunInstances(&ec2.RunInstancesInput{
+			ImageId:      aws.String(amiId),
+			InstanceType: aws.String("t3.2xlarge"),
+			MinCount:     aws.Int64(1),
+			MaxCount:     aws.Int64(1),
+			BlockDeviceMappings: []*ec2.BlockDeviceMapping{
+				{
+					DeviceName: aws.String("/dev/xvda"),
+					Ebs: &ec2.EbsBlockDevice{
+						VolumeSize: aws.Int64(100),
 					},
 				},
 			},
-		},
+			IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
+				Name: aws.String(instanceProfileName),
+			},
+			SubnetId: aws.String(subnetId),
+			TagSpecifications: []*ec2.TagSpecification{
+				{
+					ResourceType: aws.String("instance"),
+					Tags: []*ec2.Tag{
+						{
+							Key:   aws.String(key),
+							Value: aws.String(tag),
+						},
+						{
+							Key:   aws.String("Name"),
+							Value: aws.String(name),
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("error creating instance: %v", err)
+		}
+
+		return nil
 	})
 	if err != nil {
-		return "", fmt.Errorf("error creating instance: %v", err)
+		return "", fmt.Errorf("retries exhausted when trying to create instances: %v", err)
 	}
 
 	logger.V(2).Info("Waiting until the instance starts running")


### PR DESCRIPTION
Launching Amazon EC2 instances is subject to request rate limiting. So our e2e job should implement retry logic to accommodate the refill rate of the EC2 request token bucket.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
