### PR TITLE
Add Tinkerbell CRDs and update EKS-A components manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -474,7 +474,7 @@ $(RELEASE_DIR):
 release-manifests: $(KUSTOMIZE) generate-manifests $(RELEASE_DIR) $(CONTROLLER_MANIFEST_OUTPUT_DIR)
 	# Build core-components.
 	$(KUSTOMIZE) build config/prod > $(RELEASE_DIR)/$(RELEASE_MANIFEST_TARGET)
-	cp eksa-components.yaml $(CONTROLLER_MANIFEST_OUTPUT_DIR)
+	cp $(RELEASE_DIR)/$(RELEASE_MANIFEST_TARGET) $(CONTROLLER_MANIFEST_OUTPUT_DIR)
 
 .PHONY: run-controller # Run eksa controller from local repo with tilt
 run-controller:

--- a/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbelldatacenterconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbelldatacenterconfigs.yaml
@@ -1,0 +1,71 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: tinkerbelldatacenterconfigs.anywhere.eks.amazonaws.com
+spec:
+  group: anywhere.eks.amazonaws.com
+  names:
+    kind: TinkerbellDatacenterConfig
+    listKind: TinkerbellDatacenterConfigList
+    plural: tinkerbelldatacenterconfigs
+    singular: tinkerbelldatacenterconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TinkerbellDatacenterConfig is the Schema for the TinkerbellDatacenterConfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TinkerbellDatacenterConfigSpec defines the desired state
+              of TinkerbellDatacenterConfig
+            properties:
+              tinkerbellCertURL:
+                type: string
+              tinkerbellGRPCAuth:
+                type: string
+              tinkerbellIP:
+                description: 'Important: Run "make generate" to regenerate code after
+                  modifying this file'
+                type: string
+              tinkerbellPBnJGRPCAuth:
+                type: string
+            required:
+            - tinkerbellCertURL
+            - tinkerbellGRPCAuth
+            - tinkerbellIP
+            - tinkerbellPBnJGRPCAuth
+            type: object
+          status:
+            description: TinkerbellDatacenterConfigStatus defines the observed state
+              of TinkerbellDatacenterConfig
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbellmachineconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbellmachineconfigs.yaml
@@ -1,0 +1,76 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: tinkerbellmachineconfigs.anywhere.eks.amazonaws.com
+spec:
+  group: anywhere.eks.amazonaws.com
+  names:
+    kind: TinkerbellMachineConfig
+    listKind: TinkerbellMachineConfigList
+    plural: tinkerbellmachineconfigs
+    singular: tinkerbellmachineconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TinkerbellMachineConfig is the Schema for the tinkerbellmachineconfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TinkerbellMachineConfigSpec defines the desired state of
+              TinkerbellMachineConfig
+            properties:
+              osFamily:
+                type: string
+              users:
+                items:
+                  description: UserConfiguration defines the configuration of the
+                    user to be added to the VSphere VM
+                  properties:
+                    name:
+                      type: string
+                    sshAuthorizedKeys:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  - sshAuthorizedKeys
+                  type: object
+                type: array
+            required:
+            - osFamily
+            type: object
+          status:
+            description: TinkerbellMachineConfigStatus defines the observed state
+              of TinkerbellMachineConfig
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -1570,6 +1570,64 @@ spec:
                       type: object
                     kubeVersion:
                       type: string
+                    tinkerbell:
+                      properties:
+                        clusterAPIController:
+                          properties:
+                            arch:
+                              description: Architectures of the asset
+                              items:
+                                type: string
+                              type: array
+                            description:
+                              type: string
+                            imageDigest:
+                              description: The SHA256 digest of the image manifest
+                              type: string
+                            name:
+                              description: The asset name
+                              type: string
+                            os:
+                              description: Operating system of the asset
+                              enum:
+                              - linux
+                              - darwin
+                              - windows
+                              type: string
+                            osName:
+                              description: Name of the OS like ubuntu, bottlerocket
+                              type: string
+                            uri:
+                              description: The image repository, name, and tag
+                              type: string
+                          type: object
+                        clusterTemplate:
+                          properties:
+                            uri:
+                              description: URI points to the manifest yaml file
+                              type: string
+                          type: object
+                        components:
+                          properties:
+                            uri:
+                              description: URI points to the manifest yaml file
+                              type: string
+                          type: object
+                        metadata:
+                          properties:
+                            uri:
+                              description: URI points to the manifest yaml file
+                              type: string
+                          type: object
+                        version:
+                          type: string
+                      required:
+                      - clusterAPIController
+                      - clusterTemplate
+                      - components
+                      - metadata
+                      - version
+                      type: object
                     vSphere:
                       properties:
                         clusterAPIController:
@@ -1795,6 +1853,7 @@ spec:
                   - flux
                   - kindnetd
                   - kubeVersion
+                  - tinkerbell
                   - vSphere
                   type: object
                 type: array


### PR DESCRIPTION
- Adding Tinkerbell Datacenter config and machine config manifests.
- Add Tinkerbell bundle to EKS-A components manifest.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
