### PR TITLE
output logs to cw for e2e tests

### DIFF
--- a/internal/pkg/ssm/command.go
+++ b/internal/pkg/ssm/command.go
@@ -36,6 +36,17 @@ func WithOutputToS3(bucket, dir string) CommandOpt {
 	}
 }
 
+func WithOutputToCloudwatch(logGroup string) CommandOpt {
+	return func(c *ssm.SendCommandInput) {
+		cwEnabled := true
+		cw := ssm.CloudWatchOutputConfig{
+			CloudWatchLogGroupName:  &logGroup,
+			CloudWatchOutputEnabled: &cwEnabled,
+		}
+		c.CloudWatchOutputConfig = &cw
+	}
+}
+
 var nonFinalStatuses = map[string]struct{}{
 	ssm.CommandInvocationStatusInProgress: {}, ssm.CommandInvocationStatusDelayed: {}, ssm.CommandInvocationStatusPending: {},
 }
@@ -43,6 +54,7 @@ var nonFinalStatuses = map[string]struct{}{
 // TODO: cleanup this method
 func Run(session *session.Session, instanceId string, command string, opts ...CommandOpt) error {
 	service := ssm.New(session)
+
 	c := &ssm.SendCommandInput{
 		DocumentName: aws.String("AWS-RunShellScript"),
 		InstanceIds:  []*string{aws.String(instanceId)},

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -29,6 +29,7 @@ type E2ESession struct {
 	amiId               string
 	instanceProfileName string
 	storageBucket       string
+	logGroup            string
 	jobId               string
 	subnetId            string
 	instanceId          string
@@ -36,7 +37,7 @@ type E2ESession struct {
 	bundlesOverride     bool
 }
 
-func newSession(amiId, instanceProfileName, storageBucket, jobId, subnetId string, bundlesOverride bool) (*E2ESession, error) {
+func newSession(amiId, instanceProfileName, storageBucket, logGroup, jobId, subnetId string, bundlesOverride bool) (*E2ESession, error) {
 	session, err := session.NewSession()
 	if err != nil {
 		return nil, fmt.Errorf("error creating session: %v", err)
@@ -47,6 +48,7 @@ func newSession(amiId, instanceProfileName, storageBucket, jobId, subnetId strin
 		amiId:               amiId,
 		instanceProfileName: instanceProfileName,
 		storageBucket:       storageBucket,
+		logGroup:            logGroup,
 		jobId:               jobId,
 		subnetId:            subnetId,
 		testEnvVars:         make(map[string]string),


### PR DESCRIPTION
*Description of changes:*

Add an option which adds CW logging to a ssm session run.

Logs will be output to the base log group, `/eks-anywhere/test/e2e`; if they have a 'parent job', in this case the job ID of the parallel configuration, it will be appended to the log group path; and then the job ID. So for a full path, it'd be like...
`/eks-anywhere/test/e2e/$JOB_ID/$JOB_ID_$TEST_NUMBER`

we will then be able to look at the logs for individual tests in isolation (solving the non-blocking io issue with print and goroutines which was messing with the ordering) and make it easier to look at non-truncated log outputs.

## NOTE
don't merge this yet, we need to ensure that the instance profile has sufficient permissions to write to the logstream

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
