### PR TITLE
quick fix for integ test job name not matching cw log group

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -92,9 +92,11 @@ func (i *instanceRunConf) cloudwatchLogGroup() string {
 	var path []string
 	path = append(path, baseLogGroup)
 	if i.parentJobId != "" {
-		path = append(path, i.parentJobId)
+		j := strings.ReplaceAll(i.parentJobId, ":", "-")
+		path = append(path, j)
 	}
-	path = append(path, i.jobId)
+	j := strings.ReplaceAll(i.parentJobId, ":", "-")
+	path = append(path, j)
 	return strings.Join(path, "/")
 }
 


### PR DESCRIPTION
*Description of changes:*

We started using the 'jobId' as the CloudWatch log group name for the SSM jobs in e2e tests -- turns out, there's a `:` in those job IDs. This is a quick fix to address this right now, a follow-up pr will come with a regex to validate each section prior and default to no cw logging if the log groups are constructed incorrectly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
