### PR TITLE
Add back vsphere vm cleanup for failed tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -58,7 +58,7 @@ phases:
       "eks-a-cli"
       $CODEBUILD_BUILD_NUMBER
       $GIT_HASH
-    # - >
-    #   ./bin/test e2e cleanup vsphere
-    #   -n eksa-test
-    #   -v 4
+     - >
+       ./bin/test e2e cleanup vsphere
+       -n eksa-test
+       -v 4


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Till we have a way of cleaning up only VMs associated with failed tests while their ec2 instances are being cleaned up

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
