### PR TITLE
Dependency factory

### DIFF
--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -12,9 +12,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/executables"
-	"github.com/aws/eks-anywhere/pkg/filewriter"
-	"github.com/aws/eks-anywhere/pkg/providers/factory"
+	"github.com/aws/eks-anywhere/pkg/dependencies"
 	support "github.com/aws/eks-anywhere/pkg/support"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/version"
@@ -94,58 +92,33 @@ func (csbo *createSupportBundleOptions) createBundle(ctx context.Context, since,
 		return fmt.Errorf("unable to get cluster config from file: %v", err)
 	}
 
-	eksaToolsImage := clusterSpec.VersionsBundle.Eksa.CliTools
-	image := eksaToolsImage.VersionedImage()
-	executableBuilder, err := executables.NewExecutableBuilder(ctx, image)
-	if err != nil {
-		return fmt.Errorf("unable to initialize executables: %v", err)
-	}
-	troubleshoot := executableBuilder.BuildTroubleshootExecutable()
-
-	writerDir := fmt.Sprintf(clusterSpec.Name)
-	writer, err := filewriter.NewWriter(writerDir)
-	if err != nil {
-		return fmt.Errorf("unable to write: %v", err)
-	}
-
-	clusterawsadm := executableBuilder.BuildClusterAwsAdmExecutable()
-	kubectl := executableBuilder.BuildKubectlExecutable()
-	govc := executableBuilder.BuildGovcExecutable(writer)
-	docker := executables.BuildDockerExecutable()
-
-	providerFactory := &factory.ProviderFactory{
-		AwsClient:            clusterawsadm,
-		DockerClient:         docker,
-		DockerKubectlClient:  kubectl,
-		VSphereGovcClient:    govc,
-		VSphereKubectlClient: kubectl,
-		Writer:               writer,
-	}
-	provider, err := providerFactory.BuildProvider(csbo.fileName, clusterSpec.Cluster)
+	deps, err := dependencies.ForSpec(ctx, clusterSpec).
+		WithProvider(csbo.fileName, clusterSpec.Cluster, cc.skipIpCheck).
+		WithAnalyzerFactory().
+		WithCollectorFactory().
+		WithWriter().
+		WithTroubleshoot().
+		Build()
 	if err != nil {
 		return err
+	}
+
+	opts := support.EksaDiagnosticBundleOpts{
+		AnalyzerFactory:  deps.AnalyzerFactory,
+		CollectorFactory: deps.CollectorFactory,
+		Client:           deps.Troubleshoot,
+		Writer:           deps.Writer,
+	}
+
+	supportBundle, err := support.NewDiagnosticBundle(clusterSpec, deps.Provider, csbo.kubeConfig(clusterSpec.Name), bundleConfig, opts)
+	if err != nil {
+		return fmt.Errorf("failed to parse collector: %v", err)
 	}
 
 	var sinceTimeValue *time.Time
 	sinceTimeValue, err = support.ParseTimeOptions(since, sinceTime)
 	if err != nil {
 		return fmt.Errorf("failed parse since time: %v", err)
-	}
-
-	collectorImage := clusterSpec.VersionsBundle.Eksa.DiagnosticCollector.VersionedImage()
-	cf := support.NewCollectorFactory(collectorImage)
-	af := support.NewAnalyzerFactory()
-
-	opts := support.EksaDiagnosticBundleOpts{
-		AnalyzerFactory:  af,
-		CollectorFactory: cf,
-		Client:           troubleshoot,
-		Writer:           writer,
-	}
-
-	supportBundle, err := support.NewDiagnosticBundle(clusterSpec, provider, csbo.kubeConfig(clusterSpec.Name), bundleConfig, opts)
-	if err != nil {
-		return fmt.Errorf("failed to parse collector: %v", err)
 	}
 
 	err = supportBundle.CollectAndAnalyze(ctx, sinceTimeValue)

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -10,15 +10,8 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/aws/eks-anywhere/pkg/addonmanager/addonclients"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/bootstrapper"
-	fluxclient "github.com/aws/eks-anywhere/pkg/clients/flux"
-	"github.com/aws/eks-anywhere/pkg/clustermanager"
-	"github.com/aws/eks-anywhere/pkg/executables"
-	"github.com/aws/eks-anywhere/pkg/filewriter"
-	"github.com/aws/eks-anywhere/pkg/networking"
-	"github.com/aws/eks-anywhere/pkg/providers/factory"
+	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/upgradevalidations"
@@ -85,69 +78,24 @@ func (uc *upgradeClusterOptions) upgradeCluster(ctx context.Context) error {
 		return err
 	}
 
