### PR TITLE
Add command to generate a list of images used by eks-anywhere

### DIFF
--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/version"
+	"github.com/aws/eks-anywhere/release/api/v1alpha1"
+)
+
+func getImages(spec string) ([]v1alpha1.Image, error) {
+	clusterSpec, err := cluster.NewSpec(spec, version.Get())
+	if err != nil {
+		return nil, err
+	}
+	bundle := clusterSpec.VersionsBundle
+	images := append(bundle.Images(), clusterSpec.KubeDistroImages()...)
+	return images, nil
+}

--- a/cmd/eksctl-anywhere/cmd/importimages.go
+++ b/cmd/eksctl-anywhere/cmd/importimages.go
@@ -55,20 +55,15 @@ func importImages(context context.Context, spec string) error {
 	}
 	endpoint := clusterSpec.Spec.RegistryMirrorConfiguration.Endpoint
 
-	bundle := clusterSpec.VersionsBundle
-
-	for _, image := range bundle.Images() {
+	images, err := getImages(spec)
+	if err != nil {
+		return err
+	}
+	for _, image := range images {
 		if err := importImage(context, de, image.URI, endpoint); err != nil {
 			return fmt.Errorf("error importing image %s: %v", image.URI, err)
 		}
 	}
-	kubeDistroImages := clusterSpec.KubeDistroImages()
-	for _, image := range kubeDistroImages {
-		if err := importImage(context, de, image.URI, endpoint); err != nil {
-			return fmt.Errorf("error importing image %s: %v", image.URI, err)
-		}
-	}
-
 	return nil
 }
 

--- a/cmd/eksctl-anywhere/cmd/listimages.go
+++ b/cmd/eksctl-anywhere/cmd/listimages.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+type listImagesOptions struct {
+	fileName string
+}
+
+var lio = &listImagesOptions{}
+
+func init() {
+	listCmd.AddCommand(listImagesCommand)
+	listImagesCommand.Flags().StringVarP(&lio.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
+	err := listImagesCommand.MarkFlagRequired("filename")
+	if err != nil {
+		log.Fatalf("Error marking filename flag as required: %v", err)
+	}
+}
+
+var listImagesCommand = &cobra.Command{
+	Use:   "images",
+	Short: "Generate a list of images used by EKS Anywhere",
+	Long:  "This command is used to generate a list of images used by EKS-Anywhere for cluster provisioning",
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+			if err := viper.BindPFlag(flag.Name, flag); err != nil {
+				log.Fatalf("Error initializing flags: %v", err)
+			}
+		})
+		return nil
+	},
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return listImages(cmd.Context(), lio.fileName)
+	},
+}
+
+func listImages(context context.Context, spec string) error {
+	images, err := getImages(spec)
+	if err != nil {
+		return err
+	}
+
+	for _, image := range images {
+		if image.ImageDigest != "" {
+			fmt.Printf("%s@%s\n", image.URI, image.ImageDigest)
+		} else {
+			fmt.Printf("%s\n", image.URI)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit adds a new generate subcommand called image-list, which
generates a file containing all images and their checksums that are used
by EKS-Anywhere.

Command: 
```
./bin/eksctl-anywhere list images -f eks-a.yaml
```

Generates a list of all images used in this format:
```
imageRepository/imageName:imageTag@imageDigest
```
for instance:
```
public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.1.0-eks-a-v0.0.0-dev-build.312@sha256:817b1278165ae65bf051e556fcd983c984b49de02ed01566f8ce1ed4e5415424
```

This way `docker pull` can be run directly against each image from the output only the expected checksums from the release manifests will get used

*Issue #, if available:* https://github.com/aws/eks-anywhere/issues/476

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
