### PR TITLE
override bundle release manifest URL for non-main branch sources when…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,16 @@ GOLANG_VERSION?="1.16"
 GO ?= $(shell source ./scripts/common.sh && build::common::get_go_path $(GOLANG_VERSION))/go
 GO_TEST ?= $(GO) test
 
+ifdef CODEBUILD_SOURCE_VERSION ## If in codebuild environment, use the branch-specific bundle manifest URL for non-main (e.g. release branch) sources
+ifeq (,$(findstring $(CODEBUILD_SOURCE_VERSION),main))
+BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${CODEBUILD_SOURCE_VERSION}/bundle-release.yaml
+$(info    Using branch-specific BUNDLE_RELEASE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))
+endif
+endif
+
 RELEASE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/eks-a-release.yaml
 BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/bundle-release.yaml
+
 DEV_GIT_VERSION:=v0.0.0-dev
 
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GO ?= $(shell source ./scripts/common.sh && build::common::get_go_path $(GOLANG_
 GO_TEST ?= $(GO) test
 
 ## ensure local execution uses the 'main' branch bundle
-CODEBUILD_SOURCE_VERSION?=main
+BRANCH_NAME?=main
 ifeq (,$(findstring $(CODEBUILD_SOURCE_VERSION),main))
 ## use the branch-specific bundle manifest if the branch is not 'main'
 BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${CODEBUILD_SOURCE_VERSION}/bundle-release.yaml

--- a/Makefile
+++ b/Makefile
@@ -15,19 +15,18 @@ GOLANG_VERSION?="1.16"
 GO ?= $(shell source ./scripts/common.sh && build::common::get_go_path $(GOLANG_VERSION))/go
 GO_TEST ?= $(GO) test
 
-CODEBUILD_SOURCE_VERSION ?= main ## If in codebuild environment, use the branch-specific bundle manifest 
+CODEBUILD_SOURCE_VERSION?=main## ensure local execution uses the 'main' branch bundle
 ifeq (,$(findstring $(CODEBUILD_SOURCE_VERSION),main))
+## use the branch-specific bundle manifest if the branch is not 'main'
 BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${CODEBUILD_SOURCE_VERSION}/bundle-release.yaml
 $(info    Using branch-specific BUNDLE_RELEASE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))
-endif
-ifeq (,$(findstring $(CODEBUILD_SOURCE_VERSION),main))
-BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${CODEBUILD_SOURCE_VERSION}/bundle-release.yaml
-$(info    Using branch-specific BUNDLE_RELEASE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))
-endif
+else
+## use the standard bundle manifest if the branch is 'main'
+BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/bundle-release.yaml
+$(info    Using stanard BUNDLE_RELEASE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))
 endif
 
 RELEASE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/eks-a-release.yaml
-BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/bundle-release.yaml
 
 DEV_GIT_VERSION:=v0.0.0-dev
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ GOLANG_VERSION?="1.16"
 GO ?= $(shell source ./scripts/common.sh && build::common::get_go_path $(GOLANG_VERSION))/go
 GO_TEST ?= $(GO) test
 
-CODEBUILD_SOURCE_VERSION?=main## ensure local execution uses the 'main' branch bundle
+## ensure local execution uses the 'main' branch bundle
+CODEBUILD_SOURCE_VERSION?=main
 ifeq (,$(findstring $(CODEBUILD_SOURCE_VERSION),main))
 ## use the branch-specific bundle manifest if the branch is not 'main'
 BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${CODEBUILD_SOURCE_VERSION}/bundle-release.yaml

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GO_TEST ?= $(GO) test
 BRANCH_NAME?=main
 ifeq (,$(findstring $(BRANCH_NAME),main))
 ## use the branch-specific bundle manifest if the branch is not 'main'
-BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${CODEBUILD_SOURCE_VERSION}/bundle-release.yaml
+BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${BRANCH_NAME}/bundle-release.yaml
 $(info    Using branch-specific BUNDLE_RELEASE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))
 else
 ## use the standard bundle manifest if the branch is 'main'

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GO_TEST ?= $(GO) test
 
 ## ensure local execution uses the 'main' branch bundle
 BRANCH_NAME?=main
-ifeq (,$(findstring $(CODEBUILD_SOURCE_VERSION),main))
+ifeq (,$(findstring $(BRANCH_NAME),main))
 ## use the branch-specific bundle manifest if the branch is not 'main'
 BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${CODEBUILD_SOURCE_VERSION}/bundle-release.yaml
 $(info    Using branch-specific BUNDLE_RELEASE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ GOLANG_VERSION?="1.16"
 GO ?= $(shell source ./scripts/common.sh && build::common::get_go_path $(GOLANG_VERSION))/go
 GO_TEST ?= $(GO) test
 
-ifdef CODEBUILD_SOURCE_VERSION ## If in codebuild environment, use the branch-specific bundle manifest URL for non-main (e.g. release branch) sources
+CODEBUILD_SOURCE_VERSION ?= main ## If in codebuild environment, use the branch-specific bundle manifest 
+ifeq (,$(findstring $(CODEBUILD_SOURCE_VERSION),main))
+BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${CODEBUILD_SOURCE_VERSION}/bundle-release.yaml
+$(info    Using branch-specific BUNDLE_RELEASE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))
+endif
 ifeq (,$(findstring $(CODEBUILD_SOURCE_VERSION),main))
 BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${CODEBUILD_SOURCE_VERSION}/bundle-release.yaml
 $(info    Using branch-specific BUNDLE_RELEASE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))


### PR DESCRIPTION
… building in CodeBuild enviornment

*Issue #, if available:*

*Description of changes:*
If the CODEBUILD_SOURCE_VERSION is set, and it is NOT "main", use the branch-specific release bundle URL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
