### PR TITLE
Change generated cluster name order for tests

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -401,7 +401,7 @@ func getClusterName(t *testing.T) string {
 		testNameHash := fmt.Sprintf("%x", h.Sum(nil))
 		// Append hash to make each cluster name unique per test. Using the testname will be too long
 		// and would fail validations
-		return fmt.Sprintf("%s-%s", testNameHash[:7], defaultClusterName)
+		return fmt.Sprintf("%s-%s", defaultClusterName, testNameHash[:7])
 	}
 	return value
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Was getting the following error, possibly after our cluster-name validation got fixed here https://github.com/aws/eks-anywhere/pull/781. Not sure why it was only seen locally instead of in our test infra.

```
    cluster.go:289: Running shell command [ eksctl anywhere generate clusterconfig 53ee980-eksa-test -p vsphere > cluster.yaml ]
Error: 53ee980-eksa-test is not a valid cluster name, cluster names must start with lowercase/uppercase letters and can include numbers and dashes. For instance 'testCluster-123' is a valid name but '123testCluster' is not. 
Usage:
  anywhere generate clusterconfig <cluster-name> (max 80 chars) [flags]

Flags:
  -h, --help              help for clusterconfig
  -p, --provider string   Provider to use (vsphere or docker)

Global Flags:
  -v, --verbosity int   Set the log level verbosity

    cluster.go:305: Error running command eksctl anywhere [generate clusterconfig 53ee980-eksa-test -p vsphere > cluster.yaml]: exit status 255
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
