### PR TITLE
Enabling GOVC_PERSIST_SESSION for all govc commands

### DIFF
--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -32,6 +32,7 @@ const (
 	govcInsecure         = "GOVC_INSECURE"
 	govcTlsHostsFile     = "govc_known_hosts"
 	govcTlsKnownHostsKey = "GOVC_TLS_KNOWN_HOSTS"
+	govcPersistSession   = "GOVC_PERSIST_SESSION"
 	vSphereUsernameKey   = "EKSA_VSPHERE_USERNAME"
 	vSpherePasswordKey   = "EKSA_VSPHERE_PASSWORD"
 	vSphereServerKey     = "VSPHERE_SERVER"
@@ -308,7 +309,6 @@ func (g *Govc) deployTemplate(ctx context.Context, library, templateName, deploy
 		"-pool", resourcePool,
 		"-folder", deployFolder,
 		"-options", deployOptsPath,
-		"-persist-session=false",
 		templateInLibraryPath, templateName,
 	}
 	if _, err := g.exec(ctx, params...); err != nil {
@@ -354,14 +354,14 @@ func (g *Govc) deleteVM(ctx context.Context, path string) error {
 }
 
 func (g *Govc) createVMSnapshot(ctx context.Context, name string) error {
-	if _, err := g.exec(ctx, "snapshot.create", "-m=false", "-persist-session=false", "-vm", name, "root"); err != nil {
+	if _, err := g.exec(ctx, "snapshot.create", "-m=false", "-vm", name, "root"); err != nil {
 		return fmt.Errorf("govc failed taking vm snapshot: %v", err)
 	}
 	return nil
 }
 
 func (g *Govc) markVMAsTemplate(ctx context.Context, vmName string) error {
-	if _, err := g.exec(ctx, "vm.markastemplate", "-persist-session=false", vmName); err != nil {
+	if _, err := g.exec(ctx, "vm.markastemplate", vmName); err != nil {
 		return fmt.Errorf("error marking VM as template: %v", err)
 	}
 	return nil
@@ -382,6 +382,8 @@ func (g *Govc) getEnvMap() (map[string]string, error) {
 			}
 		}
 	}
+	envMap[govcPersistSession] = "false"
+
 	return envMap, nil
 }
 

--- a/pkg/executables/govc_test.go
+++ b/pkg/executables/govc_test.go
@@ -22,21 +22,23 @@ import (
 )
 
 const (
-	govcUsername    = "GOVC_USERNAME"
-	govcPassword    = "GOVC_PASSWORD"
-	govcURL         = "GOVC_URL"
-	govcInsecure    = "GOVC_INSECURE"
-	vSphereUsername = "EKSA_VSPHERE_USERNAME"
-	vSpherePassword = "EKSA_VSPHERE_PASSWORD"
-	vSphereServer   = "VSPHERE_SERVER"
-	templateLibrary = "eks-a-templates"
+	govcUsername       = "GOVC_USERNAME"
+	govcPassword       = "GOVC_PASSWORD"
+	govcURL            = "GOVC_URL"
+	govcInsecure       = "GOVC_INSECURE"
+	govcPersistSession = "GOVC_PERSIST_SESSION"
+	vSphereUsername    = "EKSA_VSPHERE_USERNAME"
+	vSpherePassword    = "EKSA_VSPHERE_PASSWORD"
+	vSphereServer      = "VSPHERE_SERVER"
+	templateLibrary    = "eks-a-templates"
 )
 
 var govcEnvironment = map[string]string{
-	govcUsername: "vsphere_username",
-	govcPassword: "vsphere_password",
-	govcURL:      "vsphere_server",
-	govcInsecure: "false",
+	govcUsername:       "vsphere_username",
+	govcPassword:       "vsphere_password",
+	govcURL:            "vsphere_server",
+	govcInsecure:       "false",
+	govcPersistSession: "false",
 }
 
 type testContext struct {
@@ -151,21 +153,21 @@ func newMachineConfig(t *testing.T) *v1alpha1.VSphereMachineConfig {
 func (dt *deployTemplateTest) expectDeployToReturn(err error) {
 	dt.expectations = append(
 		dt.expectations,
-		dt.mockExecutable.EXPECT().ExecuteWithEnv(dt.ctx, dt.env, "library.deploy", "-dc", dt.datacenter, "-pool", dt.resourcePool, "-folder", dt.deployFolder, "-options", test.OfType("string"), "-persist-session=false", dt.templateInLibraryPathAbs, dt.templateName).Return(*dt.fakeExecResponse, err),
+		dt.mockExecutable.EXPECT().ExecuteWithEnv(dt.ctx, dt.env, "library.deploy", "-dc", dt.datacenter, "-pool", dt.resourcePool, "-folder", dt.deployFolder, "-options", test.OfType("string"), dt.templateInLibraryPathAbs, dt.templateName).Return(*dt.fakeExecResponse, err),
 	)
 }
 
 func (dt *deployTemplateTest) expectCreateSnapshotToReturn(err error) {
 	dt.expectations = append(
 		dt.expectations,
-		dt.mockExecutable.EXPECT().ExecuteWithEnv(dt.ctx, dt.env, "snapshot.create", "-m=false", "-persist-session=false", "-vm", dt.templateName, "root").Return(*dt.fakeExecResponse, err),
+		dt.mockExecutable.EXPECT().ExecuteWithEnv(dt.ctx, dt.env, "snapshot.create", "-m=false", "-vm", dt.templateName, "root").Return(*dt.fakeExecResponse, err),
 	)
 }
 
 func (dt *deployTemplateTest) expectMarkAsTemplateToReturn(err error) {
 	dt.expectations = append(
 		dt.expectations,
-		dt.mockExecutable.EXPECT().ExecuteWithEnv(dt.ctx, dt.env, "vm.markastemplate", "-persist-session=false", dt.templateName).Return(*dt.fakeExecResponse, err),
+		dt.mockExecutable.EXPECT().ExecuteWithEnv(dt.ctx, dt.env, "vm.markastemplate", dt.templateName).Return(*dt.fakeExecResponse, err),
 	)
 }
 


### PR DESCRIPTION
*Description of changes:*
Setting `GOVC_PERSIST_SESSION=false` to prevent multiple sessions to be created during cli execution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
