### PR TITLE
Composable command for executables

### DIFF
--- a/pkg/executables/command.go
+++ b/pkg/executables/command.go
@@ -1,0 +1,40 @@
+package executables
+
+import (
+	"bytes"
+	"context"
+)
+
+type commandRunner interface {
+	Run(cmd *Command) (stdout bytes.Buffer, err error)
+}
+
+type Command struct {
+	commandRunner commandRunner
+	ctx           context.Context
+	args          []string
+	stdIn         []byte
+	envVars       map[string]string
+}
+
+func NewCommand(ctx context.Context, commandRunner commandRunner, args ...string) *Command {
+	return &Command{
+		commandRunner: commandRunner,
+		ctx:           ctx,
+		args:          args,
+	}
+}
+
+func (c *Command) WithEnvVars(envVars map[string]string) *Command {
+	c.envVars = envVars
+	return c
+}
+
+func (c *Command) WithStdIn(stdIn []byte) *Command {
+	c.stdIn = stdIn
+	return c
+}
+
+func (c *Command) Run() (out bytes.Buffer, err error) {
+	return c.commandRunner.Run(c)
+}

--- a/pkg/executables/mocks/executables.go
+++ b/pkg/executables/mocks/executables.go
@@ -9,6 +9,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	executables "github.com/aws/eks-anywhere/pkg/executables"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -33,6 +34,25 @@ func NewMockExecutable(ctrl *gomock.Controller) *MockExecutable {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExecutable) EXPECT() *MockExecutableMockRecorder {
 	return m.recorder
+}
+
+// Command mocks base method.
+func (m *MockExecutable) Command(arg0 context.Context, arg1 ...string) *executables.Command {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Command", varargs...)
+	ret0, _ := ret[0].(*executables.Command)
+	return ret0
+}
+
+// Command indicates an expected call of Command.
+func (mr *MockExecutableMockRecorder) Command(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockExecutable)(nil).Command), varargs...)
 }
 
 // Execute mocks base method.
@@ -93,4 +113,19 @@ func (mr *MockExecutableMockRecorder) ExecuteWithStdin(arg0, arg1 interface{}, a
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteWithStdin", reflect.TypeOf((*MockExecutable)(nil).ExecuteWithStdin), varargs...)
+}
+
+// Run mocks base method.
+func (m *MockExecutable) Run(arg0 *executables.Command) (bytes.Buffer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Run", arg0)
+	ret0, _ := ret[0].(bytes.Buffer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Run indicates an expected call of Run.
+func (mr *MockExecutableMockRecorder) Run(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockExecutable)(nil).Run), arg0)
 }


### PR DESCRIPTION
*Description of changes:*
I'm gonna need a `ExecuteWithStdInAndEnvVars` soon, so instead of keeping bloating the interface, I propose a composable command: `e.Command(ctx, args...).WithStdIn(in).WithEnvVars(envs).Run()`

Ideally we will slowly refactor existing calls for `ExecuteWithEnv` and `ExecuteWithStdin` to use the new approach. I think leaving `Execute` as a shortcut is fine

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
