### PR TITLE
Make docs links relative

### DIFF
--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -50,5 +50,4 @@ Amazon EKS Anywhere gives you on-premises Kubernetes operational tooling that’
 
 {{< blocks/section height="auto" color="white" >}}
 
-<a href="{{< relref "/v0.5/getting-started/" >}}">.</a>
 {{< /blocks/section >}}

--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -7,7 +7,7 @@ linkTitle = "EKS-A"
 {{< blocks/cover title="Amazon EKS Anywhere" image_anchor="top" height="min" >}}
 <p class="lead">Run EKS in your datacenter</p>
 <div class="mx-auto mt-5">
-	<a class="btn rounded-lg btn-primary" href="{{< relref "/docs/getting-started/" >}}">
+	<a class="btn rounded-lg btn-primary" href="{{< relref "./docs/getting-started/" >}}">
 		Get Started
 	</a>
 </div>
@@ -50,4 +50,5 @@ Amazon EKS Anywhere gives you on-premises Kubernetes operational tooling that’
 
 {{< blocks/section height="auto" color="white" >}}
 
+<a href="{{< relref "/v0.5/getting-started/" >}}">.</a>
 {{< /blocks/section >}}

--- a/docs/content/en/docs/concepts/clusterworkflow.md
+++ b/docs/content/en/docs/concepts/clusterworkflow.md
@@ -335,7 +335,7 @@ The project documents the use of [Emissary-ingress]({{< relref "../tasks/workloa
 ### Operating systems
 
 The Ubuntu or Mac operating system representing the Administrative machine can continue to use the binaries to manage the EKS anywhere cluster.
-You may need to [update those binaries]({{< relref "/docs/getting-started/install/#upgrade-eksctl-anywhere" >}}) (`kubectl`, `eksctl anywhere`, and others) from time to time.
+You may need to [update those binaries]({{< relref "../getting-started/install/#upgrade-eksctl-anywhere" >}}) (`kubectl`, `eksctl anywhere`, and others) from time to time.
 
 In the workload cluster itself, the operating system on each node is provided from either Bottlerocket or Ubuntu OVAs.
 Note that it is not recommended that you add software or change the configuration of these systems once they are running in the cluster.

--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -9,7 +9,7 @@ Other deployment targets will be added in the future, including bare metal suppo
 
 Creating an EKS Anywhere cluster begins with setting up an Administrative machine where you will run Docker and add some binaries.
 From there, you create the cluster for your chosen provider.
-See [Create cluster workflow]({{< relref "/docs/concepts/clusterworkflow" >}}) for an overview of the cluster creation process.
+See [Create cluster workflow]({{< relref "../../concepts/clusterworkflow" >}}) for an overview of the cluster creation process.
 
 To create an EKS Anywhere cluster you will need [`eksctl`](https://eksctl.io) and the `eksctl-anywhere` plugin.
 This will let you create a cluster in multiple providers for local development or production workloads.

--- a/docs/content/en/docs/getting-started/production-environment/_index.md
+++ b/docs/content/en/docs/getting-started/production-environment/_index.md
@@ -12,7 +12,7 @@ EKS Anywhere allows you to provision and manage Amazon EKS on your own infrastru
 EKS Anywhere needs to be run on an administrative machine that has certain [machine
 requirements]({{< relref "../install" >}}).
 An EKS Anywhere deployment will also require the availability of certain
-[resources from your VMware vSphere deployment]({{< relref "/docs/reference/vsphere/vsphere-prereq/_index.md" >}}).
+[resources from your VMware vSphere deployment]({{< relref "../../reference/vsphere/vsphere-prereq/_index.md" >}}).
 
 ## Steps
 

--- a/docs/content/en/docs/overview/_index.md
+++ b/docs/content/en/docs/overview/_index.md
@@ -28,4 +28,4 @@ The delete process is similar to the create process.
 
 
 Next steps:
-* [Getting Started](/docs/getting-started/)
+* [Getting Started]({{< relref "../getting-started/" >}})

--- a/docs/content/en/docs/reference/vsphere/customize-ovas.md
+++ b/docs/content/en/docs/reference/vsphere/customize-ovas.md
@@ -117,6 +117,6 @@ Convert VM to template
 govc vm.markastemplate $VM
 ```
 
-Tag the template appropriately as described [here]({{< ref "/docs/reference/vsphere/vsphere-ovas#important-additional-steps-to-tag-the-ova" >}})
+Tag the template appropriately as described [here]({{< relref "./vsphere-ovas#important-additional-steps-to-tag-the-ova" >}})
 
 Use this customized template to create/upgrade EKS Anywhere clusters

--- a/docs/content/en/docs/reference/vsphere/vsphere-ovas.md
+++ b/docs/content/en/docs/reference/vsphere/vsphere-ovas.md
@@ -22,7 +22,7 @@ EKS Anywhere supports the following operating system families
 * Bottlerocket (default)
 * Ubuntu
 
-A list of OVAs for this release can be found on the [artifacts page]({{< relref "artifacts" >}}).
+A list of OVAs for this release can be found on the [artifacts page]({{< relref "../artifacts" >}}).
 
 ## Using vCenter Web User Interface
 

--- a/docs/content/en/docs/reference/vsphere/vsphere-prereq.md
+++ b/docs/content/en/docs/reference/vsphere/vsphere-prereq.md
@@ -36,4 +36,4 @@ Each VM will require:
 
 The administrative machine and the target workload environment will need network access to:
 
-{{% content "domains.md" %}}
+{{% content "./domains.md" %}}

--- a/docs/content/en/docs/tasks/cluster/cluster-flux.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-flux.md
@@ -76,7 +76,7 @@ If you have an existing repo you can set that as your repository name in the con
 If you specify a repo in your `GitOpsConfig` which does not exist EKS Anywhere will create it for you.
 If you would like to create a new repo you can [click here](https://github.new) to create a new repo.
 
-If your repository contains multiple cluster specification files, store them in subfolders and specify the [configuration path](/docs/reference/clusterspec/gitops/#__clusterconfigpath__-optional) in your cluster specification.
+If your repository contains multiple cluster specification files, store them in subfolders and specify the [configuration path]({{< relref "../../reference/clusterspec/gitops/#__clusterconfigpath__-optional" >}}) in your cluster specification.
 
 Example repository structure:
 ```

--- a/docs/content/en/docs/tasks/troubleshoot/_troubleshooting.md
+++ b/docs/content/en/docs/tasks/troubleshoot/_troubleshooting.md
@@ -215,7 +215,7 @@ Ensure that you have DHCP running and run the create command again.
 If there are any IPv4 IPs assigned, check if one of the VMs have the controlPlane IP specified in `Cluster.spec.controlPlaneConfiguration.endpoint.host` in the clusterconfig yaml.
 If this IP is not present on any control plane VM, make sure the `network` has access to the following endpoints:
 
-{{% content "domains.md" %}}
+{{% content "../../reference/vsphere/domains.md" %}}
 
 If no VMs are created, check the `capi-controller-manager`, `capv-controller-manager` and `capi-kubeadm-control-plane-controller-manager` logs using the commands mentioned in [Generic cluster unavailable](#problem-generic-cluster-unavailable) section.
 

--- a/docs/content/en/docs/tasks/workload/ingress.md
+++ b/docs/content/en/docs/tasks/workload/ingress.md
@@ -24,13 +24,13 @@ We currently recommend using Emissary-ingress Kubernetes Ingress Controller by A
 
 ## Setting up Emissary-ingress for Ingress Controller
 
-1. Deploy the [Hello EKS Anywhere]({{< ref "/docs/tasks/workload/test-app" >}}) test application.
+1. Deploy the [Hello EKS Anywhere]({{< relref "./test-app" >}}) test application.
     ```bash
     kubectl apply -f "https://anywhere.eks.amazonaws.com/manifests/hello-eks-a.yaml"
     ```
 
-2. Set up kube-vip service type: Load Balancer in your cluster by following the instructions [here]({{< ref "/docs/tasks/workload/loadbalance#setting-up-kube-vip-for-service-type-load-balancer" >}}).
-Alternatively, you can set up MetalLB Load Balancer by following the instructions [here]({{< ref "/docs/tasks/workload/loadbalance#alternatives" >}})
+2. Set up kube-vip service type: Load Balancer in your cluster by following the instructions [here]({{< relref "./loadbalance#setting-up-kube-vip-for-service-type-load-balancer" >}}).
+Alternatively, you can set up MetalLB Load Balancer by following the instructions [here]({{< relref "./loadbalance#alternatives" >}})
 
 3. Install Ambassador CRDs and ClusterRoles and RoleBindings
 

--- a/docs/content/en/docs/tasks/workload/loadbalance/kubevip/arp.md
+++ b/docs/content/en/docs/tasks/workload/loadbalance/kubevip/arp.md
@@ -57,7 +57,7 @@ You can use either a CIDR block or an IP range
     kube-vip manifest daemonset --services --inCluster --arp --interface eth0 | kubectl apply -f -
     ```   
  
-1. Deploy the [Hello EKS Anywhere]({{< ref "/docs/tasks/workload/test-app" >}}) test application.
+1. Deploy the [Hello EKS Anywhere]({{< relref "../../test-app" >}}) test application.
 
     ```bash
     kubectl apply -f https://anywhere.eks.amazonaws.com/manifests/hello-eks-a.yaml

--- a/docs/content/en/docs/tasks/workload/loadbalance/kubevip/bgp.md
+++ b/docs/content/en/docs/tasks/workload/loadbalance/kubevip/bgp.md
@@ -163,7 +163,7 @@ You can use either a CIDR block or an IP range
      value: eth0
    ```
 
-1. Deploy the [Hello EKS Anywhere]({{< ref "/docs/tasks/workload/test-app" >}}) test application.
+1. Deploy the [Hello EKS Anywhere]({{< relref "../../test-app" >}}) test application.
 
     ```bash
     kubectl apply -f https://anywhere.eks.amazonaws.com/manifests/hello-eks-a.yaml

--- a/docs/content/en/docs/tasks/workload/loadbalance/metallb.md
+++ b/docs/content/en/docs/tasks/workload/loadbalance/metallb.md
@@ -10,7 +10,7 @@ description: >
 <!-- overview -->
 
 The purpose of this document is to walk you through getting set up with MetalLB Kubernetes Load Balancer for your cluster.
-This is suggested as an alternative if your networking requirements do not allow you to use [Kube-Vip]({{< ref "/docs/tasks/workload/loadbalance/kubevip" >}}).
+This is suggested as an alternative if your networking requirements do not allow you to use [Kube-Vip]({{< relref "./kubevip" >}}).
 
 <!-- body -->
 
@@ -60,7 +60,7 @@ MetalLB installation is described [here](https://metallb.universe.tf/installatio
     helm install metallb metallb/metallb -f values.yaml
     ```
 
-1. Deploy the [Hello EKS Anywhere]({{< ref "/docs/tasks/workload/test-app" >}}) test application.
+1. Deploy the [Hello EKS Anywhere]({{< relref "../test-app" >}}) test application.
 
     ```bash
     kubectl apply -f https://anywhere.eks.amazonaws.com/manifests/hello-eks-a.yaml

--- a/docs/content/en/docs/tasks/workload/test-app.md
+++ b/docs/content/en/docs/tasks/workload/test-app.md
@@ -72,4 +72,4 @@ https://anywhere.eks.amazonaws.com
 ⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢⬡⬢
 ```
 
-If you would like to expose your applications with an external load balancer or an ingress controller, you can follow the steps in [Adding an external load balancer]({{< ref "/docs/tasks/workload/loadbalance" >}}).
+If you would like to expose your applications with an external load balancer or an ingress controller, you can follow the steps in [Adding an external load balancer]({{< relref "./loadbalance" >}}).

--- a/docs/layouts/shortcodes/content.html
+++ b/docs/layouts/shortcodes/content.html
@@ -1,2 +1,2 @@
 {{$file := .Get 0}}
-{{ with .Site.GetPage $file }}{{ .Content | markdownify }}{{ end }}
+{{ with .Page.GetPage $file }}{{ .Content | markdownify }}{{ end }}


### PR DESCRIPTION
If we are going to support docs without github branches, these links need to be relative.
