### PR TITLE
Enabling Flux e2e test

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -25,6 +25,9 @@ env:
     T_VSPHERE_TEMPLATE_BR_1_21: "vsphere_ci_beta_connection:template_br_21"
     T_VSPHERE_TLS_INSECURE: "vsphere_ci_beta_connection:tls_insecure"
     T_VSPHERE_TLS_THUMBPRINT: "vsphere_ci_beta_connection:tls_thumbprint"
+    EKSA_GITHUB_TOKEN: "github-eks-anywhere-flux-bot:github-token"
+    T_GITHUB_USER: "github-eks-anywhere-flux-bot:github-user"
+    T_GIT_REPOSITORY: "github-eks-anywhere-flux-bot:github-repository"
 
 phases:
   pre_build:
@@ -44,7 +47,6 @@ phases:
       -m 40
       -r 'Test'
       -v 5
-      --skip 'TestDockerKubernetes119Flux,TestDockerKubernetes119ThreeReplicasFlux,TestVSphereKubernetes119Flux,TestVSphereKubernetes119ThreeReplicasFlux,TestDockerKubernetes118Flux,TestDockerKubernetes12OFlux,TestDockerKubernetes121Flux,TestVSphereKubernetes118Flux,TestVSphereKubernetes120Flux,TestVSphereKubernetes121Flux,TestDockerKubernetes119GitopsOptionsFlux,TestVSphereKubernetes119GitopsOptionsFlux,TestVSphereKubernetes120UbuntuTo121WithFluxUpgrade,TestVSphereKubernetes120BottlerocketTo121WithFluxUpgrade'
   post_build:
     commands:
     - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE

--- a/test/e2e/flux_test.go
+++ b/test/e2e/flux_test.go
@@ -34,60 +34,7 @@ func runFluxFlow(test *framework.E2ETest) {
 	test.DeleteCluster()
 }
 
-func TestDockerKubernetes119Flux(t *testing.T) {
-	test := framework.NewE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube119)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithFlux(),
-	)
-	runFluxFlow(test)
-}
-
-func TestDockerKubernetes119ThreeReplicasFlux(t *testing.T) {
-	test := framework.NewE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube119)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithFlux(),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes119Flux(t *testing.T) {
-	test := framework.NewE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu119()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube119)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithFlux(),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes119ThreeReplicasFlux(t *testing.T) {
-	test := framework.NewE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu119()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube119)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithFlux(),
-	)
-	runFluxFlow(test)
-}
-
-func TestDockerKubernetes118Flux(t *testing.T) {
-	test := framework.NewE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithFlux(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube118)),
-	)
-	runFluxFlow(test)
-}
-
-func TestDockerKubernetes12OFlux(t *testing.T) {
+func TestDockerKubernetes120Flux(t *testing.T) {
 	test := framework.NewE2ETest(t,
 		framework.NewDocker(t),
 		framework.WithFlux(),
@@ -101,15 +48,6 @@ func TestDockerKubernetes121Flux(t *testing.T) {
 		framework.NewDocker(t),
 		framework.WithFlux(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes118Flux(t *testing.T) {
-	test := framework.NewE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu118()),
-		framework.WithFlux(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube118)),
 	)
 	runFluxFlow(test)
 }
@@ -132,30 +70,61 @@ func TestVSphereKubernetes121Flux(t *testing.T) {
 	runFluxFlow(test)
 }
 
-func TestDockerKubernetes119GitopsOptionsFlux(t *testing.T) {
+func TestVSphereKubernetes120BottleRocketFlux(t *testing.T) {
 	test := framework.NewE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube119)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithFlux(api.WithFluxBranch(fluxUserProvidedBranch)),
-		framework.WithFlux(api.WithFluxNamespace(fluxUserProvidedNamespace)),
-		framework.WithFlux(api.WithFluxConfigurationPath(fluxUserProvidedPath)),
+		framework.NewVSphere(t, framework.WithBottleRocket120()),
+		framework.WithFlux(),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
+	)
+	runFluxFlow(test)
+}
+
+func TestVSphereKubernetes121BottleRocketFlux(t *testing.T) {
+	test := framework.NewE2ETest(t,
+		framework.NewVSphere(t, framework.WithBottleRocket121()),
+		framework.WithFlux(),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+	)
+	runFluxFlow(test)
+}
+
+func TestVSphereKubernetes121ThreeReplicasThreeWorkersFlux(t *testing.T) {
+	test := framework.NewE2ETest(t,
+		framework.NewVSphere(t, framework.WithUbuntu121()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
 		framework.WithFlux(),
 	)
 	runFluxFlow(test)
 }
 
-func TestVSphereKubernetes119GitopsOptionsFlux(t *testing.T) {
+func TestDockerKubernetes121GitopsOptionsFlux(t *testing.T) {
 	test := framework.NewE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu119()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube119)),
+		framework.NewDocker(t),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithFlux(api.WithFluxBranch(fluxUserProvidedBranch)),
-		framework.WithFlux(api.WithFluxNamespace(fluxUserProvidedNamespace)),
-		framework.WithFlux(api.WithFluxConfigurationPath(fluxUserProvidedPath)),
-		framework.WithFlux(),
+		framework.WithFlux(
+			api.WithFluxBranch(fluxUserProvidedBranch),
+			api.WithFluxNamespace(fluxUserProvidedNamespace),
+			api.WithFluxConfigurationPath(fluxUserProvidedPath),
+		),
+	)
+	runFluxFlow(test)
+}
+
+func TestVSphereKubernetes121GitopsOptionsFlux(t *testing.T) {
+	test := framework.NewE2ETest(t,
+		framework.NewVSphere(t, framework.WithUbuntu121()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithFlux(
+			api.WithFluxBranch(fluxUserProvidedBranch),
+			api.WithFluxNamespace(fluxUserProvidedNamespace),
+			api.WithFluxConfigurationPath(fluxUserProvidedPath),
+		),
 	)
 	runFluxFlow(test)
 }


### PR DESCRIPTION
*Description of changes:*
Enabling Flux e2e test runs. Also modified the flux tests to run only currently supported k8s versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
