### PR TITLE
Support bundle for mgmt cluster

### DIFF
--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -19,10 +19,37 @@ func NewAnalyzerFactory() *analyzerFactory {
 }
 
 func (a *analyzerFactory) DefaultAnalyzers() []*Analyze {
-	return append(a.defaultDeploymentAnalyzers(), a.defaultCrdAnalyzers()...)
+	var analyzers []*Analyze
+	analyzers = append(analyzers, a.defaultDeploymentAnalyzers()...)
+	return append(analyzers, a.ManagementClusterAnalyzers()...)
 }
 
 func (a *analyzerFactory) defaultDeploymentAnalyzers() []*Analyze {
+	d := []eksaDeployment{
+		{
+			Name:             "coredns",
+			Namespace:        constants.KubeSystemNamespace,
+			ExpectedReplicas: 2,
+		},
+	}
+	return a.generateDeploymentAnalyzers(d)
+}
+
+func (a *analyzerFactory) ManagementClusterAnalyzers() []*Analyze {
+	var analyzers []*Analyze
+	analyzers = append(analyzers, a.managementClusterDeploymentAnalyzers()...)
+	return append(analyzers, a.managementClusterCrdAnalyzers()...)
+}
+
+func (a *analyzerFactory) managementClusterCrdAnalyzers() []*Analyze {
+	crds := []string{
+		fmt.Sprintf("clusters.%s", v1alpha1.GroupVersion.Group),
+		fmt.Sprintf("bundles.%s", v1alpha1.GroupVersion.Group),
+	}
+	return a.generateCrdAnalyzers(crds)
+}
+
+func (a *analyzerFactory) managementClusterDeploymentAnalyzers() []*Analyze {
 	d := []eksaDeployment{
 		{
 			Name:             "capv-controller-manager",
@@ -32,10 +59,6 @@ func (a *analyzerFactory) defaultDeploymentAnalyzers() []*Analyze {
 			Name:             "capv-controller-manager",
 			Namespace:        constants.CapvSystemNamespace,
 			ExpectedReplicas: 1,
-		}, {
-			Name:             "coredns",
-			Namespace:        constants.KubeSystemNamespace,
-			ExpectedReplicas: 2,
 		}, {
 			Name:             "cert-manager-webhook",
 			Namespace:        constants.CertManagerNamespace,
@@ -79,14 +102,6 @@ func (a *analyzerFactory) defaultDeploymentAnalyzers() []*Analyze {
 		},
 	}
 	return a.generateDeploymentAnalyzers(d)
-}
-
-func (a *analyzerFactory) defaultCrdAnalyzers() []*Analyze {
-	crds := []string{
-		fmt.Sprintf("clusters.%s", v1alpha1.GroupVersion.Group),
-		fmt.Sprintf("bundles.%s", v1alpha1.GroupVersion.Group),
-	}
-	return a.generateCrdAnalyzers(crds)
 }
 
 func (a *analyzerFactory) EksaGitopsAnalyzers() []*Analyze {

--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -20,8 +20,7 @@ func NewAnalyzerFactory() *analyzerFactory {
 
 func (a *analyzerFactory) DefaultAnalyzers() []*Analyze {
 	var analyzers []*Analyze
-	analyzers = append(analyzers, a.defaultDeploymentAnalyzers()...)
-	return append(analyzers, a.ManagementClusterAnalyzers()...)
+	return append(analyzers, a.defaultDeploymentAnalyzers()...)
 }
 
 func (a *analyzerFactory) defaultDeploymentAnalyzers() []*Analyze {

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -41,7 +41,6 @@ func (c *collectorFactory) DefaultCollectors() []*Collect {
 		},
 	}
 	collectors = append(collectors, c.defaultLogCollectors()...)
-	collectors = append(collectors, c.defaultCrdCollectors()...)
 	return collectors
 }
 
@@ -57,6 +56,13 @@ func (c *collectorFactory) EksaHostCollectors(machineConfigs []providers.Machine
 			osFamiliesSeen[config.OSFamily()] = true
 		}
 	}
+	return collectors
+}
+
+func (c *collectorFactory) ManagementClusterCollectors() []*Collect {
+	var collectors []*Collect
+	collectors = append(collectors, c.managementClusterCrdCollectors()...)
+	collectors = append(collectors, c.managementClusterLogCollectors()...)
 	return collectors
 }
 
@@ -105,10 +111,39 @@ func (c *collectorFactory) defaultLogCollectors() []*Collect {
 	return []*Collect{
 		{
 			Logs: &logs{
-				Namespace: constants.CapdSystemNamespace,
-				Name:      logpath(constants.CapdSystemNamespace),
+				Namespace: constants.EksaSystemNamespace,
+				Name:      logpath(constants.EksaSystemNamespace),
 			},
 		},
+		{
+			Logs: &logs{
+				Namespace: constants.DefaultNamespace,
+				Name:      logpath(constants.DefaultNamespace),
+			},
+		},
+		{
+			Logs: &logs{
+				Namespace: constants.KubeNodeLeaseNamespace,
+				Name:      logpath(constants.KubeNodeLeaseNamespace),
+			},
+		},
+		{
+			Logs: &logs{
+				Namespace: constants.KubePublicNamespace,
+				Name:      logpath(constants.KubePublicNamespace),
+			},
+		},
+		{
+			Logs: &logs{
+				Namespace: constants.KubeSystemNamespace,
+				Name:      logpath(constants.KubeSystemNamespace),
+			},
+		},
+	}
+}
+
+func (c *collectorFactory) managementClusterLogCollectors() []*Collect {
+	return []*Collect{
 		{
 			Logs: &logs{
 				Namespace: constants.CapiKubeadmBootstrapSystemNamespace,
@@ -141,18 +176,6 @@ func (c *collectorFactory) defaultLogCollectors() []*Collect {
 		},
 		{
 			Logs: &logs{
-				Namespace: constants.EksaSystemNamespace,
-				Name:      logpath(constants.EksaSystemNamespace),
-			},
-		},
-		{
-			Logs: &logs{
-				Namespace: constants.DefaultNamespace,
-				Name:      logpath(constants.DefaultNamespace),
-			},
-		},
-		{
-			Logs: &logs{
 				Namespace: constants.EtcdAdminBootstrapProviderSystemNamespace,
 				Name:      logpath(constants.EtcdAdminBootstrapProviderSystemNamespace),
 			},
@@ -163,36 +186,18 @@ func (c *collectorFactory) defaultLogCollectors() []*Collect {
 				Name:      logpath(constants.EtcdAdminControllerSystemNamespace),
 			},
 		},
-		{
-			Logs: &logs{
-				Namespace: constants.KubeNodeLeaseNamespace,
-				Name:      logpath(constants.KubeNodeLeaseNamespace),
-			},
-		},
-		{
-			Logs: &logs{
-				Namespace: constants.KubePublicNamespace,
-				Name:      logpath(constants.KubePublicNamespace),
-			},
-		},
-		{
-			Logs: &logs{
-				Namespace: constants.KubeSystemNamespace,
-				Name:      logpath(constants.KubeSystemNamespace),
-			},
-		},
 	}
 }
 
-func (c *collectorFactory) defaultCrdCollectors() []*Collect {
-	defaultCrds := []string{
+func (c *collectorFactory) managementClusterCrdCollectors() []*Collect {
+	mgmtCrds := []string{
 		"clusters.anywhere.eks.amazonaws.com",
 		"bundles.anywhere.eks.amazonaws.com",
 		"clusters.cluster.x-k8s.io",
 		"machinedeployments.cluster.x-k8s.io",
 		"machines.cluster.x-k8s.io",
 	}
-	return c.generateCrdCollectors(defaultCrds)
+	return c.generateCrdCollectors(mgmtCrds)
 }
 
 func (c *collectorFactory) generateCrdCollectors(crds []string) []*Collect {

--- a/pkg/diagnostics/diagnostic_bundle.go
+++ b/pkg/diagnostics/diagnostic_bundle.go
@@ -67,7 +67,7 @@ func newDiagnosticBundleManagementCluster(af AnalyzerFactory, cf CollectorFactor
 		writer:           writer,
 	}
 
-	b.WithDefaultCollectors().WithDefaultAnalyzers()
+	b.WithDefaultCollectors().WithDefaultAnalyzers().WithManagementCluster(true)
 
 	err := b.WriteBundleConfig()
 	if err != nil {

--- a/pkg/diagnostics/diagnostic_bundle.go
+++ b/pkg/diagnostics/diagnostic_bundle.go
@@ -106,6 +106,7 @@ func newDiagnosticBundleFromSpec(af AnalyzerFactory, cf CollectorFactory, spec *
 		WithExternalEtcd(spec.Spec.ExternalEtcdConfiguration).
 		WithDatacenterConfig(spec.Spec.DatacenterRef).
 		WithMachineConfigs(provider.MachineConfigs()).
+		WithManagementCluster(spec.IsSelfManaged()).
 		WithDefaultAnalyzers().
 		WithDefaultCollectors().
 		WithLogTextAnalyzers()
@@ -239,6 +240,14 @@ func (e *EksaDiagnosticBundle) WithDefaultCollectors() *EksaDiagnosticBundle {
 
 func (e *EksaDiagnosticBundle) WithDefaultAnalyzers() *EksaDiagnosticBundle {
 	e.bundle.Spec.Analyzers = append(e.bundle.Spec.Analyzers, e.analyzerFactory.DefaultAnalyzers()...)
+	return e
+}
+
+func (e *EksaDiagnosticBundle) WithManagementCluster(isSelfManaged bool) *EksaDiagnosticBundle {
+	if isSelfManaged {
+		e.bundle.Spec.Analyzers = append(e.bundle.Spec.Analyzers, e.analyzerFactory.ManagementClusterAnalyzers()...)
+		e.bundle.Spec.Collectors = append(e.bundle.Spec.Collectors, e.collectorFactory.ManagementClusterCollectors()...)
+	}
 	return e
 }
 

--- a/pkg/diagnostics/diagnostic_bundle.go
+++ b/pkg/diagnostics/diagnostic_bundle.go
@@ -134,7 +134,7 @@ func newDiagnosticBundleDefault(af AnalyzerFactory, cf CollectorFactory) *EksaDi
 		analyzerFactory:  af,
 		collectorFactory: cf,
 	}
-	return b.WithDefaultAnalyzers().WithDefaultCollectors()
+	return b.WithDefaultAnalyzers().WithDefaultCollectors().WithManagementCluster(true)
 }
 
 func newDiagnosticBundleCustom(af AnalyzerFactory, cf CollectorFactory, client BundleClient, kubectl *executables.Kubectl, bundlePath string, kubeconfig string) *EksaDiagnosticBundle {

--- a/pkg/diagnostics/diagnostic_bundle_test.go
+++ b/pkg/diagnostics/diagnostic_bundle_test.go
@@ -115,10 +115,12 @@ func TestGenerateBundleConfigWithExternalEtcd(t *testing.T) {
 		a.EXPECT().DataCenterConfigAnalyzers(spec.Cluster.Spec.DatacenterRef).Return(nil)
 		a.EXPECT().DefaultAnalyzers().Return(nil)
 		a.EXPECT().EksaLogTextAnalyzers(gomock.Any()).Return(nil)
+		a.EXPECT().ManagementClusterAnalyzers().Return(nil)
 
 		c := givenMockCollectorsFactory(t)
 		c.EXPECT().DefaultCollectors().Return(nil)
 		c.EXPECT().EksaHostCollectors(gomock.Any()).Return(nil)
+		c.EXPECT().ManagementClusterCollectors().Return(nil)
 
 		w := givenWriter(t)
 		w.EXPECT().Write(gomock.Any(), gomock.Any())
@@ -165,6 +167,7 @@ func TestGenerateBundleConfigWithOidc(t *testing.T) {
 		a.EXPECT().DataCenterConfigAnalyzers(spec.Cluster.Spec.DatacenterRef).Return(nil)
 		a.EXPECT().DefaultAnalyzers().Return(nil)
 		a.EXPECT().EksaLogTextAnalyzers(gomock.Any()).Return(nil)
+		a.EXPECT().ManagementClusterAnalyzers().Return(nil)
 
 		w := givenWriter(t)
 		w.EXPECT().Write(gomock.Any(), gomock.Any())
@@ -172,6 +175,7 @@ func TestGenerateBundleConfigWithOidc(t *testing.T) {
 		c := givenMockCollectorsFactory(t)
 		c.EXPECT().DefaultCollectors().Return(nil)
 		c.EXPECT().EksaHostCollectors(gomock.Any()).Return(nil)
+		c.EXPECT().ManagementClusterCollectors().Return(nil)
 
 		opts := diagnostics.EksaDiagnosticBundleFactoryOpts{
 			AnalyzerFactory:  a,
@@ -215,6 +219,7 @@ func TestGenerateBundleConfigWithGitOps(t *testing.T) {
 		a.EXPECT().DataCenterConfigAnalyzers(spec.Cluster.Spec.DatacenterRef).Return(nil)
 		a.EXPECT().DefaultAnalyzers().Return(nil)
 		a.EXPECT().EksaLogTextAnalyzers(gomock.Any()).Return(nil)
+		a.EXPECT().ManagementClusterAnalyzers().Return(nil)
 
 		w := givenWriter(t)
 		w.EXPECT().Write(gomock.Any(), gomock.Any())
@@ -222,6 +227,7 @@ func TestGenerateBundleConfigWithGitOps(t *testing.T) {
 		c := givenMockCollectorsFactory(t)
 		c.EXPECT().DefaultCollectors().Return(nil)
 		c.EXPECT().EksaHostCollectors(gomock.Any()).Return(nil)
+		c.EXPECT().ManagementClusterCollectors().Return(nil)
 
 		opts := diagnostics.EksaDiagnosticBundleFactoryOpts{
 			AnalyzerFactory:  a,
@@ -290,10 +296,12 @@ func TestBundleFromSpecComplete(t *testing.T) {
 		a.EXPECT().DataCenterConfigAnalyzers(spec.Cluster.Spec.DatacenterRef).Return(nil)
 		a.EXPECT().DefaultAnalyzers().Return(nil)
 		a.EXPECT().EksaLogTextAnalyzers(gomock.Any()).Return(nil)
+		a.EXPECT().ManagementClusterAnalyzers().Return(nil)
 
 		c := givenMockCollectorsFactory(t)
 		c.EXPECT().DefaultCollectors().Return(nil)
 		c.EXPECT().EksaHostCollectors(gomock.Any()).Return(nil)
+		c.EXPECT().ManagementClusterCollectors().Return(nil)
 
 		w := givenWriter(t)
 		w.EXPECT().Write(gomock.Any(), gomock.Any()).Times(2)

--- a/pkg/diagnostics/diagnostic_bundle_test.go
+++ b/pkg/diagnostics/diagnostic_bundle_test.go
@@ -244,9 +244,11 @@ func TestGenerateDefaultBundle(t *testing.T) {
 	t.Run(t.Name(), func(t *testing.T) {
 		a := givenMockAnalyzerFactory(t)
 		a.EXPECT().DefaultAnalyzers().Return(nil)
+		a.EXPECT().ManagementClusterAnalyzers().Return(nil)
 
 		c := givenMockCollectorsFactory(t)
 		c.EXPECT().DefaultCollectors().Return(nil)
+		c.EXPECT().ManagementClusterCollectors().Return(nil)
 
 		w := givenWriter(t)
 

--- a/pkg/diagnostics/interfaces.go
+++ b/pkg/diagnostics/interfaces.go
@@ -46,9 +46,11 @@ type AnalyzerFactory interface {
 	EksaOidcAnalyzers() []*Analyze
 	EksaExternalEtcdAnalyzers() []*Analyze
 	DataCenterConfigAnalyzers(datacenter v1alpha1.Ref) []*Analyze
+	ManagementClusterAnalyzers() []*Analyze
 }
 
 type CollectorFactory interface {
 	DefaultCollectors() []*Collect
+	ManagementClusterCollectors() []*Collect
 	EksaHostCollectors(configs []providers.MachineConfig) []*Collect
 }

--- a/pkg/diagnostics/interfaces/mocks/diagnostics.go
+++ b/pkg/diagnostics/interfaces/mocks/diagnostics.go
@@ -479,6 +479,20 @@ func (mr *MockAnalyzerFactoryMockRecorder) EksaOidcAnalyzers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EksaOidcAnalyzers", reflect.TypeOf((*MockAnalyzerFactory)(nil).EksaOidcAnalyzers))
 }
 
+// ManagementClusterAnalyzers mocks base method.
+func (m *MockAnalyzerFactory) ManagementClusterAnalyzers() []*diagnostics.Analyze {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ManagementClusterAnalyzers")
+	ret0, _ := ret[0].([]*diagnostics.Analyze)
+	return ret0
+}
+
+// ManagementClusterAnalyzers indicates an expected call of ManagementClusterAnalyzers.
+func (mr *MockAnalyzerFactoryMockRecorder) ManagementClusterAnalyzers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagementClusterAnalyzers", reflect.TypeOf((*MockAnalyzerFactory)(nil).ManagementClusterAnalyzers))
+}
+
 // MockCollectorFactory is a mock of CollectorFactory interface.
 type MockCollectorFactory struct {
 	ctrl     *gomock.Controller
@@ -528,4 +542,18 @@ func (m *MockCollectorFactory) EksaHostCollectors(configs []providers.MachineCon
 func (mr *MockCollectorFactoryMockRecorder) EksaHostCollectors(configs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EksaHostCollectors", reflect.TypeOf((*MockCollectorFactory)(nil).EksaHostCollectors), configs)
+}
+
+// ManagementClusterCollectors mocks base method.
+func (m *MockCollectorFactory) ManagementClusterCollectors() []*diagnostics.Collect {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ManagementClusterCollectors")
+	ret0, _ := ret[0].([]*diagnostics.Collect)
+	return ret0
+}
+
+// ManagementClusterCollectors indicates an expected call of ManagementClusterCollectors.
+func (mr *MockCollectorFactoryMockRecorder) ManagementClusterCollectors() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagementClusterCollectors", reflect.TypeOf((*MockCollectorFactory)(nil).ManagementClusterCollectors))
 }


### PR DESCRIPTION
*Description of changes:*
Previously, we assumed all clusters were self-managed when generating a support bundle.

Now, we check the `isSelfManaged()` method of the spec to determine if the we should collect and analyze management resources (CAPI crds, cluster crd, bundle, etc) when generating a support bundle for a cluster.

the method `WithManagementCluster(isSelfManaged bool)` will determine if a bundle uses the mgmt cluster collectors/analyzers or not.

### Testing
generated default support bundles w/out spec input
generated support bundles w/spec input
generated support bundles for workload and management clusters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

