### PR TITLE
Add RegistryCACertVar to required env var list for registryMirror tests

### DIFF
--- a/test/framework/registryMirror.go
+++ b/test/framework/registryMirror.go
@@ -12,18 +12,7 @@ const (
 	RegistryCACertVar   = "T_REGISTRY_MIRROR_CA_CERT"
 )
 
-var registryMirrorRequiredEnvVars = []string{RegistryEndpointVar}
-
-func WithRegistryMirrorEndpoint() E2ETestOpt {
-	return func(e *E2ETest) {
-		checkRequiredEnvVars(e.T, registryMirrorRequiredEnvVars)
-		registryEndpoint := os.Getenv(RegistryEndpointVar)
-
-		e.clusterFillers = append(e.clusterFillers,
-			api.WithRegistryMirror(registryEndpoint, ""),
-		)
-	}
-}
+var registryMirrorRequiredEnvVars = []string{RegistryEndpointVar, RegistryCACertVar}
 
 func WithRegistryMirrorEndpointAndCert() E2ETestOpt {
 	return func(e *E2ETest) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add registry cert to list of required env vars in e2e since it's required for self-signed cert registries.
Also remove `WithRegistryMirrorEndpoint` since it's not being used

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
