### PR TITLE
Parametrize os and arch list to upload script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,6 @@ eks-a-e2e:
 		fi \
 	else \
 		make check-eksa-components-override; \
-		make eks-a-cross-platform; \
 		make eks-a; \
 	fi
 

--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -76,4 +76,6 @@ phases:
       "eks-a-cli"
       $CODEBUILD_BUILD_NUMBER
       $GIT_HASH
+      "linux,darwin"
+      "amd64"
       false

--- a/scripts/e2e_test_docker.sh
+++ b/scripts/e2e_test_docker.sh
@@ -26,6 +26,7 @@ if [ "$TEST_ROLE_ARN" == "" ]; then
 fi
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
+BIN_FOLDER=$REPO_ROOT/bin
 TEST_REGEX="${1:-TestDockerKubernetes121SimpleFlow}"
 
 cat << EOF > config_file
@@ -45,10 +46,10 @@ export AWS_PROFILE=e2e-docker-test
 unset AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE
 
 BUNDLES_OVERRIDE=false
-if [ -f "$REPO_ROOT/bin/local-bundle-release.yaml" ]; then
+if [ -f "$BIN_FOLDER/local-bundle-release.yaml" ]; then
     BUNDLES_OVERRIDE=true
 fi
-$REPO_ROOT/bin/test e2e run \
+$BIN_FOLDER/test e2e run \
     -a ${INTEGRATION_TEST_AL2_AMI_ID} \
     -s ${INTEGRATION_TEST_STORAGE_BUCKET} \
     -j ${JOB_ID} \
@@ -56,10 +57,16 @@ $REPO_ROOT/bin/test e2e run \
     -r ${TEST_REGEX} \
     --bundles-override=${BUNDLES_OVERRIDE}
 
+# Faking cross-platform versioned folders for dry-run
+mkdir -p $BIN_FOLDER/linux/amd64
+cp $BIN_FOLDER/eksctl-anywhere $BIN_FOLDER/linux/amd64/eksctl-anywhere
+
 $REPO_ROOT/cmd/integration_test/build/script/upload_artifacts.sh \
     "s3://artifacts-bucket" \
     $REPO_ROOT \
     "eks-a-cli" \
     $PROW_JOB_ID \
     $PULL_PULL_SHA \
+    "linux" \
+    "amd64" \
     true


### PR DESCRIPTION
* Removing cross-platform builds in e2e presubmits
* Faking cross-platform folder structure to support tarball creation/upload dry-run
* Parametrize os and archs for tarball creation, so we can pass in different list per usecase


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
