### PR TITLE
ensure e2e delete commands on 06 are using the correct invocation of …

### DIFF
--- a/test/framework/e2e.go
+++ b/test/framework/e2e.go
@@ -201,7 +201,7 @@ func (e *E2ETest) buildClusterConfigFile() {
 }
 
 func (e *E2ETest) DeleteCluster() {
-	deleteClusterArgs := []string{"delete", "cluster", e.ClusterName, "-v", "4"}
+	deleteClusterArgs := []string{"anywhere", "delete", "cluster", e.ClusterName, "-v", "4"}
 	if getBundlesOverride() == "true" {
 		deleteClusterArgs = append(deleteClusterArgs, "--bundles-override", defaultBundleReleaseManifestFile)
 	}


### PR DESCRIPTION
…eksctl anywhere

*Issue #, if available:*

*Description of changes:*

removed 'anywhere' command arg in e2e test invocations when backporting updates to 0.6, since it's been changed in the 'main' branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
