### PR TITLE
Fix Bottlerocket filepaths in template

### DIFF
--- a/pkg/providers/vsphere/config/template.yaml
+++ b/pkg/providers/vsphere/config/template.yaml
@@ -180,7 +180,11 @@ spec:
 {{ .apiserverExtraArgs.ToYaml | indent 10 }}
 {{- end }}
         extraVolumes:
+{{- if (eq .format "bottlerocket") }}
+        - hostPath: /var/lib/kubeadm/audit-policy.yaml
+{{- else }}
         - hostPath: /etc/kubernetes/audit-policy.yaml
+{{- end }}
           mountPath: /etc/kubernetes/audit-policy.yaml
           name: audit-policy
           pathType: File

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd.yaml
@@ -153,7 +153,7 @@ spec:
           oidc-username-claim: username-claim
           oidc-username-prefix: username-prefix1
         extraVolumes:
-        - hostPath: /etc/kubernetes/audit-policy.yaml
+        - hostPath: /var/lib/kubeadm/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml
           name: audit-policy
           pathType: File


### PR DESCRIPTION
Writing file to `/var/lib/kubeadm` instead of `/etc`, and hosting from there.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
