### PR TITLE
Refactor git tag assignment for EKS-A cluster controller project

### DIFF
--- a/release/pkg/assets_cluster_controller.go
+++ b/release/pkg/assets_cluster_controller.go
@@ -25,17 +25,22 @@ import (
 
 // GetClusterControllerAssets returns the artifacts for eks-a cluster controller
 func (r *ReleaseConfig) GetClusterControllerAssets() ([]Artifact, error) {
-	// Get git tag
-	cmd := exec.Command("git", "-C", r.CliRepoSource, "describe", "--tag")
-	out, err := execCommand(cmd)
-	if err != nil {
-		return nil, errors.Cause(err)
-	}
+	var gitTag string
+	if r.DevRelease {
+		// Get git tag
+		cmd := exec.Command("git", "-C", r.CliRepoSource, "describe", "--tag")
+		out, err := execCommand(cmd)
+		if err != nil {
+			return nil, errors.Cause(err)
+		}
 
-	gitVersion := strings.Split(out, "-")
-	gitTag := gitVersion[0]
-	if err != nil {
-		return nil, errors.Cause(err)
+		gitVersion := strings.Split(out, "-")
+		gitTag = gitVersion[0]
+		if err != nil {
+			return nil, errors.Cause(err)
+		}
+	} else {
+		gitTag = r.ReleaseVersion
 	}
 
 	name := "eks-anywhere-cluster-controller"


### PR DESCRIPTION
This PR refactors how we assign the git tag for cluster-controller project based on the release type.
For dev release, run `git describe --tag` to get the tag.
For staging and prod releases, we want the image/manifests for the cluster-controller to be aligned with the current CLI version, so we read it from the ReleaseVersion parameter.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
