### PR TITLE
Encapsulate uses of cluster management api fields in methods

### DIFF
--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -369,7 +369,7 @@ func (fc *fluxForCluster) commitFluxAndClusterConfigToGit(ctx context.Context) e
 		return &ConfigVersionControlFailedError{Err: err}
 	}
 
-	if fc.clusterSpec.Spec.Management == nil || *fc.clusterSpec.Spec.Management {
+	if fc.clusterSpec.IsSelfManaged() {
 		logger.V(3).Info("Generating flux custom manifest files...")
 		err = fc.writeFluxSystemFiles()
 		if err != nil {

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -29,18 +29,16 @@ type ClusterGenerateOpt func(config *ClusterGenerate)
 
 // Used for generating yaml for generate clusterconfig command
 func NewClusterGenerate(clusterName string, opts ...ClusterGenerateOpt) *ClusterGenerate {
-	isManagement := true
-	config := &ClusterGenerate{
+	clusterConfig := &Cluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       ClusterKind,
 			APIVersion: SchemeBuilder.GroupVersion.String(),
 		},
-		ObjectMeta: ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterName,
 		},
 		Spec: ClusterSpec{
 			KubernetesVersion: Kube121,
-			Management:        &isManagement,
 			ClusterNetwork: ClusterNetwork{
 				Pods: Pods{
 					CidrBlocks: []string{"192.168.0.0/16"},
@@ -52,6 +50,9 @@ func NewClusterGenerate(clusterName string, opts ...ClusterGenerateOpt) *Cluster
 			},
 		},
 	}
+	clusterConfig.SetSelfManaged()
+	config := clusterConfig.ConvertConfigToConfigGenerateStruct()
+
 	for _, opt := range opts {
 		opt(config)
 	}
@@ -136,7 +137,6 @@ func WithEtcdMachineGroupRef(ref ProviderRefAccessor) ClusterGenerateOpt {
 }
 
 func NewCluster(clusterName string) *Cluster {
-	isManagement := true
 	c := &Cluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       ClusterKind,
@@ -147,10 +147,10 @@ func NewCluster(clusterName string) *Cluster {
 		},
 		Spec: ClusterSpec{
 			KubernetesVersion: Kube119,
-			Management:        &isManagement,
 		},
 		Status: ClusterStatus{},
 	}
+	c.SetSelfManaged()
 
 	return c
 }

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -273,12 +273,27 @@ func (c *Cluster) EtcdAnnotation() string {
 	return etcdAnnotation
 }
 
+func (s *Cluster) IsSelfManaged() bool {
+	return s.Spec.Management == nil || *s.Spec.Management
+}
+
 func (s *Cluster) SetManagedBy(managementClusterName string) {
 	if s.Annotations == nil {
 		s.Annotations = map[string]string{}
 	}
 
 	s.Annotations[managementAnnotation] = managementClusterName
+	f := false
+	s.Spec.Management = &f
+}
+
+func (s *Cluster) SetSelfManaged() {
+	t := true
+	s.Spec.Management = &t
+}
+
+func (s *Cluster) ManagementClusterEqual(s2 *Cluster) bool {
+	return s.IsSelfManaged() == s2.IsSelfManaged()
 }
 
 func (c *Cluster) MachineConfigRefs() []Ref {

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -3,8 +3,14 @@ package v1alpha1_test
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
+
+func boolPointer(b bool) *bool {
+	return &b
+}
 
 func TestClusterMachineConfigRefs(t *testing.T) {
 	cluster := &v1alpha1.Cluster{
@@ -79,5 +85,107 @@ func TestClusterMachineConfigRefs(t *testing.T) {
 
 	if !v1alpha1.RefSliceEqual(got, want) {
 		t.Fatalf("Expected %v, got %v", want, got)
+	}
+}
+
+func TestClusterIsSelfManaged(t *testing.T) {
+	testCases := []struct {
+		testName string
+		cluster  *v1alpha1.Cluster
+		want     bool
+	}{
+		{
+			testName: "nil flag",
+			cluster:  &v1alpha1.Cluster{},
+			want:     true,
+		},
+		{
+			testName: "true flag",
+			cluster: &v1alpha1.Cluster{
+				Spec: v1alpha1.ClusterSpec{
+					Management: boolPointer(true),
+				},
+			},
+			want: true,
+		},
+		{
+			testName: "false flag",
+			cluster: &v1alpha1.Cluster{
+				Spec: v1alpha1.ClusterSpec{
+					Management: boolPointer(false),
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.cluster.IsSelfManaged()).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestClusterSetManagedBy(t *testing.T) {
+	c := &v1alpha1.Cluster{}
+	managementClusterName := "managament-cluster"
+	c.SetManagedBy(managementClusterName)
+
+	g := NewWithT(t)
+	g.Expect(c.IsSelfManaged()).To(BeFalse())
+	g.Expect(c.ManagedBy()).To(Equal(managementClusterName))
+}
+
+func TestClusterSetSelfManaged(t *testing.T) {
+	c := &v1alpha1.Cluster{}
+	c.SetSelfManaged()
+
+	g := NewWithT(t)
+	g.Expect(c.IsSelfManaged()).To(BeTrue())
+}
+
+func TestClusterManagementClusterEqual(t *testing.T) {
+	testCases := []struct {
+		testName                                 string
+		cluster1SelfManaged, cluster2SelfManaged bool
+		want                                     bool
+	}{
+		{
+			testName:            "both self managed",
+			cluster1SelfManaged: true,
+			cluster2SelfManaged: true,
+			want:                true,
+		},
+		{
+			testName:            "both managed",
+			cluster1SelfManaged: false,
+			cluster2SelfManaged: false,
+			want:                true,
+		},
+		{
+			testName:            "one managed, one self managed",
+			cluster1SelfManaged: false,
+			cluster2SelfManaged: true,
+			want:                false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			cluster1 := &v1alpha1.Cluster{}
+			setSelfManaged(cluster1, tt.cluster1SelfManaged)
+			cluster2 := &v1alpha1.Cluster{}
+			setSelfManaged(cluster2, tt.cluster2SelfManaged)
+
+			g := NewWithT(t)
+			g.Expect(cluster1.ManagementClusterEqual(cluster2)).To(Equal(tt.want))
+		})
+	}
+}
+
+func setSelfManaged(c *v1alpha1.Cluster, s bool) {
+	if s {
+		c.SetSelfManaged()
+	} else {
+		c.SetManagedBy("management-cluster")
 	}
 }

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -68,18 +68,6 @@ func (r *Cluster) ValidateUpdate(old runtime.Object) error {
 	return apierrors.NewInvalid(GroupVersion.WithKind(ClusterKind).GroupKind(), r.Name, allErrs)
 }
 
-func managementEqual(n, o *bool) bool {
-	var p, c bool
-	if n == nil || *n {
-		c = true
-	}
-
-	if o == nil || *o {
-		p = true
-	}
-	return p == c
-}
-
 func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 	if old.IsReconcilePaused() {
 		return nil
@@ -87,7 +75,7 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 
 	var allErrs field.ErrorList
 
-	if !managementEqual(new.Spec.Management, old.Spec.Management) {
+	if !old.ManagementClusterEqual(new) {
 		allErrs = append(
 			allErrs,
 			field.Invalid(field.NewPath("spec", "Management"), new.Spec.Management, "field is immutable"))
@@ -144,7 +132,7 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 			field.Invalid(field.NewPath("spec", "IdentityProviderRefs"), new.Spec.IdentityProviderRefs, "field is immutable"))
 	}
 
-	if old.Spec.Management != nil && !*old.Spec.Management {
+	if !old.IsSelfManaged() {
 		clusterlog.Info("Cluster config is associated with workload cluster")
 		return allErrs
 	}

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -9,40 +9,30 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
-func boolPointer(b bool) *bool {
-	return &b
-}
-
 func TestClusterValidateUpdateManagementValueImmutable(t *testing.T) {
-	cOld := &v1alpha1.Cluster{
-		Spec: v1alpha1.ClusterSpec{
-			Management: boolPointer(true),
-		},
-	}
+	cOld := &v1alpha1.Cluster{}
+	cOld.SetSelfManaged()
+
 	c := cOld.DeepCopy()
-	c.Spec.Management = boolPointer(false)
+	c.SetManagedBy("management-cluster")
 
 	g := NewWithT(t)
 	g.Expect(c.ValidateUpdate(cOld)).NotTo(Succeed())
 }
 
 func TestClusterValidateUpdateManagementOldNilNewTrueSuccess(t *testing.T) {
-	cOld := &v1alpha1.Cluster{
-		Spec: v1alpha1.ClusterSpec{},
-	}
+	cOld := &v1alpha1.Cluster{}
 	c := cOld.DeepCopy()
-	c.Spec.Management = boolPointer(true)
+	c.SetSelfManaged()
 
 	g := NewWithT(t)
 	g.Expect(c.ValidateUpdate(cOld)).To(Succeed())
 }
 
 func TestClusterValidateUpdateManagementOldNilNewFalseImmutable(t *testing.T) {
-	cOld := &v1alpha1.Cluster{
-		Spec: v1alpha1.ClusterSpec{},
-	}
+	cOld := &v1alpha1.Cluster{}
 	c := cOld.DeepCopy()
-	c.Spec.Management = boolPointer(false)
+	c.SetManagedBy("management-cluster")
 
 	g := NewWithT(t)
 	g.Expect(c.ValidateUpdate(cOld)).NotTo(Succeed())
@@ -66,9 +56,9 @@ func TestManagementClusterValidateUpdateKubernetesVersionImmutable(t *testing.T)
 			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
 				Count: 3, Endpoint: &v1alpha1.Endpoint{Host: "1.1.1.1/1"},
 			},
-			Management: boolPointer(true),
 		},
 	}
+	cOld.SetSelfManaged()
 	c := cOld.DeepCopy()
 	c.Spec.KubernetesVersion = v1alpha1.Kube120
 
@@ -101,9 +91,10 @@ func TestWorkloadClusterValidateUpdateKubernetesVersionSuccess(t *testing.T) {
 			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
 				Count: 3, Endpoint: &v1alpha1.Endpoint{Host: "1.1.1.1/1"},
 			},
-			Management: boolPointer(false),
 		},
 	}
+	cOld.SetManagedBy("management-cluster")
+
 	c := cOld.DeepCopy()
 	c.Spec.KubernetesVersion = v1alpha1.Kube120
 
@@ -119,9 +110,10 @@ func TestManagementClusterValidateUpdateControlPlaneConfigurationEqual(t *testin
 				Endpoint:        &v1alpha1.Endpoint{Host: "1.1.1.1/1"},
 				MachineGroupRef: &v1alpha1.Ref{Name: "test", Kind: "MachineConfig"},
 			},
-			Management: boolPointer(true),
 		},
 	}
+	cOld.SetSelfManaged()
+
 	c := cOld.DeepCopy()
 	c.Spec.ControlPlaneConfiguration = v1alpha1.ControlPlaneConfiguration{
 		Count:           3,
@@ -141,9 +133,10 @@ func TestWorkloadClusterValidateUpdateControlPlaneConfigurationEqual(t *testing.
 				Endpoint:        &v1alpha1.Endpoint{Host: "1.1.1.1/1"},
 				MachineGroupRef: &v1alpha1.Ref{Name: "test", Kind: "MachineConfig"},
 			},
-			Management: boolPointer(false),
 		},
 	}
+	cOld.SetManagedBy("management-cluster")
+
 	c := cOld.DeepCopy()
 	c.Spec.ControlPlaneConfiguration = v1alpha1.ControlPlaneConfiguration{
 		Count:           3,
@@ -233,9 +226,10 @@ func TestManagementClusterValidateUpdateControlPlaneConfigurationOldMachineGroup
 			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
 				MachineGroupRef: &v1alpha1.Ref{Name: "test1", Kind: "MachineConfig"},
 			},
-			Management: boolPointer(true),
 		},
 	}
+	cOld.SetSelfManaged()
+
 	c := cOld.DeepCopy()
 	c.Spec.ControlPlaneConfiguration = v1alpha1.ControlPlaneConfiguration{
 		MachineGroupRef: &v1alpha1.Ref{Name: "test2", Kind: "MachineConfig"},
@@ -251,9 +245,10 @@ func TestWorkloadClusterValidateUpdateControlPlaneConfigurationMachineGroupRef(t
 			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
 				MachineGroupRef: &v1alpha1.Ref{Name: "test1", Kind: "MachineConfig"},
 			},
-			Management: boolPointer(false),
 		},
 	}
