### PR TITLE
Set Spec.Management=false when creating workload clusters

### DIFF
--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -51,13 +51,16 @@ func (c *Create) Run(ctx context.Context, clusterSpec *cluster.Spec, forceCleanu
 		Rollback:       false,
 		Writer:         c.writer,
 	}
+	mgmtCluster := true
 	if kubeconfig != "" {
 		commandContext.BootstrapCluster = &types.Cluster{
 			Name:           clusterSpec.Name,
 			KubeconfigFile: kubeconfig,
 			ExistingMgnt:   true,
 		}
+		mgmtCluster = false
 	}
+	commandContext.ClusterSpec.Spec.Management = &mgmtCluster
 
 	err := task.NewTaskRunner(&SetAndValidateTask{}).RunTask(ctx, commandContext)
 	if err != nil {

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -265,6 +265,11 @@ func TestCreateWorkloadClusterRunSuccess(t *testing.T) {
 	test.expectInstallMHC()
 
 	err := test.run(managementKubeconfig)
+
+	if test.clusterSpec.Spec.Management == nil || *test.clusterSpec.Spec.Management {
+		t.Fatalf("Error setting management flag, expected Spec.management %v got %t", false, *test.clusterSpec.Spec.Management)
+	}
+
 	if err != nil {
 		t.Fatalf("Create.Run() err = %v, want err = nil", err)
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set Spec.management flag to false when creating workload clusters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
