### PR TITLE
Delete old template in library before attempting to import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,6 @@ else
 	TAR_PATH?="_output/tar"
 endif
 
-GOPROXY_DNS?=https://proxy.golang.org
-export GOPROXY=$(GOPROXY_DNS)
-
 BASE_REPO?=public.ecr.aws/eks-distro-build-tooling
 CLUSTER_CONTROLLER_BASE_IMAGE_NAME?=eks-distro-minimal-base
 CLUSTER_CONTROLLER_BASE_TAG?=$(shell cat controllers/EKS_DISTRO_MINIMAL_BASE_TAG_FILE)

--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -130,6 +130,15 @@ func (g *Govc) LibraryElementExists(ctx context.Context, library string) (bool, 
 	return response.Len() > 0, nil
 }
 
+func (g *Govc) DeleteLibraryElement(ctx context.Context, element string) error {
+	_, err := g.exec(ctx, "library.rm", element)
+	if err != nil {
+		return fmt.Errorf("govc failed deleting library item: %v", err)
+	}
+
+	return nil
+}
+
 func (g *Govc) ResizeDisk(ctx context.Context, template, diskName string, diskSizeInGB int) error {
 	_, err := g.exec(ctx, "vm.disk.change", "-vm", template, "-disk.name", diskName, "-size", strconv.Itoa(diskSizeInGB)+"G")
 	if err != nil {

--- a/pkg/executables/govc_test.go
+++ b/pkg/executables/govc_test.go
@@ -269,6 +269,32 @@ func TestLibraryElementExistsError(t *testing.T) {
 	}
 }
 
+func TestDeleteLibraryElementSuccess(t *testing.T) {
+	ctx := context.Background()
+	libraryElement := "/eks-a-templates/ubuntu-2004-kube-v1.19.6"
+
+	g, executable, env := setup(t)
+	executable.EXPECT().ExecuteWithEnv(ctx, env, "library.rm", libraryElement).Return(*bytes.NewBufferString("testing"), nil)
+
+	err := g.DeleteLibraryElement(ctx, libraryElement)
+	if err != nil {
+		t.Fatalf("Govc.DeleteLibraryElement() err = %v, want err nil", err)
+	}
+}
+
+func TestDeleteLibraryElementError(t *testing.T) {
+	ctx := context.Background()
+	libraryElement := "/eks-a-templates/ubuntu-2004-kube-v1.19.6"
+
+	g, executable, env := setup(t)
+	executable.EXPECT().ExecuteWithEnv(ctx, env, "library.rm", libraryElement).Return(bytes.Buffer{}, errors.New("error from execute with env"))
+
+	err := g.DeleteLibraryElement(ctx, libraryElement)
+	if err == nil {
+		t.Fatal("Govc.DeleteLibraryElement() err = nil, want err not nil")
+	}
+}
+
 func TestGovcTemplateHasSnapshot(t *testing.T) {
 	_, writer := test.NewWriter(t)
 	template := "/SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.19.6"

--- a/pkg/providers/vsphere/internal/templates/factory_test.go
+++ b/pkg/providers/vsphere/internal/templates/factory_test.go
@@ -227,6 +227,8 @@ func TestFactoryCreateIfMissingSuccessTemplateInLibrarytExists(t *testing.T) {
 	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig).Return("", nil) // template not present
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateLibrary).Return(true, nil)
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateInLibrary).Return(true, nil)
+	ct.govc.EXPECT().DeleteLibraryElement(ct.ctx, ct.templateInLibrary).Return(nil)
+	ct.govc.EXPECT().ImportTemplate(ct.ctx, ct.templateLibrary, ct.ovaURL, ct.templateName).Return(nil)
 	ct.govc.EXPECT().DeployTemplateFromLibrary(
 		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool, ct.resizeDisk2,
 	).Return(nil)

--- a/pkg/providers/vsphere/internal/templates/mocks/govc.go
+++ b/pkg/providers/vsphere/internal/templates/mocks/govc.go
@@ -91,6 +91,20 @@ func (mr *MockGovcClientMockRecorder) CreateTag(ctx, tag, category interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTag", reflect.TypeOf((*MockGovcClient)(nil).CreateTag), ctx, tag, category)
 }
 
+// DeleteLibraryElement mocks base method.
+func (m *MockGovcClient) DeleteLibraryElement(ctx context.Context, library string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteLibraryElement", ctx, library)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteLibraryElement indicates an expected call of DeleteLibraryElement.
+func (mr *MockGovcClientMockRecorder) DeleteLibraryElement(ctx, library interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLibraryElement", reflect.TypeOf((*MockGovcClient)(nil).DeleteLibraryElement), ctx, library)
+}
+
 // DeployTemplateFromLibrary mocks base method.
 func (m *MockGovcClient) DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, resourcePool string, resizeDisk2 bool) error {
 	m.ctrl.T.Helper()

--- a/pkg/providers/vsphere/mocks/client.go
+++ b/pkg/providers/vsphere/mocks/client.go
@@ -97,6 +97,20 @@ func (mr *MockProviderGovcClientMockRecorder) CreateTag(arg0, arg1, arg2 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTag", reflect.TypeOf((*MockProviderGovcClient)(nil).CreateTag), arg0, arg1, arg2)
 }
 
+// DeleteLibraryElement mocks base method.
+func (m *MockProviderGovcClient) DeleteLibraryElement(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteLibraryElement", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteLibraryElement indicates an expected call of DeleteLibraryElement.
+func (mr *MockProviderGovcClientMockRecorder) DeleteLibraryElement(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLibraryElement", reflect.TypeOf((*MockProviderGovcClient)(nil).DeleteLibraryElement), arg0, arg1)
+}
+
 // DeployTemplateFromLibrary mocks base method.
 func (m *MockProviderGovcClient) DeployTemplateFromLibrary(arg0 context.Context, arg1, arg2, arg3, arg4 string, arg5 bool) error {
 	m.ctrl.T.Helper()

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -104,6 +104,7 @@ type vsphereProvider struct {
 type ProviderGovcClient interface {
 	SearchTemplate(ctx context.Context, datacenter string, machineConfig *v1alpha1.VSphereMachineConfig) (string, error)
 	LibraryElementExists(ctx context.Context, library string) (bool, error)
+	DeleteLibraryElement(ctx context.Context, element string) error
 	TemplateHasSnapshot(ctx context.Context, template string) (bool, error)
 	GetWorkloadAvailableSpace(ctx context.Context, machineConfig *v1alpha1.VSphereMachineConfig) (float64, error)
 	ValidateVCenterSetup(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, selfSigned *bool) error

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -85,6 +85,10 @@ func (pc *DummyProviderGovcClient) LibraryElementExists(ctx context.Context, lib
 	return true, nil
 }
 
+func (pc *DummyProviderGovcClient) DeleteLibraryElement(ctx context.Context, element string) error {
+	return nil
+}
+
 func (pc *DummyProviderGovcClient) CreateLibrary(ctx context.Context, datastore, library string) error {
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If the template does not exist, the CLI checks if the OVA already exists in the library before attempting to import it. If an OVA in the library matches the name of the template that we want, it attempts to deploy it. However, there are cases where an OVA import via CLI could fail, thus leaving an empty OVA with that name in the library. Any future attempts to deploy a template using this empty OVA would lead to more CLI failures. 

This PR fixes this issue by deleting any library items with that name before starting a template import. 

I also removed setting the GOPROXY env variable from the Makefile because it conflicts with generating mocks for unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
