### PR TITLE
Add git tags to EKS-A cluster controller and kind image options

### DIFF
--- a/release/pkg/assets_bottlerocket_bootstrap.go
+++ b/release/pkg/assets_bottlerocket_bootstrap.go
@@ -31,6 +31,7 @@ func (r *ReleaseConfig) GetBottlerocketBootstrapAssets(eksDReleaseChannel, eksDR
 	tagOptions := map[string]string{
 		"eksDReleaseChannel": eksDReleaseChannel,
 		"eksDReleaseNumber":  eksDReleaseNumber,
+		"gitTag":             "non-existent",
 	}
 
 	sourceImageUri, err := r.GetSourceImageURI(name, repoName, tagOptions)

--- a/release/pkg/assets_cluster_controller.go
+++ b/release/pkg/assets_cluster_controller.go
@@ -62,6 +62,7 @@ func (r *ReleaseConfig) GetClusterControllerAssets() ([]Artifact, error) {
 	}
 
 	tagOptions := map[string]string{
+		"gitTag":      gitTag,
 		"projectPath": eksAnywhereProjectPath,
 	}
 

--- a/release/pkg/assets_eksd.go
+++ b/release/pkg/assets_eksd.go
@@ -36,7 +36,7 @@ func (r *ReleaseConfig) GetEksDChannelAssets(eksDReleaseChannel, kubeVer, eksDRe
 	arch := "amd64"
 	osNames := []string{"ubuntu", "bottlerocket"}
 	artifacts := []Artifact{}
-	gitTag, err := r.readGitTag(imageBuilderProjectPath, r.BuildRepoBranchName)
+	imageBuilderGitTag, err := r.readGitTag(imageBuilderProjectPath, r.BuildRepoBranchName)
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
@@ -105,14 +105,18 @@ func (r *ReleaseConfig) GetEksDChannelAssets(eksDReleaseChannel, kubeVer, eksDRe
 			OS:             os,
 			OSName:         osName,
 			Arch:           []string{arch},
-			GitTag:         gitTag,
+			GitTag:         imageBuilderGitTag,
 			ProjectPath:    imageBuilderProjectPath,
 		}
 
 		artifacts = append(artifacts, Artifact{Archive: archiveArtifact})
 	}
 
-	// Add kind images
+	kindGitTag, err := r.readGitTag(kindProjectPath, r.BuildRepoBranchName)
+	if err != nil {
+		return nil, errors.Cause(err)
+	}
+
 	name := "kind-node"
 	repoName := "kubernetes-sigs/kind/node"
 	tagOptions := map[string]string{
@@ -120,6 +124,7 @@ func (r *ReleaseConfig) GetEksDChannelAssets(eksDReleaseChannel, kubeVer, eksDRe
 		"eksDReleaseNumber":  eksDReleaseNumber,
 		"kubeVersion":        kubeVer,
 		"projectPath":        kindProjectPath,
+		"gitTag":             kindGitTag,
 	}
 
 	sourceImageUri, err := r.GetSourceImageURI(name, repoName, tagOptions)

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -582,7 +582,8 @@ func (r *ReleaseConfig) GetPreviousReleaseImageSemver(releaseImageUri string) (s
 					if strings.Contains(image.URI, releaseImageUri) {
 						imageUri := image.URI
 						numDashes := strings.Count(imageUri, "-")
-						imageUriSplit := strings.SplitAfterN(imageUri, "-", numDashes-1)
+						splitIndex := numDashes - strings.Count(r.BuildRepoBranchName, "-") - 1
+						imageUriSplit := strings.SplitAfterN(imageUri, "-", splitIndex)
 						semver = imageUriSplit[len(imageUriSplit)-1]
 					}
 				}


### PR DESCRIPTION
* Adding the git tag so that the `strings.NewReplacer` works properly.
* Adding branch name to dev release version if not releasing from `main`.
* Remove dry-run check for generating release version since we have replaced S3 API calls with `HEAD` requests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
