### PR TITLE
Update Flux e2e cofig default setting

### DIFF
--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -44,10 +44,9 @@ func WithFlux(opts ...api.GitOpsConfigOpt) ClusterE2ETestOpt {
 			api.WithPersonalFluxRepository(true),
 			api.WithStringFromEnvVarGitOpsConfig(gitRepositoryVar, api.WithFluxRepository),
 			api.WithStringFromEnvVarGitOpsConfig(githubUserVar, api.WithFluxOwner),
-			api.WithStringFromEnvVarGitOpsConfig("main", api.WithFluxBranch),
-			api.WithFluxNamespace("main"),
+			api.WithFluxNamespace("default"),
 			api.WithFluxConfigurationPath("path2"),
-			api.WithFluxBranch("default"),
+			api.WithFluxBranch("main"),
 		)
 		e.clusterFillers = append(e.clusterFillers,
 			api.WithGitOpsRef(defaultClusterName),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- remove duplicate setting for branch
- set default namespace to "default" instead of "main"
- set default branch to "main" instead of "default"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
