### PR TITLE
Trim suffix for govc library info output

### DIFF
--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -140,6 +140,7 @@ func (g *Govc) GetLibraryElementContentVersion(ctx context.Context, element stri
 		return "", fmt.Errorf("govc failed getting library element info: %v", err)
 	}
 	elementInfoJson := response.String()
+	elementInfoJson = strings.TrimSuffix(elementInfoJson, "\n")
 	if elementInfoJson == "null" {
 		return "-1", nil
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Trim suffix on output for call to `govc library.info` to effectively check if the output was equal to "null"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
