### PR TITLE
Add centralized method to fetch Bundles for a particular Cluster

### DIFF
--- a/controllers/controllers/resource/fetcher.go
+++ b/controllers/controllers/resource/fetcher.go
@@ -203,9 +203,9 @@ func (r *capiResourceFetcher) VSphereMachineTemplate(ctx context.Context, cs *an
 	return vsphereMachineTemplate, nil
 }
 
-func (r *capiResourceFetcher) clusterBundle(ctx context.Context, cs *anywherev1.Cluster) (*releasev1alpha1.Bundles, error) {
+func (r *capiResourceFetcher) bundles(ctx context.Context, name, namespace string) (*releasev1alpha1.Bundles, error) {
 	clusterBundle := &releasev1alpha1.Bundles{}
-	err := r.FetchObjectByName(ctx, cs.Name, cs.Namespace, clusterBundle)
+	err := r.FetchObjectByName(ctx, name, namespace, clusterBundle)
 	if err != nil {
 		return nil, err
 	}
@@ -229,15 +229,7 @@ func (r *capiResourceFetcher) ControlPlane(ctx context.Context, cs *anywherev1.C
 }
 
 func (r *capiResourceFetcher) FetchAppliedSpec(ctx context.Context, cs *anywherev1.Cluster) (*cluster.Spec, error) {
-	bundle, err := r.clusterBundle(ctx, cs)
-	if err != nil {
-		return nil, err
-	}
-	spec, err := cluster.BuildSpecFromBundles(cs, bundle)
-	if err != nil {
-		return nil, err
-	}
-	return spec, nil
+	return cluster.BuildSpecForCluster(ctx, cs, r.bundles)
 }
 
 func (r *capiResourceFetcher) ExistingVSphereDatacenterConfig(ctx context.Context, cs *anywherev1.Cluster) (*anywherev1.VSphereDatacenterConfig, error) {

--- a/internal/test/cluster.go
+++ b/internal/test/cluster.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
@@ -54,6 +55,20 @@ func NewFullClusterSpec(t *testing.T, clusterConfigFile string) *cluster.Spec {
 	}
 
 	return s
+}
+
+func Bundles(t *testing.T) *releasev1alpha1.Bundles {
+	content, err := configFS.ReadFile("testdata/bundles.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read embed bundles manifest: %s", err)
+	}
+
+	bundles := &releasev1alpha1.Bundles{}
+	if err = yaml.Unmarshal(content, bundles); err != nil {
+		t.Fatalf("Failed to unmarshal bundles manifest: %s", err)
+	}
+
+	return bundles
 }
 
 func SetTag(image *releasev1alpha1.Image, tag string) {

--- a/pkg/cluster/fetch.go
+++ b/pkg/cluster/fetch.go
@@ -1,0 +1,29 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	v1alpha1release "github.com/aws/eks-anywhere/release/api/v1alpha1"
+)
+
+type BundlesFetch func(ctx context.Context, name, namespace string) (*v1alpha1release.Bundles, error)
+
+func BuildSpecForCluster(ctx context.Context, cluster *v1alpha1.Cluster, fetch BundlesFetch) (*Spec, error) {
+	bundles, err := GetBundlesForCluster(ctx, cluster, fetch)
+	if err != nil {
+		return nil, err
+	}
+
+	return BuildSpecFromBundles(cluster, bundles)
+}
+
+func GetBundlesForCluster(ctx context.Context, cluster *v1alpha1.Cluster, fetch BundlesFetch) (*v1alpha1release.Bundles, error) {
+	bundles, err := fetch(ctx, cluster.Name, cluster.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed fetching Bundles for cluster: %v", err)
+	}
+
+	return bundles, nil
+}

--- a/pkg/cluster/fetch_test.go
+++ b/pkg/cluster/fetch_test.go
@@ -1,0 +1,34 @@
+package cluster_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	v1alpha1release "github.com/aws/eks-anywhere/release/api/v1alpha1"
+)
+
+func TestGetBundlesForCluster(t *testing.T) {
+	g := NewWithT(t)
+	c := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eksa-cluster",
+			Namespace: "eksa",
+		},
+	}
+	wantBundles := &v1alpha1release.Bundles{}
+	mockFetch := func(ctx context.Context, name, namespace string) (*v1alpha1release.Bundles, error) {
+		g.Expect(name).To(Equal(c.Name))
+		g.Expect(namespace).To(Equal(c.Namespace))
+
+		return wantBundles, nil
+	}
+
+	gotBundles, err := cluster.GetBundlesForCluster(context.Background(), c, mockFetch)
+	g.Expect(err).To(BeNil())
+	g.Expect(gotBundles).To(Equal(wantBundles))
+}


### PR DESCRIPTION
Resolves #313 

*Description of changes:*
Move logic to get `Bundles` and build a cluster spec for a certain `Cluster` to the `cluster` package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
