### PR TITLE
Avoid redundant method invocations during release

### DIFF
--- a/release/pkg/assets_bottlerocket_bootstrap.go
+++ b/release/pkg/assets_bottlerocket_bootstrap.go
@@ -49,10 +49,7 @@ func (r *ReleaseConfig) GetBottlerocketBootstrapAssets(eksDReleaseChannel, eksDR
 }
 
 func (r *ReleaseConfig) GetBottlerocketBootstrapBundle(eksDReleaseChannel, eksDReleaseNumber string, imageDigests map[string]string) (anywherev1alpha1.BottlerocketBootstrapBundle, error) {
-	artifacts, err := r.GetBottlerocketBootstrapAssets(eksDReleaseChannel, eksDReleaseNumber)
-	if err != nil {
-		return anywherev1alpha1.BottlerocketBootstrapBundle{}, errors.Cause(err)
-	}
+	artifacts := r.BundleArtifactsTable[fmt.Sprintf("bottlerocket-bootstrap-%s-%s", eksDReleaseChannel, eksDReleaseNumber)]
 
 	bundleArtifacts := map[string]anywherev1alpha1.Image{}
 

--- a/release/pkg/assets_capa.go
+++ b/release/pkg/assets_capa.go
@@ -122,9 +122,9 @@ func (r *ReleaseConfig) GetCapaAssets() ([]Artifact, error) {
 }
 
 func (r *ReleaseConfig) GetAwsBundle(imageDigests map[string]string) (anywherev1alpha1.AwsBundle, error) {
-	awsBundleArtifactsFuncs := map[string]func() ([]Artifact, error){
-		"cluster-api-provider-aws": r.GetCapaAssets,
-		"kube-proxy":               r.GetKubeRbacProxyAssets,
+	awsBundleArtifacts := map[string][]Artifact{
+		"cluster-api-provider-aws": r.BundleArtifactsTable["cluster-api-provider-aws"],
+		"kube-rbac-proxy":          r.BundleArtifactsTable["kube-rbac-proxy"],
 	}
 
 	version, err := BuildComponentVersion(
@@ -136,12 +136,7 @@ func (r *ReleaseConfig) GetAwsBundle(imageDigests map[string]string) (anywherev1
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
 
-	for componentName, artifactFunc := range awsBundleArtifactsFuncs {
-		artifacts, err := artifactFunc()
-		if err != nil {
-			return anywherev1alpha1.AwsBundle{}, errors.Wrapf(err, "Error getting artifact information for %s", componentName)
-		}
-
+	for _, artifacts := range awsBundleArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
 				imageArtifact := artifact.Image

--- a/release/pkg/assets_capd.go
+++ b/release/pkg/assets_capd.go
@@ -105,9 +105,9 @@ func (r *ReleaseConfig) GetDockerAssets() ([]Artifact, error) {
 }
 
 func (r *ReleaseConfig) GetDockerBundle(imageDigests map[string]string) (anywherev1alpha1.DockerBundle, error) {
-	dockerBundleArtifactsFuncs := map[string]func() ([]Artifact, error){
-		"cluster-api-provider-docker": r.GetDockerAssets,
-		"kube-proxy":                  r.GetKubeRbacProxyAssets,
+	dockerBundleArtifacts := map[string][]Artifact{
+		"cluster-api-provider-docker": r.BundleArtifactsTable["cluster-api-provider-docker"],
+		"kube-rbac-proxy":             r.BundleArtifactsTable["kube-rbac-proxy"],
 	}
 
 	version, err := BuildComponentVersion(
@@ -118,12 +118,7 @@ func (r *ReleaseConfig) GetDockerBundle(imageDigests map[string]string) (anywher
 	}
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
-	for componentName, artifactFunc := range dockerBundleArtifactsFuncs {
-		artifacts, err := artifactFunc()
-		if err != nil {
-			return anywherev1alpha1.DockerBundle{}, errors.Wrapf(err, "Error getting artifact information for %s", componentName)
-		}
-
+	for _, artifacts := range dockerBundleArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
 				imageArtifact := artifact.Image

--- a/release/pkg/assets_capi.go
+++ b/release/pkg/assets_capi.go
@@ -128,9 +128,9 @@ func (r *ReleaseConfig) GetCAPIAssets() ([]Artifact, error) {
 }
 
 func (r *ReleaseConfig) GetCoreClusterAPIBundle(imageDigests map[string]string) (anywherev1alpha1.CoreClusterAPI, error) {
-	coreClusterAPIBundleArtifactsFuncs := map[string]func() ([]Artifact, error){
-		"cluster-api": r.GetCAPIAssets,
-		"kube-proxy":  r.GetKubeRbacProxyAssets,
+	coreClusterAPIBundleArtifacts := map[string][]Artifact{
+		"cluster-api":     r.BundleArtifactsTable["cluster-api"],
+		"kube-rbac-proxy": r.BundleArtifactsTable["kube-rbac-proxy"],
 	}
 
 	version, err := BuildComponentVersion(
@@ -141,12 +141,7 @@ func (r *ReleaseConfig) GetCoreClusterAPIBundle(imageDigests map[string]string) 
 	}
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
-	for componentName, artifactFunc := range coreClusterAPIBundleArtifactsFuncs {
-		artifacts, err := artifactFunc()
-		if err != nil {
-			return anywherev1alpha1.CoreClusterAPI{}, errors.Wrapf(err, "Error getting artifact information for %s", componentName)
-		}
-
+	for componentName, artifacts := range coreClusterAPIBundleArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
 				imageArtifact := artifact.Image
@@ -194,9 +189,9 @@ func (r *ReleaseConfig) GetCoreClusterAPIBundle(imageDigests map[string]string) 
 }
 
 func (r *ReleaseConfig) GetKubeadmBootstrapBundle(imageDigests map[string]string) (anywherev1alpha1.KubeadmBootstrapBundle, error) {
-	kubeadmBootstrapBundleArtifactsFuncs := map[string]func() ([]Artifact, error){
-		"cluster-api": r.GetCAPIAssets,
-		"kube-proxy":  r.GetKubeRbacProxyAssets,
+	kubeadmBootstrapBundleArtifacts := map[string][]Artifact{
+		"cluster-api":     r.BundleArtifactsTable["cluster-api"],
+		"kube-rbac-proxy": r.BundleArtifactsTable["kube-rbac-proxy"],
 	}
 
 	version, err := BuildComponentVersion(
@@ -207,12 +202,7 @@ func (r *ReleaseConfig) GetKubeadmBootstrapBundle(imageDigests map[string]string
 	}
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
-	for componentName, artifactFunc := range kubeadmBootstrapBundleArtifactsFuncs {
-		artifacts, err := artifactFunc()
-		if err != nil {
-			return anywherev1alpha1.KubeadmBootstrapBundle{}, errors.Wrapf(err, "Error getting artifact information for %s", componentName)
-		}
-
+	for componentName, artifacts := range kubeadmBootstrapBundleArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
 				imageArtifact := artifact.Image
@@ -260,9 +250,9 @@ func (r *ReleaseConfig) GetKubeadmBootstrapBundle(imageDigests map[string]string
 }
 
 func (r *ReleaseConfig) GetKubeadmControlPlaneBundle(imageDigests map[string]string) (anywherev1alpha1.KubeadmControlPlaneBundle, error) {
-	kubeadmControlPlaneBundleArtifactsFuncs := map[string]func() ([]Artifact, error){
-		"cluster-api": r.GetCAPIAssets,
-		"kube-proxy":  r.GetKubeRbacProxyAssets,
+	kubeadmControlPlaneBundleArtifacts := map[string][]Artifact{
+		"cluster-api":     r.BundleArtifactsTable["cluster-api"],
+		"kube-rbac-proxy": r.BundleArtifactsTable["kube-rbac-proxy"],
 	}
 
 	version, err := BuildComponentVersion(
@@ -273,12 +263,7 @@ func (r *ReleaseConfig) GetKubeadmControlPlaneBundle(imageDigests map[string]str
 	}
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
-	for componentName, artifactFunc := range kubeadmControlPlaneBundleArtifactsFuncs {
-		artifacts, err := artifactFunc()
-		if err != nil {
-			return anywherev1alpha1.KubeadmControlPlaneBundle{}, errors.Wrapf(err, "Error getting artifact information for %s", componentName)
-		}
-
+	for componentName, artifacts := range kubeadmControlPlaneBundleArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
 				imageArtifact := artifact.Image

--- a/release/pkg/assets_certmanager.go
+++ b/release/pkg/assets_certmanager.go
@@ -64,10 +64,7 @@ func (r *ReleaseConfig) GetCertManagerAssets() ([]Artifact, error) {
 }
 
 func (r *ReleaseConfig) GetCertManagerBundle(imageDigests map[string]string) (anywherev1alpha1.CertManagerBundle, error) {
-	artifacts, err := r.GetCertManagerAssets()
-	if err != nil {
-		return anywherev1alpha1.CertManagerBundle{}, errors.Cause(err)
-	}
+	artifacts := r.BundleArtifactsTable["cert-manager"]
 
 	version, err := BuildComponentVersion(
 		newVersionerWithGITTAG(filepath.Join(r.BuildRepoSource, "projects/jetstack/cert-manager")),

--- a/release/pkg/assets_cilium.go
+++ b/release/pkg/assets_cilium.go
@@ -70,10 +70,7 @@ func (r *ReleaseConfig) GetCiliumAssets() ([]Artifact, error) {
 }
 
 func (r *ReleaseConfig) GetCiliumBundle() (anywherev1alpha1.CiliumBundle, error) {
-	artifacts, err := r.GetCiliumAssets()
-	if err != nil {
-		return anywherev1alpha1.CiliumBundle{}, errors.Cause(err)
-	}
+	artifacts := r.BundleArtifactsTable["cilium"]
 
 	ciliumContainerRegistry := "public.ecr.aws/isovalent"
 	ciliumGitTag, err := r.getCiliumGitTag()

--- a/release/pkg/assets_cli.go
+++ b/release/pkg/assets_cli.go
@@ -73,10 +73,11 @@ func (r *ReleaseConfig) GetEksACliArtifacts() ([]Artifact, error) {
 }
 
 func (r *ReleaseConfig) GetEksARelease() (anywherev1alpha1.EksARelease, error) {
-	artifacts, err := r.GetEksACliArtifacts()
-	if err != nil {
-		return anywherev1alpha1.EksARelease{}, errors.Cause(err)
-	}
+	fmt.Println("\n==========================================================")
+	fmt.Println("               EKS-A Release Spec Generation")
+	fmt.Println("==========================================================")
+
+	artifacts := r.EksAArtifactsTable["eks-a-cli"]
 
 	var bundleManifestUrl string
 	bundleArchiveArtifacts := map[string]anywherev1alpha1.Archive{}
@@ -121,6 +122,8 @@ func (r *ReleaseConfig) GetEksARelease() (anywherev1alpha1.EksARelease, error) {
 		},
 		BundleManifestUrl: bundleManifestUrl,
 	}
+
+	fmt.Printf("%s Successfully generated EKS-A release spec\n", SuccessIcon)
 
 	return eksARelease, nil
 }

--- a/release/pkg/assets_eksa_tools.go
+++ b/release/pkg/assets_eksa_tools.go
@@ -69,20 +69,15 @@ func (r *ReleaseConfig) GetEksAToolsAssets() ([]Artifact, error) {
 }
 
 func (r *ReleaseConfig) GetEksaBundle(imageDigests map[string]string) (anywherev1alpha1.EksaBundle, error) {
-	eksABundleArtifactsFuncs := map[string]func() ([]Artifact, error){
-		"eks-a-tools":           r.GetEksAToolsAssets,
-		"cluster-controller":    r.GetClusterControllerAssets,
-		"diagnostic-collector:": r.GetDiagnosticCollectorAssets,
+	eksABundleArtifacts := map[string][]Artifact{
+		"eks-a-tools":          r.BundleArtifactsTable["eks-a-tools"],
+		"cluster-controller":   r.BundleArtifactsTable["cluster-controller"],
+		"diagnostic-collector": r.BundleArtifactsTable["diagnostic-collector"],
 	}
 
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
-	for componentName, artifactFunc := range eksABundleArtifactsFuncs {
-		artifacts, err := artifactFunc()
-		if err != nil {
-			return anywherev1alpha1.EksaBundle{}, errors.Wrapf(err, "Error getting artifact information for %s", componentName)
-		}
-
+	for _, artifacts := range eksABundleArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
 				imageArtifact := artifact.Image

--- a/release/pkg/assets_etcdadm_bootstrap.go
+++ b/release/pkg/assets_etcdadm_bootstrap.go
@@ -106,9 +106,9 @@ func (r *ReleaseConfig) GetEtcdadmBootstrapAssets() ([]Artifact, error) {
 }
 
 func (r *ReleaseConfig) GetEtcdadmBootstrapBundle(imageDigests map[string]string) (anywherev1alpha1.EtcdadmBootstrapBundle, error) {
-	etcdadmBootstrapBundleArtifactsFuncs := map[string]func() ([]Artifact, error){
-		"etcdadm-bootstrap-provider": r.GetEtcdadmBootstrapAssets,
-		"kube-proxy":                 r.GetKubeRbacProxyAssets,
+	etcdadmBootstrapBundleArtifacts := map[string][]Artifact{
+		"etcdadm-bootstrap-provider": r.BundleArtifactsTable["etcdadm-bootstrap-provider"],
+		"kube-rbac-proxy":            r.BundleArtifactsTable["kube-rbac-proxy"],
 	}
 
 	version, err := BuildComponentVersion(
@@ -117,15 +117,11 @@ func (r *ReleaseConfig) GetEtcdadmBootstrapBundle(imageDigests map[string]string
 	if err != nil {
 		return anywherev1alpha1.EtcdadmBootstrapBundle{}, errors.Wrapf(err, "Error getting version for etcdadm-bootstrap-provider")
 	}
+
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
 
-	for componentName, artifactFunc := range etcdadmBootstrapBundleArtifactsFuncs {
-		artifacts, err := artifactFunc()
-		if err != nil {
-			return anywherev1alpha1.EtcdadmBootstrapBundle{}, errors.Wrapf(err, "Error getting artifact information for %s", componentName)
-		}
-
+	for _, artifacts := range etcdadmBootstrapBundleArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
 				imageArtifact := artifact.Image

--- a/release/pkg/assets_etcdadm_controller.go
+++ b/release/pkg/assets_etcdadm_controller.go
@@ -106,9 +106,9 @@ func (r *ReleaseConfig) GetEtcdadmControllerAssets() ([]Artifact, error) {
 }
 
 func (r *ReleaseConfig) GetEtcdadmControllerBundle(imageDigests map[string]string) (anywherev1alpha1.EtcdadmControllerBundle, error) {
-	etcdadmControllerBundleArtifactsFuncs := map[string]func() ([]Artifact, error){
-		"etcdadm-controller": r.GetEtcdadmControllerAssets,
-		"kube-proxy":         r.GetKubeRbacProxyAssets,
+	etcdadmControllerBundleArtifacts := map[string][]Artifact{
+		"etcdadm-controller": r.BundleArtifactsTable["etcdadm-controller"],
+		"kube-rbac-proxy":    r.BundleArtifactsTable["kube-rbac-proxy"],
 	}
 
 	version, err := BuildComponentVersion(
@@ -117,15 +117,11 @@ func (r *ReleaseConfig) GetEtcdadmControllerBundle(imageDigests map[string]strin
 	if err != nil {
 		return anywherev1alpha1.EtcdadmControllerBundle{}, errors.Wrapf(err, "Error getting version for etcdadm-controller")
 	}
+
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
 
-	for componentName, artifactFunc := range etcdadmControllerBundleArtifactsFuncs {
-		artifacts, err := artifactFunc()
-		if err != nil {
-			return anywherev1alpha1.EtcdadmControllerBundle{}, errors.Wrapf(err, "Error getting artifact information for %s", componentName)
-		}
-
+	for _, artifacts := range etcdadmControllerBundleArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
 				imageArtifact := artifact.Image

--- a/release/pkg/assets_flux.go
+++ b/release/pkg/assets_flux.go
@@ -53,10 +53,7 @@ func (r *ReleaseConfig) GetFluxAssets() ([]Artifact, error) {
 }
 
 func (r *ReleaseConfig) GetFluxBundle(imageDigests map[string]string) (anywherev1alpha1.FluxBundle, error) {
-	artifacts, err := r.GetFluxAssets()
-	if err != nil {
-		return anywherev1alpha1.FluxBundle{}, errors.Cause(err)
-	}
+	artifacts := r.BundleArtifactsTable["flux"]
 
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	for _, artifact := range artifacts {

--- a/release/pkg/assets_kindnetd.go
+++ b/release/pkg/assets_kindnetd.go
@@ -94,10 +94,7 @@ func (r *ReleaseConfig) GetKindnetdAssets() ([]Artifact, error) {
 }
 
 func (r *ReleaseConfig) GetKindnetdBundle() (anywherev1alpha1.KindnetdBundle, error) {
-	artifacts, err := r.GetKindnetdAssets()
-	if err != nil {
-		return anywherev1alpha1.KindnetdBundle{}, errors.Cause(err)
-	}
+	artifacts := r.BundleArtifactsTable["kindnetd"]
 
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
 

--- a/release/pkg/assets_vsphere.go
+++ b/release/pkg/assets_vsphere.go
@@ -24,11 +24,11 @@ import (
 )
 
 func (r *ReleaseConfig) GetVsphereBundle(eksDReleaseChannel string, imageDigests map[string]string) (anywherev1alpha1.VSphereBundle, error) {
-	vsphereBundleArtifactsFuncs := map[string]func() ([]Artifact, error){
-		"cluster-api-provider-vsphere": r.GetCapvAssets,
-		"kube-proxy":                   r.GetKubeRbacProxyAssets,
-		"kube-vip":                     r.GetKubeVipAssets,
-		"vsphere-csi-driver":           r.GetVsphereCsiAssets,
+	vsphereBundleArtifacts := map[string][]Artifact{
+		"cluster-api-provider-vsphere": r.BundleArtifactsTable["cluster-api-provider-vsphere"],
+		"kube-rbac-proxy":              r.BundleArtifactsTable["kube-rbac-proxy"],
+		"kube-vip":                     r.BundleArtifactsTable["kube-vip"],
+		"vsphere-csi-driver":           r.BundleArtifactsTable["vsphere-csi-driver"],
 	}
 
 	version, err := BuildComponentVersion(
@@ -37,14 +37,10 @@ func (r *ReleaseConfig) GetVsphereBundle(eksDReleaseChannel string, imageDigests
 	if err != nil {
 		return anywherev1alpha1.VSphereBundle{}, errors.Wrapf(err, "Error getting version for cluster-api-provider-sphere")
 	}
+
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
-	for componentName, artifactFunc := range vsphereBundleArtifactsFuncs {
-		artifacts, err := artifactFunc()
-		if err != nil {
-			return anywherev1alpha1.VSphereBundle{}, errors.Wrapf(err, "Error getting artifact information for %s", componentName)
-		}
-
+	for _, artifacts := range vsphereBundleArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
 				imageArtifact := artifact.Image
@@ -70,10 +66,7 @@ func (r *ReleaseConfig) GetVsphereBundle(eksDReleaseChannel string, imageDigests
 		}
 	}
 
-	vSphereCloudProviderArtifacts, err := r.GetVsphereCloudProviderAssets(eksDReleaseChannel)
-	if err != nil {
-		return anywherev1alpha1.VSphereBundle{}, errors.Wrapf(err, "Error getting artifact information for cloud-provider-vsphere for channel %s", eksDReleaseChannel)
-	}
+	vSphereCloudProviderArtifacts := r.BundleArtifactsTable[fmt.Sprintf("cloud-provider-vsphere-%s", eksDReleaseChannel)]
 
 	for _, artifact := range vSphereCloudProviderArtifacts {
 		imageArtifact := artifact.Image

--- a/release/pkg/clients.go
+++ b/release/pkg/clients.go
@@ -66,11 +66,13 @@ type ReleaseECRPublicClient struct {
 
 // Function to create release clients for dev release
 func (r *ReleaseConfig) CreateDevReleaseClients() (*SourceClients, *ReleaseClients, error) {
+	fmt.Println("\n==========================================================")
+	fmt.Println("                 Dev Release Clients Creation")
+	fmt.Println("==========================================================")
 	if r.DryRun {
 		fmt.Println("Skipping clients creation in dry-run mode")
 		return nil, nil, nil
 	}
-	fmt.Println("Creating new dev release clients for S3, docker and ECR public")
 
 	// PDX session for eks-a-build-prod-pdx
 	pdxSession, err := session.NewSession(&aws.Config{
@@ -131,12 +133,16 @@ func (r *ReleaseConfig) CreateDevReleaseClients() (*SourceClients, *ReleaseClien
 		},
 	}
 
+	fmt.Printf("%s Successfully created dev release clients\n", SuccessIcon)
+
 	return sourceClients, releaseClients, nil
 }
 
 // Function to create clients for staging release
 func (r *ReleaseConfig) CreateStagingReleaseClients() (*SourceClients, *ReleaseClients, error) {
-	fmt.Println("Creating new staging release clients for S3, docker and ECR public")
+	fmt.Println("\n==========================================================")
+	fmt.Println("              Staging Release Clients Creation")
+	fmt.Println("==========================================================")
 
 	// Session for eks-a-build-prod-pdx
 	sourceSession, err := session.NewSessionWithOptions(session.Options{
@@ -205,12 +211,16 @@ func (r *ReleaseConfig) CreateStagingReleaseClients() (*SourceClients, *ReleaseC
 		},
 	}
 
+	fmt.Printf("%s Successfully created staging release clients\n", SuccessIcon)
+
 	return sourceClients, releaseClients, nil
 }
 
 // Function to create clients for production release
 func (r *ReleaseConfig) CreateProdReleaseClients() (*SourceClients, *ReleaseClients, error) {
-	fmt.Println("Creating new production release clients for S3, docker and ECR public")
+	fmt.Println("\n==========================================================")
+	fmt.Println("             Production Release Clients Creation")
+	fmt.Println("==========================================================")
 
 	// Session for eks-a-artifact-beta-iad
 	sourceSession, err := session.NewSessionWithOptions(session.Options{
@@ -279,6 +289,8 @@ func (r *ReleaseConfig) CreateProdReleaseClients() (*SourceClients, *ReleaseClie
 			AuthConfig: releaseAuthConfig,
 		},
 	}
+
+	fmt.Printf("%s Successfully created production release clients\n", SuccessIcon)
 
 	return sourceClients, releaseClients, nil
 }

--- a/release/pkg/file_reader.go
+++ b/release/pkg/file_reader.go
@@ -141,6 +141,10 @@ func GetEksDReleaseManifestUrl(releaseChannel, releaseNumber string) string {
 }
 
 func (r *ReleaseConfig) GetCurrentEksADevReleaseVersion(releaseVersion string) (string, error) {
+	fmt.Println("\n==========================================================")
+	fmt.Println("              Dev Release Version Computation")
+	fmt.Println("==========================================================")
+
 	var latestBuildVersion string
 	if r.DryRun {
 		latestBuildVersion = "v0.0.0-dev+build.0"
@@ -183,6 +187,8 @@ func (r *ReleaseConfig) GetCurrentEksADevReleaseVersion(releaseVersion string) (
 	}
 
 	fmt.Printf("Next release version: %s\n", newDevReleaseVersion)
+
+	fmt.Printf("%s Successfully computed current dev release version\n", SuccessIcon)
 	return newDevReleaseVersion, nil
 }
 

--- a/release/pkg/prepare_release.go
+++ b/release/pkg/prepare_release.go
@@ -28,6 +28,10 @@ import (
 type EksAReleases []anywherev1alpha1.EksARelease
 
 func (r *ReleaseConfig) SetRepoHeads() error {
+	fmt.Println("\n==========================================================")
+	fmt.Println("                    Local Repository Setup")
+	fmt.Println("==========================================================")
+
 	// Get the repos from env var
 	if r.CliRepoUrl == "" || r.BuildRepoUrl == "" {
 		return fmt.Errorf("One or both clone URLs are empty")
@@ -90,57 +94,50 @@ func (r *ReleaseConfig) SetRepoHeads() error {
 		return errors.Cause(err)
 	}
 	fmt.Printf("Head of build repo: %s\n", r.BuildRepoHead)
+
+	fmt.Printf("%s Successfully completed local repository setup\n", SuccessIcon)
+
 	return nil
 }
 
-func (r *ReleaseConfig) PrepareBundleRelease(artifactsTable map[string][]Artifact) error {
-	fmt.Println("Preparing bundle release")
-	err := r.downloadArtifacts(artifactsTable)
+func (r *ReleaseConfig) PrepareBundleRelease() error {
+	fmt.Println("\n==========================================================")
+	fmt.Println("                  Bundle Release Preparation")
+	fmt.Println("==========================================================")
+	err := r.downloadArtifacts(r.BundleArtifactsTable)
 	if err != nil {
 		return errors.Cause(err)
 	}
-	fmt.Println("Artifacts download complete")
 
-	err = r.renameArtifacts(artifactsTable)
+	err = r.renameArtifacts(r.BundleArtifactsTable)
 	if err != nil {
 		return errors.Cause(err)
 	}
-	fmt.Println("Renaming artifacts complete")
 
 	return nil
 }
 
 func (r *ReleaseConfig) PrepareEksARelease() error {
-	if r.DryRun {
-		fmt.Println("Skipping EKS-A artifacts download and rename in dry-run mode")
-		return nil
-	}
-	fmt.Println("Preparing EKS-A release")
-	artifactsTable, err := r.GetEksAArtifactsData()
+	fmt.Println("\n==========================================================")
+	fmt.Println("                 EKS-A CLI Release Preparation")
+	fmt.Println("==========================================================")
+	err := r.downloadArtifacts(r.EksAArtifactsTable)
 	if err != nil {
 		return errors.Cause(err)
 	}
-	fmt.Println("Initialized artifacts data")
 
-	err = r.downloadArtifacts(artifactsTable)
+	err = r.renameArtifacts(r.EksAArtifactsTable)
 	if err != nil {
 		return errors.Cause(err)
 	}
-	fmt.Println("Artifacts download complete")
-
-	err = r.renameArtifacts(artifactsTable)
-	if err != nil {
-		return errors.Cause(err)
-	}
-	fmt.Println("Renaming artifacts complete")
 
 	return nil
 }
 
 func (r *ReleaseConfig) renameArtifacts(artifacts map[string][]Artifact) error {
-	fmt.Println("============================================================")
-	fmt.Println("                 Renaming Artifacts                         ")
-	fmt.Println("============================================================")
+	fmt.Println("\n==========================================================")
+	fmt.Println("                    Artifacts Rename")
+	fmt.Println("==========================================================")
 	for _, artifactsList := range artifacts {
 		for _, artifact := range artifactsList {
 
@@ -200,6 +197,8 @@ func (r *ReleaseConfig) renameArtifacts(artifacts map[string][]Artifact) error {
 			}
 		}
 	}
+	fmt.Printf("%s Successfully renamed artifacts\n", SuccessIcon)
+
 	return nil
 }
 
@@ -220,9 +219,9 @@ func (r *ReleaseConfig) downloadArtifacts(eksArtifacts map[string][]Artifact) er
 			return false, 0
 		}))
 	}
-	fmt.Println("============================================================")
-	fmt.Println("                 Downloading Artifacts                      ")
-	fmt.Println("============================================================")
+	fmt.Println("==========================================================")
+	fmt.Println("                  Artifacts Download")
+	fmt.Println("==========================================================")
 
 	for _, artifacts := range eksArtifacts {
 		for _, artifact := range artifacts {
@@ -302,10 +301,15 @@ func (r *ReleaseConfig) downloadArtifacts(eksArtifacts map[string][]Artifact) er
 			}
 		}
 	}
+	fmt.Printf("%s Successfully downloaded artifacts\n", SuccessIcon)
+
 	return nil
 }
 
 func (r *ReleaseConfig) UploadArtifacts(eksArtifacts map[string][]Artifact) error {
+	fmt.Println("\n==========================================================")
+	fmt.Println("                  Artifacts Upload")
+	fmt.Println("==========================================================")
 	if r.DryRun {
 		fmt.Println("Skipping artifacts upload in dry-run mode")
 		return nil
@@ -313,10 +317,6 @@ func (r *ReleaseConfig) UploadArtifacts(eksArtifacts map[string][]Artifact) erro
 
 	sourceEcrAuthConfig := r.SourceClients.ECR.AuthConfig
 	releaseEcrAuthConfig := r.ReleaseClients.ECRPublic.AuthConfig
-
-	fmt.Println("============================================================")
-	fmt.Println("                 Uploading Artifacts                      ")
-	fmt.Println("============================================================")
 
 	for _, artifacts := range eksArtifacts {
 		for _, artifact := range artifacts {
@@ -365,6 +365,7 @@ func (r *ReleaseConfig) UploadArtifacts(eksArtifacts map[string][]Artifact) erro
 			}
 		}
 	}
+	fmt.Printf("%s Successsfully uploaded artifacts\n", SuccessIcon)
 
 	return nil
 }
@@ -451,10 +452,10 @@ func execCommand(cmd *exec.Cmd) (string, error) {
 	return string(stdout), nil
 }
 
-func (r *ReleaseConfig) UpdateImageDigests(eksArtifacts map[string][]Artifact) (map[string]string, error) {
-	fmt.Println("============================================================")
-	fmt.Println("                 Updating Image Digests                      ")
-	fmt.Println("============================================================")
+func (r *ReleaseConfig) GenerateImageDigestsTable(eksArtifacts map[string][]Artifact) (map[string]string, error) {
+	fmt.Println("\n==========================================================")
+	fmt.Println("                 Image Digests Table Generation")
+	fmt.Println("==========================================================")
 	imageDigests := make(map[string]string)
 
 	for _, artifacts := range eksArtifacts {
@@ -480,6 +481,7 @@ func (r *ReleaseConfig) UpdateImageDigests(eksArtifacts map[string][]Artifact) (
 			}
 		}
 	}
+	fmt.Printf("%s Successfully generated image digests table\n", SuccessIcon)
 
 	return imageDigests, nil
 }


### PR DESCRIPTION
The methods to set artifacts parameters like S3/ECR URIs were being called twice, once in `GenerateBundleArtifactsTable` and again for each bundle where that artifact is required. This PR refactors the code to only call it once, for the inital artifacts table generation, after which the generated table is re-used.

Additional changes:
* Beautified release output with demarcated sections and success icon
* Minor renames of methods

[Sample output](https://prow.eks.amazonaws.com/log?container=test&id=1466117328339996672&job=eks-anywhere-release-tooling-presubmit)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
