### PR TITLE
add diagnostic collectors based on datacenter type

### DIFF
--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -59,6 +59,39 @@ func (c *collectorFactory) EksaHostCollectors(machineConfigs []providers.Machine
 	return collectors
 }
 
+func (c *collectorFactory) DataCenterConfigCollectors(datacenter v1alpha1.Ref) []*Collect {
+	switch datacenter.Kind {
+	case v1alpha1.VSphereDatacenterKind:
+		return c.eksaVsphereCollectors()
+	case v1alpha1.DockerDatacenterKind:
+		return c.eksaDockerCollectors()
+	default:
+		return nil
+	}
+}
+
+func (c *collectorFactory) eksaVsphereCollectors() []*Collect {
+	return []*Collect{
+		{
+			Logs: &logs{
+				Namespace: constants.CapvSystemNamespace,
+				Name:      logpath(constants.CapvSystemNamespace),
+			},
+		},
+	}
+}
+
+func (c *collectorFactory) eksaDockerCollectors() []*Collect {
+	return []*Collect{
+		{
+			Logs: &logs{
+				Namespace: constants.CapdSystemNamespace,
+				Name:      logpath(constants.CapdSystemNamespace),
+			},
+		},
+	}
+}
+
 func (c *collectorFactory) ManagementClusterCollectors() []*Collect {
 	var collectors []*Collect
 	collectors = append(collectors, c.managementClusterCrdCollectors()...)

--- a/pkg/diagnostics/diagnostic_bundle.go
+++ b/pkg/diagnostics/diagnostic_bundle.go
@@ -253,6 +253,7 @@ func (e *EksaDiagnosticBundle) WithManagementCluster(isSelfManaged bool) *EksaDi
 
 func (e *EksaDiagnosticBundle) WithDatacenterConfig(config v1alpha1.Ref) *EksaDiagnosticBundle {
 	e.bundle.Spec.Analyzers = append(e.bundle.Spec.Analyzers, e.analyzerFactory.DataCenterConfigAnalyzers(config)...)
+	e.bundle.Spec.Collectors = append(e.bundle.Spec.Collectors, e.collectorFactory.DataCenterConfigCollectors(config)...)
 	return e
 }
 

--- a/pkg/diagnostics/diagnostic_bundle_test.go
+++ b/pkg/diagnostics/diagnostic_bundle_test.go
@@ -121,6 +121,7 @@ func TestGenerateBundleConfigWithExternalEtcd(t *testing.T) {
 		c.EXPECT().DefaultCollectors().Return(nil)
 		c.EXPECT().EksaHostCollectors(gomock.Any()).Return(nil)
 		c.EXPECT().ManagementClusterCollectors().Return(nil)
+		c.EXPECT().DataCenterConfigCollectors(spec.Cluster.Spec.DatacenterRef).Return(nil)
 
 		w := givenWriter(t)
 		w.EXPECT().Write(gomock.Any(), gomock.Any())
@@ -176,6 +177,7 @@ func TestGenerateBundleConfigWithOidc(t *testing.T) {
 		c.EXPECT().DefaultCollectors().Return(nil)
 		c.EXPECT().EksaHostCollectors(gomock.Any()).Return(nil)
 		c.EXPECT().ManagementClusterCollectors().Return(nil)
+		c.EXPECT().DataCenterConfigCollectors(spec.Cluster.Spec.DatacenterRef).Return(nil)
 
 		opts := diagnostics.EksaDiagnosticBundleFactoryOpts{
 			AnalyzerFactory:  a,
@@ -228,6 +230,7 @@ func TestGenerateBundleConfigWithGitOps(t *testing.T) {
 		c.EXPECT().DefaultCollectors().Return(nil)
 		c.EXPECT().EksaHostCollectors(gomock.Any()).Return(nil)
 		c.EXPECT().ManagementClusterCollectors().Return(nil)
+		c.EXPECT().DataCenterConfigCollectors(spec.Cluster.Spec.DatacenterRef).Return(nil)
 
 		opts := diagnostics.EksaDiagnosticBundleFactoryOpts{
 			AnalyzerFactory:  a,
@@ -304,6 +307,7 @@ func TestBundleFromSpecComplete(t *testing.T) {
 		c.EXPECT().DefaultCollectors().Return(nil)
 		c.EXPECT().EksaHostCollectors(gomock.Any()).Return(nil)
 		c.EXPECT().ManagementClusterCollectors().Return(nil)
+		c.EXPECT().DataCenterConfigCollectors(spec.Cluster.Spec.DatacenterRef).Return(nil)
 
 		w := givenWriter(t)
 		w.EXPECT().Write(gomock.Any(), gomock.Any()).Times(2)

--- a/pkg/diagnostics/interfaces.go
+++ b/pkg/diagnostics/interfaces.go
@@ -53,4 +53,5 @@ type CollectorFactory interface {
 	DefaultCollectors() []*Collect
 	ManagementClusterCollectors() []*Collect
 	EksaHostCollectors(configs []providers.MachineConfig) []*Collect
+	DataCenterConfigCollectors(datacenter v1alpha1.Ref) []*Collect
 }

--- a/pkg/diagnostics/interfaces/mocks/diagnostics.go
+++ b/pkg/diagnostics/interfaces/mocks/diagnostics.go
@@ -516,6 +516,20 @@ func (m *MockCollectorFactory) EXPECT() *MockCollectorFactoryMockRecorder {
 	return m.recorder
 }
 
+// DataCenterConfigCollectors mocks base method.
+func (m *MockCollectorFactory) DataCenterConfigCollectors(datacenter v1alpha1.Ref) []*diagnostics.Collect {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DataCenterConfigCollectors", datacenter)
+	ret0, _ := ret[0].([]*diagnostics.Collect)
+	return ret0
+}
+
+// DataCenterConfigCollectors indicates an expected call of DataCenterConfigCollectors.
+func (mr *MockCollectorFactoryMockRecorder) DataCenterConfigCollectors(datacenter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataCenterConfigCollectors", reflect.TypeOf((*MockCollectorFactory)(nil).DataCenterConfigCollectors), datacenter)
+}
+
 // DefaultCollectors mocks base method.
 func (m *MockCollectorFactory) DefaultCollectors() []*diagnostics.Collect {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add diagnostic collectors based on datacenter type, including the CAPV system namespace which was missing. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
