### PR TITLE
Accept service account issuer for Pod based IAM

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -166,6 +166,13 @@ spec:
                 description: 'Deprecated: This field has no function and is going
                   to be removed in a future release.'
                 type: string
+              podIamConfig:
+                properties:
+                  serviceAccountIssuer:
+                    type: string
+                required:
+                - serviceAccountIssuer
+                type: object
               proxyConfiguration:
                 properties:
                   httpProxy:

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -163,6 +163,7 @@ var clusterConfigValidations = []func(*Cluster) error{
 	validateIdentityProviderRefs,
 	validateProxyConfig,
 	validateMirrorConfig,
+	validatePodIAMConfig,
 }
 
 func GetClusterConfig(fileName string) (*Cluster, error) {
@@ -462,6 +463,16 @@ func validateGitOps(clusterConfig *Cluster) error {
 	}
 	if gitOpsRef.Name == "" {
 		return errors.New("GitOpsConfig name can't be empty; specify a valid name for GitOpsConfig")
+	}
+	return nil
+}
+
+func validatePodIAMConfig(clusterConfig *Cluster) error {
+	if clusterConfig.Spec.PodIAMConfig == nil {
+		return nil
+	}
+	if clusterConfig.Spec.PodIAMConfig.ServiceAccountIssuer == "" {
+		return errors.New("ServiceAccount Issuer can't be empty while configuring IAM roles for pods")
 	}
 	return nil
 }

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -47,6 +47,7 @@ type ClusterSpec struct {
 	ProxyConfiguration          *ProxyConfiguration          `json:"proxyConfiguration,omitempty"`
 	RegistryMirrorConfiguration *RegistryMirrorConfiguration `json:"registryMirrorConfiguration,omitempty"`
 	ManagementCluster           ManagementCluster            `json:"managementCluster,omitempty"`
+	PodIAMConfig                *PodIAMConfig                `json:"podIamConfig,omitempty"`
 }
 
 func (n *Cluster) Equal(o *Cluster) bool {
@@ -361,6 +362,20 @@ type ManagementCluster struct {
 
 func (n *ManagementCluster) Equal(o ManagementCluster) bool {
 	return n.Name == o.Name
+}
+
+type PodIAMConfig struct {
+	ServiceAccountIssuer string `json:"serviceAccountIssuer"`
+}
+
+func (n *PodIAMConfig) Equal(o *PodIAMConfig) bool {
+	if n == o {
+		return true
+	}
+	if n == nil || o == nil {
+		return false
+	}
+	return n.ServiceAccountIssuer == o.ServiceAccountIssuer
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -1159,6 +1159,55 @@ func TestRegistryMirrorConfigurationEqual(t *testing.T) {
 	}
 }
 
+func TestPodIAMServiceAccountIssuerHasNotChanged(t *testing.T) {
+	testCases := []struct {
+		testName                                   string
+		cluster1PodIAMConfig, cluster2PodIAMConfig *v1alpha1.PodIAMConfig
+		want                                       bool
+	}{
+		{
+			testName:             "both nil",
+			cluster1PodIAMConfig: nil,
+			cluster2PodIAMConfig: nil,
+			want:                 true,
+		},
+		{
+			testName: "one nil, one exists",
+			cluster1PodIAMConfig: &v1alpha1.PodIAMConfig{
+				ServiceAccountIssuer: "https://test",
+			},
+			cluster2PodIAMConfig: nil,
+			want:                 false,
+		},
+		{
+			testName: "both exist, same",
+			cluster1PodIAMConfig: &v1alpha1.PodIAMConfig{
+				ServiceAccountIssuer: "https://test",
+			},
+			cluster2PodIAMConfig: &v1alpha1.PodIAMConfig{
+				ServiceAccountIssuer: "https://test",
+			},
+			want: true,
+		},
+		{
+			testName: "both exist, service account issuer different",
+			cluster1PodIAMConfig: &v1alpha1.PodIAMConfig{
+				ServiceAccountIssuer: "https://test1",
+			},
+			cluster2PodIAMConfig: &v1alpha1.PodIAMConfig{
+				ServiceAccountIssuer: "https://test2",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.cluster1PodIAMConfig.Equal(tt.cluster2PodIAMConfig)).To(Equal(tt.want))
+		})
+	}
+}
+
 func setSelfManaged(c *v1alpha1.Cluster, s bool) {
 	if s {
 		c.SetSelfManaged()

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -88,6 +88,9 @@ spec:
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
           profiling: "false"
+{{- if .serviceAccountIssuer }}
+          service-account-issuer: {{ .serviceAccountIssuer }}
+{{- end }}
 {{- if .apiserverExtraArgs }}
 {{ .apiserverExtraArgs.ToYaml | indent 10 }}
 {{- end }}

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -199,6 +199,9 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) map[string]interface{} {
 		values["controlPlaneTaints"] = clusterSpec.Spec.ControlPlaneConfiguration.Taints
 	}
 
+	if clusterSpec.Spec.PodIAMConfig != nil {
+		values["serviceAccountIssuer"] = clusterSpec.Spec.PodIAMConfig.ServiceAccountIssuer
+	}
 	return values
 }
 

--- a/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
@@ -1,0 +1,274 @@
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: Cluster
+metadata:
+  name: test-cluster
+  namespace: eksa-system
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: [192.168.0.0/16]
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks: [10.128.0.0/12]
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    kind: KubeadmControlPlane
+    name: test-cluster
+    namespace: eksa-system
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: DockerCluster
+    name: test-cluster
+    namespace: eksa-system
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: DockerCluster
+metadata:
+  name: test-cluster
+  namespace: eksa-system
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: DockerMachineTemplate
+metadata:
+  name: test-cluster-control-plane-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      extraMounts:
+      - containerPath: /var/run/docker.sock
+        hostPath: /var/run/docker.sock
+      customImage: public.ecr.aws/eks-distro/kubernetes-sigs/kind/node:v1.18.16-eks-1-18-4-216edda697a37f8bf16651af6c23b7e2bb7ef42f-62681885fe3a97ee4f2b110cc277e084e71230fa
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+kind: KubeadmControlPlane
+metadata:
+  name: test-cluster
+  namespace: eksa-system
+spec:
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: DockerMachineTemplate
+    name: test-cluster-control-plane-template-1234567890000
+    namespace: eksa-system
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      imageRepository: public.ecr.aws/eks-distro/kubernetes
+      etcd:
+        local:
+          imageRepository: public.ecr.aws/eks-distro/etcd-io
+          imageTag: v3.4.14-eks-1-19-2
+      dns:
+        type: CoreDNS
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.8.0-eks-1-19-2
+      apiServer:
+        certSANs:
+        - localhost
+        - 127.0.0.1
+        extraArgs:
+          audit-policy-file: /etc/kubernetes/audit-policy.yaml
+          audit-log-path: /var/log/kubernetes/api-audit.log
+          audit-log-maxage: "30"
+          audit-log-maxbackup: "10"
+          audit-log-maxsize: "512"
+          profiling: "false"
+          service-account-issuer: https://test
+        extraVolumes:
+        - hostPath: /etc/kubernetes/audit-policy.yaml
+          mountPath: /etc/kubernetes/audit-policy.yaml
+          name: audit-policy
+          pathType: File
+          readOnly: true
+        - hostPath: /var/log/kubernetes
+          mountPath: /var/log/kubernetes
+          name: audit-log-dir
+          pathType: DirectoryOrCreate
+          readOnly: false
+        - hostPath: /var/log/kubernetes/api-audit.log
+          mountPath: /var/log/kubernetes/api-audit.log
+          name: audit-log
+          pathType: FileOrCreate
+          readOnly: false
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+          profiling: "false"
+      scheduler:
+        extraArgs:
+          profiling: "false"
+    files:
+    - content: |
+        apiVersion: audit.k8s.io/v1beta1
+        kind: Policy
+        rules:
+        # Log aws-auth configmap changes
+        - level: RequestResponse
+          namespaces: ["kube-system"]
+          verbs: ["update", "patch", "delete"]
+          resources:
+          - group: "" # core
+            resources: ["configmaps"]
+            resourceNames: ["aws-auth"]
+          omitStages:
+          - "RequestReceived"
+        # The following requests were manually identified as high-volume and low-risk,
+        # so drop them.
+        - level: None
+          users: ["system:kube-proxy"]
+          verbs: ["watch"]
+          resources:
+          - group: "" # core
+            resources: ["endpoints", "services", "services/status"]
+        - level: None
+          users: ["kubelet"] # legacy kubelet identity
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["nodes", "nodes/status"]
+        - level: None
+          userGroups: ["system:nodes"]
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["nodes", "nodes/status"]
+        - level: None
+          users:
+          - system:kube-controller-manager
+          - system:kube-scheduler
+          - system:serviceaccount:kube-system:endpoint-controller
+          verbs: ["get", "update"]
+          namespaces: ["kube-system"]
+          resources:
+          - group: "" # core
+            resources: ["endpoints"]
+        - level: None
+          users: ["system:apiserver"]
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+        # Don't log HPA fetching metrics.
+        - level: None
+          users:
+          - system:kube-controller-manager
+          verbs: ["get", "list"]
+          resources:
+          - group: "metrics.k8s.io"
+        # Don't log these read-only URLs.
+        - level: None
+          nonResourceURLs:
+          - /healthz*
+          - /version
+          - /swagger*
+        # Don't log events requests.
+        - level: None
+          resources:
+          - group: "" # core
+            resources: ["events"]
+        # node and pod status calls from nodes are high-volume and can be large, don't log responses for expected updates from nodes
+        - level: Request
+          users: ["kubelet", "system:node-problem-detector", "system:serviceaccount:kube-system:node-problem-detector"]
+          verbs: ["update","patch"]
+          resources:
+          - group: "" # core
+            resources: ["nodes/status", "pods/status"]
+          omitStages:
+          - "RequestReceived"
+        - level: Request
+          userGroups: ["system:nodes"]
+          verbs: ["update","patch"]
+          resources:
+          - group: "" # core
+            resources: ["nodes/status", "pods/status"]
+          omitStages:
+          - "RequestReceived"
+        # deletecollection calls can be large, don't log responses for expected namespace deletions
+        - level: Request
+          users: ["system:serviceaccount:kube-system:namespace-controller"]
+          verbs: ["deletecollection"]
+          omitStages:
+          - "RequestReceived"
+        # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
+        # so only log at the Metadata level.
+        - level: Metadata
+          resources:
+          - group: "" # core
+            resources: ["secrets", "configmaps"]
+          - group: authentication.k8s.io
+            resources: ["tokenreviews"]
+          omitStages:
+            - "RequestReceived"
+        - level: Request
+          resources:
+          - group: ""
+            resources: ["serviceaccounts/token"]
+        # Get repsonses can be large; skip them.
+        - level: Request
+          verbs: ["get", "list", "watch"]
+          resources: 
+          - group: "" # core
+          - group: "admissionregistration.k8s.io"
+          - group: "apiextensions.k8s.io"
+          - group: "apiregistration.k8s.io"
+          - group: "apps"
+          - group: "authentication.k8s.io"
+          - group: "authorization.k8s.io"
+          - group: "autoscaling"
+          - group: "batch"
+          - group: "certificates.k8s.io"
+          - group: "extensions"
+          - group: "metrics.k8s.io"
+          - group: "networking.k8s.io"
+          - group: "policy"
+          - group: "rbac.authorization.k8s.io"
+          - group: "scheduling.k8s.io"
+          - group: "settings.k8s.io"
+          - group: "storage.k8s.io"
+          omitStages:
+          - "RequestReceived"
+        # Default level for known APIs
+        - level: RequestResponse
+          resources: 
+          - group: "" # core
+          - group: "admissionregistration.k8s.io"
+          - group: "apiextensions.k8s.io"
+          - group: "apiregistration.k8s.io"
+          - group: "apps"
+          - group: "authentication.k8s.io"
+          - group: "authorization.k8s.io"
+          - group: "autoscaling"
+          - group: "batch"
+          - group: "certificates.k8s.io"
+          - group: "extensions"
+          - group: "metrics.k8s.io"
+          - group: "networking.k8s.io"
+          - group: "policy"
+          - group: "rbac.authorization.k8s.io"
+          - group: "scheduling.k8s.io"
+          - group: "settings.k8s.io"
+          - group: "storage.k8s.io"
+          omitStages:
+          - "RequestReceived"
+        # Default level for all other requests.
+        - level: Metadata
+          omitStages:
+          - "RequestReceived"
+      owner: root:root
+      path: /etc/kubernetes/audit-policy.yaml
+    initConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+        taints: []
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+        taints: []
+  replicas: 1
+  version: v1.19.6-eks-1-19-2

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -2,148 +2,109 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: {{.clusterName}}
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+    cluster.x-k8s.io/cluster-name: test
+  name: test
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks: {{.podCidrs}}
+      cidrBlocks: [192.168.0.0/16]
     services:
-      cidrBlocks: {{.serviceCidrs}}
+      cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
-    name: {{.clusterName}}
+    name: test
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
-    name: {{.clusterName}}
-{{- if .externalEtcd }}
+    name: test
   managedExternalEtcdRef:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
-    name: {{.clusterName}}-etcd
-{{- end }}
+    name: test-etcd
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test
+  namespace: eksa-system
 spec:
   cloudProviderConfiguration:
     global:
       secretName: cloud-provider-vsphere-credentials
       secretNamespace: kube-system
-      thumbprint: '{{.thumbprint}}'
-      insecure: {{.insecure}}
+      thumbprint: 'ABCDEFG'
+      insecure: false
     network:
-      name: {{.vsphereNetwork}}
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
     providerConfig:
       cloud:
-        controllerImage: {{.managerImage}}
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
     virtualCenter:
-      {{.vsphereServer}}:
-        datacenters: {{.vsphereDatacenter}}
-        thumbprint: '{{.thumbprint}}'
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
     workspace:
-      datacenter: {{.vsphereDatacenter}}
-      datastore: {{.controlPlaneVsphereDatastore}}
-      folder: '{{.controlPlaneVsphereFolder}}'
-      resourcePool: '{{.controlPlaneVsphereResourcePool}}'
-      server: {{.vsphereServer}}
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
-    host: {{.controlPlaneEndpointIp}}
+    host: 1.2.3.4
     port: 6443
-  server: {{.vsphereServer}}
-  thumbprint: '{{.thumbprint}}'
+  server: vsphere_server
+  thumbprint: 'ABCDEFG'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
-  name: {{.controlPlaneTemplateName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test-control-plane-template-1234567890000
+  namespace: eksa-system
 spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{.vsphereDatacenter}}
-      datastore: {{.controlPlaneVsphereDatastore}}
-      diskGiB: {{.controlPlaneDiskGiB}}
-      folder: '{{.controlPlaneVsphereFolder}}'
-      memoryMiB: {{.controlPlaneVMsMemoryMiB}}
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 8192
       network:
         devices:
         - dhcp4: true
-          networkName: {{.vsphereNetwork}}
-      numCPUs: {{.controlPlaneVMsNumCPUs}}
-      resourcePool: '{{.controlPlaneVsphereResourcePool}}'
-      server: {{.vsphereServer}}
-{{- if (ne .controlPlaneVsphereStoragePolicyName "") }}
-      storagePolicyName: "{{.controlPlaneVsphereStoragePolicyName}}"
-{{- end }}
-      template: {{.vsphereTemplate}}
-      thumbprint: '{{.thumbprint}}'
+          networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 2
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
+      thumbprint: 'ABCDEFG'
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test
+  namespace: eksa-system
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
-    name: {{.controlPlaneTemplateName}}
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: {{.kubernetesRepository}}
+      imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
-{{- if .externalEtcd }}
         external:
           endpoints: []
-{{- if (eq .format "bottlerocket") }}
-          caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
-          certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
-          keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"
-{{- else }}
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
-{{- end }}
-{{- else }}
-        local:
-          imageRepository: {{.etcdRepository}}
-          imageTag: {{.etcdImageTag}}
-{{- end }}
       dns:
         type: CoreDNS
-        imageRepository: {{.corednsRepository}}
-        imageTag: {{.corednsVersion}}
-{{- if (eq .format "bottlerocket") }}
-      pause:
-        imageRepository: {{.pauseRepository}}
-        imageTag: {{.pauseVersion}}
-      bottlerocketBootstrap:
-        imageRepository: {{.bottlerocketBootstrapRepository}}
-        imageTag: {{.bottlerocketBootstrapVersion}}
-{{- end }}
-{{- if and .proxyConfig (eq .format "bottlerocket") }}
-      proxy:
-        httpsProxy: {{.httpsProxy}}
-        noProxy: {{ range .noProxy }}
-          - {{ . }}
-        {{- end }}
-{{- end }}
-{{- if and .registryMirrorConfiguration (eq .format "bottlerocket") }}
-      registryMirror:
-        endpoint: {{.registryMirrorConfiguration}}
-        {{- if .registryCACert }}
-        caCert: |
-{{ .registryCACert | indent 10 }}
-        {{- end }}
-{{- end }}
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.8.0-eks-1-19-4
       apiServer:
         extraArgs:
           cloud-provider: external
@@ -153,18 +114,9 @@ spec:
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
           profiling: "false"
-{{- if .serviceAccountIssuer }}
-          service-account-issuer: {{ .serviceAccountIssuer }}
-{{- end }}
-{{- if .apiserverExtraArgs }}
-{{ .apiserverExtraArgs.ToYaml | indent 10 }}
-{{- end }}
+          service-account-issuer: https://test
         extraVolumes:
-{{- if (eq .format "bottlerocket") }}
-        - hostPath: /var/lib/kubeadm/audit-policy.yaml
-{{- else }}
         - hostPath: /etc/kubernetes/audit-policy.yaml
-{{- end }}
           mountPath: /etc/kubernetes/audit-policy.yaml
           name: audit-policy
           pathType: File
@@ -179,40 +131,13 @@ spec:
           name: audit-log
           pathType: FileOrCreate
           readOnly: false
-{{- if .awsIamAuth}}
-        - hostPath: /var/lib/kubeadm/aws-iam-authenticator/
-          mountPath: /etc/kubernetes/aws-iam-authenticator/
-          name: authconfig
-          readOnly: false
-        - hostPath: /var/lib/kubeadm/aws-iam-authenticator/pki/
-          mountPath: /var/aws-iam-authenticator/
-          name: awsiamcert
-          readOnly: false
-{{- end}}
       controllerManager:
         extraArgs:
           cloud-provider: external
           profiling: "false"
-{{- if (eq .format "bottlerocket") }}
-        extraVolumes:
-        - hostPath: /var/lib/kubeadm/controller-manager.conf
-          mountPath: /etc/kubernetes/controller-manager.conf
-          name: kubeconfig
-          pathType: File
-          readOnly: true
-{{- end }}
       scheduler:
         extraArgs:
           profiling: "false"
-{{- if (eq .format "bottlerocket") }}
-        extraVolumes:
-        - hostPath: /var/lib/kubeadm/scheduler.conf
-          mountPath: /etc/kubernetes/scheduler.conf
-          name: kubeconfig
-          pathType: File
-          readOnly: true
-      certificatesDir: /var/lib/kubeadm/pki
-{{- end }}
     files:
     - content: |
         apiVersion: v1
@@ -231,7 +156,7 @@ spec:
             - name: vip_leaderelection
               value: "true"
             - name: vip_address
-              value: {{.controlPlaneEndpointIp}}
+              value: 1.2.3.4
             - name: vip_interface
               value: eth0
             - name: vip_leaseduration
@@ -240,7 +165,7 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: {{.kubeVipImage}}
+            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}
@@ -262,168 +187,204 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-{{ .auditPolicy | indent 8 }}
+        apiVersion: audit.k8s.io/v1beta1
+        kind: Policy
+        rules:
+        # Log aws-auth configmap changes
+        - level: RequestResponse
+          namespaces: ["kube-system"]
+          verbs: ["update", "patch", "delete"]
+          resources:
+          - group: "" # core
+            resources: ["configmaps"]
+            resourceNames: ["aws-auth"]
+          omitStages:
+          - "RequestReceived"
+        # The following requests were manually identified as high-volume and low-risk,
+        # so drop them.
+        - level: None
+          users: ["system:kube-proxy"]
+          verbs: ["watch"]
+          resources:
+          - group: "" # core
+            resources: ["endpoints", "services", "services/status"]
+        - level: None
+          users: ["kubelet"] # legacy kubelet identity
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["nodes", "nodes/status"]
+        - level: None
+          userGroups: ["system:nodes"]
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["nodes", "nodes/status"]
+        - level: None
+          users:
+          - system:kube-controller-manager
+          - system:kube-scheduler
+          - system:serviceaccount:kube-system:endpoint-controller
+          verbs: ["get", "update"]
+          namespaces: ["kube-system"]
+          resources:
+          - group: "" # core
+            resources: ["endpoints"]
+        - level: None
+          users: ["system:apiserver"]
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+        # Don't log HPA fetching metrics.
+        - level: None
+          users:
+          - system:kube-controller-manager
+          verbs: ["get", "list"]
+          resources:
+          - group: "metrics.k8s.io"
+        # Don't log these read-only URLs.
+        - level: None
+          nonResourceURLs:
+          - /healthz*
+          - /version
+          - /swagger*
+        # Don't log events requests.
+        - level: None
+          resources:
+          - group: "" # core
+            resources: ["events"]
+        # node and pod status calls from nodes are high-volume and can be large, don't log responses for expected updates from nodes
+        - level: Request
+          users: ["kubelet", "system:node-problem-detector", "system:serviceaccount:kube-system:node-problem-detector"]
+          verbs: ["update","patch"]
+          resources:
+          - group: "" # core
+            resources: ["nodes/status", "pods/status"]
+          omitStages:
+          - "RequestReceived"
+        - level: Request
+          userGroups: ["system:nodes"]
+          verbs: ["update","patch"]
+          resources:
+          - group: "" # core
+            resources: ["nodes/status", "pods/status"]
+          omitStages:
+          - "RequestReceived"
+        # deletecollection calls can be large, don't log responses for expected namespace deletions
+        - level: Request
+          users: ["system:serviceaccount:kube-system:namespace-controller"]
+          verbs: ["deletecollection"]
+          omitStages:
+          - "RequestReceived"
+        # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
+        # so only log at the Metadata level.
+        - level: Metadata
+          resources:
+          - group: "" # core
+            resources: ["secrets", "configmaps"]
+          - group: authentication.k8s.io
+            resources: ["tokenreviews"]
+          omitStages:
+            - "RequestReceived"
+        - level: Request
+          resources:
+          - group: ""
+            resources: ["serviceaccounts/token"]
+        # Get repsonses can be large; skip them.
+        - level: Request
+          verbs: ["get", "list", "watch"]
+          resources: 
+          - group: "" # core
+          - group: "admissionregistration.k8s.io"
+          - group: "apiextensions.k8s.io"
+          - group: "apiregistration.k8s.io"
+          - group: "apps"
+          - group: "authentication.k8s.io"
+          - group: "authorization.k8s.io"
+          - group: "autoscaling"
+          - group: "batch"
+          - group: "certificates.k8s.io"
+          - group: "extensions"
+          - group: "metrics.k8s.io"
+          - group: "networking.k8s.io"
+          - group: "policy"
+          - group: "rbac.authorization.k8s.io"
+          - group: "scheduling.k8s.io"
+          - group: "settings.k8s.io"
+          - group: "storage.k8s.io"
+          omitStages:
+          - "RequestReceived"
+        # Default level for known APIs
+        - level: RequestResponse
+          resources: 
+          - group: "" # core
+          - group: "admissionregistration.k8s.io"
+          - group: "apiextensions.k8s.io"
+          - group: "apiregistration.k8s.io"
+          - group: "apps"
+          - group: "authentication.k8s.io"
+          - group: "authorization.k8s.io"
+          - group: "autoscaling"
+          - group: "batch"
+          - group: "certificates.k8s.io"
+          - group: "extensions"
+          - group: "metrics.k8s.io"
+          - group: "networking.k8s.io"
+          - group: "policy"
+          - group: "rbac.authorization.k8s.io"
+          - group: "scheduling.k8s.io"
+          - group: "settings.k8s.io"
+          - group: "storage.k8s.io"
+          omitStages:
+          - "RequestReceived"
+        # Default level for all other requests.
+        - level: Metadata
+          omitStages:
+          - "RequestReceived"
       owner: root:root
       path: /etc/kubernetes/audit-policy.yaml
-{{- if and .proxyConfig (ne .format "bottlerocket")}}
-    - content: |
-        [Service]
-        Environment="HTTP_PROXY={{.httpProxy}}"
-        Environment="HTTPS_PROXY={{.httpsProxy}}"
-        Environment="NO_PROXY={{ stringsJoin .noProxy "," }}"
-      owner: root:root
-      path: /etc/systemd/system/containerd.service.d/http-proxy.conf
-{{- end }}
-{{- if (ne .format "bottlerocket") }}
-{{- if .registryCACert }}
-    - content: |
-{{ .registryCACert | indent 8 }}
-      owner: root:root
-      path: "/etc/containerd/certs.d/{{.registryMirrorConfiguration}}/ca.crt"
-{{- end }}
-{{- if .registryMirrorConfiguration }}
-    - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://{{.registryMirrorConfiguration}}"]
-          {{- if .registryCACert }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{.registryMirrorConfiguration}}".tls]
-            ca_file = "/etc/containerd/certs.d/{{.registryMirrorConfiguration}}/ca.crt"
-          {{- end }}
-      owner: root:root
-      path: "/etc/containerd/config_append.toml"
-{{- end }}
-{{- end }}
-{{- if .awsIamAuth}}
-    - content: |
-        # clusters refers to the remote service.
-        clusters:
-          - name: aws-iam-authenticator
-            cluster:
-              certificate-authority: /var/aws-iam-authenticator/cert.pem
-              server: https://localhost:21362/authenticate
-        # users refers to the API Server's webhook configuration
-        # (we don't need to authenticate the API server).
-        users:
-          - name: apiserver
-        # kubeconfig files require a context. Provide one for the API Server.
-        current-context: webhook
-        contexts:
-        - name: webhook
-          context:
-            cluster: aws-iam-authenticator
-            user: apiserver
-      permissions: "0640"
-      owner: root:root
-      path: /var/lib/kubeadm/aws-iam-authenticator/kubeconfig.yaml
-    - contentFrom:
-        secret:
-          name: aws-iam-authenticator-ca
-          key: cert.pem
-      permissions: "0640"
-      owner: root:root
-      path: /var/lib/kubeadm/aws-iam-authenticator/pki/cert.pem
-    - contentFrom:
-        secret:
-          name: aws-iam-authenticator-ca
-          key: key.pem
-      permissions: "0640"
-      owner: root:root
-      path: /var/lib/kubeadm/aws-iam-authenticator/pki/key.pem
-{{- end}}
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
-        name: '{{`{{ ds.meta_data.hostname }}`}}'
-{{- if .controlPlaneTaints }}
-        taints: {{ range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-        {{- end }}
-{{- else}}
+        name: '{{ ds.meta_data.hostname }}'
         taints: []
-{{- end }}
     joinConfiguration:
-{{- if (eq .format "bottlerocket") }}
-      pause:
-        imageRepository: {{.pauseRepository}}
-        imageTag: {{.pauseVersion}}
-      bottlerocketBootstrap:
-        imageRepository: {{.bottlerocketBootstrapRepository}}
-        imageTag: {{.bottlerocketBootstrapVersion}}
-{{- end }}
-{{- if and .proxyConfig (eq .format "bottlerocket") }}
-      proxy:
-        httpsProxy: {{.httpsProxy}}
-        noProxy: {{ range .noProxy }}
-        - {{ . }}
-        {{- end }}
-{{- end }}
-{{- if and .registryMirrorConfiguration (eq .format "bottlerocket") }}
-      registryMirror:
-        endpoint: {{.registryMirrorConfiguration}}
-        {{- if .registryCACert }}
-        caCert: |
-{{ .registryCACert | indent 10 }}
-        {{- end }}
-{{- end }}
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
-        name: '{{`{{ ds.meta_data.hostname }}`}}'
-{{- if .controlPlaneTaints }}
-        taints: {{ range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-        {{- end }}
-{{- else}}
+        name: '{{ ds.meta_data.hostname }}'
         taints: []
-{{- end }}
     preKubeadmCommands:
-{{- if and .registryMirrorConfiguration (ne .format "bottlerocket") }}
-    - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
-{{- end }}
-{{- if and (or .proxyConfig .registryMirrorConfiguration) (ne .format "bottlerocket") }}
-    - sudo systemctl daemon-reload
-    - sudo systemctl restart containerd
-{{- end }}
-    - hostname "{{`{{ ds.meta_data.hostname }}`}}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
-    - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     useExperimentalRetryJoin: true
     users:
-    - name: {{.controlPlaneSshUsername}}
+    - name: capv
       sshAuthorizedKeys:
-      - '{{.vsphereControlPlaneSshAuthorizedKey}}'
+      - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
       sudo: ALL=(ALL) NOPASSWD:ALL
-    format: {{.format}}
-  replicas: {{.controlPlaneReplicas}}
-  version: {{.kubernetesVersion}}
+    format: cloud-config
+  replicas: 3
+  version: v1.19.8-eks-1-19-4
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: {{.clusterName}}
-  name: {{.resourceSetName}}
-  namespace: {{.eksaSystemNamespace}}
+    cluster.x-k8s.io/cluster-name: test
+  name: test-crs-0
+  namespace: eksa-system
 spec:
   clusterSelector:
     matchLabels:
-      cluster.x-k8s.io/cluster-name: {{.clusterName}}
+      cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
     name: vsphere-csi-controller
@@ -440,92 +401,65 @@ spec:
   - kind: ConfigMap
     name: vsphere-csi-controller
 ---
-{{- if .externalEtcd }}
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
-  name: {{.clusterName}}-etcd
-  namespace: {{.eksaSystemNamespace}}
+  name: test-etcd
+  namespace: eksa-system
 spec:
-  replicas: {{.externalEtcdReplicas}}
+  replicas: 3
   etcdadmConfigSpec:
     etcdadmBuiltin: true
-    format: {{.format}}
-{{- if (eq .format "bottlerocket") }}
-    bottlerocketConfig:
-      etcdImage: {{.etcdImage}}
-      bootstrapImage: {{.bottlerocketBootstrapRepository}}:{{.bottlerocketBootstrapVersion}}
-      pauseImage: {{.pauseRepository}}:{{.pauseVersion}}
-{{- else}}
+    format: cloud-config
     cloudInitConfig:
-      version: {{.externalEtcdVersion}}
+      version: 3.4.14
       installDir: "/usr/bin"
     preEtcdadmCommands:
-      - hostname "{{`{{ ds.meta_data.hostname }}`}}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
-      - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
-{{- end }}
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     users:
-      - name: {{.etcdSshUsername}}
+      - name: capv
         sshAuthorizedKeys:
-          - '{{.vsphereEtcdSshAuthorizedKey}}'
+          - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
-{{- if .proxyConfig }}
-    proxy:
-      httpProxy: {{ .httpProxy }}
-      httpsProxy: {{ .httpsProxy }}
-      noProxy: {{ range .noProxy }}
-        - {{ . }}
-      {{- end }}
-{{- end }}
-{{- if .registryMirrorConfiguration }}
-    registryMirror:
-      endpoint: {{.registryMirrorConfiguration}}
-      {{- if .registryCACert }}
-      caCert: |
-{{ .registryCACert | indent 8 }}
-      {{- end }}
-{{- end }}
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
-    name: {{.etcdTemplateName}}
+    name: test-etcd-template-1234567890000
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
-  name: {{.etcdTemplateName}}
-  namespace: '{{.eksaSystemNamespace}}'
+  name: test-etcd-template-1234567890000
+  namespace: 'eksa-system'
 spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{.vsphereDatacenter}}
-      datastore: {{.etcdVsphereDatastore}}
-      diskGiB: {{.etcdDiskGiB}}
-      folder: '{{.etcdVsphereFolder}}'
-      memoryMiB: {{.etcdVMsMemoryMiB}}
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 8192
       network:
         devices:
           - dhcp4: true
-            networkName: {{.vsphereNetwork}}
-      numCPUs: {{.etcdVMsNumCPUs}}
-      resourcePool: '{{.etcdVsphereResourcePool}}'
-      server: {{.vsphereServer}}
-{{- if (ne .etcdVsphereStoragePolicyName "") }}
-      storagePolicyName: "{{.etcdVsphereStoragePolicyName}}"
-{{- end }}
-      template: {{.vsphereTemplate}}
-      thumbprint: '{{.thumbprint}}'
+            networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 3
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
+      thumbprint: 'ABCDEFG'
 ---
-{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-csi-controller
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -645,7 +579,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-role
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -665,7 +599,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-binding
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -679,7 +613,7 @@ data:
 kind: ConfigMap
 metadata:
   name: csi.vsphere.vmware.com
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -709,7 +643,7 @@ data:
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-            image: {{.nodeDriverRegistrarImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-19-4
             lifecycle:
               preStop:
                 exec:
@@ -743,7 +677,7 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            image: {{.driverImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-7c2690c880c6521afdd9ffa8d90443a11c6b817b
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -776,7 +710,7 @@ data:
               name: device-dir
           - args:
             - --csi-address=/csi/csi.sock
-            image: {{.livenessProbeImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-19-4
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -812,7 +746,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-node
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -842,7 +776,7 @@ data:
             env:
             - name: ADDRESS
               value: /csi/csi.sock
-            image: {{.externalAttacherImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v3.1.0-eks-1-19-4
             name: csi-attacher
             resources: {}
             volumeMounts:
@@ -859,7 +793,7 @@ data:
               value: PRODUCTION
             - name: X_CSI_LOG_LEVEL
               value: INFO
-            image: {{.driverImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-7c2690c880c6521afdd9ffa8d90443a11c6b817b
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -885,7 +819,7 @@ data:
             env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            image: {{.livenessProbeImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-19-4
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -900,7 +834,7 @@ data:
               value: PRODUCTION
             - name: VSPHERE_CSI_CONFIG
               value: /etc/cloud/csi-vsphere.conf
-            image: {{.syncerImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-7c2690c880c6521afdd9ffa8d90443a11c6b817b
             name: vsphere-syncer
             resources: {}
             volumeMounts:
@@ -916,7 +850,7 @@ data:
             env:
             - name: ADDRESS
               value: /csi/csi.sock
-            image: {{.externalProvisionerImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-19-4
             name: csi-provisioner
             resources: {}
             volumeMounts:
@@ -937,7 +871,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -952,4 +886,4 @@ data:
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1245,6 +1245,10 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		values["awsIamAuth"] = true
 	}
 
+	if clusterSpec.Spec.PodIAMConfig != nil {
+		values["serviceAccountIssuer"] = clusterSpec.Spec.PodIAMConfig.ServiceAccountIssuer
+	}
+
 	return values
 }
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/eks-anywhere/issues/601

*Description of changes:* EKS-A users can leverage the IAM Role for Service Account (IRSA) feature following the [special instructions for DIY Kubernetes](https://github.com/aws/amazon-eks-pod-identity-webhook/blob/master/SELF_HOSTED_SETUP.md) to enable AWS authentication. This commit enables that by allowing the configuration of service-account-issuer flag for kube-apiserver with the identity issuer URL as per the self-hosted setup guide.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
