### PR TITLE
Add quotes around env vars to handle special characters

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -133,7 +133,7 @@ func (e *E2ESession) commandWithEnvVars(command string) string {
 	fullCommand := make([]string, 0, len(e.testEnvVars)+1)
 
 	for k, v := range e.testEnvVars {
-		fullCommand = append(fullCommand, fmt.Sprintf("export %s=%s", k, v))
+		fullCommand = append(fullCommand, fmt.Sprintf("export %s=\"%s\"", k, v))
 	}
 	fullCommand = append(fullCommand, command)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add quotes around env vars to handle special characters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
