### PR TITLE
Reuse executable container

### DIFF
--- a/cmd/eks-a-tool/cmd/validatecluster.go
+++ b/cmd/eks-a-tool/cmd/validatecluster.go
@@ -50,6 +50,7 @@ func validateCluster(ctx context.Context, cluster *types.Cluster, clusterName st
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
 	kubectl := executableBuilder.BuildKubectlExecutable()
+	defer kubectl.Close(ctx)
 	err = kubectl.ValidateNodes(ctx, cluster.KubeconfigFile)
 	if err != nil {
 		return err

--- a/cmd/eks-a-tool/cmd/versions.go
+++ b/cmd/eks-a-tool/cmd/versions.go
@@ -32,5 +32,8 @@ func versions(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
-	return executableBuilder.BuildKubectlExecutable().ListCluster(ctx)
+	kubectl := executableBuilder.BuildKubectlExecutable()
+	defer kubectl.Close(ctx)
+
+	return kubectl.ListCluster(ctx)
 }

--- a/cmd/eks-a-tool/cmd/vspherermvms.go
+++ b/cmd/eks-a-tool/cmd/vspherermvms.go
@@ -51,5 +51,8 @@ func vsphereRmVms(ctx context.Context, clusterName string, dryRun bool) error {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
 	tmpWriter, _ := filewriter.NewWriter("rmvms")
-	return executableBuilder.BuildGovcExecutable(tmpWriter).CleanupVms(ctx, clusterName, dryRun)
+	govc := executableBuilder.BuildGovcExecutable(tmpWriter)
+	defer govc.Close(ctx)
+
+	return govc.CleanupVms(ctx, clusterName, dryRun)
 }

--- a/cmd/eksctl-anywhere/cmd/cleanup.go
+++ b/cmd/eksctl-anywhere/cmd/cleanup.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/types"
+)
+
+func close(ctx context.Context, closer types.Closer) {
+	if err := closer.Close(ctx); err != nil {
+		logger.Error(err, "Closer failed", "closerType", fmt.Sprintf("%T", closer))
+	}
+}

--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -81,16 +81,17 @@ func (cc *createClusterOptions) createCluster(ctx context.Context) error {
 		return err
 	}
 
-	deps, err := dependencies.ForSpec(ctx, clusterSpec).
+	deps, err := dependencies.ForSpec(ctx, clusterSpec).WithExecutableMountDirs(cc.mountDirs()...).
 		WithBootstrapper().
 		WithClusterManager().
 		WithProvider(cc.fileName, clusterSpec.Cluster, cc.skipIpCheck).
 		WithFluxAddonClient(ctx, clusterSpec.Cluster, clusterSpec.GitOpsConfig).
 		WithWriter().
-		Build()
+		Build(ctx)
 	if err != nil {
 		return err
 	}
+	defer close(ctx, deps)
 
 	createCluster := workflows.NewCreate(
 		deps.Bootstrapper,

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -86,16 +86,17 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 		return fmt.Errorf("unable to get cluster config from file: %v", err)
 	}
 
-	deps, err := dependencies.ForSpec(ctx, clusterSpec).
+	deps, err := dependencies.ForSpec(ctx, clusterSpec).WithExecutableMountDirs(cc.mountDirs()...).
 		WithBootstrapper().
 		WithClusterManager().
 		WithProvider(dc.fileName, clusterSpec.Cluster, cc.skipIpCheck).
 		WithFluxAddonClient(ctx, clusterSpec.Cluster, clusterSpec.GitOpsConfig).
 		WithWriter().
-		Build()
+		Build(ctx)
 	if err != nil {
 		return err
 	}
+	defer close(ctx, deps)
 
 	deleteCluster := workflows.NewDelete(
 		deps.Bootstrapper,

--- a/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
@@ -94,10 +94,11 @@ func (gsbo *generateSupportBundleOptions) generateBundleConfig(ctx context.Conte
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).
 		WithProvider(f, clusterSpec.Cluster, cc.skipIpCheck).
 		WithDiagnosticBundleFactory().
-		Build()
+		Build(ctx)
 	if err != nil {
 		return nil, err
 	}
+	defer close(ctx, deps)
 
 	return deps.DignosticCollectorFactory.DiagnosticBundleFromSpec(clusterSpec, deps.Provider, gsbo.kubeConfig(clusterSpec.Name))
 }

--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/version"
@@ -11,6 +12,15 @@ type clusterOptions struct {
 	fileName             string
 	bundlesOverride      string
 	managementKubeconfig string
+}
+
+func (c clusterOptions) mountDirs() []string {
+	var dirs []string
+	if c.managementKubeconfig != "" {
+		dirs = append(dirs, filepath.Dir(c.managementKubeconfig))
+	}
+
+	return dirs
 }
 
 func newClusterSpec(options clusterOptions) (*cluster.Spec, error) {

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -95,10 +95,11 @@ func (csbo *createSupportBundleOptions) createBundle(ctx context.Context, since,
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).
 		WithProvider(csbo.fileName, clusterSpec.Cluster, cc.skipIpCheck).
 		WithDiagnosticBundleFactory().
-		Build()
+		Build(ctx)
 	if err != nil {
 		return err
 	}
+	defer close(ctx, deps)
 
 	supportBundle, err := deps.DignosticCollectorFactory.DiagnosticBundle(clusterSpec, deps.Provider, csbo.kubeConfig(clusterSpec.Name), bundleConfig)
 	if err != nil {

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -79,7 +79,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(ctx context.Context) error {
 		return err
 	}
 
-	deps, err := dependencies.ForSpec(ctx, clusterSpec).
+	deps, err := dependencies.ForSpec(ctx, clusterSpec).WithExecutableMountDirs(cc.mountDirs()...).
 		WithBootstrapper().
 		WithClusterManager().
 		WithProvider(uc.fileName, clusterSpec.Cluster, cc.skipIpCheck).
@@ -87,10 +87,11 @@ func (uc *upgradeClusterOptions) upgradeCluster(ctx context.Context) error {
 		WithWriter().
 		WithCAPIManager().
 		WithKubectl().
-		Build()
+		Build(ctx)
 	if err != nil {
 		return err
 	}
+	defer close(ctx, deps)
 
 	upgradeCluster := workflows.NewUpgrade(
 		deps.Bootstrapper,

--- a/internal/test/e2e/vsphere.go
+++ b/internal/test/e2e/vsphere.go
@@ -46,5 +46,8 @@ func vsphereRmVms(ctx context.Context, clusterName string) error {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
 	tmpWriter, _ := filewriter.NewWriter("rmvms")
-	return executableBuilder.BuildGovcExecutable(tmpWriter).CleanupVms(ctx, clusterName, false)
+	govc := executableBuilder.BuildGovcExecutable(tmpWriter)
+	defer govc.Close(ctx)
+
+	return govc.CleanupVms(ctx, clusterName, false)
 }

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -2,6 +2,7 @@ package dependencies_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -20,6 +21,11 @@ type factoryTest struct {
 
 func newTest(t *testing.T) *factoryTest {
 	clusterConfigFile := "testdata/cluster_vsphere.yaml"
+	// Disable tools image executable for the tests
+	if err := os.Setenv("MR_TOOLS_DISABLE", "true"); err != nil {
+		t.Fatal(err)
+	}
+
 	return &factoryTest{
 		WithT:             NewGomegaWithT(t),
 		clusterConfigFile: clusterConfigFile,
@@ -32,7 +38,7 @@ func TestFactoryBuildWithProvider(t *testing.T) {
 	tt := newTest(t)
 	deps, err := dependencies.NewFactory().
 		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false).
-		Build()
+		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())
 	tt.Expect(deps.Provider).NotTo(BeNil())
@@ -42,7 +48,7 @@ func TestFactoryBuildWithClusterManager(t *testing.T) {
 	tt := newTest(t)
 	deps, err := dependencies.NewFactory().
 		WithClusterManager().
-		Build()
+		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())
 	tt.Expect(deps.ClusterManager).NotTo(BeNil())
@@ -61,7 +67,7 @@ func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
 		WithCollectorFactory().
 		WithTroubleshoot().
 		WithCAPIManager().
-		Build()
+		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())
 	tt.Expect(deps.Bootstrapper).NotTo(BeNil())

--- a/pkg/executables/awscli.go
+++ b/pkg/executables/awscli.go
@@ -8,17 +8,17 @@ import (
 const awsCliPath = "aws"
 
 type AwsCli struct {
-	executable Executable
+	Executable
 }
 
 func NewAwsCli(executable Executable) *AwsCli {
 	return &AwsCli{
-		executable: executable,
+		Executable: executable,
 	}
 }
 
 func (ac *AwsCli) CreateAccessKey(ctx context.Context, username string) (string, error) {
-	stdOut, err := ac.executable.Execute(ctx, "iam", "create-access-key", "--user-name", username)
+	stdOut, err := ac.Execute(ctx, "iam", "create-access-key", "--user-name", username)
 	if err != nil {
 		return "", fmt.Errorf("error executing iam create-access-key: %v", err)
 	}

--- a/pkg/executables/builder.go
+++ b/pkg/executables/builder.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
-const defaultEksaImage = "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v1-21-4-ed8ad899e40f0a0e625b7a49d7d90e6077f97a28"
+const defaultEksaImage = "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.1.0-eks-a-v0.0.0-dev-build.529"
 
 type ExecutableBuilder struct {
 	useDocker  bool

--- a/pkg/executables/clusterawsadm.go
+++ b/pkg/executables/clusterawsadm.go
@@ -11,15 +11,15 @@ import (
 const clusterAwsAdminPath = "clusterawsadm"
 
 type Clusterawsadm struct {
-	executable Executable
+	Executable
 }
 
 func NewClusterawsadm(executable Executable) *Clusterawsadm {
-	return &Clusterawsadm{executable: executable}
+	return &Clusterawsadm{Executable: executable}
 }
 
 func (c *Clusterawsadm) BootstrapIam(ctx context.Context, envs map[string]string, configFile string) error {
-	_, err := c.executable.ExecuteWithEnv(ctx, envs, "bootstrap", "iam", "create-cloudformation-stack",
+	_, err := c.ExecuteWithEnv(ctx, envs, "bootstrap", "iam", "create-cloudformation-stack",
 		"--config", configFile)
 	if err != nil {
 		return fmt.Errorf("error executing bootstrap iam: %v", err)
@@ -28,7 +28,7 @@ func (c *Clusterawsadm) BootstrapIam(ctx context.Context, envs map[string]string
 }
 
 func (c *Clusterawsadm) BootstrapCreds(ctx context.Context, envs map[string]string) (string, error) {
-	stdOut, err := c.executable.ExecuteWithEnv(ctx, envs, "bootstrap", "credentials", "encode-as-profile")
+	stdOut, err := c.ExecuteWithEnv(ctx, envs, "bootstrap", "credentials", "encode-as-profile")
 	if err != nil {
 		return "", fmt.Errorf("error executing bootstrap credentials: %v", err)
 	}
@@ -36,7 +36,7 @@ func (c *Clusterawsadm) BootstrapCreds(ctx context.Context, envs map[string]stri
 }
 
 func (c *Clusterawsadm) ListAccessKeys(ctx context.Context, userName string) (string, error) {
-	stdOut, err := c.executable.Execute(ctx, "aws", "iam", "list-access-keys", "--user-name", userName)
+	stdOut, err := c.Execute(ctx, "aws", "iam", "list-access-keys", "--user-name", userName)
 	if err != nil {
 		return "", fmt.Errorf("error listing user keys: %v", err)
 	}
@@ -45,7 +45,7 @@ func (c *Clusterawsadm) ListAccessKeys(ctx context.Context, userName string) (st
 
 func (c *Clusterawsadm) DeleteCloudformationStack(ctx context.Context, envs map[string]string, fileName string) error {
 	logger.V(1).Info("Deleting AWS user")
-	_, err := c.executable.ExecuteWithEnv(ctx, envs, "bootstrap", "iam", "delete-cloudformation-stack", "--config", fileName)
+	_, err := c.ExecuteWithEnv(ctx, envs, "bootstrap", "iam", "delete-cloudformation-stack", "--config", fileName)
 	if err != nil {
 		if strings.Contains(err.Error(), "status code: 400") {
 			return nil

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -33,8 +33,8 @@ const (
 var clusterctlConfigTemplate string
 
 type Clusterctl struct {
-	executable Executable
-	writer     filewriter.FileWriter
+	Executable
+	writer filewriter.FileWriter
 }
 
 type clusterctlConfiguration struct {
@@ -48,7 +48,7 @@ type clusterctlConfiguration struct {
 
 func NewClusterctl(executable Executable, writer filewriter.FileWriter) *Clusterctl {
 	return &Clusterctl{
-		executable: executable,
+		Executable: executable,
 		writer:     writer,
 	}
 }
@@ -148,7 +148,7 @@ func (c *Clusterctl) MoveManagement(ctx context.Context, from, to *types.Cluster
 	if from.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", from.KubeconfigFile)
 	}
-	_, err := c.executable.Execute(ctx, params...)
+	_, err := c.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("failed moving management cluster: %v", err)
 	}
@@ -156,7 +156,7 @@ func (c *Clusterctl) MoveManagement(ctx context.Context, from, to *types.Cluster
 }
 
 func (c *Clusterctl) GetWorkloadKubeconfig(ctx context.Context, clusterName string, cluster *types.Cluster) ([]byte, error) {
-	stdOut, err := c.executable.Execute(
+	stdOut, err := c.Execute(
 		ctx, "get", "kubeconfig", clusterName,
 		"--kubeconfig", cluster.KubeconfigFile,
 		"--namespace", constants.EksaSystemNamespace,
@@ -203,7 +203,7 @@ func (c *Clusterctl) InitInfrastructure(ctx context.Context, clusterSpec *cluste
 		return err
 	}
 
-	_, err = c.executable.ExecuteWithEnv(ctx, envMap, params...)
+	_, err = c.ExecuteWithEnv(ctx, envMap, params...)
 	if err != nil {
 		return fmt.Errorf("error executing init: %v", err)
 	}
@@ -334,7 +334,7 @@ func (c *Clusterctl) Upgrade(ctx context.Context, managementCluster *types.Clust
 		return fmt.Errorf("failed generating provider env map for clusterctl upgrade: %v", err)
 	}
 
-	if _, err = c.executable.ExecuteWithEnv(ctx, providerEnvMap, upgradeCommand...); err != nil {
+	if _, err = c.ExecuteWithEnv(ctx, providerEnvMap, upgradeCommand...); err != nil {
 		return fmt.Errorf("failed running upgrade apply with clusterctl: %v", err)
 	}
 
@@ -383,7 +383,7 @@ func (c *Clusterctl) InstallEtcdadmProviders(ctx context.Context, clusterSpec *c
 		return err
 	}
 
-	_, err = c.executable.ExecuteWithEnv(ctx, envMap, params...)
+	_, err = c.ExecuteWithEnv(ctx, envMap, params...)
 	if err != nil {
 		return fmt.Errorf("error executing init: %v", err)
 	}

--- a/pkg/executables/docker.go
+++ b/pkg/executables/docker.go
@@ -15,16 +15,16 @@ const (
 )
 
 type Docker struct {
-	executable Executable
+	Executable
 }
 
 func NewDocker(executable Executable) *Docker {
-	return &Docker{executable: executable}
+	return &Docker{Executable: executable}
 }
 
 func (d *Docker) GetDockerLBPort(ctx context.Context, clusterName string) (port string, err error) {
 	clusterLBName := fmt.Sprintf("%s-lb", clusterName)
-	if stdout, err := d.executable.Execute(ctx, "port", clusterLBName, "6443/tcp"); err != nil {
+	if stdout, err := d.Execute(ctx, "port", clusterLBName, "6443/tcp"); err != nil {
 		return "", err
 	} else {
 		return strings.Split(stdout.String(), ":")[1], nil
@@ -33,7 +33,7 @@ func (d *Docker) GetDockerLBPort(ctx context.Context, clusterName string) (port 
 
 func (d *Docker) PullImage(ctx context.Context, image string) error {
 	logger.V(2).Info("Pulling docker image", "image", image)
-	if _, err := d.executable.Execute(ctx, "pull", image); err != nil {
+	if _, err := d.Execute(ctx, "pull", image); err != nil {
 		return err
 	} else {
 		return nil
@@ -50,7 +50,7 @@ func (d *Docker) SetUpCLITools(ctx context.Context, image string) error {
 }
 
 func (d *Docker) Version(ctx context.Context) (int, error) {
-	cmdOutput, err := d.executable.Execute(ctx, "version", "--format", "{{.Client.Version}}")
+	cmdOutput, err := d.Execute(ctx, "version", "--format", "{{.Client.Version}}")
 	if err != nil {
 		return 0, fmt.Errorf("please check if docker is installed and running %v", err)
 	}
@@ -65,7 +65,7 @@ func (d *Docker) Version(ctx context.Context) (int, error) {
 }
 
 func (d *Docker) AllocatedMemory(ctx context.Context) (uint64, error) {
-	cmdOutput, err := d.executable.Execute(ctx, "info", "--format", "'{{json .MemTotal}}'")
+	cmdOutput, err := d.Execute(ctx, "info", "--format", "'{{json .MemTotal}}'")
 	if err != nil {
 		return 0, fmt.Errorf("please check if docker is installed and running %v", err)
 	}
@@ -77,7 +77,7 @@ func (d *Docker) AllocatedMemory(ctx context.Context) (uint64, error) {
 func (d *Docker) TagImage(ctx context.Context, image string, endpoint string) error {
 	localImage := strings.ReplaceAll(image, defaultRegistry, endpoint)
 	logger.Info("Tagging image", "image", image, "local image", localImage)
-	if _, err := d.executable.Execute(ctx, "tag", image, localImage); err != nil {
+	if _, err := d.Execute(ctx, "tag", image, localImage); err != nil {
 		return err
 	}
 	return nil
@@ -86,7 +86,7 @@ func (d *Docker) TagImage(ctx context.Context, image string, endpoint string) er
 func (d *Docker) PushImage(ctx context.Context, image string, endpoint string) error {
 	localImage := strings.ReplaceAll(image, defaultRegistry, endpoint)
 	logger.Info("Pushing", "image", localImage)
-	if _, err := d.executable.Execute(ctx, "push", localImage); err != nil {
+	if _, err := d.Execute(ctx, "push", localImage); err != nil {
 		return err
 	}
 	return nil
@@ -95,6 +95,6 @@ func (d *Docker) PushImage(ctx context.Context, image string, endpoint string) e
 func (d *Docker) Login(ctx context.Context, endpoint, username, password string) error {
 	params := []string{"login", endpoint, "--username", username, "--password-stdin"}
 	logger.Info(fmt.Sprintf("Logging in to docker registry %s", endpoint))
-	_, err := d.executable.ExecuteWithStdin(ctx, []byte(password), params...)
+	_, err := d.ExecuteWithStdin(ctx, []byte(password), params...)
 	return err
 }

--- a/pkg/executables/dockercontainer.go
+++ b/pkg/executables/dockercontainer.go
@@ -1,0 +1,80 @@
+package executables
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
+)
+
+type dockerContainer struct {
+	image               string
+	workingDir          string
+	mountDirs           []string
+	containerName       string
+	dockerBinary        *Docker
+	initOnce, closeOnce sync.Once
+}
+
+func newDockerContainer(image, workingDir string, mountDirs []string, dockerBinary *Docker) *dockerContainer {
+	return &dockerContainer{
+		image:         image,
+		workingDir:    workingDir,
+		mountDirs:     mountDirs,
+		containerName: containerNamePrefix + strconv.FormatInt(time.Now().UnixNano(), 10),
+		dockerBinary:  dockerBinary,
+	}
+}
+
+func (d *dockerContainer) init(ctx context.Context) error {
+	var err error
+	d.initOnce.Do(func() {
+		if err = d.dockerBinary.PullImage(ctx, d.image); err != nil {
+			return
+		}
+
+		var absWorkingDir string
+		absWorkingDir, err = filepath.Abs(d.workingDir)
+		if err != nil {
+			err = fmt.Errorf("error getting abs path for mount dir: %v", err)
+			return
+		}
+
+		params := []string{"run", "-d", "--name", d.containerName, "--network", "host", "-w", absWorkingDir, "-v", "/var/run/docker.sock:/var/run/docker.sock"}
+
+		for _, m := range d.mountDirs {
+			var absMountDir string
+			absMountDir, err = filepath.Abs(m)
+			if err != nil {
+				err = fmt.Errorf("error getting abs path for mount dir: %v", err)
+				return
+			}
+			params = append(params, "-v", fmt.Sprintf("%[1]s:%[1]s", absMountDir))
+		}
+
+		// start container and keep it running in the background
+		logger.V(3).Info("Initializing long running container", "name", d.containerName, "image", d.image)
+		params = append(params, "--entrypoint", "sleep", d.image, "infinity")
+		_, err = d.dockerBinary.Execute(ctx, params...)
+	})
+
+	return err
+}
+
+func (d *dockerContainer) Close(ctx context.Context) error {
+	if d == nil {
+		return nil
+	}
+
+	var err error
+	d.closeOnce.Do(func() {
+		logger.V(3).Info("Cleaning up long running container", "name", d.containerName)
+		_, err = d.dockerBinary.Execute(ctx, "rm", "-f", "-v", d.containerName)
+	})
+
+	return err
+}

--- a/pkg/executables/dockerlinux.go
+++ b/pkg/executables/dockerlinux.go
@@ -1,0 +1,65 @@
+package executables
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+)
+
+const containerNamePrefix = "eksa_"
+
+type linuxDockerExecutable struct {
+	*dockerContainer
+	cli string
+}
+
+// This currently returns a linuxDockerExecutable, but if we support other types of docker executables we can change
+// the name of this constructor
+func NewDockerExecutable(cli string, container *dockerContainer) Executable {
+	return &linuxDockerExecutable{
+		cli:             cli,
+		dockerContainer: container,
+	}
+}
+
+func (e *linuxDockerExecutable) Execute(ctx context.Context, args ...string) (bytes.Buffer, error) {
+	var stdout bytes.Buffer
+	if command, err := e.buildCommand(map[string]string{}, e.cli, args...); err != nil {
+		return stdout, err
+	} else {
+		return execute(ctx, "docker", nil, command...)
+	}
+}
+
+func (e *linuxDockerExecutable) ExecuteWithStdin(ctx context.Context, in []byte, args ...string) (bytes.Buffer, error) {
+	var stdout bytes.Buffer
+	if command, err := e.buildCommand(map[string]string{}, e.cli, args...); err != nil {
+		return stdout, err
+	} else {
+		return execute(ctx, "docker", in, command...)
+	}
+}
+
+func (e *linuxDockerExecutable) ExecuteWithEnv(ctx context.Context, envs map[string]string, args ...string) (bytes.Buffer, error) {
+	var stdout bytes.Buffer
+	if command, err := e.buildCommand(envs, e.cli, args...); err != nil {
+		return stdout, err
+	} else {
+		return execute(ctx, "docker", nil, command...)
+	}
+}
+
+func (e *linuxDockerExecutable) buildCommand(envs map[string]string, cli string, args ...string) ([]string, error) {
+	var envVars []string
+	for k, v := range envs {
+		envVars = append(envVars, "-e", fmt.Sprintf("%s=%s", k, v))
+	}
+
+	dockerCommands := []string{"exec", "-i"}
+	dockerCommands = append(dockerCommands, envVars...)
+
+	dockerCommands = append(dockerCommands, e.containerName, e.cli)
+	dockerCommands = append(dockerCommands, args...)
+
+	return dockerCommands, nil
+}

--- a/pkg/executables/executables.go
+++ b/pkg/executables/executables.go
@@ -7,17 +7,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
 const (
-	redactMask          = "*****"
-	containerNamePrefix = "eksa_"
+	redactMask = "*****"
 )
 
 var redactedEnvKeys = []string{vSphereUsernameKey, vSpherePasswordKey}
@@ -26,107 +22,17 @@ type executable struct {
 	cli string
 }
 
-type linuxDockerExecutable struct {
-	cli      string
-	image    string
-	mountDir string
-}
-
 type Executable interface {
 	Execute(ctx context.Context, args ...string) (stdout bytes.Buffer, err error)
 	ExecuteWithEnv(ctx context.Context, envs map[string]string, args ...string) (stdout bytes.Buffer, err error)
 	ExecuteWithStdin(ctx context.Context, in []byte, args ...string) (stdout bytes.Buffer, err error)
+	Close(ctx context.Context) error
 }
 
 // this should only be called through the executables.builder
 func NewExecutable(cli string) Executable {
 	return &executable{
 		cli: cli,
-	}
-}
-
-// This currently returns a linuxDockerExecutable, but if we support other types of docker executables we can change
-// the name of this constructor
-func NewDockerExecutable(cli, image string, mountDir string) Executable {
-	return &linuxDockerExecutable{
-		cli:      cli,
-		image:    image,
-		mountDir: mountDir,
-	}
-}
-
-func (e *linuxDockerExecutable) workingDirectory() (string, error) {
-	path, err := filepath.Abs(e.mountDir)
-	if err != nil {
-		return "", fmt.Errorf("error getting abs path for working dir: %v", err)
-	}
-
-	return path, nil
-}
-
-func (e *linuxDockerExecutable) Execute(ctx context.Context, args ...string) (bytes.Buffer, error) {
-	var stdout bytes.Buffer
-	if command, containerName, err := e.buildCommand(map[string]string{}, e.cli, args...); err != nil {
-		return stdout, err
-	} else {
-		defer e.executeCleanup(ctx, containerName)
-		return execute(ctx, "docker", nil, command...)
-	}
-}
-
-func (e *linuxDockerExecutable) ExecuteWithStdin(ctx context.Context, in []byte, args ...string) (bytes.Buffer, error) {
-	var stdout bytes.Buffer
-	if command, containerName, err := e.buildCommand(map[string]string{}, e.cli, args...); err != nil {
-		return stdout, err
-	} else {
-		defer e.executeCleanup(ctx, containerName)
-		return execute(ctx, "docker", in, command...)
-	}
-}
-
-func (e *linuxDockerExecutable) buildCommand(envs map[string]string, cli string, args ...string) ([]string, string, error) {
-	directory, err := e.workingDirectory()
-	if err != nil {
-		return nil, "", err
-	}
-
-	var envVars []string
-	for k, v := range envs {
-		envVars = append(envVars, "-e", fmt.Sprintf("%s=%s", k, v))
-	}
-	containerName := containerNamePrefix + cli + "_" + strconv.FormatInt(time.Now().UnixNano(), 10)
-	dockerCommands := []string{
-		"run", "--name", containerName, "-i", "--network", "host", "-v", fmt.Sprintf("%[1]s:%[1]s", directory),
-		"-w", directory, "-v", "/var/run/docker.sock:/var/run/docker.sock",
-	}
-
-	for idx, dir := range args {
-		if dir == "--kubeconfig" {
-			absPath, err := filepath.Abs(filepath.Dir(args[idx+1]))
-			if err != nil {
-				return nil, "", err
-			}
-			workDirAbsPath := directory
-			if absPath != "." && absPath != workDirAbsPath {
-				dockerCommands = append(dockerCommands, "-v", absPath+":"+absPath)
-			}
-		}
-	}
-
-	dockerCommands = append(dockerCommands, envVars...)
-	dockerCommands = append(dockerCommands, "--entrypoint", cli, e.image)
-	dockerCommands = append(dockerCommands, args...)
-
-	return dockerCommands, containerName, nil
-}
-
-func (e *linuxDockerExecutable) ExecuteWithEnv(ctx context.Context, envs map[string]string, args ...string) (bytes.Buffer, error) {
-	var stdout bytes.Buffer
-	if command, containerName, err := e.buildCommand(envs, e.cli, args...); err != nil {
-		return stdout, err
-	} else {
-		defer e.executeCleanup(ctx, containerName)
-		return execute(ctx, "docker", nil, command...)
 	}
 }
 
@@ -143,6 +49,10 @@ func (e *executable) ExecuteWithEnv(ctx context.Context, envs map[string]string,
 		os.Setenv(k, v)
 	}
 	return e.Execute(ctx, args...)
+}
+
+func (e *executable) Close(ctx context.Context) error {
+	return nil
 }
 
 func redactCreds(cmd string) string {
@@ -190,18 +100,4 @@ func execute(ctx context.Context, cli string, in []byte, args ...string) (bytes.
 		logger.V(8).Info(cli, "stderr", stderr.String())
 	}
 	return stdout, nil
-}
-
-func (e *linuxDockerExecutable) executeCleanup(ctx context.Context, containerName string) {
-	dockerCommands := []string{
-		"rm", "-f", "-v", containerName,
-	}
-	cmd := exec.CommandContext(ctx, "docker", dockerCommands...)
-	infoMessage := "cleaning up container " + containerName
-	logger.V(6).Info(infoMessage, "cmd", cmd)
-
-	err := cmd.Run()
-	if err != nil {
-		logger.V(1).Error(err, "error cleaning up docker container", "container", containerName)
-	}
 }

--- a/pkg/executables/flux.go
+++ b/pkg/executables/flux.go
@@ -17,12 +17,12 @@ const (
 )
 
 type Flux struct {
-	executable Executable
+	Executable
 }
 
 func NewFlux(executable Executable) *Flux {
 	return &Flux{
-		executable: executable,
+		Executable: executable,
 	}
 }
 
@@ -61,7 +61,7 @@ func (f *Flux) BootstrapToolkitsComponents(ctx context.Context, cluster *types.C
 	env := make(map[string]string)
 	env[githubTokenEnv] = token
 
-	_, err = f.executable.ExecuteWithEnv(ctx, env, params...)
+	_, err = f.ExecuteWithEnv(ctx, env, params...)
 	if err != nil {
 		return fmt.Errorf("error executing flux bootstrap: %v", err)
 	}
@@ -82,7 +82,7 @@ func (f *Flux) UninstallToolkitsComponents(ctx context.Context, cluster *types.C
 		params = append(params, "--namespace", c.FluxSystemNamespace)
 	}
 
-	_, err := f.executable.Execute(ctx, params...)
+	_, err := f.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error uninstalling flux: %v", err)
 	}
@@ -100,7 +100,7 @@ func (f *Flux) PauseKustomization(ctx context.Context, cluster *types.Cluster, g
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
 
-	_, err := f.executable.Execute(ctx, params...)
+	_, err := f.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error executing flux suspend kustomization: %v", err)
 	}
@@ -119,7 +119,7 @@ func (f *Flux) ResumeKustomization(ctx context.Context, cluster *types.Cluster, 
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
 
-	_, err := f.executable.Execute(ctx, params...)
+	_, err := f.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error executing flux resume kustomization: %v", err)
 	}
@@ -141,7 +141,7 @@ func (f *Flux) Reconcile(ctx context.Context, cluster *types.Cluster, gitOpsConf
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
 
-	if _, err := f.executable.Execute(ctx, params...); err != nil {
+	if _, err := f.Execute(ctx, params...); err != nil {
 		return fmt.Errorf("error executing flux reconcile: %v", err)
 	}
 

--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -56,15 +56,15 @@ const (
 )
 
 type Govc struct {
-	writer     filewriter.FileWriter
-	executable Executable
-	retrier    *retrier.Retrier
+	writer filewriter.FileWriter
+	Executable
+	retrier *retrier.Retrier
 }
 
 func NewGovc(executable Executable, writer filewriter.FileWriter) *Govc {
 	return &Govc{
 		writer:     writer,
-		executable: executable,
+		Executable: executable,
 		retrier:    retrier.NewWithMaxRetries(maxRetries, backOffPeriod),
 	}
 }
@@ -75,7 +75,7 @@ func (g *Govc) exec(ctx context.Context, args ...string) (stdout bytes.Buffer, e
 		return bytes.Buffer{}, fmt.Errorf("failed govc validations: %v", err)
 	}
 
-	return g.executable.ExecuteWithEnv(ctx, envMap, args...)
+	return g.ExecuteWithEnv(ctx, envMap, args...)
 }
 
 func (g *Govc) SearchTemplate(ctx context.Context, datacenter string, machineConfig *v1alpha1.VSphereMachineConfig) (string, error) {
@@ -85,7 +85,7 @@ func (g *Govc) SearchTemplate(ctx context.Context, datacenter string, machineCon
 	}
 
 	params := []string{"find", "-json", "/" + datacenter, "-type", "VirtualMachine", "-name", filepath.Base(machineConfig.Spec.Template)}
-	templateResponse, err := g.executable.ExecuteWithEnv(ctx, envMap, params...)
+	templateResponse, err := g.ExecuteWithEnv(ctx, envMap, params...)
 	if err != nil {
 		return "", fmt.Errorf("error getting template: %v", err)
 	}
@@ -196,7 +196,7 @@ func (g *Govc) TemplateHasSnapshot(ctx context.Context, template string) (bool, 
 	}
 
 	params := []string{"snapshot.tree", "-vm", template}
-	snap, err := g.executable.ExecuteWithEnv(ctx, envMap, params...)
+	snap, err := g.ExecuteWithEnv(ctx, envMap, params...)
 	if err != nil {
 		return false, fmt.Errorf("failed to get snapshot details: %v", err)
 	}
@@ -217,7 +217,7 @@ func (g *Govc) GetWorkloadAvailableSpace(ctx context.Context, machineConfig *v1a
 	}
 
 	params := []string{"datastore.info", "-json=true", machineConfig.Spec.Datastore}
-	result, err := g.executable.ExecuteWithEnv(ctx, envMap, params...)
+	result, err := g.ExecuteWithEnv(ctx, envMap, params...)
 	if err != nil {
 		return 0, fmt.Errorf("error getting datastore info: %v", err)
 	}
@@ -313,7 +313,7 @@ func (g *Govc) deployTemplate(ctx context.Context, library, templateName, deploy
 	bFolderNotFound := false
 	params := []string{"folder.info", deployFolder}
 	err = g.retrier.Retry(func() error {
-		errBuffer, err := g.executable.ExecuteWithEnv(ctx, envMap, params...)
+		errBuffer, err := g.ExecuteWithEnv(ctx, envMap, params...)
 		errString := strings.ToLower(errBuffer.String())
 		if err != nil {
 			if !strings.Contains(errString, "not found") {
@@ -327,7 +327,7 @@ func (g *Govc) deployTemplate(ctx context.Context, library, templateName, deploy
 	if err != nil || bFolderNotFound {
 		params = []string{"folder.create", deployFolder}
 		err = g.retrier.Retry(func() error {
-			errBuffer, err := g.executable.ExecuteWithEnv(ctx, envMap, params...)
+			errBuffer, err := g.ExecuteWithEnv(ctx, envMap, params...)
 			errString := strings.ToLower(errBuffer.String())
 			if err != nil && !strings.Contains(errString, "already exists") {
 				return fmt.Errorf("error creating folder: %v", err)
@@ -466,7 +466,7 @@ func (g *Govc) CleanupVms(ctx context.Context, clusterName string, dryRun bool) 
 	var result bytes.Buffer
 
 	params = strings.Fields("find -type VirtualMachine -name " + clusterName + "*")
-	result, err = g.executable.ExecuteWithEnv(ctx, envMap, params...)
+	result, err = g.ExecuteWithEnv(ctx, envMap, params...)
 	if err != nil {
 		return fmt.Errorf("error getting vm list: %v", err)
 	}
@@ -478,9 +478,9 @@ func (g *Govc) CleanupVms(ctx context.Context, clusterName string, dryRun bool) 
 			continue
 		}
 		params = strings.Fields("vm.power -off -force " + vmName)
-		result, _ = g.executable.ExecuteWithEnv(ctx, envMap, params...)
+		result, _ = g.ExecuteWithEnv(ctx, envMap, params...)
 		params = strings.Fields("object.destroy " + vmName)
-		result, _ = g.executable.ExecuteWithEnv(ctx, envMap, params...)
+		result, _ = g.ExecuteWithEnv(ctx, envMap, params...)
 		logger.Info("Deleted ", "vm_name", vmName)
 	}
 
@@ -505,7 +505,7 @@ func (g *Govc) ValidateVCenterSetup(ctx context.Context, datacenterConfig *v1alp
 
 	params := []string{"about", "-k"}
 	err = g.retrier.Retry(func() error {
-		_, err = g.executable.ExecuteWithEnv(ctx, envMap, params...)
+		_, err = g.ExecuteWithEnv(ctx, envMap, params...)
 		return err
 	})
 	if err != nil {
@@ -516,13 +516,13 @@ func (g *Govc) ValidateVCenterSetup(ctx context.Context, datacenterConfig *v1alp
 	// hack to test if thumbprint is required or not
 	if !datacenterConfig.Spec.Insecure {
 		params = []string{"about"}
-		_, err = g.executable.ExecuteWithEnv(ctx, envMap, params...)
+		_, err = g.ExecuteWithEnv(ctx, envMap, params...)
 		if err != nil {
 			// self-signed, thumbprint is be required
 			*selfSigned = true
 			if len(datacenterConfig.Spec.Thumbprint) > 0 {
 				params := []string{"about.cert", "-thumbprint", "-k"}
-				buffer, err := g.executable.ExecuteWithEnv(ctx, envMap, params...)
+				buffer, err := g.ExecuteWithEnv(ctx, envMap, params...)
 				if err != nil {
 					return fmt.Errorf("unable to retrieve thumbprint: %v", err)
 				}
@@ -552,7 +552,7 @@ func (g *Govc) ValidateVCenterSetup(ctx context.Context, datacenterConfig *v1alp
 
 	params = []string{"datacenter.info", datacenterConfig.Spec.Datacenter}
 	err = g.retrier.Retry(func() error {
-		_, err = g.executable.ExecuteWithEnv(ctx, envMap, params...)
+		_, err = g.ExecuteWithEnv(ctx, envMap, params...)
 		return err
 	})
 	if err != nil {
@@ -566,7 +566,7 @@ func (g *Govc) ValidateVCenterSetup(ctx context.Context, datacenterConfig *v1alp
 	}
 	params = []string{"find", "-maxdepth=1", filepath.Dir(datacenterConfig.Spec.Network), "-type", "n", "-name", filepath.Base(datacenterConfig.Spec.Network)}
 	err = g.retrier.Retry(func() error {
-		network, _ := g.executable.ExecuteWithEnv(ctx, envMap, params...)
+		network, _ := g.ExecuteWithEnv(ctx, envMap, params...)
 		if network.String() == "" {
 			return fmt.Errorf("network '%s' not found", filepath.Base(datacenterConfig.Spec.Network))
 		}
@@ -591,7 +591,7 @@ func (g *Govc) ValidateVCenterSetupMachineConfig(ctx context.Context, datacenter
 	}
 	params := []string{"datastore.info", machineConfig.Spec.Datastore}
 	err = g.retrier.Retry(func() error {
-		_, err = g.executable.ExecuteWithEnv(ctx, envMap, params...)
+		_, err = g.ExecuteWithEnv(ctx, envMap, params...)
 		if err != nil {
 			datastorePath := filepath.Dir(machineConfig.Spec.Datastore)
 			isValidDatastorePath := g.isValidPath(ctx, envMap, datastorePath)
@@ -616,7 +616,7 @@ func (g *Govc) ValidateVCenterSetupMachineConfig(ctx context.Context, datacenter
 		}
 		params = []string{"folder.info", machineConfig.Spec.Folder}
 		err = g.retrier.Retry(func() error {
-			_, err := g.executable.ExecuteWithEnv(ctx, envMap, params...)
+			_, err := g.ExecuteWithEnv(ctx, envMap, params...)
 			if err != nil {
 				err = g.createFolder(ctx, envMap, machineConfig)
 				if err != nil {
@@ -642,7 +642,7 @@ func (g *Govc) ValidateVCenterSetupMachineConfig(ctx context.Context, datacenter
 	var poolInfoResponse bytes.Buffer
 	params = []string{"find", "-json", "/" + datacenterConfig.Spec.Datacenter, "-type", "p", "-name", filepath.Base(machineConfig.Spec.ResourcePool)}
 	err = g.retrier.Retry(func() error {
-		poolInfoResponse, err = g.executable.ExecuteWithEnv(ctx, envMap, params...)
+		poolInfoResponse, err = g.ExecuteWithEnv(ctx, envMap, params...)
 		return err
 	})
 	if err != nil {
@@ -699,7 +699,7 @@ func prependPath(folderType FolderType, folderPath string, datacenter string) (s
 func (g *Govc) createFolder(ctx context.Context, envMap map[string]string, machineConfig *v1alpha1.VSphereMachineConfig) error {
 	params := []string{"folder.create", machineConfig.Spec.Folder}
 	err := g.retrier.Retry(func() error {
-		_, err := g.executable.ExecuteWithEnv(ctx, envMap, params...)
+		_, err := g.ExecuteWithEnv(ctx, envMap, params...)
 		if err != nil {
 			return fmt.Errorf("error creating folder: %v", err)
 		}
@@ -710,7 +710,7 @@ func (g *Govc) createFolder(ctx context.Context, envMap map[string]string, machi
 
 func (g *Govc) isValidPath(ctx context.Context, envMap map[string]string, path string) bool {
 	params := []string{"folder.info", path}
-	_, err := g.executable.ExecuteWithEnv(ctx, envMap, params...)
+	_, err := g.ExecuteWithEnv(ctx, envMap, params...)
 	return err == nil
 }
 

--- a/pkg/executables/kind.go
+++ b/pkg/executables/kind.go
@@ -23,8 +23,8 @@ var kindConfigTemplate string
 const configFileName = "kind_tmp.yaml"
 
 type Kind struct {
-	writer     filewriter.FileWriter
-	executable Executable
+	writer filewriter.FileWriter
+	Executable
 	execConfig *kindExecConfig
 }
 
@@ -50,7 +50,7 @@ type kindExecConfig struct {
 func NewKind(executable Executable, writer filewriter.FileWriter) *Kind {
 	return &Kind{
 		writer:     writer,
-		executable: executable,
+		Executable: executable,
 	}
 }
 
@@ -78,7 +78,7 @@ func (k *Kind) CreateBootstrapCluster(ctx context.Context, clusterSpec *cluster.
 	executionArgs := k.execArguments(clusterSpec.Name, kubeconfigName)
 
 	logger.V(4).Info("Creating kind cluster", "name", getInternalName(clusterSpec.Name), "kubeconfig", kubeconfigName)
-	_, err = k.executable.ExecuteWithEnv(ctx, k.execConfig.env, executionArgs...)
+	_, err = k.ExecuteWithEnv(ctx, k.execConfig.env, executionArgs...)
 	if err != nil {
 		return "", fmt.Errorf("error executing create cluster: %v", err)
 	}
@@ -88,7 +88,7 @@ func (k *Kind) CreateBootstrapCluster(ctx context.Context, clusterSpec *cluster.
 
 func (k *Kind) ClusterExists(ctx context.Context, clusterName string) (bool, error) {
 	internalName := getInternalName(clusterName)
-	stdOut, err := k.executable.Execute(ctx, "get", "clusters")
+	stdOut, err := k.Execute(ctx, "get", "clusters")
 	if err != nil {
 		return false, fmt.Errorf("error executing get clusters: %v", err)
 	}
@@ -111,7 +111,7 @@ func (k *Kind) ClusterExists(ctx context.Context, clusterName string) (bool, err
 
 func (k *Kind) GetKubeconfig(ctx context.Context, clusterName string) (string, error) {
 	internalName := getInternalName(clusterName)
-	stdOut, err := k.executable.Execute(ctx, "get", "kubeconfig", "--name", internalName)
+	stdOut, err := k.Execute(ctx, "get", "kubeconfig", "--name", internalName)
 	if err != nil {
 		return "", fmt.Errorf("error executing get kubeconfig: %v", err)
 	}
@@ -171,7 +171,7 @@ func (k *Kind) WithRegistryMirror(endpoint string, caCertFile string) bootstrapp
 func (k *Kind) DeleteBootstrapCluster(ctx context.Context, cluster *types.Cluster) error {
 	internalName := getInternalName(cluster.Name)
 	logger.V(4).Info("Deleting kind cluster", "name", internalName)
-	_, err := k.executable.Execute(ctx, "delete", "cluster", "--name", internalName)
+	_, err := k.Execute(ctx, "delete", "cluster", "--name", internalName)
 	if err != nil {
 		return fmt.Errorf("error executing delete cluster: %v", err)
 	}

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -46,7 +46,7 @@ var (
 )
 
 type Kubectl struct {
-	executable Executable
+	Executable
 }
 
 type VersionResponse struct {
@@ -56,19 +56,19 @@ type VersionResponse struct {
 
 func NewKubectl(executable Executable) *Kubectl {
 	return &Kubectl{
-		executable: executable,
+		Executable: executable,
 	}
 }
 
 func (k *Kubectl) GetNamespace(ctx context.Context, kubeconfig string, namespace string) error {
 	params := []string{"get", "namespace", namespace, "--kubeconfig", kubeconfig}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	return err
 }
 
 func (k *Kubectl) CreateNamespace(ctx context.Context, kubeconfig string, namespace string) error {
 	params := []string{"create", "namespace", namespace, "--kubeconfig", kubeconfig}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error creating namespace %v: %v", namespace, err)
 	}
@@ -77,7 +77,7 @@ func (k *Kubectl) CreateNamespace(ctx context.Context, kubeconfig string, namesp
 
 func (k *Kubectl) DeleteNamespace(ctx context.Context, kubeconfig string, namespace string) error {
 	params := []string{"delete", "namespace", namespace, "--kubeconfig", kubeconfig}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error creating namespace %v: %v", namespace, err)
 	}
@@ -86,7 +86,7 @@ func (k *Kubectl) DeleteNamespace(ctx context.Context, kubeconfig string, namesp
 
 func (k *Kubectl) LoadSecret(ctx context.Context, secretObject string, secretObjectType string, secretObjectName string, kubeConfFile string) error {
 	params := []string{"create", "secret", "generic", secretObjectName, "--type", secretObjectType, "--from-literal", secretObject, "--kubeconfig", kubeConfFile, "--namespace", constants.EksaSystemNamespace}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error loading secret: %v", err)
 	}
@@ -98,7 +98,7 @@ func (k *Kubectl) ApplyKubeSpec(ctx context.Context, cluster *types.Cluster, spe
 	if cluster.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error executing apply: %v", err)
 	}
@@ -110,7 +110,7 @@ func (k *Kubectl) ApplyKubeSpecWithNamespace(ctx context.Context, cluster *types
 	if cluster.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error executing apply: %v", err)
 	}
@@ -122,7 +122,7 @@ func (k *Kubectl) ApplyKubeSpecFromBytes(ctx context.Context, cluster *types.Clu
 	if cluster.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
-	_, err := k.executable.ExecuteWithStdin(ctx, data, params...)
+	_, err := k.ExecuteWithStdin(ctx, data, params...)
 	if err != nil {
 		return fmt.Errorf("error executing apply: %v", err)
 	}
@@ -134,7 +134,7 @@ func (k *Kubectl) ApplyKubeSpecFromBytesWithNamespace(ctx context.Context, clust
 	if cluster.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
-	_, err := k.executable.ExecuteWithStdin(ctx, data, params...)
+	_, err := k.ExecuteWithStdin(ctx, data, params...)
 	if err != nil {
 		return fmt.Errorf("error executing apply: %v", err)
 	}
@@ -146,7 +146,7 @@ func (k *Kubectl) ApplyKubeSpecFromBytesForce(ctx context.Context, cluster *type
 	if cluster.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
-	_, err := k.executable.ExecuteWithStdin(ctx, data, params...)
+	_, err := k.ExecuteWithStdin(ctx, data, params...)
 	if err != nil {
 		return fmt.Errorf("error executing apply --force: %v", err)
 	}
@@ -158,7 +158,7 @@ func (k *Kubectl) DeleteKubeSpecFromBytes(ctx context.Context, cluster *types.Cl
 	if cluster.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
-	_, err := k.executable.ExecuteWithStdin(ctx, data, params...)
+	_, err := k.ExecuteWithStdin(ctx, data, params...)
 	if err != nil {
 		return fmt.Errorf("error executing apply: %v", err)
 	}
@@ -178,7 +178,7 @@ func (k *Kubectl) WaitForDeployment(ctx context.Context, cluster *types.Cluster,
 }
 
 func (k *Kubectl) Wait(ctx context.Context, kubeconfig string, timeout string, forCondition string, property string, namespace string) error {
-	_, err := k.executable.Execute(ctx, "wait", "--timeout", timeout,
+	_, err := k.Execute(ctx, "wait", "--timeout", timeout,
 		"--for=condition="+forCondition, property, "--kubeconfig", kubeconfig, "-n", namespace)
 	if err != nil {
 		return fmt.Errorf("error executing wait: %v", err)
@@ -188,7 +188,7 @@ func (k *Kubectl) Wait(ctx context.Context, kubeconfig string, timeout string, f
 
 func (k *Kubectl) DeleteEksaVSphereDatacenterConfig(ctx context.Context, vsphereDatacenterConfigName string, kubeconfigFile string, namespace string) error {
 	params := []string{"delete", eksaVSphereDatacenterResourceType, vsphereDatacenterConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace, "--ignore-not-found=true"}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error deleting vspheredatacenterconfig cluster %s apply: %v", vsphereDatacenterConfigName, err)
 	}
@@ -197,7 +197,7 @@ func (k *Kubectl) DeleteEksaVSphereDatacenterConfig(ctx context.Context, vsphere
 
 func (k *Kubectl) DeleteEksaVSphereMachineConfig(ctx context.Context, vsphereMachineConfigName string, kubeconfigFile string, namespace string) error {
 	params := []string{"delete", eksaVSphereMachineResourceType, vsphereMachineConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace, "--ignore-not-found=true"}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error deleting vspheremachineconfig cluster %s apply: %v", vsphereMachineConfigName, err)
 	}
@@ -206,7 +206,7 @@ func (k *Kubectl) DeleteEksaVSphereMachineConfig(ctx context.Context, vsphereMac
 
 func (k *Kubectl) DeleteEKSACluster(ctx context.Context, managementCluster *types.Cluster, eksaClusterName, eksaClusterNamespace string) error {
 	params := []string{"delete", eksaClusterResourceType, eksaClusterName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", eksaClusterNamespace, "--ignore-not-found=true"}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error deleting eksa cluster %s apply: %v", eksaClusterName, err)
 	}
@@ -215,7 +215,7 @@ func (k *Kubectl) DeleteEKSACluster(ctx context.Context, managementCluster *type
 
 func (k *Kubectl) DeleteGitOpsConfig(ctx context.Context, managementCluster *types.Cluster, gitOpsConfigName, gitOpsConfigNamespace string) error {
 	params := []string{"delete", eksaGitOpsResourceType, gitOpsConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", gitOpsConfigNamespace, "--ignore-not-found=true"}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error deleting gitops config %s apply: %v", gitOpsConfigName, err)
 	}
@@ -224,7 +224,7 @@ func (k *Kubectl) DeleteGitOpsConfig(ctx context.Context, managementCluster *typ
 
 func (k *Kubectl) DeleteSecret(ctx context.Context, managementCluster *types.Cluster, secretName, namespace string) error {
 	params := []string{"delete", "secret", secretName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", namespace}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error deleting secret %s in namespace %s: %v", secretName, namespace, err)
 	}
@@ -233,7 +233,7 @@ func (k *Kubectl) DeleteSecret(ctx context.Context, managementCluster *types.Clu
 
 func (k *Kubectl) DeleteOIDCConfig(ctx context.Context, managementCluster *types.Cluster, oidcConfigName, oidcConfigNamespace string) error {
 	params := []string{"delete", eksaOIDCResourceType, oidcConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", oidcConfigNamespace, "--ignore-not-found=true"}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error deleting oidc config %s apply: %v", oidcConfigName, err)
 	}
@@ -242,7 +242,7 @@ func (k *Kubectl) DeleteOIDCConfig(ctx context.Context, managementCluster *types
 
 func (k *Kubectl) DeleteAWSIamConfig(ctx context.Context, managementCluster *types.Cluster, awsIamConfigName, awsIamConfigNamespace string) error {
 	params := []string{"delete", eksaAwsIamResourceType, awsIamConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", awsIamConfigNamespace, "--ignore-not-found=true"}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error deleting awsIam config %s apply: %v", awsIamConfigName, err)
 	}
@@ -251,7 +251,7 @@ func (k *Kubectl) DeleteAWSIamConfig(ctx context.Context, managementCluster *typ
 
 func (k *Kubectl) DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster) error {
 	params := []string{"delete", capiClustersResourceType, clusterToDelete.Name, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", constants.EksaSystemNamespace}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error deleting cluster %s apply: %v", clusterToDelete.Name, err)
 	}
@@ -260,7 +260,7 @@ func (k *Kubectl) DeleteCluster(ctx context.Context, managementCluster, clusterT
 
 func (k *Kubectl) ListCluster(ctx context.Context) error {
 	params := []string{"get", "pods", "-A", "-o", "jsonpath={..image}"}
-	output, err := k.executable.Execute(ctx, params...)
+	output, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error listing cluster versions: %v", err)
 	}
@@ -284,7 +284,7 @@ func (k *Kubectl) ListCluster(ctx context.Context) error {
 func (k *Kubectl) ValidateNodes(ctx context.Context, kubeconfig string) error {
 	template := "{{range .items}}{{.metadata.name}}\n{{end}}"
 	params := []string{"get", "nodes", "-o", "go-template", "--template", template, "--kubeconfig", kubeconfig}
-	buffer, err := k.executable.Execute(ctx, params...)
+	buffer, err := k.Execute(ctx, params...)
 	if err != nil {
 		return err
 	}
@@ -294,7 +294,7 @@ func (k *Kubectl) ValidateNodes(ctx context.Context, kubeconfig string) error {
 		if len(node) != 0 {
 			template = "{{range .status.conditions}}{{if eq .type \"Ready\"}}{{.reason}}{{end}}{{end}}"
 			params = []string{"get", "node", node, "-o", "go-template", "--template", template, "--kubeconfig", kubeconfig}
-			buffer, err = k.executable.Execute(ctx, params...)
+			buffer, err = k.Execute(ctx, params...)
 			if err != nil {
 				return err
 			}
@@ -354,7 +354,7 @@ func (k *Kubectl) VsphereWorkerNodesMachineTemplate(ctx context.Context, cluster
 	}
 
 	params := []string{"get", "vspheremachinetemplates", machineTemplateName, "-o", "go-template", "--template", "{{.spec.template.spec}}", "-o", "yaml", "--kubeconfig", kubeconfig, "--namespace", namespace}
-	buffer, err := k.executable.Execute(ctx, params...)
+	buffer, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +369,7 @@ func (k *Kubectl) MachineTemplateName(ctx context.Context, clusterName string, k
 	template := "{{.spec.template.spec.infrastructureRef.name}}"
 	params := []string{"get", "MachineDeployment", fmt.Sprintf("%s-md-0", clusterName), "-o", "go-template", "--template", template, "--kubeconfig", kubeconfig}
 	applyOpts(&params, opts...)
-	buffer, err := k.executable.Execute(ctx, params...)
+	buffer, err := k.Execute(ctx, params...)
 	if err != nil {
 		return "", err
 	}
@@ -379,7 +379,7 @@ func (k *Kubectl) MachineTemplateName(ctx context.Context, clusterName string, k
 func (k *Kubectl) ValidatePods(ctx context.Context, kubeconfig string) error {
 	template := "{{range .items}}{{.metadata.name}},{{.status.phase}}\n{{end}}"
 	params := []string{"get", "pods", "-A", "-o", "go-template", "--template", template, "--kubeconfig", kubeconfig}
-	buffer, err := k.executable.Execute(ctx, params...)
+	buffer, err := k.Execute(ctx, params...)
 	if err != nil {
 		return err
 	}
@@ -410,7 +410,7 @@ func (k *Kubectl) SaveLog(ctx context.Context, cluster *types.Cluster, deploymen
 
 	params = append(params, logParams...)
 
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error saving logs: %v", err)
 	}
@@ -432,7 +432,7 @@ func (k *Kubectl) GetMachines(ctx context.Context, cluster *types.Cluster, clust
 		"--selector=cluster.x-k8s.io/cluster-name=" + clusterName,
 		"--namespace", constants.EksaSystemNamespace,
 	}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting machines: %v", err)
 	}
@@ -468,7 +468,7 @@ type VSphereMachineConfigResponse struct {
 
 func (k *Kubectl) ValidateClustersCRD(ctx context.Context, cluster *types.Cluster) error {
 	params := []string{"get", "crd", capiClustersResourceType, "--kubeconfig", cluster.KubeconfigFile}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error getting clusters crd: %v", err)
 	}
@@ -477,7 +477,7 @@ func (k *Kubectl) ValidateClustersCRD(ctx context.Context, cluster *types.Cluste
 
 func (k *Kubectl) ValidateEKSAClustersCRD(ctx context.Context, cluster *types.Cluster) error {
 	params := []string{"get", "crd", eksaClusterResourceType, "--kubeconfig", cluster.KubeconfigFile}
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error getting eksa clusters crd: %v", err)
 	}
@@ -486,7 +486,7 @@ func (k *Kubectl) ValidateEKSAClustersCRD(ctx context.Context, cluster *types.Cl
 
 func (k *Kubectl) GetClusters(ctx context.Context, cluster *types.Cluster) ([]types.CAPICluster, error) {
 	params := []string{"get", capiClustersResourceType, "-o", "json", "--kubeconfig", cluster.KubeconfigFile, "--namespace", constants.EksaSystemNamespace}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting clusters: %v", err)
 	}
@@ -502,7 +502,7 @@ func (k *Kubectl) GetClusters(ctx context.Context, cluster *types.Cluster) ([]ty
 
 func (k *Kubectl) GetApiServerUrl(ctx context.Context, cluster *types.Cluster) (string, error) {
 	params := []string{"config", "view", "--kubeconfig", cluster.KubeconfigFile, "--minify", "--raw", "-o", "jsonpath={.clusters[0].cluster.server}"}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return "", fmt.Errorf("error getting api server url: %v", err)
 	}
@@ -513,7 +513,7 @@ func (k *Kubectl) GetApiServerUrl(ctx context.Context, cluster *types.Cluster) (
 func (k *Kubectl) GetClusterCATlsCert(ctx context.Context, clusterName string, cluster *types.Cluster, namespace string) ([]byte, error) {
 	secretName := fmt.Sprintf("%s-ca", clusterName)
 	params := []string{"get", "secret", secretName, "--kubeconfig", cluster.KubeconfigFile, "-o", `jsonpath={.data.tls\.crt}`, "--namespace", namespace}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting cluster ca tls cert: %v", err)
 	}
@@ -523,7 +523,7 @@ func (k *Kubectl) GetClusterCATlsCert(ctx context.Context, clusterName string, c
 
 func (k *Kubectl) Version(ctx context.Context, cluster *types.Cluster) (*VersionResponse, error) {
 	params := []string{"version", "-o", "json", "--kubeconfig", cluster.KubeconfigFile}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error executing kubectl version: %v", err)
 	}
@@ -584,7 +584,7 @@ func applyOpts(params *[]string, opts ...KubectlOpt) {
 func (k *Kubectl) GetPods(ctx context.Context, opts ...KubectlOpt) ([]corev1.Pod, error) {
 	params := []string{"get", "pods", "-o", "json"}
 	applyOpts(&params, opts...)
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting pods: %v", err)
 	}
@@ -601,7 +601,7 @@ func (k *Kubectl) GetPods(ctx context.Context, opts ...KubectlOpt) ([]corev1.Pod
 func (k *Kubectl) GetDeployments(ctx context.Context, opts ...KubectlOpt) ([]appsv1.Deployment, error) {
 	params := []string{"get", "deployments", "-o", "json"}
 	applyOpts(&params, opts...)
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting deployments: %v", err)
 	}
@@ -622,7 +622,7 @@ func (k *Kubectl) GetSecretFromNamespace(ctx context.Context, kubeconfigFile, na
 func (k *Kubectl) GetSecret(ctx context.Context, secretObjectName string, opts ...KubectlOpt) (*corev1.Secret, error) {
 	params := []string{"get", "secret", secretObjectName, "-o", "json"}
 	applyOpts(&params, opts...)
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting secret: %v", err)
 	}
@@ -637,7 +637,7 @@ func (k *Kubectl) GetSecret(ctx context.Context, secretObjectName string, opts .
 func (k *Kubectl) GetKubeadmControlPlanes(ctx context.Context, opts ...KubectlOpt) ([]kubeadmnv1alpha3.KubeadmControlPlane, error) {
 	params := []string{"get", fmt.Sprintf("kubeadmcontrolplanes.controlplane.%s", v1alpha3.GroupVersion.Group), "-o", "json"}
 	applyOpts(&params, opts...)
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting kubeadmcontrolplanes: %v", err)
 	}
@@ -655,7 +655,7 @@ func (k *Kubectl) GetKubeadmControlPlane(ctx context.Context, cluster *types.Clu
 	logger.V(6).Info("Getting KubeadmControlPlane CRDs", "cluster", clusterName)
 	params := []string{"get", fmt.Sprintf("kubeadmcontrolplanes.controlplane.%s", v1alpha3.GroupVersion.Group), clusterName, "-o", "json"}
 	applyOpts(&params, opts...)
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting kubeadmcontrolplane: %v", err)
 	}
@@ -672,7 +672,7 @@ func (k *Kubectl) GetKubeadmControlPlane(ctx context.Context, cluster *types.Clu
 func (k *Kubectl) GetMachineDeployment(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...KubectlOpt) (*v1alpha3.MachineDeployment, error) {
 	params := []string{"get", fmt.Sprintf("machinedeployments.%s", v1alpha3.GroupVersion.Group), fmt.Sprintf("%s-md-0", clusterName), "-o", "json"}
 	applyOpts(&params, opts...)
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting machine deployment: %v", err)
 	}
@@ -689,7 +689,7 @@ func (k *Kubectl) GetMachineDeployment(ctx context.Context, cluster *types.Clust
 func (k *Kubectl) GetMachineDeployments(ctx context.Context, opts ...KubectlOpt) ([]v1alpha3.MachineDeployment, error) {
 	params := []string{"get", fmt.Sprintf("machinedeployments.%s", v1alpha3.GroupVersion.Group), "-o", "json"}
 	applyOpts(&params, opts...)
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting machine deployments: %v", err)
 	}
@@ -709,7 +709,7 @@ func (k *Kubectl) UpdateEnvironmentVariables(ctx context.Context, resourceType, 
 		params = append(params, fmt.Sprintf("%s=%s", k, v))
 	}
 	applyOpts(&params, opts...)
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error setting the environment variables in %s %s: %v", resourceType, resourceName, err)
 	}
@@ -726,7 +726,7 @@ func (k *Kubectl) UpdateAnnotation(ctx context.Context, resourceType, objectName
 		params = append(params, fmt.Sprintf("%s=%s", k, v))
 	}
 	applyOpts(&params, opts...)
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error updating annotation: %v", err)
 	}
@@ -740,7 +740,7 @@ func (k *Kubectl) UpdateAnnotationInNamespace(ctx context.Context, resourceType,
 func (k *Kubectl) RemoveAnnotation(ctx context.Context, resourceType, objectName string, key string, opts ...KubectlOpt) error {
 	params := []string{"annotate", resourceType, objectName, fmt.Sprintf("%s-", key)}
 	applyOpts(&params, opts...)
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error removing annotation: %v", err)
 	}
@@ -753,7 +753,7 @@ func (k *Kubectl) RemoveAnnotationInNamespace(ctx context.Context, resourceType,
 
 func (k *Kubectl) GetEksaCluster(ctx context.Context, cluster *types.Cluster, clusterName string) (*v1alpha1.Cluster, error) {
 	params := []string{"get", "clusters", "-A", "-o", "jsonpath={.items[0]}", "--kubeconfig", cluster.KubeconfigFile, "--field-selector=metadata.name=" + clusterName}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting eksa cluster: %v", err)
 	}
@@ -772,7 +772,7 @@ func (k *Kubectl) SearchVsphereMachineConfig(ctx context.Context, name string, k
 		"get", eksaVSphereMachineResourceType, "-o", "json", "--kubeconfig",
 		kubeconfigFile, "--namespace", namespace, "--field-selector=metadata.name=" + name,
 	}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error searching eksa VSphereMachineConfigResponse: %v", err)
 	}
@@ -802,7 +802,7 @@ func (k *Kubectl) SearchIdentityProviderConfig(ctx context.Context, ipName strin
 		"get", internalType, "-o", "json", "--kubeconfig",
 		kubeconfigFile, "--namespace", namespace, "--field-selector=metadata.name=" + ipName,
 	}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error searching eksa IdentityProvider: %v", err)
 	}
@@ -821,7 +821,7 @@ func (k *Kubectl) SearchVsphereDatacenterConfig(ctx context.Context, datacenterN
 		"get", eksaVSphereDatacenterResourceType, "-o", "json", "--kubeconfig",
 		kubeconfigFile, "--namespace", namespace, "--field-selector=metadata.name=" + datacenterName,
 	}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error searching eksa VSphereDatacenterConfigResponse: %v", err)
 	}
@@ -840,7 +840,7 @@ func (k *Kubectl) SearchEksaGitOpsConfig(ctx context.Context, gitOpsConfigName s
 		"get", eksaGitOpsResourceType, "-o", "json", "--kubeconfig",
 		kubeconfigFile, "--namespace", namespace, "--field-selector=metadata.name=" + gitOpsConfigName,
 	}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error searching eksa GitOpsConfig: %v", err)
 	}
@@ -856,7 +856,7 @@ func (k *Kubectl) SearchEksaGitOpsConfig(ctx context.Context, gitOpsConfigName s
 
 func (k *Kubectl) GetEksaGitOpsConfig(ctx context.Context, gitOpsConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.GitOpsConfig, error) {
 	params := []string{"get", eksaGitOpsResourceType, gitOpsConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting eksa GitOpsConfig: %v", err)
 	}
@@ -872,7 +872,7 @@ func (k *Kubectl) GetEksaGitOpsConfig(ctx context.Context, gitOpsConfigName stri
 
 func (k *Kubectl) GetEksaOIDCConfig(ctx context.Context, oidcConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.OIDCConfig, error) {
 	params := []string{"get", eksaOIDCResourceType, oidcConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting eksa OIDCConfig: %v", err)
 	}
@@ -888,7 +888,7 @@ func (k *Kubectl) GetEksaOIDCConfig(ctx context.Context, oidcConfigName string, 
 
 func (k *Kubectl) GetEksaAWSIamConfig(ctx context.Context, awsIamConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.AWSIamConfig, error) {
 	params := []string{"get", eksaAwsIamResourceType, awsIamConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting eksa AWSIamConfig: %v", err)
 	}
@@ -904,7 +904,7 @@ func (k *Kubectl) GetEksaAWSIamConfig(ctx context.Context, awsIamConfigName stri
 
 func (k *Kubectl) GetEksaVSphereDatacenterConfig(ctx context.Context, vsphereDatacenterConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.VSphereDatacenterConfig, error) {
 	params := []string{"get", eksaVSphereDatacenterResourceType, vsphereDatacenterConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting eksa vsphere cluster %v", err)
 	}
@@ -920,7 +920,7 @@ func (k *Kubectl) GetEksaVSphereDatacenterConfig(ctx context.Context, vsphereDat
 
 func (k *Kubectl) GetEksaVSphereMachineConfig(ctx context.Context, vsphereMachineConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.VSphereMachineConfig, error) {
 	params := []string{"get", eksaVSphereMachineResourceType, vsphereMachineConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting eksa vsphere cluster %v", err)
 	}
@@ -936,7 +936,7 @@ func (k *Kubectl) GetEksaVSphereMachineConfig(ctx context.Context, vsphereMachin
 
 func (k *Kubectl) GetEksaAWSDatacenterConfig(ctx context.Context, awsDatacenterConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.AWSDatacenterConfig, error) {
 	params := []string{"get", eksaAwsResourceType, awsDatacenterConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting eksa aws cluster %v", err)
 	}
@@ -952,7 +952,7 @@ func (k *Kubectl) GetEksaAWSDatacenterConfig(ctx context.Context, awsDatacenterC
 
 func (k *Kubectl) GetCurrentClusterContext(ctx context.Context, cluster *types.Cluster) (string, error) {
 	params := []string{"config", "view", "--kubeconfig", cluster.KubeconfigFile, "--minify", "--raw", "-o", "jsonpath={.contexts[0].name}"}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return "", fmt.Errorf("error getting current cluster context name: %v", err)
 	}
@@ -964,7 +964,7 @@ func (k *Kubectl) GetEtcdadmCluster(ctx context.Context, cluster *types.Cluster,
 	logger.V(6).Info("Getting EtcdadmCluster CRD", "cluster", clusterName)
 	params := []string{"get", etcdadmClustersResourceType, fmt.Sprintf("%s-etcd", clusterName), "-o", "json"}
 	applyOpts(&params, opts...)
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting etcdadmCluster: %v", err)
 	}
@@ -981,7 +981,7 @@ func (k *Kubectl) GetEtcdadmCluster(ctx context.Context, cluster *types.Cluster,
 func (k *Kubectl) ValidateNodesVersion(ctx context.Context, kubeconfig string, kubeVersion v1alpha1.KubernetesVersion) error {
 	template := "{{range .items}}{{.status.nodeInfo.kubeletVersion}}\n{{end}}"
 	params := []string{"get", "nodes", "-o", "go-template", "--template", template, "--kubeconfig", kubeconfig}
-	buffer, err := k.executable.Execute(ctx, params...)
+	buffer, err := k.Execute(ctx, params...)
 	if err != nil {
 		return err
 	}
@@ -999,7 +999,7 @@ func (k *Kubectl) ValidateNodesVersion(ctx context.Context, kubeconfig string, k
 
 func (k *Kubectl) GetBundles(ctx context.Context, kubeconfigFile, name, namespace string) (*releasev1alpha1.Bundles, error) {
 	params := []string{"get", bundlesResourceType, name, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting Bundles with kubectl: %v", err)
 	}
@@ -1015,7 +1015,7 @@ func (k *Kubectl) GetBundles(ctx context.Context, kubeconfigFile, name, namespac
 
 func (k *Kubectl) GetClusterResourceSet(ctx context.Context, kubeconfigFile, name, namespace string) (*addons.ClusterResourceSet, error) {
 	params := []string{"get", clusterResourceSetResourceType, name, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting ClusterResourceSet with kubectl: %v", err)
 	}
@@ -1030,7 +1030,7 @@ func (k *Kubectl) GetClusterResourceSet(ctx context.Context, kubeconfigFile, nam
 
 func (k *Kubectl) GetConfigMap(ctx context.Context, kubeconfigFile, name, namespace string) (*corev1.ConfigMap, error) {
 	params := []string{"get", "configmap", name, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting ConfigMap with kubectl: %v", err)
 	}
@@ -1050,7 +1050,7 @@ func (k *Kubectl) SetDaemonSetImage(ctx context.Context, kubeconfigFile, name, n
 func (k *Kubectl) setImage(ctx context.Context, kind, name, container, image string, opts ...KubectlOpt) error {
 	params := []string{"set", "image", fmt.Sprintf("%s/%s", kind, name), fmt.Sprintf("%s=%s", container, image)}
 	applyOpts(&params, opts...)
-	_, err := k.executable.Execute(ctx, params...)
+	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("error setting image for %s: %v", kind, err)
 	}
@@ -1060,7 +1060,7 @@ func (k *Kubectl) setImage(ctx context.Context, kind, name, container, image str
 
 func (k *Kubectl) CheckProviderExists(ctx context.Context, kubeconfigFile, name, namespace string) (bool, error) {
 	params := []string{"get", "namespace", fmt.Sprintf("--field-selector=metadata.name=%s", namespace), "--kubeconfig", kubeconfigFile}
-	stdOut, err := k.executable.Execute(ctx, params...)
+	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return false, fmt.Errorf("error checking whether provider namespace exists: %v", err)
 	}
@@ -1069,7 +1069,7 @@ func (k *Kubectl) CheckProviderExists(ctx context.Context, kubeconfigFile, name,
 	}
 
 	params = []string{"get", "provider", "--namespace", namespace, fmt.Sprintf("--field-selector=metadata.name=%s", name), "--kubeconfig", kubeconfigFile}
-	stdOut, err = k.executable.Execute(ctx, params...)
+	stdOut, err = k.Execute(ctx, params...)
 	if err != nil {
 		return false, fmt.Errorf("error checking whether provider exists: %v", err)
 	}
@@ -1094,7 +1094,7 @@ func (k *Kubectl) ApplyTolerationsFromTaints(ctx context.Context, oldTaints []co
 		"-o", "jsonpath={range .spec.template.spec}{.tolerations} {end}",
 		"-n", namespace, "--kubeconfig", kubeconfigFile,
 	}
-	output, err := k.executable.Execute(ctx, params...)
+	output, err := k.Execute(ctx, params...)
 	if err != nil {
 		return err
 	}
@@ -1131,7 +1131,7 @@ func (k *Kubectl) ApplyTolerationsFromTaints(ctx context.Context, oldTaints []co
 			"patch", resource, name,
 			"--type=json", fmt.Sprintf("-p=[{\"op\": \"add\", \"path\": %s, \"value\":[%s]}]", path, strings.Join(finalTolerations, ", ")), "-n", namespace, "--kubeconfig", kubeconfigFile,
 		}
-		_, err = k.executable.Execute(ctx, params...)
+		_, err = k.Execute(ctx, params...)
 		if err != nil {
 			return err
 		}
@@ -1145,7 +1145,7 @@ func (k *Kubectl) KubeconfigSecretAvailable(ctx context.Context, kubeconfig stri
 
 func (k *Kubectl) GetResource(ctx context.Context, resourceType string, name string, kubeconfig string, namespace string) (bool, error) {
 	params := []string{"get", resourceType, name, "--ignore-not-found", "-n", namespace, "--kubeconfig", kubeconfig}
-	output, err := k.executable.Execute(ctx, params...)
+	output, err := k.Execute(ctx, params...)
 	var found bool
 	if err == nil && len(output.String()) > 0 {
 		found = true

--- a/pkg/executables/mocks/executables.go
+++ b/pkg/executables/mocks/executables.go
@@ -35,6 +35,20 @@ func (m *MockExecutable) EXPECT() *MockExecutableMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockExecutable) Close(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockExecutableMockRecorder) Close(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockExecutable)(nil).Close), arg0)
+}
+
 // Execute mocks base method.
 func (m *MockExecutable) Execute(arg0 context.Context, arg1 ...string) (bytes.Buffer, error) {
 	m.ctrl.T.Helper()

--- a/pkg/executables/sonobuoy.go
+++ b/pkg/executables/sonobuoy.go
@@ -12,12 +12,12 @@ import (
 const sonobuoyPath = "./sonobuoy"
 
 type Sonobuoy struct {
-	executable Executable
+	Executable
 }
 
 func NewSonobuoy(executable Executable) *Sonobuoy {
 	return &Sonobuoy{
-		executable: executable,
+		Executable: executable,
 	}
 }
 
@@ -31,7 +31,7 @@ func (k *Sonobuoy) Run(ctx context.Context, contextName string, args ...string) 
 		"--wait",
 	}
 	executionArgs = append(executionArgs, args...)
-	output, err := k.executable.Execute(ctx, executionArgs...)
+	output, err := k.Execute(ctx, executionArgs...)
 	command := strings.Join(executionArgs, " ") + "\n"
 	if err != nil {
 		return command, fmt.Errorf("error executing sonobuoy: %v", err)
@@ -47,7 +47,7 @@ func (k *Sonobuoy) GetResults(ctx context.Context, contextName string, args ...s
 		"./results",
 	}
 	var output bytes.Buffer
-	output, err := k.executable.Execute(ctx, executionArgs...)
+	output, err := k.Execute(ctx, executionArgs...)
 	if err != nil {
 		return "", fmt.Errorf("error executing sonobuoy retrieve: %v", err)
 	}
@@ -58,7 +58,7 @@ func (k *Sonobuoy) GetResults(ctx context.Context, contextName string, args ...s
 		"results",
 		outputFile,
 	}
-	output, err = k.executable.Execute(ctx, executionArgs...)
+	output, err = k.Execute(ctx, executionArgs...)
 	command := strings.Join(executionArgs, " ") + "\n"
 	if err != nil {
 		return command, fmt.Errorf("error executing sonobuoy results command: %v", err)

--- a/pkg/executables/troubleshoot.go
+++ b/pkg/executables/troubleshoot.go
@@ -14,12 +14,12 @@ const (
 )
 
 type Troubleshoot struct {
-	executable Executable
+	Executable
 }
 
 func NewTroubleshoot(executable Executable) *Troubleshoot {
 	return &Troubleshoot{
-		executable: executable,
+		Executable: executable,
 	}
 }
 
@@ -30,7 +30,7 @@ func (t *Troubleshoot) Collect(ctx context.Context, bundlePath string, sinceTime
 	}
 	params := []string{bundlePath, "--kubeconfig", kubeconfig, "--interactive=false", "--since-time", string(marshalledTime)}
 
-	output, err := t.executable.Execute(ctx, params...)
+	output, err := t.Execute(ctx, params...)
 	if err != nil {
 		return "", fmt.Errorf("error when executing support-bundle: %v", err)
 	}
@@ -43,7 +43,7 @@ func (t *Troubleshoot) Collect(ctx context.Context, bundlePath string, sinceTime
 
 func (t *Troubleshoot) Analyze(ctx context.Context, bundleSpecPath string, archivePath string) ([]*SupportBundleAnalysis, error) {
 	params := []string{"analyze", bundleSpecPath, "--bundle", archivePath, "--output", "json"}
-	output, err := t.executable.Execute(ctx, params...)
+	output, err := t.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error when analyzing support bundle %s with analyzers %s: %v", archivePath, bundleSpecPath, err)
 	}

--- a/pkg/types/closer.go
+++ b/pkg/types/closer.go
@@ -1,0 +1,7 @@
+package types
+
+import "context"
+
+type Closer interface {
+	Close(ctx context.Context) error
+}

--- a/test/framework/executables.go
+++ b/test/framework/executables.go
@@ -10,7 +10,12 @@ import (
 
 func buildKubectl(t *testing.T) *executables.Kubectl {
 	ctx := context.Background()
-	return executableBuilder(t, ctx).BuildKubectlExecutable()
+	kubectl := executableBuilder(t, ctx).BuildKubectlExecutable()
+	t.Cleanup(func() {
+		kubectl.Close(ctx)
+	})
+
+	return kubectl
 }
 
 func buildLocalKubectl() *executables.Kubectl {
@@ -32,7 +37,12 @@ func buildGovc(t *testing.T) *executables.Govc {
 	if err != nil {
 		t.Fatalf("Error creating tmp writer")
 	}
-	return executableBuilder(t, ctx).BuildGovcExecutable(tmpWriter)
+	govc := executableBuilder(t, ctx).BuildGovcExecutable(tmpWriter)
+	t.Cleanup(func() {
+		govc.Close(ctx)
+	})
+
+	return govc
 }
 
 func buildDocker(t *testing.T) *executables.Docker {


### PR DESCRIPTION
*Description of changes:*
Before this, we were creating a new container for every command and destroying it after running it.
This is a tentative attempt at trying to reuse containers. It will create a long running container in the background during initialization and use the same one for every command.
Once the CLI is done, it will destroy the container and the volumes.

This opens the option to doing things like sharing the same vsphere auth session between multiple `govc` commands.

PD: sorry for the long PR, reviewing commit by commit might help

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
