### PR TITLE
Fix cluster controller docker provider etcd machinetemplate name empty

### DIFF
--- a/controllers/controllers/resource/template.go
+++ b/controllers/controllers/resource/template.go
@@ -141,8 +141,19 @@ func (r *DockerTemplate) TemplateResources(ctx context.Context, eksaCluster *any
 	if err != nil {
 		return nil, err
 	}
+
+	var etcdTemplateName string
+	if eksaCluster.Spec.ExternalEtcdConfiguration != nil {
+		etcd, err := r.Etcd(ctx, eksaCluster)
+		if err != nil {
+			return nil, err
+		}
+		etcdTemplateName = etcd.Spec.InfrastructureTemplate.Name
+	}
+
 	cpOpt := func(values map[string]interface{}) {
 		values["controlPlaneTemplateName"] = kubeadmControlPlane.Spec.InfrastructureTemplate.Name
+		values["etcdTemplateName"] = etcdTemplateName
 	}
 	workersOpt := func(values map[string]interface{}) {
 		values["workloadTemplateName"] = mcDeployment.Spec.Template.Spec.InfrastructureRef.Name


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fetch etcdadm, get the infrastructure ref machinetemplate name to build capi template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
