### PR TITLE
add cleanup vms flag to e2e command; clean up individual clusters as …

### DIFF
--- a/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
@@ -47,9 +47,4 @@ phases:
       -n ${INTEGRATION_TEST_SUBNET_ID}
       -m ${INTEGRATION_TEST_MAX_EC2_COUNT}
       -r 'Test'
-  post_build:
-    commands:
-    - >
-      ./bin/test e2e cleanup vsphere
-      -n i-
-      -v 4
+      --cleanup-vms=true

--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -64,6 +64,7 @@ phases:
       -r 'Test'
       -v 4
       --bundles-override=${BUNDLES_OVERRIDE}
+      --cleanup-vms=true
   post_build:
     commands:
     - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE
@@ -76,7 +77,3 @@ phases:
       $CODEBUILD_BUILD_NUMBER
       $GIT_HASH
       false
-    - >
-      ./bin/test e2e cleanup vsphere
-      -n i-
-      -v 4

--- a/cmd/integration_test/cmd/run.go
+++ b/cmd/integration_test/cmd/run.go
@@ -23,6 +23,7 @@ const (
 	maxInstancesFlagName    = "max-instances"
 	skipFlagName            = "skip"
 	bundlesOverrideFlagName = "bundles-override"
+	cleanupVmsFlagName      = "cleanup-vms"
 )
 
 var runE2ECmd = &cobra.Command{
@@ -62,6 +63,7 @@ func init() {
 	runE2ECmd.Flags().IntP(maxInstancesFlagName, "m", 1, "Run tests in parallel with multiple EC2 instances")
 	runE2ECmd.Flags().StringSlice(skipFlagName, nil, "List of tests to skip")
 	runE2ECmd.Flags().Bool(bundlesOverrideFlagName, false, "Flag to indicate if the tests should run with a bundles override")
+	runE2ECmd.Flags().Bool(cleanupVmsFlagName, false, "Flag to indicate if VSphere VMs should be cleaned up automatically as tests complete")
 
 	for _, flag := range requiredFlags {
 		if err := runE2ECmd.MarkFlagRequired(flag); err != nil {
@@ -80,6 +82,7 @@ func runE2E(ctx context.Context) error {
 	maxInstances := viper.GetInt(maxInstancesFlagName)
 	testsToSkip := viper.GetStringSlice(skipFlagName)
 	bundlesOverride := viper.GetBool(bundlesOverrideFlagName)
+	cleanupVms := viper.GetBool(cleanupVmsFlagName)
 
 	runConf := e2e.ParallelRunConf{
 		MaxInstances:        maxInstances,
@@ -91,6 +94,7 @@ func runE2E(ctx context.Context) error {
 		Regex:               testRegex,
 		TestsToSkip:         testsToSkip,
 		BundlesOverride:     bundlesOverride,
+		CleanupVms:          cleanupVms,
 	}
 
 	err := e2e.RunTestsInParallel(runConf)

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -27,6 +28,7 @@ type ParallelRunConf struct {
 	Regex               string
 	TestsToSkip         []string
 	BundlesOverride     bool
+	CleanupVms          bool
 }
 
 type instanceTestsResults struct {
@@ -75,6 +77,12 @@ func RunTestsInParallel(conf ParallelRunConf) error {
 			failedInstances += 1
 		} else {
 			logger.Info("Ec2 instance tests completed successfully", "jobId", r.conf.jobId, "instanceId", r.conf.instanceId, "commandId", r.commandId, "tests", r.conf.regex, "status", passedStatus)
+		}
+		if conf.CleanupVms {
+			err := CleanUpVsphereTestResources(context.Background(), r.conf.instanceId)
+			if err != nil {
+				logger.Error(err, "Failed to clean up VSphere cluster VMs", "clusterName", r.conf.instanceId)
+			}
 		}
 	}
 

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -79,7 +79,7 @@ func RunTestsInParallel(conf ParallelRunConf) error {
 			logger.Info("Ec2 instance tests completed successfully", "jobId", r.conf.jobId, "instanceId", r.conf.instanceId, "commandId", r.commandId, "tests", r.conf.regex, "status", passedStatus)
 		}
 		if conf.CleanupVms {
-			err := CleanUpVsphereTestResources(context.Background(), r.conf.instanceId)
+			err = CleanUpVsphereTestResources(context.Background(), r.conf.instanceId)
 			if err != nil {
 				logger.Error(err, "Failed to clean up VSphere cluster VMs", "clusterName", r.conf.instanceId)
 			}


### PR DESCRIPTION
…tests complete

*Issue #, if available:*

*Description of changes:*

I'll help us run concurrent integ tests if we don't clean up every VM starting with `i-` on test completion....

instead, add a flag to the e2e command, which allows us to specify if we want ongoing cleanup.

we'll then clean up each cluster as it completes the test, and only clean up that specific cluster (cluster names are based on the instance ID).

this defaults to false so any local testing can easily retain the VMs.

this will allow us to run release branch and main branch e2e tests simultaneously without blasting 💣  all of the other running clusters are the tests are running.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
