### PR TITLE
Restrict the use of crd generate structs to the cluster marshaller

### DIFF
--- a/pkg/addonmanager/addonclients/fluxaddonclient_test.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient_test.go
@@ -1003,12 +1003,12 @@ func (tt *fluxTest) setupFlux() (owner, repo, path string) {
 	return owner, repo, path
 }
 
-func datacenterConfig() *v1alpha1.VSphereDatacenterConfigGenerate {
-	return &v1alpha1.VSphereDatacenterConfigGenerate{
+func datacenterConfig() *v1alpha1.VSphereDatacenterConfig {
+	return &v1alpha1.VSphereDatacenterConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind: v1alpha1.VSphereDatacenterKind,
 		},
-		ObjectMeta: v1alpha1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "fluxAddonTestCluster",
 		},
 		Spec: v1alpha1.VSphereDatacenterConfigSpec{
@@ -1017,12 +1017,12 @@ func datacenterConfig() *v1alpha1.VSphereDatacenterConfigGenerate {
 	}
 }
 
-func machineConfig() *v1alpha1.VSphereMachineConfigGenerate {
-	return &v1alpha1.VSphereMachineConfigGenerate{
+func machineConfig() *v1alpha1.VSphereMachineConfig {
+	return &v1alpha1.VSphereMachineConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind: v1alpha1.VSphereMachineConfigKind,
 		},
-		ObjectMeta: v1alpha1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "fluxAddonTestCluster",
 		},
 		Spec: v1alpha1.VSphereMachineConfigSpec{

--- a/pkg/api/v1alpha1/dockerdatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/dockerdatacenterconfig_types.go
@@ -63,6 +63,10 @@ func (d *DockerDatacenterConfig) ConvertConfigToConfigGenerateStruct() *DockerDa
 	return config
 }
 
+func (d *DockerDatacenterConfig) Marshallable() Marshallable {
+	return d.ConvertConfigToConfigGenerateStruct()
+}
+
 // +kubebuilder:object:generate=false
 
 // Same as DockerDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig

--- a/pkg/api/v1alpha1/marshallable.go
+++ b/pkg/api/v1alpha1/marshallable.go
@@ -1,0 +1,4 @@
+package v1alpha1
+
+// Marshallable represents all "generate" CRDs structs
+type Marshallable interface{}

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_types.go
@@ -75,6 +75,10 @@ func (v *VSphereDatacenterConfig) ConvertConfigToConfigGenerateStruct() *VSphere
 	return config
 }
 
+func (v *VSphereDatacenterConfig) Marshallable() Marshallable {
+	return v.ConvertConfigToConfigGenerateStruct()
+}
+
 // +kubebuilder:object:generate=false
 
 // Same as VSphereDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig
@@ -83,19 +87,6 @@ type VSphereDatacenterConfigGenerate struct {
 	ObjectMeta      `json:"metadata,omitempty"`
 
 	Spec VSphereDatacenterConfigSpec `json:"spec,omitempty"`
-}
-
-func (v *VSphereDatacenterConfigGenerate) PauseReconcile() {
-	if v.Annotations == nil {
-		v.Annotations = map[string]string{}
-	}
-	v.Annotations[pausedAnnotation] = "true"
-}
-
-func (v *VSphereDatacenterConfigGenerate) ClearPauseAnnotation() {
-	if v.Annotations != nil {
-		delete(v.Annotations, pausedAnnotation)
-	}
 }
 
 //+kubebuilder:object:root=true

--- a/pkg/api/v1alpha1/vspheremachineconfig_types.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_types.go
@@ -81,20 +81,6 @@ type VSphereMachineConfig struct {
 	Status VSphereMachineConfigStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:generate=false
-
-// Same as VSphereMachineConfig except stripped down for generation of yaml file during generate clusterconfig
-type VSphereMachineConfigGenerate struct {
-	metav1.TypeMeta `json:",inline"`
-	ObjectMeta      `json:"metadata,omitempty"`
-
-	Spec VSphereMachineConfigSpec `json:"spec,omitempty"`
-}
-
-func (c *VSphereMachineConfigGenerate) OSFamily() OSFamily {
-	return c.Spec.OSFamily
-}
-
 func (c *VSphereMachineConfig) ConvertConfigToConfigGenerateStruct() *VSphereMachineConfigGenerate {
 	config := &VSphereMachineConfigGenerate{
 		TypeMeta: c.TypeMeta,
@@ -107,6 +93,20 @@ func (c *VSphereMachineConfig) ConvertConfigToConfigGenerateStruct() *VSphereMac
 	}
 
 	return config
+}
+
+func (c *VSphereMachineConfig) Marshallable() Marshallable {
+	return c.ConvertConfigToConfigGenerateStruct()
+}
+
+// +kubebuilder:object:generate=false
+
+// Same as VSphereMachineConfig except stripped down for generation of yaml file during generate clusterconfig
+type VSphereMachineConfigGenerate struct {
+	metav1.TypeMeta `json:",inline"`
+	ObjectMeta      `json:"metadata,omitempty"`
+
+	Spec VSphereMachineConfigSpec `json:"spec,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/pkg/clustermarshaller/clustermarshaller_test.go
+++ b/pkg/clustermarshaller/clustermarshaller_test.go
@@ -1,0 +1,120 @@
+package clustermarshaller_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clustermarshaller"
+	"github.com/aws/eks-anywhere/pkg/providers"
+)
+
+func TestWriteClusterConfigWithOIDCAndGitOps(t *testing.T) {
+	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Cluster.APIVersion = v1alpha1.GroupVersion.String()
+		s.Cluster.TypeMeta.Kind = v1alpha1.ClusterKind
+		s.Cluster.CreationTimestamp = v1.Time{Time: time.Now()}
+		s.Cluster.Name = "mycluster"
+		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{
+			Count: 3,
+		}
+		s.Cluster.Spec.GitOpsRef = &v1alpha1.Ref{
+			Kind: v1alpha1.GitOpsConfigKind,
+			Name: "config",
+		}
+		s.Cluster.Spec.IdentityProviderRefs = []v1alpha1.Ref{
+			{
+				Kind: v1alpha1.OIDCConfigKind,
+				Name: "config",
+			},
+		}
+		s.OIDCConfig = &v1alpha1.OIDCConfig{
+			TypeMeta: v1.TypeMeta{
+				Kind:       v1alpha1.OIDCConfigKind,
+				APIVersion: v1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "config",
+				CreationTimestamp: v1.Time{Time: time.Now()},
+			},
+			Spec: v1alpha1.OIDCConfigSpec{
+				IssuerUrl: "https://url",
+			},
+		}
+
+		s.GitOpsConfig = &v1alpha1.GitOpsConfig{
+			TypeMeta: v1.TypeMeta{
+				Kind:       v1alpha1.GitOpsConfigKind,
+				APIVersion: v1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "config",
+				CreationTimestamp: v1.Time{Time: time.Now()},
+			},
+			Spec: v1alpha1.GitOpsConfigSpec{
+				Flux: v1alpha1.Flux{
+					Github: v1alpha1.Github{
+						Owner: "me",
+					},
+				},
+			},
+		}
+	})
+
+	datacenterConfig := &v1alpha1.VSphereDatacenterConfig{
+		TypeMeta: v1.TypeMeta{
+			Kind:       v1alpha1.VSphereDatacenterKind,
+			APIVersion: v1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "config",
+			CreationTimestamp: v1.Time{Time: time.Now()},
+		},
+		Spec: v1alpha1.VSphereDatacenterConfigSpec{
+			Server: "https://url",
+		},
+	}
+
+	machineConfigs := []providers.MachineConfig{
+		&v1alpha1.VSphereMachineConfig{
+			TypeMeta: v1.TypeMeta{
+				Kind:       v1alpha1.VSphereMachineConfigKind,
+				APIVersion: v1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "machineconf-1",
+				CreationTimestamp: v1.Time{Time: time.Now()},
+			},
+			Spec: v1alpha1.VSphereMachineConfigSpec{
+				Folder: "my-folder",
+			},
+		},
+		&v1alpha1.VSphereMachineConfig{
+			TypeMeta: v1.TypeMeta{
+				Kind:       v1alpha1.VSphereMachineConfigKind,
+				APIVersion: v1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "machineconf-2",
+				CreationTimestamp: v1.Time{Time: time.Now()},
+			},
+			Spec: v1alpha1.VSphereMachineConfigSpec{
+				Folder: "my-folder",
+			},
+		},
+	}
+	g := NewWithT(t)
+
+	folder, writer := test.NewWriter(t)
+	gotFile := filepath.Join(folder, "mycluster-eks-a-cluster.yaml")
+
+	g.Expect(clustermarshaller.WriteClusterConfig(clusterSpec, datacenterConfig, machineConfigs, writer)).To(Succeed())
+
+	test.AssertFilesEquals(t, gotFile, "testdata/expected_marshalled_cluster.yaml")
+}

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster.yaml
@@ -1,0 +1,82 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: mycluster
+spec:
+  clusterNetwork:
+    pods: {}
+    services: {}
+  controlPlaneConfiguration: {}
+  datacenterRef: {}
+  externalEtcdConfiguration:
+    count: 3
+  gitOpsRef:
+    kind: GitOpsConfig
+    name: config
+  identityProviderRefs:
+  - kind: OIDCConfig
+    name: config
+  workerNodeGroupConfigurations:
+  - {}
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: config
+spec:
+  datacenter: ""
+  insecure: false
+  network: ""
+  server: https://url
+  thumbprint: ""
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: machineconf-1
+spec:
+  datastore: ""
+  folder: my-folder
+  memoryMiB: 0
+  numCPUs: 0
+  osFamily: ""
+  resourcePool: ""
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: machineconf-2
+spec:
+  datastore: ""
+  folder: my-folder
+  memoryMiB: 0
+  numCPUs: 0
+  osFamily: ""
+  resourcePool: ""
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: GitOpsConfig
+metadata:
+  name: config
+spec:
+  flux:
+    github:
+      branch: main
+      clusterConfigPath: clusters/mycluster
+      fluxSystemNamespace: flux-system
+      owner: me
+      repository: ""
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: OIDCConfig
+metadata:
+  name: config
+spec:
+  issuerUrl: https://url
+
+---

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -417,6 +417,20 @@ func (mr *MockDatacenterConfigMockRecorder) Kind() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kind", reflect.TypeOf((*MockDatacenterConfig)(nil).Kind))
 }
 
+// Marshallable mocks base method.
+func (m *MockDatacenterConfig) Marshallable() v1alpha1.Marshallable {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Marshallable")
+	ret0, _ := ret[0].(v1alpha1.Marshallable)
+	return ret0
+}
+
+// Marshallable indicates an expected call of Marshallable.
+func (mr *MockDatacenterConfigMockRecorder) Marshallable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Marshallable", reflect.TypeOf((*MockDatacenterConfig)(nil).Marshallable))
+}
+
 // PauseReconcile mocks base method.
 func (m *MockDatacenterConfig) PauseReconcile() {
 	m.ctrl.T.Helper()
@@ -450,6 +464,20 @@ func NewMockMachineConfig(ctrl *gomock.Controller) *MockMachineConfig {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMachineConfig) EXPECT() *MockMachineConfigMockRecorder {
 	return m.recorder
+}
+
+// Marshallable mocks base method.
+func (m *MockMachineConfig) Marshallable() v1alpha1.Marshallable {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Marshallable")
+	ret0, _ := ret[0].(v1alpha1.Marshallable)
+	return ret0
+}
+
+// Marshallable indicates an expected call of Marshallable.
+func (mr *MockMachineConfigMockRecorder) Marshallable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Marshallable", reflect.TypeOf((*MockMachineConfig)(nil).Marshallable))
 }
 
 // OSFamily mocks base method.

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -39,6 +39,7 @@ type DatacenterConfig interface {
 	Kind() string
 	PauseReconcile()
 	ClearPauseAnnotation()
+	Marshallable() v1alpha1.Marshallable
 }
 
 type BuildMapOption func(map[string]interface{})
@@ -52,4 +53,5 @@ type TemplateBuilder interface {
 
 type MachineConfig interface {
 	OSFamily() v1alpha1.OSFamily
+	Marshallable() v1alpha1.Marshallable
 }

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1432,7 +1432,7 @@ func (p *vsphereProvider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *ty
 }
 
 func (p *vsphereProvider) DatacenterConfig() providers.DatacenterConfig {
-	return p.datacenterConfig.ConvertConfigToConfigGenerateStruct()
+	return p.datacenterConfig
 }
 
 func (p *vsphereProvider) MachineConfigs() []providers.MachineConfig {
@@ -1440,15 +1440,15 @@ func (p *vsphereProvider) MachineConfigs() []providers.MachineConfig {
 	controlPlaneMachineName := p.clusterConfig.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	workerMachineName := p.clusterConfig.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	p.machineConfigs[controlPlaneMachineName].Annotations = map[string]string{p.clusterConfig.ControlPlaneAnnotation(): "true"}
-	configs = append(configs, p.machineConfigs[controlPlaneMachineName].ConvertConfigToConfigGenerateStruct())
+	configs = append(configs, p.machineConfigs[controlPlaneMachineName])
 	if workerMachineName != controlPlaneMachineName {
-		configs = append(configs, p.machineConfigs[workerMachineName].ConvertConfigToConfigGenerateStruct())
+		configs = append(configs, p.machineConfigs[workerMachineName])
 	}
 	if p.clusterConfig.Spec.ExternalEtcdConfiguration != nil {
 		etcdMachineName := p.clusterConfig.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 		p.machineConfigs[etcdMachineName].Annotations = map[string]string{p.clusterConfig.EtcdAnnotation(): "true"}
 		if etcdMachineName != controlPlaneMachineName && etcdMachineName != workerMachineName {
-			configs = append(configs, p.machineConfigs[etcdMachineName].ConvertConfigToConfigGenerateStruct())
+			configs = append(configs, p.machineConfigs[etcdMachineName])
 		}
 	}
 	return configs
@@ -1465,8 +1465,7 @@ func (p *vsphereProvider) ValidateNewSpec(ctx context.Context, cluster *types.Cl
 		return err
 	}
 
-	datacenterConfig := p.DatacenterConfig()
-	datacenter := datacenterConfig.(*v1alpha1.VSphereDatacenterConfigGenerate)
+	datacenter := p.datacenterConfig
 
 	oSpec := prevDatacenter.Spec
 	nSpec := datacenter.Spec

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 
 	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/bootstrapper"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/features"
@@ -29,7 +30,7 @@ type upgradeTestSetup struct {
 	writer           *writermocks.MockFileWriter
 	validator        *mocks.MockValidator
 	capiUpgrader     *mocks.MockCAPIUpgrader
-	datacenterConfig *providermocks.MockDatacenterConfig
+	datacenterConfig providers.DatacenterConfig
 	machineConfigs   []providers.MachineConfig
 	workflow         *workflows.Upgrade
 	ctx              context.Context
@@ -51,9 +52,9 @@ func newUpgradeTest(t *testing.T) *upgradeTestSetup {
 	provider := providermocks.NewMockProvider(mockCtrl)
 	writer := writermocks.NewMockFileWriter(mockCtrl)
 	validator := mocks.NewMockValidator(mockCtrl)
-	datacenterConfig := providermocks.NewMockDatacenterConfig(mockCtrl)
+	datacenterConfig := &v1alpha1.VSphereDatacenterConfig{}
 	capiUpgrader := mocks.NewMockCAPIUpgrader(mockCtrl)
-	machineConfigs := []providers.MachineConfig{providermocks.NewMockMachineConfig(mockCtrl)}
+	machineConfigs := []providers.MachineConfig{&v1alpha1.VSphereMachineConfig{}}
 	workflow := workflows.NewUpgrade(bootstrapper, provider, capiUpgrader, clusterManager, addonManager, writer)
 
 	return &upgradeTestSetup{


### PR DESCRIPTION
This fixes a runtime panic during upgrade due to an invalid casting in cluster manager

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
