### PR TITLE
Change connector wording per docs team

### DIFF
--- a/docs/content/en/docs/tasks/cluster/cluster-connect.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-connect.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect cluster"
+title: "Connect cluster to console"
 linkTitle: "Connect cluster"
 weight: 13
 date: 2017-01-05
@@ -7,8 +7,7 @@ description: >
   Connect a cluster to the EKS console
 ---
 
-You can install EKS Connector to connect your EKS Anywhere cluster to AWS EKS.
-EKS Connector is a software agent that you can install on the EKS Anywhere cluster that enables the cluster to register with the EKS console.
-Once your cluster is connected, you will be able to see the cluster, its configuration, and workloads, and their status in the EKS console.
+The AWS EKS Connector lets you connect your EKS Anywhere cluster to the AWS EKS console, where you can see your the EKS Anywhere cluster, its configuration, workloads, and their status.
+EKS Connector is a software agent that can be deployed on your EKS Anywhere cluster, enabling the cluster to register with the EKS console.
 
-Visit [AWS Connector](https://docs.aws.amazon.com/eks/latest/userguide/eks-connector.html) for details.
+Visit [AWS EKS Connector](https://docs.aws.amazon.com/eks/latest/userguide/eks-connector.html) for details.


### PR DESCRIPTION
*Description of changes:*

This PR changes the name of the link on the bottom of the page from "AWS Connector" to "AWS EKS Connector" , per a request from the docs team. While I was in there, I changed some of the other wording as well.