### PR TITLE
Fix VsphereMachineConfig Webhook validation on worker nodes

### DIFF
--- a/docs/content/en/docs/tasks/cluster/cluster-flux.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-flux.md
@@ -35,7 +35,6 @@ Currently, you can manage a subset of cluster properties with GitOps:
 - `VSphereMachineConfig.memoryMiB`
 - `VSphereMachineConfig.numCPUs`
 - `VSphereMachineConfig.resourcePool`
-- `VSphereMachineConfig.template`
 
 Any other changes to the cluster configuration in the git repository will be ignored.
 If an immutable immutable field is changed in Git repsitory, there are two ways to find the error message:

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
@@ -63,6 +63,13 @@ func validateImmutableFieldsVSphereMachineConfig(new, old *VSphereMachineConfig)
 
 	var allErrs field.ErrorList
 
+	if old.Spec.Template != new.Spec.Template {
+		allErrs = append(
+			allErrs,
+			field.Invalid(field.NewPath("spec", "template"), new.Spec.Template, "field is immutable"),
+		)
+	}
+
 	if old.Spec.OSFamily != new.Spec.OSFamily {
 		allErrs = append(
 			allErrs,
@@ -89,13 +96,6 @@ func validateImmutableFieldsVSphereMachineConfig(new, old *VSphereMachineConfig)
 		return allErrs
 	}
 	vspheremachineconfiglog.Info("Machine config is associated with control plane or etcd")
-
-	if old.Spec.Template != new.Spec.Template {
-		allErrs = append(
-			allErrs,
-			field.Invalid(field.NewPath("spec", "template"), new.Spec.Template, "field is immutable"),
-		)
-	}
 
 	if old.Spec.Datastore != new.Spec.Datastore {
 		allErrs = append(

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
@@ -63,13 +63,6 @@ func validateImmutableFieldsVSphereMachineConfig(new, old *VSphereMachineConfig)
 
 	var allErrs field.ErrorList
 
-	if old.Spec.Template != new.Spec.Template {
-		allErrs = append(
-			allErrs,
-			field.Invalid(field.NewPath("spec", "template"), new.Spec.Template, "field is immutable"),
-		)
-	}
-
 	if old.Spec.OSFamily != new.Spec.OSFamily {
 		allErrs = append(
 			allErrs,
@@ -88,6 +81,19 @@ func validateImmutableFieldsVSphereMachineConfig(new, old *VSphereMachineConfig)
 		allErrs = append(
 			allErrs,
 			field.Invalid(field.NewPath("spec", "storagepolicyname"), new.Spec.StoragePolicyName, "field is immutable"),
+		)
+	}
+
+	if !old.IsControlPlane() && !old.IsEtcd() {
+		vspheremachineconfiglog.Info("Machine config is not associated with control plane or etcd")
+		return allErrs
+	}
+	vspheremachineconfiglog.Info("Machine config is associated with control plane or etcd")
+
+	if old.Spec.Template != new.Spec.Template {
+		allErrs = append(
+			allErrs,
+			field.Invalid(field.NewPath("spec", "template"), new.Spec.Template, "field is immutable"),
 		)
 	}
 
@@ -111,12 +117,6 @@ func validateImmutableFieldsVSphereMachineConfig(new, old *VSphereMachineConfig)
 			field.Invalid(field.NewPath("spec", "resourcePool"), new.Spec.ResourcePool, "field is immutable"),
 		)
 	}
-
-	if !old.IsControlPlane() && !old.IsEtcd() {
-		vspheremachineconfiglog.Info("Machine config is not associated with control plane or etcd")
-		return allErrs
-	}
-	vspheremachineconfiglog.Info("Machine config is associated with control plane or etcd")
 
 	if old.Spec.MemoryMiB != new.Spec.MemoryMiB {
 		allErrs = append(

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
@@ -9,14 +9,25 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
-func TestVSphereMachineValidateUpdateTemplateImmutable(t *testing.T) {
+func TestCPVSphereMachineValidateUpdateTemplateImmutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
+	vOld.SetControlPlane()
 	vOld.Spec.Template = "oldTemplate"
 	c := vOld.DeepCopy()
 
 	c.Spec.Template = "newTemplate"
 	g := NewWithT(t)
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
+}
+
+func TestWorkersVSphereMachineValidateUpdateTemplateSuccess(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.Spec.Template = "oldTemplate"
+	c := vOld.DeepCopy()
+
+	c.Spec.Template = "newTemplate"
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestVSphereMachineValidateUpdateOSFamilyImmutable(t *testing.T) {
@@ -29,7 +40,7 @@ func TestVSphereMachineValidateUpdateOSFamilyImmutable(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
 }
 
-func TestVSphereMachineValidateUpdateMemoryMiBImmutable(t *testing.T) {
+func TestCPVSphereMachineValidateUpdateMemoryMiBImmutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.Spec.MemoryMiB = 2
@@ -40,7 +51,17 @@ func TestVSphereMachineValidateUpdateMemoryMiBImmutable(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
 }
 
-func TestVSphereMachineValidateUpdateNumCPUsImmutable(t *testing.T) {
+func TestWorkersVSphereMachineValidateUpdateMemoryMiBSuccess(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.Spec.MemoryMiB = 2
+	c := vOld.DeepCopy()
+
+	c.Spec.MemoryMiB = 2000000
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
+}
+
+func TestCPVSphereMachineValidateUpdateNumCPUsImmutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.Spec.NumCPUs = 1
@@ -51,7 +72,17 @@ func TestVSphereMachineValidateUpdateNumCPUsImmutable(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
 }
 
-func TestVSphereMachineValidateUpdateDiskGiBImmutable(t *testing.T) {
+func TestWorkersVSphereMachineValidateUpdateNumCPUsSuccess(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.Spec.NumCPUs = 1
+	c := vOld.DeepCopy()
+
+	c.Spec.NumCPUs = 16
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
+}
+
+func TestCPVSphereMachineValidateUpdateDiskGiBImmutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.Spec.DiskGiB = 1
@@ -60,6 +91,16 @@ func TestVSphereMachineValidateUpdateDiskGiBImmutable(t *testing.T) {
 	c.Spec.DiskGiB = 160
 	g := NewWithT(t)
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
+}
+
+func TestWorkersVSphereMachineValidateUpdateDiskGiBSuccess(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.Spec.DiskGiB = 1
+	c := vOld.DeepCopy()
+
+	c.Spec.DiskGiB = 160
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestVSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
@@ -120,8 +161,9 @@ func TestVSphereMachineValidateUpdateSuccess(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestVSphereMachineValidateUpdateDatastoreImmutable(t *testing.T) {
+func TestCPVSphereMachineValidateUpdateDatastoreImmutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
+	vOld.SetControlPlane()
 	vOld.Spec.Datastore = "OldDataStore"
 	c := vOld.DeepCopy()
 
@@ -130,8 +172,19 @@ func TestVSphereMachineValidateUpdateDatastoreImmutable(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
 }
 
-func TestVSphereMachineValidateUpdateFolderImmutable(t *testing.T) {
+func TestWorkersVSphereMachineValidateUpdateDatastoreSuccess(t *testing.T) {
 	vOld := vsphereMachineConfig()
+	vOld.Spec.Datastore = "OldDataStore"
+	c := vOld.DeepCopy()
+
+	c.Spec.Datastore = "NewDataStore"
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
+}
+
+func TestCPVSphereMachineValidateUpdateFolderImmutable(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.SetControlPlane()
 	vOld.Spec.Folder = "/dev/null"
 	c := vOld.DeepCopy()
 
@@ -140,14 +193,35 @@ func TestVSphereMachineValidateUpdateFolderImmutable(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
 }
 
-func TestVSphereMachineValidateUpdateResourcePoolImmutable(t *testing.T) {
+func TestWorkersVSphereMachineValidateUpdateFolderSuccess(t *testing.T) {
 	vOld := vsphereMachineConfig()
+	vOld.Spec.Folder = "/dev/null"
+	c := vOld.DeepCopy()
+
+	c.Spec.Folder = "/tmp"
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
+}
+
+func TestCPVSphereMachineValidateUpdateResourcePoolImmutable(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.SetControlPlane()
 	vOld.Spec.ResourcePool = "AbovegroundPool"
 	c := vOld.DeepCopy()
 
 	c.Spec.ResourcePool = "IngroundPool"
 	g := NewWithT(t)
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
+}
+
+func TestWorkersVSphereMachineValidateUpdateResourcePoolSuccess(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.Spec.ResourcePool = "AbovegroundPool"
+	c := vOld.DeepCopy()
+
+	c.Spec.ResourcePool = "IngroundPool"
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestVSphereMachineValidateUpdateStoragePolicyImmutable(t *testing.T) {

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
@@ -20,14 +20,14 @@ func TestCPVSphereMachineValidateUpdateTemplateImmutable(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
 }
 
-func TestWorkersVSphereMachineValidateUpdateTemplateSuccess(t *testing.T) {
+func TestWorkersVSphereMachineValidateUpdateTemplateImmutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.Spec.Template = "oldTemplate"
 	c := vOld.DeepCopy()
 
 	c.Spec.Template = "newTemplate"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
+	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
 }
 
 func TestVSphereMachineValidateUpdateOSFamilyImmutable(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

To allow worker nodes update on fields:
- folder
- resourcePool
- datastore
- diskGiB
- numCPUs
- memoryMiB
- template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
