### PR TITLE
Adding image override for CAPT image uri

### DIFF
--- a/release/pkg/assets_capt.go
+++ b/release/pkg/assets_capt.go
@@ -65,6 +65,13 @@ func (r *ReleaseConfig) GetCaptAssets() ([]Artifact, error) {
 	}
 	artifacts := []Artifact{Artifact{Image: imageArtifact}}
 
+	imageTagOverrides := []ImageTagOverride{
+		{
+			Repository: repoName,
+			ReleaseUri: imageArtifact.ReleaseImageURI,
+		},
+	}
+
 	manifestList := []string{
 		"infrastructure-components.yaml",
 		"cluster-template.yaml",
@@ -102,7 +109,7 @@ func (r *ReleaseConfig) GetCaptAssets() ([]Artifact, error) {
 			ReleaseName:       manifest,
 			ReleaseS3Path:     releaseS3Path,
 			ReleaseCdnURI:     cdnURI,
-			ImageTagOverrides: []ImageTagOverride{},
+			ImageTagOverrides: imageTagOverrides,
 			GitTag:            gitTag,
 			ProjectPath:       captProjectPath,
 		}


### PR DESCRIPTION
*Description of changes:*
Adding Image override for CAPT to override manifest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
