### PR TITLE
Get binary for specific version of EKS-A release in E2E tests

### DIFF
--- a/internal/pkg/files/files.go
+++ b/internal/pkg/files/files.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/aws/eks-anywhere/pkg/logger"
 )
@@ -46,7 +47,7 @@ func GzipFileDownloadExtract(uri, fileToExtract, destination string) error {
 		switch header.Typeflag {
 		case tar.TypeReg:
 			name := header.FileInfo().Name()
-			if name == fileToExtract {
+			if strings.TrimPrefix(name, "./") == fileToExtract {
 				out, err := os.OpenFile(targetFile, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 				if err != nil {
 					return fmt.Errorf("error opening %s file: %v", fileToExtract, err)

--- a/pkg/semver/semver.go
+++ b/pkg/semver/semver.go
@@ -77,22 +77,22 @@ func (v *Version) LessThan(v2 *Version) bool {
 }
 
 func (v *Version) Compare(v2 *Version) int {
-	if v.Major != v2.Major {
-		if v.Major > v2.Major {
-			return 1
-		}
-		return -1
+	if c := compare(v.Major, v2.Major); c != 0 {
+		return c
 	}
-	if v.Minor != v2.Minor {
-		if v.Minor > v2.Minor {
-			return 1
-		}
-		return -1
+	if c := compare(v.Minor, v2.Minor); c != 0 {
+		return c
 	}
-	if v.Patch != v2.Patch {
-		if v.Patch > v2.Patch {
-			return 1
-		}
+	if c := compare(v.Patch, v2.Patch); c != 0 {
+		return c
+	}
+	return 0
+}
+
+func compare(i, i2 uint64) int {
+	if i > i2 {
+		return 1
+	} else if i < i2 {
 		return -1
 	}
 	return 0

--- a/test/framework/releaseVersions.go
+++ b/test/framework/releaseVersions.go
@@ -1,14 +1,23 @@
 package framework
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aws/eks-anywhere/internal/pkg/files"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/semver"
+	"github.com/aws/eks-anywhere/pkg/validations"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
-const prodReleasesManifest = "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml"
+const (
+	prodReleasesManifest = "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml"
+	releaseBinaryName    = "eksctl-anywhere"
+)
 
-func (e *ClusterE2ETest) GetLatestMinorReleaseFromMain() *releasev1alpha1.EksARelease {
+func (e *ClusterE2ETest) GetLatestMinorReleaseFromMain() string {
 	reader := cluster.NewManifestReader()
 	e.T.Logf("Reading prod release manifest %s", prodReleasesManifest)
 	releases, err := reader.GetReleases(prodReleasesManifest)
@@ -28,10 +37,15 @@ func (e *ClusterE2ETest) GetLatestMinorReleaseFromMain() *releasev1alpha1.EksARe
 		e.T.Fatalf("Releases manifest doesn't contain latest release %s", releases.Spec.LatestVersion)
 	}
 
-	return latestRelease
+	binaryPath, err := e.getBinary(latestRelease)
+	if err != nil {
+		e.T.Fatalf("Failed getting binary for latest release: %s", err)
+	}
+
+	return binaryPath
 }
 
-func (e *ClusterE2ETest) GetLatestMinorReleaseFromReleaseBranch(releaseBranchVersion *semver.Version) *releasev1alpha1.EksARelease {
+func (e *ClusterE2ETest) GetLatestMinorReleaseFromReleaseBranch(releaseBranchVersion *semver.Version) string {
 	reader := cluster.NewManifestReader()
 	e.T.Logf("Reading prod release manifest %s", prodReleasesManifest)
 	releases, err := reader.GetReleases(prodReleasesManifest)
@@ -60,5 +74,29 @@ func (e *ClusterE2ETest) GetLatestMinorReleaseFromReleaseBranch(releaseBranchVer
 		e.T.Fatalf("Releases manifest doesn't contain a version of the previous minor release")
 	}
 
-	return latestPrevMinorRelease
+	binaryPath, err := e.getBinary(latestPrevMinorRelease)
+	if err != nil {
+		e.T.Fatalf("Failed getting binary for latest previous minor release: %s", err)
+	}
+
+	return binaryPath
+}
+
+func (e *ClusterE2ETest) getBinary(release *releasev1alpha1.EksARelease) (string, error) {
+	latestReleaseBinaryFolder := filepath.Join("bin", release.Version)
+	latestReleaseBinaryPath := filepath.Join(latestReleaseBinaryFolder, releaseBinaryName)
+
+	if !validations.FileExists(latestReleaseBinaryPath) {
+		e.T.Logf("Downloading binary for EKS-A release [%s]", release.Version)
+		err := os.MkdirAll(latestReleaseBinaryFolder, os.ModePerm)
+		if err != nil {
+			return "", fmt.Errorf("failed creating directory for release [%s]: %s", release.Version, err)
+		}
+
+		err = files.GzipFileDownloadExtract(release.EksABinary.LinuxBinary.URI, releaseBinaryName, latestReleaseBinaryFolder)
+		if err != nil {
+			return "", fmt.Errorf("failed extracting binary for release [%s]: %s", release.Version, err)
+		}
+	}
+	return latestReleaseBinaryPath, nil
 }

--- a/test/framework/releaseVersions.go
+++ b/test/framework/releaseVersions.go
@@ -87,15 +87,15 @@ func (e *ClusterE2ETest) getBinary(release *releasev1alpha1.EksARelease) (string
 	latestReleaseBinaryPath := filepath.Join(latestReleaseBinaryFolder, releaseBinaryName)
 
 	if !validations.FileExists(latestReleaseBinaryPath) {
-		e.T.Logf("Downloading binary for EKS-A release [%s]", release.Version)
+		e.T.Logf("Downloading binary for EKS-A release [%s] to path ./%s", release.Version, latestReleaseBinaryPath)
 		err := os.MkdirAll(latestReleaseBinaryFolder, os.ModePerm)
 		if err != nil {
-			return "", fmt.Errorf("failed creating directory for release [%s]: %s", release.Version, err)
+			return "", fmt.Errorf("failed creating directory ./%s: %s", latestReleaseBinaryFolder, err)
 		}
 
 		err = files.GzipFileDownloadExtract(release.EksABinary.LinuxBinary.URI, releaseBinaryName, latestReleaseBinaryFolder)
 		if err != nil {
-			return "", fmt.Errorf("failed extracting binary for release [%s]: %s", release.Version, err)
+			return "", fmt.Errorf("failed extracting binary for EKS-A release [%s] to path ./%s: %s", release.Version, latestReleaseBinaryPath, err)
 		}
 	}
 	return latestReleaseBinaryPath, nil

--- a/test/framework/releaseVersions.go
+++ b/test/framework/releaseVersions.go
@@ -17,7 +17,7 @@ const (
 	releaseBinaryName    = "eksctl-anywhere"
 )
 
-func (e *ClusterE2ETest) GetLatestMinorReleaseFromMain() string {
+func (e *ClusterE2ETest) GetLatestMinorReleaseBinaryFromMain() string {
 	reader := cluster.NewManifestReader()
 	e.T.Logf("Reading prod release manifest %s", prodReleasesManifest)
 	releases, err := reader.GetReleases(prodReleasesManifest)
@@ -45,7 +45,7 @@ func (e *ClusterE2ETest) GetLatestMinorReleaseFromMain() string {
 	return binaryPath
 }
 
-func (e *ClusterE2ETest) GetLatestMinorReleaseFromReleaseBranch(releaseBranchVersion *semver.Version) string {
+func (e *ClusterE2ETest) GetLatestMinorReleaseBinaryFromReleaseBranch(releaseBranchVersion *semver.Version) string {
 	reader := cluster.NewManifestReader()
 	e.T.Logf("Reading prod release manifest %s", prodReleasesManifest)
 	releases, err := reader.GetReleases(prodReleasesManifest)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR allows us to extract the binary of the desired EKS-A release version for E2E tests.
We also changed the compare function in the semver package to increase its readability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
