### PR TITLE
Use underscore in S3 logs folder name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ public.zip
 docs/public
 docs/node_modules
 docs/public.zip
+pkg/executables/cluster-name
+cluster.yaml
+eksa-test
+generated/


### PR DESCRIPTION
* `TestVSphereKubernetes121OIDCi-012345678901bcdef` -> `TestVSphereKubernetes121OIDC_i-012345678901bcdef`.
* Create a file containing test name on the instance for better tracking.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
