### PR TITLE
Adding object key to logger info

### DIFF
--- a/internal/test/e2e/ipmanager.go
+++ b/internal/test/e2e/ipmanager.go
@@ -35,10 +35,10 @@ func getUniqueIP(cidr string, usedIPs map[string]bool) string {
 	ip, err := ipgen.GenerateUniqueIP(cidr)
 	for ; err != nil || usedIPs[ip]; ip, err = ipgen.GenerateUniqueIP(cidr) {
 		if err != nil {
-			logger.V(2).Info("Warning: getting unique IP for vsphere failed", err)
+			logger.V(2).Info("Warning: getting unique IP for vsphere failed", "error", err)
 		}
 		if usedIPs[ip] {
-			logger.V(2).Info("Warning: generated IP is already taken", ip)
+			logger.V(2).Info("Warning: generated IP is already taken", "IP", ip)
 		}
 	}
 	usedIPs[ip] = true


### PR DESCRIPTION
*Description of changes:*
Adding Interface key for `logger.Info` during e2e generate IP

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
