### PR TITLE
Pass proxy env vars to the tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    INTEGRATION_TEST_MAX_EC2_COUNT: 45
+    INTEGRATION_TEST_MAX_EC2_COUNT: 47
     T_VSPHERE_CIDR: "198.18.0.0/16"
     T_VSPHERE_PRIVATE_NETWORK_CIDR: "10.1.0.0/24"
   secrets-manager:

--- a/internal/test/e2e/proxy.go
+++ b/internal/test/e2e/proxy.go
@@ -1,0 +1,26 @@
+package e2e
+
+import (
+	"os"
+	"regexp"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
+	e2etests "github.com/aws/eks-anywhere/test/framework"
+)
+
+func (e *E2ESession) setupProxyEnv(testRegex string) error {
+	re := regexp.MustCompile(`^.*Proxy.*$`)
+	if !re.MatchString(testRegex) {
+		logger.V(2).Info("Not running Proxy tests, skipping Env variable setup")
+		return nil
+	}
+
+	requiredEnvVars := e2etests.RequiredProxyEnvVars()
+	for _, eVar := range requiredEnvVars {
+		if val, ok := os.LookupEnv(eVar); ok {
+			e.testEnvVars[eVar] = val
+		}
+	}
+
+	return nil
+}

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -93,6 +93,11 @@ func (e *E2ESession) setup(regex string) error {
 		return err
 	}
 
+	err = e.setupProxyEnv(regex)
+	if err != nil {
+		return err
+	}
+
 	// Adding JobId to Test Env variables
 	e.testEnvVars[e2etests.JobIdVar] = e.jobId
 

--- a/test/framework/proxy.go
+++ b/test/framework/proxy.go
@@ -35,3 +35,7 @@ func WithProxy() E2ETestOpt {
 		)
 	}
 }
+
+func RequiredProxyEnvVars() []string {
+	return proxyRequiredEnvVars
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The proxy tests are not getting the env vars required to run the test. This PR fixes that issue. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
