### PR TITLE
Change directory used by ssm commands

### DIFF
--- a/internal/pkg/ssm/command.go
+++ b/internal/pkg/ssm/command.go
@@ -14,6 +14,8 @@ import (
 	"github.com/aws/eks-anywhere/pkg/retrier"
 )
 
+var initE2EDirCommand = "mkdir -p /home/e2e/bin && cd /home/e2e"
+
 func WaitForSSMReady(session *session.Session, instanceId string) error {
 	err := retrier.Retry(10, 20*time.Second, func() error {
 		return Run(session, instanceId, "ls")
@@ -44,7 +46,7 @@ func Run(session *session.Session, instanceId string, command string, opts ...Co
 	c := &ssm.SendCommandInput{
 		DocumentName: aws.String("AWS-RunShellScript"),
 		InstanceIds:  []*string{aws.String(instanceId)},
-		Parameters:   map[string][]*string{"commands": {aws.String(command)}, "executionTimeout": {aws.String("10800")}},
+		Parameters:   map[string][]*string{"commands": {aws.String(initE2EDirCommand), aws.String(command)}, "executionTimeout": {aws.String("10800")}},
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
E2e tests use ssm commands for running tests, which includes downloading
the required binaries and running the command for e2e tests.
SSM by default starts a session with /usr/bin path. This is why all binaries
and test folder created by an e2e test gets saved under that path.
This commit adds a command to change directory to a new path /home/e2e
before running any other commands so that the generated test output is saved
under /home/e2e and not under /usr/bin

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
