### PR TITLE
Fix filepath for checking presence of local EKS-A components

### DIFF
--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -1982,6 +1982,13 @@ spec:
                 description: 'Deprecated: This field has no function and is going
                   to be removed in a future release.'
                 type: string
+              podIamConfig:
+                properties:
+                  serviceAccountIssuer:
+                    type: string
+                required:
+                - serviceAccountIssuer
+                type: object
               proxyConfiguration:
                 properties:
                   httpProxy:

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -147,7 +147,7 @@ func (e *E2ESession) uploadRequiredFile(file string) error {
 func (e *E2ESession) uploadRequiredFiles() error {
 	if e.bundlesOverride {
 		e.requiredFiles = append(e.requiredFiles, bundlesReleaseManifestFile)
-		if _, err := os.Stat(eksAComponentsManifestFile); err == nil {
+		if _, err := os.Stat(fmt.Sprintf("bin/%s", eksAComponentsManifestFile)); err == nil {
 			e.requiredFiles = append(e.requiredFiles, eksAComponentsManifestFile)
 		} else if errors.Is(err, os.ErrNotExist) {
 			logger.V(0).Info("WARNING: no components manifest override found, but bundle override is present. " +

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -1,7 +1,9 @@
 package e2e
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -35,6 +37,7 @@ type E2ESession struct {
 	controlPlaneIP      string
 	testEnvVars         map[string]string
 	bundlesOverride     bool
+	requiredFiles       []string
 }
 
 func newSession(amiId, instanceProfileName, storageBucket, jobId, subnetId, controlPlaneIP string, bundlesOverride bool) (*E2ESession, error) {
@@ -53,6 +56,7 @@ func newSession(amiId, instanceProfileName, storageBucket, jobId, subnetId, cont
 		controlPlaneIP:      controlPlaneIP,
 		testEnvVars:         make(map[string]string),
 		bundlesOverride:     bundlesOverride,
+		requiredFiles:       requiredFiles,
 	}
 
 	return e, nil
@@ -142,9 +146,17 @@ func (e *E2ESession) uploadRequiredFile(file string) error {
 
 func (e *E2ESession) uploadRequiredFiles() error {
 	if e.bundlesOverride {
-		requiredFiles = append(requiredFiles, bundlesReleaseManifestFile, eksAComponentsManifestFile)
+		e.requiredFiles = append(e.requiredFiles, bundlesReleaseManifestFile)
+		if _, err := os.Stat(eksAComponentsManifestFile); err == nil {
+			e.requiredFiles = append(e.requiredFiles, eksAComponentsManifestFile)
+		} else if errors.Is(err, os.ErrNotExist) {
+			logger.V(0).Info("WARNING: no components manifest override found, but bundle override is present. " +
+				"If the EKS-A components have changed be sure to provide a components override!")
+		} else {
+			return err
+		}
 	}
-	for _, file := range requiredFiles {
+	for _, file := range e.requiredFiles {
 		if file != "eksctl" {
 			err := e.uploadRequiredFile(file)
 			if err != nil {
@@ -206,16 +218,12 @@ func (e *E2ESession) generatedArtifactsBucketPath() string {
 }
 
 func (e *E2ESession) downloadRequiredFilesInInstance() error {
-	if e.bundlesOverride {
-		requiredFiles = append(requiredFiles, bundlesReleaseManifestFile, eksAComponentsManifestFile)
-	}
-	for _, file := range requiredFiles {
+	for _, file := range e.requiredFiles {
 		err := e.downloadRequiredFileInInstance(file)
 		if err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
This PR re-adds Dan's changes from #690, which were reverted in #697. It also adds a tiny fixup to the filepath that was being `stat`ed in that commit.

*Note:* Split into two commits for showing authorship.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
