### PR TITLE
Add proxy env vars to eksa-controller-manager

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -66,6 +66,7 @@ type ClusterClient interface {
 	GetClusters(ctx context.Context, cluster *types.Cluster) ([]types.CAPICluster, error)
 	GetEksaCluster(ctx context.Context, cluster *types.Cluster) (*v1alpha1.Cluster, error)
 	GetEksaVSphereDatacenterConfig(ctx context.Context, VSphereDatacenterName string, kubeconfigFile string, namespace string) (*v1alpha1.VSphereDatacenterConfig, error)
+	UpdateEnvironmentVariablesInNamespace(ctx context.Context, resourceType, resourceName string, envMap map[string]string, cluster *types.Cluster, namespace string) error
 	UpdateAnnotationInNamespace(ctx context.Context, resourceType, objectName string, annotations map[string]string, cluster *types.Cluster, namespace string) error
 	RemoveAnnotationInNamespace(ctx context.Context, resourceType, objectName, key string, cluster *types.Cluster, namespace string) error
 	GetEksaVSphereMachineConfig(ctx context.Context, VSphereDatacenterName string, kubeconfigFile string, namespace string) (*v1alpha1.VSphereMachineConfig, error)
@@ -74,7 +75,6 @@ type ClusterClient interface {
 	ValidateControlPlaneNodes(ctx context.Context, cluster *types.Cluster) error
 	ValidateWorkerNodes(ctx context.Context, cluster *types.Cluster) error
 	GetBundles(ctx context.Context, kubeconfigFile, name, namespace string) (*releasev1alpha1.Bundles, error)
-	SetEnvsInDeployment(ctx context.Context, cluster *types.Cluster, deploymentName string, namespace string, envMap map[string]string) error
 }
 
 type Networking interface {

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -285,20 +285,6 @@ func (mr *MockClusterClientMockRecorder) SaveLog(arg0, arg1, arg2, arg3, arg4 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveLog", reflect.TypeOf((*MockClusterClient)(nil).SaveLog), arg0, arg1, arg2, arg3, arg4)
 }
 
-// SetEnvsInDeployment mocks base method.
-func (m *MockClusterClient) SetEnvsInDeployment(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string, arg4 map[string]string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetEnvsInDeployment", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetEnvsInDeployment indicates an expected call of SetEnvsInDeployment.
-func (mr *MockClusterClientMockRecorder) SetEnvsInDeployment(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEnvsInDeployment", reflect.TypeOf((*MockClusterClient)(nil).SetEnvsInDeployment), arg0, arg1, arg2, arg3, arg4)
-}
-
 // UpdateAnnotationInNamespace mocks base method.
 func (m *MockClusterClient) UpdateAnnotationInNamespace(arg0 context.Context, arg1, arg2 string, arg3 map[string]string, arg4 *types.Cluster, arg5 string) error {
 	m.ctrl.T.Helper()
@@ -311,6 +297,20 @@ func (m *MockClusterClient) UpdateAnnotationInNamespace(arg0 context.Context, ar
 func (mr *MockClusterClientMockRecorder) UpdateAnnotationInNamespace(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAnnotationInNamespace", reflect.TypeOf((*MockClusterClient)(nil).UpdateAnnotationInNamespace), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+// UpdateEnvironmentVariablesInNamespace mocks base method.
+func (m *MockClusterClient) UpdateEnvironmentVariablesInNamespace(arg0 context.Context, arg1, arg2 string, arg3 map[string]string, arg4 *types.Cluster, arg5 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateEnvironmentVariablesInNamespace", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateEnvironmentVariablesInNamespace indicates an expected call of UpdateEnvironmentVariablesInNamespace.
+func (mr *MockClusterClientMockRecorder) UpdateEnvironmentVariablesInNamespace(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEnvironmentVariablesInNamespace", reflect.TypeOf((*MockClusterClient)(nil).UpdateEnvironmentVariablesInNamespace), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // ValidateControlPlaneNodes mocks base method.

--- a/pkg/clustermanager/retrier_client.go
+++ b/pkg/clustermanager/retrier_client.go
@@ -49,7 +49,7 @@ func (c *retrierClient) installCustomComponents(ctx context.Context, clusterSpec
 		}
 		err = c.Retrier.Retry(
 			func() error {
-				return c.SetEnvsInDeployment(ctx, cluster, "eksa-controller-manager", "eksa-system", envMap)
+				return c.UpdateEnvironmentVariablesInNamespace(ctx, "deployment", "eksa-controller-manager", envMap, cluster, "eksa-system")
 			},
 		)
 		if err != nil {

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -431,18 +431,6 @@ func (k *Kubectl) Version(ctx context.Context, cluster *types.Cluster) (*Version
 	return response, nil
 }
 
-func (k *Kubectl) SetEnvsInDeployment(ctx context.Context, cluster *types.Cluster, deploymentName string, namespace string, envMap map[string]string) error {
-	params := []string{"set", "env", "deployment", deploymentName, "-n", namespace, "--kubeconfig", cluster.KubeconfigFile}
-	for key, value := range envMap {
-		params = append(params, fmt.Sprintf("%s=%s", key, value))
-	}
-	_, err := k.executable.Execute(ctx, params...)
-	if err != nil {
-		return fmt.Errorf("error setting the environment variables in the deployment %s: %v", deploymentName, err)
-	}
-	return nil
-}
-
 type KubectlOpt func(*[]string)
 
 func WithToken(t string) KubectlOpt {
@@ -600,6 +588,23 @@ func (k *Kubectl) GetMachineDeployments(ctx context.Context, opts ...KubectlOpt)
 	}
 
 	return response.Items, nil
+}
+
+func (k *Kubectl) UpdateEnvironmentVariables(ctx context.Context, resourceType, resourceName string, envMap map[string]string, opts ...KubectlOpt) error {
+	params := []string{"set", "env", resourceType, resourceName}
+	for k, v := range envMap {
+		params = append(params, fmt.Sprintf("%s=%s", k, v))
+	}
+	applyOpts(&params, opts...)
+	_, err := k.executable.Execute(ctx, params...)
+	if err != nil {
+		return fmt.Errorf("error setting the environment variables in %s %s: %v", resourceType, resourceName, err)
+	}
+	return nil
+}
+
+func (k *Kubectl) UpdateEnvironmentVariablesInNamespace(ctx context.Context, resourceType, resourceName string, envMap map[string]string, cluster *types.Cluster, namespace string) error {
+	return k.UpdateEnvironmentVariables(ctx, resourceType, resourceName, envMap, WithCluster(cluster), WithNamespace(namespace))
 }
 
 func (k *Kubectl) UpdateAnnotation(ctx context.Context, resourceType, objectName string, annotations map[string]string, opts ...KubectlOpt) error {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR injects proxy env vars to the `eksa-controller-manager` so it can pull the eks-distro manifest  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
