### PR TITLE
Fix log.Info statements to prevent cli from crashing

### DIFF
--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -92,13 +92,13 @@ func (g *Govc) SearchTemplate(ctx context.Context, datacenter string, machineCon
 	templateJson := templateResponse.String()
 	templateJson = strings.TrimSuffix(templateJson, "\n")
 	if templateJson == "null" || templateJson == "" {
-		logger.V(2).Info("Template not found", "ova", filepath.Base(machineConfig.Spec.Template))
+		logger.V(2).Info(fmt.Sprintf("Template not found: %s", machineConfig.Spec.Template))
 		return "", nil
 	}
 
 	templateInfo := make([]string, 0)
 	if err = json.Unmarshal([]byte(templateJson), &templateInfo); err != nil {
-		logger.V(2).Info("failed unmarshalling govc response: %s, %v", templateJson, err)
+		logger.V(2).Info(fmt.Sprintf("Failed unmarshalling govc response: %s, %v", templateJson, err))
 		return "", nil
 	}
 
@@ -114,7 +114,7 @@ func (g *Govc) SearchTemplate(ctx context.Context, datacenter string, machineCon
 		}
 	}
 	if !bTemplateFound {
-		logger.V(2).Info("template '%s' not found", machineConfig.Spec.Template)
+		logger.V(2).Info(fmt.Sprintf("Template '%s' not found", machineConfig.Spec.Template))
 		return "", nil
 	}
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/409#issuecomment-941789171
*Description of changes:*
Fix the logger statement to prevent the cli from panicking
Resolves this issue: https://github.com/aws/eks-anywhere/issues/409#issuecomment-941789171

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
