### PR TITLE
Fix labeler regex

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,2 @@
 documentation:
-- docs/*
+- docs/**/*


### PR DESCRIPTION
My regex was wrong for subdirectories. I tested this on my own repo and it works for subdirs.
