### PR TITLE
Fix kubebuilder script to work when creating new api types

### DIFF
--- a/hack/fake-Makefile
+++ b/hack/fake-Makefile
@@ -1,0 +1,3 @@
+
+generate:
+	cd .. && make generate

--- a/hack/kubebuilder.sh
+++ b/hack/kubebuilder.sh
@@ -1,19 +1,27 @@
 #!/usr/bin/env bash
 
+TEMP_FOLDER=tmp-kubebuilder-project
+PATH_TO_KUBEBUILDER=hack/tools/bin/kubebuilder
+
 setupFakeKubebuilderEnv() {
-	ln -sr pkg/api api
-	mv controllers controllers_tmp
-	ln -sr controllers_tmp/controllers controllers
-	ln -sr controllers_tmp/main.go main.go
+	mkdir -p $TEMP_FOLDER/hack
+	ln -s $(pwd)/pkg/api $TEMP_FOLDER/api
+	ln -s $(pwd)/controllers/controllers $TEMP_FOLDER/controllers
+	ln -s $(pwd)/controllers/main.go $TEMP_FOLDER/main.go
+	ln -s $(pwd)/hack/boilerplate.go.txt $TEMP_FOLDER/hack/boilerplate.go.txt
+	ln -s $(pwd)/PROJECT $TEMP_FOLDER/PROJECT
+	cp hack/fake-Makefile $TEMP_FOLDER/Makefile
 }
 
 restoreKubebuilderEnv() {
-	rm main.go
-	rm controllers
-	mv controllers_tmp controllers
-	rm api
+	rm -rf $TEMP_FOLDER
 }
 
+if [ ! -f $PATH_TO_KUBEBUILDER ]; then
+	echo "Kubebuilder is not installed. Run 'make hack/tools/bin/kubebuilder'"
+	exit 1
+fi
+
 setupFakeKubebuilderEnv
-./hack/tools/bin/kubebuilder "$@"
+(cd $TEMP_FOLDER && ./../$PATH_TO_KUBEBUILDER "$@")
 restoreKubebuilderEnv


### PR DESCRIPTION
*Description of changes:*
For whatever reason, the kubebuilder script stopped working, at least when creating new api types. This should fix it. It follows a similar approach as before, but this time only using symlinks, without actually changing any of the original files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
