### PR TITLE
Read cidr blocks from the cluster config file for docker

### DIFF
--- a/pkg/providers/docker/config/template.yaml
+++ b/pkg/providers/docker/config/template.yaml
@@ -6,12 +6,10 @@ metadata:
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks:
-      - 192.168.0.0/16
+      cidrBlocks: {{.podCidrs}}
     serviceDomain: cluster.local
     services:
-      cidrBlocks:
-      - 10.128.0.0/12
+      cidrBlocks: {{.serviceCidrs}}
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -168,6 +168,8 @@ func BuildTemplateMap(clusterSpec *cluster.Spec) map[string]interface{} {
 		"externalEtcdVersion":    bundle.KubeDistro.EtcdVersion,
 		"eksaSystemNamespace":    constants.EksaSystemNamespace,
 		"auditPolicy":            common.GetAuditPolicy(),
+		"podCidrs":               clusterSpec.Spec.ClusterNetwork.Pods.CidrBlocks,
+		"serviceCidrs":           clusterSpec.Spec.ClusterNetwork.Services.CidrBlocks,
 	}
 
 	if clusterSpec.Spec.ExternalEtcdConfiguration != nil {

--- a/pkg/providers/docker/docker_test.go
+++ b/pkg/providers/docker/docker_test.go
@@ -97,6 +97,8 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.Name = "test-cluster"
 				s.Spec.KubernetesVersion = "1.19"
+				s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+				s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 				s.Spec.ControlPlaneConfiguration.Count = 3
 				s.Spec.WorkerNodeGroupConfigurations[0].Count = 3
 				s.VersionsBundle = versionsBundle
@@ -104,10 +106,25 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 			wantFileName: "testdata/valid_deployment_expected.yaml",
 		},
 		{
+			testName: "valid config with cidrs",
+			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Name = "test-cluster"
+				s.Spec.KubernetesVersion = "1.19"
+				s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"10.10.0.0/24", "10.128.0.0/12"}
+				s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"192.168.0.0/16", "10.10.0.0/16"}
+				s.Spec.ControlPlaneConfiguration.Count = 3
+				s.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+				s.VersionsBundle = versionsBundle
+			}),
+			wantFileName: "testdata/valid_deployment_custom_cidrs_expected.yaml",
+		},
+		{
 			testName: "with minimal oidc",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.Name = "test-cluster"
 				s.Spec.KubernetesVersion = "1.19"
+				s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+				s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 				s.Spec.ControlPlaneConfiguration.Count = 3
 				s.Spec.WorkerNodeGroupConfigurations[0].Count = 3
 				s.VersionsBundle = versionsBundle
@@ -126,6 +143,8 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.Name = "test-cluster"
 				s.Spec.KubernetesVersion = "1.19"
+				s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+				s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 				s.Spec.ControlPlaneConfiguration.Count = 3
 				s.Spec.WorkerNodeGroupConfigurations[0].Count = 3
 				s.VersionsBundle = versionsBundle
@@ -187,6 +206,8 @@ func TestProviderGenerateDeploymentFileSuccessNotUpdateMachineTemplate(t *testin
 	client := dockerMocks.NewMockProviderClient(mockCtrl)
 	kubectl := dockerMocks.NewMockProviderKubectlClient(mockCtrl)
 	clusterSpec := test.NewClusterSpec()
+	clusterSpec.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+	clusterSpec.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 	p := docker.NewProvider(&v1alpha1.DockerDatacenterConfig{}, client, kubectl, writer, test.FakeNow)
 	cluster := &types.Cluster{
 		Name: "test",

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_expected.yaml
@@ -6,12 +6,10 @@ metadata:
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks:
-      - 192.168.0.0/16
+      cidrBlocks: [192.168.0.0/16]
     serviceDomain: cluster.local
     services:
-      cidrBlocks:
-      - 10.128.0.0/12
+      cidrBlocks: [10.128.0.0/12]
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_expected.yaml
@@ -6,12 +6,10 @@ metadata:
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks:
-      - 192.168.0.0/16
+      cidrBlocks: [192.168.0.0/16]
     serviceDomain: cluster.local
     services:
-      cidrBlocks:
-      - 10.128.0.0/12
+      cidrBlocks: [10.128.0.0/12]
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_expected.yaml
@@ -1,55 +1,67 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
-  name: fluxAddonTestCluster
+  name: test-cluster
   namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks: [192.168.0.0/16]
+      cidrBlocks: [10.10.0.0/24 10.128.0.0/12]
     serviceDomain: cluster.local
     services:
-      cidrBlocks: [10.128.0.0/12]
+      cidrBlocks: [192.168.0.0/16 10.10.0.0/16]
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
-    name: fluxAddonTestCluster
+    name: test-cluster
     namespace: eksa-system
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerCluster
-    name: fluxAddonTestCluster
+    name: test-cluster
     namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerCluster
 metadata:
-  name: fluxAddonTestCluster
+  name: test-cluster
   namespace: eksa-system
 ---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: DockerMachineTemplate
+metadata:
+  name: test-cluster-control-plane-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      extraMounts:
+      - containerPath: /var/run/docker.sock
+        hostPath: /var/run/docker.sock
+      customImage: public.ecr.aws/eks-distro/kubernetes-sigs/kind/node:v1.18.16-eks-1-18-4-216edda697a37f8bf16651af6c23b7e2bb7ef42f-62681885fe3a97ee4f2b110cc277e084e71230fa
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
-  name: fluxAddonTestCluster
+  name: test-cluster
   namespace: eksa-system
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate
-    name: test-control-plane-template-original
+    name: test-cluster-control-plane-template-1234567890000
     namespace: eksa-system
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: 
+      imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         local:
-          imageRepository: 
-          imageTag: 
+          imageRepository: public.ecr.aws/eks-distro/etcd-io
+          imageTag: v3.4.14-eks-1-19-2
       dns:
         type: CoreDNS
-        imageRepository: 
-        imageTag: 
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.8.0-eks-1-19-2
       apiServer:
         certSANs:
         - localhost
@@ -255,14 +267,26 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-  replicas: 0
-  version: 
+  replicas: 3
+  version: v1.19.6-eks-1-19-2
 ---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: DockerMachineTemplate
+metadata:
+  name: test-cluster-worker-node-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      extraMounts:
+      - containerPath: /var/run/docker.sock
+        hostPath: /var/run/docker.sock
+      customImage: public.ecr.aws/eks-distro/kubernetes-sigs/kind/node:v1.18.16-eks-1-18-4-216edda697a37f8bf16651af6c23b7e2bb7ef42f-62681885fe3a97ee4f2b110cc277e084e71230fa
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
-  name: fluxAddonTestCluster-md-0
+  name: test-cluster-md-0
   namespace: eksa-system
 spec:
   template:
@@ -277,11 +301,11 @@ spec:
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
-  name: fluxAddonTestCluster-md-0
+  name: test-cluster-md-0
   namespace: eksa-system
 spec:
-  clusterName: fluxAddonTestCluster
-  replicas: 0
+  clusterName: test-cluster
+  replicas: 3
   selector:
     matchLabels: null
   template:
@@ -290,12 +314,12 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
-          name: fluxAddonTestCluster-md-0
+          name: test-cluster-md-0
           namespace: eksa-system
-      clusterName: fluxAddonTestCluster
+      clusterName: test-cluster
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: DockerMachineTemplate
-        name: test-worker-node-template-original
+        name: test-cluster-worker-node-template-1234567890000
         namespace: eksa-system
-      version: 
+      version: v1.19.6-eks-1-19-2

--- a/pkg/providers/docker/testdata/valid_deployment_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_expected.yaml
@@ -6,12 +6,10 @@ metadata:
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks:
-      - 192.168.0.0/16
+      cidrBlocks: [192.168.0.0/16]
     serviceDomain: cluster.local
     services:
-      cidrBlocks:
-      - 10.128.0.0/12
+      cidrBlocks: [10.128.0.0/12]
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
At the moment, the pod and service cidr values are all hard coded for docker. With this change, these values will be read from the cluster spec file. This should fix #219.
Test output result:

> eks-anywhere bnrjee$ kubectl cluster-info dump --kubeconfig abc/abc-eks-a-cluster.kubeconfig | grep -i cidr
                    "io.cilium.network.ipv4-pod-cidr": "10.10.1.0/24",
                "podCIDR": "10.10.1.0/24",
                "podCIDRs": [
                    "io.cilium.network.ipv4-pod-cidr": "10.10.0.0/24",
                "podCIDR": "10.10.0.0/24",
                "podCIDRs": [
                            "--allocate-node-cidrs=true",
                            "--cluster-cidr=10.10.0.0/16",
I0921 17:04:45.014930       1 range_allocator.go:116] No Secondary Service CIDR provided. Skipping filtering out secondary service addresses.
I0921 17:04:45.115527       1 range_allocator.go:172] Starting range CIDR allocator
I0921 17:04:45.115532       1 shared_informer.go:240] Waiting for caches to sync for cidrallocator
I0921 17:04:45.115535       1 shared_informer.go:247] Caches are synced for cidrallocator 
I0921 17:04:45.120349       1 range_allocator.go:373] Set node abc-sn6jz PodCIDR to [10.10.0.0/24]
I0921 17:04:51.571683       1 range_allocator.go:373] Set node abc-md-0-85c9ccb857-vt6pw PodCIDR to [10.10.1.0/24]
W0921 17:04:47.239883       1 server_others.go:512] detect-local-mode set to ClusterCIDR, but no IPv6 cluster CIDR defined, , defaulting to no-op detect-local for IPv6
W0921 17:04:59.054069       1 server_others.go:512] detect-local-mode set to ClusterCIDR, but no IPv6 cluster CIDR defined, , defaulting to no-op detect-local for IPv6

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
