### PR TITLE
Refactor image copying from source to destination registry

### DIFF
--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -158,7 +158,7 @@ var releaseCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			err = pkg.UploadArtifacts(releaseClients, releaseConfig, artifactsTable)
+			err = pkg.UploadArtifacts(sourceClients, releaseClients, releaseConfig, artifactsTable)
 			if err != nil {
 				fmt.Printf("Error uploading release artifacts: %v\n", err)
 				os.Exit(1)
@@ -252,7 +252,7 @@ var releaseCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			err = pkg.UploadArtifacts(releaseClients, releaseConfig, artifactsTable)
+			err = pkg.UploadArtifacts(sourceClients, releaseClients, releaseConfig, artifactsTable)
 			if err != nil {
 				fmt.Printf("Error uploading release artifacts: %v\n", err)
 				os.Exit(1)

--- a/release/scripts/policy.json
+++ b/release/scripts/policy.json
@@ -1,0 +1,9 @@
+{
+    "default": [{"type": "reject"}],
+    "transports": {
+            "docker": {
+                    "857151390494.dkr.ecr.us-west-2.amazonaws.com": [{"type": "insecureAcceptAnything"}],
+                    "public.ecr.aws": [{"type": "insecureAcceptAnything"}]
+            }
+    }
+}

--- a/release/scripts/setup.sh
+++ b/release/scripts/setup.sh
@@ -7,6 +7,10 @@ set -o pipefail
 if [ ! -d "/root/.docker" ]; then
     mkdir -p /root/.docker
 fi
+if [ ! -d "/root/.config/containers" ]; then
+    mkdir -p /root/.config/containers
+fi
 mv release/scripts/docker-ecr-config.json /root/.docker/config.json
+mv release/scripts/policy.json /root/.config/containers/policy.json
 git config --global credential.helper '!aws codecommit credential-helper $@'
 git config --global credential.UseHttpPath true


### PR DESCRIPTION
During release, we pull down the latest images from the source container registry and then push them to the release container registry using docker pull-then-docker push method. While this method works well for single-architecture images, it fails for multi-architecture images (which all projects will be building soon) since the Docker engine pulls images only for the architecture of the build environment where it’s running, in this case, amd64. So even though the source image is of type `manifest list`, the release image will be pushed as a single `image manifest`, which is not what we want.

This PR refactors the release process to use [`skopeo`](https://github.com/containers/skopeo) utility for copying images from source container registry to release container registry. We can use Skopeo to push entire manifest lists by passing the `--all` flag to `skopeo copy`.

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
