### PR TITLE
Add ".svc" to noProxy list

### DIFF
--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -78,6 +78,11 @@ var mhcTemplate []byte
 var (
 	eksaVSphereDatacenterResourceType = fmt.Sprintf("vspheredatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaVSphereMachineResourceType    = fmt.Sprintf("vspheremachineconfigs.%s", v1alpha1.GroupVersion.Group)
+	noProxyDefaults                   = []string{
+		"localhost",
+		"127.0.0.1",
+		".svc",
+	}
 )
 
 var requiredEnvs = []string{vSphereUsernameKey, vSpherePasswordKey, expClusterResourceSetKey}
@@ -1087,9 +1092,8 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		noProxyList = append(noProxyList, clusterSpec.Spec.ProxyConfiguration.NoProxy...)
 
 		// Add no-proxy defaults
+		noProxyList = append(noProxyList, noProxyDefaults...)
 		noProxyList = append(noProxyList,
-			"localhost",
-			"127.0.0.1",
 			datacenterSpec.Server,
 			clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host,
 		)
@@ -1165,9 +1169,8 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		noProxyList = append(noProxyList, clusterSpec.Spec.ProxyConfiguration.NoProxy...)
 
 		// Add no-proxy defaults
+		noProxyList = append(noProxyList, noProxyDefaults...)
 		noProxyList = append(noProxyList,
-			"localhost",
-			"127.0.0.1",
 			datacenterSpec.Server,
 			clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host,
 		)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If proxy is configured, the endpoints ".svc" are going through the proxy which shouldn't happen. This PR adds ".svc" to the default noProxy list so they don't go through the proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
