### PR TITLE
Remove unreleased section for v0.6.0 branch

### DIFF
--- a/docs/content/en/docs/reference/changelog.md
+++ b/docs/content/en/docs/reference/changelog.md
@@ -6,12 +6,6 @@ menu:
   main:
     weight: 10
 ---
-## [Unreleased]
-
-### Added
-
-- aws-iam-authenticator support
-- Allow the retention of node taints during an upgrade
 
 ## v0.6.0 - 2021-10-29
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We only want to keep the unreleased section for the main branch and not listed on the public website.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
