### PR TITLE
Change the private network cidr

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -4,7 +4,7 @@ env:
   variables:
     INTEGRATION_TEST_MAX_EC2_COUNT: 60
     T_VSPHERE_CIDR: "198.18.128.0/17"
-    T_VSPHERE_PRIVATE_NETWORK_CIDR: "10.1.128.0/17"
+    T_VSPHERE_PRIVATE_NETWORK_CIDR: "197.18.128.0/17"
   secrets-manager:
     EKSA_VSPHERE_USERNAME: "vsphere_ci_beta_connection:vsphere_username"
     EKSA_VSPHERE_PASSWORD: "vsphere_ci_beta_connection:vsphere_password"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The current private network cidr for e2e conflicts with the VPN connection. Changing this to avoid the conflict and fix the private network tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
