### PR TITLE
Make capi import aliases generic across versions

### DIFF
--- a/controllers/controllers/resource/fetcher_test.go
+++ b/controllers/controllers/resource/fetcher_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	vspherev3 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
+	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -19,7 +19,7 @@ import (
 
 func TestMapMachineTemplateToVSphereDatacenterConfigSpec(t *testing.T) {
 	type args struct {
-		vsMachineTemplate *vspherev3.VSphereMachineTemplate
+		vsMachineTemplate *vspherev1.VSphereMachineTemplate
 	}
 	tests := []struct {
 		name    string
@@ -31,11 +31,11 @@ func TestMapMachineTemplateToVSphereDatacenterConfigSpec(t *testing.T) {
 			name:    "All path are available",
 			wantErr: false,
 			args: args{
-				vsMachineTemplate: &vspherev3.VSphereMachineTemplate{
-					Spec: vspherev3.VSphereMachineTemplateSpec{
-						Template: vspherev3.VSphereMachineTemplateResource{
-							Spec: vspherev3.VSphereMachineSpec{
-								VirtualMachineCloneSpec: vspherev3.VirtualMachineCloneSpec{
+				vsMachineTemplate: &vspherev1.VSphereMachineTemplate{
+					Spec: vspherev1.VSphereMachineTemplateSpec{
+						Template: vspherev1.VSphereMachineTemplateResource{
+							Spec: vspherev1.VSphereMachineSpec{
+								VirtualMachineCloneSpec: vspherev1.VirtualMachineCloneSpec{
 									MemoryMiB:    int64(64),
 									DiskGiB:      int32(100),
 									NumCPUs:      int32(3),
@@ -46,8 +46,8 @@ func TestMapMachineTemplateToVSphereDatacenterConfigSpec(t *testing.T) {
 									Datacenter:   "daaa",
 									Datastore:    "ds-aaa",
 									Folder:       "folder/A",
-									Network: vspherev3.NetworkSpec{
-										Devices: []vspherev3.NetworkDeviceSpec{
+									Network: vspherev1.NetworkSpec{
+										Devices: []vspherev1.NetworkDeviceSpec{
 											{
 												NetworkName: "networkA",
 											},
@@ -72,11 +72,11 @@ func TestMapMachineTemplateToVSphereDatacenterConfigSpec(t *testing.T) {
 			name:    "NetworkName missing, throw error",
 			wantErr: true,
 			args: args{
-				vsMachineTemplate: &vspherev3.VSphereMachineTemplate{
-					Spec: vspherev3.VSphereMachineTemplateSpec{
-						Template: vspherev3.VSphereMachineTemplateResource{
-							Spec: vspherev3.VSphereMachineSpec{
-								VirtualMachineCloneSpec: vspherev3.VirtualMachineCloneSpec{
+				vsMachineTemplate: &vspherev1.VSphereMachineTemplate{
+					Spec: vspherev1.VSphereMachineTemplateSpec{
+						Template: vspherev1.VSphereMachineTemplateResource{
+							Spec: vspherev1.VSphereMachineSpec{
+								VirtualMachineCloneSpec: vspherev1.VirtualMachineCloneSpec{
 									MemoryMiB:    int64(64),
 									DiskGiB:      int32(100),
 									NumCPUs:      int32(3),
@@ -111,7 +111,7 @@ func TestMapMachineTemplateToVSphereDatacenterConfigSpec(t *testing.T) {
 
 func TestMapMachineTemplateToVSphereWorkerMachineConfigSpec(t *testing.T) {
 	type args struct {
-		vsMachineTemplate *vspherev3.VSphereMachineTemplate
+		vsMachineTemplate *vspherev1.VSphereMachineTemplate
 	}
 	tests := []struct {
 		name    string
@@ -123,11 +123,11 @@ func TestMapMachineTemplateToVSphereWorkerMachineConfigSpec(t *testing.T) {
 			name:    "All path are available",
 			wantErr: false,
 			args: args{
-				vsMachineTemplate: &vspherev3.VSphereMachineTemplate{
-					Spec: vspherev3.VSphereMachineTemplateSpec{
-						Template: vspherev3.VSphereMachineTemplateResource{
-							Spec: vspherev3.VSphereMachineSpec{
-								VirtualMachineCloneSpec: vspherev3.VirtualMachineCloneSpec{
+				vsMachineTemplate: &vspherev1.VSphereMachineTemplate{
+					Spec: vspherev1.VSphereMachineTemplateSpec{
+						Template: vspherev1.VSphereMachineTemplateResource{
+							Spec: vspherev1.VSphereMachineSpec{
+								VirtualMachineCloneSpec: vspherev1.VirtualMachineCloneSpec{
 									MemoryMiB:    int64(64),
 									DiskGiB:      int32(100),
 									NumCPUs:      int32(3),
@@ -138,8 +138,8 @@ func TestMapMachineTemplateToVSphereWorkerMachineConfigSpec(t *testing.T) {
 									Datacenter:   "daaa",
 									Datastore:    "ds-aaa",
 									Folder:       "folder/A",
-									Network: vspherev3.NetworkSpec{
-										Devices: []vspherev3.NetworkDeviceSpec{
+									Network: vspherev1.NetworkSpec{
+										Devices: []vspherev1.NetworkDeviceSpec{
 											{
 												NetworkName: "networkA",
 											},

--- a/controllers/controllers/resource/reconciler_test.go
+++ b/controllers/controllers/resource/reconciler_test.go
@@ -7,14 +7,14 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	etcdv1alpha3 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
+	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
-	kubeadmnv1alpha3 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
+	bootstrapv1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -138,12 +138,12 @@ func TestClusterReconcilerReconcile(t *testing.T) {
 					assert.Equal(t, objectKey.Name, "testMachineGroupRef-etcd", "expected Name to be testMachineGroupRef-etcd")
 				}).Return(nil)
 
-				kubeAdmControlPlane := &kubeadmnv1alpha3.KubeadmControlPlane{}
+				kubeAdmControlPlane := &bootstrapv1.KubeadmControlPlane{}
 				if err := yaml.Unmarshal([]byte(kubeadmcontrolplaneFile), kubeAdmControlPlane); err != nil {
 					t.Errorf("unmarshal failed: %v", err)
 				}
 
-				etcdadmCluster := &etcdv1alpha3.EtcdadmCluster{}
+				etcdadmCluster := &etcdv1.EtcdadmCluster{}
 				if err := yaml.Unmarshal([]byte(etcdadmclusterFile), etcdadmCluster); err != nil {
 					t.Errorf("unmarshal failed: %v", err)
 				}
@@ -243,7 +243,7 @@ func TestClusterReconcilerReconcile(t *testing.T) {
 				fetcher.EXPECT().ExistingVSphereControlPlaneMachineConfig(ctx, gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
 				fetcher.EXPECT().ExistingVSphereWorkerMachineConfig(ctx, gomock.Any()).Return(existingVSMachine, nil)
 
-				kubeAdmControlPlane := &kubeadmnv1alpha3.KubeadmControlPlane{}
+				kubeAdmControlPlane := &bootstrapv1.KubeadmControlPlane{}
 				if err := yaml.Unmarshal([]byte(kubeadmcontrolplaneFile), kubeAdmControlPlane); err != nil {
 					t.Errorf("unmarshal failed: %v", err)
 				}

--- a/controllers/controllers/resource/template.go
+++ b/controllers/controllers/resource/template.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	etcdv1alpha3 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
+	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 
@@ -89,7 +89,7 @@ func (r *VsphereTemplate) TemplateResources(ctx context.Context, eksaCluster *an
 			return nil, err
 		}
 		if updateEtcdTemplate {
-			etcd.SetAnnotations(map[string]string{etcdv1alpha3.UpgradeInProgressAnnotation: "true"})
+			etcd.SetAnnotations(map[string]string{etcdv1.UpgradeInProgressAnnotation: "true"})
 			if err := r.ApplyPatch(ctx, etcd, false); err != nil {
 				return nil, err
 			}

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -4,12 +4,12 @@ import (
 	"flag"
 	"os"
 
-	etcdv1alpha3 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
+	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	vspherev3 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
+	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -34,8 +34,8 @@ func init() {
 	utilruntime.Must(releasev1alpha1.AddToScheme(scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
 	utilruntime.Must(controlplanev1.AddToScheme(scheme))
-	utilruntime.Must(vspherev3.AddToScheme(scheme))
-	utilruntime.Must(etcdv1alpha3.AddToScheme(scheme))
+	utilruntime.Must(vspherev1.AddToScheme(scheme))
+	utilruntime.Must(etcdv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/go.sum
+++ b/go.sum
@@ -72,7 +72,6 @@ github.com/Microsoft/hcsshim v0.8.9/go.mod h1:5692vkUqntj1idxauYlpoINNKeqCiG6Sg3
 github.com/Microsoft/hcsshim v0.8.14/go.mod h1:NtVKoYxQuTLx6gEq0L96c9Ju4JbRJ4nY2ow3VK6a9Lg=
 github.com/Microsoft/hcsshim v0.8.15/go.mod h1:x38A4YbHbdxJtc0sF6oIz+RG0npwSCAvn69iY6URG00=
 github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+VxGOoXdC600=
-github.com/Microsoft/hcsshim v0.8.21/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/pkg/clusterapi/resourceset.go
+++ b/pkg/clusterapi/resourceset.go
@@ -5,8 +5,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/cluster-api/api/v1alpha3"
-	addonsalpha3 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	addons "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
 	"sigs.k8s.io/yaml"
 
 	"github.com/aws/eks-anywhere/pkg/templater"
@@ -38,23 +38,23 @@ func (c ClusterResourceSet) ToYaml() ([]byte, error) {
 	return marshall(append(c.buildResourceConfigMaps(), c.buildSet())...)
 }
 
-func (c ClusterResourceSet) buildSet() *addonsalpha3.ClusterResourceSet {
-	return &addonsalpha3.ClusterResourceSet{
+func (c ClusterResourceSet) buildSet() *addons.ClusterResourceSet {
+	return &addons.ClusterResourceSet{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: addonsalpha3.GroupVersion.Identifier(),
+			APIVersion: addons.GroupVersion.Identifier(),
 			Kind:       "ClusterResourceSet",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s-crs", c.clusterName),
 			Labels: map[string]string{
-				v1alpha3.ClusterLabelName: c.clusterName,
+				clusterv1.ClusterLabelName: c.clusterName,
 			},
 			Namespace: c.namespace,
 		},
-		Spec: addonsalpha3.ClusterResourceSetSpec{
+		Spec: addons.ClusterResourceSetSpec{
 			ClusterSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					v1alpha3.ClusterLabelName: c.clusterName,
+					clusterv1.ClusterLabelName: c.clusterName,
 				},
 			},
 			Resources: c.resourceRefs(),
@@ -62,11 +62,11 @@ func (c ClusterResourceSet) buildSet() *addonsalpha3.ClusterResourceSet {
 	}
 }
 
-func (c ClusterResourceSet) resourceRefs() []addonsalpha3.ResourceRef {
-	refs := make([]addonsalpha3.ResourceRef, 0, len(c.resources))
+func (c ClusterResourceSet) resourceRefs() []addons.ResourceRef {
+	refs := make([]addons.ResourceRef, 0, len(c.resources))
 
 	for name := range c.resources {
-		refs = append(refs, addonsalpha3.ResourceRef{Name: name, Kind: string(addonsalpha3.ConfigMapClusterResourceSetResourceKind)})
+		refs = append(refs, addons.ResourceRef{Name: name, Kind: string(addons.ConfigMapClusterResourceSetResourceKind)})
 	}
 
 	return refs

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
-	"sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	addons "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
 
 	"github.com/aws/eks-anywhere/internal/test"
@@ -30,7 +30,7 @@ const (
 	secretObjectName = "csi-vsphere-config"
 )
 
-var capiClustersResourceType = fmt.Sprintf("clusters.%s", v1alpha3.GroupVersion.Group)
+var capiClustersResourceType = fmt.Sprintf("clusters.%s", clusterv1.GroupVersion.Group)
 
 func newKubectl(t *testing.T) (*executables.Kubectl, context.Context, *types.Cluster, *mockexecutables.MockExecutable) {
 	kubeconfigFile := "c.kubeconfig"

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -8,9 +8,9 @@ import (
 	"regexp"
 	"time"
 
-	etcdv1alpha3 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
-	"sigs.k8s.io/cluster-api/api/v1alpha3"
-	kubeadmnv1alpha3 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
+	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	bootstrapv1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/bootstrapper"
@@ -51,9 +51,9 @@ type provider struct {
 
 type ProviderKubectlClient interface {
 	GetEksaCluster(ctx context.Context, cluster *types.Cluster, clusterName string) (*v1alpha1.Cluster, error)
-	GetKubeadmControlPlane(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*kubeadmnv1alpha3.KubeadmControlPlane, error)
-	GetMachineDeployment(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*v1alpha3.MachineDeployment, error)
-	GetEtcdadmCluster(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*etcdv1alpha3.EtcdadmCluster, error)
+	GetKubeadmControlPlane(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*bootstrapv1.KubeadmControlPlane, error)
+	GetMachineDeployment(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*clusterv1.MachineDeployment, error)
+	GetEtcdadmCluster(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*etcdv1.EtcdadmCluster, error)
 	UpdateAnnotation(ctx context.Context, resourceType, objectName string, annotations map[string]string, opts ...executables.KubectlOpt) error
 }
 
@@ -281,7 +281,7 @@ func (p *provider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapClus
 			so that KCP checks this annotation and does not proceed if etcd cluster is upgrading. The etcdadm controller removes this annotation once the etcd upgrade is complete.
 			*/
 			err = p.providerKubectlClient.UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", newClusterSpec.Name),
-				map[string]string{etcdv1alpha3.UpgradeInProgressAnnotation: "true"},
+				map[string]string{etcdv1.UpgradeInProgressAnnotation: "true"},
 				executables.WithCluster(bootstrapCluster),
 				executables.WithNamespace(constants.EksaSystemNamespace))
 			if err != nil {

--- a/pkg/providers/docker/docker_test.go
+++ b/pkg/providers/docker/docker_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	etcdv1alpha3 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
+	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/cluster-api/api/v1alpha3"
-	kubeadmnv1alpha3 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	bootstrapv1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -240,7 +240,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				Name: "bootstrap-test",
 			}
 			kubectl.EXPECT().UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", tt.clusterSpec.Name),
-				map[string]string{etcdv1alpha3.UpgradeInProgressAnnotation: "true"}, gomock.Any(), gomock.Any())
+				map[string]string{etcdv1.UpgradeInProgressAnnotation: "true"}, gomock.Any(), gomock.Any())
 			cpContent, mdContent, err := p.GenerateCAPISpecForUpgrade(ctx, bootstrapCluster, cluster, currentSpec, tt.clusterSpec)
 			if err != nil {
 				t.Fatalf("provider.GenerateCAPISpecForUpgrade() error = %v, wantErr nil", err)
@@ -268,17 +268,17 @@ func TestProviderGenerateDeploymentFileSuccessNotUpdateMachineTemplate(t *testin
 		Name: "bootstrap-test",
 	}
 
-	cp := &kubeadmnv1alpha3.KubeadmControlPlane{
-		Spec: kubeadmnv1alpha3.KubeadmControlPlaneSpec{
+	cp := &bootstrapv1.KubeadmControlPlane{
+		Spec: bootstrapv1.KubeadmControlPlaneSpec{
 			InfrastructureTemplate: v1.ObjectReference{
 				Name: "test-control-plane-template-original",
 			},
 		},
 	}
-	md := &v1alpha3.MachineDeployment{
-		Spec: v1alpha3.MachineDeploymentSpec{
-			Template: v1alpha3.MachineTemplateSpec{
-				Spec: v1alpha3.MachineSpec{
+	md := &clusterv1.MachineDeployment{
+		Spec: clusterv1.MachineDeploymentSpec{
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
 					InfrastructureRef: v1.ObjectReference{
 						Name: "test-worker-node-template-original",
 					},

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -15,11 +15,11 @@ import (
 	"text/template"
 	"time"
 
-	etcdv1alpha3 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
+	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/cluster-api/api/v1alpha3"
-	kubeadmnv1alpha3 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	bootstrapv1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/bootstrapper"
@@ -140,9 +140,9 @@ type ProviderKubectlClient interface {
 	GetEksaCluster(ctx context.Context, cluster *types.Cluster, clusterName string) (*v1alpha1.Cluster, error)
 	GetEksaVSphereDatacenterConfig(ctx context.Context, vsphereDatacenterConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.VSphereDatacenterConfig, error)
 	GetEksaVSphereMachineConfig(ctx context.Context, vsphereMachineConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.VSphereMachineConfig, error)
-	GetKubeadmControlPlane(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*kubeadmnv1alpha3.KubeadmControlPlane, error)
-	GetMachineDeployment(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*v1alpha3.MachineDeployment, error)
-	GetEtcdadmCluster(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*etcdv1alpha3.EtcdadmCluster, error)
+	GetKubeadmControlPlane(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*bootstrapv1.KubeadmControlPlane, error)
+	GetMachineDeployment(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*clusterv1.MachineDeployment, error)
+	GetEtcdadmCluster(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*etcdv1.EtcdadmCluster, error)
 	GetSecret(ctx context.Context, secretObjectName string, opts ...executables.KubectlOpt) (*corev1.Secret, error)
 	UpdateAnnotation(ctx context.Context, resourceType, objectName string, annotations map[string]string, opts ...executables.KubectlOpt) error
 	SearchVsphereMachineConfig(ctx context.Context, name string, kubeconfigFile string, namespace string) ([]*v1alpha1.VSphereMachineConfig, error)
@@ -1390,7 +1390,7 @@ func (p *vsphereProvider) generateCAPISpecForUpgrade(ctx context.Context, bootst
 			so that KCP checks this annotation and does not proceed if etcd cluster is upgrading. The etcdadm controller removes this annotation once the etcd upgrade is complete.
 			*/
 			err = p.providerKubectlClient.UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", clusterName),
-				map[string]string{etcdv1alpha3.UpgradeInProgressAnnotation: "true"},
+				map[string]string{etcdv1.UpgradeInProgressAnnotation: "true"},
 				executables.WithCluster(bootstrapCluster),
 				executables.WithNamespace(constants.EksaSystemNamespace))
 			if err != nil {

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -16,13 +16,13 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	etcdv1alpha3 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
+	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/cluster-api/api/v1alpha3"
-	kubeadmnv1alpha3 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	bootstrapv1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -526,7 +526,7 @@ func TestProviderGenerateCAPISpecForUpgradeUpdateMachineTemplateExternalEtcd(t *
 			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
 			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
 			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
-			kubectl.EXPECT().UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", cluster.Name), map[string]string{etcdv1alpha3.UpgradeInProgressAnnotation: "true"}, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster)))
+			kubectl.EXPECT().UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", cluster.Name), map[string]string{etcdv1.UpgradeInProgressAnnotation: "true"}, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster)))
 			datacenterConfig := givenDatacenterConfig(t, tt.clusterconfigFile)
 			machineConfigs := givenMachineConfigs(t, tt.clusterconfigFile)
 			provider := newProviderWithKubectl(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, kubectl)
@@ -565,17 +565,17 @@ func TestProviderGenerateCAPISpecForUpgradeNotUpdateMachineTemplate(t *testing.T
 	}
 	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
 
-	oldCP := &kubeadmnv1alpha3.KubeadmControlPlane{
-		Spec: kubeadmnv1alpha3.KubeadmControlPlaneSpec{
+	oldCP := &bootstrapv1.KubeadmControlPlane{
+		Spec: bootstrapv1.KubeadmControlPlaneSpec{
 			InfrastructureTemplate: v1.ObjectReference{
 				Name: "test-control-plane-template-original",
 			},
 		},
 	}
-	oldMD := &v1alpha3.MachineDeployment{
-		Spec: v1alpha3.MachineDeploymentSpec{
-			Template: v1alpha3.MachineTemplateSpec{
-				Spec: v1alpha3.MachineSpec{
+	oldMD := &clusterv1.MachineDeployment{
+		Spec: clusterv1.MachineDeploymentSpec{
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
 					InfrastructureRef: v1.ObjectReference{
 						Name: "test-worker-node-template-original",
 					},
@@ -583,8 +583,8 @@ func TestProviderGenerateCAPISpecForUpgradeNotUpdateMachineTemplate(t *testing.T
 			},
 		},
 	}
-	etcdadmCluster := &etcdv1alpha3.EtcdadmCluster{
-		Spec: etcdv1alpha3.EtcdadmClusterSpec{
+	etcdadmCluster := &etcdv1.EtcdadmCluster{
+		Spec: etcdv1.EtcdadmClusterSpec{
 			InfrastructureTemplate: v1.ObjectReference{
 				Name: "test-etcd-template-original",
 			},

--- a/pkg/validations/createvalidations/cluster_test.go
+++ b/pkg/validations/createvalidations/cluster_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -109,6 +109,6 @@ func TestValidateManagementClusterCRDs(t *testing.T) {
 }
 
 var (
-	capiClustersResourceType = fmt.Sprintf("clusters.%s", v1alpha3.GroupVersion.Group)
+	capiClustersResourceType = fmt.Sprintf("clusters.%s", clusterv1.GroupVersion.Group)
 	eksaClusterResourceType  = fmt.Sprintf("clusters.%s", v1alpha1.GroupVersion.Group)
 )

--- a/pkg/validations/upgradevalidations/cluster_test.go
+++ b/pkg/validations/upgradevalidations/cluster_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -56,4 +56,4 @@ func TestValidateClusterPresent(t *testing.T) {
 	}
 }
 
-var capiClustersResourceType = fmt.Sprintf("clusters.%s", v1alpha3.GroupVersion.Group)
+var capiClustersResourceType = fmt.Sprintf("clusters.%s", clusterv1.GroupVersion.Group)

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
@@ -47,7 +47,7 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) (err erro
 		},
 		validations.ValidationResult{
 			Name:        "cluster object present on workload cluster",
-			Remediation: fmt.Sprintf("ensure that the CAPI cluster object %s representing cluster %s is present", v1alpha3.GroupVersion, u.Opts.WorkloadCluster.Name),
+			Remediation: fmt.Sprintf("ensure that the CAPI cluster object %s representing cluster %s is present", clusterv1.GroupVersion, u.Opts.WorkloadCluster.Name),
 			Err:         ValidateClusterObjectExists(ctx, k, u.Opts.ManagementCluster),
 		},
 		validations.ValidationResult{


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/eks-anywhere/issues/634

*Description of changes:*
This PR renames import aliases used for capi/capv/etcdadm to make it generic across versions. This is just to minimize changes required when upgrading to newer api versions. This does not affect any functionality. This is same as how these packages are imported upstream in [capi](https://github.com/kubernetes-sigs/cluster-api/blob/main/controlplane/kubeadm/controllers/controller.go#L32-L35) and [capv](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/master/controllers/vspherecluster_controller.go#L25-L38) 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
