### PR TITLE
Exclude fields like `Status` and `creationTimestamp`

### DIFF
--- a/pkg/addonmanager/addonclients/testdata/cluster-config-default-path.yaml
+++ b/pkg/addonmanager/addonclients/testdata/cluster-config-default-path.yaml
@@ -1,7 +1,6 @@
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Cluster
 metadata:
-  creationTimestamp: null
   name: fluxAddonTestCluster
 spec:
   clusterNetwork:
@@ -13,7 +12,6 @@ spec:
     kind: GitOpsConfig
     name: test-gitops
   kubernetesVersion: "1.19"
-status: {}
 
 ---
 kind: VSphereDatacenterConfig
@@ -47,7 +45,6 @@ status: {}
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: GitOpsConfig
 metadata:
-  creationTimestamp: null
   name: test-gitops
   namespace: default
 spec:
@@ -59,6 +56,5 @@ spec:
       owner: mFowler
       personal: true
       repository: testRepo
-status: {}
 
 ---

--- a/pkg/addonmanager/addonclients/testdata/cluster-config-user-provided-path.yaml
+++ b/pkg/addonmanager/addonclients/testdata/cluster-config-user-provided-path.yaml
@@ -1,7 +1,6 @@
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Cluster
 metadata:
-  creationTimestamp: null
   name: fluxAddonTestCluster
 spec:
   clusterNetwork:
@@ -13,7 +12,6 @@ spec:
     kind: GitOpsConfig
     name: test-gitops
   kubernetesVersion: "1.19"
-status: {}
 
 ---
 kind: VSphereDatacenterConfig
@@ -47,7 +45,6 @@ status: {}
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: GitOpsConfig
 metadata:
-  creationTimestamp: null
   name: test-gitops
   namespace: default
 spec:
@@ -59,6 +56,5 @@ spec:
       owner: mFowler
       personal: true
       repository: testRepo
-status: {}
 
 ---

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -267,6 +267,20 @@ func (c *Cluster) EtcdAnnotation() string {
 	return etcdAnnotation
 }
 
