### PR TITLE
Change upgrade plan to upgrade plan cluster

### DIFF
--- a/cmd/eksctl-anywhere/cmd/upgradeplan.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplan.go
@@ -19,8 +19,8 @@ import (
 )
 
 var upgradePlanCmd = &cobra.Command{
-	Use:          "plan",
-	Short:        "Provides new release versions for the next upgrade",
+	Use:          "plan cluster",
+	Short:        "Provides new release versions for the next cluster upgrade",
 	Long:         "Provides a list of target versions for upgrading the core components in the workload cluster",
 	PreRunE:      preRunUpgradePlanCluster,
 	SilenceUsage: true,
@@ -91,7 +91,7 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 	w := tabwriter.NewWriter(os.Stdout, 10, 4, 3, ' ', 0)
 	fmt.Fprintln(w, "NAME\tCURRENT VERSION\tNEXT VERSION")
 	for i := range componentChangeDiffs.ComponentReports {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", componentChangeDiffs.ComponentReports[i].ComponentName, componentChangeDiffs.ComponentReports[i].NewVersion, componentChangeDiffs.ComponentReports[i].OldVersion)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", componentChangeDiffs.ComponentReports[i].ComponentName, componentChangeDiffs.ComponentReports[i].OldVersion, componentChangeDiffs.ComponentReports[i].NewVersion)
 	}
 
 	if err := w.Flush(); err != nil {


### PR DESCRIPTION
*Issue #, if available:*
#499 
*Description of changes:*
Change command from `upgrade plan` to `upgrade plan cluster`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
