### PR TITLE
Moved controlplane count and externaletcd count logs to cluster spec file

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -259,6 +259,11 @@ func validateControlPlaneReplicas(clusterConfig *Cluster) error {
 	if clusterConfig.Spec.ControlPlaneConfiguration.Count%2 == 0 {
 		return errors.New("control plane node count cannot be an even number")
 	}
+	if clusterConfig.Spec.ControlPlaneConfiguration.Count != 3 && clusterConfig.Spec.ControlPlaneConfiguration.Count != 5 {
+		if clusterConfig.Spec.DatacenterRef.Kind != DockerDatacenterKind {
+			logger.Info("Warning: The recommended number of control plane nodes is 3 or 5")
+		}
+	}
 	return nil
 }
 

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -421,12 +421,6 @@ func (p *vsphereProvider) setupAndValidateCluster(ctx context.Context, clusterSp
 	if err := os.Setenv(govcInsecure, strconv.FormatBool(p.datacenterConfig.Spec.Insecure)); err != nil {
 		return fmt.Errorf("unable to set %s: %v", govcInsecure, err)
 	}
-	if clusterSpec.Spec.ControlPlaneConfiguration.Count != 3 && clusterSpec.Spec.ControlPlaneConfiguration.Count != 5 && clusterSpec.Spec.ExternalEtcdConfiguration == nil {
-		logger.Info("Warning: The recommended number of control plane nodes is 3 or 5")
-	}
-	if clusterSpec.Spec.ExternalEtcdConfiguration != nil && clusterSpec.Spec.ExternalEtcdConfiguration.Count != 3 && clusterSpec.Spec.ExternalEtcdConfiguration.Count != 5 {
-		logger.Info("Warning: The recommended number of etcd machines is 3 or 5")
-	}
 	if len(clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host) <= 0 {
 		return errors.New("cluster controlPlaneConfiguration.Endpoint.Host is not set or is empty")
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Moved control plane and external etcd count logs from provider specific file to cluster.go file. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
