### PR TITLE
fix typo in troubleshoot executable

### DIFF
--- a/pkg/executables/builder.go
+++ b/pkg/executables/builder.go
@@ -47,7 +47,7 @@ func (b *ExecutableBuilder) BuildFluxExecutable() *Flux {
 }
 
 func (b *ExecutableBuilder) BuildTroubleshootExecutable() *Troubleshoot {
-	return NewTroubleshoot(buildExecutable(troulbeshootPath, b.useDocker, b.image, b.mountDir))
+	return NewTroubleshoot(buildExecutable(troubleshootPath, b.useDocker, b.image, b.mountDir))
 }
 
 func BuildSonobuoyExecutable() *Sonobuoy {

--- a/pkg/executables/troubleshoot.go
+++ b/pkg/executables/troubleshoot.go
@@ -1,7 +1,7 @@
 package executables
 
 const (
-	troulbeshootPath = "support-bundle"
+	troubleshootPath = "support-bundle"
 )
 
 type Troubleshoot struct {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I can't NOT type `troulbeshoot`, pronounced troll-b-shoot

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
