### PR TITLE
Update NewClusterGenerate not use ConvertConfigToConfigGenerateStruct

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -29,12 +29,12 @@ type ClusterGenerateOpt func(config *ClusterGenerate)
 
 // Used for generating yaml for generate clusterconfig command
 func NewClusterGenerate(clusterName string, opts ...ClusterGenerateOpt) *ClusterGenerate {
-	clusterConfig := &Cluster{
+	clusterConfig := &ClusterGenerate{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       ClusterKind,
 			APIVersion: SchemeBuilder.GroupVersion.String(),
 		},
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: ObjectMeta{
 			Name: clusterName,
 		},
 		Spec: ClusterSpec{
@@ -51,12 +51,11 @@ func NewClusterGenerate(clusterName string, opts ...ClusterGenerateOpt) *Cluster
 		},
 	}
 	clusterConfig.SetSelfManaged()
-	config := clusterConfig.ConvertConfigToConfigGenerateStruct()
 
 	for _, opt := range opts {
-		opt(config)
+		opt(clusterConfig)
 	}
-	return config
+	return clusterConfig
 }
 
 func ControlPlaneConfigCount(count int) ClusterGenerateOpt {

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -403,6 +403,10 @@ func (s *Cluster) SetSelfManaged() {
 	s.Spec.ManagementCluster.Name = s.Name
 }
 
+func (c *ClusterGenerate) SetSelfManaged() {
+	c.Spec.ManagementCluster.Name = c.Name
+}
+
 func (s *Cluster) ManagementClusterEqual(s2 *Cluster) bool {
 	return s.IsSelfManaged() && s2.IsSelfManaged() || s.Spec.ManagementCluster.Equal(s2.Spec.ManagementCluster)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

So that `eksctl-anywhere generate clusterconfig` won't include `default` namespace for cluster resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
