### PR TITLE
Allow existing EKS-A releases to be updated

### DIFF
--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -262,7 +262,8 @@ var releaseCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			release.Spec.Releases = append(release.Spec.Releases, eksARelease)
+			currentReleases := pkg.EksAReleases(release.Spec.Releases)
+			release.Spec.Releases = currentReleases.AppendOrUpdateRelease(eksARelease)
 
 			output, err := yaml.Marshal(release)
 			if err != nil {

--- a/release/pkg/prepare_release.go
+++ b/release/pkg/prepare_release.go
@@ -15,10 +15,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecrpublic"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	anywherev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/go-git/go-git/v5"
 	"github.com/pkg/errors"
 )
+
+type EksAReleases []anywherev1alpha1.EksARelease
 
 func (r *ReleaseConfig) SetRepoHeads() error {
 	// Get the repos from env var
@@ -425,4 +428,17 @@ func UpdateImageDigests(releaseClients *ReleaseClients, r *ReleaseConfig, eksArt
 	}
 
 	return imageDigests, nil
+}
+
+func (releases EksAReleases) AppendOrUpdateRelease(r anywherev1alpha1.EksARelease) EksAReleases {
+	for i, release := range releases {
+		if release.Version == r.Version {
+			releases[i] = r
+			fmt.Println("Updating existing release in releases manifest")
+			return releases
+		}
+	}
+	releases = append(releases, r)
+	fmt.Println("Adding new release to releases manifest")
+	return releases
 }


### PR DESCRIPTION
Adding the functionality to update existing EKS-A releases with new bundle versions. This will allow customers to pull down base-image updated versions of the same bundle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
