### PR TITLE
Use correct repository path when deleting workload cluster

### DIFF
--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -310,7 +310,12 @@ func (f *FluxAddonClient) CleanupGitRepo(ctx context.Context, clusterSpec *clust
 		return err
 	}
 
-	p := fc.path()
+	var p string
+	if clusterSpec.IsManaged() {
+		p = fc.eksaSystemDir()
+	} else {
+		p = fc.path()
+	}
 
 	if !validations.FileExists(path.Join(f.gitOpts.Writer.Dir(), p)) {
 		logger.V(3).Info("cluster dir does not exist in git, skip clean up")


### PR DESCRIPTION
Use the correct repository path when deleting a workload cluster

*Issue #, if available:*
#751

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
