### PR TITLE
Prevent nil pointer by checking for nil in interface value

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -2,6 +2,7 @@ package dependencies
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/aws/eks-anywhere/pkg/addonmanager/addonclients"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -47,7 +48,7 @@ type Dependencies struct {
 func (d *Dependencies) Close(ctx context.Context) error {
 	closers := []types.Closer{d.Govc, d.DockerClient, d.Kubectl, d.Kind, d.Clusterctl, d.Flux, d.Troubleshoot}
 	for _, c := range closers {
-		if c != nil {
+		if !reflect.ValueOf(c).IsNil() {
 			if err := c.Close(ctx); err != nil {
 				return err
 			}


### PR DESCRIPTION
*Description of changes:*
temporal solution. Prevents:
```
180 panic: runtime error: invalid memory address or nil pointer dereference
181 [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x16bbe2b]
182
183 goroutine 1 [running]:
184 github.com/aws/eks-anywhere/pkg/executables.(*Docker).Close(0x0, 0x1f326c8, 0xc00004c028, 0x0, 0x0)
185         <autogenerated>:1 +0x2b
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
