### PR TITLE
increase s3 object retention to one week

### DIFF
--- a/internal/test/e2e/cleanup.go
+++ b/internal/test/e2e/cleanup.go
@@ -41,7 +41,12 @@ func CleanUpAwsTestResources(storageBucket string, maxAge string, tag string) er
 		logger.V(1).Info("No EC2 instances available for termination")
 	}
 	logger.V(1).Info("Clean up s3 bucket objects")
-	err = s3.CleanUpS3Bucket(session, storageBucket, maxAgeFloat)
+	s3MaxAge := "604800" // one week
+	s3MaxAgeFloat, err := strconv.ParseFloat(s3MaxAge, 64)
+	if err != nil {
+		return fmt.Errorf("error parsing S3 max age: %v", err)
+	}
+	err = s3.CleanUpS3Bucket(session, storageBucket, s3MaxAgeFloat)
 	if err != nil {
 		return fmt.Errorf("error clean up s3 bucket objects: %v", err)
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
quick adjustment to ensure we're retaining test artifacts. 
this will ensure we're retaining the binaries (reproducable executions) alongside artifacts like the support bundle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
