### PR TITLE
Add unit tests for capi installer and kubectl get provider

### DIFF
--- a/pkg/clusterapi/installer_test.go
+++ b/pkg/clusterapi/installer_test.go
@@ -1,0 +1,73 @@
+package clusterapi_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	"github.com/aws/eks-anywhere/pkg/clusterapi/mocks"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	providerMocks "github.com/aws/eks-anywhere/pkg/providers/mocks"
+	"github.com/aws/eks-anywhere/pkg/types"
+)
+
+type installerTest struct {
+	*WithT
+	ctx           context.Context
+	capiClient    *mocks.MockCAPIClient
+	kubectlClient *mocks.MockKubectlClient
+	installer     *clusterapi.Installer
+	currentSpec   *cluster.Spec
+	cluster       *types.Cluster
+	provider      *providerMocks.MockProvider
+}
+
+func newInstallerTest(t *testing.T) installerTest {
+	ctrl := gomock.NewController(t)
+	capiClient := mocks.NewMockCAPIClient(ctrl)
+	kubectlClient := mocks.NewMockKubectlClient(ctrl)
+
+	currentSpec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Bundles.Spec.Number = 1
+		s.VersionsBundle.ExternalEtcdBootstrap.Version = "v0.1.0"
+		s.VersionsBundle.ExternalEtcdController.Version = "v0.1.0"
+	})
+
+	return installerTest{
+		WithT:         NewWithT(t),
+		ctx:           context.Background(),
+		capiClient:    capiClient,
+		kubectlClient: kubectlClient,
+		installer:     clusterapi.NewInstaller(capiClient, kubectlClient),
+		currentSpec:   currentSpec,
+		provider:      providerMocks.NewMockProvider(ctrl),
+		cluster: &types.Cluster{
+			Name:           "cluster-name",
+			KubeconfigFile: "k.kubeconfig",
+		},
+	}
+}
+
+func TestEnsureEtcdProviderInstallStackedEtcd(t *testing.T) {
+	tt := newInstallerTest(t)
+
+	tt.kubectlClient.EXPECT().CheckProviderExists(tt.ctx, tt.cluster.KubeconfigFile, constants.EtcdAdmBootstrapProviderName, constants.EtcdAdmBootstrapProviderSystemNamespace).Return(false, nil)
+	tt.kubectlClient.EXPECT().CheckProviderExists(tt.ctx, tt.cluster.KubeconfigFile, constants.EtcdadmControllerProviderName, constants.EtcdAdmControllerSystemNamespace).Return(false, nil)
+	tt.capiClient.EXPECT().InstallEtcdadmProviders(tt.ctx, tt.currentSpec, tt.cluster, tt.provider, []string{constants.EtcdAdmBootstrapProviderName, constants.EtcdadmControllerProviderName})
+
+	tt.Expect(tt.installer.EnsureEtcdProvidersInstallation(tt.ctx, tt.cluster, tt.provider, tt.currentSpec))
+}
+
+func TestEnsureEtcdProviderInstallExternalEtcd(t *testing.T) {
+	tt := newInstallerTest(t)
+
+	tt.kubectlClient.EXPECT().CheckProviderExists(tt.ctx, tt.cluster.KubeconfigFile, constants.EtcdAdmBootstrapProviderName, constants.EtcdAdmBootstrapProviderSystemNamespace).Return(true, nil)
+	tt.kubectlClient.EXPECT().CheckProviderExists(tt.ctx, tt.cluster.KubeconfigFile, constants.EtcdadmControllerProviderName, constants.EtcdAdmControllerSystemNamespace).Return(true, nil)
+
+	tt.Expect(tt.installer.EnsureEtcdProvidersInstallation(tt.ctx, tt.cluster, tt.provider, tt.currentSpec))
+}

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -1356,3 +1356,28 @@ func TestKubectlSetDaemonSetImage(t *testing.T) {
 
 	tt.Expect(tt.k.SetDaemonSetImage(tt.ctx, tt.cluster.KubeconfigFile, daemonSetName, tt.namespace, container, image)).To(Succeed())
 }
+
+func TestKubectlCheckCAPIProviderExistsNotInstalled(t *testing.T) {
+	tt := newKubectlTest(t)
+	providerName := "providerName"
+	providerNs := "providerNs"
+
+	tt.e.EXPECT().Execute(tt.ctx,
+		[]string{"get", "namespace", fmt.Sprintf("--field-selector=metadata.name=%s", providerNs), "--kubeconfig", tt.cluster.KubeconfigFile}).Return(bytes.Buffer{}, nil)
+
+	tt.Expect(tt.k.CheckProviderExists(tt.ctx, tt.cluster.KubeconfigFile, providerName, providerNs))
+}
+
+func TestKubectlCheckCAPIProviderExistsInstalled(t *testing.T) {
+	tt := newKubectlTest(t)
+	providerName := "providerName"
+	providerNs := "providerNs"
+
+	tt.e.EXPECT().Execute(tt.ctx,
+		[]string{"get", "namespace", fmt.Sprintf("--field-selector=metadata.name=%s", providerNs), "--kubeconfig", tt.cluster.KubeconfigFile}).Return(*bytes.NewBufferString("namespace"), nil)
+
+	tt.e.EXPECT().Execute(tt.ctx,
+		[]string{"get", "provider", "--namespace", providerNs, fmt.Sprintf("--field-selector=metadata.name=%s", providerName), "--kubeconfig", tt.cluster.KubeconfigFile})
+
+	tt.Expect(tt.k.CheckProviderExists(tt.ctx, tt.cluster.KubeconfigFile, providerName, providerNs))
+}


### PR DESCRIPTION
*Issue #, if available:*
 https://github.com/aws/eks-anywhere/issues/569

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
