### PR TITLE
Fix controller images kustomization for manifest in controller build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,6 +255,7 @@ cluster-controller-binaries: $(OUTPUT_BIN_DIR)
 	mkdir -p $(OUTPUT_BIN_DIR)/$(BINARY_NAME)
 	$(GO) mod vendor
 	$(MAKE) create-cluster-controller-binaries
+	$(MAKE) update-kustomization-yaml
 	$(MAKE) release-manifests RELEASE_DIR=.
 	source ./scripts/common.sh && build::gather_licenses $(OUTPUT_DIR) "./controllers"
 


### PR DESCRIPTION
*Description of changes:*
This fixes a regression from [this change](https://github.com/aws/eks-anywhere/pull/855/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L424)

Since I don't know why `update-kustomization-yaml` was removed, I'm adding it manually instead of putting it back in the prerequisites (in case the original change was trying to fix something else)

We might want to add a new target that runs both `update-kustomization-yaml` and `release-manifests` once we know more about the original change

This was causing all the dev bundles to include an eksa manifest with a very old version of the controller. Because of this, some of the E2E were fail, since the controller wasn't even registering all the validation webhooks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
