### PR TITLE
Change wording on domains to be more accurate

### DIFF
--- a/docs/content/en/docs/reference/vsphere/domains.md
+++ b/docs/content/en/docs/reference/vsphere/domains.md
@@ -1,6 +1,6 @@
 
 * public.ecr.aws
-* anywhere-assets.eks.amazonaws.com (to download the binaries, manifests and OVAs)
+* anywhere-assets.eks.amazonaws.com (to download the EKS Anywhere binaries, manifests and OVAs)
 * distro.eks.amazonaws.com (to download EKS Distro binaries and manifests)
 * d2glxqk2uabbnd.cloudfront.net (for EKS Anywhere and EKS Distro ECR container images)
 * api.github.com (only if GitOps is enabled)


### PR DESCRIPTION
I think we are only pulling binaries and manifests from the distro web site, so this is more accurate. The rest comes from ECR
