### PR TITLE
Controller reconcile utils

### DIFF
--- a/controllers/controllers/reconciler/main_test.go
+++ b/controllers/controllers/reconciler/main_test.go
@@ -1,0 +1,14 @@
+package reconciler_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/aws/eks-anywhere/internal/test/envtest"
+)
+
+var env *envtest.Environment
+
+func TestMain(m *testing.M) {
+	os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+}

--- a/controllers/controllers/reconciler/reconcile.go
+++ b/controllers/controllers/reconciler/reconcile.go
@@ -1,0 +1,39 @@
+package reconciler
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const fieldManager = "eks-a-controller"
+
+func ReconcileYaml(ctx context.Context, c client.Client, yaml []byte) error {
+	objs, err := YamlToClientObjects(yaml)
+	if err != nil {
+		return err
+	}
+
+	return ReconcileObjects(ctx, c, objs)
+}
+
+func ReconcileObjects(ctx context.Context, c client.Client, objs []client.Object) error {
+	for _, o := range objs {
+		if err := ReconcileObject(ctx, c, o); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ReconcileObject(ctx context.Context, c client.Client, obj client.Object) error {
+	// Server side apply
+	err := c.Patch(ctx, obj, client.Apply, &client.PatchOptions{FieldManager: fieldManager})
+	if err != nil {
+		return errors.Wrapf(err, "failed to reconcile object %s, %s/%s", obj.GetObjectKind().GroupVersionKind(), obj.GetNamespace(), obj.GetName())
+	}
+
+	return nil
+}

--- a/controllers/controllers/reconciler/reconcile_test.go
+++ b/controllers/controllers/reconciler/reconcile_test.go
@@ -1,0 +1,149 @@
+package reconciler_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/eks-anywhere/controllers/controllers/reconciler"
+)
+
+func TestReconcileYaml(t *testing.T) {
+	cluster1 := newCluster("cluster-1")
+	cluster2 := newCluster("cluster-2")
+	tests := []struct {
+		name         string
+		initialObjs  []*clusterapiv1.Cluster
+		yaml         []byte
+		expectedObjs []*clusterapiv1.Cluster
+	}{
+		{
+			name: "new object",
+			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1alpha3
+kind: Cluster
+metadata:
+  name: cluster-1
+  namespace: #namespace#
+spec:
+  controlPlaneEndpoint:
+    host: 1.1.1.1
+    port: 8080`),
+			expectedObjs: []*clusterapiv1.Cluster{
+				updatedCluster(cluster1, func(c capiCluster) {
+					c.Spec.ControlPlaneEndpoint.Port = 8080
+					c.Spec.ControlPlaneEndpoint.Host = "1.1.1.1"
+				}),
+			},
+		},
+		{
+			name: "existing object",
+			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1alpha3
+kind: Cluster
+metadata:
+  name: cluster-1
+  namespace: #namespace#
+spec:
+  paused: true`),
+			initialObjs: []*clusterapiv1.Cluster{
+				cluster1.DeepCopy(),
+			},
+			expectedObjs: []*clusterapiv1.Cluster{
+				updatedCluster(cluster1, func(c capiCluster) { c.Spec.Paused = true }),
+			},
+		},
+		{
+			name: "new and existing object",
+			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1alpha3
+kind: Cluster
+metadata:
+  name: cluster-1
+  namespace: #namespace#
+spec:
+  paused: true
+---
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: Cluster
+metadata:
+  name: cluster-2
+  namespace: #namespace#
+spec:
+  paused: true`),
+			initialObjs: []*clusterapiv1.Cluster{
+				cluster1.DeepCopy(),
+			},
+			expectedObjs: []*clusterapiv1.Cluster{
+				updatedCluster(cluster1, func(c capiCluster) { c.Spec.Paused = true }),
+				updatedCluster(cluster2, func(c capiCluster) { c.Spec.Paused = true }),
+			},
+		},
+	}
+
+	c := env.Client()
+	reader := env.APIReader()
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ns := env.CreateNamespaceForTest(ctx, t)
+
+			for _, o := range tt.initialObjs {
+				o.SetNamespace(ns)
+
+				if err := c.Create(ctx, o); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			tt.yaml = []byte(strings.ReplaceAll(string(tt.yaml), "#namespace#", ns))
+
+			g.Expect(reconciler.ReconcileYaml(ctx, c, tt.yaml)).To(Succeed(), "Failed to reconcile with ReconcileYaml()")
+
+			for _, o := range tt.expectedObjs {
+				key := client.ObjectKey{
+					Namespace: ns,
+					Name:      o.GetName(),
+				}
+
+				cluster := &clusterapiv1.Cluster{}
+
+				g.Expect(reader.Get(ctx, key, cluster)).To(Succeed(), "Failed getting obj from cluster")
+				g.Expect(
+					equality.Semantic.DeepDerivative(o.Spec, cluster.Spec),
+				).To(BeTrue(), "Object spec in cluster is not equal to expected object spec:\n Actual:\n%#v\n Expected:\n%#v", cluster.Spec, o.Spec)
+			}
+		})
+	}
+}
+
+type capiCluster = *clusterapiv1.Cluster
+
+func newCluster(name string, changes ...func(capiCluster)) *clusterapiv1.Cluster {
+	c := &clusterapiv1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Cluster",
+			APIVersion: clusterapiv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	for _, change := range changes {
+		change(c)
+	}
+
+	return c
+}
+
+func updatedCluster(cluster *clusterapiv1.Cluster, f func(*clusterapiv1.Cluster)) *clusterapiv1.Cluster {
+	copy := cluster.DeepCopy()
+	f(copy)
+	return copy
+}

--- a/controllers/controllers/reconciler/yaml.go
+++ b/controllers/controllers/reconciler/yaml.go
@@ -1,0 +1,27 @@
+package reconciler
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cluster-api/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func YamlToClientObjects(yamlObjects []byte) ([]client.Object, error) {
+	unstructuredObjs, err := YamlToUnstructured(yamlObjects)
+	if err != nil {
+		return nil, err
+	}
+
+	objs := make([]client.Object, 0, len(unstructuredObjs))
+	// Use a numbered loop to avoid problems when retrieving the pointer
+	for i := range unstructuredObjs {
+		objs = append(objs, &unstructuredObjs[i])
+	}
+
+	return objs, nil
+}
+
+func YamlToUnstructured(yamlObjects []byte) ([]unstructured.Unstructured, error) {
+	// Using this CAPI util for now, not sure if we want to depend on it but it's well written
+	return yaml.ToUnstructured(yamlObjects)
+}

--- a/controllers/controllers/reconciler/yaml_test.go
+++ b/controllers/controllers/reconciler/yaml_test.go
@@ -1,0 +1,83 @@
+package reconciler_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/eks-anywhere/controllers/controllers/reconciler"
+)
+
+func TestYamlToClientObjects(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml []byte
+		want map[string]client.Object
+	}{
+		{
+			name: "two objects",
+			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1alpha3
+kind: Cluster
+metadata:
+  name: cluster-1
+  namespace: ns-1
+spec:
+  paused: true
+---
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: Cluster
+metadata:
+  name: cluster-2
+  namespace: ns-1
+spec:
+  controlPlaneEndpoint:
+    host: 1.1.1.1
+    port: 8080`),
+			want: map[string]client.Object{
+				"cluster-1": &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "cluster.x-k8s.io/v1alpha3",
+						"kind":       "Cluster",
+						"metadata": map[string]interface{}{
+							"name":      "cluster-1",
+							"namespace": "ns-1",
+						},
+						"spec": map[string]interface{}{
+							"paused": true,
+						},
+					},
+				},
+				"cluster-2": &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "cluster.x-k8s.io/v1alpha3",
+						"kind":       "Cluster",
+						"metadata": map[string]interface{}{
+							"name":      "cluster-2",
+							"namespace": "ns-1",
+						},
+						"spec": map[string]interface{}{
+							"controlPlaneEndpoint": map[string]interface{}{
+								"host": "1.1.1.1",
+								"port": float64(8080),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got, err := reconciler.YamlToClientObjects(tt.yaml)
+			g.Expect(err).To(BeNil(), "YamlToClientObjects() returned an error")
+			g.Expect(len(got)).To(Equal(len(tt.want)), "Should have got %d objects", len(tt.want))
+			for _, obj := range got {
+				g.Expect(equality.Semantic.DeepDerivative(obj, tt.want[obj.GetName()])).To(BeTrue(), "Returned object %s is not equal to expected object", obj.GetName())
+			}
+		})
+	}
+}

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1alpha3"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -17,6 +21,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
@@ -42,7 +47,10 @@ type Environment struct {
 	scheme  *runtime.Scheme
 	client  client.Client
 	env     *envtest.Environment
-	cancelF context.CancelFunc
+	manager manager.Manager
+	// apiReader is a non cached client (only for reads), helpful when testing the actual state of objects
+	apiReader client.Reader
+	cancelF   context.CancelFunc
 }
 
 type EnvironmentOpt func(ctx context.Context, e *Environment)
