### PR TITLE
Enable external etcd for proxy BR e2e test

### DIFF
--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -19,8 +19,7 @@ func runProxyConfigFlow(test *framework.E2ETest) {
 func TestVSphereKubernetes121UbuntuProxyConfig(t *testing.T) {
 	test := framework.NewE2ETest(
 		t,
-		framework.NewVSphere(t, framework.WithUbuntu121(),
-		framework.WithPrivateNetwork()),
+		framework.NewVSphere(t, framework.WithUbuntu121(), framework.WithPrivateNetwork()),
 		framework.WithClusterFiller(api.WithControlPlaneCount(2)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(3)),
@@ -33,12 +32,9 @@ func TestVSphereKubernetes121UbuntuProxyConfig(t *testing.T) {
 func TestVSphereKubernetes121BottlerocketProxyConfig(t *testing.T) {
 	test := framework.NewE2ETest(
 		t,
-		framework.NewVSphere(t, framework.WithBottleRocket121(),
-		framework.WithPrivateNetwork()),
+		framework.NewVSphere(t, framework.WithBottleRocket121(), framework.WithPrivateNetwork()),
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		// enable external etcd when proxyconfig for etcd is fixed
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithProxy(),
 	)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Now that there is support for proxy on BR/ubuntu on external etcd nodes this commit enables external etcd for BR proxy e2e test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
