### PR TITLE
Fix controller fetch cluster log

### DIFF
--- a/controllers/controllers/resource/fetcher.go
+++ b/controllers/controllers/resource/fetcher.go
@@ -81,7 +81,7 @@ func (r *capiResourceFetcher) fetchClusterKind(ctx context.Context, objectKey ty
 }
 
 func (r *capiResourceFetcher) FetchCluster(ctx context.Context, objectKey types.NamespacedName) (*anywherev1.Cluster, error) {
-	r.log.Info("looking up cluster", "objectKey", objectKey)
+	r.log.Info("looking up resource", "objectKey", objectKey)
 	kind, err := r.fetchClusterKind(ctx, objectKey)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Misleading log msg. Instead of "looking up cluster", the function looks up resource in a set of resource types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
