### PR TITLE
Fix dev release bundle manifest url generation

### DIFF
--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -514,7 +514,7 @@ func (r *ReleaseConfig) GetPreviousReleaseImageSemver(releaseImageUri string) (s
 	} else {
 		bundles := &anywherev1alpha1.Bundles{}
 		bundleReleaseManifestKey := r.GetManifestFilepaths(anywherev1alpha1.BundlesKind)
-		bundleManifestUrl := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", r.ReleaseBucket, bundleReleaseManifestKey)
+		bundleManifestUrl := fmt.Sprintf("https://%s.s3.amazonaws.com%s", r.ReleaseBucket, bundleReleaseManifestKey)
 		contents, err := ReadHttpFile(bundleManifestUrl)
 		if err != nil {
 			return "", fmt.Errorf("Error reading bundle manifest from S3: %v", err)


### PR DESCRIPTION
The key already has a slash prefix.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
