### PR TITLE
Remove project path from cluster-controller buildspec

### DIFF
--- a/controllers/buildspec.yml
+++ b/controllers/buildspec.yml
@@ -7,8 +7,8 @@ phases:
 
   build:
     commands:
-      - make release-cluster-controller -C $PROJECT_PATH
+      - make release-cluster-controller
 
   post_build:
     commands:
-      - make upload-artifacts -C $PROJECT_PATH
+      - make upload-artifacts


### PR DESCRIPTION
We don't need this since the Makefile is at root.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
