### PR TITLE
Use longer wait time when waiting for control plane to be ready (#734)

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -32,7 +32,7 @@ const (
 	machineMaxWait    = 10 * time.Minute
 	machineBackoff    = 1 * time.Second
 	machinesMinWait   = 30 * time.Minute
-	moveCAPIWait      = 5 * time.Minute
+	moveCAPIWait      = 15 * time.Minute
 	ctrlPlaneWaitStr  = "60m"
 	etcdWaitStr       = "60m"
 	deploymentWaitStr = "30m"

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -590,7 +590,7 @@ func TestClusterManagerMoveCAPISuccess(t *testing.T) {
 	capiClusterName := "capi-cluster"
 	clusters := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}}}
 	m.client.EXPECT().GetClusters(ctx, to).Return(clusters, nil)
-	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "5m0s", capiClusterName)
+	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "15m0s", capiClusterName)
 	m.client.EXPECT().ValidateControlPlaneNodes(ctx, to, to.Name)
 	m.client.EXPECT().ValidateWorkerNodes(ctx, to, to.Name)
 	m.client.EXPECT().GetMachines(ctx, to, to.Name)
@@ -667,7 +667,7 @@ func TestClusterManagerMoveCAPIErrorWaitForControlPlane(t *testing.T) {
 	clusters := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}}}
 	m.client.EXPECT().GetMachines(ctx, from, from.Name)
 	m.client.EXPECT().GetClusters(ctx, to).Return(clusters, nil)
-	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "5m0s", capiClusterName).Return(errors.New("error waiting for control plane"))
+	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "15m0s", capiClusterName).Return(errors.New("error waiting for control plane"))
 
 	if err := c.MoveCAPI(ctx, from, to, from.Name, clusterSpec); err == nil {
 		t.Error("ClusterManager.MoveCAPI() error = nil, wantErr not nil")


### PR DESCRIPTION
Backporting to 0.6 branch

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
