### PR TITLE
E2E tests creating cluster with latest release & upgrading with main

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    INTEGRATION_TEST_MAX_EC2_COUNT: 60
+    INTEGRATION_TEST_MAX_EC2_COUNT: 65
     T_VSPHERE_CIDR: "198.18.128.0/17"
     T_VSPHERE_PRIVATE_NETWORK_CIDR: "197.18.128.0/17"
   secrets-manager:

--- a/test/e2e/upgrade_from_latest_test.go
+++ b/test/e2e/upgrade_from_latest_test.go
@@ -1,0 +1,97 @@
+// +build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/test/framework"
+)
+
+func runUpgradeFromLatestReleaseFlow(test *framework.ClusterE2ETest, wantVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
+	latestRelease, err := framework.GetLatestMinorReleaseFromTestBranch()
+	if err != nil {
+		test.T.Fatal(err)
+	}
+	test.GenerateClusterConfigForVersion(latestRelease.Version, framework.ExecuteWithEksaRelease(latestRelease))
+	test.CreateCluster(framework.ExecuteWithEksaRelease(latestRelease))
+	// Adding this manual wait because old versions of the cli don't wait long enough
+	// after creation, which makes the upgrade preflight validations fail
+	test.WaitForControlPlaneReady()
+	test.UpgradeCluster(clusterOpts)
+	test.ValidateCluster(wantVersion)
+	test.StopIfFailed()
+	test.DeleteCluster()
+}
+
+func TestVSphereKubernetes120BottlerocketUpgradeFromLatestMinorRelease(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithBottleRocket120())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+	)
+	runUpgradeFromLatestReleaseFlow(
+		test,
+		v1alpha1.Kube120,
+	)
+}
+
+func TestVSphereKubernetes121BottlerocketUpgradeFromLatestMinorRelease(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithBottleRocket121())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+	)
+	runUpgradeFromLatestReleaseFlow(
+		test,
+		v1alpha1.Kube121,
+	)
+}
+
+func TestVSphereKubernetes120UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithUbuntu120())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+	)
+	runUpgradeFromLatestReleaseFlow(
+		test,
+		v1alpha1.Kube120,
+	)
+}
+
+func TestVSphereKubernetes121UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithUbuntu121())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+	)
+	runUpgradeFromLatestReleaseFlow(
+		test,
+		v1alpha1.Kube121,
+	)
+}
+
+func TestDockerKubernetes121UpgradeFromLatestMinorRelease(t *testing.T) {
+	provider := framework.NewDocker(t)
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+	)
+	runUpgradeFromLatestReleaseFlow(
+		test,
+		v1alpha1.Kube121,
+	)
+}

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -320,8 +320,7 @@ func TestVSphereKubernetes120BottlerocketCreateWithLatestReleaseUpgradeWithMain(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
 	)
 	runUpgradeFlowDiffCliVersionFromMain(
 		test,
@@ -335,8 +334,7 @@ func TestVSphereKubernetes121BottlerocketCreateWithLatestReleaseUpgradeWithMain(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
 	)
 	runUpgradeFlowDiffCliVersionFromMain(
 		test,
@@ -350,8 +348,7 @@ func TestVSphereKubernetes120UbuntuCreateWithLatestReleaseUpgradeWithMain(t *tes
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
 	)
 	runUpgradeFlowDiffCliVersionFromMain(
 		test,
@@ -365,8 +362,7 @@ func TestVSphereKubernetes121UbuntuCreateWithLatestReleaseUpgradeWithMain(t *tes
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
 	)
 	runUpgradeFlowDiffCliVersionFromMain(
 		test,
@@ -380,8 +376,7 @@ func TestDockerKubernetes121CreateWithLatestReleaseUpgradeWithMain(t *testing.T)
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
 	)
 	runUpgradeFlowDiffCliVersionFromMain(
 		test,

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -32,15 +32,6 @@ func runSimpleUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1
 	test.DeleteCluster()
 }
 
-func runUpgradeFlowDiffCliVersionFromMain(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
-	test.GenerateClusterConfig(framework.ExecuteWithLatestMinorReleaseFromMain())
-	test.CreateCluster(framework.ExecuteWithLatestMinorReleaseFromMain())
-	test.UpgradeCluster(clusterOpts)
-	test.ValidateCluster(updateVersion)
-	test.StopIfFailed()
-	test.DeleteCluster()
-}
-
 func TestVSphereKubernetes120UbuntuTo121Upgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu120())
 	test := framework.NewClusterE2ETest(
@@ -311,75 +302,5 @@ func TestVSphereKubernetes120BottlerocketTo121StackedEtcdUpgrade(t *testing.T) {
 		v1alpha1.Kube121,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		provider.WithProviderUpgrade(framework.UpdateBottlerocketTemplate121()),
-	)
-}
-
-func TestVSphereKubernetes120BottlerocketCreateWithLatestReleaseUpgradeWithMain(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket120())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-	)
-	runUpgradeFlowDiffCliVersionFromMain(
-		test,
-		v1alpha1.Kube120,
-	)
-}
-
-func TestVSphereKubernetes121BottlerocketCreateWithLatestReleaseUpgradeWithMain(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket121())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-	)
-	runUpgradeFlowDiffCliVersionFromMain(
-		test,
-		v1alpha1.Kube121,
-	)
-}
-
-func TestVSphereKubernetes120UbuntuCreateWithLatestReleaseUpgradeWithMain(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu120())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-	)
-	runUpgradeFlowDiffCliVersionFromMain(
-		test,
-		v1alpha1.Kube120,
-	)
-}
-
-func TestVSphereKubernetes121UbuntuCreateWithLatestReleaseUpgradeWithMain(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu121())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-	)
-	runUpgradeFlowDiffCliVersionFromMain(
-		test,
-		v1alpha1.Kube121,
-	)
-}
-
-func TestDockerKubernetes121CreateWithLatestReleaseUpgradeWithMain(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-	)
-	runUpgradeFlowDiffCliVersionFromMain(
-		test,
-		v1alpha1.Kube121,
 	)
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -32,6 +32,15 @@ func runSimpleUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1
 	test.DeleteCluster()
 }
 
