### PR TITLE
Govc session persistance

### DIFF
--- a/pkg/filewriter/filewriter.go
+++ b/pkg/filewriter/filewriter.go
@@ -8,6 +8,7 @@ type FileWriter interface {
 	CleanUp()
 	CleanUpTemp()
 	Dir() string
+	TmpDir() string
 }
 
 type FileOptions struct {

--- a/pkg/filewriter/mocks/filewriter.go
+++ b/pkg/filewriter/mocks/filewriter.go
@@ -72,6 +72,20 @@ func (mr *MockFileWriterMockRecorder) Dir() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockFileWriter)(nil).Dir))
 }
 
+// TmpDir mocks base method.
+func (m *MockFileWriter) TmpDir() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TmpDir")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// TmpDir indicates an expected call of TmpDir.
+func (mr *MockFileWriterMockRecorder) TmpDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TmpDir", reflect.TypeOf((*MockFileWriter)(nil).TmpDir))
+}
+
 // WithDir mocks base method.
 func (m *MockFileWriter) WithDir(arg0 string) (filewriter.FileWriter, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
*Description of changes:*
Persist govc sessions to known tmp dir mounted in container
This should allow our cli to reuse the same vsphere session per command execution. It should help with concurrent session problems

We should add a mechanism to destroy the session at the end of each cli execution, to avoid leaving orphan sessions. If not, these will stay active until they expire. I'll follow up with a fix for this in the next PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
