### PR TITLE
Backport select bundle based on branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,20 @@ GIT_VERSION?=$(shell git describe --tag)
 GIT_TAG?=$(shell git describe --tag | cut -d'-' -f1)
 GOLANG_VERSION?="1.16"
 
-RELEASE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/eks-a-release.yaml
+## ensure local execution uses the 'main' branch bundle
+CODEBUILD_SOURCE_VERSION?=main
+ifeq (,$(findstring $(CODEBUILD_SOURCE_VERSION),main))
+## use the branch-specific bundle manifest if the branch is not 'main'
+BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${CODEBUILD_SOURCE_VERSION}/bundle-release.yaml
+$(info    Using branch-specific BUNDLE_RELEASE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))
+else
+## use the standard bundle manifest if the branch is 'main'
 BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/bundle-release.yaml
+$(info    Using stanard BUNDLE_RELEASE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))
+endif
+
+RELEASE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/eks-a-release.yaml
+
 DEV_GIT_VERSION:=v0.0.0-dev
 
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GIT_VERSION?=$(shell git describe --tag)
 GIT_TAG?=$(shell git describe --tag | cut -d'-' -f1)
 GOLANG_VERSION?="1.16"
 
-## ensure local execution uses the 'main' branch bundle
+## ensure local execution uses the 'release-0.6' branch bundle
 CODEBUILD_SOURCE_VERSION?=release-0.6
 ifeq (,$(findstring $(CODEBUILD_SOURCE_VERSION),main))
 ## use the branch-specific bundle manifest if the branch is not 'main'

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GIT_TAG?=$(shell git describe --tag | cut -d'-' -f1)
 GOLANG_VERSION?="1.16"
 
 ## ensure local execution uses the 'main' branch bundle
-CODEBUILD_SOURCE_VERSION?=main
+CODEBUILD_SOURCE_VERSION?=release-0.6
 ifeq (,$(findstring $(CODEBUILD_SOURCE_VERSION),main))
 ## use the branch-specific bundle manifest if the branch is not 'main'
 BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${CODEBUILD_SOURCE_VERSION}/bundle-release.yaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

if the CODEBUILD_SOURCE_VERSION is not set, use 'release-0.6' and the corresponding bundle; if it is set, use standard bundle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
