### PR TITLE
Clean up EKSA resources

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -1006,7 +1006,7 @@ func (c *ClusterManager) DeleteOIDCConfig(ctx context.Context, managementCluster
 }
 
 func (c *ClusterManager) DeleteAWSIamConfig(ctx context.Context, managementCluster *types.Cluster, name string, namespace string) error {
-	return c.clusterClient.DeleteOIDCConfig(ctx, managementCluster, name, namespace)
+	return c.clusterClient.DeleteAWSIamConfig(ctx, managementCluster, name, namespace)
 }
 
 func (c *ClusterManager) DeleteEKSACluster(ctx context.Context, managementCluster *types.Cluster, name string, namespace string) error {

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -62,6 +62,7 @@ type ClusterClient interface {
 	DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster) error
 	DeleteGitOpsConfig(ctx context.Context, managementCluster *types.Cluster, gitOpsName, namespace string) error
 	DeleteOIDCConfig(ctx context.Context, managementCluster *types.Cluster, oidcConfigName, oidcConfigNamespace string) error
+	DeleteAWSIamConfig(ctx context.Context, managementCluster *types.Cluster, awsIamConfigName, awsIamConfigNamespace string) error
 	DeleteEKSACluster(ctx context.Context, managementCluster *types.Cluster, eksaClusterName, eksaClusterNamespace string) error
 	InitInfrastructure(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
 	WaitForDeployment(ctx context.Context, cluster *types.Cluster, timeout string, condition string, target string, namespace string) error
@@ -276,6 +277,13 @@ func (c *ClusterManager) DeleteCluster(ctx context.Context, managementCluster, c
 					return err
 				}
 			}
+
+			if clusterSpec.AWSIamConfig != nil {
+				if err := c.DeleteAWSIamConfig(ctx, managementCluster, clusterSpec.AWSIamConfig.Name, clusterSpec.AWSIamConfig.Namespace); err != nil {
+					return err
+				}
+			}
+
 			if err := provider.DeleteResources(ctx, clusterSpec); err != nil {
 				return err
 			}
@@ -992,6 +1000,10 @@ func (c *ClusterManager) DeleteGitOpsConfig(ctx context.Context, managementClust
 }
 
 func (c *ClusterManager) DeleteOIDCConfig(ctx context.Context, managementCluster *types.Cluster, name string, namespace string) error {
+	return c.clusterClient.DeleteOIDCConfig(ctx, managementCluster, name, namespace)
+}
+
+func (c *ClusterManager) DeleteAWSIamConfig(ctx context.Context, managementCluster *types.Cluster, name string, namespace string) error {
 	return c.clusterClient.DeleteOIDCConfig(ctx, managementCluster, name, namespace)
 }
 

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -272,7 +272,6 @@ func (c *ClusterManager) DeleteCluster(ctx context.Context, managementCluster, c
 				}
 			}
 			if clusterSpec.OIDCConfig != nil {
-				fmt.Printf("deleting oicd\n")
 				if err := c.DeleteOIDCConfig(ctx, managementCluster, clusterSpec.OIDCConfig.Name, clusterSpec.OIDCConfig.Namespace); err != nil {
 					return err
 				}

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -60,6 +60,9 @@ type ClusterClient interface {
 	WaitForManagedExternalEtcdReady(ctx context.Context, cluster *types.Cluster, timeout string, newClusterName string) error
 	GetWorkloadKubeconfig(ctx context.Context, clusterName string, cluster *types.Cluster) ([]byte, error)
 	DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster) error
+	DeleteGitOpsConfig(ctx context.Context, managementCluster *types.Cluster, gitOpsName, namespace string) error
+	DeleteOIDCConfig(ctx context.Context, managementCluster *types.Cluster, oidcConfigName, oidcConfigNamespace string) error
+	DeleteEKSACluster(ctx context.Context, managementCluster *types.Cluster, eksaClusterName, eksaClusterNamespace string) error
 	InitInfrastructure(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
 	WaitForDeployment(ctx context.Context, cluster *types.Cluster, timeout string, condition string, target string, namespace string) error
 	SaveLog(ctx context.Context, cluster *types.Cluster, deployment *types.Deployment, fileName string, writer filewriter.FileWriter) error
@@ -252,10 +255,33 @@ func (c *ClusterManager) generateWorkloadKubeconfig(ctx context.Context, cluster
 	return writtenFile, nil
 }
 
-func (c *ClusterManager) DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster) error {
+func (c *ClusterManager) DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster, provider providers.Provider, clusterSpec *cluster.Spec) error {
 	return c.Retrier.Retry(
 		func() error {
-			return c.clusterClient.DeleteCluster(ctx, managementCluster, clusterToDelete)
+			if err := c.PauseEKSAControllerReconcile(ctx, clusterToDelete, clusterSpec, provider); err != nil {
+				return err
+			}
+
+			if err := c.clusterClient.DeleteCluster(ctx, managementCluster, clusterToDelete); err != nil {
+				return err
+			}
+
+			if clusterSpec.GitOpsConfig != nil {
+				if err := c.DeleteGitOpsConfig(ctx, managementCluster, clusterSpec.GitOpsConfig.Name, clusterSpec.GitOpsConfig.Namespace); err != nil {
+					return err
+				}
+			}
+			if clusterSpec.OIDCConfig != nil {
+				fmt.Printf("deleting oicd\n")
+				if err := c.DeleteOIDCConfig(ctx, managementCluster, clusterSpec.OIDCConfig.Name, clusterSpec.OIDCConfig.Namespace); err != nil {
+					return err
+				}
+			}
+			if err := provider.DeleteResources(ctx, clusterSpec); err != nil {
+				return err
+			}
+
+			return c.DeleteEKSACluster(ctx, managementCluster, clusterSpec.Name, clusterSpec.Namespace)
 		},
 	)
 }
@@ -960,4 +986,16 @@ func (c *ClusterManager) bundlesFetcher(cluster *types.Cluster) cluster.BundlesF
 	return func(ctx context.Context, name, namespace string) (*releasev1alpha1.Bundles, error) {
 		return c.clusterClient.GetBundles(ctx, cluster.KubeconfigFile, name, namespace)
 	}
+}
+
+func (c *ClusterManager) DeleteGitOpsConfig(ctx context.Context, managementCluster *types.Cluster, name string, namespace string) error {
+	return c.clusterClient.DeleteGitOpsConfig(ctx, managementCluster, name, namespace)
+}
+
+func (c *ClusterManager) DeleteOIDCConfig(ctx context.Context, managementCluster *types.Cluster, name string, namespace string) error {
+	return c.clusterClient.DeleteOIDCConfig(ctx, managementCluster, name, namespace)
+}
+
+func (c *ClusterManager) DeleteEKSACluster(ctx context.Context, managementCluster *types.Cluster, name string, namespace string) error {
+	return c.clusterClient.DeleteEKSACluster(ctx, managementCluster, name, namespace)
 }

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -110,6 +110,48 @@ func (mr *MockClusterClientMockRecorder) DeleteCluster(arg0, arg1, arg2 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockClusterClient)(nil).DeleteCluster), arg0, arg1, arg2)
 }
 
