### PR TITLE
Fix Namespace for MachineHealthCheck Objects

### DIFF
--- a/pkg/providers/vsphere/config/machine-health-check-template.yaml
+++ b/pkg/providers/vsphere/config/machine-health-check-template.yaml
@@ -2,6 +2,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineHealthCheck
 metadata:
   name: {{.clusterName}}-node-unhealthy-5m
+  namespace: {{.eksaSystemNamespace}}
 spec:
   clusterName: {{.clusterName}}
   maxUnhealthy: 40%
@@ -21,6 +22,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineHealthCheck
 metadata:
   name: {{.clusterName}}-kcp-unhealthy-5m
+  namespace: {{.eksaSystemNamespace}}
 spec:
   clusterName: {{.clusterName}}
   maxUnhealthy: 100%

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1273,7 +1273,8 @@ func (p *vsphereProvider) GenerateStorageClass() []byte {
 
 func (p *vsphereProvider) GenerateMHC() ([]byte, error) {
 	data := map[string]string{
-		"clusterName": p.clusterConfig.Name,
+		"clusterName":         p.clusterConfig.Name,
+		"eksaSystemNamespace": constants.EksaSystemNamespace,
 	}
 	mhc, err := templater.Execute(string(mhcTemplate), data)
 	if err != nil {

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -2152,7 +2152,7 @@ func TestGetMHCSuccess(t *testing.T) {
 kind: MachineHealthCheck
 metadata:
   name: test-node-unhealthy-5m
-  namespace: %s
+  namespace: %[1]s
 spec:
   clusterName: test
   maxUnhealthy: 40%%
@@ -2172,7 +2172,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineHealthCheck
 metadata:
   name: test-kcp-unhealthy-5m
-  namespace: %s
+  namespace: %[1]s
 spec:
   clusterName: test
   maxUnhealthy: 100%%
@@ -2186,7 +2186,7 @@ spec:
     - type: Ready
       status: "False"
       timeout: 300s
-`, constants.EksaSystemNamespace, constants.EksaSystemNamespace)
+`, constants.EksaSystemNamespace)
 
 	mch, err := provider.GenerateMHC()
 	assert.NoError(t, err, "Expected successful execution of GenerateMHC() but got an error", "error", err)


### PR DESCRIPTION
Modify the template that generates MachineHealthChecks (MHC) to use the
eksa-system namespace (the same used by other CRs).

During cluster creation if the MHCs are created on a separate namespace they will not be available.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
