### PR TITLE
Add README and jobs for kube-bench

### DIFF
--- a/test/kube-bench/README.md
+++ b/test/kube-bench/README.md
@@ -1,0 +1,29 @@
+# Kube-bench
+
+[`kube-bench`](https://github.com/aquasecurity/kube-bench) is a security tool that checks whether Kubernetes is deployed securely by running the checks documented in the CIS Kubernetes Benchmark, for example, pod specification file permissions, setting insecure flags to false, etc.
+
+The ideal way to run the benchmark tests on your EKS Anywhere cluster is to apply the [Job YAML](jobs/controlplane/kube-bench-default.yaml) to the cluster. This runs the kube-bench tests on a Pod on the cluster, and the logs of the Pod provide the test results.
+
+Kube-bench currently does not support unstacked `etcd` topology (which is the default for EKS Anywhere), so the following checks are skipped in the default kube-bench Job YAML. If you created your EKS Anywhere cluster with stacked `etcd` configuration, you can apply the stacked `etcd` [Job YAML](jobs/controlplane/kube-bench-stacked-etcd.yaml) instead.
+
+| Check number | Check description |
+| :---: | :---: |
+| 1.1.7 | Ensure that the etcd pod specification file permissions are set to 644 or more restrictive |
+| 1.1.8 | Ensure that the etcd pod specification file ownership is set to root:root |
+| 1.1.11 | Ensure that the etcd data directory permissions are set to 700 or more restrictive |
+| 1.1.12 | Ensure that the etcd data directory ownership is set to etcd:etcd |
+
+The following tests are also skipped they are not applicable or check for settings that might make the cluster unstable.
+
+| Check number | Check description | Reason for skipping |
+| :---: | :---: | :---: |
+| **Controlplane node configuration** |
+| 1.2.6 | Ensure that the –kubelet-certificate-authority argument is set as appropriate | When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers |
+| 1.2.16 | Ensure that the admission control plugin PodSecurityPolicy is set | Enabling Pod Security Policy can cause applications to unexpectedly fail |
+| 1.2.32 | Ensure that the –encryption-provider-config argument is set as appropriate | Enabling encryption changes how data can be recovered as data is encrypted |
+| 1.2.33 | Ensure that encryption providers are appropriately configured | Enabling encryption changes how data can be recovered as data is encrypted |
+| **Worker node configuration** |
+| 4.2.6 | Ensure that the –protect-kernel-defaults argument is set to true | System level configurations are required before provisioning the cluster in order for this argument to be set to true |
+| 4.2.10 | Ensure that the–tls-cert-file and –tls-private-key-file arguments are set as appropriate | When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers |
+
+**Note:** Running kube-bench on Bottlerocket controlplane currently produces false negatives with respect to pod specification file (manifest) permissions, since the [default configuration](https://github.com/aquasecurity/kube-bench/blob/main/cfg/config.yaml) does not include the file locations in which Bottlerocket places these manifests. This issue is being tracked [here](https://github.com/aquasecurity/kube-bench/issues/996).

--- a/test/kube-bench/jobs/controlplane/kube-bench-default.yaml
+++ b/test/kube-bench/jobs/controlplane/kube-bench-default.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kube-bench-controlplane
+spec:
+  template:
+    spec:
+      hostPID: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: kube-bench
+          image: public.ecr.aws/aquasecurity/kube-bench:latest
+          command:
+          - kube-bench
+          args:
+          - run
+          - --targets
+          - master
+          - --version
+          - $(KUBERNETES_VERSION)
+          - --skip
+          - $(SKIPPED_TESTS)
+          # Uncomment to get more verbose logs for debugging
+          # - -v
+          # - 3
+          env:
+          - name: KUBERNETES_VERSION
+            value: "1.21"
+          - name: SKIPPED_TESTS
+            value: "1.1.7,1.1.8,1.1.11,1.1.12,1.2.6,1.2.16,1.2.32,1.2.33,1.2.34"
+          - n
+          volumeMounts:
+            - name: var-lib-etcd
+              mountPath: /var/lib/etcd
+              readOnly: true
+            - name: var-lib-kubelet
+              mountPath: /var/lib/kubelet
+              readOnly: true
+            - name: var-lib-kubeadm
+              mountPath: /var/lib/kubeadm
+              readOnly: true
+            - name: var-lib-kube-scheduler
+              mountPath: /var/lib/kube-scheduler
+              readOnly: true
+            - name: var-lib-kube-controller-manager
+              mountPath: /var/lib/kube-controller-manager
+              readOnly: true
+            - name: etc-systemd
+              mountPath: /etc/systemd
+              readOnly: true
+            - name: lib-systemd
+              mountPath: /lib/systemd/
+              readOnly: true
+            - name: etc-kubernetes
+              mountPath: /etc/kubernetes
+              readOnly: true
+            - name: etc-cni-netd
+              mountPath: /etc/cni/net.d/
+              readOnly: true
+            - name: opt-cni-bin
+              mountPath: /opt/cni/bin/
+              readOnly: true
+            - name: etc-passwd
+              mountPath: /etc/passwd
+              readOnly: true
+            - name: etc-group
+              mountPath: /etc/group
+              readOnly: true
+      restartPolicy: Never
+      volumes:
+        - name: var-lib-etcd
+          hostPath:
+            path: "/var/lib/etcd"
+        - name: var-lib-kubelet
+          hostPath:
+            path: "/var/lib/kubelet"
+        - name: var-lib-kubeadm
+          hostPath:
+            path: "/var/lib/kubeadm"
+        - name: var-lib-kube-scheduler
+          hostPath:
+            path: "/var/lib/kube-scheduler"
+        - name: var-lib-kube-controller-manager
+          hostPath:
+            path: "/var/lib/kube-controller-manager"
+        - name: etc-systemd
+          hostPath:
+            path: "/etc/systemd"
+        - name: lib-systemd
+          hostPath:
+            path: "/lib/systemd"
+        - name: etc-kubernetes
+          hostPath:
+            path: "/etc/kubernetes"
+        - name: usr-bin
+          hostPath:
+            path: "/usr/bin"
+        - name: etc-cni-netd
+          hostPath:
+            path: "/etc/cni/net.d/"
+        - name: opt-cni-bin
+          hostPath:
+            path: "/opt/cni/bin/"
+        - name: etc-passwd
+          hostPath:
+            path: "/etc/passwd"
+        - name: etc-group
+          hostPath:
+            path: "/etc/group"

--- a/test/kube-bench/jobs/controlplane/kube-bench-stacked-etcd.yaml
+++ b/test/kube-bench/jobs/controlplane/kube-bench-stacked-etcd.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kube-bench-controlplane
+spec:
+  template:
+    spec:
+      hostPID: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: kube-bench
+          image: public.ecr.aws/aquasecurity/kube-bench:latest
+          command:
+          - kube-bench
+          args:
+          - run
+          - --targets
+          - master
+          - --version
+          - $(KUBERNETES_VERSION)
+          - --skip
+          - $(SKIPPED_TESTS)
+          # Uncomment to get more verbose logs for debugging
+          # - -v
+          # - 3
+          env:
+          - name: KUBERNETES_VERSION
+            value: "1.21"
+          - name: SKIPPED_TESTS
+            value: "1.2.6,1.2.16,1.2.32,1.2.33"
+          volumeMounts:
+            - name: var-lib-etcd
+              mountPath: /var/lib/etcd
+              readOnly: true
+            - name: var-lib-kubelet
+              mountPath: /var/lib/kubelet
+              readOnly: true
+            - name: var-lib-kubeadm
+              mountPath: /var/lib/kubeadm
+              readOnly: true
+            - name: var-lib-kube-scheduler
+              mountPath: /var/lib/kube-scheduler
+              readOnly: true
+            - name: var-lib-kube-controller-manager
+              mountPath: /var/lib/kube-controller-manager
+              readOnly: true
+            - name: etc-systemd
+              mountPath: /etc/systemd
+              readOnly: true
+            - name: lib-systemd
+              mountPath: /lib/systemd/
+              readOnly: true
+            - name: etc-kubernetes
+              mountPath: /etc/kubernetes
+              readOnly: true
+            - name: etc-cni-netd
+              mountPath: /etc/cni/net.d/
+              readOnly: true
+            - name: opt-cni-bin
+              mountPath: /opt/cni/bin/
+              readOnly: true
+            - name: etc-passwd
+              mountPath: /etc/passwd
+              readOnly: true
+            - name: etc-group
+              mountPath: /etc/group
+              readOnly: true
+      restartPolicy: Never
+      volumes:
+        - name: var-lib-etcd
+          hostPath:
+            path: "/var/lib/etcd"
+        - name: var-lib-kubelet
+          hostPath:
+            path: "/var/lib/kubelet"
+        - name: var-lib-kubeadm
+          hostPath:
+            path: "/var/lib/kubeadm"
+        - name: var-lib-kube-scheduler
+          hostPath:
+            path: "/var/lib/kube-scheduler"
+        - name: var-lib-kube-controller-manager
+          hostPath:
+            path: "/var/lib/kube-controller-manager"
+        - name: etc-systemd
+          hostPath:
+            path: "/etc/systemd"
+        - name: lib-systemd
+          hostPath:
+            path: "/lib/systemd"
+        - name: etc-kubernetes
+          hostPath:
+            path: "/etc/kubernetes"
+        - name: usr-bin
+          hostPath:
+            path: "/usr/bin"
+        - name: etc-cni-netd
+          hostPath:
+            path: "/etc/cni/net.d/"
+        - name: opt-cni-bin
+          hostPath:
+            path: "/opt/cni/bin/"
+        - name: etc-passwd
+          hostPath:
+            path: "/etc/passwd"
+        - name: etc-group
+          hostPath:
+            path: "/etc/group"

--- a/test/kube-bench/jobs/worker/kube-bench-node.yaml
+++ b/test/kube-bench/jobs/worker/kube-bench-node.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kube-bench-worker
+spec:
+  template:
+    spec:
+      hostPID: true
+      containers:
+        - name: kube-bench
+          image: public.ecr.aws/aquasecurity/kube-bench:latest
+          command:
+          - kube-bench
+          args:
+          - run
+          - --targets
+          - node
+          - --version
+          - $(KUBERNETES_VERSION)
+          - --skip
+          - $(SKIPPED_TESTS)
+          # Uncomment to get more verbose logs for debugging
+          # - -v
+          # - 3
+          env:
+          - name: KUBERNETES_VERSION
+            value: "1.21"
+          - name: SKIPPED_TESTS
+            value: "4.2.6,4.2.10"
+          volumeMounts:
+            - name: var-lib-etcd
+              mountPath: /var/lib/etcd
+              readOnly: true
+            - name: var-lib-kubelet
+              mountPath: /var/lib/kubelet
+              readOnly: true
+            - name: var-lib-kube-scheduler
+              mountPath: /var/lib/kube-scheduler
+              readOnly: true
+            - name: var-lib-kube-controller-manager
+              mountPath: /var/lib/kube-controller-manager
+              readOnly: true
+            - name: etc-systemd
+              mountPath: /etc/systemd
+              readOnly: true
+            - name: lib-systemd
+              mountPath: /lib/systemd/
+              readOnly: true
+            - name: etc-kubernetes
+              mountPath: /etc/kubernetes
+              readOnly: true
+            - name: etc-cni-netd
+              mountPath: /etc/cni/net.d/
+              readOnly: true
+            - name: opt-cni-bin
+              mountPath: /opt/cni/bin/
+              readOnly: true
+      restartPolicy: Never
+      volumes:
+        - name: var-lib-etcd
+          hostPath:
+            path: "/var/lib/etcd"
+        - name: var-lib-kubelet
+          hostPath:
+            path: "/var/lib/kubelet"
+        - name: var-lib-kube-scheduler
+          hostPath:
+            path: "/var/lib/kube-scheduler"
+        - name: var-lib-kube-controller-manager
+          hostPath:
+            path: "/var/lib/kube-controller-manager"
+        - name: etc-systemd
+          hostPath:
+            path: "/etc/systemd"
+        - name: lib-systemd
+          hostPath:
+            path: "/lib/systemd"
+        - name: etc-kubernetes
+          hostPath:
+            path: "/etc/kubernetes"
+        - name: usr-bin
+          hostPath:
+            path: "/usr/bin"
+        - name: etc-cni-netd
+          hostPath:
+            path: "/etc/cni/net.d/"
+        - name: opt-cni-bin
+          hostPath:
+            path: "/opt/cni/bin/"


### PR DESCRIPTION
Add Readme and Job YAMLs for running kube-bench tests on EKS Anywhere clusters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
