### PR TITLE
Add upgrade wrapper for `clusterctl` and skeleton for `clusterapi` upgrader

### DIFF
--- a/cmd/eksctl-anywhere/cmd/generateclusterconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generateclusterconfig.go
@@ -11,8 +11,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/providers/docker"
-	"github.com/aws/eks-anywhere/pkg/providers/vsphere"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/templater"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
@@ -59,7 +58,7 @@ func generateClusterConfig(clusterName string) error {
 	var machineGroupYaml [][]byte
 	var clusterConfigOpts []v1alpha1.ClusterGenerateOpt
 	switch strings.ToLower(viper.GetString("provider")) {
-	case docker.ProviderName:
+	case constants.DockerProviderName:
 		datacenterConfig := v1alpha1.NewDockerDatacenterConfigGenerate(clusterName)
 		clusterConfigOpts = append(clusterConfigOpts, v1alpha1.WithDatacenterRef(datacenterConfig))
 		clusterConfigOpts = append(clusterConfigOpts,
@@ -72,7 +71,7 @@ func generateClusterConfig(clusterName string) error {
 			return fmt.Errorf("error outputting yaml: %v", err)
 		}
 		datacenterYaml = dcyaml
-	case vsphere.ProviderName:
+	case constants.VSphereProviderName:
 		clusterConfigOpts = append(clusterConfigOpts, v1alpha1.WithClusterEndpoint())
 		datacenterConfig := v1alpha1.NewVSphereDatacenterConfigGenerate(clusterName)
 		clusterConfigOpts = append(clusterConfigOpts, v1alpha1.WithDatacenterRef(datacenterConfig))

--- a/pkg/clusterapi/upgrader.go
+++ b/pkg/clusterapi/upgrader.go
@@ -13,36 +13,36 @@ type Upgrader struct {
 }
 
 type capiClient interface {
-	Upgrade(ctx context.Context, managementCluster *types.Cluster, newSpec *cluster.Spec, changeReport *CAPIChangeReport) error
+	Upgrade(ctx context.Context, managementCluster *types.Cluster, newSpec *cluster.Spec, changeDiff *CAPIChangeDiff) error
 }
 
 func (u *Upgrader) Upgrade(ctx context.Context, managementCluster *types.Cluster, currentSpec, newSpec *cluster.Spec) error {
-	changeReport := u.capiChangeReport(currentSpec, newSpec)
-	if changeReport == nil {
+	changeDiff := u.capiChangeDiff(currentSpec, newSpec)
+	if changeDiff == nil {
 		return nil
 	}
 
-	if err := u.capiClient.Upgrade(ctx, managementCluster, newSpec, changeReport); err != nil {
+	if err := u.capiClient.Upgrade(ctx, managementCluster, newSpec, changeDiff); err != nil {
 		return fmt.Errorf("failed upgrading ClusterAPI from bundles %d to bundles %d: %v", currentSpec.Bundles.Spec.Number, newSpec.Bundles.Spec.Number, err)
 	}
 
 	return nil
 }
 
-type CAPIChangeReport struct {
-	Core                   *types.ComponentChangeReport
-	ControlPlane           *types.ComponentChangeReport
-	BootstrapProviders     []types.ComponentChangeReport
-	InfrastructureProvider *types.ComponentChangeReport
+type CAPIChangeDiff struct {
+	Core                   *types.ComponentChangeDiff
+	ControlPlane           *types.ComponentChangeDiff
+	BootstrapProviders     []types.ComponentChangeDiff
+	InfrastructureProvider *types.ComponentChangeDiff
 }
 
-func (u *Upgrader) capiChangeReport(currentSpec, newSpec *cluster.Spec) *CAPIChangeReport {
+func (u *Upgrader) capiChangeDiff(currentSpec, newSpec *cluster.Spec) *CAPIChangeDiff {
 	// TODO: check version changes for all providers
 	return nil
 }
 
-func (u *Upgrader) ChangeReport(currentSpec, newSpec *cluster.Spec) *types.ChangeReport {
-	u.capiChangeReport(currentSpec, newSpec)
-	// TODO: convert from capiChangeReport to generic changeReport
+func (u *Upgrader) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
+	u.capiChangeDiff(currentSpec, newSpec)
+	// TODO: convert from capiChangeDiff to generic changeDiff
 	return nil
 }

--- a/pkg/clusterapi/upgrader.go
+++ b/pkg/clusterapi/upgrader.go
@@ -1,0 +1,48 @@
+package clusterapi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/types"
+)
+
+type Upgrader struct {
+	capiClient capiClient
+}
+
+type capiClient interface {
+	Upgrade(ctx context.Context, managementCluster *types.Cluster, newSpec *cluster.Spec, changeReport *CAPIChangeReport) error
+}
+
+func (u *Upgrader) Upgrade(ctx context.Context, managementCluster *types.Cluster, currentSpec, newSpec *cluster.Spec) error {
+	changeReport := u.capiChangeReport(currentSpec, newSpec)
+	if changeReport == nil {
+		return nil
+	}
+
+	if err := u.capiClient.Upgrade(ctx, managementCluster, newSpec, changeReport); err != nil {
+		return fmt.Errorf("failed upgrading ClusterAPI from bundles %d to bundles %d: %v", currentSpec.Bundles.Spec.Number, newSpec.Bundles.Spec.Number, err)
+	}
+
+	return nil
+}
+
+type CAPIChangeReport struct {
+	Core                   *types.ComponentChangeReport
+	ControlPlane           *types.ComponentChangeReport
+	BootstrapProviders     []types.ComponentChangeReport
+	InfrastructureProvider *types.ComponentChangeReport
+}
+
+func (u *Upgrader) capiChangeReport(currentSpec, newSpec *cluster.Spec) *CAPIChangeReport {
+	// TODO: check version changes for all providers
+	return nil
+}
+
+func (u *Upgrader) ChangeReport(currentSpec, newSpec *cluster.Spec) *types.ChangeReport {
+	u.capiChangeReport(currentSpec, newSpec)
+	// TODO: convert from capiChangeReport to generic changeReport
+	return nil
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -9,6 +9,7 @@ const (
 	CapiSystemNamespace                       = "capi-system"
 	CapiWebhookSystemNamespace                = "capi-webhook-system"
 	CapvSystemNamespace                       = "capv-system"
+	CapaSystemNamespace                       = "capa-system"
 	CertManagerNamespace                      = "cert-manager"
 	DefaultNamespace                          = "default"
 	EtcdAdminBootstrapProviderSystemNamespace = "etcdadm-bootstrap-provider-system"
@@ -17,4 +18,8 @@ const (
 	KubePublicNamespace                       = "kube-public"
 	KubeSystemNamespace                       = "kube-system"
 	LocalPathStorageNamespace                 = "local-path-storage"
+
+	VSphereProviderName = "vsphere"
+	DockerProviderName  = "docker"
+	AWSProviderName     = "aws"
 )

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -309,11 +309,11 @@ func (c *Clusterctl) Upgrade(ctx context.Context, managementCluster *types.Clust
 	}
 
 	if changeDiff.ControlPlane != nil {
-		upgradeCommand = append(upgradeCommand, "--control-plane", fmt.Sprintf("capi-kubeadm-control-plane-system/kubeadm:%s", changeDiff.ControlPlane.NewVersion))
+		upgradeCommand = append(upgradeCommand, "--control-plane", fmt.Sprintf("%s/kubeadm:%s", constants.CapiKubeadmControlPlaneSystemNamespace, changeDiff.ControlPlane.NewVersion))
 	}
 
 	if changeDiff.Core != nil {
-		upgradeCommand = append(upgradeCommand, "--core", fmt.Sprintf("capi-system/cluster-api:%s", changeDiff.Core.NewVersion))
+		upgradeCommand = append(upgradeCommand, "--core", fmt.Sprintf("%s/cluster-api:%s", constants.CapiSystemNamespace, changeDiff.Core.NewVersion))
 	}
 
 	if changeDiff.InfrastructureProvider != nil {

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -295,7 +295,7 @@ var providerNamespaces = map[string]string{
 	kubeadmBootstrapProviderName:  constants.CapiKubeadmBootstrapSystemNamespace,
 }
 
-func (c *Clusterctl) Upgrade(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, newSpec *cluster.Spec, changeReport *clusterapi.CAPIChangeReport) error {
+func (c *Clusterctl) Upgrade(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, newSpec *cluster.Spec, changeDiff *clusterapi.CAPIChangeDiff) error {
 	clusterctlConfig, err := c.buildConfig(newSpec, managementCluster.Name, provider)
 	if err != nil {
 		return err
@@ -308,20 +308,20 @@ func (c *Clusterctl) Upgrade(ctx context.Context, managementCluster *types.Clust
 		"--kubeconfig", managementCluster.KubeconfigFile,
 	}
 
-	if changeReport.ControlPlane != nil {
-		upgradeCommand = append(upgradeCommand, "--control-plane", fmt.Sprintf("capi-kubeadm-control-plane-system/kubeadm:%s", changeReport.ControlPlane.NewVersion))
+	if changeDiff.ControlPlane != nil {
+		upgradeCommand = append(upgradeCommand, "--control-plane", fmt.Sprintf("capi-kubeadm-control-plane-system/kubeadm:%s", changeDiff.ControlPlane.NewVersion))
 	}
 
-	if changeReport.Core != nil {
-		upgradeCommand = append(upgradeCommand, "--core", fmt.Sprintf("capi-system/cluster-api:%s", changeReport.Core.NewVersion))
+	if changeDiff.Core != nil {
+		upgradeCommand = append(upgradeCommand, "--core", fmt.Sprintf("capi-system/cluster-api:%s", changeDiff.Core.NewVersion))
 	}
 
-	if changeReport.InfrastructureProvider != nil {
-		newInfraProvider := fmt.Sprintf("%s/%s:%s", providerNamespaces[changeReport.InfrastructureProvider.ComponentName], changeReport.InfrastructureProvider.ComponentName, changeReport.InfrastructureProvider.NewVersion)
+	if changeDiff.InfrastructureProvider != nil {
+		newInfraProvider := fmt.Sprintf("%s/%s:%s", providerNamespaces[changeDiff.InfrastructureProvider.ComponentName], changeDiff.InfrastructureProvider.ComponentName, changeDiff.InfrastructureProvider.NewVersion)
 		upgradeCommand = append(upgradeCommand, "--infrastructure", newInfraProvider)
 	}
 
-	for _, bootstrapProvider := range changeReport.BootstrapProviders {
+	for _, bootstrapProvider := range changeDiff.BootstrapProviders {
 		newBootstrapProvider := fmt.Sprintf("%s/%s:%s", providerNamespaces[bootstrapProvider.ComponentName], bootstrapProvider.ComponentName, bootstrapProvider.NewVersion)
 		upgradeCommand = append(upgradeCommand, "--bootstrap", newBootstrapProvider)
 	}

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -11,6 +11,7 @@ import (
 
 	anywherev1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/providers"
@@ -20,9 +21,12 @@ import (
 )
 
 const (
-	clusterCtlPath       = "clusterctl"
-	clusterctlConfigFile = "clusterctl_tmp.yaml"
-	capiPrefix           = "/generated/overrides"
+	clusterCtlPath                = "clusterctl"
+	clusterctlConfigFile          = "clusterctl_tmp.yaml"
+	capiPrefix                    = "/generated/overrides"
+	etcdadmBootstrapProviderName  = "etcdadm-bootstrap"
+	etcdadmControllerProviderName = "etcdadm-controller"
+	kubeadmBootstrapProviderName  = "kubeadm"
 )
 
 //go:embed config/clusterctl.yaml
@@ -274,10 +278,57 @@ func (c *Clusterctl) buildConfig(clusterSpec *cluster.Spec, clusterName string, 
 
 	return &clusterctlConfiguration{
 		configFile:               filePath,
-		bootstrapVersion:         fmt.Sprintf("kubeadm:%s", bundle.Bootstrap.Version),
+		bootstrapVersion:         fmt.Sprintf("%s:%s", kubeadmBootstrapProviderName, bundle.Bootstrap.Version),
 		controlPlaneVersion:      fmt.Sprintf("kubeadm:%s", bundle.ControlPlane.Version),
 		coreVersion:              fmt.Sprintf("cluster-api:%s", bundle.ClusterAPI.Version),
-		etcdadmBootstrapVersion:  fmt.Sprintf("etcdadm-bootstrap:%s", bundle.ExternalEtcdBootstrap.Version),
-		etcdadmControllerVersion: fmt.Sprintf("etcdadm-controller:%s", bundle.ExternalEtcdController.Version),
+		etcdadmBootstrapVersion:  fmt.Sprintf("%s:%s", etcdadmBootstrapProviderName, bundle.ExternalEtcdBootstrap.Version),
+		etcdadmControllerVersion: fmt.Sprintf("%s:%s", etcdadmControllerProviderName, bundle.ExternalEtcdController.Version),
 	}, nil
+}
+
+var providerNamespaces = map[string]string{
+	constants.VSphereProviderName: constants.CapvSystemNamespace,
+	constants.DockerProviderName:  constants.CapdSystemNamespace,
+	constants.AWSProviderName:     constants.CapaSystemNamespace,
+	etcdadmBootstrapProviderName:  constants.EtcdAdminBootstrapProviderSystemNamespace,
+	etcdadmControllerProviderName: constants.EtcdAdminControllerSystemNamespace,
+	kubeadmBootstrapProviderName:  constants.CapiKubeadmBootstrapSystemNamespace,
+}
+
+func (c *Clusterctl) Upgrade(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, newSpec *cluster.Spec, changeReport *clusterapi.CAPIChangeReport) error {
+	clusterctlConfig, err := c.buildConfig(newSpec, managementCluster.Name, provider)
+	if err != nil {
+		return err
+	}
+
+	upgradeCommand := []string{
+		"upgrade", "apply",
+		"--config", clusterctlConfig.configFile,
+		"--management-group", "capi-system/cluster-api",
+		"--kubeconfig", managementCluster.KubeconfigFile,
+	}
+
+	if changeReport.ControlPlane != nil {
+		upgradeCommand = append(upgradeCommand, "--control-plane", fmt.Sprintf("capi-kubeadm-control-plane-system/kubeadm:%s", changeReport.ControlPlane.NewVersion))
+	}
+
+	if changeReport.Core != nil {
+		upgradeCommand = append(upgradeCommand, "--core", fmt.Sprintf("capi-system/cluster-api:%s", changeReport.Core.NewVersion))
+	}
+
+	if changeReport.InfrastructureProvider != nil {
+		newInfraProvider := fmt.Sprintf("%s/%s:%s", providerNamespaces[changeReport.InfrastructureProvider.ComponentName], changeReport.InfrastructureProvider.ComponentName, changeReport.InfrastructureProvider.NewVersion)
+		upgradeCommand = append(upgradeCommand, "--infrastructure", newInfraProvider)
+	}
+
+	for _, bootstrapProvider := range changeReport.BootstrapProviders {
+		newBootstrapProvider := fmt.Sprintf("%s/%s:%s", providerNamespaces[bootstrapProvider.ComponentName], bootstrapProvider.ComponentName, bootstrapProvider.NewVersion)
+		upgradeCommand = append(upgradeCommand, "--bootstrap", newBootstrapProvider)
+	}
+
+	if _, err := c.executable.Execute(ctx, upgradeCommand...); err != nil {
+		return fmt.Errorf("failed running upgrade apply with clusterctl: %v", err)
+	}
+
+	return nil
 }

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -375,20 +375,20 @@ func TestClusterctlMoveManagement(t *testing.T) {
 func TestClusterctlUpgradeAllProvidersSucess(t *testing.T) {
 	tt := newClusterctlTest(t)
 
-	changeReport := &clusterapi.CAPIChangeReport{
-		Core: &types.ComponentChangeReport{
+	changeDiff := &clusterapi.CAPIChangeDiff{
+		Core: &types.ComponentChangeDiff{
 			ComponentName: "cluster-api",
 			NewVersion:    "v0.3.19",
 		},
-		ControlPlane: &types.ComponentChangeReport{
+		ControlPlane: &types.ComponentChangeDiff{
 			ComponentName: "kubeadm",
 			NewVersion:    "v0.3.19",
 		},
-		InfrastructureProvider: &types.ComponentChangeReport{
+		InfrastructureProvider: &types.ComponentChangeDiff{
 			ComponentName: "vsphere",
 			NewVersion:    "v0.4.1",
 		},
-		BootstrapProviders: []types.ComponentChangeReport{
+		BootstrapProviders: []types.ComponentChangeDiff{
 			{
 				ComponentName: "kubeadm",
 				NewVersion:    "v0.3.19",
@@ -418,14 +418,14 @@ func TestClusterctlUpgradeAllProvidersSucess(t *testing.T) {
 		"--bootstrap", "etcdadm-controller-system/etcdadm-controller:v0.1.0",
 	)
 
-	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeReport)).To(Succeed())
+	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeDiff)).To(Succeed())
 }
 
 func TestClusterctlUpgradeInfrastructureProvidersSucess(t *testing.T) {
 	tt := newClusterctlTest(t)
 
-	changeReport := &clusterapi.CAPIChangeReport{
-		InfrastructureProvider: &types.ComponentChangeReport{
+	changeDiff := &clusterapi.CAPIChangeDiff{
+		InfrastructureProvider: &types.ComponentChangeDiff{
 			ComponentName: "vsphere",
 			NewVersion:    "v0.4.1",
 		},
@@ -440,14 +440,14 @@ func TestClusterctlUpgradeInfrastructureProvidersSucess(t *testing.T) {
 		"--infrastructure", "capv-system/vsphere:v0.4.1",
 	)
 
-	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeReport)).To(Succeed())
+	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeDiff)).To(Succeed())
 }
 
 func TestClusterctlUpgradeInfrastructureProvidersError(t *testing.T) {
 	tt := newClusterctlTest(t)
 
-	changeReport := &clusterapi.CAPIChangeReport{
-		InfrastructureProvider: &types.ComponentChangeReport{
+	changeDiff := &clusterapi.CAPIChangeDiff{
+		InfrastructureProvider: &types.ComponentChangeDiff{
 			ComponentName: "vsphere",
 			NewVersion:    "v0.4.1",
 		},
@@ -462,7 +462,7 @@ func TestClusterctlUpgradeInfrastructureProvidersError(t *testing.T) {
 		"--infrastructure", "capv-system/vsphere:v0.4.1",
 	).Return(bytes.Buffer{}, errors.New("error in exec"))
 
-	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeReport)).NotTo(Succeed())
+	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeDiff)).NotTo(Succeed())
 }
 
 var clusterSpec = test.NewClusterSpec(func(s *cluster.Spec) {

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -9,19 +9,55 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	specv1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	mockexecutables "github.com/aws/eks-anywhere/pkg/executables/mocks"
+	"github.com/aws/eks-anywhere/pkg/filewriter"
 	mockswriter "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
 	mockproviders "github.com/aws/eks-anywhere/pkg/providers/mocks"
 	"github.com/aws/eks-anywhere/pkg/templater"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
+
+type clusterctlTest struct {
+	*WithT
+	ctx        context.Context
+	cluster    *types.Cluster
+	clusterctl *executables.Clusterctl
+	e          *mockexecutables.MockExecutable
+	provider   *mockproviders.MockProvider
+	writer     filewriter.FileWriter
+}
+
+func newClusterctlTest(t *testing.T) *clusterctlTest {
+	ctrl := gomock.NewController(t)
+	_, writer := test.NewWriter(t)
+	e := mockexecutables.NewMockExecutable(ctrl)
+
+	return &clusterctlTest{
+		WithT: NewWithT(t),
+		ctx:   context.Background(),
+		cluster: &types.Cluster{
+			Name:           "cluster-name",
+			KubeconfigFile: "config/c.kubeconfig",
+		},
+		e:          e,
+		provider:   mockproviders.NewMockProvider(ctrl),
+		clusterctl: executables.NewClusterctl(e, writer),
+		writer:     writer,
+	}
+}
+
+func (ct *clusterctlTest) expectBuildOverrideLayer() {
+	ct.provider.EXPECT().GetInfrastructureBundle(clusterSpec).Return(&types.InfrastructureBundle{})
+}
 
 func TestClusterctlInitInfrastructure(t *testing.T) {
 	_, writer := test.NewWriter(t)
@@ -334,6 +370,99 @@ func TestClusterctlMoveManagement(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClusterctlUpgradeAllProvidersSucess(t *testing.T) {
+	tt := newClusterctlTest(t)
+
+	changeReport := &clusterapi.CAPIChangeReport{
+		Core: &types.ComponentChangeReport{
+			ComponentName: "cluster-api",
+			NewVersion:    "v0.3.19",
+		},
+		ControlPlane: &types.ComponentChangeReport{
+			ComponentName: "kubeadm",
+			NewVersion:    "v0.3.19",
+		},
+		InfrastructureProvider: &types.ComponentChangeReport{
+			ComponentName: "vsphere",
+			NewVersion:    "v0.4.1",
+		},
+		BootstrapProviders: []types.ComponentChangeReport{
+			{
+				ComponentName: "kubeadm",
+				NewVersion:    "v0.3.19",
+			},
+			{
+				ComponentName: "etcdadm-bootstrap",
+				NewVersion:    "v0.1.0",
+			},
+			{
+				ComponentName: "etcdadm-controller",
+				NewVersion:    "v0.1.0",
+			},
+		},
+	}
+
+	tt.expectBuildOverrideLayer()
+	tt.e.EXPECT().Execute(tt.ctx,
+		"upgrade", "apply",
+		"--config", test.OfType("string"),
+		"--management-group", "capi-system/cluster-api",
+		"--kubeconfig", tt.cluster.KubeconfigFile,
+		"--control-plane", "capi-kubeadm-control-plane-system/kubeadm:v0.3.19",
+		"--core", "capi-system/cluster-api:v0.3.19",
+		"--infrastructure", "capv-system/vsphere:v0.4.1",
+		"--bootstrap", "capi-kubeadm-bootstrap-system/kubeadm:v0.3.19",
+		"--bootstrap", "etcdadm-bootstrap-provider-system/etcdadm-bootstrap:v0.1.0",
+		"--bootstrap", "etcdadm-controller-system/etcdadm-controller:v0.1.0",
+	)
+
+	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeReport)).To(Succeed())
+}
+
+func TestClusterctlUpgradeInfrastructureProvidersSucess(t *testing.T) {
+	tt := newClusterctlTest(t)
+
+	changeReport := &clusterapi.CAPIChangeReport{
+		InfrastructureProvider: &types.ComponentChangeReport{
+			ComponentName: "vsphere",
+			NewVersion:    "v0.4.1",
+		},
+	}
+
+	tt.expectBuildOverrideLayer()
+	tt.e.EXPECT().Execute(tt.ctx,
+		"upgrade", "apply",
+		"--config", test.OfType("string"),
+		"--management-group", "capi-system/cluster-api",
+		"--kubeconfig", tt.cluster.KubeconfigFile,
+		"--infrastructure", "capv-system/vsphere:v0.4.1",
+	)
+
+	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeReport)).To(Succeed())
+}
+
+func TestClusterctlUpgradeInfrastructureProvidersError(t *testing.T) {
+	tt := newClusterctlTest(t)
+
+	changeReport := &clusterapi.CAPIChangeReport{
+		InfrastructureProvider: &types.ComponentChangeReport{
+			ComponentName: "vsphere",
+			NewVersion:    "v0.4.1",
+		},
+	}
+
+	tt.expectBuildOverrideLayer()
+	tt.e.EXPECT().Execute(tt.ctx,
+		"upgrade", "apply",
+		"--config", test.OfType("string"),
+		"--management-group", "capi-system/cluster-api",
+		"--kubeconfig", tt.cluster.KubeconfigFile,
+		"--infrastructure", "capv-system/vsphere:v0.4.1",
+	).Return(bytes.Buffer{}, errors.New("error in exec"))
+
+	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeReport)).NotTo(Succeed())
 }
 
 var clusterSpec = test.NewClusterSpec(func(s *cluster.Spec) {

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -27,7 +27,6 @@ import (
 )
 
 const (
-	ProviderName      = "docker"
 	githubTokenEnvVar = "GITHUB_TOKEN"
 )
 
@@ -78,7 +77,7 @@ func (p *provider) BootstrapSetup(ctx context.Context, clusterConfig *v1alpha1.C
 }
 
 func (p *provider) Name() string {
-	return ProviderName
+	return constants.DockerProviderName
 }
 
 func (p *provider) DatacenterResourceType() string {

--- a/pkg/providers/factory/providerfactory.go
+++ b/pkg/providers/factory/providerfactory.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/providers/docker"
@@ -39,5 +40,5 @@ func (p *ProviderFactory) BuildProvider(clusterConfigFileName string, clusterCon
 		}
 		return docker.NewProvider(datacenterConfig, p.DockerClient, p.DockerKubectlClient, time.Now), nil
 	}
-	return nil, errors.New("valid providers include: " + docker.ProviderName + ", " + vsphere.ProviderName)
+	return nil, errors.New("valid providers include: " + constants.DockerProviderName + ", " + constants.VSphereProviderName)
 }

--- a/pkg/providers/factory/providerfactory_test.go
+++ b/pkg/providers/factory/providerfactory_test.go
@@ -9,11 +9,10 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	mockswriter "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
-	"github.com/aws/eks-anywhere/pkg/providers/docker"
 	dockerMocks "github.com/aws/eks-anywhere/pkg/providers/docker/mocks"
 	"github.com/aws/eks-anywhere/pkg/providers/factory"
-	"github.com/aws/eks-anywhere/pkg/providers/vsphere"
 	vsphereMocks "github.com/aws/eks-anywhere/pkg/providers/vsphere/mocks"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
@@ -53,7 +52,7 @@ func TestProviderFactoryBuildProvider(t *testing.T) {
 				clusterConfigFileName: "testdata/cluster_vsphere.yaml",
 			},
 			want: providerMatch{
-				kind:    vsphere.ProviderName,
+				kind:    constants.VSphereProviderName,
 				version: "v0.7.8",
 			},
 		},
@@ -68,7 +67,7 @@ func TestProviderFactoryBuildProvider(t *testing.T) {
 				clusterConfigFileName: "testdata/cluster_docker.yaml",
 			},
 			want: providerMatch{
-				kind:    docker.ProviderName,
+				kind:    constants.DockerProviderName,
 				version: "v0.3.19",
 			},
 		},
@@ -82,7 +81,7 @@ func TestProviderFactoryBuildProvider(t *testing.T) {
 				}},
 				clusterConfigFileName: "testdata/cluster_aws.yaml",
 			},
-			wantErr: fmt.Errorf("valid providers include: %s, %s", docker.ProviderName, vsphere.ProviderName),
+			wantErr: fmt.Errorf("valid providers include: %s, %s", constants.DockerProviderName, constants.VSphereProviderName),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -40,7 +40,6 @@ import (
 )
 
 const (
-	ProviderName             = "vsphere"
 	eksaLicense              = "EKSA_LICENSE"
 	vSphereUsernameKey       = "VSPHERE_USERNAME"
 	vSpherePasswordKey       = "VSPHERE_PASSWORD"
@@ -229,7 +228,7 @@ func (p *vsphereProvider) BootstrapClusterOpts() ([]bootstrapper.BootstrapCluste
 }
 
 func (p *vsphereProvider) Name() string {
-	return ProviderName
+	return constants.VSphereProviderName
 }
 
 func (p *vsphereProvider) DatacenterResourceType() string {

--- a/pkg/types/upgrades.go
+++ b/pkg/types/upgrades.go
@@ -1,10 +1,10 @@
 package types
 
-type ChangeReport struct {
-	ComponentReports []ComponentChangeReport
+type ChangeDiff struct {
+	ComponentReports []ComponentChangeDiff
 }
 
-type ComponentChangeReport struct {
+type ComponentChangeDiff struct {
 	ComponentName string
 	OldVersion    string
 	NewVersion    string

--- a/pkg/types/upgrades.go
+++ b/pkg/types/upgrades.go
@@ -1,0 +1,11 @@
+package types
+
+type ChangeReport struct {
+	ComponentReports []ComponentChangeReport
+}
+
+type ComponentChangeReport struct {
+	ComponentName string
+	OldVersion    string
+	NewVersion    string
+}


### PR DESCRIPTION
This is part of #314 

*Description of changes:*
In order to have smaller PRs, splitting this issue into multiple parts
This one adds the `upgrade apply` command wrapper to `clusterctl` and the skeleton for a `clusterapi` upgrader

The idea is that the `clusterapi.Upgrader` is a higher level entity that takes care of comparing versions and determine what has changed and needs to be upgraded. And `clusterctl` just generates the proper command to update those components to those specific versions

The `clusterapi.Upgrader` will probably be called from the upgrade workflow or from `ClusterManager` directly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
