### PR TITLE
Call import-images during registry-mirror tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -35,6 +35,8 @@ env:
     T_HTTPS_PROXY: "proxy-config-data:httpsProxy"
     T_NO_PROXY: "proxy-config-data:noProxy"
     T_REGISTRY_MIRROR_ENDPOINT: "harbor-registry-data:endpoint"
+    T_REGISTRY_MIRROR_USERNAME: "harbor-registry-data:username"
+    T_REGISTRY_MIRROR_PASSWORD: "harbor-registry-data:password"
     T_REGISTRY_MIRROR_CA_CERT: "harbor-registry-data:caCert"
 
 phases:

--- a/pkg/executables/docker.go
+++ b/pkg/executables/docker.go
@@ -91,3 +91,10 @@ func (d *Docker) PushImage(ctx context.Context, image string, endpoint string) e
 	}
 	return nil
 }
+
+func (d *Docker) Login(ctx context.Context, endpoint, username, password string) error {
+	params := []string{"login", endpoint, "--username", username, "--password-stdin"}
+	logger.Info(fmt.Sprintf("Logging in to docker registry %s", endpoint))
+	_, err := d.executable.ExecuteWithStdin(ctx, []byte(password), params...)
+	return err
+}

--- a/test/e2e/registry_mirror_test.go
+++ b/test/e2e/registry_mirror_test.go
@@ -12,7 +12,9 @@ import (
 
 func runRegistryMirrorConfigFlow(test *framework.E2ETest) {
 	test.GenerateClusterConfig()
+	test.ImportImages()
 	test.CreateCluster()
+	test.ImportImages()
 	test.DeleteCluster()
 }
 

--- a/test/framework/e2e.go
+++ b/test/framework/e2e.go
@@ -107,6 +107,10 @@ func (e *E2ETest) GenerateClusterConfig() {
 	})
 }
 
+func (e *E2ETest) ImportImages() {
+	e.RunEKSA("anywhere", "import-images", "-f", e.ClusterConfigLocation)
+}
+
 func (e *E2ETest) CreateCluster() {
 	createClusterArgs := []string{"anywhere", "create", "cluster", "-f", e.ClusterConfigLocation, "-v", "4"}
 	if getBundlesOverride() == "true" {

--- a/test/framework/executables.go
+++ b/test/framework/executables.go
@@ -30,3 +30,7 @@ func buildGovc(t *testing.T) *executables.Govc {
 	}
 	return executableBuilder(t, ctx).BuildGovcExecutable(tmpWriter)
 }
+
+func buildDocker(t *testing.T) *executables.Docker {
+	return executables.BuildDockerExecutable()
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Call import-images during registry-mirror tests so the private registry has all the required images

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
