### PR TITLE
Add clusterSpec.Equal method that replaces DeepEqual to compare spec

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"reflect"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -44,19 +46,57 @@ type ClusterSpec struct {
 	Management *bool `json:"management,omitempty"`
 }
 
+func (n *ClusterSpec) Equal(o *ClusterSpec) bool {
+	if n == o {
+		return true
+	}
+	if n == nil || o == nil {
+		return false
+	}
+	if n.KubernetesVersion != o.KubernetesVersion {
+		return false
+	}
+	if !n.ControlPlaneConfiguration.Equal(&o.ControlPlaneConfiguration) {
+		return false
+	}
+	if !reflect.DeepEqual(n.WorkerNodeGroupConfigurations, o.WorkerNodeGroupConfigurations) {
+		return false
+	}
+	if !n.DatacenterRef.Equal(&o.DatacenterRef) {
+		return false
+	}
+	if !RefSliceEqual(n.IdentityProviderRefs, o.IdentityProviderRefs) {
+		return false
+	}
+	if n.GitOpsRef.Equal(o.GitOpsRef) {
+		return false
+	}
+	if !n.ClusterNetwork.Equal(&o.ClusterNetwork) {
+		return false
+	}
+	if !n.ExternalEtcdConfiguration.Equal(o.ExternalEtcdConfiguration) {
+		return false
+	}
+	if !n.ProxyConfiguration.Equal(o.ProxyConfiguration) {
+		return false
+	}
+	if !n.RegistryMirrorConfiguration.Equal(o.RegistryMirrorConfiguration) {
+		return false
+	}
+	if n.isSelfManaged() != o.isSelfManaged() {
+		return false
+	}
+	return true
+}
+
+func (s *ClusterSpec) isSelfManaged() bool {
+	return s.Management == nil || *s.Management
+}
+
 type ProxyConfiguration struct {
 	HttpProxy  string   `json:"httpProxy,omitempty"`
 	HttpsProxy string   `json:"httpsProxy,omitempty"`
 	NoProxy    []string `json:"noProxy,omitempty"`
-}
-
-// RegistryMirrorConfiguration defines the settings for image registry mirror
-type RegistryMirrorConfiguration struct {
-	// Endpoint defines the registry mirror endpoint to use for pulling images
-	Endpoint string `json:"endpoint,omitempty"`
-
-	// CACertContent defines the contents registry mirror CA certificate
-	CACertContent string `json:"caCertContent,omitempty"`
 }
 
 func (n *ProxyConfiguration) Equal(o *ProxyConfiguration) bool {
@@ -69,6 +109,25 @@ func (n *ProxyConfiguration) Equal(o *ProxyConfiguration) bool {
 	return n.HttpProxy == o.HttpProxy && n.HttpsProxy == o.HttpsProxy && SliceEqual(n.NoProxy, o.NoProxy)
 }
 
+// RegistryMirrorConfiguration defines the settings for image registry mirror
+type RegistryMirrorConfiguration struct {
+	// Endpoint defines the registry mirror endpoint to use for pulling images
+	Endpoint string `json:"endpoint,omitempty"`
+
+	// CACertContent defines the contents registry mirror CA certificate
+	CACertContent string `json:"caCertContent,omitempty"`
+}
+
+func (n *RegistryMirrorConfiguration) Equal(o *RegistryMirrorConfiguration) bool {
+	if n == o {
+		return true
+	}
+	if n == nil || o == nil {
+		return false
+	}
+	return n.Endpoint == o.Endpoint && n.CACertContent == o.CACertContent
+}
+
 type ControlPlaneConfiguration struct {
 	// Count defines the number of desired control plane nodes. Defaults to 1.
 	Count int `json:"count,omitempty"`
@@ -76,6 +135,16 @@ type ControlPlaneConfiguration struct {
 	Endpoint *Endpoint `json:"endpoint,omitempty"`
 	// MachineGroupRef defines the machine group configuration for the control plane.
 	MachineGroupRef *Ref `json:"machineGroupRef,omitempty"`
+}
+
+func (n *ControlPlaneConfiguration) Equal(o *ControlPlaneConfiguration) bool {
+	if n == o {
+		return true
+	}
+	if n == nil || o == nil {
+		return false
+	}
+	return n.Count == o.Count && n.Endpoint.Equal(o.Endpoint) && n.MachineGroupRef.Equal(o.MachineGroupRef)
 }
 
 type Endpoint struct {
@@ -230,6 +299,16 @@ type ExternalEtcdConfiguration struct {
 	MachineGroupRef *Ref `json:"machineGroupRef,omitempty"`
 }
 
+func (n *ExternalEtcdConfiguration) Equal(o *ExternalEtcdConfiguration) bool {
+	if n == o {
+		return true
+	}
+	if n == nil || o == nil {
+		return false
+	}
+	return n.Count == o.Count && n.MachineGroupRef.Equal(o.MachineGroupRef)
+}
+
 // +kubebuilder:object:root=true
 // Cluster is the Schema for the clusters API
 type Cluster struct {
@@ -273,8 +352,8 @@ func (c *Cluster) EtcdAnnotation() string {
 	return etcdAnnotation
 }
 
-func (s *Cluster) IsSelfManaged() bool {
-	return s.Spec.Management == nil || *s.Spec.Management
+func (c *Cluster) IsSelfManaged() bool {
+	return c.Spec.isSelfManaged()
 }
 
 func (s *Cluster) SetManagedBy(managementClusterName string) {

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -182,6 +182,926 @@ func TestClusterManagementClusterEqual(t *testing.T) {
 	}
 }
 
+func TestClusterSpecEqualKubernetesVersion(t *testing.T) {
+	testCases := []struct {
+		testName                         string
+		cluster1Version, cluster2Version v1alpha1.KubernetesVersion
+		want                             bool
+	}{
+		{
+			testName:        "both empty",
+			cluster1Version: "",
+			cluster2Version: "",
+			want:            true,
+		},
+		{
+			testName:        "one empty, one exists",
+			cluster1Version: "",
+			cluster2Version: v1alpha1.Kube118,
+			want:            false,
+		},
+		{
+			testName:        "both exists, diff",
+			cluster1Version: v1alpha1.Kube118,
+			cluster2Version: v1alpha1.Kube119,
+			want:            false,
+		},
+		{
+			testName:        "both exists, same",
+			cluster1Version: v1alpha1.Kube118,
+			cluster2Version: v1alpha1.Kube118,
+			want:            true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			clusterSpec1 := &v1alpha1.ClusterSpec{
+				KubernetesVersion: tt.cluster1Version,
+			}
+			clusterSpec2 := &v1alpha1.ClusterSpec{
+				KubernetesVersion: tt.cluster2Version,
+			}
+
+			g := NewWithT(t)
+			g.Expect(clusterSpec1.Equal(clusterSpec2)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestClusterSpecEqualWorkerNodeGroupConfigurations(t *testing.T) {
+	testCases := []struct {
+		testName                   string
+		cluster1Wngs, cluster2Wngs []v1alpha1.WorkerNodeGroupConfiguration
+		want                       bool
+	}{
+		{
+			testName:     "both empty",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{},
+			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{},
+			want:         true,
+		},
+		{
+			testName: "one empty, one exists",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Count: 1,
+				},
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, same",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Count: 1,
+					MachineGroupRef: &v1alpha1.Ref{
+						Kind: "k",
+						Name: "n",
+					},
+				},
+			},
+			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Count: 1,
+					MachineGroupRef: &v1alpha1.Ref{
+						Kind: "k",
+						Name: "n",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			testName: "both exist, order diff",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Count: 1,
+					MachineGroupRef: &v1alpha1.Ref{
+						Kind: "k1",
+						Name: "n1",
+					},
+				},
+				{
+					Count: 2,
+					MachineGroupRef: &v1alpha1.Ref{
+						Kind: "k2",
+						Name: "n2",
+					},
+				},
+			},
+			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Count: 2,
+					MachineGroupRef: &v1alpha1.Ref{
+						Kind: "k2",
+						Name: "n2",
+					},
+				},
+				{
+					Count: 1,
+					MachineGroupRef: &v1alpha1.Ref{
+						Kind: "k1",
+						Name: "n1",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			testName: "both exist, count diff",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Count: 1,
+				},
+			},
+			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Count: 2,
+				},
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, ref diff",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					MachineGroupRef: &v1alpha1.Ref{
+						Kind: "k1",
+						Name: "n1",
+					},
+				},
+			},
+			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					MachineGroupRef: &v1alpha1.Ref{
+						Kind: "k2",
+						Name: "n2",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			clusterSpec1 := &v1alpha1.ClusterSpec{
+				WorkerNodeGroupConfigurations: tt.cluster1Wngs,
+			}
+			clusterSpec2 := &v1alpha1.ClusterSpec{
+				WorkerNodeGroupConfigurations: tt.cluster2Wngs,
+			}
+
+			g := NewWithT(t)
+			g.Expect(clusterSpec1.Equal(clusterSpec2)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestClusterSpecEqualDatacenterRef(t *testing.T) {
+	testCases := []struct {
+		testName                                     string
+		cluster1DatacenterRef, cluster2DatacenterRef v1alpha1.Ref
+		want                                         bool
+	}{
+		{
+			testName: "both empty",
+			want:     true,
+		},
+		{
+			testName: "one empty, one exists",
+			cluster1DatacenterRef: v1alpha1.Ref{
+				Kind: "k",
+				Name: "n",
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, diff",
+			cluster1DatacenterRef: v1alpha1.Ref{
+				Kind: "k1",
+				Name: "n1",
+			},
+			cluster2DatacenterRef: v1alpha1.Ref{
+				Kind: "k2",
+				Name: "n2",
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, same",
+			cluster1DatacenterRef: v1alpha1.Ref{
+				Kind: "k",
+				Name: "n",
+			},
+			cluster2DatacenterRef: v1alpha1.Ref{
+				Kind: "k",
+				Name: "n",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			clusterSpec1 := &v1alpha1.ClusterSpec{
+				DatacenterRef: tt.cluster1DatacenterRef,
+			}
+			clusterSpec2 := &v1alpha1.ClusterSpec{
+				DatacenterRef: tt.cluster2DatacenterRef,
+			}
+
+			g := NewWithT(t)
+			g.Expect(clusterSpec1.Equal(clusterSpec2)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestClusterSpecEqualIdentityProviderRefs(t *testing.T) {
+	testCases := []struct {
+		testName                 string
+		cluster1Ipr, cluster2Ipr []v1alpha1.Ref
+		want                     bool
+	}{
+		{
+			testName:    "both empty",
+			cluster1Ipr: []v1alpha1.Ref{},
+			cluster2Ipr: []v1alpha1.Ref{},
+			want:        true,
+		},
+		{
+			testName: "one empty, one exists",
+			cluster1Ipr: []v1alpha1.Ref{
+				{
+					Kind: "k",
+					Name: "n",
+				},
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, same",
+			cluster1Ipr: []v1alpha1.Ref{
+				{
+					Kind: "k",
+					Name: "n",
+				},
+			},
+			cluster2Ipr: []v1alpha1.Ref{
+				{
+					Kind: "k",
+					Name: "n",
+				},
+			},
+			want: true,
+		},
+		{
+			testName: "both exist, order diff",
+			cluster1Ipr: []v1alpha1.Ref{
+				{
+					Kind: "k1",
+					Name: "n1",
+				},
+				{
+					Kind: "k2",
+					Name: "n2",
+				},
+			},
+			cluster2Ipr: []v1alpha1.Ref{
+				{
+					Kind: "k2",
+					Name: "n2",
+				},
+				{
+					Kind: "k1",
+					Name: "n1",
+				},
+			},
+			want: true,
+		},
+		{
+			testName: "both exist, count diff",
+			cluster1Ipr: []v1alpha1.Ref{
+				{
+					Kind: "k1",
+					Name: "n1",
+				},
+			},
+			cluster2Ipr: []v1alpha1.Ref{
+				{
+					Kind: "k2",
+					Name: "n2",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			clusterSpec1 := &v1alpha1.ClusterSpec{
+				IdentityProviderRefs: tt.cluster1Ipr,
+			}
+			clusterSpec2 := &v1alpha1.ClusterSpec{
+				IdentityProviderRefs: tt.cluster2Ipr,
+			}
+
+			g := NewWithT(t)
+			g.Expect(clusterSpec1.Equal(clusterSpec2)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestClusterSpecEqualGitOpsRef(t *testing.T) {
+	testCases := []struct {
+		testName                             string
+		cluster1GitOpsRef, cluster2GitOpsRef *v1alpha1.Ref
+		want                                 bool
+	}{
+		{
+			testName:          "both nil",
+			cluster1GitOpsRef: nil,
+			cluster2GitOpsRef: nil,
+			want:              true,
+		},
+		{
+			testName: "one nil, one exists",
+			cluster1GitOpsRef: &v1alpha1.Ref{
+				Kind: "k",
+				Name: "n",
+			},
+			cluster2GitOpsRef: nil,
+			want:              false,
+		},
+		{
+			testName: "both exist, diff",
+			cluster1GitOpsRef: &v1alpha1.Ref{
+				Kind: "k1",
+				Name: "n1",
+			},
+			cluster2GitOpsRef: &v1alpha1.Ref{
+				Kind: "k2",
+				Name: "n2",
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, same",
+			cluster1GitOpsRef: &v1alpha1.Ref{
+				Kind: "k",
+				Name: "n",
+			},
+			cluster2GitOpsRef: &v1alpha1.Ref{
+				Kind: "k",
+				Name: "n",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			clusterSpec1 := &v1alpha1.ClusterSpec{
+				GitOpsRef: tt.cluster1GitOpsRef,
+			}
+			clusterSpec2 := &v1alpha1.ClusterSpec{
+				GitOpsRef: tt.cluster2GitOpsRef,
+			}
+
+			g := NewWithT(t)
+			g.Expect(clusterSpec1.Equal(clusterSpec2)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestClusterSpecEqualClusterNetwork(t *testing.T) {
+	testCases := []struct {
+		testName                                       string
+		cluster1ClusterNetwork, cluster2ClusterNetwork v1alpha1.ClusterNetwork
+		want                                           bool
+	}{
+		{
+			testName:               "both nil",
+			cluster1ClusterNetwork: v1alpha1.ClusterNetwork{},
+			cluster2ClusterNetwork: v1alpha1.ClusterNetwork{},
+			want:                   true,
+		},
+		{
+			testName: "one empty, one exists",
+			cluster1ClusterNetwork: v1alpha1.ClusterNetwork{
+				Pods: v1alpha1.Pods{
+					CidrBlocks: []string{
+						"1.2.3.4/5",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, diff",
+			cluster1ClusterNetwork: v1alpha1.ClusterNetwork{
+				Pods: v1alpha1.Pods{
+					CidrBlocks: []string{
+						"1.2.3.4/5",
+					},
+				},
+			},
+			cluster2ClusterNetwork: v1alpha1.ClusterNetwork{
+				Pods: v1alpha1.Pods{
+					CidrBlocks: []string{
+						"1.2.3.4/6",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, same",
+			cluster1ClusterNetwork: v1alpha1.ClusterNetwork{
+				Pods: v1alpha1.Pods{
+					CidrBlocks: []string{
+						"1.2.3.4/5",
+					},
+				},
+			},
+			cluster2ClusterNetwork: v1alpha1.ClusterNetwork{
+				Pods: v1alpha1.Pods{
+					CidrBlocks: []string{
+						"1.2.3.4/5",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			clusterSpec1 := &v1alpha1.ClusterSpec{
+				ClusterNetwork: tt.cluster1ClusterNetwork,
+			}
+			clusterSpec2 := &v1alpha1.ClusterSpec{
+				ClusterNetwork: tt.cluster2ClusterNetwork,
+			}
+
+			g := NewWithT(t)
+			g.Expect(clusterSpec1.Equal(clusterSpec2)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestClusterSpecEqualExternalEtcdConfiguration(t *testing.T) {
+	testCases := []struct {
+		testName                   string
+		cluster1Etcd, cluster2Etcd *v1alpha1.ExternalEtcdConfiguration
+		want                       bool
+	}{
+		{
+			testName:     "both nil",
+			cluster1Etcd: nil,
+			cluster2Etcd: nil,
+			want:         true,
+		},
+		{
+			testName: "one nil, one exists",
+			cluster1Etcd: &v1alpha1.ExternalEtcdConfiguration{
+				Count: 1,
+				MachineGroupRef: &v1alpha1.Ref{
+					Kind: "k",
+					Name: "n",
+				},
+			},
+			cluster2Etcd: nil,
+			want:         false,
+		},
+		{
+			testName: "both exist, same",
+			cluster1Etcd: &v1alpha1.ExternalEtcdConfiguration{
+				Count: 1,
+				MachineGroupRef: &v1alpha1.Ref{
+					Kind: "k",
+					Name: "n",
+				},
+			},
+			cluster2Etcd: &v1alpha1.ExternalEtcdConfiguration{
+				Count: 1,
+				MachineGroupRef: &v1alpha1.Ref{
+					Kind: "k",
+					Name: "n",
+				},
+			},
+			want: true,
+		},
+		{
+			testName: "both exist, count diff",
+			cluster1Etcd: &v1alpha1.ExternalEtcdConfiguration{
+				Count: 1,
+				MachineGroupRef: &v1alpha1.Ref{
+					Kind: "k",
+					Name: "n",
+				},
+			},
+			cluster2Etcd: &v1alpha1.ExternalEtcdConfiguration{
+				Count: 2,
+				MachineGroupRef: &v1alpha1.Ref{
+					Kind: "k",
+					Name: "n",
+				},
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, ref diff",
+			cluster1Etcd: &v1alpha1.ExternalEtcdConfiguration{
+				Count: 1,
+				MachineGroupRef: &v1alpha1.Ref{
+					Kind: "k1",
+					Name: "n1",
+				},
+			},
+			cluster2Etcd: &v1alpha1.ExternalEtcdConfiguration{
+				Count: 1,
+				MachineGroupRef: &v1alpha1.Ref{
+					Kind: "k2",
+					Name: "n2",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			clusterSpec1 := &v1alpha1.ClusterSpec{
+				ExternalEtcdConfiguration: tt.cluster1Etcd,
+			}
+			clusterSpec2 := &v1alpha1.ClusterSpec{
+				ExternalEtcdConfiguration: tt.cluster2Etcd,
+			}
+
+			g := NewWithT(t)
+			g.Expect(clusterSpec1.Equal(clusterSpec2)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestClusterSpecEqualProxyConfiguration(t *testing.T) {
+	testCases := []struct {
+		testName                     string
+		cluster1Proxy, cluster2Proxy *v1alpha1.ProxyConfiguration
+		want                         bool
+	}{
+		{
+			testName:      "both nil",
+			cluster1Proxy: nil,
+			cluster2Proxy: nil,
+			want:          true,
+		},
+		{
+			testName: "one nil, one exists",
+			cluster1Proxy: &v1alpha1.ProxyConfiguration{
+				HttpProxy: "1.2.3.4",
+			},
+			cluster2Proxy: nil,
+			want:          false,
+		},
+		{
+			testName: "both exist, same",
+			cluster1Proxy: &v1alpha1.ProxyConfiguration{
+				HttpProxy: "1.2.3.4",
+			},
+			cluster2Proxy: &v1alpha1.ProxyConfiguration{
+				HttpProxy: "1.2.3.4",
+			},
+			want: true,
+		},
+		{
+			testName: "both exist, diff",
+			cluster1Proxy: &v1alpha1.ProxyConfiguration{
+				HttpProxy: "1.2.3.4",
+			},
+			cluster2Proxy: &v1alpha1.ProxyConfiguration{
+				HttpProxy: "1.2.3.5",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			clusterSpec1 := &v1alpha1.ClusterSpec{
+				ProxyConfiguration: tt.cluster1Proxy,
+			}
+			clusterSpec2 := &v1alpha1.ClusterSpec{
+				ProxyConfiguration: tt.cluster2Proxy,
+			}
+
+			g := NewWithT(t)
+			g.Expect(clusterSpec1.Equal(clusterSpec2)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestClusterSpecEqualRegistryMirrorConfiguration(t *testing.T) {
+	testCases := []struct {
+		testName                   string
+		cluster1Regi, cluster2Regi *v1alpha1.RegistryMirrorConfiguration
+		want                       bool
+	}{
+		{
+			testName:     "both nil",
+			cluster1Regi: nil,
+			cluster2Regi: nil,
+			want:         true,
+		},
+		{
+			testName: "one nil, one exists",
+			cluster1Regi: &v1alpha1.RegistryMirrorConfiguration{
+				Endpoint:      "1.2.3.4",
+				CACertContent: "ca",
+			},
+			cluster2Regi: nil,
+			want:         false,
+		},
+		{
+			testName: "both exist, same",
+			cluster1Regi: &v1alpha1.RegistryMirrorConfiguration{
+				Endpoint:      "1.2.3.4",
+				CACertContent: "ca",
+			},
+			cluster2Regi: &v1alpha1.RegistryMirrorConfiguration{
+				Endpoint:      "1.2.3.4",
+				CACertContent: "ca",
+			},
+			want: true,
+		},
+		{
+			testName: "both exist, diff",
+			cluster1Regi: &v1alpha1.RegistryMirrorConfiguration{
+				Endpoint:      "1.2.3.4",
+				CACertContent: "ca",
+			},
+			cluster2Regi: &v1alpha1.RegistryMirrorConfiguration{
+				Endpoint:      "1.2.3.5",
+				CACertContent: "ca",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			clusterSpec1 := &v1alpha1.ClusterSpec{
+				RegistryMirrorConfiguration: tt.cluster1Regi,
+			}
+			clusterSpec2 := &v1alpha1.ClusterSpec{
+				RegistryMirrorConfiguration: tt.cluster2Regi,
+			}
+
+			g := NewWithT(t)
+			g.Expect(clusterSpec1.Equal(clusterSpec2)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestClusterSpecEqualManagement(t *testing.T) {
+	testCases := []struct {
+		testName                               string
+		cluster1Management, cluster2Management *bool
+		want                                   bool
+	}{
+		{
+			testName:           "both nil",
+			cluster1Management: nil,
+			cluster2Management: nil,
+			want:               true,
+		},
+		{
+			testName:           "one nil, one true",
+			cluster1Management: boolPointer(true),
+			cluster2Management: nil,
+			want:               true,
+		},
+		{
+			testName:           "one nil, one false",
+			cluster1Management: boolPointer(false),
+			cluster2Management: nil,
+			want:               false,
+		},
+		{
+			testName:           "one true, one false",
+			cluster1Management: boolPointer(true),
+			cluster2Management: boolPointer(false),
+			want:               false,
+		},
+		{
+			testName:           "both true",
+			cluster1Management: boolPointer(true),
+			cluster2Management: boolPointer(true),
+			want:               true,
+		},
+		{
+			testName:           "both false",
+			cluster1Management: boolPointer(false),
+			cluster2Management: boolPointer(false),
+			want:               true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			clusterSpec1 := &v1alpha1.ClusterSpec{
+				Management: tt.cluster1Management,
+			}
+			clusterSpec2 := &v1alpha1.ClusterSpec{
+				Management: tt.cluster2Management,
+			}
+
+			g := NewWithT(t)
+			g.Expect(clusterSpec1.Equal(clusterSpec2)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestControlPlaneConfigurationEqual(t *testing.T) {
+	testCases := []struct {
+		testName                           string
+		cluster1CPConfig, cluster2CPConfig *v1alpha1.ControlPlaneConfiguration
+		want                               bool
+	}{
+		{
+			testName: "both exist, same",
+			cluster1CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Count: 1,
+				Endpoint: &v1alpha1.Endpoint{
+					Host: "1.2.3.4",
+				},
+				MachineGroupRef: &v1alpha1.Ref{
+					Kind: "k",
+					Name: "n",
+				},
+			},
+			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Count: 1,
+				Endpoint: &v1alpha1.Endpoint{
+					Host: "1.2.3.4",
+				},
+				MachineGroupRef: &v1alpha1.Ref{
+					Kind: "k",
+					Name: "n",
+				},
+			},
+			want: true,
+		},
+		{
+			testName: "one nil, one exists",
+			cluster1CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Count: 1,
+				Endpoint: &v1alpha1.Endpoint{
+					Host: "1.2.3.4",
+				},
+				MachineGroupRef: &v1alpha1.Ref{
+					Kind: "k",
+					Name: "n",
+				},
+			},
+			cluster2CPConfig: nil,
+			want:             false,
+		},
+		{
+			testName: "one nil, one exists",
+			cluster1CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Count: 1,
+				Endpoint: &v1alpha1.Endpoint{
+					Host: "1.2.3.4",
+				},
+				MachineGroupRef: &v1alpha1.Ref{
+					Kind: "k",
+					Name: "n",
+				},
+			},
+			cluster2CPConfig: nil,
+			want:             false,
+		},
+		{
+			testName: "count exists, diff",
+			cluster1CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Count: 1,
+			},
+			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Count: 2,
+			},
+			want: false,
+		},
+		{
+			testName: "one count empty",
+			cluster1CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Count: 1,
+			},
+			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{},
+			want:             false,
+		},
+		{
+			testName: "endpoint diff",
+			cluster1CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Endpoint: &v1alpha1.Endpoint{
+					Host: "1.2.3.4",
+				},
+			},
+			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Endpoint: &v1alpha1.Endpoint{
+					Host: "1.2.3.5",
+				},
+			},
+			want: false,
+		},
+		{
+			testName: "one endpoint empty",
+			cluster1CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Endpoint: &v1alpha1.Endpoint{
+					Host: "1.2.3.4",
+				},
+			},
+			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Endpoint: nil,
+			},
+			want: false,
+		},
+		{
+			testName: "both endpoints empty",
+			cluster1CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Endpoint: &v1alpha1.Endpoint{
+					Host: "",
+				},
+			},
+			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Endpoint: &v1alpha1.Endpoint{},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.cluster1CPConfig.Equal(tt.cluster2CPConfig)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestRegistryMirrorConfigurationEqual(t *testing.T) {
+	testCases := []struct {
+		testName                   string
+		cluster1Regi, cluster2Regi *v1alpha1.RegistryMirrorConfiguration
+		want                       bool
+	}{
+		{
+			testName:     "both nil",
+			cluster1Regi: nil,
+			cluster2Regi: nil,
+			want:         true,
+		},
+		{
+			testName: "one nil, one exists",
+			cluster1Regi: &v1alpha1.RegistryMirrorConfiguration{
+				Endpoint:      "1.2.3.4",
+				CACertContent: "ca",
+			},
+			cluster2Regi: nil,
+			want:         false,
+		},
+		{
+			testName: "both exist, same",
+			cluster1Regi: &v1alpha1.RegistryMirrorConfiguration{
+				Endpoint:      "1.2.3.4",
+				CACertContent: "ca",
+			},
+			cluster2Regi: &v1alpha1.RegistryMirrorConfiguration{
+				Endpoint:      "1.2.3.4",
+				CACertContent: "ca",
+			},
+			want: true,
+		},
+		{
+			testName: "both exist, endpoint diff",
+			cluster1Regi: &v1alpha1.RegistryMirrorConfiguration{
+				Endpoint:      "1.2.3.4",
+				CACertContent: "",
+			},
+			cluster2Regi: &v1alpha1.RegistryMirrorConfiguration{
+				Endpoint: "1.2.3.5",
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, ca diff",
+			cluster1Regi: &v1alpha1.RegistryMirrorConfiguration{
+				CACertContent: "ca1",
+			},
+			cluster2Regi: &v1alpha1.RegistryMirrorConfiguration{
+				CACertContent: "ca2",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.cluster1Regi.Equal(tt.cluster2Regi)).To(Equal(tt.want))
+		})
+	}
+}
+
 func setSelfManaged(c *v1alpha1.Cluster, s bool) {
 	if s {
 		c.SetSelfManaged()

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -352,7 +352,7 @@ func (c *ClusterManager) EKSAClusterSpecChanged(ctx context.Context, cluster *ty
 		return false, err
 	}
 
-	if !reflect.DeepEqual(cc.Spec, newClusterSpec.Spec) {
+	if cc.Spec.Equal(&newClusterSpec.Spec) {
 		logger.V(3).Info("Existing cluster and new cluster spec differ")
 		return true, nil
 	}

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -352,7 +352,7 @@ func (c *ClusterManager) EKSAClusterSpecChanged(ctx context.Context, cluster *ty
 		return false, err
 	}
 
-	if cc.Spec.Equal(&newClusterSpec.Spec) {
+	if !cc.Spec.Equal(&newClusterSpec.Spec) {
 		logger.V(3).Info("Existing cluster and new cluster spec differ")
 		return true, nil
 	}


### PR DESCRIPTION
*Issue #, if available:*

When we check if the cluster config has changed (EKSAClusterSpecChanged), in order to determine if we need to upgrade or not, we use reflect.DeepEqual(cc.Spec, newClusterSpec.Spec)

Currently, that always returns false, because cc doesn’t have the management boolean (it’s a nil pointer) and newClusterSpec has it, bc we set it in the upgrade flow

*Description of changes:*

- Add clusterSpec.Equal method that replaces DeepEqual
- Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
