### PR TITLE
Close container independently from executables

### DIFF
--- a/cmd/eks-a-tool/cmd/validatecluster.go
+++ b/cmd/eks-a-tool/cmd/validatecluster.go
@@ -45,12 +45,12 @@ func init() {
 }
 
 func validateCluster(ctx context.Context, cluster *types.Cluster, clusterName string) error {
-	executableBuilder, err := executables.NewExecutableBuilder(ctx, executables.DefaultEksaImage())
+	executableBuilder, close, err := executables.NewExecutableBuilder(ctx, executables.DefaultEksaImage())
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
+	defer close.CheckErr(ctx)
 	kubectl := executableBuilder.BuildKubectlExecutable()
-	defer kubectl.Close(ctx)
 	err = kubectl.ValidateNodes(ctx, cluster.KubeconfigFile)
 	if err != nil {
 		return err

--- a/cmd/eks-a-tool/cmd/versions.go
+++ b/cmd/eks-a-tool/cmd/versions.go
@@ -28,12 +28,12 @@ func init() {
 }
 
 func versions(ctx context.Context) error {
-	executableBuilder, err := executables.NewExecutableBuilder(ctx, executables.DefaultEksaImage())
+	executableBuilder, close, err := executables.NewExecutableBuilder(ctx, executables.DefaultEksaImage())
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
+	defer close.CheckErr(ctx)
 	kubectl := executableBuilder.BuildKubectlExecutable()
-	defer kubectl.Close(ctx)
 
 	return kubectl.ListCluster(ctx)
 }

--- a/cmd/eks-a-tool/cmd/vspherermvms.go
+++ b/cmd/eks-a-tool/cmd/vspherermvms.go
@@ -46,10 +46,11 @@ func init() {
 }
 
 func vsphereRmVms(ctx context.Context, clusterName string, dryRun bool) error {
-	executableBuilder, err := executables.NewExecutableBuilder(ctx, executables.DefaultEksaImage())
+	executableBuilder, close, err := executables.NewExecutableBuilder(ctx, executables.DefaultEksaImage())
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
+	defer close.CheckErr(ctx)
 	tmpWriter, _ := filewriter.NewWriter("rmvms")
 	govc := executableBuilder.BuildGovcExecutable(tmpWriter)
 	defer govc.Close(ctx)

--- a/internal/test/e2e/vsphere.go
+++ b/internal/test/e2e/vsphere.go
@@ -41,10 +41,11 @@ func (e *E2ESession) setupVSphereEnv(testRegex string) error {
 
 func vsphereRmVms(ctx context.Context, clusterName string) error {
 	logger.V(1).Info("Deleting vsphere vcenter vms")
-	executableBuilder, err := executables.NewExecutableBuilder(ctx, executables.DefaultEksaImage())
+	executableBuilder, close, err := executables.NewExecutableBuilder(ctx, executables.DefaultEksaImage())
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
+	defer close.CheckErr(ctx)
 	tmpWriter, _ := filewriter.NewWriter("rmvms")
 	govc := executableBuilder.BuildGovcExecutable(tmpWriter)
 	defer govc.Close(ctx)

--- a/pkg/executables/builder.go
+++ b/pkg/executables/builder.go
@@ -85,10 +85,10 @@ func checkMRToolsDisabled() bool {
 	return false
 }
 
-func NewExecutableBuilder(ctx context.Context, image string, mountDirs ...string) (*ExecutableBuilder, error) {
+func NewExecutableBuilder(ctx context.Context, image string, mountDirs ...string) (*ExecutableBuilder, Closer, error) {
 	currentDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("error getting current directory: %v", err)
+		return nil, nil, fmt.Errorf("error getting current directory: %v", err)
 	}
 
 	mountDirs = append(mountDirs, currentDir)
@@ -105,12 +105,23 @@ func NewExecutableBuilder(ctx context.Context, image string, mountDirs ...string
 		// We build, init and store the container in the builder so we reuse the same one for all the executables
 		container := newDockerContainer(image, e.workingDir, e.mountDirs, BuildDockerExecutable())
 		if err := container.init(ctx); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		e.container = container
 	}
 
-	return e, nil
+	return e, e.closer(), nil
+}
+
+func (e *ExecutableBuilder) closer() Closer {
+	c := e.container
+
+	return func(ctx context.Context) error {
+		if c != nil {
+			return c.close(ctx)
+		}
+		return nil
+	}
 }
 
 func NewLocalExecutableBuilder() *ExecutableBuilder {
@@ -122,4 +133,19 @@ func NewLocalExecutableBuilder() *ExecutableBuilder {
 
 func DefaultEksaImage() string {
 	return defaultEksaImage
+}
+
+type Closer func(ctx context.Context) error
+
+// Close implements interface types.Closer
+func (c Closer) Close(ctx context.Context) error {
+	return c(ctx)
+}
+
+// CheckErr just calls the closer and logs an error if present
+// It's mostly a helper for defering the close in a oneliner without ignoring the error
+func (c Closer) CheckErr(ctx context.Context) {
+	if err := c(ctx); err != nil {
+		logger.Error(err, "Failed closing container for executables")
+	}
 }

--- a/pkg/executables/dockercontainer.go
+++ b/pkg/executables/dockercontainer.go
@@ -65,7 +65,7 @@ func (d *dockerContainer) init(ctx context.Context) error {
 	return err
 }
 
-func (d *dockerContainer) Close(ctx context.Context) error {
+func (d *dockerContainer) close(ctx context.Context) error {
 	if d == nil {
 		return nil
 	}

--- a/pkg/executables/executables.go
+++ b/pkg/executables/executables.go
@@ -26,7 +26,6 @@ type Executable interface {
 	Execute(ctx context.Context, args ...string) (stdout bytes.Buffer, err error)
 	ExecuteWithEnv(ctx context.Context, envs map[string]string, args ...string) (stdout bytes.Buffer, err error)
 	ExecuteWithStdin(ctx context.Context, in []byte, args ...string) (stdout bytes.Buffer, err error)
-	Close(ctx context.Context) error
 }
 
 // this should only be called through the executables.builder

--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -86,11 +86,7 @@ func (g *Govc) Close(ctx context.Context) error {
 		return nil
 	}
 
-	if err := g.Logout(ctx); err != nil {
-		return err
-	}
-
-	return g.Executable.Close(ctx)
+	return g.Logout(ctx)
 }
 
 func (g *Govc) Logout(ctx context.Context) error {

--- a/pkg/executables/mocks/executables.go
+++ b/pkg/executables/mocks/executables.go
@@ -35,20 +35,6 @@ func (m *MockExecutable) EXPECT() *MockExecutableMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method.
-func (m *MockExecutable) Close(arg0 context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Close indicates an expected call of Close.
-func (mr *MockExecutableMockRecorder) Close(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockExecutable)(nil).Close), arg0)
-}
-
 // Execute mocks base method.
 func (m *MockExecutable) Execute(arg0 context.Context, arg1 ...string) (bytes.Buffer, error) {
 	m.ctrl.T.Helper()

--- a/test/framework/executables.go
+++ b/test/framework/executables.go
@@ -11,9 +11,6 @@ import (
 func buildKubectl(t *testing.T) *executables.Kubectl {
 	ctx := context.Background()
 	kubectl := executableBuilder(t, ctx).BuildKubectlExecutable()
-	t.Cleanup(func() {
-		kubectl.Close(ctx)
-	})
 
 	return kubectl
 }
@@ -23,10 +20,15 @@ func buildLocalKubectl() *executables.Kubectl {
 }
 
 func executableBuilder(t *testing.T, ctx context.Context) *executables.ExecutableBuilder {
-	executableBuilder, err := executables.NewExecutableBuilder(ctx, executables.DefaultEksaImage())
+	executableBuilder, close, err := executables.NewExecutableBuilder(ctx, executables.DefaultEksaImage())
 	if err != nil {
 		t.Fatalf("Unable initialize executable builder: %v", err)
 	}
+	t.Cleanup(func() {
+		if err := close(ctx); err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	return executableBuilder
 }


### PR DESCRIPTION
*Description of changes:*
* Decouples closing executables from closing the long running container. This allows for more control in the closing order
* The deps factory now only closes the deps that have been built
* Now only `govc` is a closer, the rest of executable don't need to be

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
