### PR TITLE
Fix controller nil pointer error when cluster externalEtcdConfiguration not specified

### DIFF
--- a/controllers/controllers/resource/fetcher.go
+++ b/controllers/controllers/resource/fetcher.go
@@ -138,7 +138,7 @@ func (r *capiResourceFetcher) fetchClusterForRef(ctx context.Context, refId type
 					return &c, nil
 				}
 			}
-			if c.Spec.ExternalEtcdConfiguration.MachineGroupRef != nil && c.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name == refId.Name {
+			if c.Spec.ExternalEtcdConfiguration != nil && c.Spec.ExternalEtcdConfiguration.MachineGroupRef != nil && c.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name == refId.Name {
 				if _, err := r.clusterByName(ctx, constants.EksaSystemNamespace, c.Name); err == nil { // further validates a capi cluster exists
 					return &c, nil
 				}

--- a/controllers/controllers/resource/fetcher_test.go
+++ b/controllers/controllers/resource/fetcher_test.go
@@ -335,54 +335,6 @@ func TestCAPIResourceFetcherFetchCluster(t *testing.T) {
 	}
 }
 
-func TestCAPIResourceFetcherFetchClusterNotFound(t *testing.T) {
-	type fields struct {
-		client client.Reader
-	}
-	type args struct {
-		objectKey types.NamespacedName
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    *anywherev1.Cluster
-		wantErr bool
-	}{
-		{
-			name: "fetch cluster from VSphereMachineConfigKind, external etcd field empty",
-			fields: fields{
-				client: &stubbedReader{
-					clusterName: "testCluster",
-					kind:        anywherev1.VSphereMachineConfigKind,
-					cluster: anywherev1.Cluster{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "testCluster",
-						},
-						Spec: anywherev1.ClusterSpec{},
-					},
-				},
-			},
-			args: args{
-				objectKey: types.NamespacedName{Name: "testVSphereMachineConfig", Namespace: "default"},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := resource.NewCAPIResourceFetcher(tt.fields.client, log.NullLogger{})
-			got, err := r.FetchCluster(context.Background(), tt.args.objectKey)
-			if (err == nil) != tt.wantErr {
-				t.Errorf("FetchCluster() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("FetchCluster() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 type stubbedReader struct {
 	kind        string
 	cluster     anywherev1.Cluster

--- a/controllers/controllers/resource/fetcher_test.go
+++ b/controllers/controllers/resource/fetcher_test.go
@@ -300,12 +300,79 @@ func TestCAPIResourceFetcherFetchCluster(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "fetch cluster from VSphereMachineConfigKind, external etcd field empty",
+			fields: fields{
+				client: &stubbedReader{
+					clusterName: "testCluster",
+					kind:        anywherev1.VSphereMachineConfigKind,
+					cluster: anywherev1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testCluster",
+						},
+						Spec: anywherev1.ClusterSpec{},
+					},
+				},
+			},
+			args: args{
+				objectKey: types.NamespacedName{Name: "testVSphereMachineConfig", Namespace: "default"},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := resource.NewCAPIResourceFetcher(tt.fields.client, log.NullLogger{})
 			got, err := r.FetchCluster(context.Background(), tt.args.objectKey)
 			if (err != nil) != tt.wantErr {
+				t.Errorf("FetchCluster() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FetchCluster() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCAPIResourceFetcherFetchClusterNotFound(t *testing.T) {
+	type fields struct {
+		client client.Reader
+	}
+	type args struct {
+		objectKey types.NamespacedName
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *anywherev1.Cluster
+		wantErr bool
+	}{
+		{
+			name: "fetch cluster from VSphereMachineConfigKind, external etcd field empty",
+			fields: fields{
+				client: &stubbedReader{
+					clusterName: "testCluster",
+					kind:        anywherev1.VSphereMachineConfigKind,
+					cluster: anywherev1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testCluster",
+						},
+						Spec: anywherev1.ClusterSpec{},
+					},
+				},
+			},
+			args: args{
+				objectKey: types.NamespacedName{Name: "testVSphereMachineConfig", Namespace: "default"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := resource.NewCAPIResourceFetcher(tt.fields.client, log.NullLogger{})
+			got, err := r.FetchCluster(context.Background(), tt.args.objectKey)
+			if (err == nil) != tt.wantErr {
 				t.Errorf("FetchCluster() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}


### PR DESCRIPTION
… specified

*Issue #, if available:*

Fix an error in https://github.com/aws/eks-anywhere/pull/177

https://github.com/aws/eks-anywhere/pull/177/files#diff-901e66a5eff9a6cdcca9fcdd1534b0b670184b4af721ee46530fbd87aa28b995R141

*Description of changes:*

Handle case when externalEtcdConfiguration is not defined in cluster spec.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
