### PR TITLE
add vsphere crd collectors to diagnostic bundle collection

### DIFF
--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -71,7 +71,7 @@ func (c *collectorFactory) DataCenterConfigCollectors(datacenter v1alpha1.Ref) [
 }
 
 func (c *collectorFactory) eksaVsphereCollectors() []*Collect {
-	return []*Collect{
+	vsphereLogs := []*Collect{
 		{
 			Logs: &logs{
 				Namespace: constants.CapvSystemNamespace,
@@ -79,6 +79,7 @@ func (c *collectorFactory) eksaVsphereCollectors() []*Collect {
 			},
 		},
 	}
+	return append(vsphereLogs, c.vsphereCrdCollectors()...)
 }
 
 func (c *collectorFactory) eksaDockerCollectors() []*Collect {
@@ -231,6 +232,19 @@ func (c *collectorFactory) managementClusterCrdCollectors() []*Collect {
 		"machines.cluster.x-k8s.io",
 	}
 	return c.generateCrdCollectors(mgmtCrds)
+}
+
+func (c *collectorFactory) vsphereCrdCollectors() []*Collect {
+	capvCrds := []string{
+		"vsphereclusteridentities.infrastructure.cluster.x-k8s.io",
+		"vsphereclusters.infrastructure.cluster.x-k8s.io",
+		"vspheredatacenterconfigs.anywhere.eks.amazonaws.com",
+		"vspheremachineconfigs.anywhere.eks.amazonaws.com",
+		"vspheremachines.infrastructure.cluster.x-k8s.io",
+		"vspheremachinetemplates.infrastructure.cluster.x-k8s.io",
+		"vspherevms.infrastructure.cluster.x-k8s.io",
+	}
+	return c.generateCrdCollectors(capvCrds)
 }
 
 func (c *collectorFactory) generateCrdCollectors(crds []string) []*Collect {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
add capv and eks-a vsphere specific CRDs to the crd collection routine

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
