### PR TITLE
add process for generating log text analyzers based on collectors present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ mocks: ## Generate mocks
 	${GOPATH}/bin/mockgen -destination=pkg/providers/vsphere/internal/templates/mocks/govc.go -package=mocks -source "pkg/providers/vsphere/internal/templates/factory.go" GovcClient
 	${GOPATH}/bin/mockgen -destination=pkg/providers/vsphere/internal/tags/mocks/govc.go -package=mocks -source "pkg/providers/vsphere/internal/tags/factory.go" GovcClient
 	${GOPATH}/bin/mockgen -destination=pkg/validations/upgradevalidations/mocks/upgradevalidations.go -package=mocks -source "pkg/validations/upgradevalidations/upgradevalidations.go" ValidationsKubectlClient
-	${GOPATH}/bin/mockgen -destination=pkg/diagnostics/interfaces/mocks/support.go -package=mocks -source "pkg/diagnostics/interfaces.go" DiagnosticBundle,AnalyzerFactory,CollectorFactory
+	${GOPATH}/bin/mockgen -destination=pkg/diagnostics/interfaces/mocks/diagnostics.go -package=mocks -source "pkg/diagnostics/interfaces.go" DiagnosticBundle,AnalyzerFactory,CollectorFactory
 
 .PHONY: verify-mocks
 verify-mocks: mocks ## Verify if mocks need to be updated

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,5 +1,20 @@
 package constants
 
+// Namespace constants
 const (
-	EksaSystemNamespace = "eksa-system"
+	EksaSystemNamespace                       = "eksa-system"
+	CapdSystemNamespace                       = "capd-system"
+	CapiKubeadmBootstrapSystemNamespace       = "capi-kubeadm-bootstrap-system"
+	CapiKubeadmControlPlaneSystemNamespace    = "capi-kubeadm-control-plane-system"
+	CapiSystemNamespace                       = "capi-system"
+	CapiWebhookSystemNamespace                = "capi-webhook-system"
+	CapvSystemNamespace                       = "capv-system"
+	CertManagerNamespace                      = "cert-manager"
+	DefaultNamespace                          = "default"
+	EtcdAdminBootstrapProviderSystemNamespace = "etcdadm-bootstrap-provider-system"
+	EtcdAdminControllerSystemNamespace        = "etcdadm-controller-system"
+	KubeNodeLeaseNamespace                    = "kube-node-lease"
+	KubePublicNamespace                       = "kube-public"
+	KubeSystemNamespace                       = "kube-system"
+	LocalPathStorageNamespace                 = "local-path-storage"
 )

