### PR TITLE
Use ExtraArg functions to add service-account-issuer for api-server

### DIFF
--- a/pkg/clusterapi/extraargs.go
+++ b/pkg/clusterapi/extraargs.go
@@ -39,6 +39,15 @@ func AwsIamAuthExtraArgs(awsiam *v1alpha1.AWSIamConfig) ExtraArgs {
 	return args
 }
 
+func PodIAMAuthExtraArgs(podIAMConfig *v1alpha1.PodIAMConfig) ExtraArgs {
+	if podIAMConfig == nil {
+		return nil
+	}
+	args := ExtraArgs{}
+	args.AddIfNotEmpty("service-account-issuer", podIAMConfig.ServiceAccountIssuer)
+	return args
+}
+
 func (e ExtraArgs) AddIfNotEmpty(k, v string) {
 	if v != "" {
 		logger.V(5).Info("Adding extraArgs", k, v)

--- a/pkg/clusterapi/extraargs_test.go
+++ b/pkg/clusterapi/extraargs_test.go
@@ -206,6 +206,35 @@ func TestAwsIamAuthExtraArgs(t *testing.T) {
 	}
 }
 
+func TestPodIAMConfigExtraArgs(t *testing.T) {
+	tests := []struct {
+		testName string
+		podIAM   *v1alpha1.PodIAMConfig
+		want     clusterapi.ExtraArgs
+	}{
+		{
+			testName: "no pod IAM config",
+			podIAM:   nil,
+			want:     nil,
+		},
+		{
+			testName: "with pod IAM config",
+			podIAM:   &v1alpha1.PodIAMConfig{ServiceAccountIssuer: "https://test"},
+			want: clusterapi.ExtraArgs{
+				"service-account-issuer": "https://test",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			if got := clusterapi.PodIAMAuthExtraArgs(tt.podIAM); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PodIAMAuthExtraArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAppend(t *testing.T) {
 	tests := []struct {
 		testName string
@@ -234,6 +263,16 @@ func TestAppend(t *testing.T) {
 			want: clusterapi.ExtraArgs{
 				"key1": "value1",
 				"key2": "value2",
+			},
+		},
+		{
+			testName: "append nil extraArgs",
+			e: clusterapi.ExtraArgs{
+				"key1": "value1",
+			},
+			a: nil,
+			want: clusterapi.ExtraArgs{
+				"key1": "value1",
 			},
 		},
 	}

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -88,9 +88,6 @@ spec:
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
           profiling: "false"
-{{- if .serviceAccountIssuer }}
-          service-account-issuer: {{ .serviceAccountIssuer }}
-{{- end }}
 {{- if .apiserverExtraArgs }}
 {{ .apiserverExtraArgs.ToYaml | indent 10 }}
 {{- end }}

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -153,9 +153,6 @@ spec:
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
           profiling: "false"
-{{- if .serviceAccountIssuer }}
-          service-account-issuer: {{ .serviceAccountIssuer }}
-{{- end }}
 {{- if .apiserverExtraArgs }}
 {{ .apiserverExtraArgs.ToYaml | indent 10 }}
 {{- end }}


### PR DESCRIPTION
The commit changes how the extra arg for Pod IAM gets added to the api-server.
It uses the existing methods for appending extraArgs.
For reference this was the original PR that added this flag: https://github.com/aws/eks-anywhere/pull/640
It contains unit tests for generating template with pod iam config configured

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
