### PR TITLE
specify only base log group for SSM cw output

### DIFF
--- a/internal/pkg/ssm/command.go
+++ b/internal/pkg/ssm/command.go
@@ -14,6 +14,8 @@ import (
 	"github.com/aws/eks-anywhere/pkg/retrier"
 )
 
+const ssmLogGroup = "/eks-anywhere/test/e2e"
+
 var initE2EDirCommand = "mkdir -p /home/e2e/bin && cd /home/e2e"
 
 func WaitForSSMReady(session *session.Session, instanceId string) error {
@@ -36,9 +38,10 @@ func WithOutputToS3(bucket, dir string) CommandOpt {
 	}
 }
 
-func WithOutputToCloudwatch(logGroup string) CommandOpt {
+func WithOutputToCloudwatch() CommandOpt {
 	return func(c *ssm.SendCommandInput) {
 		cwEnabled := true
+		logGroup := ssmLogGroup
 		cw := ssm.CloudWatchOutputConfig{
 			CloudWatchLogGroupName:  &logGroup,
 			CloudWatchOutputEnabled: &cwEnabled,

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -13,7 +13,6 @@ import (
 const (
 	passedStatus = "pass"
 	failedStatus = "fail"
-	baseLogGroup = "/eks-anywhere/test/e2e"
 )
 
 type ParallelRunConf struct {
@@ -88,20 +87,8 @@ type instanceRunConf struct {
 	bundlesOverride                                                                            bool
 }
 
-func (i *instanceRunConf) cloudwatchLogGroup() string {
-	var path []string
-	path = append(path, baseLogGroup)
-	if i.parentJobId != "" {
-		j := strings.ReplaceAll(i.parentJobId, ":", "-")
-		path = append(path, j)
-	}
-	j := strings.ReplaceAll(i.parentJobId, ":", "-")
-	path = append(path, j)
-	return strings.Join(path, "/")
-}
-
 func RunTests(conf instanceRunConf) (testInstanceID string, err error) {
-	session, err := newSession(conf.amiId, conf.instanceProfileName, conf.storageBucket, conf.cloudwatchLogGroup(), conf.jobId, conf.subnetId, conf.bundlesOverride)
+	session, err := newSession(conf.amiId, conf.instanceProfileName, conf.storageBucket, conf.jobId, conf.subnetId, conf.bundlesOverride)
 	if err != nil {
 		return "", err
 	}
@@ -128,7 +115,7 @@ func (e *E2ESession) runTests(regex string) error {
 
 	command = e.commandWithEnvVars(command)
 
-	opt := ssm.WithOutputToCloudwatch(e.logGroup)
+	opt := ssm.WithOutputToCloudwatch()
 
 	err := ssm.Run(
 		e.session,

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -29,7 +29,6 @@ type E2ESession struct {
 	amiId               string
 	instanceProfileName string
 	storageBucket       string
-	logGroup            string
 	jobId               string
 	subnetId            string
 	instanceId          string
@@ -37,7 +36,7 @@ type E2ESession struct {
 	bundlesOverride     bool
 }
 
-func newSession(amiId, instanceProfileName, storageBucket, logGroup, jobId, subnetId string, bundlesOverride bool) (*E2ESession, error) {
+func newSession(amiId, instanceProfileName, storageBucket, jobId, subnetId string, bundlesOverride bool) (*E2ESession, error) {
 	session, err := session.NewSession()
 	if err != nil {
 		return nil, fmt.Errorf("error creating session: %v", err)
@@ -48,7 +47,6 @@ func newSession(amiId, instanceProfileName, storageBucket, logGroup, jobId, subn
 		amiId:               amiId,
 		instanceProfileName: instanceProfileName,
 		storageBucket:       storageBucket,
-		logGroup:            logGroup,
 		jobId:               jobId,
 		subnetId:            subnetId,
 		testEnvVars:         make(map[string]string),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix SSM CW output.

By default, if CW logging is enabled, SSM run command outputs the logs to `/aws/ssm/SystemsManagerDocumentName` in the format:
```
CommandID/InstanceID/PluginID/stdout
CommandID/InstanceID/PluginID/stderr
```
Be default, it will create the log-group if it dosen't exist.

I thought this auto-creation would also happen with a user-specified log group. Turns out, that's not the case.
So, I've created the log group (already merged) and now we're just telling the SSM command to use that base log group, and the command execution should save the stdout and stderr as indicated above. 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

so now we'll get the logs at the path `/eks-anywhere/test/e2e/CommandID/InstanceId/PluginID`

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