+func (c *Cluster) ConvertConfigToConfigGenerateStruct() *ClusterGenerate {
+	config := &ClusterGenerate{
+		TypeMeta: c.TypeMeta,
+		ObjectMeta: ObjectMeta{
+			Name:        c.Name,
+			Annotations: c.Annotations,
+			Namespace:   c.Namespace,
+		},
+		Spec: c.Spec,
+	}
+
+	return config
+}
+
 // +kubebuilder:object:root=true
 // ClusterList contains a list of Cluster
 type ClusterList struct {

--- a/pkg/api/v1alpha1/gitopsconfig_types.go
+++ b/pkg/api/v1alpha1/gitopsconfig_types.go
@@ -85,6 +85,20 @@ func (c *GitOpsConfig) ExpectedKind() string {
 	return GitOpsConfigKind
 }
 
+func (c *GitOpsConfig) ConvertConfigToConfigGenerateStruct() *GitOpsConfigGenerate {
+	config := &GitOpsConfigGenerate{
+		TypeMeta: c.TypeMeta,
+		ObjectMeta: ObjectMeta{
+			Name:        c.Name,
+			Annotations: c.Annotations,
+			Namespace:   c.Namespace,
+		},
+		Spec: c.Spec,
+	}
+
+	return config
+}
+
 func init() {
 	SchemeBuilder.Register(&GitOpsConfig{}, &GitOpsConfigList{})
 }

--- a/pkg/api/v1alpha1/gitopsconfig_types.go
+++ b/pkg/api/v1alpha1/gitopsconfig_types.go
@@ -49,6 +49,15 @@ type GitOpsConfig struct {
 	Status GitOpsConfigStatus `json:"status,omitempty"`
 }
 
+// +kubebuilder:object:generate=false
+// Same as GitOpsConfig except stripped down for generation of yaml file while writing to github repo when flux is enabled
+type GitOpsConfigGenerate struct {
+	metav1.TypeMeta `json:",inline"`
+	ObjectMeta      `json:"metadata,omitempty"`
+
+	Spec GitOpsConfigSpec `json:"spec,omitempty"`
+}
+
 func (e *GitOpsConfigSpec) Equal(n *GitOpsConfigSpec) bool {
 	if e == n {
 		return true

--- a/pkg/api/v1alpha1/object_meta.go
+++ b/pkg/api/v1alpha1/object_meta.go
@@ -7,6 +7,6 @@ package v1alpha1
 // as needed.
 type ObjectMeta struct {
 	Name        string            `json:"name,omitempty"`
-	Namespace   string            `namespace:"name,omitempty"`
+	Namespace   string            `json:"namespace,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/pkg/api/v1alpha1/object_meta.go
+++ b/pkg/api/v1alpha1/object_meta.go
@@ -6,5 +6,7 @@ package v1alpha1
 // and https://github.com/kubernetes-sigs/cluster-api/blob/bf790fc2a53614ff5d3405c83c0de0dd3303bb1f/api/v1alpha2/common_types.go#L67-L128
 // as needed.
 type ObjectMeta struct {
-	Name string `json:"name,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Namespace   string            `namespace:"name,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/pkg/api/v1alpha1/oidcconfig_types.go
+++ b/pkg/api/v1alpha1/oidcconfig_types.go
@@ -99,6 +99,15 @@ type OIDCConfig struct {
 	Status OIDCConfigStatus `json:"status,omitempty"`
 }
 
+// +kubebuilder:object:generate=false
+// Same as OIDCConfig except stripped down for generation of yaml file while writing to github repo when flux is enabled
+type OIDCConfigGenerate struct {
+	metav1.TypeMeta `json:",inline"`
+	ObjectMeta      `json:"metadata,omitempty"`
+
+	Spec OIDCConfigSpec `json:"spec,omitempty"`
+}
+
 //+kubebuilder:object:root=true
 
 // OIDCConfigList contains a list of OIDCConfig

--- a/pkg/api/v1alpha1/oidcconfig_types.go
+++ b/pkg/api/v1alpha1/oidcconfig_types.go
@@ -125,6 +125,19 @@ func (c *OIDCConfig) ExpectedKind() string {
 	return OIDCConfigKind
 }
 
+func (c *OIDCConfig) ConvertConfigToConfigGenerateStruct() *OIDCConfigGenerate {
+	config := &OIDCConfigGenerate{
+		TypeMeta: c.TypeMeta,
+		ObjectMeta: ObjectMeta{
+			Name:        c.Name,
+			Annotations: c.Annotations,
+			Namespace:   c.Namespace,
+		},
+		Spec: c.Spec,
+	}
+	return config
+}
+
 func init() {
 	SchemeBuilder.Register(&OIDCConfig{}, &OIDCConfigList{})
 }

--- a/pkg/api/v1alpha1/vspheremachineconfig_types.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_types.go
@@ -87,6 +87,20 @@ type VSphereMachineConfigGenerate struct {
 	Spec VSphereMachineConfigSpec `json:"spec,omitempty"`
 }
 
+func (c *VSphereMachineConfig) ConvertConfigToConfigGenerateStruct() *VSphereMachineConfigGenerate {
+	config := &VSphereMachineConfigGenerate{
+		TypeMeta: c.TypeMeta,
+		ObjectMeta: ObjectMeta{
+			Name:        c.Name,
+			Annotations: c.Annotations,
+			Namespace:   c.Namespace,
+		},
+		Spec: c.Spec,
+	}
+
+	return config
+}
+
 //+kubebuilder:object:root=true
 
 // VSphereMachineConfigList contains a list of VSphereMachineConfig

--- a/pkg/clustermarshaller/clustermarshaller.go
+++ b/pkg/clustermarshaller/clustermarshaller.go
@@ -5,7 +5,6 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/providers"
@@ -60,46 +59,4 @@ func WriteClusterConfig(clusterSpec *cluster.Spec, datacenterConfig providers.Da
 	}
 
 	return nil
-}
-
-func copyToGitOpsConfigGenerateStruct(gitopsConfig *eksav1alpha1.GitOpsConfig) *eksav1alpha1.GitOpsConfigGenerate {
-	config := &eksav1alpha1.GitOpsConfigGenerate{
-		TypeMeta: gitopsConfig.TypeMeta,
-		ObjectMeta: eksav1alpha1.ObjectMeta{
-			Name:        gitopsConfig.Name,
-			Annotations: gitopsConfig.Annotations,
-			Namespace:   gitopsConfig.Namespace,
-		},
-		Spec: gitopsConfig.Spec,
-	}
-
-	return config
-}
-
-func copyToOIDCConfigGenerateStruct(oidcConfig *eksav1alpha1.OIDCConfig) *eksav1alpha1.OIDCConfigGenerate {
-	config := &eksav1alpha1.OIDCConfigGenerate{
-		TypeMeta: oidcConfig.TypeMeta,
-		ObjectMeta: eksav1alpha1.ObjectMeta{
-			Name:        oidcConfig.Name,
-			Annotations: oidcConfig.Annotations,
-			Namespace:   oidcConfig.Namespace,
-		},
-		Spec: oidcConfig.Spec,
-	}
-
-	return config
-}
-
-func copyToClusterGenerateStruct(cluster *eksav1alpha1.Cluster) *eksav1alpha1.ClusterGenerate {
-	config := &eksav1alpha1.ClusterGenerate{
-		TypeMeta: cluster.TypeMeta,
-		ObjectMeta: eksav1alpha1.ObjectMeta{
-			Name:        cluster.Name,
-			Annotations: cluster.Annotations,
-			Namespace:   cluster.Namespace,
-		},
-		Spec: cluster.Spec,
-	}
-
-	return config
 }

--- a/pkg/clustermarshaller/clustermarshaller.go
+++ b/pkg/clustermarshaller/clustermarshaller.go
@@ -5,7 +5,6 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/providers"
@@ -13,9 +12,8 @@ import (
 )
 
 func MarshalClusterSpec(clusterSpec *cluster.Spec, datacenterConfig providers.DatacenterConfig, machineConfigs []providers.MachineConfig) ([]byte, error) {
-	copiedStruct := copyToClusterGenerateStruct(clusterSpec.Cluster)
-	clusterObj, err := yaml.Marshal(copiedStruct)
-	// clusterObj, err := yaml.Marshal(clusterSpec.Cluster)
+	convertedClusterGenerateConfig := clusterSpec.ConvertConfigToConfigGenerateStruct()
+	clusterObj, err := yaml.Marshal(convertedClusterGenerateConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error outputting cluster yaml: %v", err)
 	}
@@ -32,18 +30,16 @@ func MarshalClusterSpec(clusterSpec *cluster.Spec, datacenterConfig providers.Da
 		resources = append(resources, mObj)
 	}
 	if clusterSpec.GitOpsConfig != nil {
-		copiedGitOps := copyToGitOpsConfigGenerateStruct(clusterSpec.GitOpsConfig)
-		gitopsObj, err := yaml.Marshal(copiedGitOps)
-		// gitopsObj, err := yaml.Marshal(clusterSpec.GitOpsConfig)
+		convertedGitOpsGenerateConfig := clusterSpec.GitOpsConfig.ConvertConfigToConfigGenerateStruct()
+		gitopsObj, err := yaml.Marshal(convertedGitOpsGenerateConfig)
 		if err != nil {
 			return nil, fmt.Errorf("error outputting gitops config yaml: %v", err)
 		}
 		resources = append(resources, gitopsObj)
 	}
 	if clusterSpec.OIDCConfig != nil {
-		copiedOIDC := copyToOIDCConfigGenerateStruct(clusterSpec.OIDCConfig)
-		oidcObj, err := yaml.Marshal(copiedOIDC)
-		// oidcObj, err := yaml.Marshal(clusterSpec.OIDCConfig)
+		convertedOIDCGenerateConfig := clusterSpec.OIDCConfig.ConvertConfigToConfigGenerateStruct()
+		oidcObj, err := yaml.Marshal(convertedOIDCGenerateConfig)
 		if err != nil {
 			return nil, fmt.Errorf("error outputting oidc config yaml: %v", err)
 		}
@@ -63,46 +59,4 @@ func WriteClusterConfig(clusterSpec *cluster.Spec, datacenterConfig providers.Da
 	}
 
 	return nil
-}
-
-func copyToGitOpsConfigGenerateStruct(gitopsConfig *eksav1alpha1.GitOpsConfig) *eksav1alpha1.GitOpsConfigGenerate {
-	config := &eksav1alpha1.GitOpsConfigGenerate{
-		TypeMeta: gitopsConfig.TypeMeta,
-		ObjectMeta: eksav1alpha1.ObjectMeta{
-			Name:        gitopsConfig.Name,
-			Annotations: gitopsConfig.Annotations,
-			Namespace:   gitopsConfig.Namespace,
-		},
-		Spec: gitopsConfig.Spec,
-	}
-
-	return config
-}
-
-func copyToOIDCConfigGenerateStruct(oidcConfig *eksav1alpha1.OIDCConfig) *eksav1alpha1.OIDCConfigGenerate {
-	config := &eksav1alpha1.OIDCConfigGenerate{
-		TypeMeta: oidcConfig.TypeMeta,
-		ObjectMeta: eksav1alpha1.ObjectMeta{
-			Name:        oidcConfig.Name,
-			Annotations: oidcConfig.Annotations,
-			Namespace:   oidcConfig.Namespace,
-		},
-		Spec: oidcConfig.Spec,
-	}
-
-	return config
-}
-
-func copyToClusterGenerateStruct(cluster *eksav1alpha1.Cluster) *eksav1alpha1.ClusterGenerate {
-	config := &eksav1alpha1.ClusterGenerate{
-		TypeMeta: cluster.TypeMeta,
-		ObjectMeta: eksav1alpha1.ObjectMeta{
-			Name:        cluster.Name,
-			Annotations: cluster.Annotations,
-			Namespace:   cluster.Namespace,
-		},
-		Spec: cluster.Spec,
-	}
-
-	return config
 }

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -38,6 +38,7 @@ type DatacenterConfig interface {
 	Kind() string
 	PauseReconcile()
 	ClearPauseAnnotation()
+	// ConvertConfigToConfigGenerateStruct() *DatacenterConfig
 }
 
 type BuildMapOption func(map[string]interface{})

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -38,7 +38,6 @@ type DatacenterConfig interface {
 	Kind() string
 	PauseReconcile()
 	ClearPauseAnnotation()
-	// ConvertConfigToConfigGenerateStruct() *DatacenterConfig
 }
 
 type BuildMapOption func(map[string]interface{})

--- a/release/pkg/prepare_release.go
+++ b/release/pkg/prepare_release.go
@@ -166,7 +166,7 @@ func (r *ReleaseConfig) renameArtifacts(sourceClients *SourceClients, artifacts 
 					}
 
 					updatedManifestFileContents := compiledRegex.ReplaceAllString(string(manifestFileContents), imageTagOverride.ReleaseUri)
-					err = ioutil.WriteFile(newArtifactFile, []byte(updatedManifestFileContents), 0644)
+					err = ioutil.WriteFile(newArtifactFile, []byte(updatedManifestFileContents), 0o644)
 					if err != nil {
 						return errors.Cause(err)
 					}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://github.com/aws/eks-anywhere/issues/191
Exclude fields from getting written to the github repo if flux is enabled.
This pr takes care of removing these fields from the `cluster`, `gitops`, and `oidc` configs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
