### PR TITLE
Remove Get Bundle script invocation from 0.6 e2e tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/build-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/build-eks-a-cli.yml
@@ -4,7 +4,6 @@ phases:
   build:
     commands:
     - make e2e
-    - ${CODEBUILD_SRC_DIR}/scripts/get_bundle.sh
     - echo "$CODEBUILD_RESOLVED_SOURCE_VERSION" >> bin/githash
 
 artifacts:


### PR DESCRIPTION
with this there, we're not using the built-in release bundle, but rather the prod bundle. This may effect the tests.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
