### PR TITLE
Add diagnostic collection workflow task (#606)

### DIFF
--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -359,10 +359,6 @@ func getUpdatedKubeConfigContent(content *[]byte, dockerLbPort string) {
 	*content = updatedContentByte
 }
 
-func (p *provider) CleanupProviderInfrastructure(_ context.Context) error {
-	return nil
-}
-
 func (p *provider) Version(clusterSpec *cluster.Spec) string {
 	return clusterSpec.VersionsBundle.Docker.Version
 }

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -82,20 +82,6 @@ func (mr *MockProviderMockRecorder) ChangeDiff(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeDiff", reflect.TypeOf((*MockProvider)(nil).ChangeDiff), arg0, arg1)
 }
 
-// CleanupProviderInfrastructure mocks base method.
-func (m *MockProvider) CleanupProviderInfrastructure(arg0 context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CleanupProviderInfrastructure", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CleanupProviderInfrastructure indicates an expected call of CleanupProviderInfrastructure.
-func (mr *MockProviderMockRecorder) CleanupProviderInfrastructure(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupProviderInfrastructure", reflect.TypeOf((*MockProvider)(nil).CleanupProviderInfrastructure), arg0)
-}
-
 // DatacenterConfig mocks base method.
 func (m *MockProvider) DatacenterConfig() providers.DatacenterConfig {
 	m.ctrl.T.Helper()

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -19,7 +19,6 @@ type Provider interface {
 	GenerateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currrentSpec, newClusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error)
 	GenerateStorageClass() []byte
 	BootstrapSetup(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error
-	CleanupProviderInfrastructure(ctx context.Context) error
 	BootstrapClusterOpts() ([]bootstrapper.BootstrapClusterOption, error)
 	UpdateKubeConfig(content *[]byte, clusterName string) error
 	Version(clusterSpec *cluster.Spec) string

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1455,10 +1455,6 @@ func (p *vsphereProvider) GenerateMHC() ([]byte, error) {
 	return mhc, nil
 }
 
-func (p *vsphereProvider) CleanupProviderInfrastructure(_ context.Context) error {
-	return nil
-}
-
 func (p *vsphereProvider) createSecret(cluster *types.Cluster, contents *bytes.Buffer) error {
 	t, err := template.New("tmpl").Parse(defaultSecretObject)
 	if err != nil {

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -1192,19 +1192,6 @@ func TestSetupAndValidateUpgradeClusterEtcdSshNotExists(t *testing.T) {
 	}
 }
 
-func TestCleanupProviderInfrastructure(t *testing.T) {
-	ctx := context.Background()
-	provider := givenProvider(t)
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
-
-	err := provider.CleanupProviderInfrastructure(ctx)
-	if err != nil {
-		t.Fatalf("unexpected failure %v", err)
-	}
-}
-
 func TestVersion(t *testing.T) {
 	vSphereProviderVersion := "v0.7.10"
 	provider := givenProvider(t)

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -33,7 +33,6 @@ type CommandContext struct {
 	BootstrapCluster   *types.Cluster
 	WorkloadCluster    *types.Cluster
 	Profiler           *Profiler
-	Rollback           bool
 	OriginalError      error
 }
 
@@ -41,16 +40,6 @@ func (c *CommandContext) SetError(err error) {
 	if c.OriginalError == nil {
 		c.OriginalError = err
 	}
-}
-
-func (c *CommandContext) rollbackDisabled() bool {
-	if c.Rollback {
-		return false
-	}
-	if c.OriginalError == nil {
-		return false
-	}
-	return true
 }
 
 type Profiler struct {
@@ -127,9 +116,6 @@ func (pr *taskRunner) RunTask(ctx context.Context, commandContext *CommandContex
 		commandContext.Profiler.MarkDoneTask(task.Name())
 		commandContext.Profiler.logProfileSummary(task.Name())
 		task = nextTask
-		if commandContext.rollbackDisabled() {
-			break
-		}
 	}
 	return commandContext.OriginalError
 }

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -2,7 +2,6 @@ package task_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -54,28 +53,5 @@ func TestTaskRunnerRunTask(t *testing.T) {
 				t.Fatal("Error Profiler doesn't have metrics")
 			}
 		}
-	}
-}
-
-func TestTaskRunnerRunTaskRollback(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ctx := context.Background()
-	cmdContext := &task.CommandContext{}
-	expectedError := fmt.Errorf("error")
-	cmdContext.OriginalError = expectedError
-	cleanTaskA := mocktasks.NewMockTask(ctrl)
-	cleanTaskB := mocktasks.NewMockTask(ctrl)
-
-	cleanTaskA.EXPECT().Run(ctx, cmdContext).Return(cleanTaskB).Times(1)
-	cleanTaskA.EXPECT().Name().Return("taskA").Times(4)
-	cleanTaskB.EXPECT().Run(ctx, cmdContext).Return(nil).Times(0)
-	cleanTaskB.EXPECT().Name().Return("taskB").Times(0)
-
-	runner := task.NewTaskRunner(cleanTaskA)
-	err := runner.RunTask(ctx, cmdContext)
-	if err != expectedError {
-		t.Fatal("Expected error not returned")
 	}
 }

--- a/pkg/workflows/delete.go
+++ b/pkg/workflows/delete.go
@@ -44,18 +44,13 @@ func (c *Delete) Run(ctx context.Context, workloadCluster *types.Cluster, cluste
 		AddonManager:    c.addonManager,
 		WorkloadCluster: workloadCluster,
 		ClusterSpec:     clusterSpec,
-		Rollback:        false,
 	}
 
 	if clusterSpec.ManagementCluster != nil {
 		commandContext.BootstrapCluster = clusterSpec.ManagementCluster
 	}
 
-	err := task.NewTaskRunner(&setupAndValidate{}).RunTask(ctx, commandContext)
-	if err != nil {
-		_ = commandContext.ClusterManager.SaveLogsManagementCluster(ctx, commandContext.BootstrapCluster)
-	}
-	return err
+	return task.NewTaskRunner(&setupAndValidate{}).RunTask(ctx, commandContext)
 }
 
 type setupAndValidate struct{}
@@ -70,9 +65,9 @@ type deleteWorkloadCluster struct{}
 
 type cleanupGitRepo struct{}
 
-type deleteManagementCluster struct{}
-
-type cleanupProviderInfrastructure struct{}
+type deleteManagementCluster struct {
+	*CollectDiagnosticsTask
+}
 
 func (s *setupAndValidate) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Performing provider setup and validations")
@@ -133,7 +128,7 @@ func (s *moveClusterManagement) Run(ctx context.Context, commandContext *task.Co
 	err := commandContext.ClusterManager.MoveCAPI(ctx, commandContext.WorkloadCluster, commandContext.BootstrapCluster, commandContext.WorkloadCluster.Name, types.WithNodeRef())
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 	return &deleteWorkloadCluster{}
 }
@@ -147,7 +142,7 @@ func (s *deleteWorkloadCluster) Run(ctx context.Context, commandContext *task.Co
 	err := commandContext.ClusterManager.DeleteCluster(ctx, commandContext.BootstrapCluster, commandContext.WorkloadCluster, commandContext.Provider, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 
 	return &cleanupGitRepo{}
@@ -162,7 +157,7 @@ func (s *cleanupGitRepo) Run(ctx context.Context, commandContext *task.CommandCo
 	err := commandContext.AddonManager.CleanupGitRepo(ctx, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 
 	return &deleteManagementCluster{}
@@ -173,32 +168,22 @@ func (s *cleanupGitRepo) Name() string {
 }
 
 func (s *deleteManagementCluster) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	if commandContext.OriginalError != nil {
+		_ = s.CollectDiagnosticsTask.Run(ctx, commandContext)
+	}
 	if commandContext.BootstrapCluster != nil && !commandContext.BootstrapCluster.ExistingManagement {
 		if err := commandContext.Bootstrapper.DeleteBootstrapCluster(ctx, commandContext.BootstrapCluster, false); err != nil {
 			commandContext.SetError(err)
 		}
-		return &cleanupProviderInfrastructure{}
-	}
-	logger.Info("Bootstrap cluster information missing - skipping delete kind cluster")
-	return &cleanupProviderInfrastructure{}
-}
-
-func (s *deleteManagementCluster) Name() string {
-	return "kind-cluster-delete"
-}
-
-func (s *cleanupProviderInfrastructure) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
-	err := commandContext.Provider.CleanupProviderInfrastructure(ctx)
-	if err != nil {
-		commandContext.SetError(err)
 		return nil
 	}
+	logger.Info("Bootstrap cluster information missing - skipping delete kind cluster")
 	if commandContext.OriginalError == nil {
 		logger.MarkSuccess("Cluster deleted!")
 	}
 	return nil
 }
 
-func (s *cleanupProviderInfrastructure) Name() string {
-	return "cleanup-provider-infrastructure"
+func (s *deleteManagementCluster) Name() string {
+	return "kind-cluster-delete"
 }

--- a/pkg/workflows/delete_test.go
+++ b/pkg/workflows/delete_test.go
@@ -127,13 +127,6 @@ func (c *deleteTestSetup) expectNotToMoveManagement() {
 	)
 }
 
-func (c *deleteTestSetup) expectCleanupProvider() {
-	gomock.InOrder(
-		c.provider.EXPECT().CleanupProviderInfrastructure(
-			c.ctx,
-		).Return(nil))
-}
-
 func (c *deleteTestSetup) run() error {
 	// ctx context.Context, workloadCluster *types.Cluster, forceCleanup bool
 	return c.workflow.Run(c.ctx, c.workloadCluster, c.clusterSpec, c.forceCleanup, "")
@@ -147,7 +140,6 @@ func TestDeleteRunSuccess(t *testing.T) {
 	test.expectCleanupGitRepo()
 	test.expectMoveManagement()
 	test.expectDeleteBootstrap()
-	test.expectCleanupProvider()
 
 	err := test.run()
 	if err != nil {
@@ -169,7 +161,6 @@ func TestDeleteWorkloadRunSuccess(t *testing.T) {
 	test.expectCleanupGitRepo()
 	test.expectNotToMoveManagement()
 	test.expectNotToDeleteBootstrap()
-	test.expectCleanupProvider()
 
 	err := test.run()
 	if err != nil {

--- a/pkg/workflows/diagnostics.go
+++ b/pkg/workflows/diagnostics.go
@@ -1,0 +1,54 @@
+package workflows
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/task"
+)
+
+type CollectDiagnosticsTask struct {
+	*CollectWorkloadClusterDiagnosticsTask
+	*CollectMgmtClusterDiagnosticsTask
+}
+
+type CollectWorkloadClusterDiagnosticsTask struct{}
+
+type CollectMgmtClusterDiagnosticsTask struct{}
+
+// CollectDiagnosticsTask implementation
+
+func (s *CollectDiagnosticsTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("collecting cluster diagnostics")
+	_ = s.CollectMgmtClusterDiagnosticsTask.Run(ctx, commandContext)
+	_ = s.CollectWorkloadClusterDiagnosticsTask.Run(ctx, commandContext)
+	return nil
+}
+
+func (s *CollectDiagnosticsTask) Name() string {
+	return "collect-cluster-diagnostics"
+}
+
+// CollectWorkloadClusterDiagnosticsTask implementation
+
+func (s *CollectWorkloadClusterDiagnosticsTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("collecting workload cluster diagnostics")
+	_ = commandContext.ClusterManager.SaveLogsWorkloadCluster(ctx, commandContext.Provider, commandContext.ClusterSpec, commandContext.WorkloadCluster)
+	return nil
+}
+
+func (s *CollectWorkloadClusterDiagnosticsTask) Name() string {
+	return "collect-workload-cluster-diagnostics"
+}
+
+// CollectMgmtClusterDiagnosticsTask implementation
+
+func (s *CollectMgmtClusterDiagnosticsTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("collecting management cluster diagnostics")
+	_ = commandContext.ClusterManager.SaveLogsManagementCluster(ctx, commandContext.BootstrapCluster)
+	return nil
+}
+
+func (s *CollectMgmtClusterDiagnosticsTask) Name() string {
+	return "collect-management-cluster-diagnostics"
+}

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -57,7 +57,6 @@ func (c *Upgrade) Run(ctx context.Context, clusterSpec *cluster.Spec, workloadCl
 		WorkloadCluster:   workloadCluster,
 		ClusterSpec:       clusterSpec,
 		Validations:       validator,
-		Rollback:          true,
 		Writer:            c.writer,
 		CAPIManager:       c.capiManager,
 		UpgradeChangeDiff: c.upgradeChangeDiff,
@@ -67,11 +66,7 @@ func (c *Upgrade) Run(ctx context.Context, clusterSpec *cluster.Spec, workloadCl
 		commandContext.BootstrapCluster = clusterSpec.ManagementCluster
 	}
 
-	err := task.NewTaskRunner(&setupAndValidateTasks{}).RunTask(ctx, commandContext)
-	if err != nil {
-		_ = commandContext.ClusterManager.SaveLogsManagementCluster(ctx, commandContext.BootstrapCluster)
-	}
-	return err
+	return task.NewTaskRunner(&setupAndValidateTasks{}).RunTask(ctx, commandContext)
 }
 
 type setupAndValidateTasks struct{}
@@ -100,7 +95,9 @@ type moveManagementToWorkloadTask struct{}
 
 type upgradeWorkloadClusterTask struct{}
 
-type deleteBootstrapClusterTask struct{}
+type deleteBootstrapClusterTask struct {
+	*CollectDiagnosticsTask
+}
 
 type updateClusterAndGitResources struct{}
 
@@ -150,7 +147,7 @@ func (s *updateSecrets) Run(ctx context.Context, commandContext *task.CommandCon
 	err := commandContext.Provider.UpdateSecrets(ctx, target)
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 	return &ensureEtcdCAPIComponentsExistTask{}
 }
@@ -166,7 +163,7 @@ func (s *ensureEtcdCAPIComponentsExistTask) Run(ctx context.Context, commandCont
 	currentSpec, err := commandContext.ClusterManager.GetCurrentClusterSpec(ctx, target, commandContext.ClusterSpec.Name)
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 	commandContext.CurrentClusterSpec = currentSpec
 	if err := commandContext.CAPIManager.EnsureEtcdProvidersInstallation(ctx, target, commandContext.Provider, currentSpec); err != nil {
@@ -187,21 +184,21 @@ func (s *upgradeCoreComponents) Run(ctx context.Context, commandContext *task.Co
 	changeDiff, err := commandContext.CAPIManager.Upgrade(ctx, target, commandContext.Provider, commandContext.CurrentClusterSpec, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 	commandContext.UpgradeChangeDiff.Append(changeDiff)
 
 	changeDiff, err = commandContext.AddonManager.Upgrade(ctx, target, commandContext.CurrentClusterSpec, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 	commandContext.UpgradeChangeDiff.Append(changeDiff)
 
 	changeDiff, err = commandContext.ClusterManager.Upgrade(ctx, target, commandContext.CurrentClusterSpec, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 	commandContext.UpgradeChangeDiff.Append(changeDiff)
 
@@ -229,7 +226,7 @@ func (s *upgradeNeeded) Run(ctx context.Context, commandContext *task.CommandCon
 	diff, err := commandContext.ClusterManager.EKSAClusterSpecChanged(ctx, target, newSpec, datacenterConfig, machineConfigs)
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 
 	if !diff {
@@ -251,14 +248,14 @@ func (s *pauseEksaAndFluxReconcile) Run(ctx context.Context, commandContext *tas
 	err := commandContext.ClusterManager.PauseEKSAControllerReconcile(ctx, target, commandContext.ClusterSpec, commandContext.Provider)
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 
 	logger.Info("Pausing Flux kustomization")
 	err = commandContext.AddonManager.PauseGitOpsKustomization(ctx, target, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 	return &createBootstrapClusterTask{}
 }
@@ -311,7 +308,7 @@ func (s *moveManagementToBootstrapTask) Run(ctx context.Context, commandContext 
 	err := commandContext.ClusterManager.MoveCAPI(ctx, commandContext.WorkloadCluster, commandContext.BootstrapCluster, commandContext.WorkloadCluster.Name, types.WithNodeRef(), types.WithNodeHealthy())
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 	return &upgradeWorkloadClusterTask{}
 }
@@ -328,7 +325,7 @@ func (s *upgradeWorkloadClusterTask) Run(ctx context.Context, commandContext *ta
 	if err != nil {
 		commandContext.SetError(err)
 		if commandContext.BootstrapCluster.ExistingManagement {
-			return nil
+			return &CollectDiagnosticsTask{}
 		}
 		return &moveManagementToWorkloadTaskAndExit{}
 	}
@@ -336,7 +333,7 @@ func (s *upgradeWorkloadClusterTask) Run(ctx context.Context, commandContext *ta
 	if commandContext.UpgradeChangeDiff.Changed() {
 		if err = commandContext.ClusterManager.ApplyBundles(ctx, commandContext.ClusterSpec, target); err != nil {
 			commandContext.SetError(err)
-			return nil
+			return &CollectDiagnosticsTask{}
 		}
 	}
 
@@ -355,14 +352,14 @@ func (s *moveManagementToWorkloadTask) Run(ctx context.Context, commandContext *
 	err := commandContext.ClusterManager.MoveCAPI(ctx, commandContext.BootstrapCluster, commandContext.WorkloadCluster, commandContext.WorkloadCluster.Name, types.WithNodeRef(), types.WithNodeHealthy())
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 	return &updateClusterAndGitResources{}
 }
 
 func (s *moveManagementToWorkloadTaskAndExit) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	_ = s.moveManagementToWorkloadTask.Run(ctx, commandContext)
-	return nil
+	return &CollectDiagnosticsTask{}
 }
 
 func (s *moveManagementToWorkloadTask) Name() string {
@@ -378,21 +375,21 @@ func (s *updateClusterAndGitResources) Run(ctx context.Context, commandContext *
 	err := commandContext.ClusterManager.CreateEKSAResources(ctx, target, commandContext.ClusterSpec, datacenterConfig, machineConfigs)
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 
 	logger.Info("Resuming EKS-A controller reconciliation")
 	err = commandContext.ClusterManager.ResumeEKSAControllerReconcile(ctx, target, commandContext.ClusterSpec, commandContext.Provider)
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 
 	logger.Info("Updating Git Repo with new EKS-A cluster spec")
 	err = commandContext.AddonManager.UpdateGitEksaSpec(ctx, commandContext.ClusterSpec, datacenterConfig, machineConfigs)
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 	return &resumeFluxReconcile{}
 }
@@ -408,7 +405,7 @@ func (s *resumeFluxReconcile) Run(ctx context.Context, commandContext *task.Comm
 	err := commandContext.AddonManager.ForceReconcileGitRepo(ctx, target, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &CollectDiagnosticsTask{}
 	}
 
 	logger.Info("Resuming Flux kustomization")
@@ -438,6 +435,9 @@ func (s *writeClusterConfigTask) Name() string {
 }
 
 func (s *deleteBootstrapClusterTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	if commandContext.OriginalError != nil {
+		_ = s.CollectDiagnosticsTask.Run(ctx, commandContext)
+	}
 	if commandContext.BootstrapCluster != nil && !commandContext.BootstrapCluster.ExistingManagement {
 		if err := commandContext.Bootstrapper.DeleteBootstrapCluster(ctx, commandContext.BootstrapCluster, true); err != nil {
 			commandContext.SetError(err)

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -269,9 +269,11 @@ func (c *upgradeTestSetup) expectVerifyClusterSpecChanged(expectedCluster *types
 	)
 }
 
-func (c *upgradeTestSetup) expectSaveLogs() {
+func (c *upgradeTestSetup) expectSaveLogs(expectedWorkloadCluster *types.Cluster) {
 	gomock.InOrder(
+
 		c.clusterManager.EXPECT().SaveLogsManagementCluster(c.ctx, c.bootstrapCluster).Return(nil),
+		c.clusterManager.EXPECT().SaveLogsWorkloadCluster(c.ctx, c.provider, c.newClusterSpec, expectedWorkloadCluster),
 	)
 }
 
@@ -409,7 +411,7 @@ func TestUpgradeRunFailedUpgrade(t *testing.T) {
 	test.expectMoveManagementToBootstrap()
 	test.expectUpgradeWorkloadToReturn(test.workloadCluster, errors.New("failed upgrading"))
 	test.expectMoveManagementToWorkload()
-	test.expectSaveLogs()
+	test.expectSaveLogs(test.workloadCluster)
 
 	err := test.run()
 	if err == nil {


### PR DESCRIPTION
Include the fix for diagnostic bundle collection during setup and validation in the 0.6.1 patch release
3992ec57de953137f10ebcb8360dd2768d19e1db

* remove unused provider infrastucture cleanup method

* add common diagnostic collection workflow task

* add diagnostic collection tasks to create workflow

* add diagnostic collection tasks to delete workflow

* add diagnostic collection tasks to upgrade workflow

* update tests

* gofmt changed files

* adjust tests after merge from main

* remove unused rollback functionality from tasks and workflows

* decompose Diagnostics task into WC and MG diag tasks

* remove 'rollback' tasks form create workflow

* rename common to diagnostics

* remove unused delete-kind-cluster block from create workflow

* remove error check from bootstrap cluster delete workflow task

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