--- a/pkg/diagnostics/analyzer_types.go
+++ b/pkg/diagnostics/analyzer_types.go
@@ -5,6 +5,7 @@ type Analyze struct {
 	Secret                   *analyzeSecret            `json:"secret,omitempty"`
 	ImagePullSecret          *imagePullSecret          `json:"imagePullSecret,omitempty"`
 	DeploymentStatus         *deploymentStatus         `json:"deploymentStatus,omitempty"`
+	TextAnalyze              *textAnalyze              `json:"textAnalyze,omitempty"`
 }
 
 type customResourceDefinition struct {
@@ -32,6 +33,15 @@ type deploymentStatus struct {
 	Outcomes    []*outcome `json:"outcomes"`
 	Namespace   string     `json:"namespace"`
 	Name        string     `json:"name"`
+}
+
+type textAnalyze struct {
+	analyzeMeta   `json:",inline"`
+	CollectorName string     `json:"collectorName,omitempty"`
+	FileName      string     `json:"fileName,omitempty"`
+	RegexPattern  string     `json:"regex,omitempty"`
+	RegexGroups   string     `json:"regexGroups,omitempty"`
+	Outcomes      []*outcome `json:"outcomes"`
 }
 
 type analyzeMeta struct {

--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -175,9 +175,9 @@ func (a *analyzerFactory) EksaLogTextAnalyzers(collectors []*Collect) []*Analyze
 // namespaceLogTextAnalyzersMap is used to associated log text analyzers with the logs collected from a specific namespace.
 // the key of the analyzers map is the namespace name, and the value are the associated log text analyzers.
 func (a *analyzerFactory) namespaceLogTextAnalyzersMap() map[string][]*Analyze {
-	logTextAnalyzers := map[string][]*Analyze{}
-	logTextAnalyzers[constants.CapiKubeadmControlPlaneSystemNamespace] = a.capiKubeadmControlPlaneSystemLogAnalyzers()
-	return logTextAnalyzers
+	return map[string][]*Analyze{
+		constants.CapiKubeadmControlPlaneSystemNamespace: a.capiKubeadmControlPlaneSystemLogAnalyzers(),
+	}
 }
 
 func (a *analyzerFactory) capiKubeadmControlPlaneSystemLogAnalyzers() []*Analyze {

--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -5,6 +5,7 @@ import (
 	"path"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
 )
 
 const (
@@ -25,55 +26,55 @@ func (a *analyzerFactory) defaultDeploymentAnalyzers() []*Analyze {
 	d := []eksaDeployment{
 		{
 			Name:             "capv-controller-manager",
-			Namespace:        "capi-webhook-system",
+			Namespace:        constants.CapiWebhookSystemNamespace,
 			ExpectedReplicas: 1,
 		}, {
 			Name:             "capv-controller-manager",
-			Namespace:        "capv-system",
+			Namespace:        constants.CapvSystemNamespace,
 			ExpectedReplicas: 1,
 		}, {
 			Name:             "coredns",
-			Namespace:        "kube-system",
+			Namespace:        constants.KubeSystemNamespace,
 			ExpectedReplicas: 2,
 		}, {
 			Name:             "cert-manager-webhook",
-			Namespace:        "cert-manager",
+			Namespace:        constants.CertManagerNamespace,
 			ExpectedReplicas: 1,
 		}, {
 			Name:             "cert-manager-cainjector",
-			Namespace:        "cert-manager",
+			Namespace:        constants.CertManagerNamespace,
 			ExpectedReplicas: 1,
 		}, {
 			Name:             "cert-manager",
-			Namespace:        "cert-manager",
+			Namespace:        constants.CertManagerNamespace,
 			ExpectedReplicas: 1,
 		}, {
 			Name:             "capi-kubeadm-control-plane-controller-manager",
-			Namespace:        "capi-webhook-system",
+			Namespace:        constants.CapiWebhookSystemNamespace,
 			ExpectedReplicas: 1,
 		}, {
 			Name:             "capi-kubeadm-bootstrap-controller-manager",
-			Namespace:        "capi-webhook-system",
+			Namespace:        constants.CapiWebhookSystemNamespace,
 			ExpectedReplicas: 1,
 		}, {
 			Name:             "capi-controller-manager",
-			Namespace:        "capi-webhook-system",
+			Namespace:        constants.CapiWebhookSystemNamespace,
 			ExpectedReplicas: 1,
 		}, {
 			Name:             "capi-controller-manager",
-			Namespace:        "capi-system",
+			Namespace:        constants.CapiSystemNamespace,
 			ExpectedReplicas: 1,
 		}, {
 			Name:             "capi-kubeadm-control-plane-controller-manager",
-			Namespace:        "capi-kubeadm-control-plane-system",
+			Namespace:        constants.CapiKubeadmControlPlaneSystemNamespace,
 			ExpectedReplicas: 1,
 		}, {
 			Name:             "capi-kubeadm-control-plane-controller-manager",
-			Namespace:        "capi-kubeadm-control-plane-system",
+			Namespace:        constants.CapiKubeadmControlPlaneSystemNamespace,
 			ExpectedReplicas: 1,
 		}, {
 			Name:             "capi-kubeadm-bootstrap-controller-manager",
-			Namespace:        "capi-kubeadm-bootstrap-system",
+			Namespace:        constants.CapiKubeadmBootstrapSystemNamespace,
 			ExpectedReplicas: 1,
 		},
 	}
@@ -106,11 +107,11 @@ func (a *analyzerFactory) EksaExternalEtcdAnalyzers() []*Analyze {
 	deployments := []eksaDeployment{
 		{
 			Name:             "etcdadm-controller-controller-manager",
-			Namespace:        "etcdadm-controller-system",
+			Namespace:        constants.EtcdAdminControllerSystemNamespace,
 			ExpectedReplicas: 1,
 		}, {
 			Name:             "etcdadm-bootstrap-provider-controller-manager",
-			Namespace:        "etcdadm-bootstrap-provider-system",
+			Namespace:        constants.EtcdAdminBootstrapProviderSystemNamespace,
 			ExpectedReplicas: 1,
 		},
 	}
@@ -146,7 +147,7 @@ func (a *analyzerFactory) eksaDockerAnalyzers() []*Analyze {
 	deployments := []eksaDeployment{
 		{
 			Name:             "local-path-provisioner",
-			Namespace:        "local-path-storage",
+			Namespace:        constants.LocalPathStorageNamespace,
 			ExpectedReplicas: 1,
 		},
 	}
@@ -175,21 +176,21 @@ func (a *analyzerFactory) EksaLogTextAnalyzers(collectors []*Collect) []*Analyze
 // the key of the analyzers map is the namespace name, and the value are the associated log text analyzers.
 func (a *analyzerFactory) namespaceLogTextAnalyzersMap() map[string][]*Analyze {
 	logTextAnalyzers := map[string][]*Analyze{}
-	logTextAnalyzers[capiKubeadmControlPlaneSystem] = a.capiKubeadmControlPlaneSystemLogAnalyzers()
+	logTextAnalyzers[constants.CapiKubeadmControlPlaneSystemNamespace] = a.capiKubeadmControlPlaneSystemLogAnalyzers()
 	return logTextAnalyzers
 }
 
 func (a *analyzerFactory) capiKubeadmControlPlaneSystemLogAnalyzers() []*Analyze {
 	capiCpManagerPod := "capi-kubeadm-control-plane-controller-manager-*"
 	capiCpManagerContainerLogFile := path.Join(capiCpManagerPod, "manager.log")
-	fullManagerPodLogPath := path.Join(logpath(capiKubeadmControlPlaneSystem), capiCpManagerContainerLogFile)
+	fullManagerPodLogPath := path.Join(logpath(constants.CapiKubeadmControlPlaneSystemNamespace), capiCpManagerContainerLogFile)
 	return []*Analyze{
 		{
 			TextAnalyze: &textAnalyze{
 				analyzeMeta: analyzeMeta{
 					CheckName: fmt.Sprintf("%s: API server pod missing. Log: %s", logAnalysisAnalyzerPrefix, fullManagerPodLogPath),
 				},
-				CollectorName: capiKubeadmControlPlaneSystem,
+				CollectorName: constants.CapiKubeadmControlPlaneSystemNamespace,
 				FileName:      capiCpManagerContainerLogFile,
 				RegexPattern:  `machine (.*?) reports APIServerPodHealthy condition is false \(Error, Pod kube-apiserver-(.*?) is missing\)`,
 				Outcomes: []*outcome{

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -1,11 +1,27 @@
 package diagnostics
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/providers"
+)
+
+const (
+	capdSystem                       = "capd-system"
+	capiKubeadmBootstrapSystem       = "capi-kubeadm-bootstrap-system"
+	capiKubeadmControlPlaneSystem    = "capi-kubeadm-control-plane-system"
+	capiSystem                       = "capi-system"
+	capiWebhookSystem                = "capi-webhook-system"
+	certManager                      = "cert-manager"
+	cefaultNamespace                 = "default"
+	etcdAdminBootstrapProviderSystem = "etcdadm-bootstrap-provider-system"
+	etcdAdminControllerSystem        = "etcdadm-controller-system"
+	kubeNodeLease                    = "kube-node-lease"
+	kubePublic                       = "kube-public"
+	kubeSystem                       = "kube-system"
 )
 
 type collectorFactory struct {
@@ -40,80 +56,80 @@ func (c *collectorFactory) DefaultCollectors() []*Collect {
 		},
 		{
 			Logs: &logs{
-				Namespace: "capd-system",
-				Name:      "logs/capd-system",
+				Namespace: capdSystem,
+				Name:      logpath(capdSystem),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: "capi-kubeadm-bootstrap-system",
-				Name:      "logs/capi-kubeadm-bootstrap-system",
+				Namespace: capiKubeadmBootstrapSystem,
+				Name:      logpath(capiKubeadmBootstrapSystem),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: "capi-kubeadm-control-plane-system",
-				Name:      "logs/capi-kubeadm-control-plane-system",
+				Namespace: capiKubeadmControlPlaneSystem,
+				Name:      logpath(capiKubeadmControlPlaneSystem),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: "capi-system",
-				Name:      "logs/capi-system",
+				Namespace: capiSystem,
+				Name:      logpath(capiSystem),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: "capi-webhook-system",
-				Name:      "logs/capi-webhook-system",
+				Namespace: capiWebhookSystem,
+				Name:      logpath(capiWebhookSystem),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: "cert-manager",
-				Name:      "logs/cert-manager",
+				Namespace: certManager,
+				Name:      logpath(certManager),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: "eksa-system",
-				Name:      "logs/eksa-system",
+				Namespace: constants.EksaSystemNamespace,
+				Name:      logpath(constants.EksaSystemNamespace),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: "default",
-				Name:      "logs/default",
+				Namespace: cefaultNamespace,
+				Name:      logpath(cefaultNamespace),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: "etcdadm-bootstrap-provider-system",
-				Name:      "logs/etcdadm-bootstrap-provider-system",
+				Namespace: etcdAdminBootstrapProviderSystem,
+				Name:      logpath(etcdAdminBootstrapProviderSystem),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: "etcdadm-controller-system",
-				Name:      "logs/etcdadm-controller-system",
+				Namespace: etcdAdminControllerSystem,
+				Name:      logpath(etcdAdminControllerSystem),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: "kube-node-lease",
-				Name:      "logs/kube-node-lease",
+				Namespace: kubeNodeLease,
+				Name:      logpath(kubeNodeLease),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: "kube-public",
-				Name:      "logs/kube-public",
+				Namespace: kubePublic,
+				Name:      logpath(kubePublic),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: "kube-system",
-				Name:      "logs/kube-system",
+				Namespace: kubeSystem,
+				Name:      logpath(kubeSystem),
 			},
 		},
 	}
@@ -173,4 +189,8 @@ func (c *collectorFactory) ubuntuHostCollectors() []*Collect {
 			},
 		},
 	}
+}
+
+func logpath(namespace string) string {
+	return fmt.Sprintf("logs/%s", namespace)
 }

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -9,21 +9,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers"
 )
 
-const (
-	capdSystem                       = "capd-system"
-	capiKubeadmBootstrapSystem       = "capi-kubeadm-bootstrap-system"
-	capiKubeadmControlPlaneSystem    = "capi-kubeadm-control-plane-system"
-	capiSystem                       = "capi-system"
-	capiWebhookSystem                = "capi-webhook-system"
-	certManager                      = "cert-manager"
-	cefaultNamespace                 = "default"
-	etcdAdminBootstrapProviderSystem = "etcdadm-bootstrap-provider-system"
-	etcdAdminControllerSystem        = "etcdadm-controller-system"
-	kubeNodeLease                    = "kube-node-lease"
-	kubePublic                       = "kube-public"
-	kubeSystem                       = "kube-system"
-)
-
 type collectorFactory struct {
 	DiagnosticCollectorImage string
 }
@@ -56,38 +41,38 @@ func (c *collectorFactory) DefaultCollectors() []*Collect {
 		},
 		{
 			Logs: &logs{
-				Namespace: capdSystem,
-				Name:      logpath(capdSystem),
+				Namespace: constants.CapdSystemNamespace,
+				Name:      logpath(constants.CapdSystemNamespace),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: capiKubeadmBootstrapSystem,
-				Name:      logpath(capiKubeadmBootstrapSystem),
+				Namespace: constants.CapiKubeadmBootstrapSystemNamespace,
+				Name:      logpath(constants.CapiKubeadmBootstrapSystemNamespace),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: capiKubeadmControlPlaneSystem,
-				Name:      logpath(capiKubeadmControlPlaneSystem),
+				Namespace: constants.CapiKubeadmControlPlaneSystemNamespace,
+				Name:      logpath(constants.CapiKubeadmControlPlaneSystemNamespace),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: capiSystem,
-				Name:      logpath(capiSystem),
+				Namespace: constants.CapiSystemNamespace,
+				Name:      logpath(constants.CapiSystemNamespace),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: capiWebhookSystem,
-				Name:      logpath(capiWebhookSystem),
+				Namespace: constants.CapiWebhookSystemNamespace,
+				Name:      logpath(constants.CapiWebhookSystemNamespace),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: certManager,
-				Name:      logpath(certManager),
+				Namespace: constants.CertManagerNamespace,
+				Name:      logpath(constants.CertManagerNamespace),
 			},
 		},
 		{
@@ -98,38 +83,38 @@ func (c *collectorFactory) DefaultCollectors() []*Collect {
 		},
 		{
 			Logs: &logs{
-				Namespace: cefaultNamespace,
-				Name:      logpath(cefaultNamespace),
+				Namespace: constants.DefaultNamespace,
+				Name:      logpath(constants.DefaultNamespace),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: etcdAdminBootstrapProviderSystem,
-				Name:      logpath(etcdAdminBootstrapProviderSystem),
+				Namespace: constants.EtcdAdminBootstrapProviderSystemNamespace,
+				Name:      logpath(constants.EtcdAdminBootstrapProviderSystemNamespace),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: etcdAdminControllerSystem,
-				Name:      logpath(etcdAdminControllerSystem),
+				Namespace: constants.EtcdAdminControllerSystemNamespace,
+				Name:      logpath(constants.EtcdAdminControllerSystemNamespace),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: kubeNodeLease,
-				Name:      logpath(kubeNodeLease),
+				Namespace: constants.KubeNodeLeaseNamespace,
+				Name:      logpath(constants.KubeNodeLeaseNamespace),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: kubePublic,
-				Name:      logpath(kubePublic),
+				Namespace: constants.KubePublicNamespace,
+				Name:      logpath(constants.KubePublicNamespace),
 			},
 		},
 		{
 			Logs: &logs{
-				Namespace: kubeSystem,
-				Name:      logpath(kubeSystem),
+				Namespace: constants.KubeSystemNamespace,
+				Name:      logpath(constants.KubeSystemNamespace),
 			},
 		},
 	}

--- a/pkg/diagnostics/interfaces.go
+++ b/pkg/diagnostics/interfaces.go
@@ -27,6 +27,7 @@ type DiagnosticBundle interface {
 type AnalyzerFactory interface {
 	DefaultAnalyzers() []*Analyze
 	EksaGitopsAnalyzers() []*Analyze
+	EksaLogTextAnalyzers(collectors []*Collect) []*Analyze
 	EksaOidcAnalyzers() []*Analyze
 	EksaExternalEtcdAnalyzers() []*Analyze
 	DataCenterConfigAnalyzers(datacenter v1alpha1.Ref) []*Analyze

--- a/pkg/diagnostics/interfaces/mocks/diagnostics.go
+++ b/pkg/diagnostics/interfaces/mocks/diagnostics.go
@@ -270,10 +270,10 @@ func (mr *MockAnalyzerFactoryMockRecorder) EksaGitopsAnalyzers() *gomock.Call {
 }
 
 // EksaLogTextAnalyzers mocks base method.
-func (m *MockAnalyzerFactory) EksaLogTextAnalyzers(collectors []*supportbundle.Collect) []*supportbundle.Analyze {
+func (m *MockAnalyzerFactory) EksaLogTextAnalyzers(collectors []*diagnostics.Collect) []*diagnostics.Analyze {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EksaLogTextAnalyzers", collectors)
-	ret0, _ := ret[0].([]*supportbundle.Analyze)
+	ret0, _ := ret[0].([]*diagnostics.Analyze)
 	return ret0
 }
 

--- a/pkg/diagnostics/interfaces/mocks/support.go
+++ b/pkg/diagnostics/interfaces/mocks/support.go
@@ -269,6 +269,20 @@ func (mr *MockAnalyzerFactoryMockRecorder) EksaGitopsAnalyzers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EksaGitopsAnalyzers", reflect.TypeOf((*MockAnalyzerFactory)(nil).EksaGitopsAnalyzers))
 }
 
+// EksaLogTextAnalyzers mocks base method.
+func (m *MockAnalyzerFactory) EksaLogTextAnalyzers(collectors []*supportbundle.Collect) []*supportbundle.Analyze {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EksaLogTextAnalyzers", collectors)
+	ret0, _ := ret[0].([]*supportbundle.Analyze)
+	return ret0
+}
+
+// EksaLogTextAnalyzers indicates an expected call of EksaLogTextAnalyzers.
+func (mr *MockAnalyzerFactoryMockRecorder) EksaLogTextAnalyzers(collectors interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EksaLogTextAnalyzers", reflect.TypeOf((*MockAnalyzerFactory)(nil).EksaLogTextAnalyzers), collectors)
+}
+
 // EksaOidcAnalyzers mocks base method.
 func (m *MockAnalyzerFactory) EksaOidcAnalyzers() []*diagnostics.Analyze {
 	m.ctrl.T.Helper()

--- a/pkg/diagnostics/runsupportbundle.go
+++ b/pkg/diagnostics/runsupportbundle.go
@@ -73,7 +73,8 @@ func NewDiagnosticBundleFromSpec(spec *cluster.Spec, provider providers.Provider
 		WithDatacenterConfig(spec.Spec.DatacenterRef).
 		WithMachineConfigs(provider.MachineConfigs()).
 		WithDefaultAnalyzers().
-		WithDefaultCollectors()
+		WithDefaultCollectors().
+		WithLogTextAnalyzers()
 
 	err := b.WriteBundleConfig()
 	if err != nil {
@@ -194,6 +195,11 @@ func (e *EksaDiagnosticBundle) WithGitOpsConfig(config *v1alpha1.GitOpsConfig) *
 
 func (e *EksaDiagnosticBundle) WithMachineConfigs(configs []providers.MachineConfig) *EksaDiagnosticBundle {
 	e.bundle.Spec.Collectors = append(e.bundle.Spec.Collectors, e.collectorFactory.EksaHostCollectors(configs)...)
+	return e
+}
+
+func (e *EksaDiagnosticBundle) WithLogTextAnalyzers() *EksaDiagnosticBundle {
+	e.bundle.Spec.Analyzers = append(e.bundle.Spec.Analyzers, e.analyzerFactory.EksaLogTextAnalyzers(e.bundle.Spec.Collectors)...)
 	return e
 }
 

--- a/pkg/diagnostics/runsupportbundle_test.go
+++ b/pkg/diagnostics/runsupportbundle_test.go
@@ -108,6 +108,7 @@ func TestGenerateBundleConfigWithExternalEtcd(t *testing.T) {
 		a.EXPECT().EksaExternalEtcdAnalyzers().Return(nil)
 		a.EXPECT().DataCenterConfigAnalyzers(spec.Cluster.Spec.DatacenterRef).Return(nil)
 		a.EXPECT().DefaultAnalyzers().Return(nil)
+		a.EXPECT().EksaLogTextAnalyzers(gomock.Any()).Return(nil)
 
 		c := givenMockCollectorsFactory(t)
 		c.EXPECT().DefaultCollectors().Return(nil)
@@ -156,6 +157,7 @@ func TestGenerateBundleConfigWithOidc(t *testing.T) {
 		a.EXPECT().EksaOidcAnalyzers().Return(nil)
 		a.EXPECT().DataCenterConfigAnalyzers(spec.Cluster.Spec.DatacenterRef).Return(nil)
 		a.EXPECT().DefaultAnalyzers().Return(nil)
+		a.EXPECT().EksaLogTextAnalyzers(gomock.Any()).Return(nil)
 
 		w := givenWriter(t)
 		w.EXPECT().Write(gomock.Any(), gomock.Any())
@@ -204,6 +206,7 @@ func TestGenerateBundleConfigWithGitOps(t *testing.T) {
 		a.EXPECT().EksaGitopsAnalyzers().Return(nil)
 		a.EXPECT().DataCenterConfigAnalyzers(spec.Cluster.Spec.DatacenterRef).Return(nil)
 		a.EXPECT().DefaultAnalyzers().Return(nil)
+		a.EXPECT().EksaLogTextAnalyzers(gomock.Any()).Return(nil)
 
 		w := givenWriter(t)
 		w.EXPECT().Write(gomock.Any(), gomock.Any())


### PR DESCRIPTION
https://github.com/aws/eks-anywhere/issues/239

## changes
Add system to associate log text analyzers with logs collected from a given namespace.

Move namespace names to `constants` package.

Add initial log text analyzer for `capi-kubeadm-control-plane-system`, which checks for failed API server pods in the logs.

## explanation
Log text analyzers parse the logs collected by the associated Collector for regex matches (or, alternatively, regex group matches -- see https://troubleshoot.sh/docs/analyze/regex/) and produce an outcome based on the result.

We can now add new entires to the `logTextAnalyzersMap` for each namespace; each of the associated analyzers will then be included if the logs for that namespace are being collected. This allows us to compose the log text analyzers based on the collectors that are present; we define the different analyzers that could possibly be present, and then only use the ones that are relevant for the given input cluster. 

This allows us to generate log analyzers dynamically based on the namespaced log collector present; this is useful in cases like `flux-system` or `etcadm-controller-system`, where the logs will not be present if the customer is not using gitops or external etcd. If the customer is using one of these optional features, then we'll be collecting logs for the associated namespace, and will then subsequently add the analyzers for the given logs in the namespace.

## process for adding new text analyzers

to add text analyzers for a given namespace, we'd add an entry to the `logtextAnalyzersMap` for that namespace; the key is the namespace name, the value is a slice of analyzers. Once the entry is in the map, if we collect logs for the namespace, we'll include the analyzer.

to add a new text analyzer to a given namespace, we'd add an additional analyzer to the generator function for that namespace's analyzers -- for example, [add a new analyzer entry to this method for `capi-kubeadm-control-plane-system`](https://github.com/aws/eks-anywhere/pull/334/files#diff-bcb63ea9e7a019b94633aeda38a438f47808688c5e8f5e46775f9958dd6278cdR183).  This allows us to clearly define unique analyzers for each namespace, and control what pod logs in that namespace are analyzed and what the analyzer results return at a granular, per-namespace level.