### PR TITLE
Redo "Add support for secure cipher suites with external etcd (#759)"

### DIFF
--- a/docs/content/en/docs/reference/changelog.md
+++ b/docs/content/en/docs/reference/changelog.md
@@ -15,8 +15,9 @@ menu:
 
 ### Changed
 
-- Kubernetes components and local etcd now use TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 as the
-  configured TLS cipher suite [#657](https://github.com/aws/eks-anywhere/pull/657)
+- Kubernetes components and etcd now use TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 as the
+  configured TLS cipher suite [#657](https://github.com/aws/eks-anywhere/pull/657), 
+  [#759](https://github.com/aws/eks-anywhere/pull/759)
 
 ## v0.6.0 - 2021-10-29
 

--- a/pkg/clusterapi/extraargs.go
+++ b/pkg/clusterapi/extraargs.go
@@ -2,7 +2,6 @@ package clusterapi
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/crypto"
@@ -53,15 +52,13 @@ func PodIAMAuthExtraArgs(podIAMConfig *v1alpha1.PodIAMConfig) ExtraArgs {
 // We don't need to add these once the Kubernetes components default to using the secure cipher suites
 func SecureTlsCipherSuitesExtraArgs() ExtraArgs {
 	args := ExtraArgs{}
-	cipherSuitesString := strings.Join(crypto.SecureCipherSuiteNames(), ",")
-	args.AddIfNotEmpty("tls-cipher-suites", cipherSuitesString)
+	args.AddIfNotEmpty("tls-cipher-suites", crypto.SecureCipherSuitesString())
 	return args
 }
 
 func SecureEtcdTlsCipherSuitesExtraArgs() ExtraArgs {
 	args := ExtraArgs{}
-	cipherSuitesString := strings.Join(crypto.SecureCipherSuiteNames(), ",")
-	args.AddIfNotEmpty("cipher-suites", cipherSuitesString)
+	args.AddIfNotEmpty("cipher-suites", crypto.SecureCipherSuitesString())
 	return args
 }
 

--- a/pkg/clusterapi/extraargs_test.go
+++ b/pkg/clusterapi/extraargs_test.go
@@ -2,7 +2,6 @@ package clusterapi_test
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -245,7 +244,7 @@ func TestSecureTlsCipherSuitesExtraArgs(t *testing.T) {
 		{
 			testName: "default",
 			want: clusterapi.ExtraArgs{
-				"tls-cipher-suites": strings.Join(crypto.SecureCipherSuiteNames(), ","),
+				"tls-cipher-suites": crypto.SecureCipherSuitesString(),
 			},
 		},
 	}
@@ -267,7 +266,7 @@ func TestSecureEtcdTlsCipherSuitesExtraArgs(t *testing.T) {
 		{
 			testName: "default",
 			want: clusterapi.ExtraArgs{
-				"cipher-suites": strings.Join(crypto.SecureCipherSuiteNames(), ","),
+				"cipher-suites": crypto.SecureCipherSuitesString(),
 			},
 		},
 	}

--- a/pkg/crypto/tls.go
+++ b/pkg/crypto/tls.go
@@ -1,8 +1,16 @@
 package crypto
 
+import (
+	"strings"
+)
+
 // This is what we currently support as the default. In the future,
 // we can make this customizable and return a wider range of
 // supported names.
-func SecureCipherSuiteNames() []string {
+func secureCipherSuiteNames() []string {
 	return []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}
+}
+
+func SecureCipherSuitesString() string {
+	return strings.Join(secureCipherSuiteNames(), ",")
 }

--- a/pkg/crypto/tls_test.go
+++ b/pkg/crypto/tls_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/aws/eks-anywhere/pkg/crypto"
 )
 
-var validCipherSuites = []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}
+var validCipherSuitesString = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
 
 func TestSecureCipherSuiteNames(t *testing.T) {
-	list := crypto.SecureCipherSuiteNames()
-	if !reflect.DeepEqual(list, validCipherSuites) {
-		assert.Equal(t, validCipherSuites, list, "expected cipher suites to be list of valid")
+	string := crypto.SecureCipherSuitesString()
+	if !reflect.DeepEqual(string, validCipherSuitesString) {
+		assert.Equal(t, validCipherSuitesString, string, "cipher suites don't match")
 	}
 }

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -228,6 +228,9 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: {{.externalEtcdVersion}}
+{{- if .etcdCipherSuites }}
+    cipherSuites: {{.etcdCipherSuites}}
+{{- end }}
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/crypto"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers"
@@ -186,6 +187,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) map[string]interface{} {
 		"corednsVersion":             bundle.KubeDistro.CoreDNS.Tag,
 		"kindNodeImage":              bundle.EksD.KindNode.VersionedImage(),
 		"etcdExtraArgs":              etcdExtraArgs.ToPartialYaml(),
+		"etcdCipherSuites":           crypto.SecureCipherSuitesString(),
 		"apiserverExtraArgs":         apiServerExtraArgs.ToPartialYaml(),
 		"controllermanagerExtraArgs": sharedExtraArgs.ToPartialYaml(),
 		"schedulerExtraArgs":         sharedExtraArgs.ToPartialYaml(),

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
@@ -297,6 +297,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
@@ -292,6 +292,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
@@ -290,6 +290,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate

--- a/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
@@ -291,6 +291,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate

--- a/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
@@ -308,6 +308,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
@@ -290,6 +290,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -475,6 +475,9 @@ spec:
       - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
       - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
 {{- end }}
+{{- if .etcdCipherSuites }}
+    cipherSuites: {{.etcdCipherSuites}}
+{{- end }}
     users:
       - name: {{.etcdSshUsername}}
         sshAuthorizedKeys:

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
@@ -446,6 +446,7 @@ spec:
       etcdImage: public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.14-eks-1-19-4
       bootstrapImage: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap:v1-19-6-51a138f2cb28ccc98ced838ffc6ab984110123b
       pauseImage: public.ecr.aws/eks-distro/kubernetes/pause:v1.19.8-eks-1-19-4
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
       - name: ec2-user
         sshAuthorizedKeys:

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
@@ -443,6 +443,7 @@ spec:
       etcdImage: public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.16-eks-1-21-4
       bootstrapImage: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap:v1-21-4-eks-a-v0.0.0-dev-build.158
       pauseImage: public.ecr.aws/eks-distro/kubernetes/pause:v1.21.2-eks-1-21-4
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
       - name: ec2-user
         sshAuthorizedKeys:

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -479,6 +479,7 @@ spec:
       etcdImage: public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.16-eks-1-21-4
       bootstrapImage: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap:v1-21-4-eks-a-v0.0.0-dev-build.158
       pauseImage: public.ecr.aws/eks-distro/kubernetes/pause:v1.21.2-eks-1-21-4
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
       - name: ec2-user
         sshAuthorizedKeys:

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -419,6 +419,7 @@ spec:
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
       - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
       - name: capv
         sshAuthorizedKeys:

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -419,6 +419,7 @@ spec:
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
       - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
       - name: capv
         sshAuthorizedKeys:

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -437,6 +437,7 @@ spec:
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
       - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
       - name: capv
         sshAuthorizedKeys:

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -428,6 +428,7 @@ spec:
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
       - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
       - name: capv
         sshAuthorizedKeys:

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -450,6 +450,7 @@ spec:
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
       - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
       - name: capv
         sshAuthorizedKeys:

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -420,6 +420,7 @@ spec:
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
       - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
       - name: capv
         sshAuthorizedKeys:

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -686,6 +686,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		"podCidrs":                             clusterSpec.Spec.ClusterNetwork.Pods.CidrBlocks,
 		"serviceCidrs":                         clusterSpec.Spec.ClusterNetwork.Services.CidrBlocks,
 		"etcdExtraArgs":                        etcdExtraArgs.ToPartialYaml(),
+		"etcdCipherSuites":                     crypto.SecureCipherSuitesString(),
 		"apiserverExtraArgs":                   apiServerExtraArgs.ToPartialYaml(),
 		"controllermanagerExtraArgs":           sharedExtraArgs.ToPartialYaml(),
 		"schedulerExtraArgs":                   sharedExtraArgs.ToPartialYaml(),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Tested locally and it seems to be working as expected. Just need to make sure we release the cluster controller image and ensure that it is being used. Can merge https://github.com/aws/eks-anywhere/pull/782 after this PR to trigger that build too

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
