### PR TITLE
Add arch folders for building cross platform binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,10 @@ eks-a-embed-config: ## Build a dev release version of eks-a with embed cluster s
 .PHONY: eks-a-cross-platform-embed-latest-config
 eks-a-cross-platform-embed-latest-config: ## Build cross platform dev release versions of eks-a with the latest bundle-release.yaml embedded in cluster spec config
 	curl -L $(BUNDLE_MANIFEST_URL) --output pkg/cluster/config/bundle-release.yaml
-	$(MAKE) eks-a-embed-config GO_OS=darwin GO_ARCH=amd64 OUTPUT_FILE=bin/darwin/eksctl-anywhere
-	$(MAKE) eks-a-embed-config GO_OS=linux GO_ARCH=amd64 OUTPUT_FILE=bin/linux/eksctl-anywhere
-	$(MAKE) eks-a-embed-config GO_OS=darwin GO_ARCH=arm64 OUTPUT_FILE=bin/darwin/eksctl-anywhere
-	$(MAKE) eks-a-embed-config GO_OS=linux GO_ARCH=arm64 OUTPUT_FILE=bin/linux/eksctl-anywhere
+	$(MAKE) eks-a-embed-config GO_OS=darwin GO_ARCH=amd64 OUTPUT_FILE=bin/darwin/amd64/eksctl-anywhere
+	$(MAKE) eks-a-embed-config GO_OS=linux GO_ARCH=amd64 OUTPUT_FILE=bin/linux/amd64/eksctl-anywhere
+	$(MAKE) eks-a-embed-config GO_OS=darwin GO_ARCH=arm64 OUTPUT_FILE=bin/darwin/arm64/eksctl-anywhere
+	$(MAKE) eks-a-embed-config GO_OS=linux GO_ARCH=arm64 OUTPUT_FILE=bin/linux/arm64/eksctl-anywhere
 	rm pkg/cluster/config/bundle-release.yaml
 
 .PHONY: eks-a
@@ -99,17 +99,17 @@ eks-a-release: ## Generate a release binary
 
 .PHONY: eks-a-cross-platform
 eks-a-cross-platform: ## Generate binaries for Linux and MacOS
-	$(MAKE) eks-a-binary GIT_VERSION=$(DEV_GIT_VERSION) GO_OS=darwin GO_ARCH=amd64 OUTPUT_FILE=bin/darwin/eksctl-anywhere
-	$(MAKE) eks-a-binary GIT_VERSION=$(DEV_GIT_VERSION) GO_OS=linux GO_ARCH=amd64 OUTPUT_FILE=bin/linux/eksctl-anywhere
-	$(MAKE) eks-a-binary GIT_VERSION=$(DEV_GIT_VERSION) GO_OS=darwin GO_ARCH=arm64 OUTPUT_FILE=bin/darwin/eksctl-anywhere
-	$(MAKE) eks-a-binary GIT_VERSION=$(DEV_GIT_VERSION) GO_OS=linux GO_ARCH=arm64 OUTPUT_FILE=bin/linux/eksctl-anywhere
+	$(MAKE) eks-a-binary GIT_VERSION=$(DEV_GIT_VERSION) GO_OS=darwin GO_ARCH=amd64 OUTPUT_FILE=bin/darwin/amd64/eksctl-anywhere
+	$(MAKE) eks-a-binary GIT_VERSION=$(DEV_GIT_VERSION) GO_OS=linux GO_ARCH=amd64 OUTPUT_FILE=bin/linux/amd64/eksctl-anywhere
+	$(MAKE) eks-a-binary GIT_VERSION=$(DEV_GIT_VERSION) GO_OS=darwin GO_ARCH=arm64 OUTPUT_FILE=bin/darwin/arm64/eksctl-anywhere
+	$(MAKE) eks-a-binary GIT_VERSION=$(DEV_GIT_VERSION) GO_OS=linux GO_ARCH=arm64 OUTPUT_FILE=bin/linux/arm64/eksctl-anywhere
 
 .PHONY: eks-a-release-cross-platform
 eks-a-release-cross-platform: ## Generate binaries for Linux and MacOS
