### PR TITLE
Rename clusterChanged method in unit tests

### DIFF
--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -457,7 +457,7 @@ func TestClusterManagerUpgradeWorkloadClusterSuccess(t *testing.T) {
 		Name: clusterName,
 	}
 
-	tt := newClusterChangedTest(t)
+	tt := newSpecChangedTest(t)
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.provider.EXPECT().GenerateCAPISpecForUpgrade(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy())
@@ -486,7 +486,7 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForMachinesTimeout(t *testing.T
 		Name: clusterName,
 	}
 
-	tt := newClusterChangedTest(t, clustermanager.WithWaitForMachines(1*time.Nanosecond, 50*time.Microsecond, 100*time.Microsecond))
+	tt := newSpecChangedTest(t, clustermanager.WithWaitForMachines(1*time.Nanosecond, 50*time.Microsecond, 100*time.Microsecond))
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.provider.EXPECT().GenerateCAPISpecForUpgrade(ctx, mCluster, wCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy())
@@ -527,7 +527,7 @@ func TestClusterManagerCreateWorkloadClusterWaitForMachinesFailedWithUnhealthyNo
 		{Metadata: types.MachineMetadata{Labels: map[string]string{clusterv1.MachineControlPlaneLabelName: ""}}, Status: status},
 	}
 
-	tt := newClusterChangedTest(t, clustermanager.WithWaitForMachines(1*time.Nanosecond, 50*time.Microsecond, 100*time.Microsecond))
+	tt := newSpecChangedTest(t, clustermanager.WithWaitForMachines(1*time.Nanosecond, 50*time.Microsecond, 100*time.Microsecond))
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.provider.EXPECT().GenerateCAPISpecForUpgrade(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy())
@@ -552,7 +552,7 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForCAPITimeout(t *testing.T) {
 		Name: clusterName,
 	}
 
-	tt := newClusterChangedTest(t)
+	tt := newSpecChangedTest(t)
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.provider.EXPECT().GenerateCAPISpecForUpgrade(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy())
@@ -866,7 +866,7 @@ func TestClusterManagerInstallCustomComponentsErrorApplying(t *testing.T) {
 	}
 }
 
-type clusterChangedTest struct {
+type specChangedTest struct {
 	*testSetup
 	oldClusterConfig, newClusterConfig                         *v1alpha1.Cluster
 	oldDatacenterConfig, newDatacenterConfig                   *v1alpha1.VSphereDatacenterConfig
@@ -874,7 +874,7 @@ type clusterChangedTest struct {
 	oldWorkerMachineConfig, newWorkerMachineConfig             *v1alpha1.VSphereMachineConfig
 }
 
-func newClusterChangedTest(t *testing.T, opts ...clustermanager.ClusterManagerOpt) *clusterChangedTest {
+func newSpecChangedTest(t *testing.T, opts ...clustermanager.ClusterManagerOpt) *specChangedTest {
 	testSetup := newTest(t, opts...)
 	clusterName := testSetup.clusterName
 	clusterConfig := &v1alpha1.Cluster{
@@ -927,7 +927,7 @@ func newClusterChangedTest(t *testing.T, opts ...clustermanager.ClusterManagerOp
 	workerMachineConfig := machineConfig.DeepCopy()
 	workerMachineConfig.Name = clusterConfig.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 
-	changedTest := &clusterChangedTest{
+	changedTest := &specChangedTest{
 		testSetup:                    testSetup,
 		oldClusterConfig:             clusterConfig,
 		newClusterConfig:             newClusterConfig,
@@ -949,7 +949,7 @@ func newClusterChangedTest(t *testing.T, opts ...clustermanager.ClusterManagerOp
 }
 
 func TestClusterManagerClusterSpecChangedNoChanges(t *testing.T) {
-	tt := newClusterChangedTest(t)
+	tt := newSpecChangedTest(t)
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksaVSphereDatacenterConfig(tt.ctx, tt.oldClusterConfig.Spec.DatacenterRef.Name, gomock.Any(), gomock.Any()).Return(tt.oldDatacenterConfig, nil)
@@ -961,7 +961,7 @@ func TestClusterManagerClusterSpecChangedNoChanges(t *testing.T) {
 }
 
 func TestClusterManagerClusterSpecChangedClusterChanged(t *testing.T) {
-	tt := newClusterChangedTest(t)
+	tt := newSpecChangedTest(t)
 	tt.newClusterConfig.Spec.KubernetesVersion = "1.20"
 
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
@@ -971,7 +971,7 @@ func TestClusterManagerClusterSpecChangedClusterChanged(t *testing.T) {
 }
 
 func TestClusterManagerClusterSpecChangedEksDReleaseChanged(t *testing.T) {
-	tt := newClusterChangedTest(t)
+	tt := newSpecChangedTest(t)
 	tt.clusterSpec.VersionsBundle.EksD.Name = "kubernetes-1-19-eks-5"
 
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
@@ -982,7 +982,7 @@ func TestClusterManagerClusterSpecChangedEksDReleaseChanged(t *testing.T) {
 }
 
 func TestClusterManagerClusterSpecChangedNoChangesDatacenterSpecChanged(t *testing.T) {
-	tt := newClusterChangedTest(t)
+	tt := newSpecChangedTest(t)
 	tt.newDatacenterConfig.Spec.Insecure = false
 
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
@@ -994,7 +994,7 @@ func TestClusterManagerClusterSpecChangedNoChangesDatacenterSpecChanged(t *testi
 }
 
 func TestClusterManagerClusterSpecChangedNoChangesControlPlaneMachineConfigSpecChanged(t *testing.T) {
-	tt := newClusterChangedTest(t)
+	tt := newSpecChangedTest(t)
 	tt.newControlPlaneMachineConfig.Spec.NumCPUs = 4
 
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
@@ -1008,7 +1008,7 @@ func TestClusterManagerClusterSpecChangedNoChangesControlPlaneMachineConfigSpecC
 }
 
 func TestClusterManagerClusterSpecChangedNoChangesWorkerNodeMachineConfigSpecChanged(t *testing.T) {
-	tt := newClusterChangedTest(t)
+	tt := newSpecChangedTest(t)
 	tt.newWorkerMachineConfig.Spec.NumCPUs = 4
 
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
@@ -1023,7 +1023,7 @@ func TestClusterManagerClusterSpecChangedNoChangesWorkerNodeMachineConfigSpecCha
 }
 
 func TestClusterManagerClusterSpecChangedGitOpsDefault(t *testing.T) {
-	tt := newClusterChangedTest(t)
+	tt := newSpecChangedTest(t)
 	tt.clusterSpec.Cluster.Spec.GitOpsRef = &v1alpha1.Ref{Kind: v1alpha1.GitOpsConfigKind}
 	tt.oldClusterConfig = tt.clusterSpec.Cluster.DeepCopy()
 	tt.clusterSpec.SetDefaultGitOps()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `newClusterChangedTest` method in the cluster manager unit tests has been found to be useful for any test where the spec changes & we need to call `BuildSpecForCluster`. This PR renames this method to a more suitable name since it is now used for more than just the `...ClusterChanged` tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
