### PR TITLE
Multiclusters E2E test framework

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -121,3 +121,9 @@ func WithRegistryMirror(endpoint, caCert string) ClusterFiller {
 		c.Spec.RegistryMirrorConfiguration.CACertContent = caCert
 	}
 }
+
+func WithManagementCluster(name string) ClusterFiller {
+	return func(c *v1alpha1.Cluster) {
+		c.Spec.ManagementCluster.Name = name
+	}
+}

--- a/test/e2e/flux_test.go
+++ b/test/e2e/flux_test.go
@@ -16,7 +16,7 @@ const (
 	fluxUserProvidedPath      = "test/testerson"
 )
 
-func runUpgradeFlowWithFlux(test *framework.E2ETest, updateVersion v1alpha1.KubernetesVersion, opts ...framework.E2ETestOpt) {
+func runUpgradeFlowWithFlux(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, opts ...framework.ClusterE2ETestOpt) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
 	test.UpgradeCluster(opts...)
@@ -26,7 +26,7 @@ func runUpgradeFlowWithFlux(test *framework.E2ETest, updateVersion v1alpha1.Kube
 	test.DeleteCluster()
 }
 
-func runFluxFlow(test *framework.E2ETest) {
+func runFluxFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
 	test.ValidateFlux()
@@ -35,7 +35,7 @@ func runFluxFlow(test *framework.E2ETest) {
 }
 
 func TestDockerKubernetes120Flux(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
 		framework.WithFlux(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -44,7 +44,7 @@ func TestDockerKubernetes120Flux(t *testing.T) {
 }
 
 func TestDockerKubernetes121Flux(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
 		framework.WithFlux(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
@@ -53,7 +53,7 @@ func TestDockerKubernetes121Flux(t *testing.T) {
 }
 
 func TestVSphereKubernetes120Flux(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu120()),
 		framework.WithFlux(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -65,7 +65,7 @@ func TestVSphereKubernetes120Flux(t *testing.T) {
 }
 
 func TestVSphereKubernetes121Flux(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu121()),
 		framework.WithFlux(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
@@ -77,7 +77,7 @@ func TestVSphereKubernetes121Flux(t *testing.T) {
 }
 
 func TestVSphereKubernetes120BottleRocketFlux(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket120()),
 		framework.WithFlux(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -89,7 +89,7 @@ func TestVSphereKubernetes120BottleRocketFlux(t *testing.T) {
 }
 
 func TestVSphereKubernetes121BottleRocketFlux(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket121()),
 		framework.WithFlux(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
@@ -101,7 +101,7 @@ func TestVSphereKubernetes121BottleRocketFlux(t *testing.T) {
 }
 
 func TestVSphereKubernetes121ThreeReplicasThreeWorkersFlux(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu121()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
@@ -112,7 +112,7 @@ func TestVSphereKubernetes121ThreeReplicasThreeWorkersFlux(t *testing.T) {
 }
 
 func TestDockerKubernetes121GitopsOptionsFlux(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
@@ -127,7 +127,7 @@ func TestDockerKubernetes121GitopsOptionsFlux(t *testing.T) {
 }
 
 func TestVSphereKubernetes121GitopsOptionsFlux(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu121()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),

--- a/test/e2e/oidc_test.go
+++ b/test/e2e/oidc_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-func runOIDCFlow(test *framework.E2ETest) {
+func runOIDCFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
 	test.ValidateOIDC()
@@ -19,7 +19,7 @@ func runOIDCFlow(test *framework.E2ETest) {
 }
 
 func TestDockerKubernetes120OIDC(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
 		framework.WithOIDC(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -28,7 +28,7 @@ func TestDockerKubernetes120OIDC(t *testing.T) {
 }
 
 func TestDockerKubernetes121OIDC(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
 		framework.WithOIDC(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -37,7 +37,7 @@ func TestDockerKubernetes121OIDC(t *testing.T) {
 }
 
 func TestVSphereKubernetes120OIDC(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithUbuntu120()),
 		framework.WithOIDC(),
@@ -50,7 +50,7 @@ func TestVSphereKubernetes120OIDC(t *testing.T) {
 }
 
 func TestVSphereKubernetes121OIDC(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithUbuntu121()),
 		framework.WithOIDC(),

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-func runProxyConfigFlow(test *framework.E2ETest) {
+func runProxyConfigFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
 	test.DeleteCluster()
 }
 
 func TestVSphereKubernetes121UbuntuProxyConfig(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithUbuntu121(),
 			framework.WithPrivateNetwork()),
@@ -31,7 +31,7 @@ func TestVSphereKubernetes121UbuntuProxyConfig(t *testing.T) {
 }
 
 func TestVSphereKubernetes121BottlerocketProxyConfig(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithBottleRocket121(),
 			framework.WithPrivateNetwork()),

--- a/test/e2e/registry_mirror_test.go
+++ b/test/e2e/registry_mirror_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-func runRegistryMirrorConfigFlow(test *framework.E2ETest) {
+func runRegistryMirrorConfigFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.ImportImages()
 	test.CreateCluster()
@@ -19,7 +19,7 @@ func runRegistryMirrorConfigFlow(test *framework.E2ETest) {
 }
 
 func TestVSphereKubernetes121UbuntuRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithUbuntu121(), framework.WithPrivateNetwork()),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
@@ -32,7 +32,7 @@ func TestVSphereKubernetes121UbuntuRegistryMirrorAndCert(t *testing.T) {
 }
 
 func TestVSphereKubernetes121BottlerocketRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithBottleRocket121(), framework.WithPrivateNetwork()),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),

--- a/test/e2e/simpleflow_test.go
+++ b/test/e2e/simpleflow_test.go
@@ -19,14 +19,14 @@ func init() {
 	}
 }
 
-func runSimpleFlow(test *framework.E2ETest) {
+func runSimpleFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
 	test.DeleteCluster()
 }
 
 func TestDockerKubernetes120SimpleFlow(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewDocker(t),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -35,7 +35,7 @@ func TestDockerKubernetes120SimpleFlow(t *testing.T) {
 }
 
 func TestDockerKubernetes121SimpleFlow(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewDocker(t),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
@@ -44,7 +44,7 @@ func TestDockerKubernetes121SimpleFlow(t *testing.T) {
 }
 
 func TestVSphereKubernetes120SimpleFlow(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithUbuntu120()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -53,7 +53,7 @@ func TestVSphereKubernetes120SimpleFlow(t *testing.T) {
 }
 
 func TestVSphereKubernetes121SimpleFlow(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithUbuntu121()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
@@ -62,7 +62,7 @@ func TestVSphereKubernetes121SimpleFlow(t *testing.T) {
 }
 
 func TestVSphereKubernetes121ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithUbuntu121()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
@@ -73,7 +73,7 @@ func TestVSphereKubernetes121ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
 }
 
 func TestVSphereKubernetes121DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithUbuntu121(), framework.WithVSphereFillers(api.WithVSphereConfigNamespace(clusterNamespace))),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
@@ -83,7 +83,7 @@ func TestVSphereKubernetes121DifferentNamespaceSimpleFlow(t *testing.T) {
 }
 
 func TestVSphereKubernetes120BottleRocketSimpleFlow(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithBottleRocket120()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -92,7 +92,7 @@ func TestVSphereKubernetes120BottleRocketSimpleFlow(t *testing.T) {
 }
 
 func TestVSphereKubernetes120BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithBottleRocket120()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -103,7 +103,7 @@ func TestVSphereKubernetes120BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *t
 }
 
 func TestVSphereKubernetes120BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithBottleRocket120(), framework.WithVSphereFillers(api.WithVSphereConfigNamespace(clusterNamespace))),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),

--- a/test/e2e/stackedetcd_test.go
+++ b/test/e2e/stackedetcd_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-func runStackedEtcdFlow(test *framework.E2ETest) {
+func runStackedEtcdFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
 	test.DeleteCluster()
 }
 
 func TestVSphereKubernetes120StackedEtcdBottlerocket(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket120()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
@@ -26,7 +26,7 @@ func TestVSphereKubernetes120StackedEtcdBottlerocket(t *testing.T) {
 }
 
 func TestVSphereKubernetes120StackedEtcdUbuntu(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu120()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
@@ -35,7 +35,7 @@ func TestVSphereKubernetes120StackedEtcdUbuntu(t *testing.T) {
 }
 
 func TestVSphereKubernetes121StackedEtcdBottlerocket(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket121()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
@@ -44,7 +44,7 @@ func TestVSphereKubernetes121StackedEtcdBottlerocket(t *testing.T) {
 }
 
 func TestVSphereKubernetes121StackedEtcdUbuntu(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu121()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
@@ -53,7 +53,7 @@ func TestVSphereKubernetes121StackedEtcdUbuntu(t *testing.T) {
 }
 
 func TestDockerKubernetesStackedEtcd(t *testing.T) {
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
 		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
 	runStackedEtcdFlow(test)

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -23,7 +23,7 @@ const (
 	clusterNamespace           = "test-namespace"
 )
 
-func runSimpleUpgradeFlow(test *framework.E2ETest, updateVersion v1alpha1.KubernetesVersion, opts ...framework.E2ETestOpt) {
+func runSimpleUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, opts ...framework.ClusterE2ETestOpt) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
 	test.UpgradeCluster(opts...)
@@ -34,7 +34,7 @@ func runSimpleUpgradeFlow(test *framework.E2ETest, updateVersion v1alpha1.Kubern
 
 func TestVSphereKubernetes120UbuntuTo121Upgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu120())
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -49,7 +49,7 @@ func TestVSphereKubernetes120UbuntuTo121Upgrade(t *testing.T) {
 
 func TestVSphereKubernetes120UbuntuTo121MultipleFieldsUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu120())
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -76,7 +76,7 @@ func TestVSphereKubernetes120UbuntuTo121MultipleFieldsUpgrade(t *testing.T) {
 
 func TestVSphereKubernetes120UbuntuTo121WithFluxUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu120())
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		provider,
 		framework.WithFlux(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -94,7 +94,7 @@ func TestVSphereKubernetes120UbuntuTo121WithFluxUpgrade(t *testing.T) {
 
 func TestVSphereKubernetes120UbuntuTo121DifferentNamespaceWithFluxUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu120(), framework.WithVSphereFillers(api.WithVSphereConfigNamespace(clusterNamespace)))
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		provider,
 		framework.WithFlux(api.WithGitOpsNamespace(clusterNamespace)),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -113,7 +113,7 @@ func TestVSphereKubernetes120UbuntuTo121DifferentNamespaceWithFluxUpgrade(t *tes
 
 func TestVSphereKubernetes120UbuntuControlPlaneNodeUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu120())
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -129,7 +129,7 @@ func TestVSphereKubernetes120UbuntuControlPlaneNodeUpgrade(t *testing.T) {
 
 func TestVSphereKubernetes120UbuntuWorkerNodeUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu120())
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -145,7 +145,7 @@ func TestVSphereKubernetes120UbuntuWorkerNodeUpgrade(t *testing.T) {
 
 func TestVSphereKubernetes120BottlerocketTo121Upgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithBottleRocket120())
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -160,7 +160,7 @@ func TestVSphereKubernetes120BottlerocketTo121Upgrade(t *testing.T) {
 
 func TestVSphereKubernetes120BottlerocketTo121MultipleFieldsUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithBottleRocket120())
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -187,7 +187,7 @@ func TestVSphereKubernetes120BottlerocketTo121MultipleFieldsUpgrade(t *testing.T
 
 func TestVSphereKubernetes120BottlerocketTo121WithFluxUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithBottleRocket120())
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		provider,
 		framework.WithFlux(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -205,7 +205,7 @@ func TestVSphereKubernetes120BottlerocketTo121WithFluxUpgrade(t *testing.T) {
 
 func TestVSphereKubernetes120BottlerocketTo121DifferentNamespaceWithFluxUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithBottleRocket120(), framework.WithVSphereFillers(api.WithVSphereConfigNamespace(clusterNamespace)))
-	test := framework.NewE2ETest(t,
+	test := framework.NewClusterE2ETest(t,
 		provider,
 		framework.WithFlux(api.WithGitOpsNamespace(clusterNamespace)),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -224,7 +224,7 @@ func TestVSphereKubernetes120BottlerocketTo121DifferentNamespaceWithFluxUpgrade(
 
 func TestVSphereKubernetes120BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithBottleRocket120())
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -240,7 +240,7 @@ func TestVSphereKubernetes120BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
 
 func TestVSphereKubernetes120BottlerocketWorkerNodeUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithBottleRocket120())
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -256,7 +256,7 @@ func TestVSphereKubernetes120BottlerocketWorkerNodeUpgrade(t *testing.T) {
 
 func TestDockerKubernetes120To121StackedEtcdUpgrade(t *testing.T) {
 	provider := framework.NewDocker(t)
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
@@ -271,7 +271,7 @@ func TestDockerKubernetes120To121StackedEtcdUpgrade(t *testing.T) {
 
 func TestVSphereKubernetes120UbuntuTo121StackedEtcdUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu120())
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -289,7 +289,7 @@ func TestVSphereKubernetes120UbuntuTo121StackedEtcdUpgrade(t *testing.T) {
 
 func TestVSphereKubernetes120BottlerocketTo121StackedEtcdUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithBottleRocket120())
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),

--- a/test/e2e/vsphere_autoimport_test.go
+++ b/test/e2e/vsphere_autoimport_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-func runAutoImportFlow(test *framework.E2ETest, provider *framework.VSphere) {
+func runAutoImportFlow(test *framework.ClusterE2ETest, provider *framework.VSphere) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
 	templates := getMachineConfigs(test)
@@ -19,7 +19,7 @@ func runAutoImportFlow(test *framework.E2ETest, provider *framework.VSphere) {
 	deleteTemplates(test, provider, templates)
 }
 
-func getMachineConfigs(test *framework.E2ETest) map[string]v1alpha1.VSphereMachineConfig {
+func getMachineConfigs(test *framework.ClusterE2ETest) map[string]v1alpha1.VSphereMachineConfig {
 	test.T.Log("Getting vsphere machine configs to extract template and resource pool")
 	machineConfigs := test.GetEksaVSphereMachineConfigs()
 	uniqueMachineConfigs := make(map[string]v1alpha1.VSphereMachineConfig, len(machineConfigs))
@@ -30,7 +30,7 @@ func getMachineConfigs(test *framework.E2ETest) map[string]v1alpha1.VSphereMachi
 	return uniqueMachineConfigs
 }
 
-func deleteTemplates(test *framework.E2ETest, provider *framework.VSphere, machineConfigs map[string]v1alpha1.VSphereMachineConfig) {
+func deleteTemplates(test *framework.ClusterE2ETest, provider *framework.VSphere, machineConfigs map[string]v1alpha1.VSphereMachineConfig) {
 	ctx := context.Background()
 	for _, machineConfig := range machineConfigs {
 		test.T.Logf("Deleting vSphere template: %s", machineConfig.Spec.Template)
@@ -48,7 +48,7 @@ func TestVSphereKubernetes120UbuntuAutoimport(t *testing.T) {
 			api.WithOsFamily(v1alpha1.Ubuntu),
 		),
 	)
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -63,7 +63,7 @@ func TestVSphereKubernetes121UbuntuAutoimport(t *testing.T) {
 			api.WithOsFamily(v1alpha1.Ubuntu),
 		),
 	)
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
@@ -78,7 +78,7 @@ func TestVSphereKubernetes120BottlerocketAutoimport(t *testing.T) {
 			api.WithOsFamily(v1alpha1.Bottlerocket),
 		),
 	)
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
@@ -93,7 +93,7 @@ func TestVSphereKubernetes121BottlerocketAutoimport(t *testing.T) {
 			api.WithOsFamily(v1alpha1.Bottlerocket),
 		),
 	)
-	test := framework.NewE2ETest(
+	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),

--- a/test/e2e/workload_clusters_test.go
+++ b/test/e2e/workload_clusters_test.go
@@ -1,0 +1,49 @@
+// +build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/test/framework"
+)
+
+func runWorkloadClusterFlow(test *framework.MulticlusterE2ETest) {
+	test.CreateManagementCluster()
+	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
+		w.GenerateClusterConfig()
+		w.CreateCluster()
+		w.DeleteCluster()
+	})
+	test.DeleteManagementCluster()
+}
+
+func TestVSphereKubernetes121WorkloadClusterDemo(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithUbuntu120())
+	test := framework.NewMulticlusterE2ETest(
+		t,
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterFiller(
+				api.WithKubernetesVersion(v1alpha1.Kube120),
+				api.WithControlPlaneCount(1),
+				api.WithWorkerNodeCount(1),
+				api.WithStackedEtcdTopology(),
+			),
+		),
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterFiller(
+				api.WithKubernetesVersion(v1alpha1.Kube120),
+				api.WithControlPlaneCount(1),
+				api.WithWorkerNodeCount(1),
+				api.WithStackedEtcdTopology(),
+			),
+		),
+	)
+	runWorkloadClusterFlow(test)
+}

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -219,7 +219,16 @@ func (e *ClusterE2ETest) buildClusterConfigFile() {
 }
 
 func (e *ClusterE2ETest) DeleteCluster() {
-	e.RunEKSA("anywhere", "delete", "cluster", e.ClusterName, "-v", "4")
+	e.deleteCluster()
+}
+
+func (e *ClusterE2ETest) deleteCluster(opts ...commandOpt) {
+	deleteClusterArgs := []string{"anywhere", "delete", "cluster", e.ClusterName, "-v", "4"}
+	for _, o := range opts {
+		o(&deleteClusterArgs)
+	}
+
+	e.RunEKSA(deleteClusterArgs...)
 }
 
 func (e *ClusterE2ETest) Run(name string, args ...string) {

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -74,9 +74,9 @@ func NewClusterE2ETest(t *testing.T, provider Provider, opts ...ClusterE2ETestOp
 	return e
 }
 
-func WithClusterFiller(f api.ClusterFiller) ClusterE2ETestOpt {
+func WithClusterFiller(f ...api.ClusterFiller) ClusterE2ETestOpt {
 	return func(e *ClusterE2ETest) {
-		e.clusterFillers = append(e.clusterFillers, f)
+		e.clusterFillers = append(e.clusterFillers, f...)
 	}
 }
 

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -165,6 +165,10 @@ func WithClusterUpgrade(fillers ...api.ClusterFiller) ClusterE2ETestOpt {
 }
 
 func (e *ClusterE2ETest) UpgradeCluster(opts ...ClusterE2ETestOpt) {
+	e.upgradeCluster(nil, opts...)
+}
+
+func (e *ClusterE2ETest) upgradeCluster(commandOpts []commandOpt, opts ...ClusterE2ETestOpt) {
 	for _, opt := range opts {
 		opt(e)
 	}
@@ -174,6 +178,11 @@ func (e *ClusterE2ETest) UpgradeCluster(opts ...ClusterE2ETestOpt) {
 	if getBundlesOverride() == "true" {
 		upgradeClusterArgs = append(upgradeClusterArgs, "--bundles-override", defaultBundleReleaseManifestFile)
 	}
+
+	for _, o := range commandOpts {
+		o(&upgradeClusterArgs)
+	}
+
 	e.RunEKSA(upgradeClusterArgs...)
 }
 

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -112,9 +112,18 @@ func (e *ClusterE2ETest) ImportImages() {
 }
 
 func (e *ClusterE2ETest) CreateCluster() {
+	e.createCluster()
+}
+
+func (e *ClusterE2ETest) createCluster(opts ...commandOpt) {
+	e.T.Logf("Creating cluster %s", e.ClusterName)
 	createClusterArgs := []string{"anywhere", "create", "cluster", "-f", e.ClusterConfigLocation, "-v", "4"}
 	if getBundlesOverride() == "true" {
 		createClusterArgs = append(createClusterArgs, "--bundles-override", defaultBundleReleaseManifestFile)
+	}
+
+	for _, o := range opts {
+		o(&createClusterArgs)
 	}
 
 	e.RunEKSA(createClusterArgs...)

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -204,14 +204,16 @@ func (e *ClusterE2ETest) buildClusterConfigFile() {
 		}
 		yamlB = append(yamlB, gitOpsConfigB)
 	}
-	writer, err := filewriter.NewWriter(filepath.Dir(e.ClusterConfigLocation))
+
+	clusterConfigFolder := fmt.Sprintf("%s-config", e.ClusterName)
+	writer, err := filewriter.NewWriter(clusterConfigFolder)
 	if err != nil {
 		e.T.Fatalf("Error creating writer: %v", err)
 	}
 
 	b := templater.AppendYamlResources(yamlB...)
 
-	writtenFile, err := writer.Write(filepath.Base(e.ClusterConfigLocation), b)
+	writtenFile, err := writer.Write(filepath.Base(e.ClusterConfigLocation), b, filewriter.PersistentFile)
 	if err != nil {
 		e.T.Fatalf("Error writing cluster config to file %s: %v", e.ClusterConfigLocation, err)
 	}

--- a/test/framework/commands.go
+++ b/test/framework/commands.go
@@ -1,0 +1,13 @@
+package framework
+
+type commandOpt func(*[]string)
+
+func appendOpt(new ...string) commandOpt {
+	return func(args *[]string) {
+		*args = append(*args, new...)
+	}
+}
+
+func withKubeconfig(kubeconfigFile string) commandOpt {
+	return appendOpt("--kubeconfig", kubeconfigFile)
+}

--- a/test/framework/conformance.go
+++ b/test/framework/conformance.go
@@ -13,7 +13,7 @@ import (
 
 const kubeConformanceImage = "k8s.gcr.io/conformance"
 
-func (e *E2ETest) RunConformanceTests() {
+func (e *ClusterE2ETest) RunConformanceTests() {
 	ctx := context.Background()
 	cluster := e.cluster()
 	setKubeconfigEnvVar(e.T, e.ClusterName)
@@ -55,7 +55,7 @@ func (e *E2ETest) RunConformanceTests() {
 	}
 }
 
-func (e *E2ETest) getEksdReleaseKubeVersion() (string, error) {
+func (e *ClusterE2ETest) getEksdReleaseKubeVersion() (string, error) {
 	c, err := v1alpha1.GetClusterConfig(e.ClusterConfigLocation)
 	if err != nil {
 		return "", fmt.Errorf("error fetching cluster config from file: %v", err)

--- a/test/framework/git.go
+++ b/test/framework/git.go
@@ -18,7 +18,7 @@ type GitOptions struct {
 	Writer filewriter.FileWriter
 }
 
-func (e *E2ETest) NewGitOptions(ctx context.Context, cluster *v1alpha1.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig, writer filewriter.FileWriter, repoPath string) (*GitOptions, error) {
+func (e *ClusterE2ETest) NewGitOptions(ctx context.Context, cluster *v1alpha1.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig, writer filewriter.FileWriter, repoPath string) (*GitOptions, error) {
 	if gitOpsConfig == nil {
 		return nil, nil
 	}

--- a/test/framework/multicluster.go
+++ b/test/framework/multicluster.go
@@ -1,0 +1,49 @@
+package framework
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+)
+
+type MulticlusterE2ETest struct {
+	T                 *testing.T
+	ManagementCluster *ClusterE2ETest
+	WorkloadClusters  WorkloadClusters
+}
+
+func NewMulticlusterE2ETest(t *testing.T, managementCluster *ClusterE2ETest, workloadClusters ...*ClusterE2ETest) *MulticlusterE2ETest {
+	m := &MulticlusterE2ETest{
+		T:                 t,
+		ManagementCluster: managementCluster,
+	}
+
+	m.WorkloadClusters = make(WorkloadClusters, len(workloadClusters))
+	for i, c := range workloadClusters {
+		c.clusterFillers = append(c.clusterFillers, api.WithManagementCluster(managementCluster.ClusterName))
+		c.ClusterName = fmt.Sprintf("%s-w-%d", managementCluster.ClusterName, i)
+		m.WorkloadClusters[c.ClusterName] = &WorkloadCluster{
+			ClusterE2ETest:                  c,
+			managementClusterKubeconfigFile: managementCluster.kubeconfigFilePath,
+		}
+	}
+
+	return m
+}
+
+func (m *MulticlusterE2ETest) RunInWorkloadClusters(flow func(*WorkloadCluster)) {
+	for name, w := range m.WorkloadClusters {
+		m.T.Logf("Running test flow in workload cluster %s", name)
+		flow(w)
+	}
+}
+
+func (m *MulticlusterE2ETest) CreateManagementCluster() {
+	m.ManagementCluster.GenerateClusterConfig()
+	m.ManagementCluster.CreateCluster()
+}
+
+func (m *MulticlusterE2ETest) DeleteManagementCluster() {
+	m.ManagementCluster.DeleteCluster()
+}

--- a/test/framework/oidc.go
+++ b/test/framework/oidc.go
@@ -25,8 +25,8 @@ var oidcRequiredEnvVars = []string{
 	OIDCKeyFileVar,
 }
 
-func WithOIDC() E2ETestOpt {
-	return func(e *E2ETest) {
+func WithOIDC() ClusterE2ETestOpt {
+	return func(e *ClusterE2ETest) {
 		checkRequiredEnvVars(e.T, oidcRequiredEnvVars)
 		e.OIDCConfig = api.NewOIDCConfig(defaultClusterName,
 			api.WithOIDCRequiredClaims("kubernetesAccess", "true"),
@@ -43,7 +43,7 @@ func WithOIDC() E2ETestOpt {
 	}
 }
 
-func (e *E2ETest) ValidateOIDC() {
+func (e *ClusterE2ETest) ValidateOIDC() {
 	ctx := context.Background()
 	cluster := e.cluster()
 	e.T.Log("Creating roles for OIDC")

--- a/test/framework/proxy.go
+++ b/test/framework/proxy.go
@@ -19,8 +19,8 @@ var proxyRequiredEnvVars = []string{
 	noProxyVar,
 }
 
-func WithProxy() E2ETestOpt {
-	return func(e *E2ETest) {
+func WithProxy() ClusterE2ETestOpt {
+	return func(e *ClusterE2ETest) {
 		checkRequiredEnvVars(e.T, proxyRequiredEnvVars)
 		httpProxy := os.Getenv(httpProxyVar)
 		httpsProxy := os.Getenv(httpsProxyVar)

--- a/test/framework/registryMirror.go
+++ b/test/framework/registryMirror.go
@@ -17,8 +17,8 @@ const (
 
 var registryMirrorRequiredEnvVars = []string{RegistryEndpointVar, RegistryUsernameVar, RegistryPasswordVar, RegistryCACertVar}
 
-func WithRegistryMirrorEndpointAndCert() E2ETestOpt {
-	return func(e *E2ETest) {
+func WithRegistryMirrorEndpointAndCert() ClusterE2ETestOpt {
+	return func(e *ClusterE2ETest) {
 		checkRequiredEnvVars(e.T, registryMirrorRequiredEnvVars)
 		endpoint := os.Getenv(RegistryEndpointVar)
 		username := os.Getenv(RegistryUsernameVar)

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -206,8 +206,8 @@ func (v *VSphere) customizeProviderConfig(file string, fillers ...api.VSphereFil
 	return providerOutput
 }
 
-func (v *VSphere) WithProviderUpgrade(fillers ...api.VSphereFiller) E2ETestOpt {
-	return func(e *E2ETest) {
+func (v *VSphere) WithProviderUpgrade(fillers ...api.VSphereFiller) ClusterE2ETestOpt {
+	return func(e *ClusterE2ETest) {
 		e.ProviderConfigB = v.customizeProviderConfig(e.ClusterConfigLocation, fillers...)
 	}
 }

--- a/test/framework/workload.go
+++ b/test/framework/workload.go
@@ -1,0 +1,20 @@
+package framework
+
+type WorkloadCluster struct {
+	*ClusterE2ETest
+	managementClusterKubeconfigFile func() string
+}
+
+type WorkloadClusters map[string]*WorkloadCluster
+
+func (w *WorkloadCluster) CreateCluster() {
+	w.createCluster(withKubeconfig(w.managementClusterKubeconfigFile()))
+}
+
+func (w *WorkloadCluster) UpgradeCluster(opts ...ClusterE2ETestOpt) {
+	w.upgradeCluster([]commandOpt{withKubeconfig(w.managementClusterKubeconfigFile())}, opts...)
+}
+
+func (w *WorkloadCluster) DeleteCluster() {
+	w.deleteCluster(withKubeconfig(w.managementClusterKubeconfigFile()))
+}


### PR DESCRIPTION
*Description of changes:*
First take for adapting our e2e test framework to management+workload clusters
The changes are lengthy but super super simple, I recommend going commit by commit, that will make the review way easier

Some ideas:
* This uses the same patterns and syntax that we are used to for self managed clusters, but applied to multicluster tests.
  * Management and workload clusters are defined the same way.
  * Operations over clusters syntax is the same (`CreateCluster` `DeleteCluster`, etc.).
  * All the code to validate single cluster tests will work here as well, hopefully transparently
  * This should make writing new tests for workload clusters almost a copy paste excercise
* A multicluster test allows for one management cluster and multiple workload clusters

I added a "demo" test, so it's easier to see how the framework can be used. I'm not sure this test in particular is the most valuable one, but I think it demonstrates how any other test can be build. It can be removed once other better tests are added.

I can't guarantee that all the other testing tooling (Flux, upgrades, oidc, etc.) will work out of the box (there might be parts that were written making very specific assumptions about single cluster tests), but most of it should. I only need to make minimal modifications to the existing code to make the create-delete flow work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