+// DeleteEKSACluster mocks base method.
+func (m *MockClusterClient) DeleteEKSACluster(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteEKSACluster", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteEKSACluster indicates an expected call of DeleteEKSACluster.
+func (mr *MockClusterClientMockRecorder) DeleteEKSACluster(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEKSACluster", reflect.TypeOf((*MockClusterClient)(nil).DeleteEKSACluster), arg0, arg1, arg2, arg3)
+}
+
+// DeleteGitOpsConfig mocks base method.
+func (m *MockClusterClient) DeleteGitOpsConfig(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteGitOpsConfig", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteGitOpsConfig indicates an expected call of DeleteGitOpsConfig.
+func (mr *MockClusterClientMockRecorder) DeleteGitOpsConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGitOpsConfig", reflect.TypeOf((*MockClusterClient)(nil).DeleteGitOpsConfig), arg0, arg1, arg2, arg3)
+}
+
+// DeleteOIDCConfig mocks base method.
+func (m *MockClusterClient) DeleteOIDCConfig(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOIDCConfig", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteOIDCConfig indicates an expected call of DeleteOIDCConfig.
+func (mr *MockClusterClientMockRecorder) DeleteOIDCConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOIDCConfig", reflect.TypeOf((*MockClusterClient)(nil).DeleteOIDCConfig), arg0, arg1, arg2, arg3)
+}
+
 // GetApiServerUrl mocks base method.
 func (m *MockClusterClient) GetApiServerUrl(arg0 context.Context, arg1 *types.Cluster) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -96,6 +96,20 @@ func (mr *MockClusterClientMockRecorder) CreateNamespace(arg0, arg1, arg2 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockClusterClient)(nil).CreateNamespace), arg0, arg1, arg2)
 }
 
