### PR TITLE
Update EKS-D module version to consume API updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/aws/aws-sdk-go v1.38.40
 	github.com/aws/eks-anywhere/release v0.0.0-20210629184439-aded106d7d59
-	github.com/aws/eks-distro-build-tooling/release v0.0.0-20210810165539-7d41d9b36b74
+	github.com/aws/eks-distro-build-tooling/release v0.0.0-20211103003257-a7e2379eae5e
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/aws/aws-sdk-go v1.38.40 h1:VVqBFV24tGgXR11tFXPjmR+0ItbnUepbuQjdmhgu3U
 github.com/aws/aws-sdk-go v1.38.40/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aws/aws-sdk-go-v2 v1.5.0/go.mod h1:tI4KhsR5VkzlUa2DZAdwx7wCAYGwkZZ1H31PYrBFx1w=
-github.com/aws/eks-distro-build-tooling/release v0.0.0-20210810165539-7d41d9b36b74 h1:ejX98p7x/70w8F4Y3I4Va4UyP4b28iofwWfRawUiXZE=
-github.com/aws/eks-distro-build-tooling/release v0.0.0-20210810165539-7d41d9b36b74/go.mod h1:zS4jJCwuah31QqzRtwe0fVaj8UtjZDaC9MjaveZGmI0=
+github.com/aws/eks-distro-build-tooling/release v0.0.0-20211103003257-a7e2379eae5e h1:GB6Cn9yKEt31mDF7RrVWyM9WoppNkGYth8zBPIJGJ+w=
+github.com/aws/eks-distro-build-tooling/release v0.0.0-20211103003257-a7e2379eae5e/go.mod h1:p/KHVJAMv3kofnUnShkZ6pUnZYzm+LK2G7bIi8nnTKA=
 github.com/aws/smithy-go v1.4.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/release/go.mod
+++ b/release/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Microsoft/hcsshim v0.8.21 // indirect
 	github.com/aws/aws-sdk-go v1.38.40
 	github.com/aws/aws-sdk-go-v2 v1.5.0
-	github.com/aws/eks-distro-build-tooling/release v0.0.0-20210810165539-7d41d9b36b74
+	github.com/aws/eks-distro-build-tooling/release v0.0.0-20211103003257-a7e2379eae5e
 	github.com/docker/docker v20.10.6+incompatible // indirect
 	github.com/fsouza/go-dockerclient v1.7.2
 	github.com/go-git/go-git/v5 v5.3.0

--- a/release/go.sum
+++ b/release/go.sum
@@ -97,8 +97,8 @@ github.com/aws/aws-sdk-go v1.38.40 h1:VVqBFV24tGgXR11tFXPjmR+0ItbnUepbuQjdmhgu3U
 github.com/aws/aws-sdk-go v1.38.40/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v1.5.0 h1:o0TprBiEkqtMGD2Ira1VCq3zwWej256zHLSRcd+cxUA=
 github.com/aws/aws-sdk-go-v2 v1.5.0/go.mod h1:tI4KhsR5VkzlUa2DZAdwx7wCAYGwkZZ1H31PYrBFx1w=
-github.com/aws/eks-distro-build-tooling/release v0.0.0-20210810165539-7d41d9b36b74 h1:ejX98p7x/70w8F4Y3I4Va4UyP4b28iofwWfRawUiXZE=
-github.com/aws/eks-distro-build-tooling/release v0.0.0-20210810165539-7d41d9b36b74/go.mod h1:zS4jJCwuah31QqzRtwe0fVaj8UtjZDaC9MjaveZGmI0=
+github.com/aws/eks-distro-build-tooling/release v0.0.0-20211103003257-a7e2379eae5e h1:GB6Cn9yKEt31mDF7RrVWyM9WoppNkGYth8zBPIJGJ+w=
+github.com/aws/eks-distro-build-tooling/release v0.0.0-20211103003257-a7e2379eae5e/go.mod h1:p/KHVJAMv3kofnUnShkZ6pUnZYzm+LK2G7bIi8nnTKA=
 github.com/aws/smithy-go v1.4.0 h1:3rsQpgRe+OoQgJhEwGNpIkosl0fJLdmQqF4gSFRjg+4=
 github.com/aws/smithy-go v1.4.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
The EKS-D release API was [updated](https://github.com/aws/eks-distro-build-tooling/commit/7cedd37fb487e9e5b5c629d2b69e3815b3b3285f) to add image digests, so we need to modify the EKS-A go mods to consume the latest version of that module.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
