### PR TITLE
Avoid building all deps for all providers

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -133,7 +133,7 @@ func (f *Factory) WithExecutableBuilder() *Factory {
 }
 
 func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1.Cluster, skipIpCheck bool, hardwareConfigFile string) *Factory {
-	f.WithProviderFactory()
+	f.WithProviderFactory(clusterConfig)
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.dependencies.Provider != nil {
@@ -152,8 +152,13 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 	return f
 }
 
-func (f *Factory) WithProviderFactory() *Factory {
-	f.WithDocker().WithKubectl().WithGovc().WithWriter().WithCAPIClusterResourceSetManager()
+func (f *Factory) WithProviderFactory(clusterConfig *v1alpha1.Cluster) *Factory {
+	switch clusterConfig.Spec.DatacenterRef.Kind {
+	case v1alpha1.VSphereDatacenterKind:
+		f.WithKubectl().WithGovc().WithWriter().WithCAPIClusterResourceSetManager()
+	case v1alpha1.DockerDatacenterKind:
+		f.WithDocker().WithKubectl()
+	}
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.providerFactory != nil {

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -43,7 +43,7 @@ func TestFactoryBuildWithProvider(t *testing.T) {
 
 	tt.Expect(err).To(BeNil())
 	tt.Expect(deps.Provider).NotTo(BeNil())
-	tt.Expect(deps.DockerClient).To(BeNil(), "it only only builds deps for vsphere")
+	tt.Expect(deps.DockerClient).To(BeNil(), "it only builds deps for vsphere")
 }
 
 func TestFactoryBuildWithClusterManager(t *testing.T) {

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -43,6 +43,7 @@ func TestFactoryBuildWithProvider(t *testing.T) {
 
 	tt.Expect(err).To(BeNil())
 	tt.Expect(deps.Provider).NotTo(BeNil())
+	tt.Expect(deps.DockerClient).To(BeNil(), "it only only builds deps for vsphere")
 }
 
 func TestFactoryBuildWithClusterManager(t *testing.T) {

--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -78,6 +78,10 @@ func (g *Govc) exec(ctx context.Context, args ...string) (stdout bytes.Buffer, e
 }
 
 func (g *Govc) Close(ctx context.Context) error {
+	if g == nil {
+		return nil
+	}
+
 	if err := g.Logout(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
*Description of changes:*
This prevents execs for docker clusters to try to logout from vCenter
Drawbacks: it duplicates the logic around the datacenter type and it bleeds out of the provider factory what are the dependencies of each provider

The other option is to get rid of the provider factory and move the logic to the dependency factory

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
