### PR TITLE
Decrease log verbosity and increase retry wait during e2e tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -46,7 +46,7 @@ phases:
       -n ${INTEGRATION_TEST_SUBNET_ID}
       -m 40
       -r 'Test'
-      -v 5
+      -v 4
   post_build:
     commands:
     - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE

--- a/internal/pkg/ssm/command.go
+++ b/internal/pkg/ssm/command.go
@@ -52,8 +52,8 @@ func Run(session *session.Session, instanceId string, command string, opts ...Co
 	}
 	var result *ssm.SendCommandOutput
 	r := retrier.New(180*time.Minute, retrier.WithRetryPolicy(func(totalRetries int, err error) (retry bool, wait time.Duration) {
-		if request.IsErrorThrottle(err) && totalRetries < 50 {
-			return true, 10 * time.Second
+		if request.IsErrorThrottle(err) && totalRetries < 60 {
+			return true, 60 * time.Second
 		}
 		return false, 0
 	}))
@@ -62,7 +62,7 @@ func Run(session *session.Session, instanceId string, command string, opts ...Co
 		logger.V(2).Info("Running ssm command", "cmd", command)
 		result, err = service.SendCommand(c)
 		if err != nil {
-			return fmt.Errorf("error sending ssm command: %v", err)
+			return err
 		}
 		return nil
 	})
@@ -99,7 +99,7 @@ func Run(session *session.Session, instanceId string, command string, opts ...Co
 
 	logger.V(2).Info("Waiting for ssm command to finish")
 	var commandOut *ssm.GetCommandInvocationOutput
-	r = retrier.New(180*time.Minute, retrier.WithMaxRetries(2160, 15*time.Second))
+	r = retrier.New(180*time.Minute, retrier.WithMaxRetries(2160, 60*time.Second))
 	err = r.Retry(func() error {
 		var err error
 		commandOut, err = service.GetCommandInvocation(commandIn)


### PR DESCRIPTION
* Decrease verbosity of logs
* Increase timeout and max retries for SSM `SendCommand` call


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
