### PR TITLE
Validate Docker desktop version on Mac

### DIFF
--- a/cmd/eksctl-anywhere/cmd/validations.go
+++ b/cmd/eksctl-anywhere/cmd/validations.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"runtime"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/executables"
@@ -14,6 +15,12 @@ func commonValidation(ctx context.Context, clusterConfigFile string) (*v1alpha1.
 	err := validations.CheckMinimumDockerVersion(ctx, docker)
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate docker: %v", err)
+	}
+	if runtime.GOOS == "darwin" {
+		err = validations.CheckDockerDesktopVersion(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to validate docker desktop: %v", err)
+		}
 	}
 	validations.CheckDockerAllocatedMemory(ctx, docker)
 	clusterConfigFileExist := validations.FileExists(clusterConfigFile)


### PR DESCRIPTION
When running on Mac, check if Docker Desktop version is less than `4.3` before proceeding with cluster creation.

Addresses #792


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