-	$(MAKE) eks-a-binary GIT_VERSION=$(GIT_VERSION) GO_OS=darwin GO_ARCH=amd64 OUTPUT_FILE=bin/darwin/eksctl-anywhere LINKER_FLAGS='-s -w -X github.com/aws/eks-anywhere/pkg/eksctl.enabled=true'
-	$(MAKE) eks-a-binary GIT_VERSION=$(GIT_VERSION) GO_OS=linux GO_ARCH=amd64 OUTPUT_FILE=bin/linux/eksctl-anywhere LINKER_FLAGS='-s -w -X github.com/aws/eks-anywhere/pkg/eksctl.enabled=true'
-	$(MAKE) eks-a-binary GIT_VERSION=$(GIT_VERSION) GO_OS=darwin GO_ARCH=arm64 OUTPUT_FILE=bin/darwin/eksctl-anywhere LINKER_FLAGS='-s -w -X github.com/aws/eks-anywhere/pkg/eksctl.enabled=true'
-	$(MAKE) eks-a-binary GIT_VERSION=$(GIT_VERSION) GO_OS=linux GO_ARCH=arm64 OUTPUT_FILE=bin/linux/eksctl-anywhere LINKER_FLAGS='-s -w -X github.com/aws/eks-anywhere/pkg/eksctl.enabled=true'
+	$(MAKE) eks-a-binary GIT_VERSION=$(GIT_VERSION) GO_OS=darwin GO_ARCH=amd64 OUTPUT_FILE=bin/darwin/amd64/eksctl-anywhere LINKER_FLAGS='-s -w -X github.com/aws/eks-anywhere/pkg/eksctl.enabled=true'
+	$(MAKE) eks-a-binary GIT_VERSION=$(GIT_VERSION) GO_OS=linux GO_ARCH=amd64 OUTPUT_FILE=bin/linux/amd64/eksctl-anywhere LINKER_FLAGS='-s -w -X github.com/aws/eks-anywhere/pkg/eksctl.enabled=true'
+	$(MAKE) eks-a-binary GIT_VERSION=$(GIT_VERSION) GO_OS=darwin GO_ARCH=arm64 OUTPUT_FILE=bin/darwin/arm64/eksctl-anywhere LINKER_FLAGS='-s -w -X github.com/aws/eks-anywhere/pkg/eksctl.enabled=true'
+	$(MAKE) eks-a-binary GIT_VERSION=$(GIT_VERSION) GO_OS=linux GO_ARCH=arm64 OUTPUT_FILE=bin/linux/arm64/eksctl-anywhere LINKER_FLAGS='-s -w -X github.com/aws/eks-anywhere/pkg/eksctl.enabled=true'
 
 $(TOOLS_BIN_DIR):
 	mkdir -p $(TOOLS_BIN_DIR)

