### PR TITLE
Mount extra volume when necessary

### DIFF
--- a/pkg/executables/executables.go
+++ b/pkg/executables/executables.go
@@ -100,6 +100,19 @@ func (e *linuxDockerExecutable) buildCommand(envs map[string]string, cli string,
 		"-w", directory, "-v", "/var/run/docker.sock:/var/run/docker.sock",
 	}
 
+	for idx, dir := range args {
+		if dir == "--kubeconfig" {
+			absPath, err := filepath.Abs(filepath.Dir(args[idx+1]))
+			if err != nil {
+				return nil, "", err
+			}
+			workDirAbsPath := directory
+			if absPath != "." && absPath != workDirAbsPath {
+				dockerCommands = append(dockerCommands, "-v", absPath+":"+absPath)
+			}
+		}
+	}
+
 	dockerCommands = append(dockerCommands, envVars...)
 	dockerCommands = append(dockerCommands, "--entrypoint", cli, e.image)
 	dockerCommands = append(dockerCommands, args...)


### PR DESCRIPTION
All eksa commands run inside docker using the mr-tools image.

When creating management cluster, users only have to specify a spec file,
and the cli will mount tha path that contains the spec as a volume to be
used by the mr-tools image.

With the introduction of workload clusters, users can pass an extra flag (--kubeconfig)
that points to the kubeconfig of a management cluster.
If this kubeconfig is not in the same path as the spec then it is necessary to
mount an extra volume to make it availalbe for the cli.

Fix #581

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
