### PR TITLE
Fix issue with labeling workflow

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,7 +6,7 @@
 # https://github.com/actions/labeler
 
 name: Labeler
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   label:

--- a/cmd/integration_test/build/script/upload_artifacts.sh
+++ b/cmd/integration_test/build/script/upload_artifacts.sh
@@ -82,7 +82,7 @@ function build::cli::upload() {
 
   echo "$githash" >> "$artifactspath"/githash
 
-  # Upload artifacts to s3 
+  # Upload artifacts to s3
   # 1. To proper path on s3 with buildId-githash
   # 2. Latest path to indicate the latest build, with --delete option to delete stale files in the dest path
   aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --acl public-read

--- a/docs/content/en/docs/concepts/clusterworkflow.md
+++ b/docs/content/en/docs/concepts/clusterworkflow.md
@@ -7,7 +7,7 @@ description: >
   Explanation of the process of creating an EKS Anywhere cluster
 ---
 
-The EKS Anywhere cluster creation process makes it easy to bring up a cluster initially, but also to update configuration settings and to upgrade Kubernetes versions going forward.
+The EKS Anywhere cluster creation process makes it easy not only to bring up a cluster initially, but also to update configuration settings and to upgrade Kubernetes versions going forward.
 The EKS Anywhere cluster versions match the same Kubernetes distribution versions that are used in the AWS EKS cloud service.
 
 Each EKS Anywhere cluster is built from a cluster specification file, with the structure of the configuration file based on the target provider for the cluster.

--- a/release/scripts/release.sh
+++ b/release/scripts/release.sh
@@ -26,7 +26,7 @@ RELEASE_BUCKET="${3?Specify third argument - release bucket}"
 CDN="${4?Specify fourth argument - cdn}"
 SOURCE_CONTAINER_REGISTRY="${5?Specify fifth argument - source container registry}"
 RELEASE_CONTAINER_REGISTRY="${6?Specify sixth argument - release container registry}"
- 
+
 mkdir -p "${ARTIFACTS_DIR}"
 
 ${BASE_DIRECTORY}/release/bin/eks-anywhere-release release \


### PR DESCRIPTION
From a blog I read online
> GitHub Actions has always been about more than just continuous integration. Our goal is to enable repository maintainers to automate a variety of workflows and reduce manual effort. In order to protect public repositories for malicious users we run all pull request workflows raised from repository forks with a read-only token and no access to secrets. This makes common workflows like labeling or commenting on pull requests very difficult.
>
>In order to solve this, we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request. This event can be used in combination with the private repository settings as well.

Fingers crossed 🤞 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
