### PR TITLE
initial setup of troubleshoot executable

### DIFF
--- a/pkg/executables/builder.go
+++ b/pkg/executables/builder.go
@@ -46,6 +46,10 @@ func (b *ExecutableBuilder) BuildFluxExecutable() *Flux {
 	return NewFlux(buildExecutable(fluxPath, b.useDocker, b.image, b.mountDir))
 }
 
+func (b *ExecutableBuilder) BuildTroubleshootExecutable() *Troubleshoot {
+	return NewTroubleshoot(buildExecutable(troulbeshootPath, b.useDocker, b.image, b.mountDir))
+}
+
 func BuildSonobuoyExecutable() *Sonobuoy {
 	return NewSonobuoy(&executable{
 		cli: sonobuoyPath,

--- a/pkg/executables/troubleshoot.go
+++ b/pkg/executables/troubleshoot.go
@@ -1,0 +1,15 @@
+package executables
+
+const (
+	troulbeshootPath = "support-bundle"
+)
+
+type Troubleshoot struct {
+	executable Executable
+}
+
+func NewTroubleshoot(executable Executable) *Troubleshoot {
+	return &Troubleshoot{
+		executable: executable,
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Initial setup for the use of troubleshoot executable. 

This will be followed by porting over, piecemeal, the functionality of the `support` package to interface with this binary rather than using the troubleshoot go library. 

The `replicatedhq/troubleshoot` binary is already built into our tools image -- see https://github.com/aws/eks-anywhere-build-tooling/pull/42

part of https://github.com/aws/eks-anywhere/issues/188

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.