+// DeleteAWSIamConfig mocks base method.
+func (m *MockClusterClient) DeleteAWSIamConfig(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAWSIamConfig", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAWSIamConfig indicates an expected call of DeleteAWSIamConfig.
+func (mr *MockClusterClientMockRecorder) DeleteAWSIamConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAWSIamConfig", reflect.TypeOf((*MockClusterClient)(nil).DeleteAWSIamConfig), arg0, arg1, arg2, arg3)
+}
+
 // DeleteCluster mocks base method.
 func (m *MockClusterClient) DeleteCluster(arg0 context.Context, arg1, arg2 *types.Cluster) error {
 	m.ctrl.T.Helper()

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -199,7 +199,7 @@ func (k *Kubectl) DeleteEksaVSphereMachineConfig(ctx context.Context, vsphereMac
 	params := []string{"delete", eksaVSphereMachineResourceType, vsphereMachineConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace, "--ignore-not-found=true"}
 	_, err := k.executable.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error deleting vsphermachineconfig cluster %s apply: %v", vsphereMachineConfigName, err)
+		return fmt.Errorf("error deleting vspheremachineconfig cluster %s apply: %v", vsphereMachineConfigName, err)
 	}
 	return nil
 }

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -187,7 +187,7 @@ func (k *Kubectl) Wait(ctx context.Context, kubeconfig string, timeout string, f
 }
 
 func (k *Kubectl) DeleteEksaVSphereDatacenterConfig(ctx context.Context, vsphereDatacenterConfigName string, kubeconfigFile string, namespace string) error {
-	params := []string{"delete", eksaVSphereDatacenterResourceType, vsphereDatacenterConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace}
+	params := []string{"delete", eksaVSphereDatacenterResourceType, vsphereDatacenterConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace, "--ignore-not-found=true"}
 	_, err := k.executable.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error deleting vspheredatacenterconfig cluster %s apply: %v", vsphereDatacenterConfigName, err)
@@ -196,7 +196,7 @@ func (k *Kubectl) DeleteEksaVSphereDatacenterConfig(ctx context.Context, vsphere
 }
 
 func (k *Kubectl) DeleteEksaVSphereMachineConfig(ctx context.Context, vsphereMachineConfigName string, kubeconfigFile string, namespace string) error {
-	params := []string{"delete", eksaVSphereMachineResourceType, vsphereMachineConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace}
+	params := []string{"delete", eksaVSphereMachineResourceType, vsphereMachineConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace, "--ignore-not-found=true"}
 	_, err := k.executable.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error deleting vsphermachineconfig cluster %s apply: %v", vsphereMachineConfigName, err)
@@ -205,7 +205,7 @@ func (k *Kubectl) DeleteEksaVSphereMachineConfig(ctx context.Context, vsphereMac
 }
 
 func (k *Kubectl) DeleteEKSACluster(ctx context.Context, managementCluster *types.Cluster, eksaClusterName, eksaClusterNamespace string) error {
-	params := []string{"delete", eksaClusterResourceType, eksaClusterName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", eksaClusterNamespace}
+	params := []string{"delete", eksaClusterResourceType, eksaClusterName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", eksaClusterNamespace, "--ignore-not-found=true"}
 	_, err := k.executable.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error deleting eksa cluster %s apply: %v", eksaClusterName, err)
@@ -214,7 +214,7 @@ func (k *Kubectl) DeleteEKSACluster(ctx context.Context, managementCluster *type
 }
 
 func (k *Kubectl) DeleteGitOpsConfig(ctx context.Context, managementCluster *types.Cluster, gitOpsConfigName, gitOpsConfigNamespace string) error {
-	params := []string{"delete", eksaGitOpsResourceType, gitOpsConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", gitOpsConfigNamespace}
+	params := []string{"delete", eksaGitOpsResourceType, gitOpsConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", gitOpsConfigNamespace, "--ignore-not-found=true"}
 	_, err := k.executable.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error deleting gitops config %s apply: %v", gitOpsConfigName, err)
@@ -223,7 +223,7 @@ func (k *Kubectl) DeleteGitOpsConfig(ctx context.Context, managementCluster *typ
 }
 
 func (k *Kubectl) DeleteOIDCConfig(ctx context.Context, managementCluster *types.Cluster, oidcConfigName, oidcConfigNamespace string) error {
-	params := []string{"delete", eksaOIDCResourceType, oidcConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", oidcConfigNamespace}
+	params := []string{"delete", eksaOIDCResourceType, oidcConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", oidcConfigNamespace, "--ignore-not-found=true"}
 	_, err := k.executable.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error deleting oidc config %s apply: %v", oidcConfigName, err)
@@ -232,7 +232,7 @@ func (k *Kubectl) DeleteOIDCConfig(ctx context.Context, managementCluster *types
 }
 
 func (k *Kubectl) DeleteAWSIamConfig(ctx context.Context, managementCluster *types.Cluster, awsIamConfigName, awsIamConfigNamespace string) error {
-	params := []string{"delete", eksaAwsIamResourceType, awsIamConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", awsIamConfigNamespace}
+	params := []string{"delete", eksaAwsIamResourceType, awsIamConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", awsIamConfigNamespace, "--ignore-not-found=true"}
 	_, err := k.executable.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error deleting awsIam config %s apply: %v", awsIamConfigName, err)

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -186,6 +186,51 @@ func (k *Kubectl) Wait(ctx context.Context, kubeconfig string, timeout string, f
 	return nil
 }
 
+func (k *Kubectl) DeleteEksaVSphereDatacenterConfig(ctx context.Context, vsphereDatacenterConfigName string, kubeconfigFile string, namespace string) error {
+	params := []string{"delete", eksaVSphereDatacenterResourceType, vsphereDatacenterConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace}
+	_, err := k.executable.Execute(ctx, params...)
+	if err != nil {
+		return fmt.Errorf("error deleting vspherdatacenterconfig cluster %s apply: %v", vsphereDatacenterConfigName, err)
+	}
+	return nil
+}
+
+func (k *Kubectl) DeleteEksaVSphereMachineConfig(ctx context.Context, vsphereMachineConfigName string, kubeconfigFile string, namespace string) error {
+	params := []string{"delete", eksaVSphereMachineResourceType, vsphereMachineConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace}
+	_, err := k.executable.Execute(ctx, params...)
+	if err != nil {
+		return fmt.Errorf("error deleting vsphermachineconfig cluster %s apply: %v", vsphereMachineConfigName, err)
+	}
+	return nil
+}
+
+func (k *Kubectl) DeleteEKSACluster(ctx context.Context, managementCluster *types.Cluster, eksaClusterName, eksaClusterNamespace string) error {
+	params := []string{"delete", eksaClusterResourceType, eksaClusterName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", eksaClusterNamespace}
+	_, err := k.executable.Execute(ctx, params...)
+	if err != nil {
+		return fmt.Errorf("error deleting eksa cluster %s apply: %v", eksaClusterName, err)
+	}
+	return nil
+}
+
+func (k *Kubectl) DeleteGitOpsConfig(ctx context.Context, managementCluster *types.Cluster, gitOpsConfigName, gitOpsConfigNamespace string) error {
+	params := []string{"delete", eksaGitOpsResourceType, gitOpsConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", gitOpsConfigNamespace}
+	_, err := k.executable.Execute(ctx, params...)
+	if err != nil {
+		return fmt.Errorf("error deleting gitops config %s apply: %v", gitOpsConfigName, err)
+	}
+	return nil
+}
+
+func (k *Kubectl) DeleteOIDCConfig(ctx context.Context, managementCluster *types.Cluster, oidcConfigName, oidcConfigNamespace string) error {
+	params := []string{"delete", eksaOIDCResourceType, oidcConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", oidcConfigNamespace}
+	_, err := k.executable.Execute(ctx, params...)
+	if err != nil {
+		return fmt.Errorf("error deleting oidc config %s apply: %v", oidcConfigName, err)
+	}
+	return nil
+}
+
 func (k *Kubectl) DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster) error {
 	params := []string{"delete", capiClustersResourceType, clusterToDelete.Name, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", constants.EksaSystemNamespace}
 	_, err := k.executable.Execute(ctx, params...)

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -190,7 +190,7 @@ func (k *Kubectl) DeleteEksaVSphereDatacenterConfig(ctx context.Context, vsphere
 	params := []string{"delete", eksaVSphereDatacenterResourceType, vsphereDatacenterConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace}
 	_, err := k.executable.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error deleting vspherdatacenterconfig cluster %s apply: %v", vsphereDatacenterConfigName, err)
+		return fmt.Errorf("error deleting vspheredatacenterconfig cluster %s apply: %v", vsphereDatacenterConfigName, err)
 	}
 	return nil
 }

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -231,6 +231,15 @@ func (k *Kubectl) DeleteOIDCConfig(ctx context.Context, managementCluster *types
 	return nil
 }
 
+func (k *Kubectl) DeleteAWSIamConfig(ctx context.Context, managementCluster *types.Cluster, awsIamConfigName, awsIamConfigNamespace string) error {
+	params := []string{"delete", eksaAwsIamResourceType, awsIamConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", awsIamConfigNamespace}
+	_, err := k.executable.Execute(ctx, params...)
+	if err != nil {
+		return fmt.Errorf("error deleting awsIam config %s apply: %v", awsIamConfigName, err)
+	}
+	return nil
+}
+
 func (k *Kubectl) DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster) error {
 	params := []string{"delete", capiClustersResourceType, clusterToDelete.Name, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", constants.EksaSystemNamespace}
 	_, err := k.executable.Execute(ctx, params...)

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -88,6 +88,10 @@ func (p *provider) MachineResourceType() string {
 	return ""
 }
 
+func (p *provider) DeleteResources(_ context.Context, _ *cluster.Spec) error {
+	return nil
+}
+
 func (p *provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpec *cluster.Spec) error {
 	logger.Info("Warning: The docker infrastructure provider is meant for local development and testing only")
 	if clusterSpec.Spec.ControlPlaneConfiguration.Endpoint != nil && clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host != "" {

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -124,6 +124,20 @@ func (mr *MockProviderMockRecorder) DatacenterResourceType() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatacenterResourceType", reflect.TypeOf((*MockProvider)(nil).DatacenterResourceType))
 }
 
+// DeleteResources mocks base method.
+func (m *MockProvider) DeleteResources(arg0 context.Context, arg1 *cluster.Spec) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteResources", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteResources indicates an expected call of DeleteResources.
+func (mr *MockProviderMockRecorder) DeleteResources(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResources", reflect.TypeOf((*MockProvider)(nil).DeleteResources), arg0, arg1)
+}
+
 // EnvMap mocks base method.
 func (m *MockProvider) EnvMap() (map[string]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -35,6 +35,7 @@ type Provider interface {
 	ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff
 	RunPostUpgrade(ctx context.Context, clusterSpec *cluster.Spec, managementCluster, workloadCluster *types.Cluster) error
 	UpgradeNeeded(ctx context.Context, newSpec, currentSpec *cluster.Spec) (bool, error)
+	DeleteResources(ctx context.Context, clusterSpec *cluster.Spec) error
 }
 
 type DatacenterConfig interface {

--- a/pkg/providers/vsphere/mocks/client.go
+++ b/pkg/providers/vsphere/mocks/client.go
@@ -338,6 +338,34 @@ func (mr *MockProviderKubectlClientMockRecorder) CreateNamespace(arg0, arg1, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockProviderKubectlClient)(nil).CreateNamespace), arg0, arg1, arg2)
 }
 
+// DeleteEksaVSphereDatacenterConfig mocks base method.
+func (m *MockProviderKubectlClient) DeleteEksaVSphereDatacenterConfig(arg0 context.Context, arg1, arg2, arg3 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteEksaVSphereDatacenterConfig", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteEksaVSphereDatacenterConfig indicates an expected call of DeleteEksaVSphereDatacenterConfig.
+func (mr *MockProviderKubectlClientMockRecorder) DeleteEksaVSphereDatacenterConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEksaVSphereDatacenterConfig", reflect.TypeOf((*MockProviderKubectlClient)(nil).DeleteEksaVSphereDatacenterConfig), arg0, arg1, arg2, arg3)
+}
+
+// DeleteEksaVSphereMachineConfig mocks base method.
+func (m *MockProviderKubectlClient) DeleteEksaVSphereMachineConfig(arg0 context.Context, arg1, arg2, arg3 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteEksaVSphereMachineConfig", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteEksaVSphereMachineConfig indicates an expected call of DeleteEksaVSphereMachineConfig.
+func (mr *MockProviderKubectlClientMockRecorder) DeleteEksaVSphereMachineConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEksaVSphereMachineConfig", reflect.TypeOf((*MockProviderKubectlClient)(nil).DeleteEksaVSphereMachineConfig), arg0, arg1, arg2, arg3)
+}
+
 // GetEksaCluster mocks base method.
 func (m *MockProviderKubectlClient) GetEksaCluster(arg0 context.Context, arg1 *types.Cluster, arg2 string) (*v1alpha1.Cluster, error) {
 	m.ctrl.T.Helper()

--- a/pkg/workflows/delete.go
+++ b/pkg/workflows/delete.go
@@ -47,12 +47,8 @@ func (c *Delete) Run(ctx context.Context, workloadCluster *types.Cluster, cluste
 		Rollback:        false,
 	}
 
-	if kubeconfig != "" {
-		commandContext.BootstrapCluster = &types.Cluster{
-			Name:               clusterSpec.Name,
-			KubeconfigFile:     kubeconfig,
-			ExistingManagement: true,
-		}
+	if clusterSpec.ManagementCluster != nil {
+		commandContext.BootstrapCluster = clusterSpec.ManagementCluster
 	}
 
 	err := task.NewTaskRunner(&setupAndValidate{}).RunTask(ctx, commandContext)
@@ -148,7 +144,7 @@ func (s *moveClusterManagement) Name() string {
 
 func (s *deleteWorkloadCluster) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Deleting workload cluster")
-	err := commandContext.ClusterManager.DeleteCluster(ctx, commandContext.BootstrapCluster, commandContext.WorkloadCluster)
+	err := commandContext.ClusterManager.DeleteCluster(ctx, commandContext.BootstrapCluster, commandContext.WorkloadCluster, commandContext.Provider, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
 		return nil

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -19,7 +19,7 @@ type ClusterManager interface {
 	MoveCAPI(ctx context.Context, from, to *types.Cluster, clusterName string, checkers ...types.NodeReadyChecker) error
 	CreateWorkloadCluster(ctx context.Context, managementCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) (*types.Cluster, error)
 	UpgradeCluster(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
-	DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster) error
+	DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster, provider providers.Provider, clusterSpec *cluster.Spec) error
 	InstallCAPI(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
 	InstallNetworking(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
 	InstallStorageClass(ctx context.Context, cluster *types.Cluster, provider providers.Provider) error

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -154,17 +154,17 @@ func (mr *MockClusterManagerMockRecorder) CreateWorkloadCluster(arg0, arg1, arg2
 }
 
 // DeleteCluster mocks base method.
-func (m *MockClusterManager) DeleteCluster(arg0 context.Context, arg1, arg2 *types.Cluster) error {
+func (m *MockClusterManager) DeleteCluster(arg0 context.Context, arg1, arg2 *types.Cluster, arg3 providers.Provider, arg4 *cluster.Spec) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCluster", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "DeleteCluster", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteCluster indicates an expected call of DeleteCluster.
-func (mr *MockClusterManagerMockRecorder) DeleteCluster(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClusterManagerMockRecorder) DeleteCluster(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockClusterManager)(nil).DeleteCluster), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockClusterManager)(nil).DeleteCluster), arg0, arg1, arg2, arg3, arg4)
 }
 
 // EKSAClusterSpecChanged mocks base method.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Delete EKSA resources when deleting a workload cluster (GitOpsConfig, OIDCCOnfig, VSphereMachineConfig and VsphereDatacenterconfig)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
