### PR TITLE
Use source ECR registry name for regex

### DIFF
--- a/release/pkg/prepare_release.go
+++ b/release/pkg/prepare_release.go
@@ -159,7 +159,7 @@ func (r *ReleaseConfig) renameArtifacts(sourceClients *SourceClients, artifacts 
 					if err != nil {
 						return errors.Cause(err)
 					}
-					regex := fmt.Sprintf("public.ecr.aws.*%s.*", imageTagOverride.Repository)
+					regex := fmt.Sprintf("%s/%s.*", r.SourceContainerRegistry, imageTagOverride.Repository)
 					compiledRegex, err := regexp.Compile(regex)
 					if err != nil {
 						return errors.Cause(err)


### PR DESCRIPTION
Use source ECR registry for regex replace during release.
Dev release - private ECR (build)
Staging release - private ECR (build)
Prod release - public ECR (staging)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
