### PR TITLE
enable arm builds of controller and cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,8 @@ eks-a-cross-platform-embed-latest-config: ## Build cross platform dev release ve
 	curl -L $(BUNDLE_MANIFEST_URL) --output pkg/cluster/config/bundle-release.yaml
 	$(MAKE) eks-a-embed-config GO_OS=darwin GO_ARCH=amd64 OUTPUT_FILE=bin/darwin/eksctl-anywhere
 	$(MAKE) eks-a-embed-config GO_OS=linux GO_ARCH=amd64 OUTPUT_FILE=bin/linux/eksctl-anywhere
+	$(MAKE) eks-a-embed-config GO_OS=darwin GO_ARCH=arm64 OUTPUT_FILE=bin/darwin/eksctl-anywhere
+	$(MAKE) eks-a-embed-config GO_OS=linux GO_ARCH=arm64 OUTPUT_FILE=bin/linux/eksctl-anywhere
 	rm pkg/cluster/config/bundle-release.yaml
 
 .PHONY: eks-a
@@ -99,11 +101,15 @@ eks-a-release: ## Generate a release binary
 eks-a-cross-platform: ## Generate binaries for Linux and MacOS
 	$(MAKE) eks-a-binary GIT_VERSION=$(DEV_GIT_VERSION) GO_OS=darwin GO_ARCH=amd64 OUTPUT_FILE=bin/darwin/eksctl-anywhere
 	$(MAKE) eks-a-binary GIT_VERSION=$(DEV_GIT_VERSION) GO_OS=linux GO_ARCH=amd64 OUTPUT_FILE=bin/linux/eksctl-anywhere
+	$(MAKE) eks-a-binary GIT_VERSION=$(DEV_GIT_VERSION) GO_OS=darwin GO_ARCH=arm64 OUTPUT_FILE=bin/darwin/eksctl-anywhere
+	$(MAKE) eks-a-binary GIT_VERSION=$(DEV_GIT_VERSION) GO_OS=linux GO_ARCH=arm64 OUTPUT_FILE=bin/linux/eksctl-anywhere
 
 .PHONY: eks-a-release-cross-platform
 eks-a-release-cross-platform: ## Generate binaries for Linux and MacOS
 	$(MAKE) eks-a-binary GIT_VERSION=$(GIT_VERSION) GO_OS=darwin GO_ARCH=amd64 OUTPUT_FILE=bin/darwin/eksctl-anywhere LINKER_FLAGS='-s -w -X github.com/aws/eks-anywhere/pkg/eksctl.enabled=true'
 	$(MAKE) eks-a-binary GIT_VERSION=$(GIT_VERSION) GO_OS=linux GO_ARCH=amd64 OUTPUT_FILE=bin/linux/eksctl-anywhere LINKER_FLAGS='-s -w -X github.com/aws/eks-anywhere/pkg/eksctl.enabled=true'
+	$(MAKE) eks-a-binary GIT_VERSION=$(GIT_VERSION) GO_OS=darwin GO_ARCH=arm64 OUTPUT_FILE=bin/darwin/eksctl-anywhere LINKER_FLAGS='-s -w -X github.com/aws/eks-anywhere/pkg/eksctl.enabled=true'
+	$(MAKE) eks-a-binary GIT_VERSION=$(GIT_VERSION) GO_OS=linux GO_ARCH=arm64 OUTPUT_FILE=bin/linux/eksctl-anywhere LINKER_FLAGS='-s -w -X github.com/aws/eks-anywhere/pkg/eksctl.enabled=true'
 
 $(TOOLS_BIN_DIR):
 	mkdir -p $(TOOLS_BIN_DIR)
@@ -185,7 +191,7 @@ cluster-controller-images: cluster-controller-binaries
 	$(BUILDKIT) \
 		build \
 		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
+		--opt platform=linux/amd64,linux/arm64 \
 		--opt build-arg:BASE_IMAGE=$(CLUSTER_CONTROLLER_BASE_IMAGE) \
 		--local dockerfile=./controllers/docker/linux/eks-anywhere-cluster-controller \
 		--local context=. \

--- a/controllers/build/create_binaries.sh
+++ b/controllers/build/create_binaries.sh
@@ -43,7 +43,7 @@ function build::eks-anywhere-cluster-controller::create_binaries(){
   ARCH="$(cut -d '/' -f2 <<< ${platform})"
   CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH make build-cluster-controller-binaries
   mkdir -p ${BIN_PATH}/${OS}-${ARCH}/
-  mv bin/* ${BIN_PATH}/${OS}-${ARCH}/
+  mv bin/manager ${BIN_PATH}/${OS}-${ARCH}/
 }
 
 function build::eks-anywhere-cluster-controller::manifests(){
@@ -74,6 +74,7 @@ function build::eks-anywhere-cluster-controller::binaries(){
   build::common::use_go_version $GOLANG_VERSION
   go mod vendor
   build::eks-anywhere-cluster-controller::create_binaries "linux/amd64"
+  build::eks-anywhere-cluster-controller::create_binaries "linux/arm64"
   build::eks-anywhere-cluster-controller::manifests
   build::gather_licenses $REPO_ROOT/_output "./controllers"
 }

--- a/controllers/docker/linux/eks-anywhere-cluster-controller/Dockerfile
+++ b/controllers/docker/linux/eks-anywhere-cluster-controller/Dockerfile
@@ -1,7 +1,10 @@
 ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base
 FROM $BASE_IMAGE
 
-COPY _output/bin/eks-anywhere-cluster-controller/linux-amd64/manager /usr/local/bin/manager
+ARG TARGETARCH
+ARG TARGETOS
+
+COPY _output/bin/eks-anywhere-cluster-controller/$TARGETOS-$TARGETARCH/manager /usr/local/bin/manager
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This adds arm64 builds of both the controller and cli.  We are doing testing with arm on linux with the hope to one day support arm based macs for at least running the bootstrap kind cluster (if not a full capd based cluster).  This is one of the last components which need an arm build.

Note, this makefile could use some cleanup, esp with some of the techniques we have started using in the build tooling repos.  I plan on make a pass at it in a future PR.  For now, I added to the mess a bit...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
