### PR TITLE
fix issue with using EKSA_REGISTRY_MIRROR_CA env var

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -388,7 +388,7 @@ func validateMirrorConfig(clusterConfig *Cluster) error {
 		return errors.New("no value set for ECRMirror.Endpoint")
 	}
 
-	tlsValidator := crypto.NewTlsValidator(clusterConfig.Spec.RegistryMirrorConfiguration.CACertContent, clusterConfig.Spec.RegistryMirrorConfiguration.Endpoint)
+	tlsValidator := crypto.NewTlsValidator(clusterConfig.Spec.RegistryMirrorConfiguration.Endpoint)
 	selfSigned, err := tlsValidator.HasSelfSignedCert()
 	if err != nil {
 		return fmt.Errorf("error validating registy mirror endpoint: %v", err)
@@ -411,7 +411,7 @@ func validateMirrorConfig(clusterConfig *Cluster) error {
 	}
 
 	if certContent != "" {
-		err := tlsValidator.ValidateCert()
+		err := tlsValidator.ValidateCert(certContent)
 		if err != nil {
 			return fmt.Errorf("error validating the registry certificate: %v", err)
 		}

--- a/pkg/crypto/tls.go
+++ b/pkg/crypto/tls.go
@@ -8,19 +8,17 @@ import (
 )
 
 type DefaultTlsValidator struct {
-	cert string
-	url  string
+	url string
 }
 
 type TlsValidator interface {
-	ValidateCert() error
+	ValidateCert(cert string) error
 	HasSelfSignedCert() (bool, error)
 }
 
-func NewTlsValidator(cert, url string) TlsValidator {
+func NewTlsValidator(url string) TlsValidator {
 	return &DefaultTlsValidator{
-		cert: cert,
-		url:  url,
+		url: url,
 	}
 }
 
@@ -42,9 +40,9 @@ func (tv *DefaultTlsValidator) HasSelfSignedCert() (bool, error) {
 }
 
 // ValidateCert parses the cert, ensures that the cert format is valid and verifies that the cert is valid for the url
-func (tv *DefaultTlsValidator) ValidateCert() error {
+func (tv *DefaultTlsValidator) ValidateCert(cert string) error {
 	// Validates that the cert format is valid
-	block, _ := pem.Decode([]byte(tv.cert))
+	block, _ := pem.Decode([]byte(cert))
 	if block == nil {
 		return fmt.Errorf("failed to parse certificate PEM")
 	}

--- a/pkg/crypto/tls_test.go
+++ b/pkg/crypto/tls_test.go
@@ -1,0 +1,64 @@
+package crypto_test
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/pkg/crypto"
+)
+
+const (
+	endpoint         = "unit-test.local"
+	invalid_endpoint = "invalid-endpoint.local"
+	cert             = `
+-----BEGIN CERTIFICATE-----
+MIID/jCCAuagAwIBAgIUO/ncrEaWxLUqZ8IioBVCRl1P2R4wDQYJKoZIhvcNAQEL
+BQAwgagxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApXYXNoaW5ndG9uMRAwDgYDVQQH
+DAdTZWF0dGxlMRwwGgYDVQQKDBNBbWF6b24gV2ViIFNlcnZpY2VzMRUwEwYDVQQL
+DAxFS1MgQW55d2hlcmUxGDAWBgNVBAMMD3VuaXQtdGVzdC5sb2NhbDEjMCEGCSqG
+SIb3DQEJARYUdGVzdEB1bml0LXRlc3QubG9jYWwwHhcNMjExMTE2MjMwNzUzWhcN
+MjIxMTE2MjMwNzUzWjCBqDELMAkGA1UEBhMCVVMxEzARBgNVBAgMCldhc2hpbmd0
+b24xEDAOBgNVBAcMB1NlYXR0bGUxHDAaBgNVBAoME0FtYXpvbiBXZWIgU2Vydmlj
+ZXMxFTATBgNVBAsMDEVLUyBBbnl3aGVyZTEYMBYGA1UEAwwPdW5pdC10ZXN0Lmxv
+Y2FsMSMwIQYJKoZIhvcNAQkBFhR0ZXN0QHVuaXQtdGVzdC5sb2NhbDCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBALC+5yZrxn8sy7WilquxsjRjqCzaUoio
+i31TlU1lRCI1HhgCjAE5xvMMS1vd1lhXxx7VdOS4b5UO+S+IAOjWWTQDfX7H+hOm
+AIAU45ejaUtQDZ7hjdHXyfIOhi5Qb+D4ZLiMAQEe/EHLpB0dxBu+KD0nlBxHKUQY
+HT1s41u9J4gOjhB+oVAQZmWvoTt0v5iPrljOfjsHPV4HqDUxPh9ngeL3a7AkMxIG
+Nf4nh7hqFKKwGMgifAXG3k4aec/gOIKBEt9Ns43uTn45zKHkL2C4NHTGjFGWlnT8
+ixxUW3bXFTI6LjKzllprYimGaMiyMPSOEtXOFV2xHedv39Qaq6yp4/sCAwEAAaMe
+MBwwGgYDVR0RBBMwEYIPdW5pdC10ZXN0LmxvY2FsMA0GCSqGSIb3DQEBCwUAA4IB
+AQCUHw792stgHCPJ6qYD6ij1ehp4yAdXKdaOykTwOxvPvcjdKxnwBYJ7feU+Wh6B
+fauk1tpUp6tEF/FzFXdGoYfMvMJtHeS57dFf/mx9uUgHXnhgIYFDe4bM+4W2LHHC
+mbvwOYSLAyPfjhihryCRSmIk2X+JYhTSnTXUwKkacEMn3BiEyTfZG9pzr/aIpsIE
+e/rwWa9a4BdrhqTBK6VWtTvNYbRaDVP8cbQPVl0qdIyqbTPI/QrITGchY2Qk/eoS
+zwaAnAW1ZiriAbeFx+xOaO1fETVSm+5Poyl97r5Mmu97+3IpoWHFPO2z4Os9vn3q
+XsKvL2lz2uQY+ZbrfvrL20p2
+-----END CERTIFICATE-----
+`
+	invalid_cert = `
+-----BEGIN CERTIFICATE-----
+invalidCert
+-----END CERTIFICATE-----
+`
+)
+
+func TestValidateCertValidCert(t *testing.T) {
+	tv := crypto.NewTlsValidator(endpoint)
+	if err := tv.ValidateCert(cert); err != nil {
+		t.Fatalf("Failed to validate cert: %v", err)
+	}
+}
+
+func TestValidateCertInvalidEndpoint(t *testing.T) {
+	tv := crypto.NewTlsValidator(invalid_endpoint)
+	if err := tv.ValidateCert(cert); err == nil {
+		t.Fatalf("Certificate validation passed for invalid endpoint")
+	}
+}
+
+func TestValidateCertInvalidCert(t *testing.T) {
+	tv := crypto.NewTlsValidator(endpoint)
+	if err := tv.ValidateCert(invalid_cert); err == nil {
+		t.Fatalf("Certificate validation passed for invalid cert")
+	}
+}

--- a/pkg/crypto/tls_test.go
+++ b/pkg/crypto/tls_test.go
@@ -9,7 +9,14 @@ import (
 const (
 	endpoint         = "unit-test.local"
 	invalid_endpoint = "invalid-endpoint.local"
-	cert             = `
+	/*
+		This certificate was generated using the following commands and is valid only for `unit-test.local`
+		openssl genrsa -out ca.key 2048
+		openssl req -new -x509 -days 3650 -key ca.key -out ca.crt
+		openssl req -newkey rsa:2048 -nodes -keyout server.key -out server.csr
+		openssl x509 -req -extfile <(printf "subjectAltName=DNS:unit-test.local") -days 365 -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt
+	*/
+	cert = `
 -----BEGIN CERTIFICATE-----
 MIID/jCCAuagAwIBAgIUO/ncrEaWxLUqZ8IioBVCRl1P2R4wDQYJKoZIhvcNAQEL
 BQAwgagxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApXYXNoaW5ndG9uMRAwDgYDVQQH


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Environment variable `EKSA_REGISTRY_MIRROR_CA` was not being used to validate the cert. This was causing the CLI to fail validations in case of self-signed certs. This PR fixes that issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
