### PR TITLE
Add bundles version check for etcd and workload template update

### DIFF
--- a/pkg/providers/docker/docker_test.go
+++ b/pkg/providers/docker/docker_test.go
@@ -209,12 +209,6 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 			bootstrapCluster := &types.Cluster{
 				Name: "bootstrap-test",
 			}
-			oriCluster := &v1alpha1.Cluster{
-				Spec: v1alpha1.ClusterSpec{
-					KubernetesVersion: v1alpha1.Kube118,
-				},
-			}
-			kubectl.EXPECT().GetEksaCluster(ctx, cluster, tt.clusterSpec.Name).Return(oriCluster, nil)
 			cpContent, mdContent, err := p.GenerateCAPISpecForUpgrade(ctx, bootstrapCluster, cluster, currentSpec, tt.clusterSpec)
 			if err != nil {
 				t.Fatalf("provider.GenerateCAPISpecForUpgrade() error = %v, wantErr nil", err)
@@ -261,7 +255,6 @@ func TestProviderGenerateDeploymentFileSuccessNotUpdateMachineTemplate(t *testin
 		},
 	}
 
-	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Name).Return(clusterSpec.Cluster, nil)
 	kubectl.EXPECT().GetKubeadmControlPlane(ctx, cluster, cluster.Name, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(cp, nil)
 	kubectl.EXPECT().GetMachineDeployment(ctx, cluster, clusterSpec.Name, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(md, nil)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added the check for bundles version change when deciding if we need a new template for etcd and worker machines

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
