### PR TITLE
[Doc Change]export GOPATH if not available.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,8 +4,9 @@
 
 #### Prerequisites
 
-1. We need mockgen installed, `go get github.com/golang/mock/mockgen`
-2. Verify the binary was installed, `$GOPATH/bin/mockgen`
+1. Set GOPATH, `export GOPATH=${GOPATH:=$(go env GOPATH)}`  
+2. We need mockgen installed, `go get github.com/golang/mock/mockgen`
+3. Verify the binary was installed, `$GOPATH/bin/mockgen`
 
 #### Generate/Update
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
GOPATH may not be available on an environment and in such case  `go env GOPATH` is helpful. Updated the file to export GOPATH to a default value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