+func runUpgradeFlowDiffCliVersionFromMain(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
+	test.GenerateClusterConfig(framework.ExecuteWithLatestMinorReleaseFromMain())
+	test.CreateCluster(framework.ExecuteWithLatestMinorReleaseFromMain())
+	test.UpgradeCluster(clusterOpts)
+	test.ValidateCluster(updateVersion)
+	test.StopIfFailed()
+	test.DeleteCluster()
+}
+
 func TestVSphereKubernetes120UbuntuTo121Upgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu120())
 	test := framework.NewClusterE2ETest(
@@ -302,5 +311,80 @@ func TestVSphereKubernetes120BottlerocketTo121StackedEtcdUpgrade(t *testing.T) {
 		v1alpha1.Kube121,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		provider.WithProviderUpgrade(framework.UpdateBottlerocketTemplate121()),
+	)
+}
+
+func TestVSphereKubernetes120BottlerocketCreateWithLatestReleaseUpgradeWithMain(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithBottleRocket120())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+	)
+	runUpgradeFlowDiffCliVersionFromMain(
+		test,
+		v1alpha1.Kube120,
+	)
+}
+
+func TestVSphereKubernetes121BottlerocketCreateWithLatestReleaseUpgradeWithMain(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithBottleRocket121())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+	)
+	runUpgradeFlowDiffCliVersionFromMain(
+		test,
+		v1alpha1.Kube121,
+	)
+}
+
+func TestVSphereKubernetes120UbuntuCreateWithLatestReleaseUpgradeWithMain(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithUbuntu120())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+	)
+	runUpgradeFlowDiffCliVersionFromMain(
+		test,
+		v1alpha1.Kube120,
+	)
+}
+
+func TestVSphereKubernetes121UbuntuCreateWithLatestReleaseUpgradeWithMain(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithUbuntu121())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+	)
+	runUpgradeFlowDiffCliVersionFromMain(
+		test,
+		v1alpha1.Kube121,
+	)
+}
+
+func TestDockerKubernetes121CreateWithLatestReleaseUpgradeWithMain(t *testing.T) {
+	provider := framework.NewDocker(t)
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+	)
+	runUpgradeFlowDiffCliVersionFromMain(
+		test,
+		v1alpha1.Kube121,
 	)
 }

