### PR TITLE
Add dry-run mode for local bundle manifest generation

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -9,13 +9,20 @@ BUNDLE_NUMBER?=$(shell cat triggers/bundle-release/$(RELEASE_ENVIRONMENT)/BUNDLE
 RELEASE_NUMBER?=$(shell cat triggers/eks-a-release/$(RELEASE_ENVIRONMENT)/RELEASE_NUMBER)
 CLI_MIN_VERSION?=$(shell cat triggers/bundle-release/$(RELEASE_ENVIRONMENT)/CLI_MIN_VERSION)
 CLI_MAX_VERSION?=$(shell cat triggers/bundle-release/$(RELEASE_ENVIRONMENT)/CLI_MAX_VERSION)
-SOURCE_BUCKET?=my-source-bucket
-RELEASE_BUCKET?=my-s3-bucket
+SOURCE_BUCKET?=source-bucket
+RELEASE_BUCKET?=release-bucket
 SOURCE_CONTAINER_REGISTRY?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 RELEASE_CONTAINER_REGISTRY?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
-CDN?=https://my-s3-bucket
+CDN?=https://$(RELEASE_BUCKET)
+CLI_REPO_URL?=https://github.com/aws/eks-anywhere.git
+BUILD_REPO_URL?=https://github.com/aws/eks-anywhere-build-tooling.git
 BUILD_REPO_BRANCH_NAME?=main
 CLI_REPO_BRANCH_NAME?=main
+ifeq ($(CODEBUILD_CI),)
+DRY_RUN=true
+else
+DRY_RUN=false
+endif
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
@@ -54,7 +61,7 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 clean: ## Cleanup resources created by make targets
-	rm -rf bin
+	rm -rf bin $(HOME)/eks-a-source
 
 ##@ Development
 
@@ -80,7 +87,7 @@ test: manifests generate fmt vet ## Run tests.
 
 ##@ Build
 
-build: fmt vet ## Build release binary.
+build: clean fmt vet ## Build release binary.
 	go build -o bin/eks-anywhere-release main.go
 
 .PHONY: lint
@@ -98,7 +105,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 ##@ Release
 
 dev-release: build ## Perform a dev release of EKS-A bundles and CLI manifests
-	scripts/release.sh $(REPO_ROOT)/artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(SOURCE_CONTAINER_REGISTRY) $(RELEASE_CONTAINER_REGISTRY) $(BUILD_REPO_BRANCH_NAME) $(CLI_REPO_BRANCH_NAME)
+	scripts/release.sh $(REPO_ROOT)/artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(SOURCE_CONTAINER_REGISTRY) $(RELEASE_CONTAINER_REGISTRY) $(BUILD_REPO_URL) $(CLI_REPO_URL) $(BUILD_REPO_BRANCH_NAME) $(CLI_REPO_BRANCH_NAME) $(DRY_RUN)
 
 bundle-release: build ## Perform EKS-A versioned bundles release
 	scripts/bundle-release.sh $(REPO_ROOT)/artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(BUNDLE_NUMBER) $(CLI_MIN_VERSION) $(CLI_MAX_VERSION) $(SOURCE_CONTAINER_REGISTRY) $(RELEASE_CONTAINER_REGISTRY) $(RELEASE_ENVIRONMENT) $(BUILD_REPO_BRANCH_NAME)

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,15 @@
+# EKS Anywhere Release Tooling
+
+This folder contains the release tooling code for EKS Anywhere. It defines the APIs and CRDs corresponding to the two kinds of release supported by EKS Anywhere - the versioned bundle release and EKS Anywhere CLI release. It also contains logic to perform the release process, that includes downloading artifacts from the source locations, uploading them to release locations, and generating the versioned bundles manifest and EKS Anywhere releases manifest.
+
+## Versioned Bundles Release
+
+The versioned bundles are comprised of version-tagged bundles of EKS-A/EKS-D artifacts. This includes the list of container images and manifests from EKS-A as well as EKS-D dependent artifacts such as OVAs and kind images. These image and S3 URIs will be embedded into a bundles manifest that the CLI will use to fetch the images and manifests that it needs to pull when creating a cluster. The bundles release manifest URI will be referenced in the EKS-A CLI release manifest, so that customers will know what version bundle each release version of the CLI will be supporting.
+
+## EKS-A CLI release
+
+The EKS-A CLI release is the build and release of the tagged version of the EKS-A CLI, along with a reference to the corresponding bundle release manifest. The staging EKS-A release will be kicked off after the staging bundle release, so that this release manifest can reference a bundle manifest that exists in the artifacts S3. After the staging release has been uploaded to S3, we can do integration tests in staging, by obtaining the CLI from the release manifest and running it against the staging versioned bundles. Once the tests pass, all the manifests and artifacts can be moved from staging to prod.
+
+## Testing release tooling changes locally
+
+Changes made to release tooling, such as modifying the release API or adding a new component to the versioned bundle, can change the manifest specs produced during release. To visualize these changes, you can simply run `make dev-release` which will simulate the release process in dry-run mode and generate the resultant versioned bundle and release manifests.

--- a/release/pkg/clients.go
+++ b/release/pkg/clients.go
@@ -67,6 +67,10 @@ type ReleaseECRPublicClient struct {
 
 // Function to create release clients for dev release
 func (r *ReleaseConfig) CreateDevReleaseClients() (*SourceClients, *ReleaseClients, error) {
+	if r.DryRun {
+		fmt.Println("Skipping clients creation in dry-run mode")
+		return nil, nil, nil
+	}
 	fmt.Println("Creating new dev release clients for S3, docker and ECR public")
 
 	// PDX session for eks-a-build-prod-pdx

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -33,12 +33,14 @@ type ReleaseConfig struct {
 	BundleNumber             int
 	CliMinVersion            string
 	CliMaxVersion            string
+	CliRepoUrl               string
 	CliRepoSource            string
 	CliRepoHead              string
+	CliRepoBranchName        string
+	BuildRepoUrl             string
 	BuildRepoSource          string
 	BuildRepoHead            string
 	BuildRepoBranchName      string
-	CliRepoBranchName        string
 	ArtifactDir              string
 	SourceBucket             string
 	ReleaseBucket            string
@@ -48,6 +50,7 @@ type ReleaseConfig struct {
 	ReleaseNumber            int
 	ReleaseDate              time.Time
 	DevRelease               bool
+	DryRun                   bool
 	ReleaseEnvironment       string
 }
 
@@ -184,7 +187,6 @@ func (r *ReleaseConfig) GetVersionsBundles(imageDigests map[string]string) ([]an
 func (r *ReleaseConfig) GenerateBundleSpec(bundles *anywherev1alpha1.Bundles, imageDigests map[string]string) error {
 	fmt.Println("Generating versions bundles")
 	versionsBundles, err := r.GetVersionsBundles(imageDigests)
-	fmt.Println(versionsBundles)
 	if err != nil {
 		return err
 	}

--- a/release/pkg/prepare_release.go
+++ b/release/pkg/prepare_release.go
@@ -28,10 +28,8 @@ type EksAReleases []anywherev1alpha1.EksARelease
 
 func (r *ReleaseConfig) SetRepoHeads() error {
 	// Get the repos from env var
-	cliRepoUrl := os.Getenv("CLI_REPO_URL")
-	buildRepoUrl := os.Getenv("BUILD_REPO_URL")
-	if cliRepoUrl == "" || buildRepoUrl == "" {
-		return fmt.Errorf("clone env urls not set")
+	if r.CliRepoUrl == "" || r.BuildRepoUrl == "" {
+		return fmt.Errorf("One or both clone URLs are empty")
 	}
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -42,7 +40,7 @@ func (r *ReleaseConfig) SetRepoHeads() error {
 	fmt.Println("Cloning CLI repository")
 	parentSourceDir := filepath.Join(homeDir, "eks-a-source")
 	r.CliRepoSource = filepath.Join(parentSourceDir, "eks-a-cli")
-	cmd := exec.Command("git", "clone", cliRepoUrl, r.CliRepoSource)
+	cmd := exec.Command("git", "clone", r.CliRepoUrl, r.CliRepoSource)
 	out, err := execCommand(cmd)
 	if err != nil {
 		return errors.Cause(err)
@@ -52,7 +50,7 @@ func (r *ReleaseConfig) SetRepoHeads() error {
 	// Clone the build-tooling repository
 	fmt.Println("Cloning build-tooling repository")
 	r.BuildRepoSource = filepath.Join(parentSourceDir, "eks-a-build")
-	cmd = exec.Command("git", "clone", buildRepoUrl, r.BuildRepoSource)
+	cmd = exec.Command("git", "clone", r.BuildRepoUrl, r.BuildRepoSource)
 	out, err = execCommand(cmd)
 	if err != nil {
 		return errors.Cause(err)
@@ -94,48 +92,52 @@ func (r *ReleaseConfig) SetRepoHeads() error {
 	return nil
 }
 
-func (r *ReleaseConfig) PrepareBundleRelease(sourceClients *SourceClients) (map[string][]Artifact, error) {
-	artifactsTable, err := r.GetBundleArtifactsData()
-	if err != nil {
-		return nil, errors.Cause(err)
+func (r *ReleaseConfig) PrepareBundleRelease(artifactsTable map[string][]Artifact, sourceClients *SourceClients) error {
+	if r.DryRun {
+		fmt.Println("Skipping bundle artifacts download and rename in dry-run mode")
+		return nil
 	}
-	fmt.Println("Initialized artifacts data")
-
-	err = downloadArtifacts(sourceClients, r, artifactsTable)
+	fmt.Println("Preparing bundle release")
+	err := downloadArtifacts(sourceClients, r, artifactsTable)
 	if err != nil {
-		return nil, errors.Cause(err)
+		return errors.Cause(err)
 	}
 	fmt.Println("Artifacts download complete")
 
 	err = r.renameArtifacts(sourceClients, artifactsTable)
 	if err != nil {
-		return nil, errors.Cause(err)
+		return errors.Cause(err)
 	}
 	fmt.Println("Renaming artifacts complete")
 
-	return artifactsTable, nil
+	return nil
 }
 
-func (r *ReleaseConfig) PrepareEksARelease(sourceClients *SourceClients) (map[string][]Artifact, error) {
+func (r *ReleaseConfig) PrepareEksARelease(sourceClients *SourceClients) error {
+	if r.DryRun {
+		fmt.Println("Skipping EKS-A artifacts download and rename in dry-run mode")
+		return nil
+	}
+	fmt.Println("Preparing EKS-A release")
 	artifactsTable, err := r.GetEksAArtifactsData()
 	if err != nil {
-		return nil, errors.Cause(err)
+		return errors.Cause(err)
 	}
 	fmt.Println("Initialized artifacts data")
 
 	err = downloadArtifacts(sourceClients, r, artifactsTable)
 	if err != nil {
-		return nil, errors.Cause(err)
+		return errors.Cause(err)
 	}
 	fmt.Println("Artifacts download complete")
 
 	err = r.renameArtifacts(sourceClients, artifactsTable)
 	if err != nil {
-		return nil, errors.Cause(err)
+		return errors.Cause(err)
 	}
 	fmt.Println("Renaming artifacts complete")
 
-	return artifactsTable, nil
+	return nil
 }
 
 func (r *ReleaseConfig) renameArtifacts(sourceClients *SourceClients, artifacts map[string][]Artifact) error {
@@ -289,6 +291,10 @@ func downloadArtifacts(sourceClients *SourceClients, r *ReleaseConfig, eksArtifa
 }
 
 func UploadArtifacts(sourceClients *SourceClients, releaseClients *ReleaseClients, r *ReleaseConfig, eksArtifacts map[string][]Artifact) error {
+	if r.DryRun {
+		fmt.Println("Skipping artifacts upload in dry-run mode")
+		return nil
+	}
 	// Get clients
 	s3Uploader := releaseClients.S3.Uploader
 	sourceEcrAuthConfig := sourceClients.ECR.AuthConfig
@@ -421,38 +427,48 @@ func execCommand(cmd *exec.Cmd) (string, error) {
 }
 
 func UpdateImageDigests(releaseClients *ReleaseClients, r *ReleaseConfig, eksArtifacts map[string][]Artifact) (map[string]string, error) {
-	// Get clients
-	ecrPublicClient := releaseClients.ECRPublic.Client
 	fmt.Println("============================================================")
 	fmt.Println("                 Updating Image Digests                      ")
 	fmt.Println("============================================================")
-
 	imageDigests := make(map[string]string)
+
 	for _, artifacts := range eksArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
-				var imageTag string
-				releaseUriSplit := strings.Split(artifact.Image.ReleaseImageURI, ":")
-				repoName := strings.Replace(releaseUriSplit[0], r.ReleaseContainerRegistry+"/", "", -1)
-				imageTag = releaseUriSplit[1]
-				describeImagesOutput, err := ecrPublicClient.DescribeImages(
-					&ecrpublic.DescribeImagesInput{
-						ImageIds: []*ecrpublic.ImageIdentifier{
-							{
-								ImageTag: aws.String(imageTag),
+				var imageDigestStr string
+				if r.DryRun {
+					sha256sum, err := GenerateRandomSha(256)
+					if err != nil {
+						return nil, errors.Cause(err)
+					}
+					imageDigestStr = fmt.Sprintf("sha256:%s", sha256sum)
+				} else {
+					ecrPublicClient := releaseClients.ECRPublic.Client
+
+					var imageTag string
+					releaseUriSplit := strings.Split(artifact.Image.ReleaseImageURI, ":")
+					repoName := strings.Replace(releaseUriSplit[0], r.ReleaseContainerRegistry+"/", "", -1)
+					imageTag = releaseUriSplit[1]
+					describeImagesOutput, err := ecrPublicClient.DescribeImages(
+						&ecrpublic.DescribeImagesInput{
+							ImageIds: []*ecrpublic.ImageIdentifier{
+								{
+									ImageTag: aws.String(imageTag),
+								},
 							},
+							RepositoryName: aws.String(repoName),
 						},
-						RepositoryName: aws.String(repoName),
-					},
-				)
-				if err != nil {
-					return nil, errors.Cause(err)
+					)
+					if err != nil {
+						return nil, errors.Cause(err)
+					}
+
+					imageDigest := describeImagesOutput.ImageDetails[0].ImageDigest
+					imageDigestStr = *imageDigest
 				}
 
-				imageDigest := describeImagesOutput.ImageDetails[0].ImageDigest
-
-				imageDigests[artifact.Image.ReleaseImageURI] = *imageDigest
-				fmt.Printf("Image digest for %s - %s\n", artifact.Image.ReleaseImageURI, *imageDigest)
+				imageDigests[artifact.Image.ReleaseImageURI] = imageDigestStr
+				fmt.Printf("Image digest for %s - %s\n", artifact.Image.ReleaseImageURI, imageDigestStr)
 			}
 		}
 	}

--- a/release/runbook.md
+++ b/release/runbook.md
@@ -1,16 +1,8 @@
 # EKS Anywhere Release Runbook
 
-EKS Anywhere releases are of two variants - the versioned bundle release and the EKS-A CLI release.
+The following steps are to be followed when performing a full EKS Anywhere release (bundle + EKS-A CLI).
 
-### Versioned Bundles Release
-
-The versioned bundles are comprised of version-tagged bundles of EKS-A/EKS-D components. This includes the list of container images/manifests from EKS-A as well as EKS-D dependent artifacts such as OVAs and kind images. These image and S3 URIs will be embedded into a bundles manifest that the CLI will use to fetch the images and manifests that it needs to pull when creating a cluster. The bundles release manifest URI will be referenced in the EKS-A CLI release manifest, so that customers will know what version bundle each release version of the CLI will be supporting.
-
-### EKS-A CLI release
-
-The EKS-A CLI release is the build and release of the tagged version of the EKS-A CLI, along with a reference to the corresponding bundle release manifest. The staging EKS-A release will be kicked off after the staging bundle release, so that this release manifest can reference a bundle manifest that exists in the artifacts S3. After the staging release has been uploaded to S3, we can do integration tests in staging, by obtaining the CLI from the release manifest and running it against the staging versioned bundles. Once the tests pass, all the manifests and artifacts can be moved from staging to prod.
-
-## Staging Release
+## Bundle Release
 
 ### Create Development Versioned Bundle Release PR
 
@@ -18,29 +10,53 @@ The EKS-A CLI release is the build and release of the tagged version of the EKS-
 * release/triggers/bundle-release/development/CLI_MIN_VERSION
 * release/triggers/bundle-release/development/CLI_MAX_VERSION
 
-When the above PR gets merged, it will build all the upstream dependencies of EKS-A after which the release tool will pull them down and upload them to the Artifacts beta S3 and public ECR destinations. 
+Merging this PR will trigger
+1. Builds of artifacts for all the upstream dependencies of EKS-A.
+2. Upload of artifacts and bundle manifest to the staging S3 bucket and public ECR repositories.
+
+### Create Production Versioned Bundle Release PR
+
+* release/triggers/bundle-release/production/BUNDLE_NUMBER
+* release/triggers/bundle-release/production/CLI_MIN_VERSION
+* release/triggers/bundle-release/production/CLI_MAX_VERSION
+
+Merging this PR will trigger
+1. Download of artifacts from staging S3 bucket and public ECR repositories.
+2. Upload of artifacts and bundle manifest to the production S3 buckets and public ECR repositories.
 
 **Note:** Since we carry out the bundle release first, it is possible that the CLI version mentioned in the CLI max version file has not been released yet. After a successful bundle release, we shall create a PR for the EKS-A CLI staging release, so we use the same version in the CLI max version file as the version we will eventually be releasing (the RELEASE_VERSION file below).
+
+## EKS Anywhere CLI release
 
 ### Create Development EKS-A Release PR
 
 * release/triggers/eks-a-release/development/RELEASE_NUMBER
 * release/triggers/eks-a-release/development/RELEASE_VERSION
 
-## Release Steps on Repository
+Merging this PR will trigger
+1. Build of EKS Anywhere CLI from the branch specified.
+2. Integration test of the CLI with the previously released bundle manifest.
+3. Upload of CLI tarball and EKS-A releases manifest to the staging S3 bucket.
 
-Once we finish the staging release, we can mark the release accordingly on the repository.
-This includes adding a tag as well as a separate branch to have our website be updated to
-point to the new branch.
+### Create Production EKS-A Release PR
 
-* Update the [Changelog](docs/content/en/docs/reference/changelog.md) with changes for the release and rename `[Unreleased]` to the release version
-  * If this is not just a patch release, update the value under `versions` in the docs [config](docs/config.toml)
-  * Follow format [here](https://keepachangelog.com/)
-* Tag the commit with the release version (ex. `v0.5.0`)
+* release/triggers/eks-a-release/production/RELEASE_NUMBER
+* release/triggers/eks-a-release/production/RELEASE_VERSION
+
+Merging this PR will trigger
+1. Download of CLI tarball from the staging S3 bucket.
+2. Upload of CLI tarball and EKS-A releases manifest to the production S3 bucket.
+
+## Release Steps on EKS Anywhere Repository
+
+Once we finish the production EKS-A release, we can mark the release accordingly on the repository.This includes adding a tag as well as a separate branch and updating our website to point to the new branch.
+
+* Update the [Changelog](docs/content/en/docs/reference/changelog.md) with changes for the release and rename `[Unreleased]` to the release version.
+  * If this is not just a patch release, update the value under `versions` in the docs [config](docs/config.toml).
+  * Follow format [here](https://keepachangelog.com/).
+* Tag the commit with the release version (ex. `v0.6.0`).
 * Create a branch from the tag
 * Have one of the maintainers, who has access to the infrastructure cdk package, change the website configuration to point to the newly created branch
 * Add a file to the branch called `PUBLISHED_VERSION` to trigger a change to the infrastructure to deploy the new changes
 
 Now the [homepage](https://anywhere.eks.amazonaws.com/) for EKS-A should be updated with the changes from this new branch
-
-

--- a/release/scripts/release.sh
+++ b/release/scripts/release.sh
@@ -28,13 +28,18 @@ RELEASE_BUCKET="${3?Specify third argument - release bucket}"
 CDN="${4?Specify fourth argument - cdn}"
 SOURCE_CONTAINER_REGISTRY="${5?Specify fifth argument - source container registry}"
 RELEASE_CONTAINER_REGISTRY="${6?Specify sixth argument - release container registry}"
-BUILD_REPO_BRANCH_NAME="${7?Specify seventh argument - Build repo branch name}"
-CLI_REPO_BRANCH_NAME="${8?Specify eighth argument - CLI repo branch name}"
+BUILD_REPO_URL="${7?Specify seventh argument - Build repo URL}"
+CLI_REPO_URL="${8?Specify eighth argument - CLI repo URL}"
+BUILD_REPO_BRANCH_NAME="${9?Specify seventh argument - Build repo branch name}"
+CLI_REPO_BRANCH_NAME="${10?Specify eighth argument - CLI repo branch name}"
+DRY_RUN="${11?Specify ninth argument - Dry run}"
 
 mkdir -p "${ARTIFACTS_DIR}"
 
 ${BASE_DIRECTORY}/release/bin/eks-anywhere-release release \
     --artifact-dir "${ARTIFACTS_DIR}" \
+    --build-repo-url "${BUILD_REPO_URL}" \
+    --cli-repo-url "${CLI_REPO_URL}" \
     --build-repo-branch-name "${BUILD_REPO_BRANCH_NAME}" \
     --cli-repo-branch-name "${CLI_REPO_BRANCH_NAME}" \
     --source-bucket "${SOURCE_BUCKET}" \
@@ -42,4 +47,5 @@ ${BASE_DIRECTORY}/release/bin/eks-anywhere-release release \
     --cdn "${CDN}" \
     --release-bucket "${RELEASE_BUCKET}" \
     --release-container-registry "${RELEASE_CONTAINER_REGISTRY}" \
-    --dev-release=true
+    --dev-release=true \
+    --dry-run=${DRY_RUN}

--- a/release/scripts/setup.sh
+++ b/release/scripts/setup.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -x
 set -e


### PR DESCRIPTION
This PR adds logic to generate a bundle manifest spec locally to visualize changes to release tooling. The dry-run mode will skip the artifacts download and upload, and only print the resulting manifest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
