### PR TITLE
Add commands to list OVAs and download artifacts used by EKS Anywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/public.zip
 cluster.yaml
 eksa-test
 generated/
+eks-anywhere-downloads*

--- a/cmd/eksctl-anywhere/cmd/download.go
+++ b/cmd/eksctl-anywhere/cmd/download.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var downloadCmd = &cobra.Command{
+	Use:   "download",
+	Short: "Download resources",
+	Long:  "Use eksctl anywhere download to download artifacts (manifests, bundles) used by EKS Anywhere",
+}
+
+func init() {
+	rootCmd.AddCommand(downloadCmd)
+}

--- a/cmd/eksctl-anywhere/cmd/downloadartifacts.go
+++ b/cmd/eksctl-anywhere/cmd/downloadartifacts.go
@@ -1,0 +1,201 @@
+package cmd
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/version"
+)
+
+type downloadArtifactsOptions struct {
+	downloadDir string
+	fileName    string
+	dryRun      bool
+	retainDir   bool
+}
+
+var downloadArtifactsopts = &downloadArtifactsOptions{}
+
+func init() {
+	downloadCmd.AddCommand(downloadArtifactsCmd)
+	downloadArtifactsCmd.Flags().StringVarP(&downloadArtifactsopts.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
+	downloadArtifactsCmd.Flags().StringVarP(&downloadArtifactsopts.downloadDir, "download-dir", "d", "eks-anywhere-downloads", "Directory to download the artifacts to")
+	downloadArtifactsCmd.Flags().BoolVarP(&downloadArtifactsopts.dryRun, "dry-run", "", false, "Print the manifest URIs without downloading them")
+	downloadArtifactsCmd.Flags().BoolVarP(&downloadArtifactsopts.retainDir, "retain-dir", "r", false, "Do not delete the download folder after creating a tarball")
+	err := downloadArtifactsCmd.MarkFlagRequired("filename")
+	if err != nil {
+		log.Fatalf("Error marking filename flag as required: %v", err)
+	}
+}
+
+var downloadArtifactsCmd = &cobra.Command{
+	Use:          "artifacts",
+	Short:        "Download EKS Anywhere artifacts/manifests to a tarball on disk",
+	Long:         "This command is used to download the S3 artifacts from an EKS Anywhere bundle manifest and package them into a tarball",
+	PreRunE:      preRunDownloadArtifactsCmd,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := downloadArtifacts(cmd.Context(), downloadArtifactsopts); err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func downloadArtifacts(context context.Context, opts *downloadArtifactsOptions) error {
+	cliVersion := version.Get()
+	clusterSpec, err := cluster.NewSpec(opts.fileName, cliVersion)
+	if err != nil {
+		return err
+	}
+
+	release, err := clusterSpec.GetRelease(cliVersion)
+	if err != nil {
+		return err
+	}
+	bundlesManifestUrl := release.BundleManifestUrl
+
+	specManifests := []string{
+		bundlesManifestUrl,
+		clusterSpec.GetReleaseManifestUrl(),
+	}
+	for _, manifestURI := range specManifests {
+		if opts.dryRun {
+			logger.Info(fmt.Sprintf("Found artifact: %s\n", manifestURI))
+			continue
+		}
+		if err = downloadArtifact("", opts.downloadDir, manifestURI, clusterSpec); err != nil {
+			return fmt.Errorf("error downloading artifact: %v", err)
+		}
+	}
+
+	bundle := clusterSpec.VersionsBundle
+	for component, manifestList := range bundle.Manifests() {
+		for _, manifest := range manifestList {
+			if opts.dryRun {
+				logger.Info(fmt.Sprintf("Found artifact: %s\n", manifest.URI))
+				continue
+			}
+			if err = downloadArtifact(component, opts.downloadDir, manifest.URI, clusterSpec); err != nil {
+				return fmt.Errorf("error downloading artifact for component %s: %v", component, err)
+			}
+		}
+	}
+
+	if !opts.dryRun {
+		if err = createTarball(opts.downloadDir); err != nil {
+			return err
+		}
+
+		if !opts.retainDir {
+			if err = os.RemoveAll(opts.downloadDir); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func preRunDownloadArtifactsCmd(cmd *cobra.Command, args []string) error {
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if err := viper.BindPFlag(flag.Name, flag); err != nil {
+			log.Fatalf("Error initializing flags: %v", err)
+		}
+	})
+	return nil
+}
+
+func downloadArtifact(component, downloadDir, artifactUri string, s *cluster.Spec) error {
+	logger.V(3).Info(fmt.Sprintf("Downloading artifact: %s", artifactUri))
+
+	fileName := filepath.Base(artifactUri)
+
+	var filePath string
+	if component != "" {
+		filePath = filepath.Join(downloadDir, component, fileName)
+	} else {
+		filePath = filepath.Join(downloadDir, fileName)
+	}
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		return err
+	}
+
+	logger.V(3).Info(fmt.Sprintf("Creating local artifact file: %s", filePath))
+
+	contents, err := s.ReadFile(artifactUri)
+	if err != nil {
+		return err
+	}
+	if err = ioutil.WriteFile(filePath, contents, 0o644); err != nil {
+		return err
+	}
+
+	logger.V(3).Info(fmt.Sprintf("Successfully downloaded artifact %s to %s", artifactUri, filePath))
+
+	return nil
+}
+
+func createTarball(downloadDir string) error {
+	var buf bytes.Buffer
+	tarFileName := fmt.Sprintf("%s.tar.gz", downloadDir)
+	tarFile, err := os.Create(tarFileName)
+	if err != nil {
+		return err
+	}
+	defer tarFile.Close()
+
+	gzipWriter := gzip.NewWriter(&buf)
+	defer gzipWriter.Close()
+
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	err = filepath.Walk(downloadDir, func(file string, fileInfo os.FileInfo, walkErr error) error {
+		header, err := tar.FileInfoHeader(fileInfo, file)
+		if err != nil {
+			return err
+		}
+
+		header.Name = filepath.ToSlash(file)
+
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return err
+		}
+		if !fileInfo.IsDir() {
+			data, err := os.Open(file)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(tarWriter, data); err != nil {
+				return err
+			}
+			logger.V(3).Info(fmt.Sprintf("Added file %s to tarball", file))
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if _, err = io.Copy(tarFile, &buf); err != nil {
+		return err
+	}
+	logger.V(3).Info(fmt.Sprintf("Successfully created downloads tarball %s", tarFileName))
+
+	return nil
+}

--- a/cmd/eksctl-anywhere/cmd/list.go
+++ b/cmd/eksctl-anywhere/cmd/list.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List resources",
+	Long:  "Use eksctl anywhere list to list images and artifacts used by EKS Anywhere",
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}

--- a/cmd/eksctl-anywhere/cmd/listovas.go
+++ b/cmd/eksctl-anywhere/cmd/listovas.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"sigs.k8s.io/yaml"
+
+	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/version"
+)
+
+type listOvasOptions struct {
+	fileName string
+}
+
+type listOvasOutput struct {
+	URI    string
+	SHA256 string
+	SHA512 string
+}
+
+var listOvaOpts = &listOvasOptions{}
+
+func init() {
+	listCmd.AddCommand(listOvasCmd)
+	listOvasCmd.Flags().StringVarP(&listOvaOpts.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
+	err := listOvasCmd.MarkFlagRequired("filename")
+	if err != nil {
+		log.Fatalf("Error marking filename flag as required: %v", err)
+	}
+}
+
+var listOvasCmd = &cobra.Command{
+	Use:          "ovas",
+	Short:        "List the OVAs that are supported by current version of EKS Anywhere",
+	Long:         "This command is used to list the vSphere OVAs from the EKS Anywhere bundle manifest for the current version of the EKS Anywhere CLI",
+	PreRunE:      preRunListOvasCmd,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := listOvas(cmd.Context(), listOvaOpts.fileName); err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func listOvas(context context.Context, spec string) error {
+	clusterSpec, err := cluster.NewSpec(spec, version.Get())
+	if err != nil {
+		return err
+	}
+
+	bundle := clusterSpec.VersionsBundle
+
+	for _, ova := range bundle.Ovas() {
+		if strings.Contains(ova.URI, string(eksav1alpha1.Bottlerocket)) {
+			fmt.Printf("%s:\n", strings.Title(string(eksav1alpha1.Bottlerocket)))
+		} else {
+			fmt.Printf("%s:\n", strings.Title(string(eksav1alpha1.Ubuntu)))
+		}
+		output := listOvasOutput{
+			URI:    ova.URI,
+			SHA256: ova.SHA256,
+			SHA512: ova.SHA512,
+		}
+		yamlOutput, err := yaml.Marshal(output)
+		if err != nil {
+			return err
+		}
+		fmt.Println(yamlIndent(2, string(yamlOutput)))
+	}
+
+	return nil
+}
+
+func preRunListOvasCmd(cmd *cobra.Command, args []string) error {
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		err := viper.BindPFlag(flag.Name, flag)
+		if err != nil {
+			log.Fatalf("Error initializing flags: %v", err)
+		}
+	})
+	return nil
+}
+
+func yamlIndent(level int, yamlString string) string {
+	indentation := strings.Repeat(" ", level)
+	indentedString := fmt.Sprintf("%s%s", indentation, strings.Replace(yamlString, "\n", "\n"+indentation, -1))
+	return indentedString
+}

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -288,7 +288,7 @@ func (s *Spec) getVersionsBundle(clusterConfig *eksav1alpha1.Cluster, bundles *v
 func (s *Spec) GetBundles(cliVersion version.Info) (*v1alpha1.Bundles, error) {
 	bundlesURL := s.bundlesManifestURL
 	if bundlesURL == "" {
-		release, err := s.getRelease(cliVersion)
+		release, err := s.GetRelease(cliVersion)
 		if err != nil {
 			return nil, err
 		}
@@ -297,7 +297,7 @@ func (s *Spec) GetBundles(cliVersion version.Info) (*v1alpha1.Bundles, error) {
 	}
 
 	logger.V(4).Info("Reading bundles manifest", "url", bundlesURL)
-	content, err := s.readFile(bundlesURL)
+	content, err := s.ReadFile(bundlesURL)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ func (s *Spec) GetBundles(cliVersion version.Info) (*v1alpha1.Bundles, error) {
 	return bundles, nil
 }
 
-func (s *Spec) getRelease(cliVersion version.Info) (*v1alpha1.EksARelease, error) {
+func (s *Spec) GetRelease(cliVersion version.Info) (*v1alpha1.EksARelease, error) {
 	cliSemVersion, err := semver.New(cliVersion.GitVersion)
 	if err != nil {
 		return nil, fmt.Errorf("invalid cli version: %v", err)
@@ -337,7 +337,7 @@ func (s *Spec) getRelease(cliVersion version.Info) (*v1alpha1.EksARelease, error
 
 func (s *Spec) getReleases(releasesManifest string) (*v1alpha1.Release, error) {
 	logger.V(4).Info("Reading releases manifest", "url", releasesManifestURL)
-	content, err := s.readFile(releasesManifest)
+	content, err := s.ReadFile(releasesManifest)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +350,7 @@ func (s *Spec) getReleases(releasesManifest string) (*v1alpha1.Release, error) {
 	return releases, nil
 }
 
-func (s *Spec) readFile(uri string) ([]byte, error) {
+func (s *Spec) ReadFile(uri string) ([]byte, error) {
 	url, err := url.Parse(uri)
 	if err != nil {
 		return nil, fmt.Errorf("can't build cluster spec, invalid release manifest url: %v", err)
@@ -358,15 +358,15 @@ func (s *Spec) readFile(uri string) ([]byte, error) {
 
 	switch url.Scheme {
 	case httpsScheme:
-		return s.readHttpFile(uri)
+		return s.ReadHttpFile(uri)
 	case embedScheme:
-		return s.readEmbedFile(url)
+		return s.ReadEmbedFile(url)
 	default:
-		return readLocalFile(uri)
+		return ReadLocalFile(uri)
 	}
 }
 
-func (s *Spec) readHttpFile(uri string) ([]byte, error) {
+func (s *Spec) ReadHttpFile(uri string) ([]byte, error) {
 	request, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating http GET request for downloading file: %v", err)
@@ -387,7 +387,7 @@ func (s *Spec) readHttpFile(uri string) ([]byte, error) {
 	return data, nil
 }
 
-func (s *Spec) readEmbedFile(url *url.URL) ([]byte, error) {
+func (s *Spec) ReadEmbedFile(url *url.URL) ([]byte, error) {
 	data, err := s.configFS.ReadFile(strings.TrimPrefix(url.Path, "/"))
 	if err != nil {
 		return nil, fmt.Errorf("failed reading embed file [%s] for cluster spec: %v", url.Path, err)
@@ -396,7 +396,7 @@ func (s *Spec) readEmbedFile(url *url.URL) ([]byte, error) {
 	return data, nil
 }
 
-func readLocalFile(filename string) ([]byte, error) {
+func ReadLocalFile(filename string) ([]byte, error) {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed reading local file [%s] for cluster spec: %v", filename, err)
@@ -482,7 +482,7 @@ func kubeDistroRepository(image *eksdv1alpha1.AssetImage) (repo, tag string) {
 }
 
 func (s *Spec) getEksdRelease(versionsBundle *v1alpha1.VersionsBundle) (*eksdv1alpha1.Release, error) {
-	content, err := s.readFile(versionsBundle.EksD.EksDReleaseUrl)
+	content, err := s.ReadFile(versionsBundle.EksD.EksDReleaseUrl)
 	if err != nil {
 		return nil, err
 	}
@@ -527,7 +527,7 @@ func (s *Spec) LoadManifest(manifest v1alpha1.Manifest) (*Manifest, error) {
 		return nil, fmt.Errorf("invalid manifest URI: %v", err)
 	}
 
-	content, err := s.readFile(manifest.URI)
+	content, err := s.ReadFile(manifest.URI)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load manifest: %v", err)
 	}
@@ -615,4 +615,81 @@ func (vb *VersionsBundle) Images() []v1alpha1.Image {
 	images = append(images, vb.VsphereImages()...)
 
 	return images
+}
+
+func (vb *VersionsBundle) Ovas() []v1alpha1.Archive {
+	return []v1alpha1.Archive{
+		vb.EksD.Ova.Bottlerocket.Archive,
+		vb.EksD.Ova.Ubuntu.Archive,
+	}
+}
+
+func (vb *VersionsBundle) Manifests() map[string][]v1alpha1.Manifest {
+	manifests := map[string][]v1alpha1.Manifest{}
+
+	// CAPA manifests
+	manifests["cluster-api-provider-aws"] = []v1alpha1.Manifest{
+		vb.Aws.Components,
+		vb.Aws.ClusterTemplate,
+		vb.Aws.Metadata,
+	}
+
+	// Core CAPI manifests
+	manifests["core-cluster-api"] = []v1alpha1.Manifest{
+		vb.ClusterAPI.Components,
+		vb.ClusterAPI.Metadata,
+	}
+
+	// CAPI Kubeadm bootstrap manifests
+	manifests["capi-kubeadm-bootstrap"] = []v1alpha1.Manifest{
+		vb.Bootstrap.Components,
+		vb.Bootstrap.Metadata,
+	}
+
+	// CAPI Kubeadm Controlplane manifests
+	manifests["capi-kubeadm-control-plane"] = []v1alpha1.Manifest{
+		vb.ControlPlane.Components,
+		vb.ControlPlane.Metadata,
+	}
+
+	// CAPD manifests
+	manifests["cluster-api-provider-docker"] = []v1alpha1.Manifest{
+		vb.Docker.Components,
+		vb.Docker.ClusterTemplate,
+		vb.Docker.Metadata,
+	}
+
+	// CAPV manifests
+	manifests["cluster-api-provider-vsphere"] = []v1alpha1.Manifest{
+		vb.VSphere.Components,
+		vb.VSphere.ClusterTemplate,
+		vb.VSphere.Metadata,
+	}
+
+	// Cilium manifest
+	manifests["cilium"] = []v1alpha1.Manifest{vb.Cilium.Manifest}
+
+	// EKS Anywhere CRD manifest
+	manifests["eks-anywhere-cluster-controller"] = []v1alpha1.Manifest{vb.Eksa.Components}
+
+	// Etcdadm bootstrap provider manifests
+	manifests["etcdadm-bootstrap-provider"] = []v1alpha1.Manifest{
+		vb.ExternalEtcdBootstrap.Components,
+		vb.ExternalEtcdBootstrap.Metadata,
+	}
+
+	// Etcdadm controller manifests
+	manifests["etcdadm-controller"] = []v1alpha1.Manifest{
+		vb.ExternalEtcdController.Components,
+		vb.ExternalEtcdController.Metadata,
+	}
+
+	// EKS Distro release manifest
+	manifests["eks-distro"] = []v1alpha1.Manifest{v1alpha1.Manifest{URI: vb.EksD.EksDReleaseUrl}}
+
+	return manifests
+}
+
+func (s *Spec) GetReleaseManifestUrl() string {
+	return s.releasesManifestURL
 }


### PR DESCRIPTION
This PR adds a command to list the OVA URLs corresponding to the Kubernetes version of the current EKS Anywhere cluster configuration along their checksums.

Sample output for `eksctl anywhere list ovas`:
```
$ eksctl anywhere list ovas -f eks-a-test.yaml
Bottlerocket:
  SHA256: ...
  SHA512: ...
  URI: https://...
Ubuntu:
  SHA256: ...
  SHA512: ...
  URI: https://...
```
Sample output for `eksctl anywhere download artifacts`:
```bash
$ eksctl anywhere download artifacts -f bin/arnchlm-test.yaml
$ ls *.tar.gz
eks-anywhere-downloads.tar.gz
$ tar -tzf eks-anywhere-downloads.tar.gz 
eks-anywhere-downloads
eks-anywhere-downloads/bundle-release.yaml
eks-anywhere-downloads/capi-kubeadm-bootstrap
eks-anywhere-downloads/capi-kubeadm-bootstrap/bootstrap-components.yaml
eks-anywhere-downloads/capi-kubeadm-bootstrap/metadata.yaml
eks-anywhere-downloads/capi-kubeadm-control-plane
eks-anywhere-downloads/capi-kubeadm-control-plane/control-plane-components.yaml
eks-anywhere-downloads/capi-kubeadm-control-plane/metadata.yaml
eks-anywhere-downloads/cilium
eks-anywhere-downloads/cilium/cilium.yaml
...
```
Sample output for `eksctl anywhere download artifacts` (dry run):
```bash
$ eksctl anywhere download artifacts -f bin/arnchlm-test.yaml --dry-run
Found artifact: https://dev-release-prod-pdx.s3.amazonaws.com/bundle-release.yaml

Found artifact: https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/eks-a-release.yaml

Found artifact: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-5.yaml

Found artifact: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.352/cluster-api/manifests/bootstrap-kubeadm/v0.3.23/bootstrap-components.yaml

Found artifact: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.352/cilium/manifests/cilium/v1.9.10-eksa.1/cilium.yaml

Found artifact: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.352/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v0.1.2-rc1/bootstrap-components.yaml

Found artifact: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.352/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v0.1.2-rc1/metadata.yaml
...
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
