### PR TITLE
Kubectl methods to get deployment and daemonset

### DIFF
--- a/pkg/executables/kubectl_getter_helper_test.go
+++ b/pkg/executables/kubectl_getter_helper_test.go
@@ -1,0 +1,79 @@
+package executables_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/eks-anywhere/internal/test"
+)
+
+type (
+	getter            func(*kubectlGetterTest) (client.Object, error)
+	kubectlGetterTest struct {
+		*kubectlTest
+		resourceType, name string
+		json               string
+		getter             getter
+		want               client.Object
+	}
+)
+
+func newKubectlGetterTest(t *testing.T) *kubectlGetterTest {
+	return &kubectlGetterTest{
+		kubectlTest: newKubectlTest(t),
+		name:        "name",
+	}
+}
+
+func (tt *kubectlGetterTest) withResourceType(r string) *kubectlGetterTest {
+	tt.resourceType = r
+	return tt
+}
+
+func (tt *kubectlGetterTest) withJson(j string) *kubectlGetterTest {
+	tt.json = j
+	return tt
+}
+
+func (tt *kubectlGetterTest) withJsonFromFile(file string) *kubectlGetterTest {
+	return tt.withJson(test.ReadFile(tt.t, file))
+}
+
+func (tt *kubectlGetterTest) withGetter(g getter) *kubectlGetterTest {
+	tt.getter = g
+	return tt
+}
+
+func (tt *kubectlGetterTest) andWant(o client.Object) *kubectlGetterTest {
+	tt.want = o
+	return tt
+}
+
+func (tt *kubectlGetterTest) testSuccess() {
+	tt.WithT.THelper()
+
+	tt.e.EXPECT().Execute(
+		tt.ctx,
+		"get", "--namespace", tt.namespace, tt.resourceType, tt.name, "-o", "json", "--kubeconfig", tt.cluster.KubeconfigFile,
+	).Return(*bytes.NewBufferString(tt.json), nil)
+
+	got, err := tt.getter(tt)
+	tt.Expect(err).To(Not(HaveOccurred()), "Getter for %s should succeed", tt.resourceType)
+	tt.Expect(got).To(Equal(tt.want), "Getter for %s should return correct object", tt.resourceType)
+}
+
+func (tt *kubectlGetterTest) testError() {
+	tt.WithT.THelper()
+
+	tt.e.EXPECT().Execute(
+		tt.ctx,
+		"get", "--namespace", tt.namespace, tt.resourceType, tt.name, "-o", "json", "--kubeconfig", tt.kubeconfig,
+	).Return(bytes.Buffer{}, errors.New("error in get"))
+
+	_, err := tt.getter(tt)
+	tt.Expect(err).To(MatchError(ContainSubstring("error in get")), "Getter for %s should fail", tt.resourceType)
+}

--- a/pkg/executables/testdata/kubectl_daemonset.json
+++ b/pkg/executables/testdata/kubectl_daemonset.json
@@ -1,0 +1,23 @@
+{
+    "apiVersion": "apps/v1",
+    "kind": "DaemonSet",
+    "metadata": {
+        "name": "cilium",
+        "namespace": "kube-system"
+    },
+    "spec": {
+        "template": {
+            "spec": {
+                "containers": [
+                    {
+                        "command": [
+                            "cilium-agent"
+                        ],
+                        "image": "public.ecr.aws/isovalent/cilium:v1.9.11-eksa.1",
+                        "name": "cilium-agent"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/pkg/executables/testdata/kubectl_deployment.json
+++ b/pkg/executables/testdata/kubectl_deployment.json
@@ -1,0 +1,21 @@
+{
+	"apiVersion": "apps/v1",
+	"kind": "Deployment",
+	"metadata": {
+		"name": "coredns",
+		"namespace": "kube-system"
+	},
+	"spec": {
+		"replicas": 2,
+		"template": {
+			"spec": {
+				"containers": [
+					{
+						"image": "k8s.gcr.io/coredns:1.7.0",
+						"name": "coredns"
+					}
+				]
+			}
+		}
+	}
+}


### PR DESCRIPTION
*Description of changes:*
* Add kubectl methods to get deployment and daemonset
* Added some helpers to speed up writing kubectl getters. I realized most of the time I spent with the kubectl executable is writing getters, so hopefully this will help to speed up the process in the future. However, we take the risk of drying too much the tests and making them more difficult to read/debug. I think the code is fairly simple so hopefully this won't be an issue. Open to other opinions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
