### PR TITLE
Copy from host support

### DIFF
--- a/release/api/v1alpha1/bundle_types.go
+++ b/release/api/v1alpha1/bundle_types.go
@@ -192,9 +192,10 @@ type FluxBundle struct {
 }
 
 type EksaBundle struct {
-	CliTools          Image    `json:"cliTools"`
-	ClusterController Image    `json:"clusterController"`
-	Components        Manifest `json:"components"`
+	CliTools            Image    `json:"cliTools"`
+	ClusterController   Image    `json:"clusterController"`
+	DiagnosticCollector Image    `json:"diagnosticCollector"`
+	Components          Manifest `json:"components"`
 }
 
 type EtcdadmBootstrapBundle struct {

--- a/release/pkg/assets_diagnostic_collector.go
+++ b/release/pkg/assets_diagnostic_collector.go
@@ -1,0 +1,61 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// GetDiagnosticCollectorAssets returns the artifacts for eks-a diagnostic collector
+func (r *ReleaseConfig) GetDiagnosticCollectorAssets() ([]Artifact, error) {
+	projectSource := "projects/aws/eks-anywhere"
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	gitTag, err := readFile(tagFile)
+	if err != nil {
+		return nil, errors.Cause(err)
+	}
+	name := "eks-anywhere-cli-tools"
+
+	var sourceRepoName string
+	var releaseRepoName string
+	if r.DevRelease || r.ReleaseEnvironment == "development" {
+		sourceRepoName = "eks-anywhere-diagnostic-collector"
+	} else {
+		sourceRepoName = "diagnostic-collector"
+	}
+
+	if r.DevRelease {
+		releaseRepoName = "eks-anywhere-diagnostic-collector"
+	} else {
+		releaseRepoName = "diagnostic-collector"
+	}
+
+	tagOptions := map[string]string{
+		"gitTag": gitTag,
+	}
+	imageArtifact := &ImageArtifact{
+		AssetName:       name,
+		SourceImageURI:  r.GetSourceImageURI(name, sourceRepoName, tagOptions),
+		ReleaseImageURI: r.GetReleaseImageURI(name, releaseRepoName, tagOptions),
+		Arch:            []string{"amd64"},
+		OS:              "linux",
+	}
+
+	artifact := Artifact{Image: imageArtifact}
+
+	return []Artifact{artifact}, nil
+}

--- a/release/pkg/assets_diagnostic_collector.go
+++ b/release/pkg/assets_diagnostic_collector.go
@@ -28,7 +28,7 @@ func (r *ReleaseConfig) GetDiagnosticCollectorAssets() ([]Artifact, error) {
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
-	name := "eks-anywhere-cli-tools"
+	name := "eks-anywhere-diagnostic-collector"
 
 	var sourceRepoName string
 	var releaseRepoName string

--- a/release/pkg/assets_eksa_tools.go
+++ b/release/pkg/assets_eksa_tools.go
@@ -64,8 +64,9 @@ func (r *ReleaseConfig) GetEksAToolsAssets() ([]Artifact, error) {
 
 func (r *ReleaseConfig) GetEksaBundle(imageDigests map[string]string) (anywherev1alpha1.EksaBundle, error) {
 	eksABundleArtifactsFuncs := map[string]func() ([]Artifact, error){
-		"eks-a-tools":        r.GetEksAToolsAssets,
-		"cluster-controller": r.GetClusterControllerAssets,
+		"eks-a-tools":           r.GetEksAToolsAssets,
+		"cluster-controller":    r.GetClusterControllerAssets,
+		"diagnostic-collector:": r.GetDiagnosticCollectorAssets,
 	}
 
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
@@ -103,9 +104,10 @@ func (r *ReleaseConfig) GetEksaBundle(imageDigests map[string]string) (anywherev
 	}
 
 	bundle := anywherev1alpha1.EksaBundle{
-		CliTools:          bundleImageArtifacts["eks-anywhere-cli-tools"],
-		Components:        bundleManifestArtifacts["eksa-components.yaml"],
-		ClusterController: bundleImageArtifacts["eks-anywhere-cluster-controller"],
+		CliTools:            bundleImageArtifacts["eks-anywhere-cli-tools"],
+		Components:          bundleManifestArtifacts["eksa-components.yaml"],
+		ClusterController:   bundleImageArtifacts["eks-anywhere-cluster-controller"],
+		DiagnosticCollector: bundleImageArtifacts["eksa-diagnostic-collector"],
 	}
 
 	return bundle, nil


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/238

*Description of changes:*

looking to get the `eks-anywhere-diagnostic-bundle` image into the eks-a bundle for use in TS development work. What else needs to happen, other than this?

add `eks-anywhere-diagnostic-bundle` to the dev bundle for use in copy-from-host collectors. 

build tooling reference: https://github.com/aws/eks-anywhere-build-tooling/tree/main/projects/aws/eks-anywhere


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
