### PR TITLE
Add Tinkerbell CRDs to EKS-A components yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,7 +421,7 @@ update-kustomization-yaml:
 	yq e ".images[] |= select(.name == \"*kube-rbac-proxy\") |= .newTag = \"${KUBE_RBAC_PROXY_IMAGE_TAG_OVERRIDE}\"" -i $(KUSTOMIZATION_CONFIG)
 
 .PHONY: generate-manifests
-generate-manifests: update-kustomization-yaml ## Generate manifests e.g. CRD, RBAC etc.
+generate-manifests: ## Generate manifests e.g. CRD, RBAC etc.
 	$(MAKE) generate-core-manifests
 
 .PHONY: generate-core-manifests

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -11,6 +11,8 @@ resources:
 - bases/anywhere.eks.amazonaws.com_gitopsconfigs.yaml
 - bases/anywhere.eks.amazonaws.com_oidcconfigs.yaml
 - bases/anywhere.eks.amazonaws.com_awsiamconfigs.yaml
+- bases/anywhere.eks.amazonaws.com_tinkerbelldatacenterconfigs.yaml
+- bases/anywhere.eks.amazonaws.com_tinkerbellmachineconfigs.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -2354,6 +2354,151 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
+  name: tinkerbelldatacenterconfigs.anywhere.eks.amazonaws.com
+spec:
+  group: anywhere.eks.amazonaws.com
+  names:
+    kind: TinkerbellDatacenterConfig
+    listKind: TinkerbellDatacenterConfigList
+    plural: tinkerbelldatacenterconfigs
+    singular: tinkerbelldatacenterconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TinkerbellDatacenterConfig is the Schema for the TinkerbellDatacenterConfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TinkerbellDatacenterConfigSpec defines the desired state
+              of TinkerbellDatacenterConfig
+            properties:
+              tinkerbellCertURL:
+                type: string
+              tinkerbellGRPCAuth:
+                type: string
+              tinkerbellIP:
+                description: 'Important: Run "make generate" to regenerate code after
+                  modifying this file'
+                type: string
+              tinkerbellPBnJGRPCAuth:
+                type: string
+            required:
+            - tinkerbellCertURL
+            - tinkerbellGRPCAuth
+            - tinkerbellIP
+            - tinkerbellPBnJGRPCAuth
+            type: object
+          status:
+            description: TinkerbellDatacenterConfigStatus defines the observed state
+              of TinkerbellDatacenterConfig
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: tinkerbellmachineconfigs.anywhere.eks.amazonaws.com
+spec:
+  group: anywhere.eks.amazonaws.com
+  names:
+    kind: TinkerbellMachineConfig
+    listKind: TinkerbellMachineConfigList
+    plural: tinkerbellmachineconfigs
+    singular: tinkerbellmachineconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TinkerbellMachineConfig is the Schema for the tinkerbellmachineconfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TinkerbellMachineConfigSpec defines the desired state of
+              TinkerbellMachineConfig
+            properties:
+              osFamily:
+                type: string
+              users:
+                items:
+                  description: UserConfiguration defines the configuration of the
+                    user to be added to the VSphere VM
+                  properties:
+                    name:
+                      type: string
+                    sshAuthorizedKeys:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  - sshAuthorizedKeys
+                  type: object
+                type: array
+            required:
+            - osFamily
+            type: object
+          status:
+            description: TinkerbellMachineConfigStatus defines the observed state
+              of TinkerbellMachineConfig
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
   name: vspheredatacenterconfigs.anywhere.eks.amazonaws.com
 spec:
   group: anywhere.eks.amazonaws.com


### PR DESCRIPTION
Adding Tinkerbell CRDs to the EKS-A components yaml manifest.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
