### PR TITLE
Fix cleanup function

### DIFF
--- a/cmd/eksctl-anywhere/cmd/cleanup.go
+++ b/cmd/eksctl-anywhere/cmd/cleanup.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 
-func cleanup(ctx context.Context, deps *dependencies.Dependencies, commandErr error) {
+func cleanup(ctx context.Context, deps *dependencies.Dependencies, commandErr *error) {
 	close(ctx, deps)
 
 	if commandErr == nil {

--- a/cmd/eksctl-anywhere/cmd/cleanup.go
+++ b/cmd/eksctl-anywhere/cmd/cleanup.go
@@ -12,7 +12,7 @@ import (
 func cleanup(ctx context.Context, deps *dependencies.Dependencies, commandErr *error) {
 	close(ctx, deps)
 
-	if commandErr == nil {
+	if *commandErr == nil {
 		deps.Writer.CleanUpTemp()
 	}
 }

--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -91,7 +91,7 @@ func (cc *createClusterOptions) createCluster(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer cleanup(ctx, deps, err)
+	defer cleanup(ctx, deps, &err)
 
 	createCluster := workflows.NewCreate(
 		deps.Bootstrapper,

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -97,7 +97,7 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer cleanup(ctx, deps, err)
+	defer cleanup(ctx, deps, &err)
 
 	deleteCluster := workflows.NewDelete(
 		deps.Bootstrapper,

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -91,7 +91,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer cleanup(ctx, deps, err)
+	defer cleanup(ctx, deps, &err)
 
 	upgradeCluster := workflows.NewUpgrade(
 		deps.Bootstrapper,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This will change the cleanup function to use a pointer to an error.

The cleanUp function is currently deleting the "generated" folder because the "commandErr" parameter is always nil.

the previous code was following this pattern

```
        if err != nil {
		return err
	}
	defer cleanup(ctx, deps, err)

        err := update|create|deleteCluster(...)
```

the problem is that the deferred call's arguments are evaluated immediately, so commandErr (inside the cleanup function) was always nil

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
