### PR TITLE
Generate version field for certmanager bundle

### DIFF
--- a/release/pkg/assets_capa.go
+++ b/release/pkg/assets_capa.go
@@ -125,7 +125,7 @@ func (r *ReleaseConfig) GetAwsBundle(imageDigests map[string]string) (anywherev1
 		newVersionerWithGITTAG(filepath.Join(r.BuildRepoSource, "projects/kubernetes-sigs/cluster-api-provider-aws")),
 	)
 	if err != nil {
-		return anywherev1alpha1.AwsBundle{}, errors.Wrapf(err, "Error getting Git tag for cluster-api-provider-aws")
+		return anywherev1alpha1.AwsBundle{}, errors.Wrapf(err, "Error getting version for cluster-api-provider-aws")
 	}
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}

--- a/release/pkg/assets_capd.go
+++ b/release/pkg/assets_capd.go
@@ -110,7 +110,7 @@ func (r *ReleaseConfig) GetDockerBundle(imageDigests map[string]string) (anywher
 		newVersionerWithGITTAG(filepath.Join(r.BuildRepoSource, "projects/kubernetes-sigs/cluster-api")),
 	)
 	if err != nil {
-		return anywherev1alpha1.DockerBundle{}, errors.Wrapf(err, "Error getting git tag for cluster-api")
+		return anywherev1alpha1.DockerBundle{}, errors.Wrapf(err, "Error getting version for cluster-api")
 	}
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}

--- a/release/pkg/assets_capi.go
+++ b/release/pkg/assets_capi.go
@@ -131,7 +131,7 @@ func (r *ReleaseConfig) GetCoreClusterAPIBundle(imageDigests map[string]string) 
 		newVersionerWithGITTAG(filepath.Join(r.BuildRepoSource, "projects/kubernetes-sigs/cluster-api")),
 	)
 	if err != nil {
-		return anywherev1alpha1.CoreClusterAPI{}, errors.Wrapf(err, "Error getting git tag for cluster-api")
+		return anywherev1alpha1.CoreClusterAPI{}, errors.Wrapf(err, "Error getting version for cluster-api")
 	}
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
@@ -197,7 +197,7 @@ func (r *ReleaseConfig) GetKubeadmBootstrapBundle(imageDigests map[string]string
 		newVersionerWithGITTAG(filepath.Join(r.BuildRepoSource, "projects/kubernetes-sigs/cluster-api")),
 	)
 	if err != nil {
-		return anywherev1alpha1.KubeadmBootstrapBundle{}, errors.Wrapf(err, "Error getting git tag for cluster-api")
+		return anywherev1alpha1.KubeadmBootstrapBundle{}, errors.Wrapf(err, "Error getting version for cluster-api")
 	}
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
@@ -263,7 +263,7 @@ func (r *ReleaseConfig) GetKubeadmControlPlaneBundle(imageDigests map[string]str
 		newVersionerWithGITTAG(filepath.Join(r.BuildRepoSource, "projects/kubernetes-sigs/cluster-api")),
 	)
 	if err != nil {
-		return anywherev1alpha1.KubeadmControlPlaneBundle{}, errors.Wrapf(err, "error getting version for cluster-api")
+		return anywherev1alpha1.KubeadmControlPlaneBundle{}, errors.Wrapf(err, "Error getting version for cluster-api")
 	}
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}

--- a/release/pkg/assets_certmanager.go
+++ b/release/pkg/assets_certmanager.go
@@ -64,6 +64,12 @@ func (r *ReleaseConfig) GetCertManagerBundle(imageDigests map[string]string) (an
 		return anywherev1alpha1.CertManagerBundle{}, errors.Cause(err)
 	}
 
+	version, err := r.GenerateComponentBundleVersion(
+		newVersionerWithGITTAG(filepath.Join(r.BuildRepoSource, "projects/jetstack/cert-manager")),
+	)
+	if err != nil {
+		return anywherev1alpha1.CertManagerBundle{}, errors.Wrapf(err, "Error getting version for cert-manager")
+	}
 	bundleArtifacts := map[string]anywherev1alpha1.Image{}
 
 	for _, artifact := range artifacts {
@@ -81,6 +87,7 @@ func (r *ReleaseConfig) GetCertManagerBundle(imageDigests map[string]string) (an
 	}
 
 	bundle := anywherev1alpha1.CertManagerBundle{
+		Version:    version,
 		Acmesolver: bundleArtifacts["cert-manager-acmesolver"],
 		Cainjector: bundleArtifacts["cert-manager-cainjector"],
 		Controller: bundleArtifacts["cert-manager-controller"],

--- a/release/pkg/assets_etcdadm_bootstrap.go
+++ b/release/pkg/assets_etcdadm_bootstrap.go
@@ -111,7 +111,7 @@ func (r *ReleaseConfig) GetEtcdadmBootstrapBundle(imageDigests map[string]string
 		newVersionerWithGITTAG(filepath.Join(r.BuildRepoSource, "projects/mrajashree/etcdadm-bootstrap-provider")),
 	)
 	if err != nil {
-		return anywherev1alpha1.EtcdadmBootstrapBundle{}, errors.Wrapf(err, "Error getting git tag for etcdadm-bootstrap-provider")
+		return anywherev1alpha1.EtcdadmBootstrapBundle{}, errors.Wrapf(err, "Error getting version for etcdadm-bootstrap-provider")
 	}
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}

--- a/release/pkg/assets_etcdadm_controller.go
+++ b/release/pkg/assets_etcdadm_controller.go
@@ -111,7 +111,7 @@ func (r *ReleaseConfig) GetEtcdadmControllerBundle(imageDigests map[string]strin
 		newVersionerWithGITTAG(filepath.Join(r.BuildRepoSource, "projects/mrajashree/etcdadm-controller")),
 	)
 	if err != nil {
-		return anywherev1alpha1.EtcdadmControllerBundle{}, errors.Wrapf(err, "Error getting git tag for etcdadm-controller")
+		return anywherev1alpha1.EtcdadmControllerBundle{}, errors.Wrapf(err, "Error getting version for etcdadm-controller")
 	}
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}

--- a/release/pkg/assets_vsphere.go
+++ b/release/pkg/assets_vsphere.go
@@ -34,7 +34,7 @@ func (r *ReleaseConfig) GetVsphereBundle(eksDReleaseChannel string, imageDigests
 		newVersionerWithGITTAG(filepath.Join(r.BuildRepoSource, "projects/kubernetes-sigs/cluster-api-provider-vsphere")),
 	)
 	if err != nil {
-		return anywherev1alpha1.VSphereBundle{}, errors.Wrapf(err, "Error getting git tag for cluster-api-provider-sphere")
+		return anywherev1alpha1.VSphereBundle{}, errors.Wrapf(err, "Error getting version for cluster-api-provider-sphere")
 	}
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}


### PR DESCRIPTION
- Adding version field to cert-manager bundle during generation.
- Make error messages more precise.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
