### PR TITLE
Check for failed conformance tests

### DIFF
--- a/test/framework/conformance.go
+++ b/test/framework/conformance.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/eks-anywhere/internal/pkg/conformance"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -41,6 +42,10 @@ func (e *E2ETest) RunConformanceTests() {
 		return
 	}
 	e.T.Logf("Conformance Test results:\n %v", results)
+	if hasFailed(results) {
+		e.T.Errorf("Conformance run has failed tests")
+		return
+	}
 }
 
 func (e *E2ETest) getEksdReleaseKubeVersion() (string, error) {
@@ -56,4 +61,12 @@ func (e *E2ETest) getEksdReleaseKubeVersion() (string, error) {
 		return kubeVersion, nil
 	}
 	return "", fmt.Errorf("error getting KubeVersion from EKS-D release spec: value empty")
+}
+
+// Function to parse the conformace test results and look for any failed tests.
+// By default we run 2 plugins so we check for failed tests in twice.
+func hasFailed(results string) bool {
+	failedLog := "Failed: 0"
+	count := strings.Count(results, failedLog)
+	return count != 2
 }


### PR DESCRIPTION
*Description of changes:*
Parsing conformance test result logs to check for failed tests.
Since by default we run 2 plugins, the Sonobuoy logs should contain two failed tests messages, `Failed: 0`

Example log
`Plugin: e2e
Status: passed
Total: 5668
Passed: 311
Failed: 0
Skipped: 5357`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
