### PR TITLE
Fix split index when parsing release image URI

### DIFF
--- a/release/.gitignore
+++ b/release/.gitignore
@@ -26,3 +26,4 @@ testbin/*
 
 # Directory of artifacts downloaded during release
 downloaded-artifacts
+latest-dev-release-version

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -581,8 +581,14 @@ func (r *ReleaseConfig) GetPreviousReleaseImageSemver(releaseImageUri string) (s
 				for _, image := range vbImages {
 					if strings.Contains(image.URI, releaseImageUri) {
 						imageUri := image.URI
+						var differential int
+						if r.BuildRepoBranchName == "main" {
+							differential = 1
+						} else {
+							differential = 2
+						}
 						numDashes := strings.Count(imageUri, "-")
-						splitIndex := numDashes - strings.Count(r.BuildRepoBranchName, "-") - 2
+						splitIndex := numDashes - strings.Count(r.BuildRepoBranchName, "-") - differential
 						imageUriSplit := strings.SplitAfterN(imageUri, "-", splitIndex)
 						semver = imageUriSplit[len(imageUriSplit)-1]
 					}


### PR DESCRIPTION
Branches other than main contain `-<branchname>` in the semver, so need to account for the extra dash.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
