### PR TITLE
Skip flux upgrade when GitOps is not enabled

### DIFF
--- a/pkg/addonmanager/addonclients/upgrader.go
+++ b/pkg/addonmanager/addonclients/upgrader.go
@@ -20,6 +20,11 @@ func (f *FluxAddonClient) Upgrade(ctx context.Context, managementCluster *types.
 		return nil
 	}
 
+	if newSpec.GitOpsConfig == nil {
+		logger.V(1).Info("Skipping Flux upgrades, GitOps not enabled")
+		return nil
+	}
+
 	changeDiff := f.fluxChangeDiff(currentSpec, newSpec)
 	if !changeDiff {
 		logger.V(1).Info("Nothing to upgrade for Flux")

--- a/pkg/addonmanager/addonclients/upgrader_test.go
+++ b/pkg/addonmanager/addonclients/upgrader_test.go
@@ -115,3 +115,11 @@ func TestFluxUpgradeError(t *testing.T) {
 
 	tt.Expect(f.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).NotTo(Succeed())
 }
+
+func TestFluxUpgradeNoGitOpsConfig(t *testing.T) {
+	tt := newUpgraderTest(t)
+	f, _, _ := newAddonClient(t)
+	tt.newSpec.GitOpsConfig = nil
+
+	tt.Expect(f.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(Succeed())
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Skipping flux core components upgrade when gitops is not enabled


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
