### PR TITLE
Use controlplane endpoint IPs outside DHCP ranges for e2e

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -3,8 +3,8 @@ version: 0.2
 env:
   variables:
     INTEGRATION_TEST_MAX_EC2_COUNT: 60
-    T_VSPHERE_CIDR: "198.18.0.0/16"
-    T_VSPHERE_PRIVATE_NETWORK_CIDR: "10.1.0.0/24"
+    T_VSPHERE_CIDR: "198.18.128.0/17"
+    T_VSPHERE_PRIVATE_NETWORK_CIDR: "10.1.128.0/17"
   secrets-manager:
     EKSA_VSPHERE_USERNAME: "vsphere_ci_beta_connection:vsphere_username"
     EKSA_VSPHERE_PASSWORD: "vsphere_ci_beta_connection:vsphere_password"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, the tests generate random IPs for cp endpoint within the entire subnet range, which can conflict with the DHCP range. This can result in a situation where the DHCP can assign the same IP to other machines which can cause problems.

In this PR, I'm restricting the CIDR range for generating random IPs to avoid conflicts with DHCP.

CIDR `x.x.128.0/17` corresponds to IP range `x.x.128.0-x.x.255.255` which is outside the DHCP ranges for both networks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
