### PR TITLE
Exclude Control Plane Endpoint IP from DHCP

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/vsphere.md
+++ b/docs/content/en/docs/reference/clusterspec/vsphere.md
@@ -115,7 +115,8 @@ A unique IP you want to use for the control plane VM in your EKS Anywhere cluste
 range that does not conflict with other VMs.
 
 >**_NOTE:_** This IP should be outside the network DHCP range as it is a floating IP that gets assigned to one of
-the control plane nodes for kube-apiserver loadbalancing.
+the control plane nodes for kube-apiserver loadbalancing. Suggestions on how to ensure this IP does not cause issues during cluster 
+creation process are [here]({{< relref "../vsphere/vsphere-prereq/#:~:text=Below%20are%20some,existent%20mac%20address." >}})
 
 ### workerNodeGroupsConfiguration (required)
 This takes in a list of node groups that you can define for your workers. Please note that at this time only 1 node group is permitted.

--- a/docs/content/en/docs/reference/vsphere/vsphere-prereq.md
+++ b/docs/content/en/docs/reference/vsphere/vsphere-prereq.md
@@ -14,6 +14,19 @@ To run EKS Anywhere, you will need:
 * One network in vSphere to use for the cluster. This network must have inbound access into vCenter
 * A OVA imported into vSphere and converted into template for the workload VMs
 * User credentials to [create vms and attach networks, etc]({{< relref "user-permissions.md" >}})
+* One IP address routable from cluster but excluded from DHCP offering
+
+  This IP address is to be used as the [Control Plane Endpoint IP or kube-vip VIP address]({{< relref "../clusterspec/vsphere/#controlplaneconfigurationendpointhost-required" >}})
+
+  Below are some suggestions to ensure that this IP address is never handed out by your DHCP server. 
+ 
+  You may need to contact your network engineer.
+      
+   *  Pick an IP address reachable from cluster subnet which is excluded from DHCP range OR
+   *  Alter DHCP ranges to leave out an IP address(s) at the top and/or the bottom of the range OR
+   *  Create an IP reservation for this IP on your DHCP server. This is usually accomplished by adding 
+a dummy mapping of this IP address to a non-existent mac address.
+
 
 Each VM will require:
 


### PR DESCRIPTION
Add more specific instructions on keeping control plane endpoint IP from being handed out by DHCP server

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
