### PR TITLE
Only check flux clusterConfigPath exists when bootstrapping management cluster

### DIFF
--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -651,7 +651,7 @@ func (fc *fluxForCluster) validateLocalConfigPathDoesNotExist() error {
 func (fc *fluxForCluster) validateRemoteConfigPathDoesNotExist(ctx context.Context) error {
 	if fc.clusterSpec.IsSelfManaged() {
 		if exists, err := fc.gitOpts.Git.PathExists(ctx, fc.owner(), fc.repository(), fc.branch(), fc.path()); err != nil {
-			return fmt.Errorf("failed validating remote flux config path: %s", err)
+			return fmt.Errorf("failed validating remote flux config path: %v", err)
 		} else if exists {
 			return fmt.Errorf("flux path %s already exists in remote repository", fc.path())
 		}

--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -647,12 +647,13 @@ func (fc *fluxForCluster) validateLocalConfigPathDoesNotExist() error {
 }
 
 func (fc *fluxForCluster) validateRemoteConfigPathDoesNotExist(ctx context.Context) error {
-	if exists, err := fc.gitOpts.Git.PathExists(ctx, fc.owner(), fc.repository(), fc.branch(), fc.path()); err != nil {
-		return fmt.Errorf("failed validating remote flux config path: %s", err)
-	} else if exists {
-		return fmt.Errorf("flux path %s already exists in remote repository", fc.path())
+	if fc.clusterSpec.IsSelfManaged() {
+		if exists, err := fc.gitOpts.Git.PathExists(ctx, fc.owner(), fc.repository(), fc.branch(), fc.path()); err != nil {
+			return fmt.Errorf("failed validating remote flux config path: %s", err)
+		} else if exists {
+			return fmt.Errorf("flux path %s already exists in remote repository", fc.path())
+		}
 	}
-
 	return nil
 }
 

--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -639,9 +639,11 @@ func (fc *fluxForCluster) initializeLocalRepository() error {
 // validateLocalConfigPathDoesNotExist returns an exception if the cluster configuration file exists.
 // This is done so that we avoid clobbering existing cluster configurations in the user-provided git repository.
 func (fc *fluxForCluster) validateLocalConfigPathDoesNotExist() error {
-	p := path.Join(fc.gitOpts.Writer.Dir(), fc.path())
-	if validations.FileExists(p) {
-		return fmt.Errorf("a cluster configuration file already exists at path %s", p)
+	if fc.clusterSpec.IsSelfManaged() {
+		p := path.Join(fc.gitOpts.Writer.Dir(), fc.path())
+		if validations.FileExists(p) {
+			return fmt.Errorf("a cluster configuration file already exists at path %s", p)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