--- a/test/framework/api.go
+++ b/test/framework/api.go
@@ -1,0 +1,55 @@
+package framework
+
+import (
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+var incompatiblePathsForVersion = map[string][]string{
+	"v0.6.1": {"spec.clusterNetwork.dns"},
+}
+
+func cleanUpClusterForVersion(clusterYaml []byte, version string) ([]byte, error) {
+	return cleanupPathsFromYaml(clusterYaml, incompatiblePathsForVersion[version])
+}
+
+func cleanupPathsFromYaml(yamlContent []byte, paths []string) ([]byte, error) {
+	m := make(map[string]interface{})
+
+	if err := yaml.Unmarshal(yamlContent, &m); err != nil {
+		return nil, err
+	}
+
+	deletePaths(m, paths)
+
+	newYaml, err := yaml.Marshal(&m)
+	if err != nil {
+		return nil, err
+	}
+
+	return newYaml, nil
+}
+
+func deletePaths(m map[string]interface{}, paths []string) {
+	for _, p := range paths {
+		deletePath(m, strings.Split(p, "."))
+	}
+}
+
+func deletePath(m map[string]interface{}, path []string) {
+	currentElement := m
+	for i := 0; i < len(path)-1; i++ {
+		e, ok := currentElement[path[i]]
+		if !ok {
+			return
+		}
+
+		currentElement, ok = e.(map[string]interface{})
+		if !ok {
+			return
+		}
+	}
+
+	delete(currentElement, path[len(path)-1])
+}

--- a/test/framework/commands.go
+++ b/test/framework/commands.go
@@ -1,6 +1,9 @@
 package framework
 
-import "github.com/aws/eks-anywhere/pkg/semver"
+import (
+	"github.com/aws/eks-anywhere/pkg/semver"
+	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
+)
 
 type CommandOpt func(*string, *[]string) (err error)
 
@@ -16,36 +19,40 @@ func withKubeconfig(kubeconfigFile string) CommandOpt {
 }
 
 func ExecuteWithEksaVersion(version *semver.Version) CommandOpt {
-	return func(binaryPath *string, args *[]string) (err error) {
-		b, err := GetReleaseBinaryFromVersion(version)
-		if err != nil {
-			return err
-		}
-		*binaryPath = b
-		if err = setEksctlVersionEnvVar(); err != nil {
-			return err
-		}
-		return err
-	}
+	return executeWithBinaryCommandOpt(func() (string, error) {
+		return GetReleaseBinaryFromVersion(version)
+	})
+}
+
+func ExecuteWithEksaRelease(release *releasev1alpha1.EksARelease) CommandOpt {
+	return executeWithBinaryCommandOpt(func() (string, error) {
+		return getBinary(release)
+	})
 }
 
 func ExecuteWithLatestMinorReleaseFromVersion(version *semver.Version) CommandOpt {
-	return func(binaryPath *string, args *[]string) (err error) {
-		b, err := GetLatestMinorReleaseBinaryFromVersion(version)
-		if err != nil {
-			return err
-		}
-		*binaryPath = b
-		if err = setEksctlVersionEnvVar(); err != nil {
-			return err
-		}
-		return err
-	}
+	return executeWithBinaryCommandOpt(func() (string, error) {
+		return GetLatestMinorReleaseBinaryFromVersion(version)
+	})
 }
 
 func ExecuteWithLatestMinorReleaseFromMain() CommandOpt {
+	return executeWithBinaryCommandOpt(func() (string, error) {
+		return GetLatestMinorReleaseBinaryFromMain()
+	})
+}
+
+func ExecuteWithLatestReleaseFromTestBranch() CommandOpt {
+	return executeWithBinaryCommandOpt(func() (string, error) {
+		return GetLatestMinorReleaseBinaryFromTestBranch()
+	})
+}
+
+type binaryFetcher func() (binaryPath string, err error)
+
+func executeWithBinaryCommandOpt(fetcher binaryFetcher) CommandOpt {
 	return func(binaryPath *string, args *[]string) (err error) {
-		b, err := GetLatestMinorReleaseBinaryFromMain()
+		b, err := fetcher()
 		if err != nil {
 			return err
 		}

--- a/test/framework/commands.go
+++ b/test/framework/commands.go
@@ -18,7 +18,13 @@ func withKubeconfig(kubeconfigFile string) CommandOpt {
 func ExecuteWithEksaVersion(version *semver.Version) CommandOpt {
 	return func(binaryPath *string, args *[]string) (err error) {
 		b, err := GetReleaseBinaryFromVersion(version)
+		if err != nil {
+			return err
+		}
 		*binaryPath = b
+		if err = setEksctlVersionEnvVar(); err != nil {
+			return err
+		}
 		return err
 	}
 }
@@ -26,7 +32,13 @@ func ExecuteWithEksaVersion(version *semver.Version) CommandOpt {
 func ExecuteWithLatestMinorReleaseFromVersion(version *semver.Version) CommandOpt {
 	return func(binaryPath *string, args *[]string) (err error) {
 		b, err := GetLatestMinorReleaseBinaryFromVersion(version)
+		if err != nil {
+			return err
+		}
 		*binaryPath = b
+		if err = setEksctlVersionEnvVar(); err != nil {
+			return err
+		}
 		return err
 	}
 }
@@ -34,7 +46,13 @@ func ExecuteWithLatestMinorReleaseFromVersion(version *semver.Version) CommandOp
 func ExecuteWithLatestMinorReleaseFromMain() CommandOpt {
 	return func(binaryPath *string, args *[]string) (err error) {
 		b, err := GetLatestMinorReleaseBinaryFromMain()
+		if err != nil {
+			return err
+		}
 		*binaryPath = b
+		if err = setEksctlVersionEnvVar(); err != nil {
+			return err
+		}
 		return err
 	}
 }

--- a/test/framework/envars.go
+++ b/test/framework/envars.go
@@ -19,3 +19,11 @@ func setKubeconfigEnvVar(t *testing.T, clusterName string) {
 		t.Fatalf("Error setting KUBECONFIG env var: %v", err)
 	}
 }
+
+func getEnvWithDefault(key, defaultValue string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+
+	return defaultValue
+}

--- a/test/framework/releaseVersions.go
+++ b/test/framework/releaseVersions.go
@@ -49,12 +49,8 @@ func GetLatestMinorReleaseBinaryFromVersion(releaseBranchVersion *semver.Version
 	if err != nil {
 		return "", err
 	}
-	targetRelease := &releasev1alpha1.EksARelease{
-		Version:           "",
-		BundleManifestUrl: "",
-	}
 
-	release, err := getLatestPrevMinorRelease(releases, releaseBranchVersion, targetRelease)
+	release, err := getLatestPrevMinorRelease(releases, releaseBranchVersion)
 	if err != nil {
 		return "", err
 	}
@@ -140,7 +136,11 @@ func prodReleases() (release *releasev1alpha1.Release, err error) {
 	return releases, nil
 }
 
-func getLatestPrevMinorRelease(releases *releasev1alpha1.Release, releaseBranchVersion *semver.Version, targetRelease *releasev1alpha1.EksARelease) (*releasev1alpha1.EksARelease, error) {
+func getLatestPrevMinorRelease(releases *releasev1alpha1.Release, releaseBranchVersion *semver.Version) (*releasev1alpha1.EksARelease, error) {
+	targetRelease := &releasev1alpha1.EksARelease{
+		Version:           "",
+		BundleManifestUrl: "",
+	}
 	latestPrevMinorReleaseVersion := newVersion("0.0.0")
 
 	for _, release := range releases.Spec.Releases {
@@ -151,7 +151,7 @@ func getLatestPrevMinorRelease(releases *releasev1alpha1.Release, releaseBranchV
 		}
 	}
 
-	if targetRelease == nil {
+	if targetRelease.Version == "" {
 		return nil, fmt.Errorf("releases manifest doesn't contain a version of the previous minor release")
 	}
 

--- a/test/framework/wait.go
+++ b/test/framework/wait.go
@@ -1,0 +1,18 @@
+package framework
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/eks-anywhere/pkg/retrier"
+)
+
+func (e *ClusterE2ETest) WaitForControlPlaneReady() {
+	e.T.Log("Waiting for control plane to be ready")
+	err := retrier.New(1 * time.Minute).Retry(func() error {
+		return e.KubectlClient.ValidateControlPlaneNodes(context.Background(), e.cluster(), e.ClusterName)
+	})
+	if err != nil {
+		e.T.Fatal(err)
+	}
+}


### PR DESCRIPTION
*Resolves* https://github.com/aws/eks-anywhere/issues/324

*Description of changes:*
* Run upgrade flow e2e tests by creating the cluster with the latest minor release and upgrading with current code
* Latest release is dynamic, it uses the `T_BRANCH_NAME` env var to determine the branch where the tests are being run:
  * If in `main`, this is the latest available eksa release (eg. `v0.6.1`)
  * If in a release branch, this is the latest release from the previous minor version (eg. for `release-0.6`, `v0.5.0`)
* Removes paths from the cluster yaml config to avoid validation errors from old CLIs that don't know how to read new api fields. This is a bit hacky and it involves maintaining a list of incompatible fields in code. Ideally, we should refactor the api fillers package to not use the latest api structs. That's a considerable effort, so I went with this temporal solution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
