### PR TITLE
Avoid panic from logger with incorrect number of params

### DIFF
--- a/pkg/validations/docker.go
+++ b/pkg/validations/docker.go
@@ -35,7 +35,8 @@ func CheckMinimumDockerVersion(ctx context.Context, dockerExecutable DockerExecu
 func CheckDockerAllocatedMemory(ctx context.Context, dockerExecutable DockerExecutable) {
 	totalMemoryAllocated, err := dockerExecutable.AllocatedMemory(ctx)
 	if err != nil {
-		logger.V(3).Info("Failed to validate docker memory: error while reading memory allocated to Docker %v\n", err)
+		logger.Error(err, "Failed to validate docker memory: error while reading memory allocated to Docker")
+		return
 	}
 	if totalMemoryAllocated < recommendedTotalMemory {
 		logger.V(3).Info("Warning: recommended memory to be allocated for Docker is 6 GB, please be aware that not allocating enough memory can cause problems while cluster creation")


### PR DESCRIPTION
*Description of changes:*
Incorrect log invocation with odd number of params. Changed to `logger.Error`
Added return to avoid doing the memory comparison in the error scenario

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
