### PR TITLE
add nil check to dependency closer to avoid segfault

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -47,8 +47,10 @@ type Dependencies struct {
 func (d *Dependencies) Close(ctx context.Context) error {
 	closers := []types.Closer{d.Govc, d.DockerClient, d.Kubectl, d.Kind, d.Clusterctl, d.Flux, d.Troubleshoot}
 	for _, c := range closers {
-		if err := c.Close(ctx); err != nil {
-			return err
+		if c != nil {
+			if err := c.Close(ctx); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Avoid attempting to close un-instantiated dependencies (leading to segfault)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
