### PR TITLE
always use the bundle associated with the built branch for integratio…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,7 @@ eks-a-e2e:
 		if [[ "$(CODEBUILD_BUILD_ID)" =~ "aws-staging-eks-a-build" ]]; then \
 			make eks-a-release-cross-platform GIT_VERSION=$(shell cat release/triggers/eks-a-release/development/RELEASE_VERSION) RELEASE_MANIFEST_URL=https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml; \
 			make eks-a-release GIT_VERSION=$(DEV_GIT_VERSION); \
+			scripts/get_bundle.sh; \
 		else \
 			make eks-a-cross-platform; \
 			make eks-a; \

--- a/scripts/get_bundle.sh
+++ b/scripts/get_bundle.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+set -o pipefail
+
+bundle_number=$(cat "${CODEBUILD_SRC_DIR}/release/triggers/bundle-release/production/BUNDLE_NUMBER")
+bundle_url="https://anywhere-assets.eks.amazonaws.com/releases/bundles/${bundle_number}/manifest.yaml"
+wget -O "${CODEBUILD_SRC_DIR}/bin/local-bundle-release.yaml" "${bundle_url}"


### PR DESCRIPTION
…… (#678)

* always use the bundle associated with the built branch for integration test executions

* move logic to download custom bundle to staging makefile

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