@@ -106,7 +114,6 @@ func newEnvironment(ctx context.Context) (*Environment, error) {
 
 	cfg, err := testEnv.Start()
 	if err != nil {
-		_ = testEnv.Stop()
 		return nil, err
 	}
 
@@ -123,6 +130,7 @@ func newEnvironment(ctx context.Context) (*Environment, error) {
 	if err != nil {
 		return nil, err
 	}
+	env.manager = mgr
 
 	go func() {
 		err = mgr.Start(ctx)
@@ -133,6 +141,7 @@ func newEnvironment(ctx context.Context) (*Environment, error) {
 	}
 
 	env.client = mgr.GetClient()
+	env.apiReader = mgr.GetAPIReader()
 
 	return env, nil
 }
@@ -145,4 +154,33 @@ func (e *Environment) stop() error {
 
 func (e *Environment) Client() client.Client {
 	return e.client
+}
+
+// APIReader returns a non cached reader client
+func (e *Environment) APIReader() client.Reader {
+	return e.apiReader
+}
+
+func (e *Environment) CreateNamespaceForTest(ctx context.Context, t *testing.T) string {
+	t.Helper()
+	name := strings.ReplaceAll(t.Name(), "/", "-")
+	name = strings.ReplaceAll(name, "_", "-")
+	name = strings.ToLower(name)
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if err := e.client.Create(ctx, namespace); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if err := e.client.Delete(ctx, namespace); err != nil && !apierrors.IsNotFound(err) {
+			t.Fatal(err)
+		}
+	})
+
+	return namespace.Name
 }


### PR DESCRIPTION
*Description of changes:*
* Utils to reconcile yaml manifests and generic `client.Object` by using server side apply
* Utils to convert a yaml manifest to individual objects accepted by the controller client
* Helper method in `envtest` to create a namespace for a test and clean it up after the test. This is super useful when sharing the same environment among multiple tests since it avoids most of the overlap problems (except for tests that need specific namespaces).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
