### PR TITLE
use bundle override for delete cluster calls

### DIFF
--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -56,6 +56,7 @@ func init() {
 	deleteClusterCmd.Flags().StringVarP(&dc.wConfig, "w-config", "w", "", "Kubeconfig file to use when deleting a workload cluster")
 	deleteClusterCmd.Flags().BoolVar(&dc.forceCleanup, "force-cleanup", false, "Force deletion of previously created bootstrap cluster")
 	deleteClusterCmd.Flags().StringVar(&dc.managementKubeconfig, "kubeconfig", "", "kubeconfig file pointing to a management cluster")
+	deleteClusterCmd.Flags().StringVar(&dc.bundlesOverride, "bundles-override", "", "Override default Bundles manifest (not recommended)")
 }
 
 func (dc *deleteClusterOptions) validate(ctx context.Context, args []string) error {

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -276,6 +276,9 @@ func (e *ClusterE2ETest) DeleteCluster(opts ...CommandOpt) {
 
 func (e *ClusterE2ETest) deleteCluster(opts ...CommandOpt) {
 	deleteClusterArgs := []string{"delete", "cluster", e.ClusterName, "-v", "4"}
+	if getBundlesOverride() == "true" {
+		deleteClusterArgs = append(deleteClusterArgs, "--bundles-override", defaultBundleReleaseManifestFile)
+	}
 	e.RunEKSA(deleteClusterArgs, opts...)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When running `create` and `upgrade` on a release branch, we use a bundle-override to specify the bundle associated with the release. However, we don't do this when running `delete`, as the option didn't even exist. This PR adds the option and configures the tests to use the correct bundle override when executing `delete` cluster. This way, we have a consistent execution throughout the E2E tests. This may be related to delete failures in the current release branch tests which show CAPI move and flux cleanup failing in unexpected ways.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
