### PR TITLE
Removed extra heading from Whats New page

### DIFF
--- a/docs/content/en/docs/reference/changelog.md
+++ b/docs/content/en/docs/reference/changelog.md
@@ -6,9 +6,6 @@ menu:
   main:
     weight: 10
 ---
-
-# What's New?
-
 ## [Unreleased]
 
 ### Added


### PR DESCRIPTION
Small fix to remove duplicate heading from this page.
