### PR TITLE
Change path to build-tooling repo before running git log

### DIFF
--- a/release/pkg/prepare_release.go
+++ b/release/pkg/prepare_release.go
@@ -423,6 +423,7 @@ func UpdateImageDigests(releaseClients *ReleaseClients, r *ReleaseConfig, eksArt
 				imageDigest := describeImagesOutput.ImageDetails[0].ImageDigest
 
 				imageDigests[artifact.Image.ReleaseImageURI] = *imageDigest
+				fmt.Printf("Image digest for %s  -  %s\n", artifact.Image.ReleaseImageURI, *imageDigest)
 			}
 		}
 	}

--- a/release/pkg/versions.go
+++ b/release/pkg/versions.go
@@ -49,7 +49,7 @@ func newVersioner(pathToProject string) *versioner {
 }
 
 func (v *versioner) buildMetadata() (string, error) {
-	cmd := exec.Command("git", "log", "--pretty=format:%h", "-n1", v.pathToProject)
+	cmd := exec.Command("git", "-C", v.pathToProject, "log", "--pretty=format:%h", "-n1", v.pathToProject)
 	out, err := execCommand(cmd)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed executing git log to get build metadata in [%s]", v.pathToProject)


### PR DESCRIPTION
Without this, the context of Git would be inside the CLI repo that's checked out by Codebuild for dev release, while the query path is in the build-tooling repo that is cloned locally. This would lead to errors of the form
```
fatal: <Build-tooling projectPath>: '<Build-tooling project path>' is outside repository at '<CLI repo root>
```
during release.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
