### PR TITLE
Dropping the CLA line

### DIFF
--- a/docs/content/en/docs/community/contributing.md
+++ b/docs/content/en/docs/community/contributing.md
@@ -82,7 +82,3 @@ See the
 [LICENSE](https://github.com/aws/eks-anywhere/blob/main/LICENSE)
 file for the project's licensing. We will ask you to confirm the licensing
 of your contribution.
-
-We may ask you to sign a
-[Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement)
-for larger changes.


### PR DESCRIPTION
Hi, Amazon OSPO here,

*Description of changes:*

I've removed the CLA line from the website page on contributing. You'll note that it's no longer in the CONTRIBUTING.md file that is setup by default.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