-	writer, err := filewriter.NewWriter(clusterSpec.Name)
-	if err != nil {
-		return fmt.Errorf("unable to write: %v", err)
-	}
-
-	eksaToolsImage := clusterSpec.VersionsBundle.Eksa.CliTools
-	image := eksaToolsImage.VersionedImage()
-	executableBuilder, err := executables.NewExecutableBuilder(ctx, image)
-	if err != nil {
-		return fmt.Errorf("unable to initialize executables: %v", err)
-	}
-
-	clusterawsadm := executableBuilder.BuildClusterAwsAdmExecutable()
-	kind := executableBuilder.BuildKindExecutable(writer)
-	clusterctl := executableBuilder.BuildClusterCtlExecutable(writer)
-	kubectl := executableBuilder.BuildKubectlExecutable()
-	govc := executableBuilder.BuildGovcExecutable(writer)
-	docker := executables.BuildDockerExecutable()
-	flux := executableBuilder.BuildFluxExecutable()
-
-	providerFactory := &factory.ProviderFactory{
-		AwsClient:            clusterawsadm,
-		DockerClient:         docker,
-		DockerKubectlClient:  kubectl,
-		VSphereGovcClient:    govc,
-		VSphereKubectlClient: kubectl,
-		Writer:               writer,
-	}
-	provider, err := providerFactory.BuildProvider(uc.fileName, clusterSpec.Cluster)
+	deps, err := dependencies.ForSpec(ctx, clusterSpec).
+		WithBootstrapper().
+		WithClusterManager().
+		WithProvider(uc.fileName, clusterSpec.Cluster, cc.skipIpCheck).
+		WithFluxAddonClient(ctx, clusterSpec.Cluster, clusterSpec.GitOpsConfig).
+		WithWriter().
+		WithKubectl().
+		Build()
 	if err != nil {
 		return err
 	}
 
-	bootstrapper := bootstrapper.New(&bootstrapperClient{kind, kubectl})
-
-	clusterManager := clustermanager.New(
-		&clusterManagerClient{
-			clusterctl,
-			kubectl,
-		},
-		networking.NewCilium(),
-		writer,
-	)
-
-	gitOpts, err := addonclients.NewGitOptions(ctx, clusterSpec.Cluster, clusterSpec.GitOpsConfig, writer)
-	if err != nil {
-		return fmt.Errorf("failed to set up git options: %v", err)
-	}
-
-	addonClient := addonclients.NewFluxAddonClient(
-		&fluxclient.FluxKubectl{
-			Flux:    flux,
-			Kubectl: kubectl,
-		},
-		gitOpts,
-	)
-
 	upgradeCluster := workflows.NewUpgrade(
-		bootstrapper,
-		provider,
-		clusterManager,
-		addonClient,
-		writer,
+		deps.Bootstrapper,
+		deps.Provider,
+		deps.ClusterManager,
+		deps.FluxAddonClient,
+		deps.Writer,
 	)
 
 	workloadCluster := &types.Cluster{
@@ -156,16 +104,16 @@ func (uc *upgradeClusterOptions) upgradeCluster(ctx context.Context) error {
 	}
 
 	validationOpts := &upgradevalidations.UpgradeValidationOpts{
-		Kubectl:         kubectl,
+		Kubectl:         deps.Kubectl,
 		Spec:            clusterSpec,
 		WorkloadCluster: workloadCluster,
-		Provider:        provider,
+		Provider:        deps.Provider,
 	}
 	upgradeValidations := upgradevalidations.New(validationOpts)
 
 	err = upgradeCluster.Run(ctx, clusterSpec, workloadCluster, upgradeValidations, uc.forceClean)
 	if err == nil {
-		writer.CleanUpTemp()
+		deps.Writer.CleanUpTemp()
 	}
 	return err
 }

