### PR TITLE
Remove/refactor Docker script invocation in buildspecs

### DIFF
--- a/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
@@ -34,7 +34,9 @@ phases:
     commands:
     - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/set_profile.sh
     - make conformance-tests
-    - /docker.sh
+    - source /docker.sh
+    - start::dockerd
+    - wait::for::dockerd
   build:
     commands:
     - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -43,7 +43,9 @@ phases:
   pre_build:
     commands:
     - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/set_profile.sh
-    - /docker.sh
+    - source /docker.sh
+    - start::dockerd
+    - wait::for::dockerd
   build:
     commands:
     - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/release/buildspecs/bundle-release.yml
+++ b/release/buildspecs/bundle-release.yml
@@ -4,7 +4,6 @@ phases:
   pre_build:
     commands:
     - ./release/scripts/setup.sh
-    - /docker.sh
 
   build:
     commands:

--- a/release/buildspecs/dev-release.yml
+++ b/release/buildspecs/dev-release.yml
@@ -4,7 +4,6 @@ phases:
   pre_build:
     commands:
     - ./release/scripts/setup.sh
-    - /docker.sh
 
   build:
     commands:

--- a/release/buildspecs/eks-a-release.yml
+++ b/release/buildspecs/eks-a-release.yml
@@ -4,7 +4,6 @@ phases:
   pre_build:
     commands:
     - ./release/scripts/setup.sh
-    - /docker.sh
 
   build:
     commands:


### PR DESCRIPTION
- As of [this](https://github.com/aws/eks-distro-build-tooling/commit/7943b5b81b1f499efcbdc3c090440cfa3e431418) commit, the function calls to start the Docker daemon have been removed from this script. So it needs to be sourced and run.
- Skopeo doesn't need the Docker daemon to be running during copy operations, so we don't need it in the release buildspecs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
