### PR TITLE
Add the ability for providers to trigger upgrades based on spec changes

### DIFF
--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -425,3 +425,7 @@ func (p *provider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.Compone
 func (p *provider) RunPostUpgrade(ctx context.Context, clusterSpec *cluster.Spec, managementCluster, workloadCluster *types.Cluster) error {
 	return nil
 }
+
+func (p *provider) UpgradeNeeded(_ context.Context, _, _ *cluster.Spec) (bool, error) {
+	return false, nil
+}

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -354,6 +354,21 @@ func (mr *MockProviderMockRecorder) UpdateSecrets(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecrets", reflect.TypeOf((*MockProvider)(nil).UpdateSecrets), arg0, arg1)
 }
 
+// UpgradeNeeded mocks base method.
+func (m *MockProvider) UpgradeNeeded(arg0 context.Context, arg1, arg2 *cluster.Spec) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpgradeNeeded", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpgradeNeeded indicates an expected call of UpgradeNeeded.
+func (mr *MockProviderMockRecorder) UpgradeNeeded(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeNeeded", reflect.TypeOf((*MockProvider)(nil).UpgradeNeeded), arg0, arg1, arg2)
+}
+
 // ValidateNewSpec mocks base method.
 func (m *MockProvider) ValidateNewSpec(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec) error {
 	m.ctrl.T.Helper()

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -34,6 +34,7 @@ type Provider interface {
 	GenerateMHC() ([]byte, error)
 	ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff
 	RunPostUpgrade(ctx context.Context, clusterSpec *cluster.Spec, managementCluster, workloadCluster *types.Cluster) error
+	UpgradeNeeded(ctx context.Context, newSpec, currentSpec *cluster.Spec) (bool, error)
 }
 
 type DatacenterConfig interface {

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1644,3 +1644,12 @@ func (p *vsphereProvider) RunPostUpgrade(ctx context.Context, clusterSpec *clust
 func resourceSetName(clusterSpec *cluster.Spec) string {
 	return fmt.Sprintf("%s-crs-0", clusterSpec.Name)
 }
+
+func (p *vsphereProvider) UpgradeNeeded(_ context.Context, newSpec, currentSpec *cluster.Spec) (bool, error) {
+	newV, oldV := newSpec.VersionsBundle.VSphere, currentSpec.VersionsBundle.VSphere
+
+	return newV.Driver.ImageDigest != oldV.Driver.ImageDigest ||
+		newV.Syncer.ImageDigest != oldV.Syncer.ImageDigest ||
+		newV.Manager.ImageDigest != oldV.Manager.ImageDigest ||
+		newV.KubeVip.ImageDigest != oldV.KubeVip.ImageDigest, nil
+}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -20,20 +20,21 @@ type Task interface {
 
 // Command context maintains the mutable and shared entities
 type CommandContext struct {
-	Bootstrapper      interfaces.Bootstrapper
-	Provider          providers.Provider
-	ClusterManager    interfaces.ClusterManager
-	AddonManager      interfaces.AddonManager
-	Validations       interfaces.Validator
-	Writer            filewriter.FileWriter
-	CAPIUpgrader      interfaces.CAPIUpgrader
-	ClusterSpec       *cluster.Spec
-	UpgradeChangeDiff *types.ChangeDiff
-	BootstrapCluster  *types.Cluster
-	WorkloadCluster   *types.Cluster
-	Profiler          *Profiler
-	Rollback          bool
-	OriginalError     error
+	Bootstrapper       interfaces.Bootstrapper
+	Provider           providers.Provider
+	ClusterManager     interfaces.ClusterManager
+	AddonManager       interfaces.AddonManager
+	Validations        interfaces.Validator
+	Writer             filewriter.FileWriter
+	CAPIUpgrader       interfaces.CAPIUpgrader
+	ClusterSpec        *cluster.Spec
+	CurrentClusterSpec *cluster.Spec
+	UpgradeChangeDiff  *types.ChangeDiff
+	BootstrapCluster   *types.Cluster
+	WorkloadCluster    *types.Cluster
+	Profiler           *Profiler
+	Rollback           bool
+	OriginalError      error
 }
 
 func (c *CommandContext) SetError(err error) {

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -22,22 +22,23 @@ import (
 )
 
 type upgradeTestSetup struct {
-	t                *testing.T
-	bootstrapper     *mocks.MockBootstrapper
-	clusterManager   *mocks.MockClusterManager
-	addonManager     *mocks.MockAddonManager
-	provider         *providermocks.MockProvider
-	writer           *writermocks.MockFileWriter
-	validator        *mocks.MockValidator
-	capiUpgrader     *mocks.MockCAPIUpgrader
-	datacenterConfig providers.DatacenterConfig
-	machineConfigs   []providers.MachineConfig
-	workflow         *workflows.Upgrade
-	ctx              context.Context
-	clusterSpec      *cluster.Spec
-	forceCleanup     bool
-	bootstrapCluster *types.Cluster
-	workloadCluster  *types.Cluster
+	t                  *testing.T
+	bootstrapper       *mocks.MockBootstrapper
+	clusterManager     *mocks.MockClusterManager
+	addonManager       *mocks.MockAddonManager
+	provider           *providermocks.MockProvider
+	writer             *writermocks.MockFileWriter
+	validator          *mocks.MockValidator
+	capiUpgrader       *mocks.MockCAPIUpgrader
+	datacenterConfig   providers.DatacenterConfig
+	machineConfigs     []providers.MachineConfig
+	workflow           *workflows.Upgrade
+	ctx                context.Context
+	newClusterSpec     *cluster.Spec
+	currentClusterSpec *cluster.Spec
+	forceCleanup       bool
+	bootstrapCluster   *types.Cluster
+	workloadCluster    *types.Cluster
 }
 
 func newUpgradeTest(t *testing.T) *upgradeTestSetup {
@@ -70,14 +71,14 @@ func newUpgradeTest(t *testing.T) *upgradeTestSetup {
 		machineConfigs:   machineConfigs,
 		workflow:         workflow,
 		ctx:              context.Background(),
-		clusterSpec:      test.NewClusterSpec(func(s *cluster.Spec) { s.Name = "cluster-name" }),
+		newClusterSpec:   test.NewClusterSpec(func(s *cluster.Spec) { s.Name = "cluster-name" }),
 		bootstrapCluster: &types.Cluster{Name: "bootstrap"},
 		workloadCluster:  &types.Cluster{Name: "workload"},
 	}
 }
 
 func (c *upgradeTestSetup) expectSetup() {
-	c.provider.EXPECT().SetupAndValidateUpgradeCluster(c.ctx, c.clusterSpec)
+	c.provider.EXPECT().SetupAndValidateUpgradeCluster(c.ctx, c.newClusterSpec)
 	c.provider.EXPECT().Name()
 }
 
@@ -88,7 +89,7 @@ func (c *upgradeTestSetup) expectUpdateSecrets(expectedCluster *types.Cluster) {
 }
 
 func (c *upgradeTestSetup) expectUpgradeCoreComponents(expectedCluster *types.Cluster) {
-	currentSpec := &cluster.Spec{}
+	currentSpec := c.currentClusterSpec
 	capiChangeDiff := types.NewChangeDiff(&types.ComponentChangeDiff{
 		ComponentName: "vsphere",
 		OldVersion:    "v0.0.1",
@@ -105,10 +106,10 @@ func (c *upgradeTestSetup) expectUpgradeCoreComponents(expectedCluster *types.Cl
 		NewVersion:    "v0.0.2",
 	})
 	gomock.InOrder(
-		c.clusterManager.EXPECT().GetCurrentClusterSpec(c.ctx, expectedCluster, c.clusterSpec.Name).Return(currentSpec, nil),
-		c.capiUpgrader.EXPECT().Upgrade(c.ctx, expectedCluster, c.provider, currentSpec, c.clusterSpec).Return(capiChangeDiff, nil),
-		c.addonManager.EXPECT().Upgrade(c.ctx, expectedCluster, currentSpec, c.clusterSpec).Return(fluxChangeDiff, nil),
-		c.clusterManager.EXPECT().Upgrade(c.ctx, expectedCluster, currentSpec, c.clusterSpec).Return(eksaChangeDiff, nil),
+		c.clusterManager.EXPECT().GetCurrentClusterSpec(c.ctx, expectedCluster, c.newClusterSpec.Name).Return(currentSpec, nil),
+		c.capiUpgrader.EXPECT().Upgrade(c.ctx, expectedCluster, c.provider, currentSpec, c.newClusterSpec).Return(capiChangeDiff, nil),
+		c.addonManager.EXPECT().Upgrade(c.ctx, expectedCluster, currentSpec, c.newClusterSpec).Return(fluxChangeDiff, nil),
+		c.clusterManager.EXPECT().Upgrade(c.ctx, expectedCluster, currentSpec, c.newClusterSpec).Return(eksaChangeDiff, nil),
 	)
 }
 
@@ -158,13 +159,13 @@ func (c *upgradeTestSetup) expectNotToDeleteBootstrap() {
 
 func (c *upgradeTestSetup) expectUpgradeWorkload(expectedCluster *types.Cluster) {
 	c.expectUpgradeWorkloadToReturn(expectedCluster, nil)
-	c.clusterManager.EXPECT().ApplyBundles(c.ctx, c.clusterSpec, expectedCluster)
+	c.clusterManager.EXPECT().ApplyBundles(c.ctx, c.newClusterSpec, expectedCluster)
 }
 
 func (c *upgradeTestSetup) expectUpgradeWorkloadToReturn(expectedCluster *types.Cluster, err error) {
 	gomock.InOrder(
 		c.clusterManager.EXPECT().UpgradeCluster(
-			c.ctx, c.bootstrapCluster, expectedCluster, c.clusterSpec, c.provider,
+			c.ctx, c.bootstrapCluster, expectedCluster, c.newClusterSpec, c.provider,
 		).Return(err),
 	)
 }
@@ -196,7 +197,7 @@ func (c *upgradeTestSetup) expectNotToMoveManagementToWorkload() {
 func (c *upgradeTestSetup) expectPauseEKSAControllerReconcile(expectedCluster *types.Cluster) {
 	gomock.InOrder(
 		c.clusterManager.EXPECT().PauseEKSAControllerReconcile(
-			c.ctx, expectedCluster, c.clusterSpec, c.provider,
+			c.ctx, expectedCluster, c.newClusterSpec, c.provider,
 		),
 	)
 }
@@ -204,7 +205,7 @@ func (c *upgradeTestSetup) expectPauseEKSAControllerReconcile(expectedCluster *t
 func (c *upgradeTestSetup) expectResumeEKSAControllerReconcile(expecteCluster *types.Cluster) {
 	gomock.InOrder(
 		c.clusterManager.EXPECT().ResumeEKSAControllerReconcile(
-			c.ctx, expecteCluster, c.clusterSpec, c.provider,
+			c.ctx, expecteCluster, c.newClusterSpec, c.provider,
 		),
 	)
 }
@@ -212,7 +213,7 @@ func (c *upgradeTestSetup) expectResumeEKSAControllerReconcile(expecteCluster *t
 func (c *upgradeTestSetup) expectPauseGitOpsKustomization(expectedCluster *types.Cluster) {
 	gomock.InOrder(
 		c.addonManager.EXPECT().PauseGitOpsKustomization(
-			c.ctx, expectedCluster, c.clusterSpec,
+			c.ctx, expectedCluster, c.newClusterSpec,
 		),
 	)
 }
@@ -232,7 +233,7 @@ func (c *upgradeTestSetup) expectMachineConfigs() {
 func (c *upgradeTestSetup) expectCreateEKSAResources(expectedCluster *types.Cluster) {
 	gomock.InOrder(
 		c.clusterManager.EXPECT().CreateEKSAResources(
-			c.ctx, expectedCluster, c.clusterSpec, c.datacenterConfig, c.machineConfigs,
+			c.ctx, expectedCluster, c.newClusterSpec, c.datacenterConfig, c.machineConfigs,
 		),
 	)
 }
@@ -240,7 +241,7 @@ func (c *upgradeTestSetup) expectCreateEKSAResources(expectedCluster *types.Clus
 func (c *upgradeTestSetup) expectUpdateGitEksaSpec() {
 	gomock.InOrder(
 		c.addonManager.EXPECT().UpdateGitEksaSpec(
-			c.ctx, c.clusterSpec, c.datacenterConfig, c.machineConfigs,
+			c.ctx, c.newClusterSpec, c.datacenterConfig, c.machineConfigs,
 		),
 	)
 }
@@ -248,7 +249,7 @@ func (c *upgradeTestSetup) expectUpdateGitEksaSpec() {
 func (c *upgradeTestSetup) expectForceReconcileGitRepo(expectedCluster *types.Cluster) {
 	gomock.InOrder(
 		c.addonManager.EXPECT().ForceReconcileGitRepo(
-			c.ctx, expectedCluster, c.clusterSpec,
+			c.ctx, expectedCluster, c.newClusterSpec,
 		),
 	)
 }
@@ -256,7 +257,7 @@ func (c *upgradeTestSetup) expectForceReconcileGitRepo(expectedCluster *types.Cl
 func (c *upgradeTestSetup) expectResumeGitOpsKustomization(expectedCluster *types.Cluster) {
 	gomock.InOrder(
 		c.addonManager.EXPECT().ResumeGitOpsKustomization(
-			c.ctx, expectedCluster, c.clusterSpec,
+			c.ctx, expectedCluster, c.newClusterSpec,
 		),
 	)
 }
@@ -265,7 +266,7 @@ func (c *upgradeTestSetup) expectVerifyClusterSpecChanged(expectedCluster *types
 	gomock.InOrder(
 		c.provider.EXPECT().DatacenterConfig().Return(c.datacenterConfig),
 		c.provider.EXPECT().MachineConfigs().Return(c.machineConfigs),
-		c.clusterManager.EXPECT().EKSAClusterSpecChanged(c.ctx, expectedCluster, c.clusterSpec, c.datacenterConfig, c.machineConfigs).Return(true, nil),
+		c.clusterManager.EXPECT().EKSAClusterSpecChanged(c.ctx, expectedCluster, c.newClusterSpec, c.datacenterConfig, c.machineConfigs).Return(true, nil),
 	)
 }
 
@@ -277,23 +278,31 @@ func (c *upgradeTestSetup) expectSaveLogs() {
 
 func (c *upgradeTestSetup) run() error {
 	// ctx context.Context, workloadCluster *types.Cluster, forceCleanup bool
-	return c.workflow.Run(c.ctx, c.clusterSpec, c.workloadCluster, c.validator, c.forceCleanup)
+	return c.workflow.Run(c.ctx, c.newClusterSpec, c.workloadCluster, c.validator, c.forceCleanup)
+}
+
+func (c *upgradeTestSetup) expectProviderNoUpgradeNeeded() {
+	c.provider.EXPECT().UpgradeNeeded(c.ctx, c.newClusterSpec, c.currentClusterSpec).Return(false, nil)
+}
+
+func (c *upgradeTestSetup) expectProviderUpgradeNeeded() {
+	c.provider.EXPECT().UpgradeNeeded(c.ctx, c.newClusterSpec, c.currentClusterSpec).Return(true, nil)
 }
 
 func (c *upgradeTestSetup) expectVerifyClusterSpecNoChanges() {
 	gomock.InOrder(
 		c.provider.EXPECT().DatacenterConfig().Return(c.datacenterConfig),
 		c.provider.EXPECT().MachineConfigs().Return(c.machineConfigs),
-		c.clusterManager.EXPECT().EKSAClusterSpecChanged(c.ctx, c.workloadCluster, c.clusterSpec, c.datacenterConfig, c.machineConfigs).Return(false, nil),
+		c.clusterManager.EXPECT().EKSAClusterSpecChanged(c.ctx, c.workloadCluster, c.newClusterSpec, c.datacenterConfig, c.machineConfigs).Return(false, nil),
 	)
 }
 
 func (c *upgradeTestSetup) expectPauseEKSAControllerReconcileNotToBeCalled() {
-	c.clusterManager.EXPECT().PauseEKSAControllerReconcile(c.ctx, c.workloadCluster, c.clusterSpec, c.provider).Times(0)
+	c.clusterManager.EXPECT().PauseEKSAControllerReconcile(c.ctx, c.workloadCluster, c.newClusterSpec, c.provider).Times(0)
 }
 
 func (c *upgradeTestSetup) expectPauseGitOpsKustomizationNotToBeCalled() {
-	c.addonManager.EXPECT().PauseGitOpsKustomization(c.ctx, c.workloadCluster, c.clusterSpec).Times(0)
+	c.addonManager.EXPECT().PauseGitOpsKustomization(c.ctx, c.workloadCluster, c.newClusterSpec).Times(0)
 }
 
 func (c *upgradeTestSetup) expectCreateBootstrapNotToBeCalled() {
@@ -312,6 +321,7 @@ func TestSkipUpgradeRunSuccess(t *testing.T) {
 	test.expectPreflightValidationsToPass()
 	test.expectUpdateSecrets(test.workloadCluster)
 	test.expectUpgradeCoreComponents(test.workloadCluster)
+	test.expectProviderNoUpgradeNeeded()
 	test.expectVerifyClusterSpecNoChanges()
 	test.expectPauseEKSAControllerReconcileNotToBeCalled()
 	test.expectPauseGitOpsKustomizationNotToBeCalled()
@@ -329,7 +339,37 @@ func TestUpgradeRunSuccess(t *testing.T) {
 	test.expectPreflightValidationsToPass()
 	test.expectUpdateSecrets(test.workloadCluster)
 	test.expectUpgradeCoreComponents(test.workloadCluster)
+	test.expectProviderNoUpgradeNeeded()
 	test.expectVerifyClusterSpecChanged(test.workloadCluster)
+	test.expectPauseEKSAControllerReconcile(test.workloadCluster)
+	test.expectPauseGitOpsKustomization(test.workloadCluster)
+	test.expectCreateBootstrap()
+	test.expectMoveManagementToBootstrap()
+	test.expectUpgradeWorkload(test.workloadCluster)
+	test.expectMoveManagementToWorkload()
+	test.expectWriteClusterConfig()
+	test.expectDeleteBootstrap()
+	test.expectDatacenterConfig()
+	test.expectMachineConfigs()
+	test.expectCreateEKSAResources(test.workloadCluster)
+	test.expectResumeEKSAControllerReconcile(test.workloadCluster)
+	test.expectUpdateGitEksaSpec()
+	test.expectForceReconcileGitRepo(test.workloadCluster)
+	test.expectResumeGitOpsKustomization(test.workloadCluster)
+
+	err := test.run()
+	if err != nil {
+		t.Fatalf("Upgrade.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestUpgradeRunProviderNeedsUpgradeSuccess(t *testing.T) {
+	test := newUpgradeTest(t)
+	test.expectSetup()
+	test.expectPreflightValidationsToPass()
+	test.expectUpdateSecrets(test.workloadCluster)
+	test.expectUpgradeCoreComponents(test.workloadCluster)
+	test.expectProviderUpgradeNeeded()
 	test.expectPauseEKSAControllerReconcile(test.workloadCluster)
 	test.expectPauseGitOpsKustomization(test.workloadCluster)
 	test.expectCreateBootstrap()
@@ -358,6 +398,7 @@ func TestUpgradeRunFailedUpgrade(t *testing.T) {
 	test.expectPreflightValidationsToPass()
 	test.expectUpdateSecrets(test.workloadCluster)
 	test.expectUpgradeCoreComponents(test.workloadCluster)
+	test.expectProviderNoUpgradeNeeded()
 	test.expectVerifyClusterSpecChanged(test.workloadCluster)
 	test.expectPauseEKSAControllerReconcile(test.workloadCluster)
 	test.expectPauseGitOpsKustomization(test.workloadCluster)
@@ -375,7 +416,7 @@ func TestUpgradeRunFailedUpgrade(t *testing.T) {
 
 func TestUpgradeWorkloadRunSuccess(t *testing.T) {
 	test := newUpgradeTest(t)
-	test.clusterSpec.SetSelfManaged()
+	test.newClusterSpec.SetSelfManaged()
 
 	test.bootstrapCluster.Name = "management-cluster"
 	test.bootstrapCluster.ExistingManagement = true
@@ -383,7 +424,7 @@ func TestUpgradeWorkloadRunSuccess(t *testing.T) {
 
 	test.workloadCluster.KubeconfigFile = "wl-kubeconfig.yaml"
 
-	test.clusterSpec.ManagementCluster = &types.Cluster{
+	test.newClusterSpec.ManagementCluster = &types.Cluster{
 		Name:               test.bootstrapCluster.Name,
 		KubeconfigFile:     "kubeconfig.yaml",
 		ExistingManagement: true,
@@ -393,6 +434,7 @@ func TestUpgradeWorkloadRunSuccess(t *testing.T) {
 	test.expectPreflightValidationsToPass()
 	test.expectUpdateSecrets(test.bootstrapCluster)
 	test.expectUpgradeCoreComponents(test.bootstrapCluster)
+	test.expectProviderNoUpgradeNeeded()
 	test.expectVerifyClusterSpecChanged(test.bootstrapCluster)
 	test.expectPauseEKSAControllerReconcile(test.bootstrapCluster)
 	test.expectPauseGitOpsKustomization(test.bootstrapCluster)


### PR DESCRIPTION
*Description of changes:*
Sometimes, the spec doesn't change and there isn't a new eks-d release in the bundle. However, it's possible that some of the components in the bundle used by a provider have changed, and a new "upgrade" (just reapply the templates) is needed.

This PR adds a new method to providers to allow them to trigger upgrades even when cluster manager doesn't detect a change.
I think we should eventually move the provider specific code we have in cluster manager to these methods (that's why I added the `Context` as an argument), but I'll leave that refactor for a separate PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
