### PR TITLE
Clean up Flux paths

### DIFF
--- a/pkg/api/v1alpha1/gitopsconfig_types.go
+++ b/pkg/api/v1alpha1/gitopsconfig_types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"path"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -66,6 +68,11 @@ func (e *GitOpsConfigSpec) Equal(n *GitOpsConfigSpec) bool {
 		return false
 	}
 	return e.Flux == n.Flux
+}
+
+// ClusterRootPath is the root directory of the management and its workload clusters
+func (e *GitOpsConfigSpec) ClusterRootPath() string {
+	return path.Dir(e.Flux.Github.ClusterConfigPath)
 }
 
 //+kubebuilder:object:root=true

--- a/pkg/executables/flux.go
+++ b/pkg/executables/flux.go
@@ -3,7 +3,6 @@ package executables
 import (
 	"context"
 	"fmt"
-	"path"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/git/providers/github"
@@ -30,13 +29,14 @@ func NewFlux(executable Executable) *Flux {
 // components manifests to the main branch. Then it configures the target cluster to synchronize with the repository.
 // If the toolkit components are present on the cluster, the bootstrap command will perform an upgrade if needed.
 func (f *Flux) BootstrapToolkitsComponents(ctx context.Context, cluster *types.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) error {
-	c := gitOpsConfig.Spec.Flux.Github
+	gs := gitOpsConfig.Spec
+	c := gs.Flux.Github
 	params := []string{
 		"bootstrap",
 		gitProvider,
 		"--repository", c.Repository,
 		"--owner", c.Owner,
-		"--path", path.Dir(c.ClusterConfigPath),
+		"--path", gs.ClusterRootPath(),
 	}
 
 	if cluster.KubeconfigFile != "" {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Introduce GitOpsConfigSpec.ClusterRootPath() that returns the root directory of the management and its workload clusters
- Clean up fluxaddonclient fields

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
