### PR TITLE
Pass in source branch information to release process

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -14,6 +14,8 @@ RELEASE_BUCKET?=my-s3-bucket
 SOURCE_CONTAINER_REGISTRY?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 RELEASE_CONTAINER_REGISTRY?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 CDN?=https://my-s3-bucket
+BUILD_REPO_BRANCH_NAME?=main
+CLI_REPO_BRANCH_NAME?=main
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
@@ -96,13 +98,13 @@ run: manifests generate fmt vet ## Run a controller from your host.
 ##@ Release
 
 dev-release: build ## Perform a dev release of EKS-A bundles and CLI manifests
-	scripts/release.sh $(REPO_ROOT)/artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(SOURCE_CONTAINER_REGISTRY) $(RELEASE_CONTAINER_REGISTRY)
+	scripts/release.sh $(REPO_ROOT)/artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(SOURCE_CONTAINER_REGISTRY) $(RELEASE_CONTAINER_REGISTRY) $(BUILD_REPO_BRANCH_NAME) $(CLI_REPO_BRANCH_NAME)
 
 bundle-release: build ## Perform EKS-A versioned bundles release
-	scripts/bundle-release.sh $(REPO_ROOT)/artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(BUNDLE_NUMBER) $(CLI_MIN_VERSION) $(CLI_MAX_VERSION) $(SOURCE_CONTAINER_REGISTRY) $(RELEASE_CONTAINER_REGISTRY) $(RELEASE_ENVIRONMENT)
+	scripts/bundle-release.sh $(REPO_ROOT)/artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(BUNDLE_NUMBER) $(CLI_MIN_VERSION) $(CLI_MAX_VERSION) $(SOURCE_CONTAINER_REGISTRY) $(RELEASE_CONTAINER_REGISTRY) $(RELEASE_ENVIRONMENT) $(BUILD_REPO_BRANCH_NAME)
 
 eks-a-release: build ## Perform EKS-A CLI release
