### PR TITLE
Update gitops clusterConfigPath definition

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/gitops.md
+++ b/docs/content/en/docs/reference/clusterspec/gitops.md
@@ -68,7 +68,7 @@ spec:
 
 #### __clusterConfigPath__ (optional)
 * __Description__: The path relative to the root of the git repository where EKS Anywhere will store the cluster configuration files.
-* __Default__: `clusters/$MANAGEMENT_CLUSTER_NAME/$CLUSTER_NAME`
+* __Default__: `clusters/$MANAGEMENT_CLUSTER_NAME`
 * __Type__: string
 
 #### __fluxSystemNamespace__ (optional)

--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -175,14 +175,14 @@ func (f *FluxAddonClient) InstallGitOps(ctx context.Context, cluster *types.Clus
 	}
 
 	logger.V(3).Info("pulling from remote after Flux Bootstrap to ensure configuration files in local git repository are in sync",
-		"remote", defaultRemote, "branch", clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch)
+		"remote", defaultRemote, "branch", fc.branch())
 
 	err := f.retrier.Retry(func() error {
-		return f.gitOpts.Git.Pull(ctx, clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch)
+		return f.gitOpts.Git.Pull(ctx, fc.branch())
 	})
 	if err != nil {
 		logger.Error(err, "error when pulling from remote repository after Flux Bootstrap; ensure local repository is up-to-date with remote (git pull)",
-			"remote", defaultRemote, "branch", clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch, "error", err)
+			"remote", defaultRemote, "branch", fc.branch(), "error", err)
 	}
 	return nil
 }
@@ -209,7 +209,7 @@ func (f *FluxAddonClient) PauseGitOpsKustomization(ctx context.Context, cluster 
 		clusterSpec:     clusterSpec,
 	}
 
-	logger.V(3).Info("pause reconciliation of all Kustomization", "namespace", clusterSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace)
+	logger.V(3).Info("pause reconciliation of all Kustomization", "namespace", fc.namespace())
 
 	return f.retrier.Retry(func() error {
 		return fc.flux.PauseKustomization(ctx, cluster, clusterSpec.GitOpsConfig)
@@ -227,7 +227,7 @@ func (f *FluxAddonClient) ResumeGitOpsKustomization(ctx context.Context, cluster
 		clusterSpec:     clusterSpec,
 	}
 
-	logger.V(3).Info("resume reconciliation of all Kustomization", "namespace", clusterSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace)
+	logger.V(3).Info("resume reconciliation of all Kustomization", "namespace", fc.namespace())
 	return f.retrier.Retry(func() error {
 		return fc.flux.ResumeKustomization(ctx, cluster, clusterSpec.GitOpsConfig)
 	})
@@ -265,7 +265,7 @@ func (f *FluxAddonClient) UpdateGitEksaSpec(ctx context.Context, clusterSpec *cl
 		return err
 	}
 	logger.V(3).Info("Finished pushing updated cluster config file to git",
-		"repository", clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository)
+		"repository", fc.repository())
 	return nil
 }
 
@@ -305,7 +305,7 @@ func (f *FluxAddonClient) CleanupGitRepo(ctx context.Context, clusterSpec *clust
 		return err
 	}
 
-	p := clusterSpec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath
+	p := fc.path()
 
 	if !validations.FileExists(path.Join(f.gitOpts.Writer.Dir(), p)) {
 		logger.V(3).Info("cluster dir does not exist in git, skip clean up")
@@ -322,7 +322,7 @@ func (f *FluxAddonClient) CleanupGitRepo(ctx context.Context, clusterSpec *clust
 		return err
 	}
 	logger.V(3).Info("Finished cleaning up cluster files in git",
-		"repository", clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository)
+		"repository", fc.repository())
 	return nil
 }
 
