### PR TITLE
Clarify controlPlaneConfiguration.endpoint.host requirements

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/vsphere.md
+++ b/docs/content/en/docs/reference/clusterspec/vsphere.md
@@ -111,8 +111,11 @@ Number of control plane nodes
 Refers to the Kubernetes object with vsphere specific configuration for your nodes. See `VSphereMachineConfig Fields` below.
 
 ### controlPlaneConfiguration.endpoint.host (required)
-A unique IP you want to use for the control plane VM in your EKS Anywhere cluster. Choose an IP in your networks
+A unique IP you want to use for the control plane VM in your EKS Anywhere cluster. Choose an IP in your network
 range that does not conflict with other VMs.
+
+>**_NOTE:_** This IP should be outside the network DHCP range as it is a floating IP that gets assigned to one of
+the control plane nodes for kube-apiserver loadbalancing.
 
 ### workerNodeGroupsConfiguration (required)
 This takes in a list of node groups that you can define for your workers. Please note that at this time only 1 node group is permitted.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`controlPlaneConfiguration.endpoint.host` should be outside the dhcp range so your dhcp server doesn't assign this IP to another machine. If this happens, the cluster creation can get stuck.

Specifying this requirement in the docs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
