### PR TITLE
Refactor construction of image tag overrides for Flux and kube-rbac-proxy

### DIFF
--- a/release/pkg/assets_flux.go
+++ b/release/pkg/assets_flux.go
@@ -36,10 +36,7 @@ func (r *ReleaseConfig) GetFluxAssets() ([]Artifact, error) {
 			return nil, errors.Cause(err)
 		}
 
-		repoName := fmt.Sprintf("fluxcd/%s", project)
-		tagOptions := map[string]string{
-			"gitTag": gitTag,
-		}
+		repoName, tagOptions := r.getFluxImageAttributes(project, gitTag)
 
 		imageArtifact := &ImageArtifact{
 			AssetName:       project,
@@ -167,17 +164,24 @@ func (r *ReleaseConfig) getFluxControllerTagOverrides(projects []string) ([]Imag
 			return nil, errors.Cause(err)
 		}
 
-		tagOptions := map[string]string{
-			"gitTag": gitTag,
-		}
+		repoName, tagOptions := r.getFluxImageAttributes(project, gitTag)
 
 		imageTagOverride := ImageTagOverride{
-			Repository: fmt.Sprintf("fluxcd/%s", project),
-			ReleaseUri: r.GetReleaseImageURI(project, "fluxcd/%s", tagOptions),
+			Repository: repoName,
+			ReleaseUri: r.GetReleaseImageURI(project, repoName, tagOptions),
 		}
 
 		imageTagOverrides = append(imageTagOverrides, imageTagOverride)
 	}
 
 	return imageTagOverrides, nil
+}
+
+func (r *ReleaseConfig) getFluxImageAttributes(project, gitTag string) (string, map[string]string) {
+	repoName := fmt.Sprintf("fluxcd/%s", project)
+	tagOptions := map[string]string{
+		"gitTag": gitTag,
+	}
+
+	return repoName, tagOptions
 }

--- a/release/pkg/assets_kube_rbac_proxy.go
+++ b/release/pkg/assets_kube_rbac_proxy.go
@@ -29,11 +29,7 @@ func (r *ReleaseConfig) GetKubeRbacProxyAssets() ([]Artifact, error) {
 		return nil, errors.Cause(err)
 	}
 
-	name := "kube-rbac-proxy"
-	repoName := fmt.Sprintf("brancz/%s", name)
-	tagOptions := map[string]string{
-		"gitTag": gitTag,
-	}
+	name, repoName, tagOptions := r.getKubeRbacProxyImageAttributes(gitTag)
 
 	imageArtifact := &ImageArtifact{
 		AssetName:       name,
@@ -59,19 +55,27 @@ func (r *ReleaseConfig) getKubeRbacProxyGitTag() (string, error) {
 	return gitTag, nil
 }
 
+func (r *ReleaseConfig) getKubeRbacProxyImageAttributes(gitTag string) (string, string, map[string]string) {
+	name := "kube-rbac-proxy"
+	repoName := fmt.Sprintf("brancz/%s", name)
+	tagOptions := map[string]string{
+		"gitTag": gitTag,
+	}
+
+	return name, repoName, tagOptions
+}
+
 func (r *ReleaseConfig) GetKubeRbacProxyImageTagOverride() (ImageTagOverride, error) {
 	gitTag, err := r.getKubeRbacProxyGitTag()
 	if err != nil {
 		return ImageTagOverride{}, errors.Cause(err)
 	}
 
-	tagOptions := map[string]string{
-		"gitTag": gitTag,
-	}
+	name, repoName, tagOptions := r.getKubeRbacProxyImageAttributes(gitTag)
 
 	imageTagOverride := ImageTagOverride{
-		Repository: "brancz/kube-rbac-proxy",
-		ReleaseUri: r.GetReleaseImageURI("kube-rbac-proxy", "brancz/kube-rbac-proxy", tagOptions),
+		Repository: repoName,
+		ReleaseUri: r.GetReleaseImageURI(name, repoName, tagOptions),
 	}
 
 	return imageTagOverride, nil


### PR DESCRIPTION
Add a method to fetch image attributes needed to construct image overrides for Flux and kube-rbac-proxy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