@@ -398,24 +398,19 @@ func (fc *fluxForCluster) commitFluxAndClusterConfigToGit(ctx context.Context) e
 }
 
 func (fc *fluxForCluster) syncGitRepo(ctx context.Context) error {
-	fluxConfig := fc.clusterSpec.GitOpsConfig.Spec.Flux
-	repoName := fluxConfig.Github.Repository
-	branch := fluxConfig.Github.Branch
-
 	f := fc.FluxAddonClient
-
 	if !validations.FileExists(path.Join(f.gitOpts.Writer.Dir(), ".git")) {
 		r, err := fc.clone(ctx)
 		if err != nil {
 			return fmt.Errorf("failed cloning git repo: %v", err)
 		}
 		if r == nil {
-			return fmt.Errorf("failed to find remote git repo: %s", repoName)
+			return fmt.Errorf("failed to find remote git repo: %s", fc.repository())
 		}
 	} else {
 		// Make sure the local git repo is on the branch specified in config and up-to-date with the remote
-		if err := fc.gitOpts.Git.Branch(branch); err != nil {
-			return fmt.Errorf("failed to switch to git branch %s: %v", branch, err)
+		if err := fc.gitOpts.Git.Branch(fc.branch()); err != nil {
+			return fmt.Errorf("failed to switch to git branch %s: %v", fc.branch(), err)
 		}
 	}
 	return nil
@@ -474,12 +469,9 @@ func (fc *fluxForCluster) generateEksaKustomizeFile() error {
 }
 
 func (fc *fluxForCluster) initFluxWriter() (filewriter.FileWriter, error) {
-	ns := fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace
-	p := fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.ClusterRootPath()
-	fluxSystemDir := path.Join(p, ns)
-	w, err := fc.gitOpts.Writer.WithDir(fluxSystemDir)
+	w, err := fc.gitOpts.Writer.WithDir(fc.fluxSystemDir())
 	if err != nil {
-		err = fmt.Errorf("error creating %s directory: %v", ns, err)
+		err = fmt.Errorf("error creating %s directory: %v", fc.fluxSystemDir(), err)
 	}
 	w.CleanUpTemp()
 	return w, err
@@ -513,7 +505,7 @@ func (fc *fluxForCluster) writeFluxSystemFiles() (err error) {
 
 func (fc *fluxForCluster) generateFluxKustomizeFile(t *templater.Templater) error {
 	values := map[string]string{
-		"Namespace": fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace,
+		"Namespace": fc.namespace(),
 	}
 	if filePath, err := t.WriteToFile(fluxKustomizeContent, values, kustomizeFileName, filewriter.PersistentFile); err != nil {
 		return fmt.Errorf("error creating flux-system kustomization manifest file into %s: %v", filePath, err)
@@ -531,7 +523,7 @@ func (f *FluxAddonClient) generateFluxSyncFile(t *templater.Templater) error {
 func (fc *fluxForCluster) generateFluxPatchFile(t *templater.Templater) error {
 	bundle := fc.clusterSpec.VersionsBundle
 	values := map[string]string{
-		"Namespace":                   fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace,
+		"Namespace":                   fc.namespace(),
 		"SourceControllerImage":       bundle.Flux.SourceController.VersionedImage(),
 		"KustomizeControllerImage":    bundle.Flux.KustomizeController.VersionedImage(),
 		"HelmControllerImage":         bundle.Flux.HelmController.VersionedImage(),
@@ -596,7 +588,7 @@ func (fc *fluxForCluster) clone(ctx context.Context) (*git.Repository, error) {
 		}
 
 		logger.V(3).Info("Creating a new branch")
-		err = fc.gitOpts.Git.Branch(fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch)
+		err = fc.gitOpts.Git.Branch(fc.branch())
 		if err != nil {
 			return nil, err
 		}
@@ -638,7 +630,7 @@ func (fc *fluxForCluster) initializeLocalRepository() error {
 		return fmt.Errorf("error when initializing repository: %v", err)
 	}
 
-	if err = fc.gitOpts.Git.Branch(fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch); err != nil {
+	if err = fc.gitOpts.Git.Branch(fc.branch()); err != nil {
 		return fmt.Errorf("error when creating branch: %v", err)
 	}
 	return nil
@@ -647,7 +639,7 @@ func (fc *fluxForCluster) initializeLocalRepository() error {
 // validateLocalConfigPathDoesNotExist returns an exception if the cluster configuration file exists.
 // This is done so that we avoid clobbering existing cluster configurations in the user-provided git repository.
 func (fc *fluxForCluster) validateLocalConfigPathDoesNotExist() error {
-	p := path.Join(fc.gitOpts.Writer.Dir(), fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath)
+	p := path.Join(fc.gitOpts.Writer.Dir(), fc.path())
 	if validations.FileExists(p) {
 		return fmt.Errorf("a cluster configuration file already exists at path %s", p)
 	}
@@ -662,6 +654,10 @@ func (fc *fluxForCluster) validateRemoteConfigPathDoesNotExist(ctx context.Conte
 	}
 
 	return nil
+}
+
+func (fc *fluxForCluster) namespace() string {
+	return fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace
 }
 
 func (fc *fluxForCluster) repository() string {
@@ -693,7 +689,11 @@ func (e *ConfigVersionControlFailedError) Error() string {
 }
 
 func (fc *fluxForCluster) eksaSystemDir() string {
-	return path.Join(fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath, eksaSystemDirName)
+	return path.Join(fc.path(), fc.clusterSpec.GetName(), eksaSystemDirName)
+}
+
+func (fc *fluxForCluster) fluxSystemDir() string {
+	return path.Join(fc.path(), fc.namespace())
 }
 
 func (f *FluxAddonClient) shouldSkipFlux() bool {

--- a/pkg/addonmanager/addonclients/fluxaddonclient_test.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient_test.go
@@ -54,7 +54,7 @@ func TestFluxAddonClientInstallGitOpsOnManagementClusterWithPrexistingRepo(t *te
 			clusterName:                   "management-cluster",
 			selfManaged:                   true,
 			fluxpath:                      "",
-			expectedClusterConfigGitPath:  "clusters/management-cluster/management-cluster",
+			expectedClusterConfigGitPath:  "clusters/management-cluster",
 			expectedEksaSystemDirPath:     "clusters/management-cluster/management-cluster/eksa-system",
 			expectedEksaConfigFileName:    defaultEksaClusterConfigFileName,
 			expectedKustomizationFileName: defaultKustomizationManifestFileName,
@@ -69,11 +69,11 @@ func TestFluxAddonClientInstallGitOpsOnManagementClusterWithPrexistingRepo(t *te
 			selfManaged:                   true,
 			fluxpath:                      "user/provided/path",
 			expectedClusterConfigGitPath:  "user/provided/path",
-			expectedEksaSystemDirPath:     "user/provided/path/eksa-system",
+			expectedEksaSystemDirPath:     "user/provided/path/management-cluster/eksa-system",
 			expectedEksaConfigFileName:    defaultEksaClusterConfigFileName,
 			expectedKustomizationFileName: defaultKustomizationManifestFileName,
 			expectedConfigFileContents:    "./testdata/cluster-config-user-provided-path.yaml",
-			expectedFluxSystemDirPath:     "user/provided/flux-system",
+			expectedFluxSystemDirPath:     "user/provided/path/flux-system",
 			expectedFluxPatchesFileName:   defaultFluxPatchesFileName,
 			expectedFluxSyncFileName:      defaultFluxSyncFileName,
 		},
@@ -105,6 +105,7 @@ func TestFluxAddonClientInstallGitOpsOnManagementClusterWithPrexistingRepo(t *te
 				t.Errorf("FluxAddonClient.InstallGitOps() error = %v, want nil", err)
 			}
 			expectedEksaClusterConfigPath := path.Join(writePath, tt.expectedEksaSystemDirPath, tt.expectedEksaConfigFileName)
+			fmt.Println(expectedEksaClusterConfigPath)
 			test.AssertFilesEquals(t, expectedEksaClusterConfigPath, tt.expectedConfigFileContents)
 
 			expectedKustomizationPath := path.Join(writePath, tt.expectedEksaSystemDirPath, tt.expectedKustomizationFileName)
@@ -133,7 +134,7 @@ func TestFluxAddonClientInstallGitOpsOnWorkloadClusterWithPrexistingRepo(t *test
 	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
 	m.git.EXPECT().Clone(ctx).Return(nil)
 	m.git.EXPECT().Branch(clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
-	m.git.EXPECT().Add(path.Dir("clusters/management-cluster/workload-cluster")).Return(nil)
+	m.git.EXPECT().Add(path.Dir("clusters/management-cluster")).Return(nil)
 	m.git.EXPECT().Commit(test.OfType("string")).Return(nil)
 	m.git.EXPECT().Push(ctx).Return(nil)
 	m.git.EXPECT().Pull(ctx, clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
@@ -181,7 +182,7 @@ func TestFluxAddonClientInstallGitOpsNoPrexistingRepo(t *testing.T) {
 			testName:                      "with default config path",
 			clusterName:                   "management-cluster",
 			fluxpath:                      "",
-			expectedClusterConfigGitPath:  "clusters/management-cluster/management-cluster",
+			expectedClusterConfigGitPath:  "clusters/management-cluster",
 			expectedEksaSystemDirPath:     "clusters/management-cluster/management-cluster/eksa-system",
 			expectedEksaConfigFileName:    defaultEksaClusterConfigFileName,
 			expectedKustomizationFileName: defaultKustomizationManifestFileName,
@@ -195,11 +196,11 @@ func TestFluxAddonClientInstallGitOpsNoPrexistingRepo(t *testing.T) {
 			clusterName:                   "management-cluster",
 			fluxpath:                      "user/provided/path",
 			expectedClusterConfigGitPath:  "user/provided/path",
-			expectedEksaSystemDirPath:     "user/provided/path/eksa-system",
+			expectedEksaSystemDirPath:     "user/provided/path/management-cluster/eksa-system",
 			expectedEksaConfigFileName:    defaultEksaClusterConfigFileName,
 			expectedKustomizationFileName: defaultKustomizationManifestFileName,
 			expectedConfigFileContents:    "./testdata/cluster-config-user-provided-path.yaml",
-			expectedFluxSystemDirPath:     "user/provided/flux-system",
+			expectedFluxSystemDirPath:     "user/provided/path/flux-system",
 			expectedFluxPatchesFileName:   defaultFluxPatchesFileName,
 			expectedFluxSyncFileName:      defaultFluxSyncFileName,
 		},
@@ -277,7 +278,7 @@ func TestFluxAddonClientInstallGitOpsToolkitsBareRepo(t *testing.T) {
 			testName:                      "with default config path",
 			clusterName:                   "management-cluster",
 			fluxpath:                      "",
-			expectedClusterConfigGitPath:  "clusters/management-cluster/management-cluster",
+			expectedClusterConfigGitPath:  "clusters/management-cluster",
 			expectedEksaSystemDirPath:     "clusters/management-cluster/management-cluster/eksa-system",
 			expectedEksaConfigFileName:    defaultEksaClusterConfigFileName,
 			expectedKustomizationFileName: defaultKustomizationManifestFileName,
@@ -568,7 +569,7 @@ func TestFluxAddonClientCleanupGitRepo(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	ctx := context.Background()
 	clusterConfig := v1alpha1.NewCluster("management-cluster")
-	expectedClusterPath := "clusters/management-cluster/management-cluster"
+	expectedClusterPath := "clusters/management-cluster"
 	clusterSpec := newClusterSpec(clusterConfig, "")
 
 	gitProvider := gitMocks.NewMockProvider(mockCtrl)

--- a/pkg/addonmanager/addonclients/testdata/cluster-config-default-path-management.yaml
+++ b/pkg/addonmanager/addonclients/testdata/cluster-config-default-path-management.yaml
@@ -49,7 +49,7 @@ spec:
   flux:
     github:
       branch: testBranch
-      clusterConfigPath: clusters/management-cluster/management-cluster
+      clusterConfigPath: clusters/management-cluster
       fluxSystemNamespace: flux-system
       owner: mFowler
       personal: true

--- a/pkg/addonmanager/addonclients/testdata/cluster-config-default-path-workload.yaml
+++ b/pkg/addonmanager/addonclients/testdata/cluster-config-default-path-workload.yaml
@@ -51,7 +51,7 @@ spec:
   flux:
     github:
       branch: testBranch
-      clusterConfigPath: clusters/management-cluster/workload-cluster
+      clusterConfigPath: clusters/management-cluster
       fluxSystemNamespace: flux-system
       owner: mFowler
       personal: true

--- a/pkg/api/v1alpha1/gitopsconfig_types.go
+++ b/pkg/api/v1alpha1/gitopsconfig_types.go
@@ -1,8 +1,6 @@
 package v1alpha1
 
 import (
-	"path"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -35,10 +33,6 @@ type Github struct {
 
 	// if true, the owner is assumed to be a Git user; otherwise an org.
 	Personal bool `json:"personal,omitempty"`
-}
-
-func (g *Github) ClusterRootPath() string {
-	return path.Dir(g.ClusterConfigPath)
 }
 
 // GitOpsConfigStatus defines the observed state of GitOpsConfig

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -73,9 +73,9 @@ func (cs *Spec) SetDefaultGitOps() {
 		c := &cs.GitOpsConfig.Spec.Flux
 		if len(c.Github.ClusterConfigPath) == 0 {
 			if cs.Cluster.IsSelfManaged() {
-				c.Github.ClusterConfigPath = path.Join("clusters", cs.Name, cs.Name)
+				c.Github.ClusterConfigPath = path.Join("clusters", cs.Name)
 			} else {
-				c.Github.ClusterConfigPath = path.Join("clusters", cs.Cluster.ManagedBy(), cs.Name)
+				c.Github.ClusterConfigPath = path.Join("clusters", cs.Cluster.ManagedBy())
 			}
 		}
 		if len(c.Github.FluxSystemNamespace) == 0 {

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster.yaml
@@ -68,7 +68,7 @@ spec:
   flux:
     github:
       branch: main
-      clusterConfigPath: clusters/mycluster/mycluster
+      clusterConfigPath: clusters/mycluster
       fluxSystemNamespace: flux-system
       owner: me
       repository: ""

--- a/pkg/executables/flux.go
+++ b/pkg/executables/flux.go
@@ -36,7 +36,7 @@ func (f *Flux) BootstrapToolkitsComponents(ctx context.Context, cluster *types.C
 		gitProvider,
 		"--repository", c.Repository,
 		"--owner", c.Owner,
-		"--path", c.ClusterRootPath(),
+		"--path", c.ClusterConfigPath,
 		"--ssh-key-algorithm", privateKeyAlgorithm,
 	}
 

--- a/pkg/executables/flux_test.go
+++ b/pkg/executables/flux_test.go
@@ -51,8 +51,6 @@ func TestFluxInstallGitOpsToolkitsSuccess(t *testing.T) {
 	repo := "gitops-fleet"
 	path := "clusters/cluster-name"
 
-	expectedPath := "clusters"
-
 	tests := []struct {
 		testName     string
 		cluster      *types.Cluster
@@ -72,7 +70,7 @@ func TestFluxInstallGitOpsToolkitsSuccess(t *testing.T) {
 				},
 			},
 			wantExecArgs: []interface{}{
-				"bootstrap", gitProvider, "--repository", repo, "--owner", owner, "--path", expectedPath, "--ssh-key-algorithm", "ecdsa", "--kubeconfig", "f.kubeconfig",
+				"bootstrap", gitProvider, "--repository", repo, "--owner", owner, "--path", path, "--ssh-key-algorithm", "ecdsa", "--kubeconfig", "f.kubeconfig",
 			},
 		},
 		{
@@ -87,7 +85,7 @@ func TestFluxInstallGitOpsToolkitsSuccess(t *testing.T) {
 				},
 			},
 			wantExecArgs: []interface{}{
-				"bootstrap", gitProvider, "--repository", repo, "--owner", owner, "--path", expectedPath, "--ssh-key-algorithm", "ecdsa", "--personal",
+				"bootstrap", gitProvider, "--repository", repo, "--owner", owner, "--path", path, "--ssh-key-algorithm", "ecdsa", "--personal",
 			},
 		},
 		{
@@ -102,7 +100,7 @@ func TestFluxInstallGitOpsToolkitsSuccess(t *testing.T) {
 				},
 			},
 			wantExecArgs: []interface{}{
-				"bootstrap", gitProvider, "--repository", repo, "--owner", owner, "--path", expectedPath, "--ssh-key-algorithm", "ecdsa", "--branch", "main",
+				"bootstrap", gitProvider, "--repository", repo, "--owner", owner, "--path", path, "--ssh-key-algorithm", "ecdsa", "--branch", "main",
 			},
 		},
 		{
@@ -117,7 +115,7 @@ func TestFluxInstallGitOpsToolkitsSuccess(t *testing.T) {
 				},
 			},
 			wantExecArgs: []interface{}{
-				"bootstrap", gitProvider, "--repository", repo, "--owner", owner, "--path", expectedPath, "--ssh-key-algorithm", "ecdsa", "--namespace", "flux-system",
+				"bootstrap", gitProvider, "--repository", repo, "--owner", owner, "--path", path, "--ssh-key-algorithm", "ecdsa", "--namespace", "flux-system",
 			},
 		},
 		{
@@ -127,7 +125,7 @@ func TestFluxInstallGitOpsToolkitsSuccess(t *testing.T) {
 				Github: v1alpha1.Github{},
 			},
 			wantExecArgs: []interface{}{
-				"bootstrap", gitProvider, "--repository", "", "--owner", "", "--path", ".", "--ssh-key-algorithm", "ecdsa",
+				"bootstrap", gitProvider, "--repository", "", "--owner", "", "--path", "", "--ssh-key-algorithm", "ecdsa",
 			},
 		},
 	}

--- a/pkg/validations/createvalidations/gitops.go
+++ b/pkg/validations/createvalidations/gitops.go
@@ -41,26 +41,9 @@ func validateWorkloadFields(ctx context.Context, k validations.KubectlClient, cl
 		return err
 	}
 
-	mg := mgmtGitOps.Spec.Flux.Github
-	wg := spec.GitOpsConfig.Spec.Flux.Github
+	if !mgmtGitOps.Spec.Equal(&spec.GitOpsConfig.Spec) {
+		return fmt.Errorf("expected gitOpsConfig to be the same between management and its workload clusters")
+	}
 
-	if mg.ClusterRootPath() != wg.ClusterRootPath() {
-		return fmt.Errorf("expected spec.flux.clusterConfigPath to share the same parent directory as management cluster's")
-	}
-	if mg.Branch != wg.Branch {
-		return fmt.Errorf("spec.flux.branch must be same as management cluster's. want: %s, got: %s", mg.Branch, wg.Branch)
-	}
-	if mg.Owner != wg.Owner {
-		return fmt.Errorf("spec.flux.owner must be same as management cluster's. want: %s, got: %s", mg.Owner, wg.Owner)
-	}
-	if mg.Repository != wg.Repository {
-		return fmt.Errorf("spec.flux.repository must be same as management cluster's. want: %s, got: %s", mg.Repository, wg.Repository)
-	}
-	if mg.FluxSystemNamespace != wg.FluxSystemNamespace {
-		return fmt.Errorf("spec.flux.fluxSystemNamespace must be same as management cluster's. want: %s, got: %s", mg.FluxSystemNamespace, wg.FluxSystemNamespace)
-	}
-	if mg.Personal != wg.Personal {
-		return fmt.Errorf("spec.flux.personal must be same as management cluster's. want: %v, got: %v", mg.Personal, wg.Personal)
-	}
 	return nil
 }

--- a/pkg/validations/createvalidations/gitops_test.go
+++ b/pkg/validations/createvalidations/gitops_test.go
@@ -30,25 +30,25 @@ func TestValidateGitopsForWorkloadClustersPath(t *testing.T) {
 				Repository:          "repo",
 				FluxSystemNamespace: "flux-system",
 				Branch:              "main",
-				ClusterConfigPath:   "clusters/" + testclustername,
+				ClusterConfigPath:   "clusters/management-gitops",
 				Personal:            false,
 			},
 		},
 		{
-			name:    "Failure, path invalid",
-			wantErr: errors.New("workload cluster gitOpsConfig is invalid: expected spec.flux.clusterConfigPath to share the same parent directory as management cluster's"),
+			name:    "Failure, path diff",
+			wantErr: errors.New("workload cluster gitOpsConfig is invalid: expected gitOpsConfig to be the same between management and its workload clusters"),
 			github: v1alpha1.Github{
 				Owner:               "owner",
 				Repository:          "repo",
 				FluxSystemNamespace: "flux-system",
 				Branch:              "main",
-				ClusterConfigPath:   "diffpath/" + testclustername,
+				ClusterConfigPath:   "clusters/" + testclustername,
 				Personal:            false,
 			},
 		},
 		{
 			name:    "Failure, branch diff",
-			wantErr: errors.New("workload cluster gitOpsConfig is invalid: spec.flux.branch must be same as management cluster's. want: main, got: dev"),
+			wantErr: errors.New("workload cluster gitOpsConfig is invalid: expected gitOpsConfig to be the same between management and its workload clusters"),
 			github: v1alpha1.Github{
 				Owner:               "owner",
 				Repository:          "repo",
@@ -60,7 +60,7 @@ func TestValidateGitopsForWorkloadClustersPath(t *testing.T) {
 		},
 		{
 			name:    "Failure, owner owner",
-			wantErr: errors.New("workload cluster gitOpsConfig is invalid: spec.flux.owner must be same as management cluster's. want: owner, got: janedoe"),
+			wantErr: errors.New("workload cluster gitOpsConfig is invalid: expected gitOpsConfig to be the same between management and its workload clusters"),
 			github: v1alpha1.Github{
 				Owner:               "janedoe",
 				Repository:          "repo",
@@ -72,7 +72,7 @@ func TestValidateGitopsForWorkloadClustersPath(t *testing.T) {
 		},
 		{
 			name:    "Failure, repo diff",
-			wantErr: errors.New("workload cluster gitOpsConfig is invalid: spec.flux.repository must be same as management cluster's. want: repo, got: diffrepo"),
+			wantErr: errors.New("workload cluster gitOpsConfig is invalid: expected gitOpsConfig to be the same between management and its workload clusters"),
 			github: v1alpha1.Github{
 				Owner:               "owner",
 				Repository:          "diffrepo",
@@ -84,7 +84,7 @@ func TestValidateGitopsForWorkloadClustersPath(t *testing.T) {
 		},
 		{
 			name:    "Failure, namespace diff",
-			wantErr: errors.New("workload cluster gitOpsConfig is invalid: spec.flux.fluxSystemNamespace must be same as management cluster's. want: flux-system, got: diff-ns"),
+			wantErr: errors.New("workload cluster gitOpsConfig is invalid: expected gitOpsConfig to be the same between management and its workload clusters"),
 			github: v1alpha1.Github{
 				Owner:               "owner",
 				Repository:          "repo",
@@ -96,7 +96,7 @@ func TestValidateGitopsForWorkloadClustersPath(t *testing.T) {
 		},
 		{
 			name:    "Failure, personal diff",
-			wantErr: errors.New("workload cluster gitOpsConfig is invalid: spec.flux.personal must be same as management cluster's. want: false, got: true"),
+			wantErr: errors.New("workload cluster gitOpsConfig is invalid: expected gitOpsConfig to be the same between management and its workload clusters"),
 			github: v1alpha1.Github{
 				Owner:               "owner",
 				Repository:          "repo",


### PR DESCRIPTION
Update gitops clusterConfigPath definition to be the root both management and its workload clusters

*Issue #, if available:*

#551 

*Description of changes:*

- make default clusterConfigPath values same between 0.5.0 and 0.6.0
- update flux bootstrap code to reflect changes
- update create validation so that workload cluster's clusterConfigPath has to be the same as management's
- update flux doc

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