--- a/cmd/integration_test/build/script/upload_artifacts.sh
+++ b/cmd/integration_test/build/script/upload_artifacts.sh
@@ -32,7 +32,7 @@ function build::cli::create_tarball() {
 
   build::ensure_tar
 
-  "${TAR}" czf "${tar_path}/${os}/${tar_file}" -C ${cli_artifacts_path} . --owner=0 --group=0
+  "${TAR}" czf "${tar_path}/${os}/${arch}/${tar_file}" -C ${cli_artifacts_path} . --owner=0 --group=0
 }
 
 function build::cli::generate_shasum() {
@@ -99,8 +99,8 @@ for platform in "${SUPPORTED_PLATFORMS[@]}"; do
   OS="$(cut -d '/' -f1 <<< ${platform})"
   ARCH="$(cut -d '/' -f2 <<< ${platform})"
   TAR_FILE="${REPO}-${OS}-${ARCH}.tar.gz"
-  CLI_ARTIFACTS_PATH="cli-artifacts/${OS}"
-  mkdir -p $TAR_PATH/$OS
+  CLI_ARTIFACTS_PATH="cli-artifacts/${OS}/${ARCH}"
+  mkdir -p $TAR_PATH/$OS/$ARCH
   mkdir -p $CLI_ARTIFACTS_PATH
 
   build::cli::move_artifacts $OS $ARCH $CLI_ARTIFACTS_PATH

--- a/cmd/integration_test/build/script/upload_artifacts.sh
+++ b/cmd/integration_test/build/script/upload_artifacts.sh
@@ -16,9 +16,10 @@ TAR_PATH="${CODEBUILD_SRC_DIR}/${PROJECT_PATH}/${BUILD_IDENTIFIER}-${GIT_HASH}/a
 
 function build::cli::move_artifacts() {
   local -r os=$1
-  local -r cli_artifacts_path=$2
+  local -r arch=$2
+  local -r cli_artifacts_path=$3
 
-  mv ${BINARY_PATH}/${os}/eksctl-anywhere ${cli_artifacts_path}
+  mv ${BINARY_PATH}/${os}/${arch}/eksctl-anywhere ${cli_artifacts_path}
   cp ATTRIBUTION.txt ${cli_artifacts_path}
 }
 
@@ -102,7 +103,7 @@ for platform in "${SUPPORTED_PLATFORMS[@]}"; do
   mkdir -p $TAR_PATH/$OS
   mkdir -p $CLI_ARTIFACTS_PATH
 
-  build::cli::move_artifacts $OS $CLI_ARTIFACTS_PATH
+  build::cli::move_artifacts $OS $ARCH $CLI_ARTIFACTS_PATH
   build::cli::create_tarball $OS $ARCH $TAR_FILE $TAR_PATH $CLI_ARTIFACTS_PATH
   build::cli::generate_shasum $TAR_PATH $OS
 done

--- a/release/pkg/assets_cli.go
+++ b/release/pkg/assets_cli.go
@@ -46,7 +46,7 @@ func (r *ReleaseConfig) GetEksACliArtifacts() ([]Artifact, error) {
 		}
 
 		if r.DevRelease {
-			releaseS3Path = fmt.Sprintf("eks-anywhere/%s/eks-a-cli/%s", r.DevReleaseUriVersion, os)
+			releaseS3Path = fmt.Sprintf("eks-anywhere/%s/eks-a-cli/%s/%s", r.DevReleaseUriVersion, os, arch)
 		} else {
 			releaseS3Path = fmt.Sprintf("releases/eks-a/%d/artifacts/eks-a/%s/%s/%s", r.ReleaseNumber, r.ReleaseVersion, os, arch)
 		}

--- a/release/pkg/assets_cli.go
+++ b/release/pkg/assets_cli.go
@@ -39,16 +39,16 @@ func (r *ReleaseConfig) GetEksACliArtifacts() ([]Artifact, error) {
 
 		if r.DevRelease || r.ReleaseEnvironment == "development" {
 			sourceS3Key = fmt.Sprintf("eksctl-anywhere-%s-%s.tar.gz", os, arch)
-			sourceS3Prefix = fmt.Sprintf("eks-a-cli/latest/%s", os)
+			sourceS3Prefix = fmt.Sprintf("eks-a-cli/latest/%s/%s", os, arch)
 		} else {
 			sourceS3Key = fmt.Sprintf("eksctl-anywhere-%s-%s-%s.tar.gz", r.ReleaseVersion, os, arch)
-			sourceS3Prefix = fmt.Sprintf("releases/eks-a/%d/artifacts/eks-a/%s/%s", r.ReleaseNumber, r.ReleaseVersion, os)
+			sourceS3Prefix = fmt.Sprintf("releases/eks-a/%d/artifacts/eks-a/%s/%s/%s", r.ReleaseNumber, r.ReleaseVersion, os, arch)
 		}
 
 		if r.DevRelease {
 			releaseS3Path = fmt.Sprintf("eks-anywhere/%s/eks-a-cli/%s", r.DevReleaseUriVersion, os)
 		} else {
-			releaseS3Path = fmt.Sprintf("releases/eks-a/%d/artifacts/eks-a/%s/%s", r.ReleaseNumber, r.ReleaseVersion, os)
+			releaseS3Path = fmt.Sprintf("releases/eks-a/%d/artifacts/eks-a/%s/%s/%s", r.ReleaseNumber, r.ReleaseVersion, os, arch)
 		}
 
 		cdnURI, err := r.GetURI(filepath.Join(releaseS3Path, releaseName))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The current make target for arm overwrites the amd binary when running the cross platform target. This will separate out the builds and also only upload the binaries that are supported for tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
