### PR TITLE
Doc change : Add correct url for LICENCE

### DIFF
--- a/docs/content/en/docs/community/contributing.md
+++ b/docs/content/en/docs/community/contributing.md
@@ -130,4 +130,4 @@ public GitHub issue.
 
 ## Licensing
 
-See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/aws/eks-anywhere/blob/main/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

LICENCE was pointing to a url which was not available. Corrected the URL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
