### PR TITLE
Small refactor to make cluster.Spec smaller and more reusable

### DIFF
--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -7,7 +7,7 @@ import (
 )
 
 func getImages(spec string) ([]v1alpha1.Image, error) {
-	clusterSpec, err := cluster.NewSpec(spec, version.Get())
+	clusterSpec, err := cluster.NewSpecFromClusterConfig(spec, version.Get())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
@@ -86,7 +86,7 @@ func (gsbo *generateSupportBundleOptions) generateBundleConfig(ctx context.Conte
 		return factory.DiagnosticBundleDefault(), nil
 	}
 
-	clusterSpec, err := cluster.NewSpec(f, version.Get())
+	clusterSpec, err := cluster.NewSpecFromClusterConfig(f, version.Get())
 	if err != nil {
 		return nil, fmt.Errorf("unable to get cluster config from file: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/importimages.go
+++ b/cmd/eksctl-anywhere/cmd/importimages.go
@@ -44,7 +44,7 @@ var importImagesCmd = &cobra.Command{
 }
 
 func importImages(context context.Context, spec string) error {
-	clusterSpec, err := cluster.NewSpec(spec, version.Get())
+	clusterSpec, err := cluster.NewSpecFromClusterConfig(spec, version.Get())
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/listovas.go
+++ b/cmd/eksctl-anywhere/cmd/listovas.go
@@ -52,7 +52,7 @@ var listOvasCmd = &cobra.Command{
 }
 
 func listOvas(context context.Context, spec string) error {
-	clusterSpec, err := cluster.NewSpec(spec, version.Get())
+	clusterSpec, err := cluster.NewSpecFromClusterConfig(spec, version.Get())
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -26,7 +26,7 @@ func newClusterSpec(options clusterOptions) (*cluster.Spec, error) {
 		specOpts = append(specOpts, cluster.WithManagementCluster(managementCluster))
 	}
 
-	clusterSpec, err := cluster.NewSpec(options.fileName, version.Get(), specOpts...)
+	clusterSpec, err := cluster.NewSpecFromClusterConfig(options.fileName, version.Get(), specOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get cluster config from file: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -87,7 +87,7 @@ func preRunSupportBundle(cmd *cobra.Command, args []string) error {
 }
 
 func (csbo *createSupportBundleOptions) createBundle(ctx context.Context, since, sinceTime, bundleConfig string) error {
-	clusterSpec, err := cluster.NewSpec(csbo.fileName, version.Get())
+	clusterSpec, err := cluster.NewSpecFromClusterConfig(csbo.fileName, version.Get())
 	if err != nil {
 		return fmt.Errorf("unable to get cluster config from file: %v", err)
 	}

--- a/internal/test/cluster.go
+++ b/internal/test/cluster.go
@@ -23,21 +23,20 @@ type ClusterSpecOpt func(*cluster.Spec)
 var configFS embed.FS
 
 func NewClusterSpec(opts ...ClusterSpecOpt) *cluster.Spec {
-	s := &cluster.Spec{
-		Cluster: &v1alpha1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "fluxAddonTestCluster",
-			},
-			Spec: v1alpha1.ClusterSpec{
-				WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{}},
-			},
+	s := cluster.NewSpec()
+	s.Cluster = &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fluxAddonTestCluster",
 		},
-		VersionsBundle: &cluster.VersionsBundle{
-			VersionsBundle: &releasev1alpha1.VersionsBundle{},
-			KubeDistro:     &cluster.KubeDistro{},
+		Spec: v1alpha1.ClusterSpec{
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{}},
 		},
-		Bundles: &releasev1alpha1.Bundles{},
 	}
+	s.VersionsBundle = &cluster.VersionsBundle{
+		VersionsBundle: &releasev1alpha1.VersionsBundle{},
+		KubeDistro:     &cluster.KubeDistro{},
+	}
+	s.Bundles = &releasev1alpha1.Bundles{}
 
 	for _, opt := range opts {
 		opt(s)
@@ -48,7 +47,7 @@ func NewClusterSpec(opts ...ClusterSpecOpt) *cluster.Spec {
 }
 
 func NewFullClusterSpec(t *testing.T, clusterConfigFile string) *cluster.Spec {
-	s, err := cluster.NewSpec(
+	s, err := cluster.NewSpecFromClusterConfig(
 		clusterConfigFile,
 		version.Info{GitVersion: "v0.0.0-dev"},
 		cluster.WithReleasesManifest("embed:///testdata/releases.yaml"),

--- a/pkg/cluster/manifest_reader.go
+++ b/pkg/cluster/manifest_reader.go
@@ -1,0 +1,64 @@
+package cluster
+
+import (
+	"fmt"
+
+	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-anywhere/pkg/files"
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/release/api/v1alpha1"
+)
+
+type ManifestReader struct {
+	*files.Reader
+}
+
+func NewManifestReader(opts ...files.ReaderOpt) *ManifestReader {
+	return &ManifestReader{files.NewReader(opts...)}
+}
+
+func (m *ManifestReader) GetReleases(releasesManifest string) (*v1alpha1.Release, error) {
+	logger.V(4).Info("Reading releases manifest", "url", releasesManifest)
+	content, err := m.ReadFile(releasesManifest)
+	if err != nil {
+		return nil, err
+	}
+
+	releases := &v1alpha1.Release{}
+	if err = yaml.Unmarshal(content, releases); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the release manifest: %v", err)
+	}
+
+	return releases, nil
+}
+
+func (m *ManifestReader) GetEksdRelease(versionsBundle *v1alpha1.VersionsBundle) (*eksdv1alpha1.Release, error) {
+	content, err := m.ReadFile(versionsBundle.EksD.EksDReleaseUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	eksd := &eksdv1alpha1.Release{}
+	if err = yaml.Unmarshal(content, eksd); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal eksd manifest to build cluster spec: %v", err)
+	}
+
+	return eksd, nil
+}
+
+func (m *ManifestReader) GetBundles(bundlesURL string) (*v1alpha1.Bundles, error) {
+	logger.V(4).Info("Reading bundles manifest", "url", bundlesURL)
+	content, err := m.ReadFile(bundlesURL)
+	if err != nil {
+		return nil, err
+	}
+
+	bundles := &v1alpha1.Bundles{}
+	if err = yaml.Unmarshal(content, bundles); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal bundles manifest from [%s] to build cluster spec: %v", bundlesURL, err)
+	}
+
+	return bundles, nil
+}

--- a/pkg/cluster/spec_test.go
+++ b/pkg/cluster/spec_test.go
@@ -15,7 +15,7 @@ var testdataFS embed.FS
 
 func TestNewSpecInvalidClusterConfig(t *testing.T) {
 	v := version.Info{}
-	if _, err := cluster.NewSpec("testdata/cluster_invalid_kinds.yaml", v); err == nil {
+	if _, err := cluster.NewSpecFromClusterConfig("testdata/cluster_invalid_kinds.yaml", v); err == nil {
 		t.Fatal("NewSpec() error nil , want err not nil")
 	}
 }
@@ -27,24 +27,6 @@ func TestNewSpecError(t *testing.T) {
 		clusterConfigFile string
 		cliVersion        string
 	}{
-		{
-			testName:          "InvalidManifestURL",
-			clusterConfigFile: "testdata/cluster_1_19.yaml",
-			releaseURL:        ":domain.com/",
-			cliVersion:        "",
-		},
-		{
-			testName:          "GettingReleasesManifestEmbed",
-			clusterConfigFile: "testdata/cluster_1_19.yaml",
-			releaseURL:        "embed://fake.yaml",
-			cliVersion:        "",
-		},
-		{
-			testName:          "GettingReleasesManifestLocal",
-			clusterConfigFile: "testdata/cluster_1_19.yaml",
-			releaseURL:        "fake.yaml",
-			cliVersion:        "",
-		},
 		{
 			testName:          "InvalidReleasesManifest",
 			clusterConfigFile: "testdata/cluster_1_19.yaml",
@@ -115,7 +97,7 @@ func TestNewSpecError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			v := version.Info{GitVersion: tt.cliVersion}
-			if _, err := cluster.NewSpec(tt.clusterConfigFile, v, cluster.WithReleasesManifest(tt.releaseURL)); err == nil {
+			if _, err := cluster.NewSpecFromClusterConfig(tt.clusterConfigFile, v, cluster.WithReleasesManifest(tt.releaseURL)); err == nil {
 				t.Fatal("NewSpec() error nil, want err not nil")
 			}
 		})
@@ -124,7 +106,7 @@ func TestNewSpecError(t *testing.T) {
 
 func TestNewSpecValidEmbedManifest(t *testing.T) {
 	v := version.Info{GitVersion: "v0.0.1"}
-	_, err := cluster.NewSpec(
+	_, err := cluster.NewSpecFromClusterConfig(
 		"testdata/cluster_1_19.yaml",
 		v,
 		cluster.WithReleasesManifest("embed:///testdata/simple_release.yaml"),
@@ -137,7 +119,7 @@ func TestNewSpecValidEmbedManifest(t *testing.T) {
 
 func TestNewSpecValid(t *testing.T) {
 	v := version.Info{GitVersion: "v0.0.1"}
-	gotSpec, err := cluster.NewSpec("testdata/cluster_1_19.yaml", v, cluster.WithReleasesManifest("testdata/simple_release.yaml"))
+	gotSpec, err := cluster.NewSpecFromClusterConfig("testdata/cluster_1_19.yaml", v, cluster.WithReleasesManifest("testdata/simple_release.yaml"))
 	if err != nil {
 		t.Fatalf("NewSpec() error = %v, want err nil", err)
 	}
@@ -147,7 +129,7 @@ func TestNewSpecValid(t *testing.T) {
 
 func TestNewSpecWithBundlesOverrideValid(t *testing.T) {
 	v := version.Info{GitVersion: "v0.0.1"}
-	gotSpec, err := cluster.NewSpec("testdata/cluster_1_19.yaml", v,
+	gotSpec, err := cluster.NewSpecFromClusterConfig("testdata/cluster_1_19.yaml", v,
 		cluster.WithReleasesManifest("testdata/invalid_release_version.yaml"),
 		cluster.WithOverrideBundlesManifest("testdata/simple_bundle.yaml"),
 	)
@@ -188,7 +170,7 @@ func validateVersionedRepo(t *testing.T, gotImage cluster.VersionedRepository, w
 }
 
 func TestSpecLoadManifestError(t *testing.T) {
-	s := &cluster.Spec{}
+	s := cluster.NewSpec()
 	tests := []struct {
 		testName string
 		manifest v1alpha1.Manifest
@@ -214,7 +196,7 @@ func TestSpecLoadManifestError(t *testing.T) {
 func TestSpecLoadManifestSuccess(t *testing.T) {
 	filename := "testdata/cluster_1_19.yaml"
 	wantFilename := "cluster_1_19.yaml"
-	s := &cluster.Spec{}
+	s := cluster.NewSpec()
 	manifest := v1alpha1.Manifest{URI: filename}
 	m, err := s.LoadManifest(manifest)
 	if err != nil {

--- a/pkg/files/reader.go
+++ b/pkg/files/reader.go
@@ -1,0 +1,104 @@
+package files
+
+import (
+	"embed"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	httpsScheme = "https"
+	embedScheme = "embed"
+)
+
+type Reader struct {
+	embedFS    embed.FS
+	httpClient *http.Client
+	userAgent  string
+}
+
+type ReaderOpt func(*Reader)
+
+func WithEmbedFS(embedFS embed.FS) ReaderOpt {
+	return func(s *Reader) {
+		s.embedFS = embedFS
+	}
+}
+
+func WithUserAgent(userAgent string) ReaderOpt {
+	return func(s *Reader) {
+		s.userAgent = userAgent
+	}
+}
+
+func NewReader(opts ...ReaderOpt) *Reader {
+	r := &Reader{
+		embedFS:    embed.FS{},
+		httpClient: &http.Client{},
+		userAgent:  "eks-a/unknown",
+	}
+
+	for _, o := range opts {
+		o(r)
+	}
+
+	return r
+}
+
+func (r *Reader) ReadFile(uri string) ([]byte, error) {
+	url, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("can't build cluster spec, invalid release manifest url: %v", err)
+	}
+
+	switch url.Scheme {
+	case httpsScheme:
+		return r.readHttpFile(uri)
+	case embedScheme:
+		return r.readEmbedFile(url)
+	default:
+		return readLocalFile(uri)
+	}
+}
+
+func (r *Reader) readHttpFile(uri string) ([]byte, error) {
+	request, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating http GET request for downloading file: %v", err)
+	}
+
+	request.Header.Set("User-Agent", r.userAgent)
+	resp, err := r.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading file from url [%s]: %v", uri, err)
+	}
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading file from url [%s]: %v", uri, err)
+	}
+
+	return data, nil
+}
+
+func (r *Reader) readEmbedFile(url *url.URL) ([]byte, error) {
+	data, err := r.embedFS.ReadFile(strings.TrimPrefix(url.Path, "/"))
+	if err != nil {
+		return nil, fmt.Errorf("failed reading embed file [%s] for cluster spec: %v", url.Path, err)
+	}
+
+	return data, nil
+}
+
+func readLocalFile(filename string) ([]byte, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading local file [%s] for cluster spec: %v", filename, err)
+	}
+
+	return data, nil
+}

--- a/pkg/files/reader_test.go
+++ b/pkg/files/reader_test.go
@@ -1,0 +1,73 @@
+package files_test
+
+import (
+	"embed"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/files"
+)
+
+//go:embed testdata
+var testdataFS embed.FS
+
+func TestReaderReadFileError(t *testing.T) {
+	tests := []struct {
+		testName string
+		uri      string
+		filePath string
+	}{
+		{
+			testName: "missing local file",
+			uri:      "fake-local-file.yaml",
+		},
+		{
+			testName: "missing embed file",
+			uri:      "embed:///fake-local-file.yaml",
+		},
+		{
+			testName: "invalid uri",
+			uri:      ":domain.com/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			r := files.NewReader()
+			_, err := r.ReadFile(tt.uri)
+			g.Expect(err).NotTo(BeNil())
+		})
+	}
+}
+
+func TestReaderReadFileSuccess(t *testing.T) {
+	tests := []struct {
+		testName string
+		uri      string
+		filePath string
+	}{
+		{
+			testName: "local file",
+			uri:      "testdata/file.yaml",
+			filePath: "testdata/file.yaml",
+		},
+		{
+			testName: "embed file",
+			uri:      "embed:///testdata/file.yaml",
+			filePath: "testdata/file.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			r := files.NewReader(files.WithEmbedFS(testdataFS))
+			got, err := r.ReadFile(tt.uri)
+			g.Expect(err).To(BeNil())
+			test.AssertContentToFile(t, string(got), tt.filePath)
+		})
+	}
+}

--- a/pkg/files/testdata/file.yaml
+++ b/pkg/files/testdata/file.yaml
@@ -1,0 +1,1 @@
+key: value


### PR DESCRIPTION
*Description of changes:*
It had become a bit difficult to work with, we had added too many things and we came up with a bunch of usecases to read different manifests that didn't necessary require the `Spec`

* Move the low level logic to `files.Reader`
* Move the logic to read manifests (`Release`, `Bundles` and eks-d release) to `cluster.ManifestReader`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
