### PR TITLE
Source AWS profile setup script in buildspec

### DIFF
--- a/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
@@ -32,7 +32,8 @@ env:
 phases:
   pre_build:
     commands:
-    - ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/setup.sh
+    - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/setup_profile.sh
+    - ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/start_docker.sh
     - make conformance-tests
   build:
     commands:

--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -42,7 +42,8 @@ env:
 phases:
   pre_build:
     commands:
-    - ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/setup.sh
+    - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/setup_profile.sh
+    - ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/start_docker.sh
   build:
     commands:
     - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/script/setup_profile.sh
+++ b/cmd/integration_test/build/script/setup_profile.sh
@@ -32,7 +32,3 @@ role_arn=${TEST_ROLE_ARN}
 region=us-west-2
 credential_source=EcsContainer
 EOF
-
-source /docker.sh
-start::dockerd
-wait::for::dockerd

--- a/cmd/integration_test/build/script/start_docker.sh
+++ b/cmd/integration_test/build/script/start_docker.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+set -o pipefail
+
+source /docker.sh
+start::dockerd
+wait::for::dockerd


### PR DESCRIPTION
The AWS config setup profile needs to be sourced, while the Docker startup script needs to be run directly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
