### PR TITLE
Use local bundle release override when changing spec

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -43,6 +43,11 @@ phases:
   build:
     commands:
     - export JOB_ID=$CODEBUILD_BUILD_ID
+    - BUNDLES_OVERRIDE=false
+    - |
+      if [ -f ./bin/local-bundle-release.yaml ]; then
+        BUNDLES_OVERRIDE=true
+      fi
     - > 
       ./bin/test e2e run
       -a ${INTEGRATION_TEST_AL2_AMI_ID}
@@ -53,6 +58,7 @@ phases:
       -m ${INTEGRATION_TEST_MAX_EC2_COUNT}
       -r 'Test'
       -v 4
+      --bundles-override=${BUNDLES_OVERRIDE}
   post_build:
     commands:
     - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE

--- a/cmd/integration_test/cmd/run.go
+++ b/cmd/integration_test/cmd/run.go
@@ -22,6 +22,7 @@ const (
 	regexFlagName           = "regex"
 	maxInstancesFlagName    = "max-instances"
 	skipFlagName            = "skip"
+	bundlesOverrideFlagName = "bundles-override"
 )
 
 var runE2ECmd = &cobra.Command{
@@ -60,6 +61,7 @@ func init() {
 	runE2ECmd.Flags().StringP(regexFlagName, "r", "", "Run only those tests and examples matching the regular expression. Equivalent to go test -run")
 	runE2ECmd.Flags().IntP(maxInstancesFlagName, "m", 1, "Run tests in parallel with multiple EC2 instances")
 	runE2ECmd.Flags().StringSlice(skipFlagName, nil, "List of tests to skip")
+	runE2ECmd.Flags().Bool(bundlesOverrideFlagName, false, "Flag to indicate if the tests should run with a bundles override")
 
 	for _, flag := range requiredFlags {
 		if err := runE2ECmd.MarkFlagRequired(flag); err != nil {
@@ -77,6 +79,7 @@ func runE2E(ctx context.Context) error {
 	testRegex := viper.GetString(regexFlagName)
 	maxInstances := viper.GetInt(maxInstancesFlagName)
 	testsToSkip := viper.GetStringSlice(skipFlagName)
+	bundlesOverride := viper.GetBool(bundlesOverrideFlagName)
 
 	runConf := e2e.ParallelRunConf{
 		MaxInstances:        maxInstances,
@@ -87,6 +90,7 @@ func runE2E(ctx context.Context) error {
 		SubnetId:            subnetId,
 		Regex:               testRegex,
 		TestsToSkip:         testsToSkip,
+		BundlesOverride:     bundlesOverride,
 	}
 
 	err := e2e.RunTestsInParallel(runConf)

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -1048,15 +1048,75 @@ spec:
                               description: The image repository, name, and tag
                               type: string
                           type: object
+                        clusterController:
+                          properties:
+                            arch:
+                              description: Architectures of the asset
+                              items:
+                                type: string
+                              type: array
+                            description:
+                              type: string
+                            imageDigest:
+                              description: The SHA256 digest of the image manifest
+                              type: string
+                            name:
+                              description: The asset name
+                              type: string
+                            os:
+                              description: Operating system of the asset
+                              enum:
+                              - linux
+                              - darwin
+                              - windows
+                              type: string
+                            osName:
+                              description: Name of the OS like ubuntu, bottlerocket
+                              type: string
+                            uri:
+                              description: The image repository, name, and tag
+                              type: string
+                          type: object
                         components:
                           properties:
                             uri:
                               description: URI points to the manifest yaml file
                               type: string
                           type: object
+                        diagnosticCollector:
+                          properties:
+                            arch:
+                              description: Architectures of the asset
+                              items:
+                                type: string
+                              type: array
+                            description:
+                              type: string
+                            imageDigest:
+                              description: The SHA256 digest of the image manifest
+                              type: string
+                            name:
+                              description: The asset name
+                              type: string
+                            os:
+                              description: Operating system of the asset
+                              enum:
+                              - linux
+                              - darwin
+                              - windows
+                              type: string
+                            osName:
+                              description: Name of the OS like ubuntu, bottlerocket
+                              type: string
+                            uri:
+                              description: The image repository, name, and tag
+                              type: string
+                          type: object
                       required:
                       - cliTools
+                      - clusterController
                       - components
+                      - diagnosticCollector
                       type: object
                     etcdadmBootstrap:
                       properties:
@@ -1745,6 +1805,19 @@ spec:
                     items:
                       type: string
                     type: array
+                type: object
+              registryMirrorConfiguration:
+                description: RegistryMirrorConfiguration defines the settings for
+                  image registry mirror
+                properties:
+                  caCertContent:
+                    description: CACertContent defines the contents registry mirror
+                      CA certificate
+                    type: string
+                  endpoint:
+                    description: Endpoint defines the registry mirror endpoint to
+                      use for pulling images
+                    type: string
                 type: object
               workerNodeGroupConfigurations:
                 items:

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -19,6 +19,7 @@ type ParallelRunConf struct {
 	SubnetId            string
 	Regex               string
 	TestsToSkip         []string
+	BundlesOverride     bool
 }
 
 type instanceTestsResults struct {
@@ -77,10 +78,11 @@ func RunTestsInParallel(conf ParallelRunConf) error {
 
 type instanceRunConf struct {
 	amiId, instanceProfileName, storageBucket, jobId, subnetId, regex string
+	bundlesOverride                                                   bool
 }
 
 func RunTests(conf instanceRunConf) error {
-	session, err := newSession(conf.amiId, conf.instanceProfileName, conf.storageBucket, conf.jobId, conf.subnetId)
+	session, err := newSession(conf.amiId, conf.instanceProfileName, conf.storageBucket, conf.jobId, conf.subnetId, conf.bundlesOverride)
 	if err != nil {
 		return err
 	}
@@ -156,6 +158,7 @@ func splitTests(testsList []string, conf ParallelRunConf) []instanceRunConf {
 				jobId:               fmt.Sprintf("%s-%d", conf.JobId, len(runConfs)),
 				subnetId:            conf.SubnetId,
 				regex:               strings.Join(testsInCurrentInstance, "|"),
+				bundlesOverride:     conf.BundlesOverride,
 			})
 
 			testsInCurrentInstance = make([]string, 0, testPerInstance)

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 
@@ -12,12 +13,14 @@ import (
 	e2etests "github.com/aws/eks-anywhere/test/framework"
 )
 
-var binaries = []string{cliBinary, e2eBinary, eksctlBinary}
+var requiredFiles = []string{cliBinary, e2eBinary, eksctlBinary}
 
 const (
-	cliBinary    = "eksctl-anywhere"
-	e2eBinary    = "e2e.test"
-	eksctlBinary = "eksctl"
+	cliBinary                  = "eksctl-anywhere"
+	e2eBinary                  = "e2e.test"
+	eksctlBinary               = "eksctl"
+	bundlesReleaseManifestFile = "local-bundle-release.yaml"
+	eksAComponentsManifestFile = "local-eksa-components.yaml"
 )
 
 type E2ESession struct {
@@ -29,9 +32,10 @@ type E2ESession struct {
 	subnetId            string
 	instanceId          string
 	testEnvVars         map[string]string
+	bundlesOverride     bool
 }
 
-func newSession(amiId, instanceProfileName, storageBucket, jobId, subnetId string) (*E2ESession, error) {
+func newSession(amiId, instanceProfileName, storageBucket, jobId, subnetId string, bundlesOverride bool) (*E2ESession, error) {
 	session, err := session.NewSession()
 	if err != nil {
 		return nil, fmt.Errorf("error creating session: %v", err)
@@ -45,13 +49,14 @@ func newSession(amiId, instanceProfileName, storageBucket, jobId, subnetId strin
 		jobId:               jobId,
 		subnetId:            subnetId,
 		testEnvVars:         make(map[string]string),
+		bundlesOverride:     bundlesOverride,
 	}
 
 	return e, nil
 }
 
 func (e *E2ESession) setup(regex string) error {
-	err := e.uploadBinaries()
+	err := e.uploadRequiredFiles()
 	if err != nil {
 		return err
 	}
@@ -73,7 +78,7 @@ func (e *E2ESession) setup(regex string) error {
 		return fmt.Errorf("error waiting for ssm in new instance: %v", err)
 	}
 
-	err = e.downloadBinariesInInstance()
+	err = e.downloadRequiredFilesInInstance()
 	if err != nil {
 		return err
 	}
@@ -95,26 +100,30 @@ func (e *E2ESession) setup(regex string) error {
 
 	// Adding JobId to Test Env variables
 	e.testEnvVars[e2etests.JobIdVar] = e.jobId
+	e.testEnvVars[e2etests.BundlesOverrideVar] = strconv.FormatBool(e.bundlesOverride)
 
 	return nil
 }
 
-func (e *E2ESession) uploadBinary(binary string) error {
-	file := fmt.Sprintf("bin/%s", binary)
-	key := fmt.Sprintf("%s/%s", e.jobId, binary)
-	logger.V(1).Info("Uploading binary to s3 bucket", "binary", binary, "key", key)
-	err := s3.UploadFile(e.session, file, key, e.storageBucket)
+func (e *E2ESession) uploadRequiredFile(file string) error {
+	uploadFile := fmt.Sprintf("bin/%s", file)
+	key := fmt.Sprintf("%s/%s", e.jobId, file)
+	logger.V(1).Info("Uploading file to s3 bucket", "file", file, "key", key)
+	err := s3.UploadFile(e.session, uploadFile, key, e.storageBucket)
 	if err != nil {
-		return fmt.Errorf("error uploading binary [%s]: %v", binary, err)
+		return fmt.Errorf("error uploading file [%s]: %v", file, err)
 	}
 
 	return nil
 }
 
-func (e *E2ESession) uploadBinaries() error {
-	for _, binary := range binaries {
-		if binary != "eksctl" {
-			err := e.uploadBinary(binary)
+func (e *E2ESession) uploadRequiredFiles() error {
+	if e.bundlesOverride {
+		requiredFiles = append(requiredFiles, bundlesReleaseManifestFile, eksAComponentsManifestFile)
+	}
+	for _, file := range requiredFiles {
+		if file != "eksctl" {
+			err := e.uploadRequiredFile(file)
 			if err != nil {
 				return err
 			}
@@ -124,27 +133,30 @@ func (e *E2ESession) uploadBinaries() error {
 	return nil
 }
 
-func (e *E2ESession) downloadBinaryInInstance(binary string) error {
-	logger.V(1).Info("Downloading from s3 in instance", "binary", binary)
+func (e *E2ESession) downloadRequiredFileInInstance(file string) error {
+	logger.V(1).Info("Downloading from s3 in instance", "file", file)
 
 	var command string
-	if binary == "eksctl" {
-		command = fmt.Sprintf("aws s3 cp s3://%s/eksctl/%s ./bin/ && chmod 645 ./bin/%s", e.storageBucket, binary, binary)
+	if file == "eksctl" {
+		command = fmt.Sprintf("aws s3 cp s3://%s/eksctl/%s ./bin/ && chmod 645 ./bin/%s", e.storageBucket, file, file)
 	} else {
-		command = fmt.Sprintf("aws s3 cp s3://%s/%s/%s ./bin/ && chmod 645 ./bin/%s", e.storageBucket, e.jobId, binary, binary)
+		command = fmt.Sprintf("aws s3 cp s3://%s/%s/%s ./bin/ && chmod 645 ./bin/%s", e.storageBucket, e.jobId, file, file)
 	}
 	err := ssm.Run(e.session, e.instanceId, command)
 	if err != nil {
-		return fmt.Errorf("error downloading binary in instance: %v", err)
+		return fmt.Errorf("error downloading file in instance: %v", err)
 	}
-	logger.V(1).Info("Successfully downloaded binary")
+	logger.V(1).Info("Successfully downloaded file")
 
 	return nil
 }
 
-func (e *E2ESession) downloadBinariesInInstance() error {
-	for _, binary := range binaries {
-		err := e.downloadBinaryInInstance(binary)
+func (e *E2ESession) downloadRequiredFilesInInstance() error {
+	if e.bundlesOverride {
+		requiredFiles = append(requiredFiles, bundlesReleaseManifestFile, eksAComponentsManifestFile)
+	}
+	for _, file := range requiredFiles {
+		err := e.downloadRequiredFileInInstance(file)
 		if err != nil {
 			return err
 		}

--- a/scripts/e2e_test_docker.sh
+++ b/scripts/e2e_test_docker.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -x
+
 if [ "$AWS_ROLE_ARN" == "" ]; then
     echo "Empty AWS_ROLE_ARN, this script must be run in a postsubmit pod with IAM Roles for Service Accounts"
     exit 1
@@ -41,9 +43,15 @@ export AWS_SDK_LOAD_CONFIG=true
 export AWS_CONFIG_FILE=$(pwd)/config_file
 export AWS_PROFILE=e2e-docker-test
 unset AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE
+
+BUNDLES_OVERRIDE=false
+if [ -f "$REPO_ROOT/bin/local-bundle-release.yaml" ]; then
+    BUNDLES_OVERRIDE=true
+fi
 $REPO_ROOT/bin/test e2e run \
     -a ${INTEGRATION_TEST_AL2_AMI_ID} \
     -s ${INTEGRATION_TEST_STORAGE_BUCKET} \
     -j ${JOB_ID} \
     -i ${INTEGRATION_TEST_INSTANCE_PROFILE} \
-    -r ${TEST_REGEX}
+    -r ${TEST_REGEX} \
+    --bundles-override=${BUNDLES_OVERRIDE}

--- a/scripts/eksa_components_override.sh
+++ b/scripts/eksa_components_override.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -o pipefail
+set -x
+set -o nounset
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+BUNDLE_MANIFEST_URL="$1"
+CI="${CI:-false}"
+CODEBUILD_CI="${CODEBUILD_CI:-false}"
+
+SED=sed
+if [ "$(uname -s)" = "Darwin" ]; then
+    SED=gsed
+fi
+
+if ! yq --version; then
+    echo "Cannot find yq executable. Build on Linux"
+    echo "or install yq on Mac (brew install yq)."
+    exit 1
+fi
+
+# In Prow, we can get the base commit and PR commit using these
+# environment variables and check their diff to check if files under
+# config folder changed.
+if [ "$CI" = "true" ]; then
+    CONFIG_FILES_CHANGED="$(git --no-pager diff --pretty=format:"" --name-only $PULL_BASE_SHA $PULL_PULL_SHA | grep "^config/.*" || true)"
+# In Codebuild, we can do a git show on the latest commit to check
+# if files under config folder changed.
+elif [ "$CODEBUILD_CI" = "true" ]; then
+    CONFIG_FILES_CHANGED="$(git --no-pager show --pretty=format:"" --name-only HEAD | grep "^config/.*" || true)"
+else
+# For local testing, we can either do a git diff or git show on HEAD
+# based on whether the local changes have been committed
+    while true; do
+        read -p "Have you committed your local changes? (yes/no) " response
+        case $response in
+            [Yy]* ) CONFIG_FILES_CHANGED="$(git --no-pager show --pretty=format:"" --name-only HEAD | grep "^config/.*" || true)"; break;;
+            [Nn]* ) CONFIG_FILES_CHANGED="$(git --no-pager diff --pretty=format:"" --name-only HEAD | grep "^config/.*" || true)"; break;;
+            * ) echo "Please answer yes or no.";;
+        esac
+    done
+fi
+
+if [[ "$CONFIG_FILES_CHANGED" != "" ]]; then
+    mkdir -p $REPO_ROOT/bin
+    make release-manifests RELEASE_DIR=./bin RELEASE_MANIFEST_TARGET=local-eksa-components.yaml
+    curl $BUNDLE_MANIFEST_URL -o $REPO_ROOT/bin/local-bundle-release.yaml
+    CLUSTER_CONTROLLER_OVERRIDE_IMAGE=$(yq e ".spec.versionsBundles[0].eksa.clusterController.uri" $REPO_ROOT/bin/local-bundle-release.yaml)
+    KUBE_RBAC_PROXY_OVERRIDE_IMAGE=$(yq e ".spec.versionsBundles[0].clusterAPI.kubeProxy.uri" $REPO_ROOT/bin/local-bundle-release.yaml)
+    $SED -i "s,public.ecr.aws/.*/eks-anywhere-cluster-controller:.*,${CLUSTER_CONTROLLER_OVERRIDE_IMAGE}," $REPO_ROOT/bin/local-eksa-components.yaml
+    $SED -i "s,public.ecr.aws/.*/brancz/kube-rbac-proxy:.*,${KUBE_RBAC_PROXY_OVERRIDE_IMAGE}," $REPO_ROOT/bin/local-eksa-components.yaml
+    yq e -i '.spec.versionsBundles[].eksa.components.uri |= "bin/local-eksa-components.yaml"' $REPO_ROOT/bin/local-bundle-release.yaml
+fi

--- a/test/framework/e2e.go
+++ b/test/framework/e2e.go
@@ -24,10 +24,12 @@ import (
 )
 
 const (
-	defaultClusterConfigFile = "cluster.yaml"
-	defaultClusterName       = "eksa-test"
-	clusterNameVar           = "T_CLUSTER_NAME"
-	JobIdVar                 = "T_JOB_ID"
+	defaultClusterConfigFile         = "cluster.yaml"
+	defaultBundleReleaseManifestFile = "bin/local-bundle-release.yaml"
+	defaultClusterName               = "eksa-test"
+	clusterNameVar                   = "T_CLUSTER_NAME"
+	JobIdVar                         = "T_JOB_ID"
+	BundlesOverrideVar               = "T_BUNDLES_OVERRIDE"
 )
 
 //go:embed testdata/oidc-roles.yaml
@@ -106,7 +108,12 @@ func (e *E2ETest) GenerateClusterConfig() {
 }
 
 func (e *E2ETest) CreateCluster() {
-	e.RunEKSA("anywhere", "create", "cluster", "-f", e.ClusterConfigLocation, "-v", "4")
+	createClusterArgs := []string{"anywhere", "create", "cluster", "-f", e.ClusterConfigLocation, "-v", "4"}
+	if getBundlesOverride() == "true" {
+		createClusterArgs = append(createClusterArgs, "--bundles-override", defaultBundleReleaseManifestFile)
+	}
+
+	e.RunEKSA(createClusterArgs...)
 	e.cleanup(func() {
 		os.RemoveAll(e.ClusterName)
 	})
@@ -149,7 +156,12 @@ func (e *E2ETest) UpgradeCluster(opts ...E2ETestOpt) {
 		opt(e)
 	}
 	e.buildClusterConfigFile()
-	e.RunEKSA("anywhere", "upgrade", "cluster", "-f", e.ClusterConfigLocation, "-v", "4")
+
+	upgradeClusterArgs := []string{"anywhere", "upgrade", "cluster", "-f", e.ClusterConfigLocation, "-v", "4"}
+	if getBundlesOverride() == "true" {
+		upgradeClusterArgs = append(upgradeClusterArgs, "--bundles-override", defaultBundleReleaseManifestFile)
+	}
+	e.RunEKSA(upgradeClusterArgs...)
 }
 
 func (e *E2ETest) buildClusterConfigFile() {
@@ -298,4 +310,8 @@ func getClusterName() string {
 		return defaultClusterName
 	}
 	return value
+}
+
+func getBundlesOverride() string {
+	return os.Getenv(BundlesOverrideVar)
 }


### PR DESCRIPTION
Sometimes, our PRs include changes to spec structs which would also be accompanied by changes in the `config/` folder. During every run of the E2E presubmit, the latest bundle from S3 is pulled down and is parsed to know what images to use and what manifests to apply for cluster creation. One of the steps in cluster creation is installtion of custom components and EKS-A CRDs that are defined in the `eksa-components.yaml` manifest from the bundle release. 

However due to local changes in spec, the eksa-components manifest that was pulled down from S3 will no longer work, since it corresponds to an outdated spec. This PR fixes that by detecting changes under `config/`, that imply that the spec CRD was changed, and generates a local compatible version of the eksa-components to be used in the e2e tests. The tests are configured to run with a local bundle release override in this case, where the eksa-components points to a local file rather an S3 URI.

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
