### PR TITLE
Get Kube version from EKS-D release manifest instead of file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ release-upload-cluster-controller: release-cluster-controller upload-artifacts
 
 .PHONY: upload-artifacts
 upload-artifacts:
-	controllers/build/upload_artifacts.sh $(TAR_PATH) $(ARTIFACTS_BUCKET) $(PROJECT_PATH) $(CODEBUILD_BUILD_NUMBER) $(CODEBUILD_RESOLVED_SOURCE_VERSION)
+	controllers/build/upload_artifacts.sh $(TAR_PATH) $(ARTIFACTS_BUCKET) $(PROJECT_PATH) $(CODEBUILD_BUILD_NUMBER) $(CODEBUILD_RESOLVED_SOURCE_VERSION) $(LATEST)
 
 .PHONY: create-cluster-controller-binaries
 create-cluster-controller-binaries: $(CREATE_CLUSTER_CONTROLLER_BINARIES)

--- a/controllers/build/upload_artifacts.sh
+++ b/controllers/build/upload_artifacts.sh
@@ -23,9 +23,10 @@ ARTIFACTS_BUCKET="${2?Specify second argument - artifacts buckets}"
 PROJECT_PATH="${3? Specify third argument - project path}"
 BUILD_IDENTIFIER="${4? Specify fourth argument - build identifier}"
 GIT_HASH="${5?Specify fifth argument - git hash of the tar builds}"
+LATEST_PATH="${6?Specify sixth argument - latest S3 folder path for artifacts}"
 
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 source "$REPO_ROOT/scripts/common.sh"
 
-build::common::upload_artifacts $SRC_TAR_PATH $ARTIFACTS_BUCKET $PROJECT_PATH $BUILD_IDENTIFIER $GIT_HASH
+build::common::upload_artifacts $SRC_TAR_PATH $ARTIFACTS_BUCKET $PROJECT_PATH $BUILD_IDENTIFIER $GIT_HASH $LATEST_PATH

--- a/release/pkg/file_reader_test.go
+++ b/release/pkg/file_reader_test.go
@@ -80,3 +80,71 @@ func TestGenerateNewDevReleaseVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestGetEksDKubeVersion(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		releaseChannel string
+		releaseNumber  string
+		want           string
+	}{
+		{
+			testName:       "EKS Distro 1-18-1 release",
+			releaseChannel: "1-18",
+			releaseNumber:  "1",
+			want:           "v1.18.9",
+		},
+		{
+			testName:       "EKS Distro 1-18-13 release",
+			releaseChannel: "1-18",
+			releaseNumber:  "13",
+			want:           "v1.18.20",
+		},
+		{
+			testName:       "EKS Distro 1-19-1 release",
+			releaseChannel: "1-19",
+			releaseNumber:  "1",
+			want:           "v1.19.6",
+		},
+		{
+			testName:       "EKS Distro 1-19-12 release",
+			releaseChannel: "1-19",
+			releaseNumber:  "12",
+			want:           "v1.19.15",
+		},
+		{
+			testName:       "EKS Distro 1-20-1 release",
+			releaseChannel: "1-20",
+			releaseNumber:  "1",
+			want:           "v1.20.4",
+		},
+		{
+			testName:       "EKS Distro 1-20-9 release",
+			releaseChannel: "1-20",
+			releaseNumber:  "9",
+			want:           "v1.20.11",
+		},
+		{
+			testName:       "EKS Distro 1-21-1 release",
+			releaseChannel: "1-21",
+			releaseNumber:  "1",
+			want:           "v1.21.2",
+		},
+		{
+			testName:       "EKS Distro 1-21-7 release",
+			releaseChannel: "1-21",
+			releaseNumber:  "7",
+			want:           "v1.21.5",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			if got, err := getEksDKubeVersion(tt.releaseChannel, tt.releaseNumber); err != nil {
+				t.Fatalf("getEksDKubeVersion err = %s, want err = nil", err)
+			} else if got != tt.want {
+				t.Fatalf("getEksDKubeVersion kubeVersion = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -167,11 +167,13 @@ func (r *ReleaseConfig) GetVersionsBundles(imageDigests map[string]string) ([]an
 		releaseNumberInt := releaseNumber.(int)
 		releaseNumberStr := strconv.Itoa(releaseNumberInt)
 
-		kubeVersion := release.(map[interface{}]interface{})["kubeVersion"]
-		kubeVersionStr := kubeVersion.(string)
-		shortKubeVersion := kubeVersionStr[1:strings.LastIndex(kubeVersionStr, ".")]
+		kubeVersion, err := getEksDKubeVersion(channel, releaseNumberStr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Error getting kubeversion for eks-d %s-%s release", channel, releaseNumberStr)
+		}
+		shortKubeVersion := kubeVersion[1:strings.LastIndex(kubeVersion, ".")]
 
-		eksDReleaseBundle, err := r.GetEksDReleaseBundle(channel, kubeVersionStr, releaseNumberStr, imageDigests)
+		eksDReleaseBundle, err := r.GetEksDReleaseBundle(channel, kubeVersion, releaseNumberStr, imageDigests)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error getting bundle for eks-d %s-%s release bundle", channel, releaseNumberStr)
 		}
@@ -284,10 +286,12 @@ func (r *ReleaseConfig) GenerateBundleArtifactsTable() (map[string][]Artifact, e
 		releaseNumberInt := releaseNumber.(int)
 		releaseNumberStr := strconv.Itoa(releaseNumberInt)
 
-		kubeVersion := release.(map[interface{}]interface{})["kubeVersion"]
-		kubeVersionStr := kubeVersion.(string)
+		kubeVersion, err := getEksDKubeVersion(channel, releaseNumberStr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Error getting kubeversion for eks-d %s-%s release", channel, releaseNumberStr)
+		}
 
-		eksDChannelArtifacts, err := r.GetEksDChannelAssets(channel, kubeVersionStr, releaseNumberStr)
+		eksDChannelArtifacts, err := r.GetEksDChannelAssets(channel, kubeVersion, releaseNumberStr)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error getting artifact information for %s", channel)
 		}

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -72,6 +72,7 @@ function build::common::upload_artifacts() {
   local -r projectpath=$3
   local -r buildidentifier=$4
   local -r githash=$5
+  local -r latestpath=$6
 
   echo "$githash" >> "$artifactspath"/githash
 
@@ -79,7 +80,7 @@ function build::common::upload_artifacts() {
   # 1. To proper path on s3 with buildId-githash
   # 2. Latest path to indicate the latest build, with --delete option to delete stale files in the dest path
   aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --acl public-read
-  aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/latest --delete --acl public-read
+  aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latestpath" --delete --acl public-read
 }
 
 function build::gather_licenses() {


### PR DESCRIPTION
Adding logic to get kube version directly from EKS-D releases manifest instead of from the [EKS-D releases file](https://github.com/aws/eks-anywhere-build-tooling/blob/main/EKSD_LATEST_RELEASES).

This method is a Golang version of
```zsh
$ curl -fsSL https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-7.yaml |
yq e '.status.components[] |
select(.name=="kubernetes") |
.gitTag' -
v1.21.5
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
