### PR TITLE
Handle images not present in bundle manifest

### DIFF
--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -466,23 +466,27 @@ func (r *ReleaseConfig) GetReleaseImageURI(name, repoName string, tagOptions map
 		if err != nil {
 			return "", errors.Cause(err)
 		}
-		fmt.Printf("Previous release image semver: %s\n", previousReleaseImageSemver)
-		previousReleaseImageUri := fmt.Sprintf("%s-%s", releaseImageUri, previousReleaseImageSemver)
-
-		sameDigest, err := r.CompareHashWithPreviousBundle(currentSourceImageUri, previousReleaseImageUri)
-		if err != nil {
-			return "", errors.Cause(err)
-		}
-		if sameDigest {
-			semver = previousReleaseImageSemver
-			fmt.Printf("Image digest for %s image has not changed, tagging with previous dev release semver: %s\n", repoName, semver)
+		if previousReleaseImageSemver == "" {
+			semver = r.DevReleaseUriVersion
 		} else {
-			newSemver, err := generateNewDevReleaseVersion(previousReleaseImageSemver, "vDev")
+			fmt.Printf("Previous release image semver: %s\n", previousReleaseImageSemver)
+			previousReleaseImageUri := fmt.Sprintf("%s-%s", releaseImageUri, previousReleaseImageSemver)
+
+			sameDigest, err := r.CompareHashWithPreviousBundle(currentSourceImageUri, previousReleaseImageUri)
 			if err != nil {
 				return "", errors.Cause(err)
 			}
-			semver = strings.ReplaceAll(newSemver, "+", "-")
-			fmt.Printf("Image digest for %s image has changed, tagging with new dev release semver: %s\n", repoName, semver)
+			if sameDigest {
+				semver = previousReleaseImageSemver
+				fmt.Printf("Image digest for %s image has not changed, tagging with previous dev release semver: %s\n", repoName, semver)
+			} else {
+				newSemver, err := generateNewDevReleaseVersion(previousReleaseImageSemver, "vDev")
+				if err != nil {
+					return "", errors.Cause(err)
+				}
+				semver = strings.ReplaceAll(newSemver, "+", "-")
+				fmt.Printf("Image digest for %s image has changed, tagging with new dev release semver: %s\n", repoName, semver)
+			}
 		}
 	} else {
 		semver = fmt.Sprintf("%d", r.BundleNumber)
@@ -497,7 +501,7 @@ func (r *ReleaseConfig) CompareHashWithPreviousBundle(currentSourceImageUri, pre
 	if r.DryRun {
 		return false, nil
 	}
-	fmt.Printf("Comparing digests for [%s] and [%s]", currentSourceImageUri, previousReleaseImageUri)
+	fmt.Printf("Comparing digests for [%s] and [%s]\n", currentSourceImageUri, previousReleaseImageUri)
 	currentSourceImageUriDigest, err := r.GetECRImageDigest(currentSourceImageUri)
 	if err != nil {
 		return false, errors.Cause(err)


### PR DESCRIPTION
For images not present in the bundle manifest, we can bump them to the current dev release version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
