### PR TITLE
WIP: Pull down architecture-specific images using ECR manifest

### DIFF
--- a/release/pkg/ecr_manifest.go
+++ b/release/pkg/ecr_manifest.go
@@ -1,0 +1,129 @@
+package pkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type ManifestMeta struct {
+	MediaType string
+	Digest    string
+	Size      int
+}
+
+type Platform struct {
+	Architecture string
+	Os           string
+}
+
+type Manifest struct {
+	ManifestMeta
+	Platform Platform
+}
+
+type ImageManifest struct {
+	MediaType     string
+	SchemaVersion int
+	Config        ManifestMeta
+	Layers        []ManifestMeta
+}
+
+type ManifestList struct {
+	MediaType     string
+	SchemaVersion int
+	Manifests     []Manifest
+}
+
+func (r *ReleaseConfig) getImageUriMap(sourceClients *SourceClients, sourceImageUri string) (map[string]string, error) {
+	var imageManifest ImageManifest
+	var manifestList ManifestList
+	archImageUriMap := map[string]string{}
+
+	sourceImageUriSplit := strings.Split(sourceImageUri, ":")
+	sourceImageName := strings.Replace(sourceImageUriSplit[0], r.SourceContainerRegistry+"/", "", -1)
+	sourceImageTag := sourceImageUriSplit[1]
+
+	var authToken, authHeader, requestUrl string
+	var err error
+	if r.DevRelease || r.ReleaseEnvironment == "development" {
+		// Get ECR authorization token
+		authToken, err = getEcrAuthToken(sourceClients.ECR.EcrClient)
+		if err != nil {
+			return nil, errors.Cause(err)
+		}
+		authHeader = fmt.Sprintf("Basic %s", authToken)
+		requestUrl = fmt.Sprintf("https://%s/v2/%s/manifests/%s", r.SourceContainerRegistry, sourceImageName, sourceImageTag)
+	} else {
+		// Get ECR Public authorization token
+		authToken, err = getEcrPublicAuthToken(sourceClients.ECR.EcrPublicClient)
+		if err != nil {
+			return nil, errors.Cause(err)
+		}
+		authHeader = fmt.Sprintf("Bearer %s", authToken)
+		requestUrl = fmt.Sprintf("https://public.ecr.aws/v2/%s/%s/manifests/%s", filepath.Base(r.SourceContainerRegistry), sourceImageName, sourceImageTag)
+	}
+
+	// Creating new GET request with
+	req, err := http.NewRequest("GET", requestUrl, nil)
+	if err != nil {
+		return nil, errors.Cause(err)
+	}
+	req.Header.Set("Authorization", authHeader)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errors.Cause(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Cause(err)
+	}
+	fmt.Println(string(body))
+
+	if err = json.Unmarshal(body, &imageManifest); err != nil {
+		return nil, errors.Cause(err)
+	}
+	if imageManifest.Layers == nil {
+		if err := json.Unmarshal(body, &manifestList); err != nil {
+			return nil, errors.Cause(err)
+		}
+		for _, manifest := range manifestList.Manifests {
+			archImageUriMap[manifest.Platform.Architecture] = fmt.Sprintf("%s/%s@%s", r.SourceContainerRegistry, sourceImageName, manifest.Digest)
+		}
+	} else {
+		archImageUriMap["amd64"] = fmt.Sprintf("%s/%s@%s", r.SourceContainerRegistry, sourceImageName, imageManifest.Config.Digest)
+	}
+
+	return archImageUriMap, nil
+}
+
+func createManifest(releaseImageUri string, archImageUriMap map[string]string) error {
+	cmd := exec.Command("docker", "manifest", "create", releaseImageUri, archImageUriMap["amd64"], archImageUriMap["arm64"])
+	out, err := execCommand(cmd)
+	if err != nil {
+		return errors.Cause(err)
+	}
+	fmt.Println(out)
+
+	return nil
+}
+
+func pushManifest(releaseImageUri string) error {
+	cmd := exec.Command("docker", "manifest", "push", releaseImageUri)
+	out, err := execCommand(cmd)
+	if err != nil {
+		return errors.Cause(err)
+	}
+	fmt.Println(out)
+
+	return nil
+}


### PR DESCRIPTION
During release, we pull down the latest images from the source container registry and then push them to the release container registry using `docker pull`-then-`docker push` method. While this method works well for single-architecture images, it fails for multi-architecture images (which all projects will be building soon) since the Docker engine pulls images only for the architecture of the build environment where it’s running, in this case, `amd64`. So even though the source image is of type manifest list, the release image will be pushed as a single image manifest, which is not what we want.

As a workaround for this, we need to fetch the latest image's manifest list and pull down both `amd64` and `arm64` images using the digest specified in the manifest list. Then we need to create a local Docker manifest corresponding to the release images and push the manifest, which would result in a manifest list being created on the release container registry.

- [x] Basic skeleton for fetching and parsing manifest
- [ ] Integrate manifest-based approach into release process
  - [x] Add methods to create and push Docker manifest
  - [ ] Modify release process to pull down the images using digest, create and push manifest list

Points to consider:
* `docker manifest` is [experimental](https://docs.docker.com/engine/reference/commandline/manifest)
* `docker manifest create` requires that [the manifest's constituent images be available in the remote registry](https://github.com/docker/cli/issues/2396) in order to create the manifest. This would mean that we need to push the `amd64` and `arm64` variants of the release image before even creating the manifest list for the release image. Possible approaches to this would be to delete these individual image manifests once the manifest list has been uploaded, or in the worst case, retain the architecture-variant images on ECR Public Gallery, [like some registries do](https://gallery.ecr.aws/amazonlinux/amazonlinux).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
