### PR TITLE
use bundle override for delete cluster calls (#695)

### DIFF
--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -56,6 +56,7 @@ func init() {
 	deleteClusterCmd.Flags().StringVarP(&dc.wConfig, "w-config", "w", "", "Kubeconfig file to use when deleting a workload cluster")
 	deleteClusterCmd.Flags().BoolVar(&dc.forceCleanup, "force-cleanup", false, "Force deletion of previously created bootstrap cluster")
 	deleteClusterCmd.Flags().StringVar(&dc.managementKubeconfig, "kubeconfig", "", "kubeconfig file pointing to a management cluster")
+	deleteClusterCmd.Flags().StringVar(&dc.bundlesOverride, "bundles-override", "", "Override default Bundles manifest (not recommended)")
 }
 
 func (dc *deleteClusterOptions) validate(ctx context.Context, args []string) error {

--- a/test/framework/e2e.go
+++ b/test/framework/e2e.go
@@ -201,7 +201,11 @@ func (e *E2ETest) buildClusterConfigFile() {
 }
 
 func (e *E2ETest) DeleteCluster() {
-	e.RunEKSA("anywhere", "delete", "cluster", e.ClusterName, "-v", "4")
+	deleteClusterArgs := []string{"delete", "cluster", e.ClusterName, "-v", "4"}
+	if getBundlesOverride() == "true" {
+		deleteClusterArgs = append(deleteClusterArgs, "--bundles-override", defaultBundleReleaseManifestFile)
+	}
+	e.RunEKSA(deleteClusterArgs...)
 }
 
 func (e *E2ETest) Run(name string, args ...string) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Backport bundle override in delete cluster calls in e2e tests to 0.6

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
