### PR TITLE
make sure to get the instance ID for failed tests

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -90,12 +90,12 @@ func RunTests(conf instanceRunConf) (testInstanceID string, err error) {
 
 	err = session.setup(conf.regex)
 	if err != nil {
-		return "", err
+		return session.instanceId, err
 	}
 
 	err = session.runTests(conf.regex)
 	if err != nil {
-		return "", err
+		return session.instanceId, err
 	}
 
 	return session.instanceId, nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
recently modified this to return the instance ID, but realized this morning it was only returning the instance ID for passed tests, not failed ones -- so we're doing that now, as that's the whole point.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