-	scripts/eks-a-release.sh $(RELEASE_VERSION) $(REPO_ROOT)/artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(BUNDLE_NUMBER) $(RELEASE_NUMBER) $(RELEASE_ENVIRONMENT)
+	scripts/eks-a-release.sh $(RELEASE_VERSION) $(REPO_ROOT)/artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(BUNDLE_NUMBER) $(RELEASE_NUMBER) $(RELEASE_ENVIRONMENT) $(CLI_REPO_BRANCH_NAME)
 
 ##@ Deployment
 

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -56,7 +56,8 @@ var releaseCmd = &cobra.Command{
 		releaseNumber := viper.GetInt("release-number")
 		cliRepoDir := viper.GetString("cli-repo-source")
 		buildRepoDir := viper.GetString("build-repo-source")
-		branchName := viper.GetString("branch-name")
+		buildRepoBranchName := viper.GetString("build-repo-branch-name")
+		cliRepoBranchName := viper.GetString("cli-repo-branch-name")
 		artifactDir := viper.GetString("artifact-dir")
 		sourceBucket := viper.GetString("source-bucket")
 		releaseBucket := viper.GetString("release-bucket")
@@ -82,7 +83,8 @@ var releaseCmd = &cobra.Command{
 		releaseConfig := &pkg.ReleaseConfig{
 			CliRepoSource:            cliRepoDir,
 			BuildRepoSource:          buildRepoDir,
-			BranchName:               branchName,
+			BuildRepoBranchName:      buildRepoBranchName,
+			CliRepoBranchName:        cliRepoBranchName,
 			ArtifactDir:              artifactDir,
 			SourceBucket:             sourceBucket,
 			ReleaseBucket:            releaseBucket,
@@ -192,8 +194,8 @@ var releaseCmd = &cobra.Command{
 			var bundleReleaseManifestKey string
 			if devRelease {
 				bundleReleaseManifestKey = bundleReleaseManifestFile
-				if releaseConfig.BranchName != "main" {
-					bundleReleaseManifestKey = fmt.Sprintf("/%s/%s", releaseConfig.BranchName, bundleReleaseManifestFile)
+				if releaseConfig.BuildRepoBranchName != "main" {
+					bundleReleaseManifestKey = fmt.Sprintf("/%s/%s", releaseConfig.BuildRepoBranchName, bundleReleaseManifestFile)
 				}
 			} else {
 				bundleReleaseManifestKey = fmt.Sprintf("/releases/bundles/%d/manifest.yaml", releaseConfig.BundleNumber)
@@ -313,7 +315,8 @@ func init() {
 	releaseCmd.Flags().Int("release-number", 1, "The release-number to create")
 	releaseCmd.Flags().String("cli-repo-source", "", "The eks-anywhere-cli source")
 	releaseCmd.Flags().String("build-repo-source", "", "The eks-anywhere-build-tooling source")
-	releaseCmd.Flags().String("branch-name", "main", "The branch name to build bundles from")
+	releaseCmd.Flags().String("build-repo-branch-name", "main", "The branch name to build bundles from")
+	releaseCmd.Flags().String("cli-repo-branch-name", "main", "The branch name to build EKS-A CLI from")
 	releaseCmd.Flags().String("artifact-dir", "", "The base directory for artifacts")
 	releaseCmd.Flags().String("cdn", "https://anywhere.eks.amazonaws.com", "The URL base for artifacts")
 	releaseCmd.Flags().String("source-bucket", "eks-a-source-bucket", "The bucket name where the built/staging artifacts are located to download")

--- a/release/pkg/file_reader.go
+++ b/release/pkg/file_reader.go
@@ -132,10 +132,10 @@ func (r *ReleaseConfig) GetCurrentEksADevReleaseVersion(sourceClients *SourceCli
 	defer os.Remove(tempFile.Name())
 
 	var latestReleaseKey string
-	if r.BranchName == "main" {
+	if r.BuildRepoBranchName == "main" {
 		latestReleaseKey = "LATEST_RELEASE_VERSION"
 	} else {
-		latestReleaseKey = fmt.Sprintf("%s/LATEST_RELEASE_VERSION", r.BranchName)
+		latestReleaseKey = fmt.Sprintf("%s/LATEST_RELEASE_VERSION", r.BuildRepoBranchName)
 	}
 
 	exists, err := ExistsInS3(sourceClients.S3.Client, r.ReleaseBucket, latestReleaseKey)
@@ -197,10 +197,10 @@ func (r *ReleaseConfig) PutEksAReleaseVersion(releaseClients *ReleaseClients, ve
 	s3Uploader := releaseClients.S3.Uploader
 
 	var currentReleaseKey string
-	if r.BranchName == "main" {
+	if r.BuildRepoBranchName == "main" {
 		currentReleaseKey = "LATEST_RELEASE_VERSION"
 	} else {
-		currentReleaseKey = fmt.Sprintf("%s/LATEST_RELEASE_VERSION", r.BranchName)
+		currentReleaseKey = fmt.Sprintf("%s/LATEST_RELEASE_VERSION", r.BuildRepoBranchName)
 	}
 	f, err := os.Create(currentReleaseKey)
 	if err != nil {

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -37,7 +37,8 @@ type ReleaseConfig struct {
 	CliRepoHead              string
 	BuildRepoSource          string
 	BuildRepoHead            string
-	BranchName               string
+	BuildRepoBranchName      string
+	CliRepoBranchName        string
 	ArtifactDir              string
 	SourceBucket             string
 	ReleaseBucket            string

--- a/release/pkg/prepare_release.go
+++ b/release/pkg/prepare_release.go
@@ -59,15 +59,26 @@ func (r *ReleaseConfig) SetRepoHeads() error {
 	}
 	fmt.Println(out)
 
-	if r.DevRelease && r.BranchName != "main" {
-		fmt.Printf("Checking out build-tooling repo at branch %s", r.BranchName)
-		cmd = exec.Command("git", "-C", r.BuildRepoSource, "checkout", r.BranchName)
+	if r.BuildRepoBranchName != "main" {
+		fmt.Printf("Checking out build-tooling repo at branch %s", r.BuildRepoBranchName)
+		cmd = exec.Command("git", "-C", r.BuildRepoSource, "checkout", r.BuildRepoBranchName)
 		out, err = execCommand(cmd)
 		if err != nil {
 			return errors.Cause(err)
 		}
 		fmt.Println(out)
 	}
+
+	if r.CliRepoBranchName != "main" {
+		fmt.Printf("Checking out CLI repo at branch %s", r.CliRepoBranchName)
+		cmd = exec.Command("git", "-C", r.CliRepoSource, "checkout", r.CliRepoBranchName)
+		out, err = execCommand(cmd)
+		if err != nil {
+			return errors.Cause(err)
+		}
+		fmt.Println(out)
+	}
+
 	// Set HEADs of the repos
 	r.CliRepoHead, err = GetHead(r.CliRepoSource)
 	if err != nil {
@@ -479,10 +490,10 @@ func IsImageNotFoundError(err error) bool {
 }
 
 func (r *ReleaseConfig) getLatestUploadDestination() string {
-	if r.BranchName == "main" {
+	if r.BuildRepoBranchName == "main" {
 		return "latest"
 	} else {
-		return r.BranchName
+		return r.BuildRepoBranchName
 	}
 }
 

--- a/release/scripts/bundle-release.sh
+++ b/release/scripts/bundle-release.sh
@@ -32,6 +32,7 @@ CLI_MAX_VERSION="${7?Specify seventh argument - CLI max version}"
 SOURCE_CONTAINER_REGISTRY="${8?Specify eighth argument - source container registry}"
 RELEASE_CONTAINER_REGISTRY="${9?Specify ninth argument - release container registry}"
 RELEASE_ENVIRONMENT="${10?Specify tenth argument - Release environment}"
+BUILD_REPO_BRANCH_NAME="${11?Specify eleventh argument - Build repo branch name}"
 
 set_aws_config "$RELEASE_ENVIRONMENT"
 
@@ -41,12 +42,13 @@ ${BASE_DIRECTORY}/release/bin/eks-anywhere-release release \
     --bundle-number "${BUNDLE_NUMBER}" \
     --min-version "${CLI_MIN_VERSION}" \
     --max-version "${CLI_MAX_VERSION}" \
-	--artifact-dir "${ARTIFACTS_DIR}" \
-	--source-bucket "${SOURCE_BUCKET}" \
-	--source-container-registry "${SOURCE_CONTAINER_REGISTRY}" \
-	--cdn "${CDN}" \
-	--release-bucket "${RELEASE_BUCKET}" \
-	--release-container-registry "${RELEASE_CONTAINER_REGISTRY}" \
+    --build-repo-branch-name "${BUILD_REPO_BRANCH_NAME}" \
+    --artifact-dir "${ARTIFACTS_DIR}" \
+    --source-bucket "${SOURCE_BUCKET}" \
+    --source-container-registry "${SOURCE_CONTAINER_REGISTRY}" \
+    --cdn "${CDN}" \
+    --release-bucket "${RELEASE_BUCKET}" \
+    --release-container-registry "${RELEASE_CONTAINER_REGISTRY}" \
     --release-environment ${RELEASE_ENVIRONMENT} \
-	--dev-release=false \
+    --dev-release=false \
     --bundle-release=true

--- a/release/scripts/eks-a-release.sh
+++ b/release/scripts/eks-a-release.sh
@@ -30,6 +30,7 @@ CDN="${5?Specify fifth argument - cdn}"
 BUNDLE_NUMBER="${6?Specify sixth argument - Bundle number}"
 RELEASE_NUMBER="${7?Specify seventh argument - Release number}"
 RELEASE_ENVIRONMENT="${8?Specify eighth argument - Release environment}"
+CLI_REPO_BRANCH_NAME="${9?Specify ninth argument - Branch name}"
 
 set_aws_config "$RELEASE_ENVIRONMENT"
 
@@ -38,11 +39,12 @@ mkdir -p "${ARTIFACTS_DIR}"
 ${BASE_DIRECTORY}/release/bin/eks-anywhere-release release \
     --release-version "${RELEASE_VERSION}" \
     --bundle-number "${BUNDLE_NUMBER}" \
-	--release-number "${RELEASE_NUMBER}" \
-	--artifact-dir "${ARTIFACTS_DIR}" \
-	--source-bucket "${SOURCE_BUCKET}" \
-	--cdn "${CDN}" \
-	--release-bucket "${RELEASE_BUCKET}" \
+    --release-number "${RELEASE_NUMBER}" \
+    --cli-repo-branch-name "${CLI_REPO_BRANCH_NAME}" \
+    --artifact-dir "${ARTIFACTS_DIR}" \
+    --source-bucket "${SOURCE_BUCKET}" \
+    --cdn "${CDN}" \
+    --release-bucket "${RELEASE_BUCKET}" \
     --release-environment ${RELEASE_ENVIRONMENT} \
-	--dev-release=false \
+    --dev-release=false \
     --bundle-release=false


### PR DESCRIPTION
The branch name env variables will be set when the release pipeline is triggered, and will override the default values set in the Makefile.

/hold for CDK changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