+	cOld.SetManagedBy("management-cluster")
+
 	c := cOld.DeepCopy()
 	c.Spec.ControlPlaneConfiguration = v1alpha1.ControlPlaneConfiguration{
 		MachineGroupRef: &v1alpha1.Ref{Name: "test2", Kind: "MachineConfig"},
@@ -269,9 +264,10 @@ func TestManagementClusterValidateUpdateControlPlaneConfigurationOldMachineGroup
 			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
 				MachineGroupRef: nil,
 			},
-			Management: boolPointer(true),
 		},
 	}
+	cOld.SetSelfManaged()
+
 	c := cOld.DeepCopy()
 	c.Spec.ControlPlaneConfiguration = v1alpha1.ControlPlaneConfiguration{
 		MachineGroupRef: &v1alpha1.Ref{Name: "test", Kind: "MachineConfig"},
@@ -287,9 +283,10 @@ func TestWorkloadClusterValidateUpdateControlPlaneConfigurationOldMachineGroupRe
 			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
 				MachineGroupRef: nil,
 			},
-			Management: boolPointer(false),
 		},
 	}
+	cOld.SetManagedBy("management-cluster")
+
 	c := cOld.DeepCopy()
 	c.Spec.ControlPlaneConfiguration = v1alpha1.ControlPlaneConfiguration{
 		MachineGroupRef: &v1alpha1.Ref{Name: "test", Kind: "MachineConfig"},
@@ -305,9 +302,10 @@ func TestManagementClusterValidateUpdateControlPlaneConfigurationNewMachineGroup
 			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
 				MachineGroupRef: &v1alpha1.Ref{Name: "test", Kind: "MachineConfig"},
 			},
