### PR TITLE
Branch specific bundle override for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,8 +408,8 @@ integration-test-binary:
 check-eksa-components-override:
 	scripts/eksa_components_override.sh $(BUNDLE_MANIFEST_URL)
 
-.PHONY: get-override-dev-bundle
-get-override-dev-bundle:
+.PHONY: get-override-bundle
+get-override-bundle:
 	curl -L $(BUNDLE_MANIFEST_URL) --output bin/local-bundle-release.yaml
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,13 @@ GO_TEST ?= $(GO) test
 ## ensure local execution uses the 'main' branch bundle
 BRANCH_NAME?=main
 ifeq (,$(findstring $(BRANCH_NAME),main))
-## use the branch-specific bundle manifest if the branch is not 'main'
+## use the branch-specific dev release bundle manifest if the branch is not 'main'
 BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${BRANCH_NAME}/bundle-release.yaml
-$(info    Using branch-specific BUNDLE_RELEASE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))
+$(info    Using branch-specific BUNDLE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))
 else
-## use the standard bundle manifest if the branch is 'main'
+## use the standard dev release bundle manifest if the branch is 'main'
 BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/bundle-release.yaml
-$(info    Using stanard BUNDLE_RELEASE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))
+$(info    Using stanard BUNDLE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))
 endif
 
 RELEASE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/eks-a-release.yaml
@@ -386,7 +386,6 @@ eks-a-e2e:
 		if [[ "$(CODEBUILD_BUILD_ID)" =~ "aws-staging-eks-a-build" ]]; then \
 			make eks-a-release-cross-platform GIT_VERSION=$(shell cat release/triggers/eks-a-release/development/RELEASE_VERSION) RELEASE_MANIFEST_URL=https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml; \
 			make eks-a-release GIT_VERSION=$(DEV_GIT_VERSION); \
-			scripts/get_bundle.sh; \
 		else \
 			make check-eksa-components-override; \
 			make eks-a-cross-platform; \
@@ -408,6 +407,10 @@ integration-test-binary:
 .PHONY: check-eksa-components-override
 check-eksa-components-override:
 	scripts/eksa_components_override.sh $(BUNDLE_MANIFEST_URL)
+
+.PHONY: get-override-dev-bundle
+get-override-dev-bundle:
+	curl -L $(BUNDLE_MANIFEST_URL) --output bin/local-bundle-release.yaml
 
 .PHONY: help
 help:  ## Display this help

--- a/cmd/integration_test/build/buildspecs/build-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/build-eks-a-cli.yml
@@ -4,7 +4,7 @@ phases:
   build:
     commands:
     - make e2e
-    - make get-override-dev-bundle
+    - make get-override-bundle
     - echo "$CODEBUILD_RESOLVED_SOURCE_VERSION" >> bin/githash
 
 artifacts:

--- a/cmd/integration_test/build/buildspecs/build-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/build-eks-a-cli.yml
@@ -4,6 +4,7 @@ phases:
   build:
     commands:
     - make e2e
+    - make get-override-dev-bundle
     - echo "$CODEBUILD_RESOLVED_SOURCE_VERSION" >> bin/githash
 
 artifacts:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Use the branch-specific dev release bundle as an override for the e2e test execution. This will ensure that the automated tests are testing wether the latest dev release works with the head of the given CLI branch.  

### How?
Adds a make target which pulls the dev bundle manifest for the given branch and saves it to the override location.

Updates the e2e build spec to invoke this target, pulling the dev bundle manifest for the given branch; this is saved to `bin/local-bundle-release.yaml` passed as an artifact to the next stage. This means that the build stage will generate an override bundle for the corresponding branch, and the following test stage will consume that bundle and use it as an override. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
