### PR TITLE
Remove temporary files created by unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ public.zip
 docs/public
 docs/node_modules
 docs/public.zip
-pkg/executables/cluster-name
 cluster.yaml
 eksa-test
 generated/

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -265,6 +265,12 @@ func TestClusterctlInitInfrastructureInstallEtcdadmControllers(t *testing.T) {
 }
 
 func TestClusterctlInitInfrastructureEnvMapError(t *testing.T) {
+	cluster := &types.Cluster{Name: "cluster-name"}
+	defer func() {
+		if !t.Failed() {
+			os.RemoveAll(cluster.Name)
+		}
+	}()
 	ctx := context.Background()
 
 	_, writer := test.NewWriter(t)
@@ -280,7 +286,7 @@ func TestClusterctlInitInfrastructureEnvMapError(t *testing.T) {
 
 	c := executables.NewClusterctl(executable, writer)
 
-	if err := c.InitInfrastructure(ctx, clusterSpec, &types.Cluster{Name: "cluster-name"}, provider); err == nil {
+	if err := c.InitInfrastructure(ctx, clusterSpec, cluster, provider); err == nil {
 		t.Fatal("Clusterctl.InitInfrastructure() error = nil")
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove temporary folder `pkg/executables/cluster-name` created by `clusterctl_test.go` at the end of the test

We currently do the same thing for another test as well, just copied the same logic for this test https://github.com/aws/eks-anywhere/blob/9063b9e623d90601c48e59feb637a1f43dd246a3/pkg/executables/clusterctl_test.go#L288-L294

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
