### PR TITLE
Govc validate vcenter no side effects

### DIFF
--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -48,7 +48,6 @@ type FolderType string
 
 const (
 	datastore     FolderType = "datastore"
-	network       FolderType = "network"
 	vm            FolderType = "vm"
 	maxRetries               = 5
 	backOffPeriod            = 5 * time.Second
@@ -57,14 +56,19 @@ const (
 type Govc struct {
 	writer filewriter.FileWriter
 	Executable
-	retrier *retrier.Retrier
+	retrier      *retrier.Retrier
+	requiredEnvs *syncSlice
 }
 
 func NewGovc(executable Executable, writer filewriter.FileWriter) *Govc {
+	envVars := newSyncSlice()
+	envVars.append(requiredEnvs...)
+
 	return &Govc{
-		writer:     writer,
-		Executable: executable,
-		retrier:    retrier.NewWithMaxRetries(maxRetries, backOffPeriod),
+		writer:       writer,
+		Executable:   executable,
+		retrier:      retrier.NewWithMaxRetries(maxRetries, backOffPeriod),
+		requiredEnvs: envVars,
 	}
 }
 
@@ -90,6 +94,13 @@ func (g *Govc) Logout(ctx context.Context) error {
 	if _, err := g.exec(ctx, "session.logout"); err != nil {
 		return fmt.Errorf("govc returned error when logging out: %v", err)
 	}
+
+	// Commands that skip cert verification will have a different session.
+	// So we try to destroy it as well here to avoid leaving it orphaned
+	if _, err := g.exec(ctx, "session.logout", "-k"); err != nil {
+		return fmt.Errorf("govc returned error when logging out from session without cert verification: %v", err)
+	}
+
 	return nil
 }
 
@@ -415,7 +426,7 @@ func (g *Govc) markVMAsTemplate(ctx context.Context, datacenter, vmName string) 
 
 func (g *Govc) getEnvMap() (map[string]string, error) {
 	envMap := make(map[string]string)
-	for _, key := range requiredEnvs {
+	for key := range g.requiredEnvs.iterate() {
 		if env, ok := os.LookupEnv(key); ok && len(env) > 0 {
 			envMap[key] = env
 		} else {
@@ -499,101 +510,109 @@ func (g *Govc) CleanupVms(ctx context.Context, clusterName string, dryRun bool) 
 	return nil
 }
 
-func (g *Govc) ValidateVCenterSetup(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, selfSigned *bool) error {
-	envMap, err := g.validateAndSetupCreds()
-	if err != nil {
-		return fmt.Errorf("failed govc validations: %v", err)
-	}
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	_, err = http.Get("https://" + datacenterConfig.Spec.Server)
-	if err != nil {
-		return fmt.Errorf("failed to reach server %s: %v", datacenterConfig.Spec.Server, err)
+func (g *Govc) ValidateVCenterConnection(ctx context.Context, server string) error {
+	skipVerifyTransport := http.DefaultTransport.(*http.Transport).Clone()
+	skipVerifyTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	client := &http.Client{Transport: skipVerifyTransport}
+
+	if _, err := client.Get("https://" + server); err != nil {
+		return fmt.Errorf("failed to reach server %s: %v", server, err)
 	}
 
-	logger.MarkPass("Connected to server")
+	return nil
+}
 
-	params := []string{"about", "-k"}
-	err = g.retrier.Retry(func() error {
-		_, err = g.ExecuteWithEnv(ctx, envMap, params...)
+func (g *Govc) ValidateVCenterAuthentication(ctx context.Context) error {
+	err := g.retrier.Retry(func() error {
+		_, err := g.exec(ctx, "about", "-k")
 		return err
 	})
 	if err != nil {
 		return fmt.Errorf("vSphere authentication failed: %v", err)
 	}
-	logger.MarkPass("Authenticated to vSphere")
 
-	// hack to test if thumbprint is required or not
-	if !datacenterConfig.Spec.Insecure {
-		params = []string{"about"}
-		_, err = g.ExecuteWithEnv(ctx, envMap, params...)
-		if err != nil {
-			// self-signed, thumbprint is be required
-			*selfSigned = true
-			if len(datacenterConfig.Spec.Thumbprint) > 0 {
-				params := []string{"about.cert", "-thumbprint", "-k"}
-				buffer, err := g.ExecuteWithEnv(ctx, envMap, params...)
-				if err != nil {
-					return fmt.Errorf("unable to retrieve thumbprint: %v", err)
-				}
-				data := strings.Split(strings.Trim(buffer.String(), "\n"), " ")
-				if len(data) != 2 {
-					return fmt.Errorf("unable to retrieve thumbprint")
-				} else if thumbprint := data[1]; thumbprint != datacenterConfig.Spec.Thumbprint {
-					return fmt.Errorf("thumbprint mismatch detected, expected: %s, actual: %s", datacenterConfig.Spec.Thumbprint, thumbprint)
-				}
-				path, err := g.writer.Write(filepath.Base(govcTlsHostsFile), []byte(buffer.Bytes()))
-				if err != nil {
-					return fmt.Errorf("error writing to file %s: %v", govcTlsHostsFile, err)
-				}
+	return nil
+}
 
-				// The next command after adding GOVC_TLS_KNOWN_HOSTS will create a new session
-				// So we destroy the existing session here to avoid leaving it orphaned
-				if _, err = g.ExecuteWithEnv(ctx, envMap, "session.logout", "-k"); err != nil {
-					return err
-				}
+func (g *Govc) IsCertSelfSigned(ctx context.Context) bool {
+	_, err := g.exec(ctx, "about")
+	return err != nil
+}
 
-				if err = os.Setenv(govcTlsKnownHostsKey, path); err != nil {
-					return fmt.Errorf("unable to set %s: %v", govcTlsKnownHostsKey, err)
-				}
-				requiredEnvs = append(requiredEnvs, govcTlsKnownHostsKey)
-				envMap, err = g.getEnvMap()
-				if err != nil {
-					return fmt.Errorf("error adding %s to the environment: %v", govcTlsKnownHostsKey, err)
-				}
-			} else {
-				return fmt.Errorf("thumbprint is required for secure mode with self-signed certificates")
-			}
-		}
+func (g *Govc) GetCertThumbprint(ctx context.Context) (string, error) {
+	bufferResponse, err := g.exec(ctx, "about.cert", "-thumbprint", "-k")
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve thumbprint: %v", err)
 	}
 
-	params = []string{"datacenter.info", datacenterConfig.Spec.Datacenter}
-	err = g.retrier.Retry(func() error {
-		_, err = g.ExecuteWithEnv(ctx, envMap, params...)
+	data := strings.Split(strings.Trim(bufferResponse.String(), "\n"), " ")
+	if len(data) != 2 {
+		return "", fmt.Errorf("invalid thumbprint format")
+	}
+
+	return data[1], nil
+}
+
+func (g *Govc) ConfigureCertThumbprint(ctx context.Context, server, thumbprint string) error {
+	path, err := g.writer.Write(filepath.Base(govcTlsHostsFile), []byte(fmt.Sprintf("%s %s", server, thumbprint)))
+	if err != nil {
+		return fmt.Errorf("error writing to file %s: %v", govcTlsHostsFile, err)
+	}
+
+	if err = os.Setenv(govcTlsKnownHostsKey, path); err != nil {
+		return fmt.Errorf("unable to set %s: %v", govcTlsKnownHostsKey, err)
+	}
+
+	g.requiredEnvs.append(govcTlsKnownHostsKey)
+
+	return nil
+}
+
+func (g *Govc) DatacenterExists(ctx context.Context, datacenter string) (bool, error) {
+	exists := false
+	err := g.retrier.Retry(func() error {
+		result, err := g.exec(ctx, "datacenter.info", datacenter)
+		if err == nil {
+			exists = true
+			return nil
+		}
+
+		if strings.HasSuffix(result.String(), "not found") {
+			exists = false
+			return nil
+		}
+
 		return err
 	})
 	if err != nil {
-		return fmt.Errorf("failed to get datacenter: %v", err)
+		return false, fmt.Errorf("failed to get datacenter: %v", err)
 	}
-	logger.MarkPass("Datacenter validated")
 
-	datacenterConfig.Spec.Network, err = prependPath(network, datacenterConfig.Spec.Network, datacenterConfig.Spec.Datacenter)
-	if err != nil {
-		return err
-	}
-	params = []string{"find", "-maxdepth=1", filepath.Dir(datacenterConfig.Spec.Network), "-type", "n", "-name", filepath.Base(datacenterConfig.Spec.Network)}
-	err = g.retrier.Retry(func() error {
-		network, _ := g.ExecuteWithEnv(ctx, envMap, params...)
-		if network.String() == "" {
-			return fmt.Errorf("network '%s' not found", filepath.Base(datacenterConfig.Spec.Network))
+	return exists, nil
+}
+
+func (g *Govc) NetworkExists(ctx context.Context, network string) (bool, error) {
+	exists := false
+
+	err := g.retrier.Retry(func() error {
+		networkResponse, err := g.exec(ctx, "find", "-maxdepth=1", filepath.Dir(network), "-type", "n", "-name", filepath.Base(network))
+		if err != nil {
+			return err
 		}
+
+		if networkResponse.String() == "" {
+			exists = false
+			return nil
+		}
+
+		exists = true
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("network '%s' not found", filepath.Base(datacenterConfig.Spec.Network))
+		return false, fmt.Errorf("failed checking '%s' network", filepath.Base(network))
 	}
-	logger.MarkPass("Network validated")
 
-	return nil
+	return exists, nil
 }
 
 func (g *Govc) ValidateVCenterSetupMachineConfig(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, machineConfig *v1alpha1.VSphereMachineConfig, _ *bool) error {

--- a/pkg/executables/sync_slice.go
+++ b/pkg/executables/sync_slice.go
@@ -1,0 +1,35 @@
+package executables
+
+import "sync"
+
+type syncSlice struct {
+	internal []string
+	sync.RWMutex
+}
+
+func newSyncSlice() *syncSlice {
+	return &syncSlice{
+		internal: []string{},
+	}
+}
+
+func (s *syncSlice) append(v ...string) {
+	s.Lock()
+	defer s.Unlock()
+	s.internal = append(s.internal, v...)
+}
+
+func (s *syncSlice) iterate() <-chan string {
+	c := make(chan string)
+
+	go func() {
+		s.RLock()
+		defer s.RUnlock()
+		defer close(c)
+		for _, v := range s.internal {
+			c <- v
+		}
+	}()
+
+	return c
+}

--- a/pkg/providers/vsphere/defaults.go
+++ b/pkg/providers/vsphere/defaults.go
@@ -44,6 +44,8 @@ func setDefaultsForDatacenterConfig(datacenterConfig *anywherev1.VSphereDatacent
 		logger.Info("Warning: VSphereDatacenterConfig configured in insecure mode")
 		datacenterConfig.Spec.Thumbprint = ""
 	}
+
+	datacenterConfig.Spec.Network = generateFullVCenterPath(networkFolderType, datacenterConfig.Spec.Network, datacenterConfig.Spec.Datacenter)
 }
 
 func setDefaultsForEtcdMachineConfig(machineConfig *anywherev1.VSphereMachineConfig) {

--- a/pkg/providers/vsphere/mocks/client.go
+++ b/pkg/providers/vsphere/mocks/client.go
@@ -55,6 +55,20 @@ func (mr *MockProviderGovcClientMockRecorder) AddTag(arg0, arg1, arg2 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTag", reflect.TypeOf((*MockProviderGovcClient)(nil).AddTag), arg0, arg1, arg2)
 }
 
+// ConfigureCertThumbprint mocks base method.
+func (m *MockProviderGovcClient) ConfigureCertThumbprint(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConfigureCertThumbprint", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ConfigureCertThumbprint indicates an expected call of ConfigureCertThumbprint.
+func (mr *MockProviderGovcClientMockRecorder) ConfigureCertThumbprint(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureCertThumbprint", reflect.TypeOf((*MockProviderGovcClient)(nil).ConfigureCertThumbprint), arg0, arg1, arg2)
+}
+
 // CreateCategoryForVM mocks base method.
 func (m *MockProviderGovcClient) CreateCategoryForVM(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -97,6 +111,21 @@ func (mr *MockProviderGovcClientMockRecorder) CreateTag(arg0, arg1, arg2 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTag", reflect.TypeOf((*MockProviderGovcClient)(nil).CreateTag), arg0, arg1, arg2)
 }
 
+// DatacenterExists mocks base method.
+func (m *MockProviderGovcClient) DatacenterExists(arg0 context.Context, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DatacenterExists", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DatacenterExists indicates an expected call of DatacenterExists.
+func (mr *MockProviderGovcClientMockRecorder) DatacenterExists(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatacenterExists", reflect.TypeOf((*MockProviderGovcClient)(nil).DatacenterExists), arg0, arg1)
+}
+
 // DeleteLibraryElement mocks base method.
 func (m *MockProviderGovcClient) DeleteLibraryElement(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -123,6 +152,21 @@ func (m *MockProviderGovcClient) DeployTemplateFromLibrary(arg0 context.Context,
 func (mr *MockProviderGovcClientMockRecorder) DeployTemplateFromLibrary(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTemplateFromLibrary", reflect.TypeOf((*MockProviderGovcClient)(nil).DeployTemplateFromLibrary), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+}
+
+// GetCertThumbprint mocks base method.
+func (m *MockProviderGovcClient) GetCertThumbprint(arg0 context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCertThumbprint", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCertThumbprint indicates an expected call of GetCertThumbprint.
+func (mr *MockProviderGovcClientMockRecorder) GetCertThumbprint(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCertThumbprint", reflect.TypeOf((*MockProviderGovcClient)(nil).GetCertThumbprint), arg0)
 }
 
 // GetLibraryElementContentVersion mocks base method.
@@ -184,6 +228,20 @@ func (mr *MockProviderGovcClientMockRecorder) ImportTemplate(arg0, arg1, arg2, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportTemplate", reflect.TypeOf((*MockProviderGovcClient)(nil).ImportTemplate), arg0, arg1, arg2, arg3)
 }
 
+// IsCertSelfSigned mocks base method.
+func (m *MockProviderGovcClient) IsCertSelfSigned(arg0 context.Context) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsCertSelfSigned", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsCertSelfSigned indicates an expected call of IsCertSelfSigned.
+func (mr *MockProviderGovcClientMockRecorder) IsCertSelfSigned(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsCertSelfSigned", reflect.TypeOf((*MockProviderGovcClient)(nil).IsCertSelfSigned), arg0)
+}
+
 // LibraryElementExists mocks base method.
 func (m *MockProviderGovcClient) LibraryElementExists(arg0 context.Context, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()
@@ -229,6 +287,21 @@ func (mr *MockProviderGovcClientMockRecorder) ListTags(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTags", reflect.TypeOf((*MockProviderGovcClient)(nil).ListTags), arg0)
 }
 
+// NetworkExists mocks base method.
+func (m *MockProviderGovcClient) NetworkExists(arg0 context.Context, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NetworkExists", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NetworkExists indicates an expected call of NetworkExists.
+func (mr *MockProviderGovcClientMockRecorder) NetworkExists(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkExists", reflect.TypeOf((*MockProviderGovcClient)(nil).NetworkExists), arg0, arg1)
+}
+
 // SearchTemplate mocks base method.
 func (m *MockProviderGovcClient) SearchTemplate(arg0 context.Context, arg1 string, arg2 *v1alpha1.VSphereMachineConfig) (string, error) {
 	m.ctrl.T.Helper()
@@ -259,18 +332,32 @@ func (mr *MockProviderGovcClientMockRecorder) TemplateHasSnapshot(arg0, arg1 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemplateHasSnapshot", reflect.TypeOf((*MockProviderGovcClient)(nil).TemplateHasSnapshot), arg0, arg1)
 }
 
-// ValidateVCenterSetup mocks base method.
-func (m *MockProviderGovcClient) ValidateVCenterSetup(arg0 context.Context, arg1 *v1alpha1.VSphereDatacenterConfig, arg2 *bool) error {
+// ValidateVCenterAuthentication mocks base method.
+func (m *MockProviderGovcClient) ValidateVCenterAuthentication(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateVCenterSetup", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ValidateVCenterAuthentication", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ValidateVCenterSetup indicates an expected call of ValidateVCenterSetup.
-func (mr *MockProviderGovcClientMockRecorder) ValidateVCenterSetup(arg0, arg1, arg2 interface{}) *gomock.Call {
+// ValidateVCenterAuthentication indicates an expected call of ValidateVCenterAuthentication.
+func (mr *MockProviderGovcClientMockRecorder) ValidateVCenterAuthentication(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateVCenterSetup", reflect.TypeOf((*MockProviderGovcClient)(nil).ValidateVCenterSetup), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateVCenterAuthentication", reflect.TypeOf((*MockProviderGovcClient)(nil).ValidateVCenterAuthentication), arg0)
+}
+
+// ValidateVCenterConnection mocks base method.
+func (m *MockProviderGovcClient) ValidateVCenterConnection(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateVCenterConnection", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateVCenterConnection indicates an expected call of ValidateVCenterConnection.
+func (mr *MockProviderGovcClientMockRecorder) ValidateVCenterConnection(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateVCenterConnection", reflect.TypeOf((*MockProviderGovcClient)(nil).ValidateVCenterConnection), arg0, arg1)
 }
 
 // ValidateVCenterSetupMachineConfig mocks base method.

--- a/pkg/providers/vsphere/paths.go
+++ b/pkg/providers/vsphere/paths.go
@@ -1,0 +1,40 @@
+package vsphere
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
+)
+
+type folderType string
+
+const (
+	networkFolderType folderType = "network"
+)
+
+func generateFullVCenterPath(foldType folderType, folderPath string, datacenter string) string {
+	if folderPath == "" {
+		return folderPath
+	}
+
+	prefix := fmt.Sprintf("/%s", datacenter)
+	modPath := folderPath
+	if !strings.HasPrefix(folderPath, prefix) {
+		modPath = fmt.Sprintf("%s/%s/%s", prefix, foldType, folderPath)
+		logger.V(4).Info(fmt.Sprintf("Relative %s path specified, using path %s", foldType, modPath))
+		return modPath
+	}
+
+	return modPath
+}
+
+func validatePath(foldType folderType, folderPath string, datacenter string) error {
+	prefix := filepath.Join(fmt.Sprintf("/%s", datacenter), string(foldType))
+	if !strings.HasPrefix(folderPath, prefix) {
+		return fmt.Errorf("invalid path, expected path [%s] to be under [%s]", folderPath, prefix)
+	}
+
+	return nil
+}

--- a/pkg/providers/vsphere/setup.go
+++ b/pkg/providers/vsphere/setup.go
@@ -1,0 +1,32 @@
+package vsphere
+
+import (
+	"context"
+	"fmt"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+func (v *vsphereProvider) setup(ctx context.Context, datacenterConfig *anywherev1.VSphereDatacenterConfig) error {
+	if err := setupEnvVars(datacenterConfig); err != nil {
+		return err
+	}
+
+	if err := v.setupGovc(ctx, datacenterConfig); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (v *vsphereProvider) setupGovc(ctx context.Context, datacenterConfig *anywherev1.VSphereDatacenterConfig) error {
+	if datacenterConfig.Spec.Thumbprint == "" {
+		return nil
+	}
+
+	if err := v.providerGovcClient.ConfigureCertThumbprint(ctx, datacenterConfig.Spec.Server, datacenterConfig.Spec.Thumbprint); err != nil {
+		return fmt.Errorf("failed setting up govc: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -71,8 +71,32 @@ func (pc *DummyProviderGovcClient) DeployTemplate(ctx context.Context, datacente
 	return nil
 }
 
-func (pc *DummyProviderGovcClient) ValidateVCenterSetup(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, selfSigned *bool) error {
+func (pc *DummyProviderGovcClient) ValidateVCenterConnection(ctx context.Context, server string) error {
 	return nil
+}
+
+func (pc *DummyProviderGovcClient) ValidateVCenterAuthentication(ctx context.Context) error {
+	return nil
+}
+
+func (pc *DummyProviderGovcClient) IsCertSelfSigned(ctx context.Context) bool {
+	return false
+}
+
+func (pc *DummyProviderGovcClient) GetCertThumbprint(ctx context.Context) (string, error) {
+	return "", nil
+}
+
+func (pc *DummyProviderGovcClient) ConfigureCertThumbprint(ctx context.Context, server, thumbprint string) error {
+	return nil
+}
+
+func (pc *DummyProviderGovcClient) DatacenterExists(ctx context.Context, datacenter string) (bool, error) {
+	return true, nil
+}
+
+func (pc *DummyProviderGovcClient) NetworkExists(ctx context.Context, network string) (bool, error) {
+	return true, nil
 }
 
 func (pc *DummyProviderGovcClient) ValidateVCenterSetupMachineConfig(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, machineConfig *v1alpha1.VSphereMachineConfig, selfSigned *bool) error {
@@ -305,12 +329,21 @@ func (tt *providerTest) setExpectationsForDefaultDiskGovcCalls() {
 }
 
 func (tt *providerTest) setExpectationForVCenterValidation() {
-	tt.govc.EXPECT().ValidateVCenterSetup(tt.ctx, tt.datacenterConfig, &tt.provider.validator.selfSigned).Return(nil)
+	tt.govc.EXPECT().IsCertSelfSigned(tt.ctx).Return(false)
+	tt.govc.EXPECT().DatacenterExists(tt.ctx, tt.datacenterConfig.Spec.Datacenter).Return(true, nil)
+	tt.govc.EXPECT().NetworkExists(tt.ctx, tt.datacenterConfig.Spec.Network).Return(true, nil)
+}
+
+func (tt *providerTest) setExpectationForSetup() {
+	tt.govc.EXPECT().ValidateVCenterConnection(tt.ctx, tt.datacenterConfig.Spec.Server).Return(nil)
+	tt.govc.EXPECT().ValidateVCenterAuthentication(tt.ctx).Return(nil)
+	tt.govc.EXPECT().ConfigureCertThumbprint(tt.ctx, tt.datacenterConfig.Spec.Server, tt.datacenterConfig.Spec.Thumbprint).Return(nil)
 }
 
 func (tt *providerTest) setExpectationsForMachineConfigsVCenterValidation() {
 	for _, m := range tt.machineConfigs {
-		tt.govc.EXPECT().ValidateVCenterSetupMachineConfig(tt.ctx, tt.datacenterConfig, m, &tt.provider.validator.selfSigned).Return(nil)
+		var b bool
+		tt.govc.EXPECT().ValidateVCenterSetupMachineConfig(tt.ctx, tt.datacenterConfig, m, &b).Return(nil)
 	}
 }
 
@@ -2036,6 +2069,7 @@ func TestSetupAndValidateCreateClusterTemplateDifferent(t *testing.T) {
 func TestSetupAndValidateCreateClusterTemplateDoesNotExist(t *testing.T) {
 	tt := newProviderTest(t)
 
+	tt.setExpectationForSetup()
 	tt.setExpectationsForDefaultDiskGovcCalls()
 	tt.setExpectationForVCenterValidation()
 	tt.setExpectationsForMachineConfigsVCenterValidation()
@@ -2050,6 +2084,7 @@ func TestSetupAndValidateCreateClusterErrorCheckingTemplate(t *testing.T) {
 	tt := newProviderTest(t)
 	errorMessage := "failed getting template"
 
+	tt.setExpectationForSetup()
 	tt.setExpectationsForDefaultDiskGovcCalls()
 	tt.setExpectationForVCenterValidation()
 	tt.setExpectationsForMachineConfigsVCenterValidation()
@@ -2065,6 +2100,7 @@ func TestSetupAndValidateCreateClusterTemplateMissingTags(t *testing.T) {
 	controlPlaneMachineConfigName := tt.clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	controlPlaneMachineConfig := tt.machineConfigs[controlPlaneMachineConfigName]
 
+	tt.setExpectationForSetup()
 	tt.setExpectationsForDefaultDiskGovcCalls()
 	tt.setExpectationForVCenterValidation()
 	tt.setExpectationsForMachineConfigsVCenterValidation()
@@ -2083,6 +2119,7 @@ func TestSetupAndValidateCreateClusterErrorGettingTags(t *testing.T) {
 	controlPlaneMachineConfigName := tt.clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	controlPlaneMachineConfig := tt.machineConfigs[controlPlaneMachineConfigName]
 
+	tt.setExpectationForSetup()
 	tt.setExpectationsForDefaultDiskGovcCalls()
 	tt.setExpectationForVCenterValidation()
 	tt.setExpectationsForMachineConfigsVCenterValidation()


### PR DESCRIPTION
*Description of changes:*
* Move the logic to validate vcenter setup to the `validator`
* Remove side effects, all the code updating the vsphere api structs now is in the `defaulter`
* Prevents modifying global vars in runtime (store required env vars in `govc` struct)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
