### PR TITLE
Add resolv-conf to kubelet extra args

### DIFF
--- a/pkg/clusterapi/extraargs.go
+++ b/pkg/clusterapi/extraargs.go
@@ -62,6 +62,12 @@ func SecureEtcdTlsCipherSuitesExtraArgs() ExtraArgs {
 	return args
 }
 
+func ResolvConfExtraArgs() ExtraArgs {
+	args := ExtraArgs{}
+	args.AddIfNotEmpty("resolv-conf", "/etc/resolv.conf")
+	return args
+}
+
 func (e ExtraArgs) AddIfNotEmpty(k, v string) {
 	if v != "" {
 		logger.V(5).Info("Adding extraArgs", k, v)

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -171,6 +171,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) map[string]interface{} {
 	bundle := clusterSpec.VersionsBundle
 	etcdExtraArgs := clusterapi.SecureEtcdTlsCipherSuitesExtraArgs()
 	sharedExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs()
+	kubeletExtraArgs := clusterapi.ResolvConfExtraArgs().Append(sharedExtraArgs)
 	apiServerExtraArgs := clusterapi.OIDCToExtraArgs(clusterSpec.OIDCConfig).
 		Append(clusterapi.AwsIamAuthExtraArgs(clusterSpec.AWSIamConfig)).
 		Append(clusterapi.PodIAMAuthExtraArgs(clusterSpec.Spec.PodIAMConfig)).
@@ -191,7 +192,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) map[string]interface{} {
 		"apiserverExtraArgs":         apiServerExtraArgs.ToPartialYaml(),
 		"controllermanagerExtraArgs": sharedExtraArgs.ToPartialYaml(),
 		"schedulerExtraArgs":         sharedExtraArgs.ToPartialYaml(),
-		"kubeletExtraArgs":           sharedExtraArgs.ToPartialYaml(),
+		"kubeletExtraArgs":           kubeletExtraArgs.ToPartialYaml(),
 		"externalEtcdVersion":        bundle.KubeDistro.EtcdVersion,
 		"eksaSystemNamespace":        constants.EksaSystemNamespace,
 		"auditPolicy":                common.GetAuditPolicy(),
@@ -216,7 +217,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) map[string]interface{} {
 
 func buildTemplateMapMD(clusterSpec *cluster.Spec) map[string]interface{} {
 	bundle := clusterSpec.VersionsBundle
-	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs()
+	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().Append(clusterapi.ResolvConfExtraArgs())
 
 	values := map[string]interface{}{
 		"clusterName":         clusterSpec.Name,

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
@@ -273,6 +273,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
     joinConfiguration:
@@ -281,6 +282,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
   replicas: 3

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_md_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_md_expected.yaml
@@ -12,6 +12,7 @@ spec:
           kubeletExtraArgs:
             cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            resolv-conf: /etc/resolv.conf
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
@@ -268,6 +268,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
     joinConfiguration:
@@ -276,6 +277,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
   replicas: 3

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_md_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_md_expected.yaml
@@ -12,6 +12,7 @@ spec:
           kubeletExtraArgs:
             cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            resolv-conf: /etc/resolv.conf
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3

--- a/pkg/providers/docker/testdata/no_machinetemplate_update_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/no_machinetemplate_update_cp_expected.yaml
@@ -261,6 +261,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
     joinConfiguration:
@@ -269,6 +270,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
   replicas: 0

--- a/pkg/providers/docker/testdata/no_machinetemplate_update_md_expected.yaml
+++ b/pkg/providers/docker/testdata/no_machinetemplate_update_md_expected.yaml
@@ -12,6 +12,7 @@ spec:
           kubeletExtraArgs:
             cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            resolv-conf: /etc/resolv.conf
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
@@ -266,6 +266,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
     joinConfiguration:
@@ -274,6 +275,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
   replicas: 3

--- a/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
@@ -267,6 +267,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
     joinConfiguration:
@@ -275,6 +276,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
   replicas: 1

--- a/pkg/providers/docker/testdata/valid_deployment_cp_stacked_etcd_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_stacked_etcd_expected.yaml
@@ -261,6 +261,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
     joinConfiguration:
@@ -269,6 +270,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
   replicas: 1

--- a/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
@@ -266,6 +266,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: 
           - key: key1
@@ -283,6 +284,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: 
           - key: key1

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
@@ -266,6 +266,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
     joinConfiguration:
@@ -274,6 +275,7 @@ spec:
         kubeletExtraArgs:
           cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
   replicas: 3

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_md_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_md_expected.yaml
@@ -12,6 +12,7 @@ spec:
           kubeletExtraArgs:
             cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            resolv-conf: /etc/resolv.conf
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3

--- a/pkg/providers/docker/testdata/valid_deployment_md_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_md_expected.yaml
@@ -12,6 +12,7 @@ spec:
           kubeletExtraArgs:
             cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            resolv-conf: /etc/resolv.conf
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
@@ -372,6 +372,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []
@@ -386,6 +387,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_md.yaml
@@ -17,6 +17,7 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-provider: external
+            resolv-conf: /etc/resolv.conf
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
           name: '{{ ds.meta_data.hostname }}'
       preKubeadmCommands:

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
@@ -367,6 +367,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []
@@ -383,6 +384,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_md.yaml
@@ -19,6 +19,7 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-provider: external
+            resolv-conf: /etc/resolv.conf
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
           name: '{{ ds.meta_data.hostname }}'
       preKubeadmCommands:

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -385,6 +385,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []
@@ -419,6 +420,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_md.yaml
@@ -37,6 +37,7 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-provider: external
+            resolv-conf: /etc/resolv.conf
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
           name: '{{ ds.meta_data.hostname }}'
       preKubeadmCommands:

--- a/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
@@ -349,6 +349,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []
@@ -357,6 +358,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -346,6 +346,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []
@@ -354,6 +355,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []

--- a/pkg/providers/vsphere/testdata/expected_results_main_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_md.yaml
@@ -11,6 +11,7 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-provider: external
+            resolv-conf: /etc/resolv.conf
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
           name: '{{ ds.meta_data.hostname }}'
       preKubeadmCommands:

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -346,6 +346,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []
@@ -354,6 +355,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_md.yaml
@@ -11,6 +11,7 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-provider: external
+            resolv-conf: /etc/resolv.conf
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
           name: '{{ ds.meta_data.hostname }}'
       preKubeadmCommands:

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -346,6 +346,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: 
@@ -363,6 +364,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: 

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
@@ -341,6 +341,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []
@@ -349,6 +350,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_md.yaml
@@ -11,6 +11,7 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-provider: external
+            resolv-conf: /etc/resolv.conf
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
           name: '{{ ds.meta_data.hostname }}'
       preKubeadmCommands:

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
@@ -344,6 +344,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []
@@ -352,6 +353,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -352,6 +352,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []
@@ -360,6 +361,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_md.yaml
@@ -11,6 +11,7 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-provider: external
+            resolv-conf: /etc/resolv.conf
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
           name: '{{ ds.meta_data.hostname }}'
       files:

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -374,6 +374,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []
@@ -382,6 +383,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
@@ -11,6 +11,7 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-provider: external
+            resolv-conf: /etc/resolv.conf
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
           name: '{{ ds.meta_data.hostname }}'
       files:

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -347,6 +347,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []
@@ -355,6 +356,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          resolv-conf: /etc/resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
         taints: []

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -660,6 +660,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 	format := "cloud-config"
 	etcdExtraArgs := clusterapi.SecureEtcdTlsCipherSuitesExtraArgs()
 	sharedExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs()
+	kubeletExtraArgs := clusterapi.ResolvConfExtraArgs().Append(sharedExtraArgs)
 	apiServerExtraArgs := clusterapi.OIDCToExtraArgs(clusterSpec.OIDCConfig).
 		Append(clusterapi.AwsIamAuthExtraArgs(clusterSpec.AWSIamConfig)).
 		Append(clusterapi.PodIAMAuthExtraArgs(clusterSpec.Spec.PodIAMConfig)).
@@ -704,7 +705,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		"apiserverExtraArgs":                   apiServerExtraArgs.ToPartialYaml(),
 		"controllermanagerExtraArgs":           sharedExtraArgs.ToPartialYaml(),
 		"schedulerExtraArgs":                   sharedExtraArgs.ToPartialYaml(),
-		"kubeletExtraArgs":                     sharedExtraArgs.ToPartialYaml(),
+		"kubeletExtraArgs":                     kubeletExtraArgs.ToPartialYaml(),
 		"format":                               format,
 		"externalEtcdVersion":                  bundle.KubeDistro.EtcdVersion,
 		"etcdImage":                            bundle.KubeDistro.EtcdImage.VersionedImage(),
@@ -777,7 +778,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 func buildTemplateMapMD(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphereDatacenterConfigSpec, workerNodeGroupMachineSpec v1alpha1.VSphereMachineConfigSpec) map[string]interface{} {
 	bundle := clusterSpec.VersionsBundle
 	format := "cloud-config"
-	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs()
+	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().Append(clusterapi.ResolvConfExtraArgs())
 
 	values := map[string]interface{}{
 		"clusterName":                    clusterSpec.ObjectMeta.Name,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add `resolv-conf` to kubelet configuration to enable custom configuration for resolv.conf file
Issue: #552 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
