### PR TITLE
explicitly set shell encoding to UTF-8 to handle AWS returning UTF-8 chars

### DIFF
--- a/release/scripts/release.sh
+++ b/release/scripts/release.sh
@@ -18,6 +18,8 @@ set -e
 set -x
 set -o pipefail
 
+export LANG=C.UTF-8
+
 BASE_DIRECTORY=$(git rev-parse --show-toplevel)
 
 ARTIFACTS_DIR="${1?Specify first argument - artifacts path}"


### PR DESCRIPTION
Dev release are failing.

In some cases, this is due to:
'ascii' codec can't encode character '\u2026' in position 70: ordinal not in range(128)
 
Following the execution of:
https://github.com/aws/eks-anywhere/blob/1d8c6229957af941aaad6c5aabaf1bb6785a639a/release/scripts/release.sh#L38

This was recently changed, moving from the built-in query flag of the AWS CLI to a pipe to JQ:
https://github.com/aws/eks-anywhere/commit/1d8c6229957af941aaad6c5aabaf1bb6785a639a#diff-fe485b94c27f6331b2c691676b72997180060d9b063cc8d29e2e9b5e850b1098R43

To ensure we're properly encoding the UTF-8 characters that the AWS CLI is returning, we can explicitly set the encoding of the shell. This should handle this issue if it is what it appears to be (AWS CLI returning unicode characters to an ASCII locale shell). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
