### PR TITLE
Assigned instanceID as the test name for e2e jobs

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -71,5 +71,5 @@ phases:
       $GIT_HASH
     - >
       ./bin/test e2e cleanup vsphere
-      -n eksa-test
+      -n i-
       -v 4

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -106,7 +106,7 @@ func (e *E2ESession) setup(regex string) error {
 	// Adding JobId to Test Env variables
 	e.testEnvVars[e2etests.JobIdVar] = e.jobId
 	e.testEnvVars[e2etests.BundlesOverrideVar] = strconv.FormatBool(e.bundlesOverride)
-
+	e.testEnvVars[e2etests.ClusterNameVar] = instanceId
 	return nil
 }
 

--- a/test/framework/e2e.go
+++ b/test/framework/e2e.go
@@ -27,7 +27,7 @@ const (
 	defaultClusterConfigFile         = "cluster.yaml"
 	defaultBundleReleaseManifestFile = "bin/local-bundle-release.yaml"
 	defaultClusterName               = "eksa-test"
-	clusterNameVar                   = "T_CLUSTER_NAME"
+	ClusterNameVar                   = "T_CLUSTER_NAME"
 	JobIdVar                         = "T_JOB_ID"
 	BundlesOverrideVar               = "T_BUNDLES_OVERRIDE"
 )
@@ -305,7 +305,7 @@ func (e *E2ETest) getJobIdFromEnv() string {
 }
 
 func getClusterName() string {
-	value := os.Getenv(clusterNameVar)
+	value := os.Getenv(ClusterNameVar)
 	if len(value) == 0 {
 		return defaultClusterName
 	}


### PR DESCRIPTION
*Issue #, if available:* [#306](https://github.com/aws/eks-anywhere/issues/306)

*Description of changes:*
For tests running in the e2e job, assign instanceID as the test name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
