### PR TITLE
Bumping max EC2 count for e2e tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -2,6 +2,7 @@ version: 0.2
 
 env:
   variables:
+    INTEGRATION_TEST_MAX_EC2_COUNT: 45
     T_VSPHERE_CIDR: "198.18.0.0/16"
   secrets-manager:
     EKSA_VSPHERE_USERNAME: "vsphere_ci_beta_connection:vsphere_username"
@@ -44,7 +45,7 @@ phases:
       -j ${JOB_ID}
       -i ${INTEGRATION_TEST_INSTANCE_PROFILE}
       -n ${INTEGRATION_TEST_SUBNET_ID}
-      -m 40
+      -m ${INTEGRATION_TEST_MAX_EC2_COUNT}
       -r 'Test'
       -v 4
   post_build:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -51,3 +51,14 @@ T_GITHUB_USER
 GITHUB_TOKEN
 ```
 The [oidc](https://github.com/aws/eks-anywhere/blob/main/internal/pkg/oidc/server.go) and [e2e](https://github.com/aws/eks-anywhere/blob/main/internal/test/e2e/oidc.go) packages can be used to create a minimal compliant OIDC server in S3 
+
+# Adding new tests
+When adding new tests to run in our postsubmit environment we need to bump up the total number of EC2s we create for the tests.
+
+The value is controlled by the `INTEGRATION_TEST_MAX_EC2_COUNT` env variable in the [test-eks-a-cli.yaml](https://github.com/aws/eks-anywhere/blob/main/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml) buildspec.
+
+```
+env:
+  variables:
+    INTEGRATION_TEST_MAX_EC2_COUNT: <COUNT>
+```


### PR DESCRIPTION
*Description of changes:*
Increasing the max on the number of EC2s we create for e2e tests. Also added a note on the readme to increase the count when adding new tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
