### PR TITLE
Workload cluster tls cert fix for iam-auth kubeconfig

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -81,7 +81,7 @@ type ClusterClient interface {
 	ValidateWorkerNodes(ctx context.Context, cluster *types.Cluster, clusterName string) error
 	GetBundles(ctx context.Context, kubeconfigFile, name, namespace string) (*releasev1alpha1.Bundles, error)
 	GetApiServerUrl(ctx context.Context, cluster *types.Cluster) (string, error)
-	GetClusterCATlsCert(ctx context.Context, cluster *types.Cluster, namespace string) ([]byte, error)
+	GetClusterCATlsCert(ctx context.Context, clusterName string, cluster *types.Cluster, namespace string) ([]byte, error)
 }
 
 type Networking interface {
@@ -594,7 +594,7 @@ func (c *ClusterManager) generateAwsIamAuthKubeconfig(ctx context.Context, manag
 	if err != nil {
 		return fmt.Errorf("error generating aws-iam-authenticator kubeconfig: %v", err)
 	}
-	tlsCert, err := c.clusterClient.GetClusterCATlsCert(ctx, managementCluster, constants.EksaSystemNamespace)
+	tlsCert, err := c.clusterClient.GetClusterCATlsCert(ctx, workloadCluster.Name, managementCluster, constants.EksaSystemNamespace)
 	if err != nil {
 		return fmt.Errorf("error generating aws-iam-authenticator kubeconfig: %v", err)
 	}

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -197,18 +197,18 @@ func (mr *MockClusterClientMockRecorder) GetBundles(arg0, arg1, arg2, arg3 inter
 }
 
 // GetClusterCATlsCert mocks base method.
-func (m *MockClusterClient) GetClusterCATlsCert(arg0 context.Context, arg1 *types.Cluster, arg2 string) ([]byte, error) {
+func (m *MockClusterClient) GetClusterCATlsCert(arg0 context.Context, arg1 string, arg2 *types.Cluster, arg3 string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterCATlsCert", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetClusterCATlsCert", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetClusterCATlsCert indicates an expected call of GetClusterCATlsCert.
-func (mr *MockClusterClientMockRecorder) GetClusterCATlsCert(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClusterClientMockRecorder) GetClusterCATlsCert(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterCATlsCert", reflect.TypeOf((*MockClusterClient)(nil).GetClusterCATlsCert), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterCATlsCert", reflect.TypeOf((*MockClusterClient)(nil).GetClusterCATlsCert), arg0, arg1, arg2, arg3)
 }
 
 // GetClusters mocks base method.

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -501,8 +501,8 @@ func (k *Kubectl) GetApiServerUrl(ctx context.Context, cluster *types.Cluster) (
 	return stdOut.String(), nil
 }
 
-func (k *Kubectl) GetClusterCATlsCert(ctx context.Context, cluster *types.Cluster, namespace string) ([]byte, error) {
-	secretName := fmt.Sprintf("%s-ca", cluster.Name)
+func (k *Kubectl) GetClusterCATlsCert(ctx context.Context, clusterName string, cluster *types.Cluster, namespace string) ([]byte, error) {
+	secretName := fmt.Sprintf("%s-ca", clusterName)
 	params := []string{"get", "secret", secretName, "--kubeconfig", cluster.KubeconfigFile, "-o", `jsonpath={.data.tls\.crt}`, "--namespace", namespace}
 	stdOut, err := k.executable.Execute(ctx, params...)
 	if err != nil {


### PR DESCRIPTION
*Description of changes:*
When creating a workload cluster from a management cluster, the generated aws-iam-authenticator Kubeconfig was using the TLS cert of the management cluster and not the workload cluster. Fix to pass in the right cluster name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