--- a/pkg/clients/flux/client.go
+++ b/pkg/clients/flux/client.go
@@ -1,4 +1,4 @@
-package fluxclient
+package flux
 
 import (
 	"context"

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -1,0 +1,391 @@
+package dependencies
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/eks-anywhere/pkg/addonmanager/addonclients"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/bootstrapper"
+	"github.com/aws/eks-anywhere/pkg/clients/flux"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clustermanager"
+	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/filewriter"
+	"github.com/aws/eks-anywhere/pkg/networking"
+	"github.com/aws/eks-anywhere/pkg/providers"
+	"github.com/aws/eks-anywhere/pkg/providers/factory"
+	supportbundle "github.com/aws/eks-anywhere/pkg/support"
+)
+
+type Dependencies struct {
+	Provider         providers.Provider
+	ClusterAwsCli    *executables.Clusterawsadm
+	DockerClient     *executables.Docker
+	Kubectl          *executables.Kubectl
+	Govc             *executables.Govc
+	Writer           filewriter.FileWriter
+	Kind             *executables.Kind
+	Clusterctl       *executables.Clusterctl
+	Flux             *executables.Flux
+	Troubleshoot     *executables.Troubleshoot
+	Networking       clustermanager.Networking
+	ClusterManager   *clustermanager.ClusterManager
+	Bootstrapper     *bootstrapper.Bootstrapper
+	FluxAddonClient  *addonclients.FluxAddonClient
+	AnalyzerFactory  supportbundle.AnalyzerFactory
+	CollectorFactory supportbundle.CollectorFactory
+}
+
+func ForSpec(ctx context.Context, clusterSpec *cluster.Spec) *Factory {
+	eksaToolsImage := clusterSpec.VersionsBundle.Eksa.CliTools
+	return NewFactory().
+		WithExecutableBuilder(ctx, clusterSpec.UseImageMirror(eksaToolsImage.VersionedImage())).
+		WithWriterFolder(clusterSpec.Name).
+		WithDiagnosticCollectorImage(clusterSpec.VersionsBundle.Eksa.DiagnosticCollector.VersionedImage())
+}
+
+type Factory struct {
+	executableBuilder        *executables.ExecutableBuilder
+	providerFactory          *factory.ProviderFactory
+	writerFolder             string
+	diagnosticCollectorImage string
+	buildSteps               []func() error
+	dependencies             Dependencies
+}
+
+func NewFactory() *Factory {
+	return &Factory{
+		executableBuilder: executables.NewLocalExecutableBuilder(),
+		writerFolder:      "./",
+		buildSteps:        make([]func() error, 0),
+	}
+}
+
+func (f *Factory) Build() (*Dependencies, error) {
+	for _, step := range f.buildSteps {
+		if err := step(); err != nil {
+			return nil, err
+		}
+	}
+
+	// clean up stack
+	f.buildSteps = make([]func() error, 0)
+
+	// Make copy of dependencies since its attributes are public
+	d := f.dependencies
+
+	return &d, nil
+}
+
+func (f *Factory) WithWriterFolder(folder string) *Factory {
+	f.writerFolder = folder
+	return f
+}
+
+func (f *Factory) WithExecutableBuilder(ctx context.Context, image string) *Factory {
+	f.buildSteps = append(f.buildSteps, func() error {
+		b, err := executables.NewExecutableBuilder(ctx, image)
+		if err != nil {
+			return err
+		}
+
+		f.executableBuilder = b
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1.Cluster, skipIpCheck bool) *Factory {
+	f.WithProviderFactory()
+
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.Provider != nil {
+			return nil
+		}
+
+		var err error
+		f.dependencies.Provider, err = f.providerFactory.BuildProvider(clusterConfigFile, clusterConfig, skipIpCheck)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithProviderFactory() *Factory {
+	f.WithClusterAwsCli().WithDocker().WithKubectl().WithGovc().WithWriter()
+
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.providerFactory != nil {
+			return nil
+		}
+
+		f.providerFactory = &factory.ProviderFactory{
+			AwsClient:            f.dependencies.ClusterAwsCli,
+			DockerClient:         f.dependencies.DockerClient,
+			DockerKubectlClient:  f.dependencies.Kubectl,
+			VSphereGovcClient:    f.dependencies.Govc,
+			VSphereKubectlClient: f.dependencies.Kubectl,
+			Writer:               f.dependencies.Writer,
+		}
+
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithClusterAwsCli() *Factory {
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.ClusterAwsCli != nil {
+			return nil
+		}
+
+		f.dependencies.ClusterAwsCli = f.executableBuilder.BuildClusterAwsAdmExecutable()
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithDocker() *Factory {
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.DockerClient != nil {
+			return nil
+		}
+
+		f.dependencies.DockerClient = executables.BuildDockerExecutable()
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithKubectl() *Factory {
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.Kubectl != nil {
+			return nil
+		}
+
+		f.dependencies.Kubectl = f.executableBuilder.BuildKubectlExecutable()
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithGovc() *Factory {
+	f.WithWriter()
+
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.Govc != nil {
+			return nil
+		}
+
+		f.dependencies.Govc = f.executableBuilder.BuildGovcExecutable(f.dependencies.Writer)
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithWriter() *Factory {
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.Writer != nil {
+			return nil
+		}
+
+		var err error
+		f.dependencies.Writer, err = filewriter.NewWriter(f.writerFolder)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithKind() *Factory {
+	f.WithWriter()
+
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.Kind != nil {
+			return nil
+		}
+
+		f.dependencies.Kind = f.executableBuilder.BuildKindExecutable(f.dependencies.Writer)
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithClusterctl() *Factory {
+	f.WithWriter()
+
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.Clusterctl != nil {
+			return nil
+		}
+
+		f.dependencies.Clusterctl = f.executableBuilder.BuildClusterCtlExecutable(f.dependencies.Writer)
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithFlux() *Factory {
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.Flux != nil {
+			return nil
+		}
+
+		f.dependencies.Flux = f.executableBuilder.BuildFluxExecutable()
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithTroubleshoot() *Factory {
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.Troubleshoot != nil {
+			return nil
+		}
+
+		f.dependencies.Troubleshoot = f.executableBuilder.BuildTroubleshootExecutable()
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithNetworking() *Factory {
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.Networking != nil {
+			return nil
+		}
+
+		f.dependencies.Networking = networking.NewCilium()
+		return nil
+	})
+
+	return f
+}
+
+type bootstrapperClient struct {
+	*executables.Kind
+	*executables.Kubectl
+}
+
+func (f *Factory) WithBootstrapper() *Factory {
+	f.WithKind().WithKubectl()
+
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.Bootstrapper != nil {
+			return nil
+		}
+
+		f.dependencies.Bootstrapper = bootstrapper.New(&bootstrapperClient{f.dependencies.Kind, f.dependencies.Kubectl})
+		return nil
+	})
+
+	return f
+}
+
+type clusterManagerClient struct {
+	*executables.Clusterctl
+	*executables.Kubectl
+}
+
+func (f *Factory) WithClusterManager() *Factory {
+	f.WithClusterctl().WithKubectl().WithNetworking().WithWriter()
+
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.ClusterManager != nil {
+			return nil
+		}
+
+		f.dependencies.ClusterManager = clustermanager.New(
+			&clusterManagerClient{
+				f.dependencies.Clusterctl,
+				f.dependencies.Kubectl,
+			},
+			f.dependencies.Networking,
+			f.dependencies.Writer,
+		)
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithFluxAddonClient(ctx context.Context, clusterConfig *v1alpha1.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) *Factory {
+	f.WithWriter().WithFlux().WithKubectl()
+
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.FluxAddonClient != nil {
+			return nil
+		}
+
+		gitOpts, err := addonclients.NewGitOptions(ctx, clusterConfig, gitOpsConfig, f.dependencies.Writer)
+		if err != nil {
+			return err
+		}
+
+		f.dependencies.FluxAddonClient = addonclients.NewFluxAddonClient(
+			&flux.FluxKubectl{
+				Flux:    f.dependencies.Flux,
+				Kubectl: f.dependencies.Kubectl,
+			},
+			gitOpts,
+		)
+
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithAnalyzerFactory() *Factory {
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.AnalyzerFactory != nil {
+			return nil
+		}
+
+		f.dependencies.AnalyzerFactory = supportbundle.NewAnalyzerFactory()
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) WithDiagnosticCollectorImage(diagnosticCollectorImage string) *Factory {
+	f.diagnosticCollectorImage = diagnosticCollectorImage
+	return f
+}
+
+func (f *Factory) WithCollectorFactory() *Factory {
+	f.buildSteps = append(f.buildSteps, func() error {
+		if f.dependencies.CollectorFactory != nil {
+			return nil
+		}
+
+		if f.diagnosticCollectorImage == "" {
+			return errors.New("diagnostic collector image is required to build CollectorFactory")
+		}
+
+		f.dependencies.CollectorFactory = supportbundle.NewCollectorFactory(f.diagnosticCollectorImage)
+		return nil
+	})
+
+	return f
+}

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -1,0 +1,74 @@
+package dependencies_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/dependencies"
+)
+
+type factoryTest struct {
+	*WithT
+	clusterConfigFile string
+	clusterSpec       *cluster.Spec
+	ctx               context.Context
+}
+
+func newTest(t *testing.T) *factoryTest {
+	clusterConfigFile := "testdata/cluster_vsphere.yaml"
+	return &factoryTest{
+		WithT:             NewGomegaWithT(t),
+		clusterConfigFile: clusterConfigFile,
+		clusterSpec:       test.NewFullClusterSpec(t, clusterConfigFile),
+		ctx:               context.Background(),
+	}
+}
+
+func TestFactoryBuildWithProvider(t *testing.T) {
+	tt := newTest(t)
+	deps, err := dependencies.NewFactory().
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false).
+		Build()
+
+	tt.Expect(err).To(BeNil())
+	tt.Expect(deps.Provider).NotTo(BeNil())
+}
+
+func TestFactoryBuildWithClusterManager(t *testing.T) {
+	tt := newTest(t)
+	deps, err := dependencies.NewFactory().
+		WithClusterManager().
+		Build()
+
+	tt.Expect(err).To(BeNil())
+	tt.Expect(deps.ClusterManager).NotTo(BeNil())
+}
+
+func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
+	tt := newTest(t)
+	deps, err := dependencies.NewFactory().
+		WithBootstrapper().
+		WithClusterManager().
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false).
+		WithFluxAddonClient(tt.ctx, tt.clusterSpec.Cluster, tt.clusterSpec.GitOpsConfig).
+		WithWriter().
+		WithDiagnosticCollectorImage("public.ecr.aws/collector").
+		WithAnalyzerFactory().
+		WithCollectorFactory().
+		WithTroubleshoot().
+		Build()
+
+	tt.Expect(err).To(BeNil())
+	tt.Expect(deps.Bootstrapper).NotTo(BeNil())
+	tt.Expect(deps.ClusterManager).NotTo(BeNil())
+	tt.Expect(deps.Provider).NotTo(BeNil())
+	tt.Expect(deps.FluxAddonClient).NotTo(BeNil())
+	tt.Expect(deps.Writer).NotTo(BeNil())
+	tt.Expect(deps.AnalyzerFactory).NotTo(BeNil())
+	tt.Expect(deps.CollectorFactory).NotTo(BeNil())
+	tt.Expect(deps.Troubleshoot).NotTo(BeNil())
+}

--- a/pkg/dependencies/testdata/cluster_vsphere.yaml
+++ b/pkg/dependencies/testdata/cluster_vsphere.yaml
@@ -1,0 +1,59 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: VSphereMachineConfig
+  kubernetesVersion: "1.19"
+  workerNodeGroupConfigurations:
+    - count: 3
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: VSphereMachineConfig
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  diskGiB: 25
+  datastore: "myDatastore"
+  folder: "myFolder"
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: "ubuntu"
+  resourcePool: "myResourcePool"
+  storagePolicyName: "myStoragePolicyName"
+  template: "myTemplate"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  datacenter: "myDatacenter"
+  network: "myNetwork"
+  server: "myServer"
+  thumbprint: "myTlsThumbprint"
+  insecure: false

--- a/pkg/executables/builder.go
+++ b/pkg/executables/builder.go
@@ -97,6 +97,14 @@ func NewExecutableBuilder(ctx context.Context, image string) (*ExecutableBuilder
 	}, nil
 }
 
+func NewLocalExecutableBuilder() *ExecutableBuilder {
+	return &ExecutableBuilder{
+		useDocker: false,
+		image:     "",
+		mountDir:  "",
+	}
+}
+
 func setupDockerDependencies(ctx context.Context, image string) error {
 	if err := BuildDockerExecutable().SetUpCLITools(ctx, image); err != nil {
 		return fmt.Errorf("failed to setup eks-a dependencies: %v", err)

--- a/pkg/providers/factory/providerfactory.go
+++ b/pkg/providers/factory/providerfactory.go
@@ -20,10 +20,9 @@ type ProviderFactory struct {
 	VSphereGovcClient    vsphere.ProviderGovcClient
 	VSphereKubectlClient vsphere.ProviderKubectlClient
 	Writer               filewriter.FileWriter
-	SkipIpCheck          bool
 }
 
-func (p *ProviderFactory) BuildProvider(clusterConfigFileName string, clusterConfig *v1alpha1.Cluster) (providers.Provider, error) {
+func (p *ProviderFactory) BuildProvider(clusterConfigFileName string, clusterConfig *v1alpha1.Cluster, skipIpCheck bool) (providers.Provider, error) {
 	switch clusterConfig.Spec.DatacenterRef.Kind {
 	case v1alpha1.VSphereDatacenterKind:
 		datacenterConfig, err := v1alpha1.GetVSphereDatacenterConfig(clusterConfigFileName)
@@ -34,7 +33,7 @@ func (p *ProviderFactory) BuildProvider(clusterConfigFileName string, clusterCon
 		if err != nil {
 			return nil, fmt.Errorf("unable to get machine config from file %s: %v", clusterConfigFileName, err)
 		}
-		return vsphere.NewProvider(datacenterConfig, machineConfigs, clusterConfig, p.VSphereGovcClient, p.VSphereKubectlClient, p.Writer, time.Now, p.SkipIpCheck), nil
+		return vsphere.NewProvider(datacenterConfig, machineConfigs, clusterConfig, p.VSphereGovcClient, p.VSphereKubectlClient, p.Writer, time.Now, skipIpCheck), nil
 	case v1alpha1.DockerDatacenterKind:
 		datacenterConfig, err := v1alpha1.GetDockerDatacenterConfig(clusterConfigFileName)
 		if err != nil {

--- a/pkg/providers/factory/providerfactory_test.go
+++ b/pkg/providers/factory/providerfactory_test.go
@@ -97,7 +97,7 @@ func TestProviderFactoryBuildProvider(t *testing.T) {
 				VSphereKubectlClient: vsphereMocks.NewMockProviderKubectlClient(mockCtrl),
 				Writer:               mockswriter.NewMockFileWriter(mockCtrl),
 			}
-			got, err := p.BuildProvider(tt.args.clusterConfigFileName, tt.args.clusterConfig)
+			got, err := p.BuildProvider(tt.args.clusterConfigFileName, tt.args.clusterConfig, false)
 			if err == nil {
 				if got.Name() != tt.want.kind || got.Version(clusterSpec) != tt.want.version {
 					t.Errorf("BuildProvider() got = %v, want %v", got, tt.want)


### PR DESCRIPTION
Resolves #310 

In order to facilitate adding/removing/changing the dependencies for our types and at the same time reduce the duplicated code/work at the `cmd` level (that's where we usually do DI), this OR add a factory to build a dependency graph.

It's a pretty simple implementation but it achieves:
* Only building whatever is necessary based on the input
* Only build each entity once
* Graph encapsulation (the caller doesn't need to know anything about the dependencies)
* Changing the graph is fairly simple

Some drawbacks:
* It requires to write a bit of boring code every time we want to add a new entity to the graph
* It requires to mark the dependencies for a certain entity explicitly (no inference)

There is definitely room for improvement but I believe the current state is good enough to start using it.

I also considered using https://github.com/google/wire instead, but with the amount of dependencies we have, it was going to take the same amount of time to learn how to use it than the time that saves by generating the boilerplate code. It's something that we could reconsider in the future if we start spending too much time adding entities to the factory.

There might be other places where we can use the factory (maybe E2E tests). I just started with the commands since they were the most obvious place.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
