### PR TITLE
Split clustermanager logic into multiple composable types

### DIFF
--- a/pkg/clustermanager/client.go
+++ b/pkg/clustermanager/client.go
@@ -1,0 +1,28 @@
+package clustermanager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/eks-anywhere/pkg/types"
+)
+
+type client struct {
+	ClusterClient
+}
+
+func newClient(clusterClient ClusterClient) *client {
+	return &client{ClusterClient: clusterClient}
+}
+
+func (c *client) waitForDeployments(ctx context.Context, deploymentsByNamespace map[string][]string, cluster *types.Cluster) error {
+	for namespace, deployments := range deploymentsByNamespace {
+		for _, deployment := range deployments {
+			err := c.WaitForDeployment(ctx, cluster, deploymentWaitStr, "Available", deployment, namespace)
+			if err != nil {
+				return fmt.Errorf("error waiting for %s in namespace %s: %v", deployment, namespace, err)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -852,9 +852,8 @@ func TestClusterManagerInstallCustomComponentsErrorReadingManifest(t *testing.T)
 }
 
 func TestClusterManagerInstallCustomComponentsErrorApplying(t *testing.T) {
-	tt := newTest(t)
+	tt := newTest(t, clustermanager.WithRetrier(retrier.NewWithMaxRetries(2, 0)))
 	tt.clusterSpec.VersionsBundle.Eksa.Components.URI = "testdata/testClusterSpec.yaml"
-	tt.clusterManager.Retrier = retrier.NewWithMaxRetries(2, 0)
 
 	tt.mocks.client.EXPECT().ApplyKubeSpecFromBytes(tt.ctx, tt.cluster, gomock.Not(gomock.Nil())).Return(errors.New("error from apply")).Times(2)
 

--- a/pkg/clustermanager/retrier_client.go
+++ b/pkg/clustermanager/retrier_client.go
@@ -1,0 +1,40 @@
+package clustermanager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clustermanager/internal"
+	"github.com/aws/eks-anywhere/pkg/retrier"
+	"github.com/aws/eks-anywhere/pkg/types"
+)
+
+type retrierClient struct {
+	*client
+	*retrier.Retrier
+}
+
+func newRetrierClient(client *client, retrier *retrier.Retrier) *retrierClient {
+	return &retrierClient{
+		client:  client,
+		Retrier: retrier,
+	}
+}
+
+func (c *retrierClient) installCustomComponents(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster) error {
+	componentsManifest, err := clusterSpec.LoadManifest(clusterSpec.VersionsBundle.Eksa.Components)
+	if err != nil {
+		return fmt.Errorf("failed loading manifest for eksa components: %v", err)
+	}
+
+	err = c.Retry(
+		func() error {
+			return c.ApplyKubeSpecFromBytes(ctx, cluster, componentsManifest.Content)
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("error applying eks-a components spec: %v", err)
+	}
+	return c.waitForDeployments(ctx, internal.EksaDeployments, cluster)
+}


### PR DESCRIPTION
*Description of changes:*
Coming from #452: we wanted to make a couple of methods reusable in the `clustermanager` package but without depending on the `ClusterManager` type

This PR splits the logic into multiple composable types that contain the minimum amount of dependencies needed. There are possibly more methods that can be moved from `ClusterManager`  into these two new types, but leaving that for when is needed/future refactors, in order to keep this PR small.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
