### PR TITLE
Patch `vsphere-cloud-controller-manager` daemonset image

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -979,3 +979,18 @@ func (k *Kubectl) GetConfigMap(ctx context.Context, kubeconfigFile, name, namesp
 
 	return response, nil
 }
+
+func (k *Kubectl) SetDaemonSetImage(ctx context.Context, kubeconfigFile, name, namespace, container, image string) error {
+	return k.setImage(ctx, "daemonset", name, container, image, WithNamespace(namespace), WithKubeconfig(kubeconfigFile))
+}
+
+func (k *Kubectl) setImage(ctx context.Context, kind, name, container, image string, opts ...KubectlOpt) error {
+	params := []string{"set", "image", fmt.Sprintf("%s/%s", kind, name), fmt.Sprintf("%s=%s", container, image)}
+	applyOpts(&params, opts...)
+	_, err := k.executable.Execute(ctx, params...)
+	if err != nil {
+		return fmt.Errorf("error setting image for %s: %v", kind, err)
+	}
+
+	return nil
+}

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -1342,3 +1342,17 @@ spec:
 	tt.Expect(err).To(BeNil())
 	tt.Expect(gotConfigmap).To(Equal(wantConfigmap))
 }
+
+func TestKubectlSetDaemonSetImage(t *testing.T) {
+	tt := newKubectlTest(t)
+	daemonSetName := "ds-1"
+	container := "cont1"
+	image := "public.ecr.aws/image2"
+
+	tt.e.EXPECT().Execute(
+		tt.ctx,
+		"set", "image", "daemonset/ds-1", "cont1=public.ecr.aws/image2", "--namespace", tt.namespace, "--kubeconfig", tt.cluster.KubeconfigFile,
+	).Return(bytes.Buffer{}, nil)
+
+	tt.Expect(tt.k.SetDaemonSetImage(tt.ctx, tt.cluster.KubeconfigFile, daemonSetName, tt.namespace, container, image)).To(Succeed())
+}

--- a/pkg/providers/vsphere/mocks/client.go
+++ b/pkg/providers/vsphere/mocks/client.go
@@ -507,6 +507,20 @@ func (mr *MockProviderKubectlClientMockRecorder) SearchVsphereMachineConfig(arg0
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchVsphereMachineConfig", reflect.TypeOf((*MockProviderKubectlClient)(nil).SearchVsphereMachineConfig), arg0, arg1, arg2, arg3)
 }
 
+// SetDaemonSetImage mocks base method.
+func (m *MockProviderKubectlClient) SetDaemonSetImage(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetDaemonSetImage", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetDaemonSetImage indicates an expected call of SetDaemonSetImage.
+func (mr *MockProviderKubectlClientMockRecorder) SetDaemonSetImage(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDaemonSetImage", reflect.TypeOf((*MockProviderKubectlClient)(nil).SetDaemonSetImage), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
 // UpdateAnnotation mocks base method.
 func (m *MockProviderKubectlClient) UpdateAnnotation(arg0 context.Context, arg1, arg2 string, arg3 map[string]string, arg4 ...executables.KubectlOpt) error {
 	m.ctrl.T.Helper()

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1636,7 +1636,7 @@ func (p *vsphereProvider) RunPostUpgrade(ctx context.Context, clusterSpec *clust
 		cloudControllerDaemonSetContainerName,
 		clusterSpec.VersionsBundle.VSphere.Manager.VersionedImage(),
 	); err != nil {
-		return fmt.Errorf("failed updating the vs[here cloud controller manager daemonset post upgrade: %v", err)
+		return fmt.Errorf("failed updating the VSphere cloud controller manager daemonset post upgrade: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
*Description of changes:*
Update `vsphere-cloud-controller-manager` image manually after upgrades
Unfortunately, the capv controller doesn't do this even if we update the `VSphereCLuster`, so we need to do it manually for now
In new versions of the capv provider, this is not managed by the controller directly anymore but just with a `ClusterResourceSet`
Which means that adding update capabilities to the `ClusterResourceSe` controller and updating our capv provider version will solve this problem

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
