### PR TITLE
Separate vsphere datacenterconfig validation from rest of the cluster validation

### DIFF
--- a/pkg/providers/vsphere/defaults.go
+++ b/pkg/providers/vsphere/defaults.go
@@ -16,14 +16,13 @@ type defaulter struct {
 	govc ProviderGovcClient
 }
 
-func newDefaulter(govc ProviderGovcClient) *defaulter {
+func NewDefaulter(govc ProviderGovcClient) *defaulter {
 	return &defaulter{
 		govc: govc,
 	}
 }
 
-func (d *defaulter) setDefaults(ctx context.Context, spec *spec) error {
-	setDefaultsForDatacenterConfig(spec.datacenterConfig)
+func (d *defaulter) setDefaultsForMachineConfig(ctx context.Context, spec *spec) error {
 	setDefaultsForEtcdMachineConfig(spec.etcdMachineConfig())
 	for _, m := range spec.machineConfigs() {
 		setDefaultsForMachineConfig(m)
@@ -43,7 +42,7 @@ func (d *defaulter) setDefaults(ctx context.Context, spec *spec) error {
 	return nil
 }
 
-func setDefaultsForDatacenterConfig(datacenterConfig *anywherev1.VSphereDatacenterConfig) {
+func (d *defaulter) SetDefaultsForDatacenterConfig(datacenterConfig *anywherev1.VSphereDatacenterConfig) {
 	if datacenterConfig.Spec.Insecure {
 		logger.Info("Warning: VSphereDatacenterConfig configured in insecure mode")
 		datacenterConfig.Spec.Thumbprint = ""

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -2094,13 +2094,14 @@ func TestSetupAndValidateCreateClusterTemplateDoesNotExist(t *testing.T) {
 	tt := newProviderTest(t)
 
 	tt.setExpectationForSetup()
+	tt.setExpectationForVCenterValidation()
 	for _, mc := range tt.machineConfigs {
 		tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, mc).Return("", nil).MaxTimes(1)
 	}
 
 	err := tt.provider.SetupAndValidateCreateCluster(tt.ctx, tt.clusterSpec)
 
-	thenErrorExpected(t, "failed setup and validations: template <"+testTemplate+"> not found", err)
+	thenErrorExpected(t, "failed setting default values for vsphere machine configs: template <"+testTemplate+"> not found", err)
 }
 
 func TestSetupAndValidateCreateClusterErrorCheckingTemplate(t *testing.T) {
@@ -2108,13 +2109,14 @@ func TestSetupAndValidateCreateClusterErrorCheckingTemplate(t *testing.T) {
 	errorMessage := "failed getting template"
 
 	tt.setExpectationForSetup()
+	tt.setExpectationForVCenterValidation()
 	for _, mc := range tt.machineConfigs {
 		tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, mc).Return("", errors.New(errorMessage)).MaxTimes(1)
 	}
 
 	err := tt.provider.SetupAndValidateCreateCluster(tt.ctx, tt.clusterSpec)
 
-	thenErrorExpected(t, "failed setup and validations: error setting template full path: "+errorMessage, err)
+	thenErrorExpected(t, "failed setting default values for vsphere machine configs: error setting template full path: "+errorMessage, err)
 }
 
 func TestSetupAndValidateCreateClusterTemplateMissingTags(t *testing.T) {


### PR DESCRIPTION

*Issue #, if available:*

Prep for #870 

*Description of changes:*
- Move vsphere datacenter validation and setDefaults to its own method

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
