### PR TITLE
Make Flux clusterConfigPath mutable during upgrade through controller

### DIFF
--- a/pkg/api/v1alpha1/gitopsconfig_webhook.go
+++ b/pkg/api/v1alpha1/gitopsconfig_webhook.go
@@ -63,10 +63,38 @@ func (r *GitOpsConfig) ValidateDelete() error {
 func validateImmutableGitOpsFields(new, old *GitOpsConfig) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if !new.Spec.Equal(&old.Spec) {
+	if old.Spec.Flux.Github.Owner != new.Spec.Flux.Github.Owner {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "GitOpsConfig"), new, "config is immutable"),
+			field.Invalid(field.NewPath("spec.flux.github", "owner"), new.Spec.Flux.Github.Owner, "field is immutable"),
+		)
+	}
+
+	if old.Spec.Flux.Github.Repository != new.Spec.Flux.Github.Repository {
+		allErrs = append(
+			allErrs,
+			field.Invalid(field.NewPath("spec.flux.github", "repository"), new.Spec.Flux.Github.Repository, "field is immutable"),
+		)
+	}
+
+	if old.Spec.Flux.Github.FluxSystemNamespace != new.Spec.Flux.Github.FluxSystemNamespace {
+		allErrs = append(
+			allErrs,
+			field.Invalid(field.NewPath("spec.flux.github", "fluxSystemNamespace"), new.Spec.Flux.Github.FluxSystemNamespace, "field is immutable"),
+		)
+	}
+
+	if old.Spec.Flux.Github.Branch != new.Spec.Flux.Github.Branch {
+		allErrs = append(
+			allErrs,
+			field.Invalid(field.NewPath("spec.flux.github", "branch"), new.Spec.Flux.Github.Branch, "field is immutable"),
+		)
+	}
+
+	if old.Spec.Flux.Github.Personal != new.Spec.Flux.Github.Personal {
+		allErrs = append(
+			allErrs,
+			field.Invalid(field.NewPath("spec.flux.github", "personal"), new.Spec.Flux.Github.Personal, "field is immutable"),
 		)
 	}
 

--- a/pkg/api/v1alpha1/gitopsconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/gitopsconfig_webhook_test.go
@@ -19,6 +19,16 @@ func TestClusterValidateUpdateGitOpsRepoImmutable(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&gOld)).NotTo(Succeed())
 }
 
+func TestClusterValidateUpdateGitOpsPathMutable(t *testing.T) {
+	gOld := gitOpsConfig()
+	gOld.Spec.Flux.Github.ClusterConfigPath = "oldPath"
+	c := gOld.DeepCopy()
+
+	c.Spec.Flux.Github.ClusterConfigPath = "newPath"
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&gOld)).To(Succeed())
+}
+
 func TestClusterValidateUpdateGitOpsBranchImmutable(t *testing.T) {
 	gOld := gitOpsConfig()
 	gOld.Spec.Flux.Github.Branch = "oldMain"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

To upgrade a GitOps enabled cluster with the new 0.6.0 release, we need to manually update the Git repo file structure with GitOpsConfig's clusterConfigPath field change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
