### PR TITLE
Generate cert-manager changediff from capi upgrader

### DIFF
--- a/pkg/clusterapi/upgrader_test.go
+++ b/pkg/clusterapi/upgrader_test.go
@@ -35,6 +35,7 @@ func newUpgraderTest(t *testing.T) *upgraderTest {
 
 	currentSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Bundles.Spec.Number = 1
+		s.VersionsBundle.CertManager.Version = "v0.1.0"
 		s.VersionsBundle.ClusterAPI.Version = "v0.1.0"
 		s.VersionsBundle.ControlPlane.Version = "v0.1.0"
 		s.VersionsBundle.Bootstrap.Version = "v0.1.0"
@@ -115,12 +116,18 @@ func TestUpgraderUpgradeCoreChanges(t *testing.T) {
 
 func TestUpgraderUpgradeEverythingChangesStackedEtcd(t *testing.T) {
 	tt := newUpgraderTest(t)
+	tt.newSpec.VersionsBundle.CertManager.Version = "v0.2.0"
 	tt.newSpec.VersionsBundle.ClusterAPI.Version = "v0.2.0"
 	tt.newSpec.VersionsBundle.ControlPlane.Version = "v0.2.0"
 	tt.newSpec.VersionsBundle.Bootstrap.Version = "v0.2.0"
 	tt.newSpec.VersionsBundle.ExternalEtcdBootstrap.Version = "v0.2.0"
 	tt.newSpec.VersionsBundle.ExternalEtcdController.Version = "v0.2.0"
 	changeDiff := &clusterapi.CAPIChangeDiff{
+		CertManager: &types.ComponentChangeDiff{
+			ComponentName: "cert-manager",
+			NewVersion:    "v0.2.0",
+			OldVersion:    "v0.1.0",
+		},
 		Core: &types.ComponentChangeDiff{
 			ComponentName: "cluster-api",
 			NewVersion:    "v0.2.0",
@@ -141,7 +148,7 @@ func TestUpgraderUpgradeEverythingChangesStackedEtcd(t *testing.T) {
 		InfrastructureProvider: tt.providerChangeDiff,
 	}
 	wantDiff := &types.ChangeDiff{
-		ComponentReports: []types.ComponentChangeDiff{*changeDiff.Core, *changeDiff.ControlPlane, *tt.providerChangeDiff, changeDiff.BootstrapProviders[0]},
+		ComponentReports: []types.ComponentChangeDiff{*changeDiff.CertManager, *changeDiff.Core, *changeDiff.ControlPlane, *tt.providerChangeDiff, changeDiff.BootstrapProviders[0]},
 	}
 
 	tt.provider.EXPECT().ChangeDiff(tt.currentSpec, tt.newSpec).Return(tt.providerChangeDiff)
@@ -153,12 +160,18 @@ func TestUpgraderUpgradeEverythingChangesStackedEtcd(t *testing.T) {
 func TestUpgraderUpgradeEverythingChangesExternalEtcd(t *testing.T) {
 	tt := newUpgraderTest(t)
 	tt.newSpec.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{}
+	tt.newSpec.VersionsBundle.CertManager.Version = "v0.2.0"
 	tt.newSpec.VersionsBundle.ClusterAPI.Version = "v0.2.0"
 	tt.newSpec.VersionsBundle.ControlPlane.Version = "v0.2.0"
 	tt.newSpec.VersionsBundle.Bootstrap.Version = "v0.2.0"
 	tt.newSpec.VersionsBundle.ExternalEtcdBootstrap.Version = "v0.2.0"
 	tt.newSpec.VersionsBundle.ExternalEtcdController.Version = "v0.2.0"
 	changeDiff := &clusterapi.CAPIChangeDiff{
+		CertManager: &types.ComponentChangeDiff{
+			ComponentName: "cert-manager",
+			NewVersion:    "v0.2.0",
+			OldVersion:    "v0.1.0",
+		},
 		Core: &types.ComponentChangeDiff{
 			ComponentName: "cluster-api",
 			NewVersion:    "v0.2.0",
@@ -190,7 +203,7 @@ func TestUpgraderUpgradeEverythingChangesExternalEtcd(t *testing.T) {
 	}
 	wantDiff := &types.ChangeDiff{
 		ComponentReports: []types.ComponentChangeDiff{
-			*changeDiff.Core, *changeDiff.ControlPlane, *tt.providerChangeDiff,
+			*changeDiff.CertManager, *changeDiff.Core, *changeDiff.ControlPlane, *tt.providerChangeDiff,
 			changeDiff.BootstrapProviders[0],
 			changeDiff.BootstrapProviders[1],
 			changeDiff.BootstrapProviders[2],


### PR DESCRIPTION
*Description of changes:*
This is mostly for completion and correctness, but `clusterctl` doesn't need this info. It will help with logging and with a future `upgrade plan` command

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
