### PR TITLE
Skip capi and flux upgrades when cluster is not self managed

### DIFF
--- a/pkg/addonmanager/addonclients/upgrader.go
+++ b/pkg/addonmanager/addonclients/upgrader.go
@@ -15,6 +15,11 @@ const upgradeFluxconfigCommitMessage = "Upgrade commit of flux configuration; ge
 
 func (f *FluxAddonClient) Upgrade(ctx context.Context, managementCluster *types.Cluster, currentSpec *cluster.Spec, newSpec *cluster.Spec) error {
 	logger.V(1).Info("Checking for Flux upgrades")
+	if !newSpec.Cluster.IsSelfManaged() {
+		logger.V(1).Info("Skipping Flux upgrades, not a self-managed cluster")
+		return nil
+	}
+
 	changeDiff := f.fluxChangeDiff(currentSpec, newSpec)
 	if !changeDiff {
 		logger.V(1).Info("Nothing to upgrade for Flux")

--- a/pkg/addonmanager/addonclients/upgrader_test.go
+++ b/pkg/addonmanager/addonclients/upgrader_test.go
@@ -51,6 +51,14 @@ func newUpgraderTest(t *testing.T) *upgraderTest {
 	}
 }
 
+func TestFluxUpgradeNoSelfManaged(t *testing.T) {
+	tt := newUpgraderTest(t)
+	f, _, _ := newAddonClient(t)
+	tt.newSpec.Cluster.SetManagedBy("management-cluster")
+
+	tt.Expect(f.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(Succeed())
+}
+
 func TestFluxUpgradeNoChanges(t *testing.T) {
 	tt := newUpgraderTest(t)
 	f, _, _ := newAddonClient(t)

--- a/pkg/clusterapi/upgrader.go
+++ b/pkg/clusterapi/upgrader.go
@@ -26,6 +26,11 @@ func NewUpgrader(client CAPIClient) *Upgrader {
 
 func (u *Upgrader) Upgrade(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, currentSpec, newSpec *cluster.Spec) error {
 	logger.V(1).Info("Checking for CAPI upgrades")
+	if !newSpec.Cluster.IsSelfManaged() {
+		logger.V(1).Info("Skipping CAPI upgrades, not a self-managed cluster")
+		return nil
+	}
+
 	changeDiff := u.capiChangeDiff(currentSpec, newSpec, provider)
 	if changeDiff == nil {
 		logger.V(1).Info("Nothing to upgrade for CAPI")

--- a/pkg/clusterapi/upgrader_test.go
+++ b/pkg/clusterapi/upgrader_test.go
@@ -62,6 +62,13 @@ func newUpgraderTest(t *testing.T) *upgraderTest {
 	}
 }
 
+func TestUpgraderUpgradeNoSelfManaged(t *testing.T) {
+	tt := newUpgraderTest(t)
+	tt.newSpec.Cluster.SetManagedBy("management-cluster")
+
+	tt.Expect(tt.upgrader.Upgrade(tt.ctx, tt.cluster, tt.provider, tt.currentSpec, tt.newSpec)).To(Succeed())
+}
+
 func TestUpgraderUpgradeNoChanges(t *testing.T) {
 	tt := newUpgraderTest(t)
 	tt.provider.EXPECT().ChangeDiff(tt.currentSpec, tt.newSpec).Return(nil)


### PR DESCRIPTION
Resolves #463 

*Description of changes:*
Skip capi and flux upgrades when cluster is not self managed
We need to add the same thing for eks-a controller and CRD, we will do that as part of #452

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
