### PR TITLE
log SSM command ID in e2e test run outcome

### DIFF
--- a/internal/pkg/ssm/command.go
+++ b/internal/pkg/ssm/command.go
@@ -20,7 +20,8 @@ var initE2EDirCommand = "mkdir -p /home/e2e/bin && cd /home/e2e"
 
 func WaitForSSMReady(session *session.Session, instanceId string) error {
 	err := retrier.Retry(10, 20*time.Second, func() error {
-		return Run(session, instanceId, "ls")
+		_, err := Run(session, instanceId, "ls")
+		return err
 	})
 	if err != nil {
 		return fmt.Errorf("error waiting for ssm to be ready: %v", err)
@@ -55,7 +56,7 @@ var nonFinalStatuses = map[string]struct{}{
 }
 
 // TODO: cleanup this method
-func Run(session *session.Session, instanceId string, command string, opts ...CommandOpt) error {
+func Run(session *session.Session, instanceId, command string, opts ...CommandOpt) (commandId string, err error) {
 	service := ssm.New(session)
 
 	c := &ssm.SendCommandInput{
@@ -74,7 +75,7 @@ func Run(session *session.Session, instanceId string, command string, opts ...Co
 		}
 		return false, 0
 	}))
-	err := r.Retry(func() error {
+	err = r.Retry(func() error {
 		var err error
 		logger.V(2).Info("Running ssm command", "cmd", command)
 		result, err = service.SendCommand(c)
@@ -84,7 +85,7 @@ func Run(session *session.Session, instanceId string, command string, opts ...Co
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("retries exhausted sending ssm command: %v", err)
+		return "", fmt.Errorf("retries exhausted sending ssm command: %v", err)
 	}
 
 	logger.V(2).Info("SSM command started", "commandId", result.Command.CommandId)
@@ -95,8 +96,9 @@ func Run(session *session.Session, instanceId string, command string, opts ...Co
 		)
 	}
 
+	commandId = *result.Command.CommandId
 	commandIn := &ssm.GetCommandInvocationInput{
-		CommandId:  result.Command.CommandId,
+		CommandId:  &commandId,
 		InstanceId: aws.String(instanceId),
 	}
 
@@ -111,7 +113,7 @@ func Run(session *session.Session, instanceId string, command string, opts ...Co
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("error waiting for ssm command to be registered: %v", err)
+		return commandId, fmt.Errorf("error waiting for ssm command to be registered: %v", err)
 	}
 
 	logger.V(2).Info("Waiting for ssm command to finish")
@@ -126,7 +128,7 @@ func Run(session *session.Session, instanceId string, command string, opts ...Co
 
 		status := *commandOut.Status
 		if isFinalStatus(status) {
-			logger.V(2).Info("SSM command finished", "status", status)
+			logger.V(2).Info("SSM command finished", "status", status, "commandId", result.Command.CommandId)
 			// TODO: these outputs might be truncated (8000 chars max). Get the logs from s3 with StandardErrorUrl and StandardOutputContent instead
 			fmt.Println("Command stdout:")
 			fmt.Println(*commandOut.StandardOutputContent)
@@ -141,14 +143,14 @@ func Run(session *session.Session, instanceId string, command string, opts ...Co
 		return fmt.Errorf("command still running with status %s", status)
 	})
 	if err != nil {
-		return fmt.Errorf("retries exhausted running ssm command: %v", err)
+		return commandId, fmt.Errorf("retries exhausted running ssm command: %v", err)
 	}
 
 	if *commandOut.Status != ssm.CommandInvocationStatusSuccess {
-		return errors.New("failed to execute ssm command")
+		return commandId, errors.New("failed to execute ssm command")
 	}
 
-	return nil
+	return commandId, nil
 }
 
 func isFinalStatus(status string) bool {

--- a/internal/test/e2e/oidc.go
+++ b/internal/test/e2e/oidc.go
@@ -114,7 +114,7 @@ func (e *E2ESession) downloadSignerKeyInInstance(folder string) (pathInInstance 
 	saSignerKey := filepath.Join(folder, saSignerPath)
 	logger.V(1).Info("Downloading from s3 in instance", "key", saSignerKey)
 	command := fmt.Sprintf("aws s3 cp s3://%s/%s ./%s", e.storageBucket, saSignerKey, saSignerPath)
-	err = ssm.Run(e.session, e.instanceId, command)
+	_, err = ssm.Run(e.session, e.instanceId, command)
 	if err != nil {
 		return "", fmt.Errorf("error downloading signer key in instance: %v", err)
 	}

--- a/internal/test/e2e/registryMirror.go
+++ b/internal/test/e2e/registryMirror.go
@@ -34,7 +34,7 @@ func (e *E2ESession) setupRegistryMirrorEnv(testRegex string) error {
 
 func (e *E2ESession) mountRegistryCert(cert string, endpoint string) error {
 	command := fmt.Sprintf("sudo mkdir -p /etc/docker/certs.d/%s", endpoint)
-	err := ssm.Run(e.session, e.instanceId, command)
+	_, err := ssm.Run(e.session, e.instanceId, command)
 	if err != nil {
 		return fmt.Errorf("error creating directory in instance: %v", err)
 	}
@@ -43,7 +43,7 @@ func (e *E2ESession) mountRegistryCert(cert string, endpoint string) error {
 		return fmt.Errorf("failed to decode certificate: %v", err)
 	}
 	command = fmt.Sprintf("sudo cat <<EOF>> /etc/docker/certs.d/%s/ca.crt\n%s\nEOF", endpoint, string(decodedCert))
-	err = ssm.Run(e.session, e.instanceId, command)
+	_, err = ssm.Run(e.session, e.instanceId, command)
 	if err != nil {
 		return fmt.Errorf("error mounting certificate in instance: %v", err)
 	}

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -34,6 +34,7 @@ type E2ESession struct {
 	instanceId          string
 	testEnvVars         map[string]string
 	bundlesOverride     bool
+	commandId           string
 }
 
 func newSession(amiId, instanceProfileName, storageBucket, jobId, subnetId string, bundlesOverride bool) (*E2ESession, error) {
@@ -158,7 +159,7 @@ func (e *E2ESession) downloadRequiredFileInInstance(file string) error {
 	} else {
 		command = fmt.Sprintf("aws s3 cp s3://%s/%s/%s ./bin/ && chmod 645 ./bin/%s", e.storageBucket, e.jobId, file, file)
 	}
-	err := ssm.Run(e.session, e.instanceId, command)
+	_, err := ssm.Run(e.session, e.instanceId, command)
 	if err != nil {
 		return fmt.Errorf("error downloading file in instance: %v", err)
 	}
@@ -172,7 +173,7 @@ func (e *E2ESession) uploadGeneratedFilesFromInstance(testName string) {
 	command := fmt.Sprintf("aws s3 cp /home/e2e/%s/ %s/%s/ --recursive",
 		e.instanceId, e.generatedArtifactsBucketPath(), testName)
 
-	err := ssm.Run(e.session, e.instanceId, command)
+	_, err := ssm.Run(e.session, e.instanceId, command)
 	if err != nil {
 		logger.Error(err, "error uploading log files from instance")
 	} else {
@@ -186,7 +187,7 @@ func (e *E2ESession) uploadDiagnosticArchiveFromInstance(testName string) {
 	command := fmt.Sprintf("aws s3 cp /home/e2e/ %s/%s/ --recursive --exclude \"*\" --include \"%s\"",
 		e.generatedArtifactsBucketPath(), testName, bundleNameFormat)
 
-	err := ssm.Run(e.session, e.instanceId, command)
+	_, err := ssm.Run(e.session, e.instanceId, command)
 	if err != nil {
 		logger.Error(err, "error uploading diagnostic bundle from instance")
 	} else {
@@ -214,7 +215,7 @@ func (e *E2ESession) downloadRequiredFilesInInstance() error {
 
 func (e *E2ESession) createTestNameFile(testName string) error {
 	command := fmt.Sprintf("echo %s > %s", testName, testNameFile)
-	err := ssm.Run(e.session, e.instanceId, command)
+	_, err := ssm.Run(e.session, e.instanceId, command)
 	if err != nil {
 		return fmt.Errorf("error creating test name file in instance: %v", err)
 	}

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -34,7 +34,6 @@ type E2ESession struct {
 	instanceId          string
 	testEnvVars         map[string]string
 	bundlesOverride     bool
-	commandId           string
 }
 
 func newSession(amiId, instanceProfileName, storageBucket, jobId, subnetId string, bundlesOverride bool) (*E2ESession, error) {


### PR DESCRIPTION
*Description of changes:*
bubble up the SSM command id from the execution of each test run, and include it in the final log message for completed tests. This is useful for indexing various things include the CW log streams generated by each command

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

