### PR TITLE
Assign bundle version based on branch artifact was built from

### DIFF
--- a/release/pkg/artifacts_types.go
+++ b/release/pkg/artifacts_types.go
@@ -20,27 +20,29 @@ type ImageTagOverride struct {
 }
 
 type ArchiveArtifact struct {
-	SourceS3Prefix string // S3 uri till base to download artifact, and the checksums
-	SourceS3Key    string
-	ArtifactPath   string
-	ReleaseName    string
-	ReleaseS3Path  string
-	ReleaseCdnURI  string
-	OS             string
-	OSName         string
-	Arch           []string
-	GitTag         string
-	ProjectPath    string
+	SourceS3Prefix    string // S3 uri till base to download artifact, and the checksums
+	SourceS3Key       string
+	ArtifactPath      string
+	ReleaseName       string
+	ReleaseS3Path     string
+	ReleaseCdnURI     string
+	OS                string
+	OSName            string
+	Arch              []string
+	GitTag            string
+	ProjectPath       string
+	SourcedFromBranch string
 }
 
 type ImageArtifact struct {
-	AssetName       string
-	SourceImageURI  string
-	ReleaseImageURI string
-	OS              string
-	Arch            []string
-	GitTag          string
-	ProjectPath     string
+	AssetName         string
+	SourceImageURI    string
+	ReleaseImageURI   string
+	OS                string
+	Arch              []string
+	GitTag            string
+	ProjectPath       string
+	SourcedFromBranch string
 }
 
 type ManifestArtifact struct {
@@ -53,6 +55,7 @@ type ManifestArtifact struct {
 	ImageTagOverrides []ImageTagOverride
 	GitTag            string
 	ProjectPath       string
+	SourcedFromBranch string
 }
 
 type Artifact struct {

--- a/release/pkg/assets_bottlerocket_bootstrap.go
+++ b/release/pkg/assets_bottlerocket_bootstrap.go
@@ -34,7 +34,7 @@ func (r *ReleaseConfig) GetBottlerocketBootstrapAssets(eksDReleaseChannel, eksDR
 		"gitTag":             "non-existent",
 	}
 
-	sourceImageUri, err := r.GetSourceImageURI(name, repoName, tagOptions)
+	sourceImageUri, sourcedFromBranch, err := r.GetSourceImageURI(name, repoName, tagOptions)
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
@@ -44,12 +44,13 @@ func (r *ReleaseConfig) GetBottlerocketBootstrapAssets(eksDReleaseChannel, eksDR
 	}
 
 	imageArtifact := &ImageArtifact{
-		AssetName:       name,
-		SourceImageURI:  sourceImageUri,
-		ReleaseImageURI: releaseImageUri,
-		Arch:            []string{"amd64"},
-		OS:              "linux",
-		ProjectPath:     bottlerocketBootstrapProjectPath,
+		AssetName:         name,
+		SourceImageURI:    sourceImageUri,
+		ReleaseImageURI:   releaseImageUri,
+		Arch:              []string{"amd64"},
+		OS:                "linux",
+		ProjectPath:       bottlerocketBootstrapProjectPath,
+		SourcedFromBranch: sourcedFromBranch,
 	}
 
 	artifact := Artifact{Image: imageArtifact}

--- a/release/pkg/assets_capa.go
+++ b/release/pkg/assets_capa.go
@@ -39,6 +39,7 @@ func (r *ReleaseConfig) GetCapaAssets() ([]Artifact, error) {
 	}
 
 	var imageTagOverrides []ImageTagOverride
+	sourcedFromBranch := r.BuildRepoBranchName
 	artifacts := []Artifact{}
 
 	for _, image := range capaImages {
@@ -49,9 +50,16 @@ func (r *ReleaseConfig) GetCapaAssets() ([]Artifact, error) {
 			"projectPath": capaProjectPath,
 		}
 
-		sourceImageUri, err := r.GetSourceImageURI(image, repoName, tagOptions)
+		sourceImageUri, sourcedFromBranch, err := r.GetSourceImageURI(image, repoName, tagOptions)
 		if err != nil {
 			return nil, errors.Cause(err)
+		}
+		if sourcedFromBranch != r.BuildRepoBranchName {
+			gitTag, err = r.readGitTag(capaProjectPath, sourcedFromBranch)
+			if err != nil {
+				return nil, errors.Cause(err)
+			}
+			tagOptions["gitTag"] = gitTag
 		}
 		releaseImageUri, err := r.GetReleaseImageURI(image, repoName, tagOptions)
 		if err != nil {
@@ -59,13 +67,14 @@ func (r *ReleaseConfig) GetCapaAssets() ([]Artifact, error) {
 		}
 
 		imageArtifact := &ImageArtifact{
-			AssetName:       image,
-			SourceImageURI:  sourceImageUri,
-			ReleaseImageURI: releaseImageUri,
-			Arch:            []string{"amd64"},
-			OS:              "linux",
-			GitTag:          gitTag,
-			ProjectPath:     capaProjectPath,
+			AssetName:         image,
+			SourceImageURI:    sourceImageUri,
+			ReleaseImageURI:   releaseImageUri,
+			Arch:              []string{"amd64"},
+			OS:                "linux",
+			GitTag:            gitTag,
+			ProjectPath:       capaProjectPath,
+			SourcedFromBranch: sourcedFromBranch,
 		}
 
 		artifacts = append(artifacts, Artifact{Image: imageArtifact})
@@ -95,7 +104,7 @@ func (r *ReleaseConfig) GetCapaAssets() ([]Artifact, error) {
 	for _, manifest := range manifestList {
 		var sourceS3Prefix string
 		var releaseS3Path string
-		latestPath := r.getLatestUploadDestination()
+		latestPath := getLatestUploadDestination(sourcedFromBranch)
 
 		if r.DevRelease || r.ReleaseEnvironment == "development" {
 			sourceS3Prefix = fmt.Sprintf("%s/%s/manifests/infrastructure-aws/%s", capaProjectPath, latestPath, gitTag)
@@ -126,6 +135,7 @@ func (r *ReleaseConfig) GetCapaAssets() ([]Artifact, error) {
 			ImageTagOverrides: imageTagOverrides,
 			GitTag:            gitTag,
 			ProjectPath:       capaProjectPath,
+			SourcedFromBranch: sourcedFromBranch,
 		}
 		artifacts = append(artifacts, Artifact{Manifest: manifestArtifact})
 	}
@@ -139,20 +149,23 @@ func (r *ReleaseConfig) GetAwsBundle(imageDigests map[string]string) (anywherev1
 		"kube-rbac-proxy":          r.BundleArtifactsTable["kube-rbac-proxy"],
 	}
 
-	version, err := BuildComponentVersion(
-		newVersionerWithGITTAG(filepath.Join(r.BuildRepoSource, capaProjectPath)),
-	)
-	if err != nil {
-		return anywherev1alpha1.AwsBundle{}, errors.Wrapf(err, "Error getting version for cluster-api-provider-aws")
-	}
+	var version string
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
 
-	for _, artifacts := range awsBundleArtifacts {
+	for componentName, artifacts := range awsBundleArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
 				imageArtifact := artifact.Image
-
+				if componentName == "cluster-api-provider-aws" {
+					componentVersion, err := BuildComponentVersion(
+						newVersionerWithGITTAG(r.BuildRepoSource, capaProjectPath, imageArtifact.SourcedFromBranch, r),
+					)
+					if err != nil {
+						return anywherev1alpha1.AwsBundle{}, errors.Wrapf(err, "Error getting version for cluster-api-provider-aws")
+					}
+					version = componentVersion
+				}
 				bundleImageArtifact := anywherev1alpha1.Image{
 					Name:        imageArtifact.AssetName,
 					Description: fmt.Sprintf("Container image for %s image", imageArtifact.AssetName),

--- a/release/pkg/assets_certmanager.go
+++ b/release/pkg/assets_certmanager.go
@@ -16,7 +16,6 @@ package pkg
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/pkg/errors"
 
@@ -47,9 +46,16 @@ func (r *ReleaseConfig) GetCertManagerAssets() ([]Artifact, error) {
 			"projectPath": certManagerProjectPath,
 		}
 
-		sourceImageUri, err := r.GetSourceImageURI(image, repoName, tagOptions)
+		sourceImageUri, sourcedFromBranch, err := r.GetSourceImageURI(image, repoName, tagOptions)
 		if err != nil {
 			return nil, errors.Cause(err)
+		}
+		if sourcedFromBranch != r.BuildRepoBranchName {
+			gitTag, err = r.readGitTag(certManagerProjectPath, sourcedFromBranch)
+			if err != nil {
+				return nil, errors.Cause(err)
+			}
+			tagOptions["gitTag"] = gitTag
 		}
 		releaseImageUri, err := r.GetReleaseImageURI(image, repoName, tagOptions)
 		if err != nil {
@@ -57,13 +63,14 @@ func (r *ReleaseConfig) GetCertManagerAssets() ([]Artifact, error) {
 		}
 
 		imageArtifact := &ImageArtifact{
-			AssetName:       image,
-			SourceImageURI:  sourceImageUri,
-			ReleaseImageURI: releaseImageUri,
-			Arch:            []string{"amd64"},
-			OS:              "linux",
-			GitTag:          gitTag,
-			ProjectPath:     certManagerProjectPath,
+			AssetName:         image,
+			SourceImageURI:    sourceImageUri,
+			ReleaseImageURI:   releaseImageUri,
+			Arch:              []string{"amd64"},
+			OS:                "linux",
+			GitTag:            gitTag,
+			ProjectPath:       certManagerProjectPath,
+			SourcedFromBranch: sourcedFromBranch,
 		}
 		artifacts = append(artifacts, Artifact{Image: imageArtifact})
 	}
@@ -74,16 +81,19 @@ func (r *ReleaseConfig) GetCertManagerAssets() ([]Artifact, error) {
 func (r *ReleaseConfig) GetCertManagerBundle(imageDigests map[string]string) (anywherev1alpha1.CertManagerBundle, error) {
 	artifacts := r.BundleArtifactsTable["cert-manager"]
 
-	version, err := BuildComponentVersion(
-		newVersionerWithGITTAG(filepath.Join(r.BuildRepoSource, certManagerProjectPath)),
-	)
-	if err != nil {
-		return anywherev1alpha1.CertManagerBundle{}, errors.Wrapf(err, "Error getting version for cert-manager")
-	}
+	var version string
 	bundleArtifacts := map[string]anywherev1alpha1.Image{}
 
 	for _, artifact := range artifacts {
 		imageArtifact := artifact.Image
+		componentVersion, err := BuildComponentVersion(
+			newVersionerWithGITTAG(r.BuildRepoSource, certManagerProjectPath, imageArtifact.SourcedFromBranch, r),
+		)
+		if err != nil {
+			return anywherev1alpha1.CertManagerBundle{}, errors.Wrapf(err, "Error getting version for cert-manager")
+		}
+		version = componentVersion
+
 		bundleArtifact := anywherev1alpha1.Image{
 			Name:        imageArtifact.AssetName,
 			Description: fmt.Sprintf("Container image for %s image", imageArtifact.AssetName),

--- a/release/pkg/assets_cilium.go
+++ b/release/pkg/assets_cilium.go
@@ -36,7 +36,8 @@ func (r *ReleaseConfig) GetCiliumAssets() ([]Artifact, error) {
 
 	var sourceS3Prefix string
 	var releaseS3Path string
-	latestPath := r.getLatestUploadDestination()
+	sourcedFromBranch := r.BuildRepoBranchName
+	latestPath := getLatestUploadDestination(sourcedFromBranch)
 
 	if r.DevRelease || r.ReleaseEnvironment == "development" {
 		sourceS3Prefix = fmt.Sprintf("%s/%s/manifests/cilium/%s", ciliumProjectPath, latestPath, gitTag)
@@ -67,6 +68,7 @@ func (r *ReleaseConfig) GetCiliumAssets() ([]Artifact, error) {
 		ImageTagOverrides: []ImageTagOverride{},
 		GitTag:            gitTag,
 		ProjectPath:       ciliumProjectPath,
+		SourcedFromBranch: sourcedFromBranch,
 	}
 	artifacts := []Artifact{Artifact{Manifest: manifestArtifact}}
 

--- a/release/pkg/assets_cluster_controller.go
+++ b/release/pkg/assets_cluster_controller.go
@@ -66,9 +66,16 @@ func (r *ReleaseConfig) GetClusterControllerAssets() ([]Artifact, error) {
 		"projectPath": eksAnywhereProjectPath,
 	}
 
-	sourceImageUri, err := r.GetSourceImageURI(name, sourceRepoName, tagOptions)
+	sourceImageUri, sourcedFromBranch, err := r.GetSourceImageURI(name, sourceRepoName, tagOptions)
 	if err != nil {
 		return nil, errors.Cause(err)
+	}
+	if sourcedFromBranch != r.BuildRepoBranchName {
+		gitTag, err = r.readGitTag(eksAnywhereProjectPath, sourcedFromBranch)
+		if err != nil {
+			return nil, errors.Cause(err)
+		}
+		tagOptions["gitTag"] = gitTag
 	}
 	releaseImageUri, err := r.GetReleaseImageURI(name, releaseRepoName, tagOptions)
 	if err != nil {
@@ -76,13 +83,14 @@ func (r *ReleaseConfig) GetClusterControllerAssets() ([]Artifact, error) {
 	}
 
 	imageArtifact := &ImageArtifact{
-		AssetName:       name,
-		SourceImageURI:  sourceImageUri,
-		ReleaseImageURI: releaseImageUri,
-		Arch:            []string{"amd64"},
-		OS:              "linux",
-		GitTag:          gitTag,
-		ProjectPath:     eksAnywhereProjectPath,
+		AssetName:         name,
+		SourceImageURI:    sourceImageUri,
+		ReleaseImageURI:   releaseImageUri,
+		Arch:              []string{"amd64"},
+		OS:                "linux",
+		GitTag:            gitTag,
+		ProjectPath:       eksAnywhereProjectPath,
+		SourcedFromBranch: sourcedFromBranch,
 	}
 	artifacts := []Artifact{Artifact{Image: imageArtifact}}
 
@@ -103,7 +111,7 @@ func (r *ReleaseConfig) GetClusterControllerAssets() ([]Artifact, error) {
 
 	var sourceS3Prefix string
 	var releaseS3Path string
-	latestPath := r.getLatestUploadDestination()
+	latestPath := getLatestUploadDestination(sourcedFromBranch)
 
 	if r.DevRelease || r.ReleaseEnvironment == "development" {
 		sourceS3Prefix = fmt.Sprintf("%s/%s/manifests/cluster-controller", eksAnywhereProjectPath, latestPath)

--- a/release/pkg/assets_cri_tools.go
+++ b/release/pkg/assets_cri_tools.go
@@ -36,7 +36,8 @@ func (r *ReleaseConfig) GetCriToolsAssets() ([]Artifact, error) {
 	var sourceS3Prefix string
 	var releaseS3Path string
 	var releaseName string
-	latestPath := r.getLatestUploadDestination()
+	sourcedFromBranch := r.BuildRepoBranchName
+	latestPath := getLatestUploadDestination(sourcedFromBranch)
 
 	if r.DevRelease || r.ReleaseEnvironment == "development" {
 		sourceS3Key = fmt.Sprintf("cri-tools-%s-%s-%s.tar.gz", os, arch, gitTag)
@@ -60,16 +61,17 @@ func (r *ReleaseConfig) GetCriToolsAssets() ([]Artifact, error) {
 	}
 
 	archiveArtifact := &ArchiveArtifact{
-		SourceS3Key:    sourceS3Key,
-		SourceS3Prefix: sourceS3Prefix,
-		ArtifactPath:   filepath.Join(r.ArtifactDir, "cri-tools", r.BuildRepoHead),
-		ReleaseName:    releaseName,
-		ReleaseS3Path:  releaseS3Path,
-		ReleaseCdnURI:  cdnURI,
-		OS:             os,
-		Arch:           []string{arch},
-		GitTag:         gitTag,
-		ProjectPath:    criToolsProjectPath,
+		SourceS3Key:       sourceS3Key,
+		SourceS3Prefix:    sourceS3Prefix,
+		ArtifactPath:      filepath.Join(r.ArtifactDir, "cri-tools", r.BuildRepoHead),
+		ReleaseName:       releaseName,
+		ReleaseS3Path:     releaseS3Path,
+		ReleaseCdnURI:     cdnURI,
+		OS:                os,
+		Arch:              []string{arch},
+		GitTag:            gitTag,
+		ProjectPath:       criToolsProjectPath,
+		SourcedFromBranch: sourcedFromBranch,
 	}
 	artifacts := []Artifact{Artifact{Archive: archiveArtifact}}
 

--- a/release/pkg/assets_diagnostic_collector.go
+++ b/release/pkg/assets_diagnostic_collector.go
@@ -45,9 +45,16 @@ func (r *ReleaseConfig) GetDiagnosticCollectorAssets() ([]Artifact, error) {
 		"projectPath": eksAnywhereProjectPath,
 	}
 
-	sourceImageUri, err := r.GetSourceImageURI(name, sourceRepoName, tagOptions)
+	sourceImageUri, sourcedFromBranch, err := r.GetSourceImageURI(name, sourceRepoName, tagOptions)
 	if err != nil {
 		return nil, errors.Cause(err)
+	}
+	if sourcedFromBranch != r.BuildRepoBranchName {
+		gitTag, err = r.readGitTag(eksAnywhereProjectPath, sourcedFromBranch)
+		if err != nil {
+			return nil, errors.Cause(err)
+		}
+		tagOptions["gitTag"] = gitTag
 	}
 	releaseImageUri, err := r.GetReleaseImageURI(name, releaseRepoName, tagOptions)
 	if err != nil {
@@ -55,13 +62,14 @@ func (r *ReleaseConfig) GetDiagnosticCollectorAssets() ([]Artifact, error) {
 	}
 
 	imageArtifact := &ImageArtifact{
-		AssetName:       name,
-		SourceImageURI:  sourceImageUri,
-		ReleaseImageURI: releaseImageUri,
-		Arch:            []string{"amd64"},
-		OS:              "linux",
-		GitTag:          gitTag,
-		ProjectPath:     eksAnywhereProjectPath,
+		AssetName:         name,
+		SourceImageURI:    sourceImageUri,
+		ReleaseImageURI:   releaseImageUri,
+		Arch:              []string{"amd64"},
+		OS:                "linux",
+		GitTag:            gitTag,
+		ProjectPath:       eksAnywhereProjectPath,
+		SourcedFromBranch: sourcedFromBranch,
 	}
 
 	artifacts := []Artifact{Artifact{Image: imageArtifact}}

--- a/release/pkg/assets_eksa_tools.go
+++ b/release/pkg/assets_eksa_tools.go
@@ -51,9 +51,16 @@ func (r *ReleaseConfig) GetEksAToolsAssets() ([]Artifact, error) {
 		"projectPath": eksAToolsProjectPath,
 	}
 
-	sourceImageUri, err := r.GetSourceImageURI(name, sourceRepoName, tagOptions)
+	sourceImageUri, sourcedFromBranch, err := r.GetSourceImageURI(name, sourceRepoName, tagOptions)
 	if err != nil {
 		return nil, errors.Cause(err)
+	}
+	if sourcedFromBranch != r.BuildRepoBranchName {
+		gitTag, err = r.readGitTag(eksAToolsProjectPath, sourcedFromBranch)
+		if err != nil {
+			return nil, errors.Cause(err)
+		}
+		tagOptions["gitTag"] = gitTag
 	}
 	releaseImageUri, err := r.GetReleaseImageURI(name, releaseRepoName, tagOptions)
 	if err != nil {
@@ -61,13 +68,14 @@ func (r *ReleaseConfig) GetEksAToolsAssets() ([]Artifact, error) {
 	}
 
 	imageArtifact := &ImageArtifact{
-		AssetName:       name,
-		SourceImageURI:  sourceImageUri,
-		ReleaseImageURI: releaseImageUri,
-		Arch:            []string{"amd64"},
-		OS:              "linux",
-		GitTag:          gitTag,
-		ProjectPath:     eksAToolsProjectPath,
+		AssetName:         name,
+		SourceImageURI:    sourceImageUri,
+		ReleaseImageURI:   releaseImageUri,
+		Arch:              []string{"amd64"},
+		OS:                "linux",
+		GitTag:            gitTag,
+		ProjectPath:       eksAToolsProjectPath,
+		SourcedFromBranch: sourcedFromBranch,
 	}
 
 	artifacts := []Artifact{Artifact{Image: imageArtifact}}

--- a/release/pkg/assets_etcdadm.go
+++ b/release/pkg/assets_etcdadm.go
@@ -36,7 +36,8 @@ func (r *ReleaseConfig) GetEtcdadmAssets() ([]Artifact, error) {
 	var sourceS3Prefix string
 	var releaseS3Path string
 	var releaseName string
-	latestPath := r.getLatestUploadDestination()
+	sourcedFromBranch := r.BuildRepoBranchName
+	latestPath := getLatestUploadDestination(sourcedFromBranch)
 
 	if r.DevRelease || r.ReleaseEnvironment == "development" {
 		sourceS3Key = fmt.Sprintf("etcdadm-%s-%s-%s.tar.gz", os, arch, gitTag)
@@ -60,16 +61,17 @@ func (r *ReleaseConfig) GetEtcdadmAssets() ([]Artifact, error) {
 	}
 
 	archiveArtifact := &ArchiveArtifact{
-		SourceS3Key:    sourceS3Key,
-		SourceS3Prefix: sourceS3Prefix,
-		ArtifactPath:   filepath.Join(r.ArtifactDir, "etcdadm", r.BuildRepoHead),
-		ReleaseName:    releaseName,
-		ReleaseS3Path:  releaseS3Path,
-		ReleaseCdnURI:  cdnURI,
-		OS:             os,
-		Arch:           []string{arch},
-		GitTag:         gitTag,
-		ProjectPath:    etcdadmProjectPath,
+		SourceS3Key:       sourceS3Key,
+		SourceS3Prefix:    sourceS3Prefix,
+		ArtifactPath:      filepath.Join(r.ArtifactDir, "etcdadm", r.BuildRepoHead),
+		ReleaseName:       releaseName,
+		ReleaseS3Path:     releaseS3Path,
+		ReleaseCdnURI:     cdnURI,
+		OS:                os,
+		Arch:              []string{arch},
+		GitTag:            gitTag,
+		ProjectPath:       etcdadmProjectPath,
+		SourcedFromBranch: sourcedFromBranch,
 	}
 	artifacts := []Artifact{Artifact{Archive: archiveArtifact}}
 

--- a/release/pkg/assets_etcdadm_bootstrap.go
+++ b/release/pkg/assets_etcdadm_bootstrap.go
@@ -39,7 +39,7 @@ func (r *ReleaseConfig) GetEtcdadmBootstrapAssets() ([]Artifact, error) {
 		"projectPath": etcdadmBootstrapProviderProjectPath,
 	}
 
-	sourceImageUri, err := r.GetSourceImageURI(name, repoName, tagOptions)
+	sourceImageUri, sourcedFromBranch, err := r.GetSourceImageURI(name, repoName, tagOptions)
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
@@ -49,13 +49,14 @@ func (r *ReleaseConfig) GetEtcdadmBootstrapAssets() ([]Artifact, error) {
 	}
 
 	imageArtifact := &ImageArtifact{
-		AssetName:       name,
-		SourceImageURI:  sourceImageUri,
-		ReleaseImageURI: releaseImageUri,
-		Arch:            []string{"amd64"},
-		OS:              "linux",
-		GitTag:          gitTag,
-		ProjectPath:     etcdadmBootstrapProviderProjectPath,
+		AssetName:         name,
+		SourceImageURI:    sourceImageUri,
+		ReleaseImageURI:   releaseImageUri,
+		Arch:              []string{"amd64"},
+		OS:                "linux",
+		GitTag:            gitTag,
+		ProjectPath:       etcdadmBootstrapProviderProjectPath,
+		SourcedFromBranch: sourcedFromBranch,
 	}
 	artifacts := []Artifact{Artifact{Image: imageArtifact}}
 
@@ -80,7 +81,7 @@ func (r *ReleaseConfig) GetEtcdadmBootstrapAssets() ([]Artifact, error) {
 	for _, manifest := range manifestList {
 		var sourceS3Prefix string
 		var releaseS3Path string
-		latestPath := r.getLatestUploadDestination()
+		latestPath := getLatestUploadDestination(sourcedFromBranch)
 
 		if r.DevRelease || r.ReleaseEnvironment == "development" {
 			sourceS3Prefix = fmt.Sprintf("%s/%s/manifests/bootstrap-etcdadm-bootstrap/%s", etcdadmBootstrapProviderProjectPath, latestPath, gitTag)
@@ -109,6 +110,7 @@ func (r *ReleaseConfig) GetEtcdadmBootstrapAssets() ([]Artifact, error) {
 			ImageTagOverrides: imageTagOverrides,
 			GitTag:            gitTag,
 			ProjectPath:       etcdadmBootstrapProviderProjectPath,
+			SourcedFromBranch: sourcedFromBranch,
 		}
 		artifacts = append(artifacts, Artifact{Manifest: manifestArtifact})
 	}
@@ -122,21 +124,24 @@ func (r *ReleaseConfig) GetEtcdadmBootstrapBundle(imageDigests map[string]string
 		"kube-rbac-proxy":            r.BundleArtifactsTable["kube-rbac-proxy"],
 	}
 
-	version, err := BuildComponentVersion(
-		newVersionerWithGITTAG(filepath.Join(r.BuildRepoSource, etcdadmBootstrapProviderProjectPath)),
-	)
-	if err != nil {
-		return anywherev1alpha1.EtcdadmBootstrapBundle{}, errors.Wrapf(err, "Error getting version for etcdadm-bootstrap-provider")
-	}
-
+	var version string
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
 
-	for _, artifacts := range etcdadmBootstrapBundleArtifacts {
+	for componentName, artifacts := range etcdadmBootstrapBundleArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
 				imageArtifact := artifact.Image
 
+				if componentName == "etcdadm-bootstrap-provider" {
+					componentVersion, err := BuildComponentVersion(
+						newVersionerWithGITTAG(r.BuildRepoSource, etcdadmBootstrapProviderProjectPath, imageArtifact.SourcedFromBranch, r),
+					)
+					if err != nil {
+						return anywherev1alpha1.EtcdadmBootstrapBundle{}, errors.Wrapf(err, "Error getting version for etcdadm-bootstrap-provider")
+					}
+					version = componentVersion
+				}
 				bundleImageArtifact := anywherev1alpha1.Image{
 					Name:        imageArtifact.AssetName,
 					Description: fmt.Sprintf("Container image for %s image", imageArtifact.AssetName),

--- a/release/pkg/assets_kube_rbac_proxy.go
+++ b/release/pkg/assets_kube_rbac_proxy.go
@@ -31,7 +31,7 @@ func (r *ReleaseConfig) GetKubeRbacProxyAssets() ([]Artifact, error) {
 
 	name, repoName, tagOptions := r.getKubeRbacProxyImageAttributes(gitTag)
 
-	sourceImageUri, err := r.GetSourceImageURI(name, repoName, tagOptions)
+	sourceImageUri, sourcedFromBranch, err := r.GetSourceImageURI(name, repoName, tagOptions)
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
@@ -41,13 +41,14 @@ func (r *ReleaseConfig) GetKubeRbacProxyAssets() ([]Artifact, error) {
 	}
 
 	imageArtifact := &ImageArtifact{
-		AssetName:       name,
-		SourceImageURI:  sourceImageUri,
-		ReleaseImageURI: releaseImageUri,
-		Arch:            []string{"amd64"},
-		OS:              "linux",
-		GitTag:          gitTag,
-		ProjectPath:     kubeRbacProxyProjectPath,
+		AssetName:         name,
+		SourceImageURI:    sourceImageUri,
+		ReleaseImageURI:   releaseImageUri,
+		Arch:              []string{"amd64"},
+		OS:                "linux",
+		GitTag:            gitTag,
+		ProjectPath:       kubeRbacProxyProjectPath,
+		SourcedFromBranch: sourcedFromBranch,
 	}
 	artifacts := []Artifact{Artifact{Image: imageArtifact}}
 

--- a/release/pkg/assets_kube_vip.go
+++ b/release/pkg/assets_kube_vip.go
@@ -36,7 +36,7 @@ func (r *ReleaseConfig) GetKubeVipAssets() ([]Artifact, error) {
 		"projectPath": kubeVipProjectPath,
 	}
 
-	sourceImageUri, err := r.GetSourceImageURI(name, repoName, tagOptions)
+	sourceImageUri, sourcedFromBranch, err := r.GetSourceImageURI(name, repoName, tagOptions)
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
@@ -46,13 +46,14 @@ func (r *ReleaseConfig) GetKubeVipAssets() ([]Artifact, error) {
 	}
 
 	imageArtifact := &ImageArtifact{
-		AssetName:       name,
-		SourceImageURI:  sourceImageUri,
-		ReleaseImageURI: releaseImageUri,
-		Arch:            []string{"amd64"},
-		OS:              "linux",
-		GitTag:          gitTag,
-		ProjectPath:     kubeVipProjectPath,
+		AssetName:         name,
+		SourceImageURI:    sourceImageUri,
+		ReleaseImageURI:   releaseImageUri,
+		Arch:              []string{"amd64"},
+		OS:                "linux",
+		GitTag:            gitTag,
+		ProjectPath:       kubeVipProjectPath,
+		SourcedFromBranch: sourcedFromBranch,
 	}
 	artifacts := []Artifact{Artifact{Image: imageArtifact}}
 

--- a/release/pkg/assets_local_path_provisioner.go
+++ b/release/pkg/assets_local_path_provisioner.go
@@ -36,7 +36,7 @@ func (r *ReleaseConfig) GetLocalPathProvisionerAssets() ([]Artifact, error) {
 		"projectPath": localPathProvisonerProjectPath,
 	}
 
-	sourceImageUri, err := r.GetSourceImageURI(name, repoName, tagOptions)
+	sourceImageUri, sourcedFromBranch, err := r.GetSourceImageURI(name, repoName, tagOptions)
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
@@ -46,13 +46,14 @@ func (r *ReleaseConfig) GetLocalPathProvisionerAssets() ([]Artifact, error) {
 	}
 
 	imageArtifact := &ImageArtifact{
-		AssetName:       name,
-		SourceImageURI:  sourceImageUri,
-		ReleaseImageURI: releaseImageUri,
-		Arch:            []string{"amd64"},
-		OS:              "linux",
-		GitTag:          gitTag,
-		ProjectPath:     localPathProvisonerProjectPath,
+		AssetName:         name,
+		SourceImageURI:    sourceImageUri,
+		ReleaseImageURI:   releaseImageUri,
+		Arch:              []string{"amd64"},
+		OS:                "linux",
+		GitTag:            gitTag,
+		ProjectPath:       localPathProvisonerProjectPath,
+		SourcedFromBranch: sourcedFromBranch,
 	}
 	artifacts := []Artifact{Artifact{Image: imageArtifact}}
 

--- a/release/pkg/assets_vsphere_cloud_provider.go
+++ b/release/pkg/assets_vsphere_cloud_provider.go
@@ -38,7 +38,7 @@ func (r *ReleaseConfig) GetVsphereCloudProviderAssets(eksDReleaseChannel string)
 		"projectPath":        gitTagFolder,
 	}
 
-	sourceImageUri, err := r.GetSourceImageURI(name, repoName, tagOptions)
+	sourceImageUri, sourcedFromBranch, err := r.GetSourceImageURI(name, repoName, tagOptions)
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
@@ -48,13 +48,14 @@ func (r *ReleaseConfig) GetVsphereCloudProviderAssets(eksDReleaseChannel string)
 	}
 
 	imageArtifact := &ImageArtifact{
-		AssetName:       name,
-		SourceImageURI:  sourceImageUri,
-		ReleaseImageURI: releaseImageUri,
-		Arch:            []string{"amd64"},
-		OS:              "linux",
-		GitTag:          gitTag,
-		ProjectPath:     vsphereCloudProviderProjectPath,
+		AssetName:         name,
+		SourceImageURI:    sourceImageUri,
+		ReleaseImageURI:   releaseImageUri,
+		Arch:              []string{"amd64"},
+		OS:                "linux",
+		GitTag:            gitTag,
+		ProjectPath:       vsphereCloudProviderProjectPath,
+		SourcedFromBranch: sourcedFromBranch,
 	}
 	artifacts := []Artifact{Artifact{Image: imageArtifact}}
 

--- a/release/pkg/assets_vsphere_csi.go
+++ b/release/pkg/assets_vsphere_csi.go
@@ -42,7 +42,7 @@ func (r *ReleaseConfig) GetVsphereCsiAssets() ([]Artifact, error) {
 			"projectPath": vSphereCsiProjectPath,
 		}
 
-		sourceImageUri, err := r.GetSourceImageURI(image, repoName, tagOptions)
+		sourceImageUri, sourcedFromBranch, err := r.GetSourceImageURI(image, repoName, tagOptions)
 		if err != nil {
 			return nil, errors.Cause(err)
 		}
@@ -52,13 +52,14 @@ func (r *ReleaseConfig) GetVsphereCsiAssets() ([]Artifact, error) {
 		}
 
 		imageArtifact := &ImageArtifact{
-			AssetName:       fmt.Sprintf("vsphere-csi-%s", image),
-			SourceImageURI:  sourceImageUri,
-			ReleaseImageURI: releaseImageUri,
-			Arch:            []string{"amd64"},
-			OS:              "linux",
-			GitTag:          gitTag,
-			ProjectPath:     vSphereCsiProjectPath,
+			AssetName:         fmt.Sprintf("vsphere-csi-%s", image),
+			SourceImageURI:    sourceImageUri,
+			ReleaseImageURI:   releaseImageUri,
+			Arch:              []string{"amd64"},
+			OS:                "linux",
+			GitTag:            gitTag,
+			ProjectPath:       vSphereCsiProjectPath,
+			SourcedFromBranch: sourcedFromBranch,
 		}
 		artifacts = append(artifacts, Artifact{Image: imageArtifact})
 	}

--- a/release/pkg/file_reader_test.go
+++ b/release/pkg/file_reader_test.go
@@ -9,43 +9,70 @@ func TestGenerateNewDevReleaseVersion(t *testing.T) {
 		testName           string
 		latestBuildVersion string
 		releaseVersion     string
+		branch             string
 		want               string
 	}{
 		{
 			testName:           "vDev release",
 			latestBuildVersion: "vDev.build.68",
 			releaseVersion:     "vDev",
+			branch:             "main",
 			want:               "v0.0.0-dev+build.69",
 		},
 		{
 			testName:           "vDev release with latest v0.0.0",
 			latestBuildVersion: "v0.0.0-dev+build.5",
 			releaseVersion:     "vDev",
+			branch:             "main",
 			want:               "v0.0.0-dev+build.6",
 		},
 		{
 			testName:           "v0.0.0 release with latest vDev",
 			latestBuildVersion: "vDev.build.5",
 			releaseVersion:     "v0.0.0",
+			branch:             "main",
 			want:               "v0.0.0-dev+build.6",
 		},
 		{
 			testName:           "v0.0.0 release with latest v0.0.0",
 			latestBuildVersion: "v0.0.0-dev+build.68",
 			releaseVersion:     "v0.0.0",
+			branch:             "main",
 			want:               "v0.0.0-dev+build.69",
 		},
 		{
 			testName:           "different semver",
 			latestBuildVersion: "v0.0.0-dev+build.5",
 			releaseVersion:     "v0.0.1",
+			branch:             "main",
 			want:               "v0.0.1-dev+build.0",
+		},
+		{
+			testName:           "vDev release, non-main",
+			latestBuildVersion: "vDev.build.68",
+			releaseVersion:     "vDev",
+			branch:             "v1beta1",
+			want:               "v0.0.0-dev-v1beta1+build.69",
+		},
+		{
+			testName:           "vDev release with latest v0.0.0, non-main",
+			latestBuildVersion: "v0.0.0-dev-v1beta+build.5",
+			releaseVersion:     "vDev",
+			branch:             "v1beta1",
+			want:               "v0.0.0-dev-v1beta1+build.6",
+		},
+		{
+			testName:           "v0.0.0 release with latest v0.0.0, non-main branch",
+			latestBuildVersion: "v0.0.0-dev-v1beta1+build.0",
+			releaseVersion:     "v0.0.0",
+			branch:             "v1beta1",
+			want:               "v0.0.0-dev-v1beta1+build.1",
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			if got, err := generateNewDevReleaseVersion(tt.latestBuildVersion, tt.releaseVersion); err != nil {
+			if got, err := generateNewDevReleaseVersion(tt.latestBuildVersion, tt.releaseVersion, tt.branch); err != nil {
 				t.Fatalf("generateNewDevReleaseVersion err = %s, want err = nil", err)
 			} else if got != tt.want {
 				t.Fatalf("generateNewDevReleaseVersion version = %s, want %s", got, tt.want)

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -328,11 +328,11 @@ func (r *ReleaseConfig) GetURI(path string) (string, error) {
 	return uri.String(), nil
 }
 
-func (r *ReleaseConfig) GetSourceImageURI(name, repoName string, tagOptions map[string]string) (string, error) {
+func (r *ReleaseConfig) GetSourceImageURI(name, repoName string, tagOptions map[string]string) (string, string, error) {
 	var sourceImageUri string
-
+	sourcedFromBranch := r.BuildRepoBranchName
 	if r.DevRelease || r.ReleaseEnvironment == "development" {
-		latestTag := r.getLatestUploadDestination()
+		latestTag := getLatestUploadDestination(r.BuildRepoBranchName)
 		if name == "bottlerocket-bootstrap" {
 			sourceImageUri = fmt.Sprintf("%s/%s:v%s-%s-%s",
 				r.SourceContainerRegistry,
@@ -376,12 +376,13 @@ func (r *ReleaseConfig) GetSourceImageURI(name, repoName string, tagOptions map[
 					} else {
 						gitTagFromMain, err = r.readGitTag(tagOptions["projectPath"], "main")
 						if err != nil {
-							return "", errors.Cause(err)
+							return "", "", errors.Cause(err)
 						}
 					}
 					sourceImageUri = strings.NewReplacer(r.BuildRepoBranchName, "latest", tagOptions["gitTag"], gitTagFromMain).Replace(sourceImageUri)
+					sourcedFromBranch = "main"
 				} else {
-					return "", errors.Cause(err)
+					return "", "", errors.Cause(err)
 				}
 			}
 		}
@@ -433,9 +434,10 @@ func (r *ReleaseConfig) GetSourceImageURI(name, repoName string, tagOptions map[
 				r.BundleNumber,
 			)
 		}
+
 	}
 
-	return sourceImageUri, nil
+	return sourceImageUri, sourcedFromBranch, nil
 }
 
 func (r *ReleaseConfig) GetReleaseImageURI(name, repoName string, tagOptions map[string]string) (string, error) {
@@ -499,7 +501,7 @@ func (r *ReleaseConfig) GetReleaseImageURI(name, repoName string, tagOptions map
 
 	var semver string
 	if r.DevRelease {
-		currentSourceImageUri, err := r.GetSourceImageURI(name, repoName, tagOptions)
+		currentSourceImageUri, _, err := r.GetSourceImageURI(name, repoName, tagOptions)
 		if err != nil {
 			return "", errors.Cause(err)
 		}
@@ -522,7 +524,7 @@ func (r *ReleaseConfig) GetReleaseImageURI(name, repoName string, tagOptions map
 				semver = previousReleaseImageSemver
 				fmt.Printf("Image digest for %s image has not changed, tagging with previous dev release semver: %s\n", repoName, semver)
 			} else {
-				newSemver, err := generateNewDevReleaseVersion(previousReleaseImageSemver, "vDev")
+				newSemver, err := generateNewDevReleaseVersion(previousReleaseImageSemver, "vDev", r.BuildRepoBranchName)
 				if err != nil {
 					return "", errors.Cause(err)
 				}
@@ -593,7 +595,6 @@ func (r *ReleaseConfig) GetPreviousReleaseImageSemver(releaseImageUri string) (s
 						semver = imageUriSplit[len(imageUriSplit)-1]
 					}
 				}
-
 			}
 		}
 	}

--- a/release/pkg/prepare_release.go
+++ b/release/pkg/prepare_release.go
@@ -570,11 +570,11 @@ func IsImageNotFoundError(err error) bool {
 	return err.Error() == "Requested image not found"
 }
 
-func (r *ReleaseConfig) getLatestUploadDestination() string {
-	if r.BuildRepoBranchName == "main" {
+func getLatestUploadDestination(sourcedFromBranch string) string {
+	if sourcedFromBranch == "main" {
 		return "latest"
 	} else {
-		return r.BuildRepoBranchName
+		return sourcedFromBranch
 	}
 }
 


### PR DESCRIPTION
When performing dev release, artifacts for some branches may be sourced from `main` if they don't exist in the branch that triggered the release. The support for using those artifacts was added in #744. In the same vein, this PR adds logic to set the bundle version based on the branch the bundle's artifacts were sourced from.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
