### PR TITLE
add cherry-pick-pull from upstream along with docs for backporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Refer to our [end to end guide](https://github.com/aws/eks-anywhere/tree/main/te
 The dependencies which make up EKS Anywhere are defined and built via the [build-tooling](https://github.com/aws/eks-anywhere-build-tooling) repo.
 To update dependencies please review the Readme for the specific dependency before opening a PR.
 
+See [Cherry picking](./docs/developer/cherry-picks.md) for backporting to release branches
+
 ## Security
 
 If you discover a potential security issue in this project, or think you may

--- a/docs/developer/cherry-picks.md
+++ b/docs/developer/cherry-picks.md
@@ -1,0 +1,29 @@
+# Release Branches
+
+eks-anywhere maintains multiple release branches to represent the currently supported versions.  
+
+In general, bug fixes should be backported to currently supported release branches, new features should not.
+
+## Currently supported release branches
+
+- [release-0.6](https://github.com/aws/eks-anywhere/tree/release-0.6)
+
+# "Automated" Cherry Picks
+
+The [cherry_pick_pull.sh](../../hack/cherry_pick_pull.sh) is provided 
+to assist in backporting.  The script is the same used by upstream [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes/blob/master/hack/cherry_pick_pull.sh)
+
+## To create a Cherry Pick
+
+- Open + Merge PR in eks-anywhere repo
+- Run `GITHUB_USER=<github_user> ./build/lib/cherry_pick_pull.sh upstream/<release-branch> <pr number>`
+	- The script assumes your remotes are setup such that `upstream` points the `aws/eks-anywhere` and `origin`
+	points to your fork at `<github_user>/eks-anywhere-build-tooling`
+	- If your remotes are not setup this way you can set `UPSTREAM_REMOTE=<upstream remote name>` `FORK_REMOTE=<fork remote name>`
+	when calling the script to override the defaults
+	- There a couple of pre-reqs, having a `GITHUB_TOKEN` set and the `gh` cli installed.  The script will let you know if you are missing any of these
+- If there is a merge conflict, the script will wait and give you a chance to fix conflicts in another terminal before continuing
+- The script will push a new branch and open a PR automatically
+- Run the above script for each currently supported release branch
+
+Refer to the upstream [doc](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/cherry-picks.md) for more information.

--- a/docs/developer/cherry-picks.md
+++ b/docs/developer/cherry-picks.md
@@ -18,7 +18,7 @@ to assist in backporting.  The script is the same used by upstream [kubernetes/k
 - Open + Merge PR in eks-anywhere repo
 - Run `GITHUB_USER=<github_user> ./build/lib/cherry_pick_pull.sh upstream/<release-branch> <pr number>`
 	- The script assumes your remotes are setup such that `upstream` points the `aws/eks-anywhere` and `origin`
-	points to your fork at `<github_user>/eks-anywhere-build-tooling`
+	points to your fork at `<github_user>/eks-anywhere`
 	- If your remotes are not setup this way you can set `UPSTREAM_REMOTE=<upstream remote name>` `FORK_REMOTE=<fork remote name>`
 	when calling the script to override the defaults
 	- There a couple of pre-reqs, having a `GITHUB_TOKEN` set and the `gh` cli installed.  The script will let you know if you are missing any of these

--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+
+# Copyright 2015 The Kubernetes Authors.
+# - https://github.com/kubernetes/kubernetes/blob/master/hack/cherry_pick_pull.sh
+# Modifications Copyright Amazon.com Inc. or its affiliates. All Rights Reserved. Licensed under the Apache2 License
+
+# Modifications:
+# - changed instructions link to doc in this repo instead of upstream
+# - harcoded MAIN_REPO_ORG and MAIN_REPO_NAME to avoid difference with awk on mac vs linux
+
+# Usage Instructions: https://github.com/aws/eks-anywhere-build-tooling/tree/main/docs/development/cherry-picks.md
+
+# Checkout a PR from GitHub. (Yes, this is sitting in a Git tree. How
+# meta.) Assumes you care about pulls from remote "upstream" and
+# checks them out to a branch named:
+#  automated-cherry-pick-of-<pr>-<target branch>-<timestamp>
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+declare -r REPO_ROOT
+cd "${REPO_ROOT}"
+
+STARTINGBRANCH=$(git symbolic-ref --short HEAD)
+declare -r STARTINGBRANCH
+declare -r REBASEMAGIC="${REPO_ROOT}/.git/rebase-apply"
+DRY_RUN=${DRY_RUN:-""}
+REGENERATE_DOCS=${REGENERATE_DOCS:-""}
+UPSTREAM_REMOTE=${UPSTREAM_REMOTE:-upstream}
+FORK_REMOTE=${FORK_REMOTE:-origin}
+MAIN_REPO_ORG=aws # ${MAIN_REPO_ORG:-$(git remote get-url "$UPSTREAM_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $3}')}
+MAIN_REPO_NAME=eks-anywhere # ${MAIN_REPO_NAME:-$(git remote get-url "$UPSTREAM_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $4}')}
+
+if [[ -z ${GITHUB_USER:-} ]]; then
+  echo "Please export GITHUB_USER=<your-user> (or GH organization, if that's where your fork lives)"
+  exit 1
+fi
+
+if ! command -v gh > /dev/null; then
+  echo "Can't find 'gh' tool in PATH, please install from https://github.com/cli/cli"
+  exit 1
+fi
+
+if [[ "$#" -lt 2 ]]; then
+  echo "${0} <remote branch> <pr-number>...: cherry pick one or more <pr> onto <remote branch> and leave instructions for proposing pull request"
+  echo
+  echo "  Checks out <remote branch> and handles the cherry-pick of <pr> (possibly multiple) for you."
+  echo "  Examples:"
+  echo "    $0 upstream/release-3.14 12345        # Cherry-picks PR 12345 onto upstream/release-3.14 and proposes that as a PR."
+  echo "    $0 upstream/release-3.14 12345 56789  # Cherry-picks PR 12345, then 56789 and proposes the combination as a single PR."
+  echo
+  echo "  Set the DRY_RUN environment var to skip git push and creating PR."
+  echo "  This is useful for creating patches to a release branch without making a PR."
+  echo "  When DRY_RUN is set the script will leave you in a branch containing the commits you cherry-picked."
+  echo
+  echo "  Set the REGENERATE_DOCS environment var to regenerate documentation for the target branch after picking the specified commits."
+  echo "  This is useful when picking commits containing changes to API documentation."
+  echo
+  echo "  Set UPSTREAM_REMOTE (default: upstream) and FORK_REMOTE (default: origin)"
+  echo "  to override the default remote names to what you have locally."
+  echo
+  echo "  For merge process info, see https://github.com/aws/eks-anywhere-build-tooling/tree/main/docs/development/cherry-picks.md"
+  exit 2
+fi
+
+# Checks if you are logged in. Will error/bail if you are not.
+gh auth status
+
+if git_status=$(git status --porcelain --untracked=no 2>/dev/null) && [[ -n "${git_status}" ]]; then
+  echo "!!! Dirty tree. Clean up and try again."
+  exit 1
+fi
+
+if [[ -e "${REBASEMAGIC}" ]]; then
+  echo "!!! 'git rebase' or 'git am' in progress. Clean up and try again."
+  exit 1
+fi
+
+declare -r BRANCH="$1"
+shift 1
+declare -r PULLS=( "$@" )
+
+function join { local IFS="$1"; shift; echo "$*"; }
+PULLDASH=$(join - "${PULLS[@]/#/#}") # Generates something like "#12345-#56789"
+declare -r PULLDASH
+PULLSUBJ=$(join " " "${PULLS[@]/#/#}") # Generates something like "#12345 #56789"
+declare -r PULLSUBJ
+
+echo "+++ Updating remotes..."
+git remote update "${UPSTREAM_REMOTE}" "${FORK_REMOTE}"
+
+if ! git log -n1 --format=%H "${BRANCH}" >/dev/null 2>&1; then
+  echo "!!! '${BRANCH}' not found. The second argument should be something like ${UPSTREAM_REMOTE}/release-0.21."
+  echo "    (In particular, it needs to be a valid, existing remote branch that I can 'git checkout'.)"
+  exit 1
+fi
+
+NEWBRANCHREQ="automated-cherry-pick-of-${PULLDASH}" # "Required" portion for tools.
+declare -r NEWBRANCHREQ
+NEWBRANCH="$(echo "${NEWBRANCHREQ}-${BRANCH}" | sed 's/\//-/g')"
+declare -r NEWBRANCH
+NEWBRANCHUNIQ="${NEWBRANCH}-$(date +%s)"
+declare -r NEWBRANCHUNIQ
+echo "+++ Creating local branch ${NEWBRANCHUNIQ}"
+
+cleanbranch=""
+gitamcleanup=false
+function return_to_kansas {
+  if [[ "${gitamcleanup}" == "true" ]]; then
+    echo
+    echo "+++ Aborting in-progress git am."
+    git am --abort >/dev/null 2>&1 || true
+  fi
+
+  # return to the starting branch and delete the PR text file
+  if [[ -z "${DRY_RUN}" ]]; then
+    echo
+    echo "+++ Returning you to the ${STARTINGBRANCH} branch and cleaning up."
+    git checkout -f "${STARTINGBRANCH}" >/dev/null 2>&1 || true
+    if [[ -n "${cleanbranch}" ]]; then
+      git branch -D "${cleanbranch}" >/dev/null 2>&1 || true
+    fi
+  fi
+}
+trap return_to_kansas EXIT
+
+SUBJECTS=()
+function make-a-pr() {
+  local rel
+  rel="$(basename "${BRANCH}")"
+  echo
+  echo "+++ Creating a pull request on GitHub at ${GITHUB_USER}:${NEWBRANCH}"
+
+  local numandtitle
+  numandtitle=$(printf '%s\n' "${SUBJECTS[@]}")
+  prtext=$(cat <<EOF
+Cherry pick of ${PULLSUBJ} on ${rel}.
+
+${numandtitle}
+
+For details on the cherry pick process, see the [cherry pick requests](https://github.com/aws/eks-anywhere-build-tooling/tree/main/docs/development/cherry-picks.md) page.
+
+\`\`\`release-note
+
+\`\`\`
+EOF
+)
+
+  gh pr create --title="Automated cherry pick of ${numandtitle}" --body="${prtext}" --head "${GITHUB_USER}:${NEWBRANCH}" --base "${rel}" --repo="${MAIN_REPO_ORG}/${MAIN_REPO_NAME}"
+}
+
+git checkout -b "${NEWBRANCHUNIQ}" "${BRANCH}"
+cleanbranch="${NEWBRANCHUNIQ}"
+
+gitamcleanup=true
+for pull in "${PULLS[@]}"; do
+  echo "+++ Downloading patch to /tmp/${pull}.patch (in case you need to do this again)"
+
+  curl -o "/tmp/${pull}.patch" -sSL "https://github.com/${MAIN_REPO_ORG}/${MAIN_REPO_NAME}/pull/${pull}.patch"
+  echo
+  echo "+++ About to attempt cherry pick of PR. To reattempt:"
+  echo "  $ git am -3 /tmp/${pull}.patch"
+  echo
+  git am -3 "/tmp/${pull}.patch" || {
+    conflicts=false
+    while unmerged=$(git status --porcelain | grep ^U) && [[ -n ${unmerged} ]] \
+      || [[ -e "${REBASEMAGIC}" ]]; do
+      conflicts=true # <-- We should have detected conflicts once
+      echo
+      echo "+++ Conflicts detected:"
+      echo
+      (git status --porcelain | grep ^U) || echo "!!! None. Did you git am --continue?"
+      echo
+      echo "+++ Please resolve the conflicts in another window (and remember to 'git add / git am --continue')"
+      read -p "+++ Proceed (anything but 'y' aborts the cherry-pick)? [y/n] " -r
+      echo
+      if ! [[ "${REPLY}" =~ ^[yY]$ ]]; then
+        echo "Aborting." >&2
+        exit 1
+      fi
+    done
+
+    if [[ "${conflicts}" != "true" ]]; then
+      echo "!!! git am failed, likely because of an in-progress 'git am' or 'git rebase'"
+      exit 1
+    fi
+  }
+
+  # set the subject
+  subject=$(grep -m 1 "^Subject" "/tmp/${pull}.patch" | sed -e 's/Subject: \[PATCH//g' | sed 's/.*] //')
+  SUBJECTS+=("#${pull}: ${subject}")
+
+  # remove the patch file from /tmp
+  rm -f "/tmp/${pull}.patch"
+done
+gitamcleanup=false
+
+# Re-generate docs (if needed)
+if [[ -n "${REGENERATE_DOCS}" ]]; then
+  echo
+  echo "Regenerating docs..."
+  if ! hack/generate-docs.sh; then
+    echo
+    echo "hack/generate-docs.sh FAILED to complete."
+    exit 1
+  fi
+fi
+
+if [[ -n "${DRY_RUN}" ]]; then
+  echo "!!! Skipping git push and PR creation because you set DRY_RUN."
+  echo "To return to the branch you were in when you invoked this script:"
+  echo
+  echo "  git checkout ${STARTINGBRANCH}"
+  echo
+  echo "To delete this branch:"
+  echo
+  echo "  git branch -D ${NEWBRANCHUNIQ}"
+  exit 0
+fi
+
+if git remote -v | grep ^"${FORK_REMOTE}" | grep "${MAIN_REPO_ORG}/${MAIN_REPO_NAME}.git"; then
+  echo "!!! You have ${FORK_REMOTE} configured as your ${MAIN_REPO_ORG}/${MAIN_REPO_NAME}.git"
+  echo "This isn't normal. Leaving you with push instructions:"
+  echo
+  echo "+++ First manually push the branch this script created:"
+  echo
+  echo "  git push REMOTE ${NEWBRANCHUNIQ}:${NEWBRANCH}"
+  echo
+  echo "where REMOTE is your personal fork (maybe ${UPSTREAM_REMOTE}? Consider swapping those.)."
+  echo "OR consider setting UPSTREAM_REMOTE and FORK_REMOTE to different values."
+  echo
+  make-a-pr
+  cleanbranch=""
+  exit 0
+fi
+
+echo
+echo "+++ I'm about to do the following to push to GitHub (and I'm assuming ${FORK_REMOTE} is your personal fork):"
+echo
+echo "  git push ${FORK_REMOTE} ${NEWBRANCHUNIQ}:${NEWBRANCH}"
+echo
+read -p "+++ Proceed (anything but 'y' aborts the cherry-pick)? [y/n] " -r
+if ! [[ "${REPLY}" =~ ^[yY]$ ]]; then
+  echo "Aborting." >&2
+  exit 1
+fi
+
+git push "${FORK_REMOTE}" -f "${NEWBRANCHUNIQ}:${NEWBRANCH}"
+make-a-pr


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We pulled this from upstream for use in eks-anywhere-build-tooling.  You can see an example PR that was opened using the script here https://github.com/aws/eks-anywhere-build-tooling/pull/61.

Added doc to the docs/developer folder, not sure if this is the best spot for development docs or not?  This obviously doesn't need to show up on the docs website.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
