### PR TITLE
Remove flux manual steps in upgrade doc

### DIFF
--- a/docs/content/en/docs/tasks/cluster/cluster-upgrades.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-upgrades.md
@@ -44,41 +44,7 @@ The command detects both component version changes and new builds of the same ve
 If there is a new Kubernetes version that is going to get rolled out, the core components get upgraded before the Kubernetes
 version. 
 Irrespective of a Kubernetes version change, the upgrade command will always upgrade the internal EKS
-Anywhere components mentioned above to their latest available versions. All upgrade changes are backwards compatible except GitOps.
-
-#### GitOps controller upgrade
-
-__Upgrading an existing GitOps enabled cluster created by an older release of the EKS-A CLI (v0.5.0 and below) requires a manual update to the git repository structure.__ 
-	
-Before running the `upgrade` command on an existing GitOps enabled cluster, you must:
-1. temporarily disable the EKS-A validating webhook 
-
-    - save the eksa validating webhook configuration to a local file 
-    - delete the validating webhook from the cluster
-    ```sh
-    kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io eksa-validating-webhook-configuration -n eksa-system -oyaml > eksa-validating-webhook.yaml
-    kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io eksa-validating-webhook-configuration -n eksa-system
-    ```
-2. move the EKS-A cluster configuration file into a subdirectory under the management cluster's root level, following the [repo directory convention]({{< relref "./cluster-flux/#create-gitops-configuration-repo" >}})
-3. update the version controlled cluster configuration file, `eksa-cluster.yaml`, so that the `clusterConfigPath` field of the `GitOpsConfig` reflects the new path of the `eksa-system` directory. For example:
-    ```yaml
-    apiVersion: anywhere.eks.amazonaws.com/v1alpha1
-    kind: GitOpsConfig
-    metadata:
-      name: management-cluster
-    spec:
-      flux:
-        github:
-          clusterConfigPath: clusters/management-cluster/management-cluster # old: clusters/management-cluster
-          ...
-    ```
-4. wait until the change is reflected in the cluster, then recreate the EKS-A validating webhook
-    ```sh
-    kubectl apply -f eksa-validating-webhook.yaml
-    ```
-
-After pushing the changes to the git repo, user can safely run the `upgrade` command, and the Flux components will be upgraded.
-
+Anywhere components mentioned above to their latest available versions. All upgrade changes are backwards compatible.
 
 ### Performing a cluster upgrade
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Manual step is no longer needed after v.0.6.1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
