### PR TITLE
Add provider env var map to clusterctl upgrade command

### DIFF
--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -334,7 +334,12 @@ func (c *Clusterctl) Upgrade(ctx context.Context, managementCluster *types.Clust
 		upgradeCommand = append(upgradeCommand, "--bootstrap", newBootstrapProvider)
 	}
 
-	if _, err := c.executable.Execute(ctx, upgradeCommand...); err != nil {
+	providerEnvMap, err := provider.EnvMap()
+	if err != nil {
+		return fmt.Errorf("failed generating provider env map for clusterctl upgrade: %v", err)
+	}
+
+	if _, err = c.executable.ExecuteWithEnv(ctx, providerEnvMap, upgradeCommand...); err != nil {
 		return fmt.Errorf("failed running upgrade apply with clusterctl: %v", err)
 	}
 


### PR DESCRIPTION
*Description of changes:*
When upgrading a vsphere infra provider, clusterctl will require the VSPHERE user and password.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
