### PR TITLE
Make sure IP is unique in e2e tests

### DIFF
--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -221,13 +221,13 @@ func RequiredVsphereEnvVars() []string {
 }
 
 func (v *VSphere) generateUniqueIp() string {
+	ipgen := networkutils.NewIPGenerator(&networkutils.DefaultNetClient{})
 	ip := os.Getenv(vsphereHost)
-	if len(ip) > 0 {
+	if len(ip) > 0 && ipgen.IsIPUnique(ip) {
 		logger.V(1).Info("Using configured ip: " + ip)
 		return ip
 	}
 	logger.V(1).Info("Generating unique IP for vsphere control plane")
-	ipgen := networkutils.NewIPGenerator(&networkutils.DefaultNetClient{})
 	ip, err := ipgen.GenerateUniqueIP(v.cidr)
 	if err != nil {
 		v.t.Fatalf("Error getting unique IP for vsphere: %v", err)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The multi-cluster E2E test always fails because when creating the second cluster, it tries to use the host IP from the `T_VSPHERE_HOST` env var. However, that IP is already in use by the first cluster so it fails. This adds a check to only use the IP from the env var if it is unique, if not it will generate a new one. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
