### PR TITLE
Add upgrade capability to EKS-A custom components

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1100,7 +1100,6 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/clustermanager/client.go
+++ b/pkg/clustermanager/client.go
@@ -11,7 +11,7 @@ type client struct {
 	ClusterClient
 }
 
-func newClient(clusterClient ClusterClient) *client {
+func NewClient(clusterClient ClusterClient) *client {
 	return &client{ClusterClient: clusterClient}
 }
 

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -41,6 +41,7 @@ const (
 )
 
 type ClusterManager struct {
+	*Upgrader
 	clusterClient   *retrierClient
 	writer          filewriter.FileWriter
 	networking      Networking
@@ -85,8 +86,10 @@ type ClusterManagerOpt func(*ClusterManager)
 
 func New(clusterClient ClusterClient, networking Networking, writer filewriter.FileWriter, opts ...ClusterManagerOpt) *ClusterManager {
 	retrier := retrier.NewWithMaxRetries(maxRetries, backOffPeriod)
+	retrierClient := NewRetrierClient(NewClient(clusterClient), retrier)
 	c := &ClusterManager{
-		clusterClient:   newRetrierClient(newClient(clusterClient), retrier),
+		Upgrader:        NewUpgrader(retrierClient),
+		clusterClient:   retrierClient,
 		writer:          writer,
 		networking:      networking,
 		Retrier:         retrier,

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -1328,7 +1328,7 @@ func TestClusterManagerClusterSpecChangedGitOpsDefault(t *testing.T) {
 type testSetup struct {
 	*WithT
 	clusterManager *clustermanager.ClusterManager
-	mocks          *mocks
+	mocks          *clusterManagerMocks
 	ctx            context.Context
 	clusterSpec    *cluster.Spec
 	cluster        *types.Cluster
@@ -1351,16 +1351,16 @@ func newTest(t *testing.T, opts ...clustermanager.ClusterManagerOpt) *testSetup 
 	}
 }
 
-type mocks struct {
+type clusterManagerMocks struct {
 	writer     *mockswriter.MockFileWriter
 	networking *mocksmanager.MockNetworking
 	client     *mocksmanager.MockClusterClient
 	provider   *mocksprovider.MockProvider
 }
 
-func newClusterManager(t *testing.T, opts ...clustermanager.ClusterManagerOpt) (*clustermanager.ClusterManager, *mocks) {
+func newClusterManager(t *testing.T, opts ...clustermanager.ClusterManagerOpt) (*clustermanager.ClusterManager, *clusterManagerMocks) {
 	mockCtrl := gomock.NewController(t)
-	m := &mocks{
+	m := &clusterManagerMocks{
 		writer:     mockswriter.NewMockFileWriter(mockCtrl),
 		networking: mocksmanager.NewMockNetworking(mockCtrl),
 		client:     mocksmanager.NewMockClusterClient(mockCtrl),

--- a/pkg/clustermanager/retrier_client.go
+++ b/pkg/clustermanager/retrier_client.go
@@ -16,7 +16,7 @@ type retrierClient struct {
 	*retrier.Retrier
 }
 
-func newRetrierClient(client *client, retrier *retrier.Retrier) *retrierClient {
+func NewRetrierClient(client *client, retrier *retrier.Retrier) *retrierClient {
 	return &retrierClient{
 		client:  client,
 		Retrier: retrier,

--- a/pkg/clustermanager/testdata/eksa_components.yaml
+++ b/pkg/clustermanager/testdata/eksa_components.yaml
@@ -1,0 +1,1 @@
+test data

--- a/pkg/clustermanager/upgrader.go
+++ b/pkg/clustermanager/upgrader.go
@@ -1,0 +1,44 @@
+package clustermanager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/types"
+)
+
+type Upgrader struct {
+	retrier *retrierClient
+}
+
+func NewUpgrader(retrier *retrierClient) *Upgrader {
+	return &Upgrader{
+		retrier: retrier,
+	}
+}
+
+func (u *Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) error {
+	logger.V(1).Info("Checking for EKS-A components upgrade")
+	if !newSpec.Cluster.IsSelfManaged() {
+		logger.V(1).Info("Skipping EKS-A components upgrade, not a self-managed cluster")
+		return nil
+	}
+	if !u.isUpgradeNeeded(currentSpec, newSpec) {
+		logger.V(1).Info("Nothing to upgrade for controller and CRDs")
+		return nil
+	}
+	logger.V(1).Info("Starting EKS-A components upgrade")
+	oldVersion := currentSpec.VersionsBundle.Eksa.Version
+	newVersion := newSpec.VersionsBundle.Eksa.Version
+	if err := u.retrier.installCustomComponents(ctx, newSpec, cluster); err != nil {
+		return fmt.Errorf("failed upgrading EKS-A components from version %v to version %v: %v", oldVersion, newVersion, err)
+	}
+
+	return nil
+}
+
+func (u *Upgrader) isUpgradeNeeded(currentSpec, newSpec *cluster.Spec) bool {
+	return currentSpec.VersionsBundle.Eksa.Version != newSpec.VersionsBundle.Eksa.Version
+}

--- a/pkg/clustermanager/upgrader_test.go
+++ b/pkg/clustermanager/upgrader_test.go
@@ -1,0 +1,84 @@
+package clustermanager_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clustermanager"
+	"github.com/aws/eks-anywhere/pkg/clustermanager/mocks"
+	"github.com/aws/eks-anywhere/pkg/retrier"
+	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/release/api/v1alpha1"
+)
+
+type upgraderTest struct {
+	*WithT
+	ctx         context.Context
+	client      *mocks.MockClusterClient
+	currentSpec *cluster.Spec
+	newSpec     *cluster.Spec
+	upgrader    *clustermanager.Upgrader
+	cluster     *types.Cluster
+}
+
+func newUpgraderTest(t *testing.T) *upgraderTest {
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockClusterClient(ctrl)
+	currentSpec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.VersionsBundle.Eksa.Version = "v0.1.0"
+	})
+
+	return &upgraderTest{
+		WithT:  NewWithT(t),
+		ctx:    context.Background(),
+		client: client,
+		upgrader: clustermanager.NewUpgrader(clustermanager.NewRetrierClient(clustermanager.NewClient(client),
+			retrier.NewWithMaxRetries(1, 0))),
+		currentSpec: currentSpec,
+		newSpec:     currentSpec.DeepCopy(),
+		cluster: &types.Cluster{
+			Name:           "cluster-name",
+			KubeconfigFile: "k.kubeconfig",
+		},
+	}
+}
+
+func TestUpgraderUpgradeNoSelfManaged(t *testing.T) {
+	tt := newUpgraderTest(t)
+	tt.newSpec.Cluster.SetManagedBy("management-cluster")
+
+	tt.Expect(tt.upgrader.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(Succeed())
+}
+
+func TestUpgraderUpgradeNoChanges(t *testing.T) {
+	tt := newUpgraderTest(t)
+
+	tt.Expect(tt.upgrader.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(Succeed())
+}
+
+func TestUpgraderUpgradeSuccess(t *testing.T) {
+	tt := newUpgraderTest(t)
+
+	tt.newSpec.VersionsBundle.Eksa.Version = "v0.2.0"
+	tt.newSpec.VersionsBundle.Eksa.Components = v1alpha1.Manifest{
+		URI: "testdata/eksa_components.yaml",
+	}
+
+	tt.client.EXPECT().ApplyKubeSpecFromBytes(tt.ctx, tt.cluster, []byte("test data")).Return(nil)
+	tt.client.EXPECT().WaitForDeployment(tt.ctx, tt.cluster, "30m", "Available", "eksa-controller-manager", "eksa-system")
+	tt.Expect(tt.upgrader.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(Succeed())
+}
+
+func TestUpgraderUpgradeInstallError(t *testing.T) {
+	tt := newUpgraderTest(t)
+
+	tt.newSpec.VersionsBundle.Eksa.Version = "v0.2.0"
+
+	// components file not set so this should return an error in failing to load manifest
+	tt.Expect(tt.upgrader.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).NotTo(Succeed())
+}

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -32,6 +32,7 @@ type ClusterManager interface {
 	InstallMachineHealthChecks(ctx context.Context, workloadCluster *types.Cluster, provider providers.Provider) error
 	GetCurrentClusterSpec(ctx context.Context, cluster *types.Cluster) (*cluster.Spec, error)
 	LoadManagement(kubeconfig string) (*types.Cluster, error)
+	Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) error
 }
 
 type AddonManager interface {

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -315,6 +315,20 @@ func (mr *MockClusterManagerMockRecorder) SaveLogs(arg0, arg1 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveLogs", reflect.TypeOf((*MockClusterManager)(nil).SaveLogs), arg0, arg1)
 }
 
+// Upgrade mocks base method.
+func (m *MockClusterManager) Upgrade(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 *cluster.Spec) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Upgrade indicates an expected call of Upgrade.
+func (mr *MockClusterManagerMockRecorder) Upgrade(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockClusterManager)(nil).Upgrade), arg0, arg1, arg2, arg3)
+}
+
 // UpgradeCluster mocks base method.
 func (m *MockClusterManager) UpgradeCluster(arg0 context.Context, arg1, arg2 *types.Cluster, arg3 *cluster.Spec, arg4 providers.Provider) error {
 	m.ctrl.T.Helper()

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -168,7 +168,10 @@ func (s *upgradeCoreComponents) Run(ctx context.Context, commandContext *task.Co
 		return nil
 	}
 
-	// TODO: Add Upgrade calls for eks-a cluster controller and CRDs
+	if err := commandContext.ClusterManager.Upgrade(ctx, commandContext.WorkloadCluster, currentSpec, commandContext.ClusterSpec); err != nil {
+		commandContext.SetError(err)
+		return nil
+	}
 
 	return &upgradeNeeded{}
 }
@@ -188,7 +191,7 @@ func (s *upgradeNeeded) Run(ctx context.Context, commandContext *task.CommandCon
 	}
 
 	if !diff {
-		logger.Info("No upgrades needed")
+		logger.Info("No upgrades needed from cluster spec")
 		return nil
 	}
 

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -92,6 +92,7 @@ func (c *upgradeTestSetup) expectUpgradeCoreComponents() {
 	gomock.InOrder(
 		c.clusterManager.EXPECT().GetCurrentClusterSpec(c.ctx, c.workloadCluster).Return(currentSpec, nil),
 		c.capiUpgrader.EXPECT().Upgrade(c.ctx, c.workloadCluster, c.provider, currentSpec, c.clusterSpec),
+		c.clusterManager.EXPECT().Upgrade(c.ctx, c.workloadCluster, currentSpec, c.clusterSpec),
 	)
 }
 


### PR DESCRIPTION
Resolves #315 

*Description of changes:*

Adding the ability to upgrade EKS-A custom components, which include the controller and the CRDs. This will first just apply the latest manifests on the cluster in order to perform the upgrade. Once we have breaking changes, we will add the ability to include conversion webhooks to facilitate the upgrades.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
