### PR TITLE
Fix golang import sections using gci tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,7 @@ capd-test-%: e2e ## Run CAPD tests
 .PHONY: mocks
 mocks: ## Generate mocks
 	go install github.com/golang/mock/mockgen@v1.5.0
+	go install github.com/daixiang0/gci@v0.2.9
 	${GOPATH}/bin/mockgen -destination=pkg/providers/mocks/providers.go -package=mocks "github.com/aws/eks-anywhere/pkg/providers" Provider,DatacenterConfig,MachineConfig
 	${GOPATH}/bin/mockgen -destination=pkg/executables/mocks/executables.go -package=mocks "github.com/aws/eks-anywhere/pkg/executables" Executable
 	${GOPATH}/bin/mockgen -destination=pkg/providers/docker/mocks/client.go -package=mocks "github.com/aws/eks-anywhere/pkg/providers/docker" ProviderClient,ProviderKubectlClient
@@ -278,6 +279,7 @@ mocks: ## Generate mocks
 	${GOPATH}/bin/mockgen -destination=pkg/clusterapi/mocks/capiclient.go -package=mocks -source "pkg/clusterapi/manager.go" CAPIClient,KubectlClient
 	${GOPATH}/bin/mockgen -destination=pkg/clusterapi/mocks/client.go -package=mocks -source "pkg/clusterapi/resourceset_manager.go" Client
 	${GOPATH}/bin/mockgen -destination=pkg/crypto/mocks/crypto.go -package=mocks -source "pkg/crypto/certificategen.go" CertificateGenerator
+	${GOPATH}/bin/gci -w -local github.com/aws/eks-anywhere .
 
 .PHONY: verify-mocks
 verify-mocks: mocks ## Verify if mocks need to be updated

--- a/controllers/controllers/resource/mocks/resource.go
+++ b/controllers/controllers/resource/mocks/resource.go
@@ -8,8 +8,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	cluster "github.com/aws/eks-anywhere/pkg/cluster"
 	gomock "github.com/golang/mock/gomock"
 	v1alpha3 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -18,6 +16,9 @@ import (
 	v1alpha31 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	v1alpha32 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	cluster "github.com/aws/eks-anywhere/pkg/cluster"
 )
 
 // MockResourceFetcher is a mock of ResourceFetcher interface.

