### PR TITLE
Override for import and list images

### DIFF
--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -2,16 +2,11 @@ package cmd
 
 import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/version"
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
-func getImages(spec string) ([]v1alpha1.Image, error) {
-	clusterSpec, err := cluster.NewSpec(spec, version.Get())
-	if err != nil {
-		return nil, err
-	}
-	bundle := clusterSpec.VersionsBundle
-	images := append(bundle.Images(), clusterSpec.KubeDistroImages()...)
+func getImages(spec *cluster.Spec) ([]v1alpha1.Image, error) {
+	bundle := spec.VersionsBundle
+	images := append(bundle.Images(), spec.KubeDistroImages()...)
 	return images, nil
 }

--- a/cmd/eksctl-anywhere/cmd/listimages.go
+++ b/cmd/eksctl-anywhere/cmd/listimages.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"log"
 
@@ -11,7 +10,7 @@ import (
 )
 
 type listImagesOptions struct {
-	fileName string
+	clusterOptions
 }
 
 var lio = &listImagesOptions{}
@@ -19,6 +18,7 @@ var lio = &listImagesOptions{}
 func init() {
 	listCmd.AddCommand(listImagesCommand)
 	listImagesCommand.Flags().StringVarP(&lio.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
+	listImagesCommand.Flags().StringVar(&lio.bundlesOverride, "bundles-override", "", "Override default Bundles manifest (not recommended)")
 	err := listImagesCommand.MarkFlagRequired("filename")
 	if err != nil {
 		log.Fatalf("Error marking filename flag as required: %v", err)
@@ -39,12 +39,17 @@ var listImagesCommand = &cobra.Command{
 	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return listImages(cmd.Context(), lio.fileName)
+		return listImages()
 	},
 }
 
-func listImages(context context.Context, spec string) error {
-	images, err := getImages(spec)
+func listImages() error {
+	clusterSpec, err := newClusterSpec(lio.clusterOptions)
+	if err != nil {
+		return err
+	}
+
+	images, err := getImages(clusterSpec)
 	if err != nil {
 		return err
 	}

--- a/test/framework/e2e.go
+++ b/test/framework/e2e.go
@@ -108,7 +108,11 @@ func (e *E2ETest) GenerateClusterConfig() {
 }
 
 func (e *E2ETest) ImportImages() {
-	e.RunEKSA("anywhere", "import-images", "-f", e.ClusterConfigLocation)
+	importImagesArgs := []string{"import-images", "-f", e.ClusterConfigLocation}
+	if getBundlesOverride() == "true" {
+		importImagesArgs = append(importImagesArgs, "--bundles-override", defaultBundleReleaseManifestFile)
+	}
+	e.RunEKSA(importImagesArgs...)
 }
 
 func (e *E2ETest) CreateCluster() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add the `bundle-overrides` flag to `list-images` and `import-images`, and adjust the tests to use this flag.

This is necessary for the release branch E2E testing of the registry mirror -- without it, we'll just be attempting to import the standard images rather than the overrides, and the process fails. 

Once this is confirmed to have solved the issues with the 06 registry mirror tests, we will forward port it to `main` for parity. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