-			Management: boolPointer(true),
 		},
 	}
+	cOld.SetSelfManaged()
+
 	c := cOld.DeepCopy()
 	c.Spec.ControlPlaneConfiguration = v1alpha1.ControlPlaneConfiguration{
 		MachineGroupRef: nil,
@@ -323,9 +321,10 @@ func TestWorkloadClusterValidateUpdateControlPlaneConfigurationNewMachineGroupRe
 			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
 				MachineGroupRef: &v1alpha1.Ref{Name: "test", Kind: "MachineConfig"},
 			},
-			Management: boolPointer(false),
 		},
 	}
+	cOld.SetManagedBy("management-cluster")
+
 	c := cOld.DeepCopy()
 	c.Spec.ControlPlaneConfiguration = v1alpha1.ControlPlaneConfiguration{
 		MachineGroupRef: nil,

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -51,17 +51,17 @@ func (c *Create) Run(ctx context.Context, clusterSpec *cluster.Spec, forceCleanu
 		Rollback:       false,
 		Writer:         c.writer,
 	}
-	mgmtCluster := true
+
 	if kubeconfig != "" {
 		managementCluster, err := commandContext.ClusterManager.LoadManagement(kubeconfig)
 		if err != nil {
 			return err
 		}
-		mgmtCluster = false
 		commandContext.BootstrapCluster = managementCluster
 		commandContext.ClusterSpec.SetManagedBy(managementCluster.Name)
+	} else {
+		commandContext.ClusterSpec.SetSelfManaged()
 	}
-	commandContext.ClusterSpec.Spec.Management = &mgmtCluster
 
 	err := task.NewTaskRunner(&SetAndValidateTask{}).RunTask(ctx, commandContext)
 	if err != nil {

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -274,8 +274,8 @@ func TestCreateWorkloadClusterRunSuccess(t *testing.T) {
 	test.expectLoadManagementCluster(managementKubeconfig, test.bootstrapCluster.Name)
 	err := test.run(managementKubeconfig)
 
-	if test.clusterSpec.Spec.Management == nil || *test.clusterSpec.Spec.Management {
-		t.Fatalf("Error setting management flag, expected Spec.management %v got %t", false, *test.clusterSpec.Spec.Management)
+	if test.clusterSpec.IsSelfManaged() {
+		t.Fatal("Error setting management, expected cluster to not be self-managed")
 	}
 
 	if err != nil {


### PR DESCRIPTION
Part of #463
*Description of changes:*
Encapsulate uses of cluster management api fields in methods to facilitate api changes
If we want to move to having a management cluster reference on the spec, this should make it easier

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