--- a/pkg/addonmanager/addonclients/mocks/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/mocks/fluxaddonclient.go
@@ -8,9 +8,10 @@ import (
 	context "context"
 	reflect "reflect"
 
+	gomock "github.com/golang/mock/gomock"
+
 	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	types "github.com/aws/eks-anywhere/pkg/types"
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockFlux is a mock of Flux interface.

--- a/pkg/bootstrapper/mocks/client.go
+++ b/pkg/bootstrapper/mocks/client.go
@@ -8,10 +8,11 @@ import (
 	context "context"
 	reflect "reflect"
 
+	gomock "github.com/golang/mock/gomock"
+
 	bootstrapper "github.com/aws/eks-anywhere/pkg/bootstrapper"
 	cluster "github.com/aws/eks-anywhere/pkg/cluster"
 	types "github.com/aws/eks-anywhere/pkg/types"
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockClusterClient is a mock of ClusterClient interface.

--- a/pkg/cluster/mocks/client.go
+++ b/pkg/cluster/mocks/client.go
@@ -8,8 +8,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	types "github.com/aws/eks-anywhere/pkg/types"
 	gomock "github.com/golang/mock/gomock"
+
+	types "github.com/aws/eks-anywhere/pkg/types"
 )
 
 // MockClusterClient is a mock of ClusterClient interface.

--- a/pkg/clusterapi/mocks/capiclient.go
+++ b/pkg/clusterapi/mocks/capiclient.go
@@ -8,11 +8,12 @@ import (
 	context "context"
 	reflect "reflect"
 
+	gomock "github.com/golang/mock/gomock"
+
 	cluster "github.com/aws/eks-anywhere/pkg/cluster"
 	clusterapi "github.com/aws/eks-anywhere/pkg/clusterapi"
 	providers "github.com/aws/eks-anywhere/pkg/providers"
 	types "github.com/aws/eks-anywhere/pkg/types"
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockCAPIClient is a mock of CAPIClient interface.

--- a/pkg/clusterapi/mocks/client.go
+++ b/pkg/clusterapi/mocks/client.go
@@ -8,10 +8,11 @@ import (
 	context "context"
 	reflect "reflect"
 
-	types "github.com/aws/eks-anywhere/pkg/types"
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	v1alpha3 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
+
+	types "github.com/aws/eks-anywhere/pkg/types"
 )
 
 // MockClient is a mock of Client interface.

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -8,13 +8,14 @@ import (
 	context "context"
 	reflect "reflect"
 
+	gomock "github.com/golang/mock/gomock"
+
 	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	cluster "github.com/aws/eks-anywhere/pkg/cluster"
 	filewriter "github.com/aws/eks-anywhere/pkg/filewriter"
 	providers "github.com/aws/eks-anywhere/pkg/providers"
 	types "github.com/aws/eks-anywhere/pkg/types"
 	v1alpha10 "github.com/aws/eks-anywhere/release/api/v1alpha1"
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockClusterClient is a mock of ClusterClient interface.

--- a/pkg/diagnostics/interfaces/mocks/diagnostics.go
+++ b/pkg/diagnostics/interfaces/mocks/diagnostics.go
@@ -9,12 +9,13 @@ import (
 	reflect "reflect"
 	time "time"
 
+	gomock "github.com/golang/mock/gomock"
+
 	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	cluster "github.com/aws/eks-anywhere/pkg/cluster"
 	diagnostics "github.com/aws/eks-anywhere/pkg/diagnostics"
 	executables "github.com/aws/eks-anywhere/pkg/executables"
 	providers "github.com/aws/eks-anywhere/pkg/providers"
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockBundleClient is a mock of BundleClient interface.

--- a/pkg/filewriter/mocks/filewriter.go
+++ b/pkg/filewriter/mocks/filewriter.go
@@ -7,8 +7,9 @@ package mocks
 import (
 	reflect "reflect"
 
-	filewriter "github.com/aws/eks-anywhere/pkg/filewriter"
 	gomock "github.com/golang/mock/gomock"
+
+	filewriter "github.com/aws/eks-anywhere/pkg/filewriter"
 )
 
 // MockFileWriter is a mock of FileWriter interface.

--- a/pkg/git/mocks/git.go
+++ b/pkg/git/mocks/git.go
@@ -8,8 +8,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	git "github.com/aws/eks-anywhere/pkg/git"
 	gomock "github.com/golang/mock/gomock"
+
+	git "github.com/aws/eks-anywhere/pkg/git"
 )
 
 // MockProvider is a mock of Provider interface.

--- a/pkg/git/providers/github/mocks/github.go
+++ b/pkg/git/providers/github/mocks/github.go
@@ -8,9 +8,10 @@ import (
 	context "context"
 	reflect "reflect"
 
-	git "github.com/aws/eks-anywhere/pkg/git"
 	gomock "github.com/golang/mock/gomock"
 	github "github.com/google/go-github/v35/github"
+
+	git "github.com/aws/eks-anywhere/pkg/git"
 )
 
 // MockGitProviderClient is a mock of GitProviderClient interface.

--- a/pkg/providers/docker/mocks/client.go
+++ b/pkg/providers/docker/mocks/client.go
@@ -8,13 +8,14 @@ import (
 	context "context"
 	reflect "reflect"
 
-	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	executables "github.com/aws/eks-anywhere/pkg/executables"
-	types "github.com/aws/eks-anywhere/pkg/types"
 	gomock "github.com/golang/mock/gomock"
 	v1alpha3 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
 	v1alpha30 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	v1alpha31 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
+
+	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	executables "github.com/aws/eks-anywhere/pkg/executables"
+	types "github.com/aws/eks-anywhere/pkg/types"
 )
 
 // MockProviderClient is a mock of ProviderClient interface.

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -8,12 +8,13 @@ import (
 	context "context"
 	reflect "reflect"
 
+	gomock "github.com/golang/mock/gomock"
+
 	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	bootstrapper "github.com/aws/eks-anywhere/pkg/bootstrapper"
 	cluster "github.com/aws/eks-anywhere/pkg/cluster"
 	providers "github.com/aws/eks-anywhere/pkg/providers"
 	types "github.com/aws/eks-anywhere/pkg/types"
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockProvider is a mock of Provider interface.

--- a/pkg/providers/vsphere/internal/templates/mocks/govc.go
+++ b/pkg/providers/vsphere/internal/templates/mocks/govc.go
@@ -8,8 +8,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	gomock "github.com/golang/mock/gomock"
+
+	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
 // MockGovcClient is a mock of GovcClient interface.

--- a/pkg/providers/vsphere/mocks/client.go
+++ b/pkg/providers/vsphere/mocks/client.go
@@ -8,14 +8,15 @@ import (
 	context "context"
 	reflect "reflect"
 
-	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	executables "github.com/aws/eks-anywhere/pkg/executables"
-	types "github.com/aws/eks-anywhere/pkg/types"
 	gomock "github.com/golang/mock/gomock"
 	v1alpha3 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
 	v1 "k8s.io/api/core/v1"
 	v1alpha30 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	v1alpha31 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
+
+	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	executables "github.com/aws/eks-anywhere/pkg/executables"
+	types "github.com/aws/eks-anywhere/pkg/types"
 )
 
 // MockProviderGovcClient is a mock of ProviderGovcClient interface.

--- a/pkg/task/mocks/task.go
+++ b/pkg/task/mocks/task.go
@@ -8,8 +8,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	task "github.com/aws/eks-anywhere/pkg/task"
 	gomock "github.com/golang/mock/gomock"
+
+	task "github.com/aws/eks-anywhere/pkg/task"
 )
 
 // MockTask is a mock of Task interface.

--- a/pkg/validations/mocks/kubectl.go
+++ b/pkg/validations/mocks/kubectl.go
@@ -8,10 +8,11 @@ import (
 	context "context"
 	reflect "reflect"
 
+	gomock "github.com/golang/mock/gomock"
+
 	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	executables "github.com/aws/eks-anywhere/pkg/executables"
 	types "github.com/aws/eks-anywhere/pkg/types"
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockKubectlClient is a mock of KubectlClient interface.

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -8,12 +8,13 @@ import (
 	context "context"
 	reflect "reflect"
 
+	gomock "github.com/golang/mock/gomock"
+
 	bootstrapper "github.com/aws/eks-anywhere/pkg/bootstrapper"
 	cluster "github.com/aws/eks-anywhere/pkg/cluster"
 	providers "github.com/aws/eks-anywhere/pkg/providers"
 	types "github.com/aws/eks-anywhere/pkg/types"
 	validations "github.com/aws/eks-anywhere/pkg/validations"
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockBootstrapper is a mock of Bootstrapper interface.


### PR DESCRIPTION
The module imports from within the EKS Anywhere repositrory should be separated from those from the rest of Github or other source control. These changes were generated using the command
```
gci -w -local github.com/aws/eks-anywhere .
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
