### PR TITLE
add CAPV infrastructure API group permissions to diagnostic collector…

### DIFF
--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -230,6 +230,8 @@ func (c *collectorFactory) managementClusterCrdCollectors() []*Collect {
 		"clusters.cluster.x-k8s.io",
 		"machinedeployments.cluster.x-k8s.io",
 		"machines.cluster.x-k8s.io",
+		"machinehealthchecks.cluster.x-k8s.io",
+		"kubeadmcontrolplane.controlplane.cluster.x-k8s.io",
 	}
 	return c.generateCrdCollectors(mgmtCrds)
 }

--- a/pkg/diagnostics/config/diagnostic-collector-rbac.yaml
+++ b/pkg/diagnostics/config/diagnostic-collector-rbac.yaml
@@ -6,6 +6,7 @@ rules:
   - apiGroups:
     - cluster.x-k8s.io
     - infrastructure.cluster.x-k8s.io
+    - controlplane.cluster.x-k8s.io
     - anywhere.eks.amazonaws.com
     resources:
     - '*'

--- a/pkg/diagnostics/config/diagnostic-collector-rbac.yaml
+++ b/pkg/diagnostics/config/diagnostic-collector-rbac.yaml
@@ -5,6 +5,7 @@ metadata:
 rules:
   - apiGroups:
     - cluster.x-k8s.io
+    - infrastructure.cluster.x-k8s.io
     - anywhere.eks.amazonaws.com
     resources:
     - '*'


### PR DESCRIPTION
… RBAC to facilitate CRD description collection; add KCP and MHC CRD collectors

*Issue #, if available:*

*Description of changes:*

need to add the vsphere infrastcuture API groups in order to collect the VSphere infra CRDs; adds collectors for KCP and MHC

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
