### PR TITLE
Fix error in e2e

### DIFF
--- a/test/framework/e2e.go
+++ b/test/framework/e2e.go
@@ -108,7 +108,11 @@ func (e *E2ETest) GenerateClusterConfig() {
 }
 
 func (e *E2ETest) ImportImages() {
-	e.RunEKSA("anywhere", "import-images", "-f", e.ClusterConfigLocation)
+	importImagesArgs := []string{"anywhere", "import-images", "-f", e.ClusterConfigLocation}
+	if getBundlesOverride() == "true" {
+		importImagesArgs = append(importImagesArgs, "--bundles-override", defaultBundleReleaseManifestFile)
+	}
+	e.RunEKSA(importImagesArgs...)
 }
 
 func (e *E2ETest) CreateCluster() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

0.6 is different from main, in the regard that `anywhere` is required in the command argument prefix. Will need to backport these changes later.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
