### PR TITLE
Provide datacenter when deploying the template from content library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/go-logr/zapr v0.4.0
 	github.com/golang/mock v1.5.0
 	github.com/google/go-github/v35 v35.2.0
-	github.com/kisielk/godepgraph v0.0.0-20190626013829-57a7e4a651a9 // indirect
 	github.com/mrajashree/etcdadm-controller v0.1.1-0.20210807012710-3e2035176ab8
 	github.com/onsi/gomega v1.14.0
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -642,8 +642,6 @@ github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
-github.com/kisielk/godepgraph v0.0.0-20190626013829-57a7e4a651a9 h1:ZkWH0x1yafBo+Y2WdGGdszlJrMreMXWl7/dqpEkwsIk=
-github.com/kisielk/godepgraph v0.0.0-20190626013829-57a7e4a651a9/go.mod h1:Gb5YEgxqiSSVrXKWQxDcKoCM94NO5QAwOwTaVmIUAMI=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=

--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -241,9 +241,9 @@ func (g *Govc) CreateLibrary(ctx context.Context, datastore, library string) err
 	return nil
 }
 
-func (g *Govc) DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, resourcePool string, resizeDisk2 bool) error {
+func (g *Govc) DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, datacenter, resourcePool string, resizeDisk2 bool) error {
 	logger.V(4).Info("Deploying template", "dir", templateDir, "templateName", templateName)
-	if err := g.deployTemplate(ctx, library, templateName, templateDir, resourcePool); err != nil {
+	if err := g.deployTemplate(ctx, library, templateName, templateDir, datacenter, resourcePool); err != nil {
 		return err
 	}
 
@@ -291,7 +291,7 @@ func (g *Govc) ImportTemplate(ctx context.Context, library, ovaURL, name string)
 	return nil
 }
 
-func (g *Govc) deployTemplate(ctx context.Context, library, templateName, deployFolder, resourcePool string) error {
+func (g *Govc) deployTemplate(ctx context.Context, library, templateName, deployFolder, datacenter, resourcePool string) error {
 	templateInLibraryPath := filepath.Join(library, templateName)
 	if !filepath.IsAbs(templateInLibraryPath) {
 		templateInLibraryPath = fmt.Sprintf("/%s", templateInLibraryPath)
@@ -304,6 +304,7 @@ func (g *Govc) deployTemplate(ctx context.Context, library, templateName, deploy
 
 	params := []string{
 		"library.deploy",
+		"-dc", datacenter,
 		"-pool", resourcePool,
 		"-folder", deployFolder,
 		"-options", deployOptsPath,

--- a/pkg/executables/govc_test.go
+++ b/pkg/executables/govc_test.go
@@ -101,6 +101,7 @@ type deployTemplateTest struct {
 	govc                     *executables.Govc
 	mockExecutable           *mockexecutables.MockExecutable
 	env                      map[string]string
+	datacenter               string
 	resourcePool             string
 	templatePath             string
 	ovaURL                   string
@@ -119,6 +120,7 @@ func newDeployTemplateTest(t *testing.T) *deployTemplateTest {
 		govc:                     g,
 		mockExecutable:           exec,
 		env:                      env,
+		datacenter:               "SDDC-Datacenter",
 		resourcePool:             "*/Resources/Compute-ResourcePool",
 		templatePath:             "/SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.19.6",
 		ovaURL:                   "https://aws.com/ova",
@@ -149,7 +151,7 @@ func newMachineConfig(t *testing.T) *v1alpha1.VSphereMachineConfig {
 func (dt *deployTemplateTest) expectDeployToReturn(err error) {
 	dt.expectations = append(
 		dt.expectations,
-		dt.mockExecutable.EXPECT().ExecuteWithEnv(dt.ctx, dt.env, "library.deploy", "-pool", dt.resourcePool, "-folder", dt.deployFolder, "-options", test.OfType("string"), "-persist-session=false", dt.templateInLibraryPathAbs, dt.templateName).Return(*dt.fakeExecResponse, err),
+		dt.mockExecutable.EXPECT().ExecuteWithEnv(dt.ctx, dt.env, "library.deploy", "-dc", dt.datacenter, "-pool", dt.resourcePool, "-folder", dt.deployFolder, "-options", test.OfType("string"), "-persist-session=false", dt.templateInLibraryPathAbs, dt.templateName).Return(*dt.fakeExecResponse, err),
 	)
 }
 
@@ -169,7 +171,7 @@ func (dt *deployTemplateTest) expectMarkAsTemplateToReturn(err error) {
 
 func (dt *deployTemplateTest) DeployTemplateFromLibrary() error {
 	gomock.InOrder(dt.expectations...)
-	return dt.govc.DeployTemplateFromLibrary(dt.ctx, dt.deployFolder, dt.templateName, templateLibrary, dt.resourcePool, dt.resizeDisk2)
+	return dt.govc.DeployTemplateFromLibrary(dt.ctx, dt.deployFolder, dt.templateName, templateLibrary, dt.datacenter, dt.resourcePool, dt.resizeDisk2)
 }
 
 func (dt *deployTemplateTest) assertDeployTemplateSuccess(t *testing.T) {

--- a/pkg/providers/vsphere/internal/templates/factory.go
+++ b/pkg/providers/vsphere/internal/templates/factory.go
@@ -18,6 +18,7 @@ const (
 
 type Factory struct {
 	client          GovcClient
+	datacenter      string
 	datastore       string
 	resourcePool    string
 	templateLibrary string
@@ -26,7 +27,7 @@ type Factory struct {
 
 type GovcClient interface {
 	CreateLibrary(ctx context.Context, datastore, library string) error
-	DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, resourcePool string, resizeDisk2 bool) error
+	DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, datacenter, resourcePool string, resizeDisk2 bool) error
 	SearchTemplate(ctx context.Context, datacenter string, machineConfig *v1alpha1.VSphereMachineConfig) (string, error)
 	ImportTemplate(ctx context.Context, library, ovaURL, name string) error
 	LibraryElementExists(ctx context.Context, library string) (bool, error)
@@ -39,9 +40,10 @@ type GovcClient interface {
 	CreateCategoryForVM(ctx context.Context, name string) error
 }
 
-func NewFactory(client GovcClient, datastore, resourcePool, templateLibrary string) *Factory {
+func NewFactory(client GovcClient, datacenter, datastore, resourcePool, templateLibrary string) *Factory {
 	return &Factory{
 		client:          client,
+		datacenter:      datacenter,
 		datastore:       datastore,
 		resourcePool:    resourcePool,
 		templateLibrary: templateLibrary,
@@ -90,7 +92,7 @@ func (f *Factory) createTemplate(ctx context.Context, templatePath, ovaURL, osFa
 	if strings.EqualFold(osFamily, string(v1alpha1.Bottlerocket)) {
 		resizeDisk2 = true
 	}
-	if err := f.client.DeployTemplateFromLibrary(ctx, templateDir, templateName, f.templateLibrary, f.resourcePool, resizeDisk2); err != nil {
+	if err := f.client.DeployTemplateFromLibrary(ctx, templateDir, templateName, f.templateLibrary, f.datacenter, f.resourcePool, resizeDisk2); err != nil {
 		return fmt.Errorf("failed deploying template: %v", err)
 	}
 

--- a/pkg/providers/vsphere/internal/templates/factory_test.go
+++ b/pkg/providers/vsphere/internal/templates/factory_test.go
@@ -15,6 +15,7 @@ import (
 
 type test struct {
 	t                          *testing.T
+	datacenter                 string
 	datastore                  string
 	resourcePool               string
 	templateLibrary            string
@@ -44,6 +45,7 @@ func newTest(t *testing.T) *test {
 	ctrl := gomock.NewController(t)
 	test := &test{
 		t:                          t,
+		datacenter:                 "SDDC-Datacenter",
 		datastore:                  "datastore",
 		resourcePool:               "*/pool/",
 		templateLibrary:            "library",
@@ -57,6 +59,7 @@ func newTest(t *testing.T) *test {
 	}
 	f := templates.NewFactory(
 		test.govc,
+		test.datacenter,
 		test.datastore,
 		test.resourcePool,
 		test.templateLibrary,
@@ -170,7 +173,7 @@ func TestFactoryCreateIfMissingErrorDeploy(t *testing.T) {
 	ct.govc.EXPECT().GetLibraryElementContentVersion(ct.ctx, ct.templateInLibrary).Return(ct.libraryContentDoesNotExist, nil)
 	ct.govc.EXPECT().ImportTemplate(ct.ctx, ct.templateLibrary, ct.ovaURL, ct.templateName).Return(nil)
 	ct.govc.EXPECT().DeployTemplateFromLibrary(
-		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool, ct.resizeDisk2,
+		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.datacenter, ct.resourcePool, ct.resizeDisk2,
 	).Return(ct.dummyError)
 
 	ct.assertErrorFromCreateIfMissing()
@@ -184,7 +187,7 @@ func TestFactoryCreateIfMissingErrorFromTagFactory(t *testing.T) {
 	ct.govc.EXPECT().GetLibraryElementContentVersion(ct.ctx, ct.templateInLibrary).Return(ct.libraryContentDoesNotExist, nil)
 	ct.govc.EXPECT().ImportTemplate(ct.ctx, ct.templateLibrary, ct.ovaURL, ct.templateName).Return(nil)
 	ct.govc.EXPECT().DeployTemplateFromLibrary(
-		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool, ct.resizeDisk2,
+		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.datacenter, ct.resourcePool, ct.resizeDisk2,
 	).Return(nil)
 
 	// expects for tagging
@@ -201,7 +204,7 @@ func TestFactoryCreateIfMissingSuccessLibraryDoesNotExist(t *testing.T) {
 	ct.govc.EXPECT().GetLibraryElementContentVersion(ct.ctx, ct.templateInLibrary).Return(ct.libraryContentDoesNotExist, nil)
 	ct.govc.EXPECT().ImportTemplate(ct.ctx, ct.templateLibrary, ct.ovaURL, ct.templateName).Return(nil)
 	ct.govc.EXPECT().DeployTemplateFromLibrary(
-		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool, ct.resizeDisk2,
+		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.datacenter, ct.resourcePool, ct.resizeDisk2,
 	).Return(nil)
 
 	// expects for tagging
@@ -218,7 +221,7 @@ func TestFactoryCreateIfMissingSuccessLibraryExists(t *testing.T) {
 	ct.govc.EXPECT().GetLibraryElementContentVersion(ct.ctx, ct.templateInLibrary).Return(ct.libraryContentDoesNotExist, nil)
 	ct.govc.EXPECT().ImportTemplate(ct.ctx, ct.templateLibrary, ct.ovaURL, ct.templateName).Return(nil)
 	ct.govc.EXPECT().DeployTemplateFromLibrary(
-		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool, ct.resizeDisk2,
+		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.datacenter, ct.resourcePool, ct.resizeDisk2,
 	).Return(nil)
 
 	// expects for tagging
@@ -234,7 +237,7 @@ func TestFactoryCreateIfMissingSuccessTemplateInLibraryExists(t *testing.T) {
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateLibrary).Return(true, nil)
 	ct.govc.EXPECT().GetLibraryElementContentVersion(ct.ctx, ct.templateInLibrary).Return(ct.libraryContentValid, nil)
 	ct.govc.EXPECT().DeployTemplateFromLibrary(
-		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool, ct.resizeDisk2,
+		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.datacenter, ct.resourcePool, ct.resizeDisk2,
 	).Return(nil)
 
 	// expects for tagging
@@ -252,7 +255,7 @@ func TestFactoryCreateIfMissingSuccessTemplateInLibraryCorrupted(t *testing.T) {
 	ct.govc.EXPECT().DeleteLibraryElement(ct.ctx, ct.templateInLibrary).Return(nil)
 	ct.govc.EXPECT().ImportTemplate(ct.ctx, ct.templateLibrary, ct.ovaURL, ct.templateName)
 	ct.govc.EXPECT().DeployTemplateFromLibrary(
-		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.resourcePool, ct.resizeDisk2,
+		ct.ctx, ct.templateDir, ct.templateName, ct.templateLibrary, ct.datacenter, ct.resourcePool, ct.resizeDisk2,
 	).Return(nil)
 
 	// expects for tagging

--- a/pkg/providers/vsphere/internal/templates/mocks/govc.go
+++ b/pkg/providers/vsphere/internal/templates/mocks/govc.go
@@ -106,17 +106,17 @@ func (mr *MockGovcClientMockRecorder) DeleteLibraryElement(ctx, element interfac
 }
 
 // DeployTemplateFromLibrary mocks base method.
-func (m *MockGovcClient) DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, resourcePool string, resizeDisk2 bool) error {
+func (m *MockGovcClient) DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, datacenter, resourcePool string, resizeDisk2 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeployTemplateFromLibrary", ctx, templateDir, templateName, library, resourcePool, resizeDisk2)
+	ret := m.ctrl.Call(m, "DeployTemplateFromLibrary", ctx, templateDir, templateName, library, datacenter, resourcePool, resizeDisk2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeployTemplateFromLibrary indicates an expected call of DeployTemplateFromLibrary.
-func (mr *MockGovcClientMockRecorder) DeployTemplateFromLibrary(ctx, templateDir, templateName, library, resourcePool, resizeDisk2 interface{}) *gomock.Call {
+func (mr *MockGovcClientMockRecorder) DeployTemplateFromLibrary(ctx, templateDir, templateName, library, datacenter, resourcePool, resizeDisk2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTemplateFromLibrary", reflect.TypeOf((*MockGovcClient)(nil).DeployTemplateFromLibrary), ctx, templateDir, templateName, library, resourcePool, resizeDisk2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTemplateFromLibrary", reflect.TypeOf((*MockGovcClient)(nil).DeployTemplateFromLibrary), ctx, templateDir, templateName, library, datacenter, resourcePool, resizeDisk2)
 }
 
 // GetLibraryElementContentVersion mocks base method.

--- a/pkg/providers/vsphere/mocks/client.go
+++ b/pkg/providers/vsphere/mocks/client.go
@@ -112,17 +112,17 @@ func (mr *MockProviderGovcClientMockRecorder) DeleteLibraryElement(arg0, arg1 in
 }
 
 // DeployTemplateFromLibrary mocks base method.
-func (m *MockProviderGovcClient) DeployTemplateFromLibrary(arg0 context.Context, arg1, arg2, arg3, arg4 string, arg5 bool) error {
+func (m *MockProviderGovcClient) DeployTemplateFromLibrary(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string, arg6 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeployTemplateFromLibrary", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "DeployTemplateFromLibrary", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeployTemplateFromLibrary indicates an expected call of DeployTemplateFromLibrary.
-func (mr *MockProviderGovcClientMockRecorder) DeployTemplateFromLibrary(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockProviderGovcClientMockRecorder) DeployTemplateFromLibrary(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTemplateFromLibrary", reflect.TypeOf((*MockProviderGovcClient)(nil).DeployTemplateFromLibrary), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTemplateFromLibrary", reflect.TypeOf((*MockProviderGovcClient)(nil).DeployTemplateFromLibrary), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // GetLibraryElementContentVersion mocks base method.

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -115,7 +115,7 @@ type ProviderGovcClient interface {
 	ValidateVCenterSetup(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, selfSigned *bool) error
 	ValidateVCenterSetupMachineConfig(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, machineConfig *v1alpha1.VSphereMachineConfig, selfSigned *bool) error
 	CreateLibrary(ctx context.Context, datastore, library string) error
-	DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, resourcePool string, resizeDisk2 bool) error
+	DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, datacenter, resourcePool string, resizeDisk2 bool) error
 	ImportTemplate(ctx context.Context, library, ovaURL, name string) error
 	GetTags(ctx context.Context, path string) (tags []string, err error)
 	ListTags(ctx context.Context) ([]string, error)
@@ -160,6 +160,7 @@ func NewProviderCustomNet(datacenterConfig *v1alpha1.VSphereDatacenterConfig, ma
 		controlPlaneMachineSpec = &machineConfigs[clusterConfig.Spec.ControlPlaneConfiguration.MachineGroupRef.Name].Spec
 		controlPlaneTemplateFactory = templates.NewFactory(
 			providerGovcClient,
+			datacenterConfig.Spec.Datacenter,
 			controlPlaneMachineSpec.Datastore,
 			controlPlaneMachineSpec.ResourcePool,
 			defaultTemplateLibrary,
@@ -169,6 +170,7 @@ func NewProviderCustomNet(datacenterConfig *v1alpha1.VSphereDatacenterConfig, ma
 		workerNodeGroupMachineSpec = &machineConfigs[clusterConfig.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name].Spec
 		workerNodeGroupTemplateFactory = templates.NewFactory(
 			providerGovcClient,
+			datacenterConfig.Spec.Datacenter,
 			workerNodeGroupMachineSpec.Datastore,
 			workerNodeGroupMachineSpec.ResourcePool,
 			defaultTemplateLibrary,
@@ -179,6 +181,7 @@ func NewProviderCustomNet(datacenterConfig *v1alpha1.VSphereDatacenterConfig, ma
 			etcdMachineSpec = &machineConfigs[clusterConfig.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name].Spec
 			etcdTemplateFactory = templates.NewFactory(
 				providerGovcClient,
+				datacenterConfig.Spec.Datacenter,
 				etcdMachineSpec.Datastore,
 				etcdMachineSpec.ResourcePool,
 				defaultTemplateLibrary,

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -97,7 +97,7 @@ func (pc *DummyProviderGovcClient) CreateLibrary(ctx context.Context, datastore,
 	return nil
 }
 
-func (pc *DummyProviderGovcClient) DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, resourcePool string, resizeDisk2 bool) error {
+func (pc *DummyProviderGovcClient) DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, datacenter, resourcePool string, resizeDisk2 bool) error {
 	return nil
 }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/437

*Description of changes:*
Passes the datacenter while deploying the ova template from the content library to avoid [please specify a datacenter](https://github.com/aws/eks-anywhere/issues/409) issues in multi-datacenter environments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
