### PR TITLE
Skeleton for new provider post upgrade changes

### DIFF
--- a/pkg/clusterapi/resourceset_manager.go
+++ b/pkg/clusterapi/resourceset_manager.go
@@ -1,0 +1,17 @@
+package clusterapi
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/types"
+)
+
+type ResourceSetManager struct {
+	client Client
+}
+
+type Client interface{}
+
+func (r *ResourceSetManager) ForceUpdate(ctx context.Context, name, namespace string, cluster *types.Cluster) error {
+	return nil
+}

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -338,6 +338,10 @@ func (c *ClusterManager) UpgradeCluster(ctx context.Context, managementCluster, 
 		return fmt.Errorf("error waiting for workload cluster capi components to be ready: %v", err)
 	}
 
+	if err = provider.RunPostUpgrade(ctx, clusterSpec, managementCluster, workloadCluster); err != nil {
+		return fmt.Errorf("failed running provider post upgrade: %v", err)
+	}
+
 	err = cluster.ApplyExtraObjects(ctx, c.clusterClient, workloadCluster, clusterSpec)
 	if err != nil {
 		return fmt.Errorf("error applying extra resources to workload cluster: %v", err)

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -421,3 +421,7 @@ func (p *provider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.Compone
 		OldVersion:    currentSpec.VersionsBundle.Docker.Version,
 	}
 }
+
+func (p *provider) RunPostUpgrade(ctx context.Context, clusterSpec *cluster.Spec, managementCluster, workloadCluster *types.Cluster) error {
+	return nil
+}

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -33,6 +33,7 @@ type Provider interface {
 	ValidateNewSpec(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
 	GenerateMHC() ([]byte, error)
 	ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff
+	RunPostUpgrade(ctx context.Context, clusterSpec *cluster.Spec, managementCluster, workloadCluster *types.Cluster) error
 }
 
 type DatacenterConfig interface {


### PR DESCRIPTION
*Description of changes:*
This is just a skeleton for the proposed solution to fix the issues we found on core component upgrades: vsphere `syncer`, `driver` and `manager` images don't ever get updated

I added comments on the code explaining why each action is needed and what should be the long term solution

I'm not super happy with this solution, so putting it out there ASAP to get feedback in case there concerns and or other possible solutions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
