### PR TITLE
Run helm template with OCI support env var

### DIFF
--- a/pkg/executables/helm.go
+++ b/pkg/executables/helm.go
@@ -7,6 +7,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+var helmTemplateEnvVars = map[string]string{
+	"HELM_EXPERIMENTAL_OCI": "1",
+}
+
 type Helm struct {
 	executable Executable
 }
@@ -23,7 +27,9 @@ func (h *Helm) Template(ctx context.Context, ociURI, version, namespace string, 
 		return nil, fmt.Errorf("failed marshalling values for helm template: %v", err)
 	}
 
-	result, err := h.executable.ExecuteWithStdin(ctx, valuesYaml, "template", ociURI, "--version", version, "--namespace", namespace, "-f", "-")
+	result, err := h.executable.Command(
+		ctx, "template", ociURI, "--version", version, "--namespace", namespace, "-f", "-",
+	).WithStdIn(valuesYaml).WithEnvVars(helmTemplateEnvVars).Run()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executables/helpers_test.go
+++ b/pkg/executables/helpers_test.go
@@ -1,0 +1,37 @@
+package executables_test
+
+import (
+	"context"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/executables/mocks"
+)
+
+type commandExpect struct {
+	command *executables.Command
+	e       *mocks.MockExecutable
+}
+
+func expectCommand(e *mocks.MockExecutable, ctx context.Context, args ...string) *commandExpect {
+	e.EXPECT().Command(ctx, args).Return(executables.NewCommand(ctx, e, args...))
+	return &commandExpect{
+		command: executables.NewCommand(ctx, e, args...),
+		e:       e,
+	}
+}
+
+func (c *commandExpect) withEnvVars(envVars map[string]string) *commandExpect {
+	c.command.WithEnvVars(envVars)
+	return c
+}
+
+func (c *commandExpect) withStdIn(stdIn []byte) *commandExpect {
+	c.command.WithStdIn(stdIn)
+	return c
+}
+
+func (c *commandExpect) to() *gomock.Call {
+	return c.e.EXPECT().Run(c.command)
+}


### PR DESCRIPTION
*Description of changes:*
Adding `HELM_EXPERIMENTAL_OCI` env var to helm executions. This is required to use oci registries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
