### PR TITLE
Validate osFamily before import

### DIFF
--- a/pkg/providers/vsphere/validator.go
+++ b/pkg/providers/vsphere/validator.go
@@ -140,6 +140,17 @@ func (v *validator) validateCluster(ctx context.Context, vsphereClusterSpec *spe
 			return fmt.Errorf("error validating vCenter setup for VSphereMachineConfig %v: %v", config.Name, err)
 		}
 	}
+	if controlPlaneMachineConfig.Spec.OSFamily != anywherev1.Bottlerocket && controlPlaneMachineConfig.Spec.OSFamily != anywherev1.Ubuntu {
+		return fmt.Errorf("control plane osFamily: %s is not supported, please use one of the following: %s, %s", controlPlaneMachineConfig.Spec.OSFamily, anywherev1.Bottlerocket, anywherev1.Ubuntu)
+	}
+
+	if workerNodeGroupMachineConfig.Spec.OSFamily != anywherev1.Bottlerocket && workerNodeGroupMachineConfig.Spec.OSFamily != anywherev1.Ubuntu {
+		return fmt.Errorf("worker node osFamily: %s is not supported, please use one of the following: %s, %s", workerNodeGroupMachineConfig.Spec.OSFamily, anywherev1.Bottlerocket, anywherev1.Ubuntu)
+	}
+
+	if etcdMachineConfig != nil && etcdMachineConfig.Spec.OSFamily != anywherev1.Bottlerocket && etcdMachineConfig.Spec.OSFamily != anywherev1.Ubuntu {
+		return fmt.Errorf("etcd node osFamily: %s is not supported, please use one of the following: %s, %s", etcdMachineConfig.Spec.OSFamily, anywherev1.Bottlerocket, anywherev1.Ubuntu)
+	}
 
 	if controlPlaneMachineConfig.Spec.OSFamily != workerNodeGroupMachineConfig.Spec.OSFamily {
 		return errors.New("control plane and worker nodes must have the same osFamily specified")

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -2004,6 +2004,54 @@ func TestSetupAndValidateCreateClusterEtcdMachineGroupRefNonexistent(t *testing.
 	}
 }
 
+func TestSetupAndValidateCreateClusterOsFamilyInvalid(t *testing.T) {
+	ctx := context.Background()
+	clusterSpec := givenEmptyClusterSpec()
+	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
+	provider := givenProvider(t)
+	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	provider.machineConfigs[controlPlaneMachineConfigName].Spec.OSFamily = "rhel"
+	var tctx testContext
+	tctx.SaveContext()
+
+	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
+	if err != nil {
+		thenErrorExpected(t, "control plane osFamily: rhel is not supported, please use one of the following: bottlerocket, ubuntu", err)
+	}
+}
+
+func TestSetupAndValidateCreateClusterOsFamilyInvalidWorkerNode(t *testing.T) {
+	ctx := context.Background()
+	clusterSpec := givenEmptyClusterSpec()
+	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
+	provider := givenProvider(t)
+	workerMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	provider.machineConfigs[workerMachineConfigName].Spec.OSFamily = "rhel"
+	var tctx testContext
+	tctx.SaveContext()
+
+	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
+	if err != nil {
+		thenErrorExpected(t, "worker node osFamily: rhel is not supported, please use one of the following: bottlerocket, ubuntu", err)
+	}
+}
+
+func TestSetupAndValidateCreateClusterOsFamilyInvalidEtcdNode(t *testing.T) {
+	ctx := context.Background()
+	clusterSpec := givenEmptyClusterSpec()
+	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
+	provider := givenProvider(t)
+	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	provider.machineConfigs[etcdMachineConfigName].Spec.OSFamily = "rhel"
+	var tctx testContext
+	tctx.SaveContext()
+
+	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
+	if err != nil {
+		thenErrorExpected(t, "etcd node osFamily: rhel is not supported, please use one of the following: bottlerocket, ubuntu", err)
+	}
+}
+
 func TestSetupAndValidateCreateClusterOsFamilyDifferent(t *testing.T) {
 	ctx := context.Background()
 	clusterSpec := givenEmptyClusterSpec()

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -2013,11 +2013,8 @@ func TestSetupAndValidateCreateClusterOsFamilyInvalid(t *testing.T) {
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.OSFamily = "rhel"
 	var tctx testContext
 	tctx.SaveContext()
-
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-	if err != nil {
-		thenErrorExpected(t, "control plane osFamily: rhel is not supported, please use one of the following: bottlerocket, ubuntu", err)
-	}
+	thenErrorExpected(t, "control plane osFamily: rhel is not supported, please use one of the following: bottlerocket, ubuntu", err)
 }
 
 func TestSetupAndValidateCreateClusterOsFamilyInvalidWorkerNode(t *testing.T) {
@@ -2029,11 +2026,8 @@ func TestSetupAndValidateCreateClusterOsFamilyInvalidWorkerNode(t *testing.T) {
 	provider.machineConfigs[workerMachineConfigName].Spec.OSFamily = "rhel"
 	var tctx testContext
 	tctx.SaveContext()
-
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-	if err != nil {
-		thenErrorExpected(t, "worker node osFamily: rhel is not supported, please use one of the following: bottlerocket, ubuntu", err)
-	}
+	thenErrorExpected(t, "worker node osFamily: rhel is not supported, please use one of the following: bottlerocket, ubuntu", err)
 }
 
 func TestSetupAndValidateCreateClusterOsFamilyInvalidEtcdNode(t *testing.T) {
@@ -2045,11 +2039,8 @@ func TestSetupAndValidateCreateClusterOsFamilyInvalidEtcdNode(t *testing.T) {
 	provider.machineConfigs[etcdMachineConfigName].Spec.OSFamily = "rhel"
 	var tctx testContext
 	tctx.SaveContext()
-
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-	if err != nil {
-		thenErrorExpected(t, "etcd node osFamily: rhel is not supported, please use one of the following: bottlerocket, ubuntu", err)
-	}
+	thenErrorExpected(t, "etcd node osFamily: rhel is not supported, please use one of the following: bottlerocket, ubuntu", err)
 }
 
 func TestSetupAndValidateCreateClusterOsFamilyDifferent(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/875

*Description of changes:*
Validate osFamily field to ensure it is set to either `ubuntu` or `bottlerocket`
This PR also resolves an issue where the cli crashes during importing the template to vSphere and the osFamily is invalid.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
