### PR TITLE
Set AWS_REGION only when there is no env var set

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -1,7 +1,7 @@
 REPO_ROOT=$(shell git rev-parse --show-toplevel)
 
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
-AWS_REGION=us-west-2
+AWS_REGION?=us-west-2
 
 RELEASE_ENVIRONMENT?=development
 RELEASE_VERSION?=$(shell cat triggers/eks-a-release/$(RELEASE_ENVIRONMENT)/RELEASE_VERSION)


### PR DESCRIPTION
*Description of changes:*
Make the AWS_REGION overrideable from environment variables.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
