### PR TITLE
Improve e2e logs coming from ssm in instance

### DIFF
--- a/internal/pkg/ssm/command.go
+++ b/internal/pkg/ssm/command.go
@@ -1,7 +1,6 @@
 package ssm
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -20,8 +19,7 @@ var initE2EDirCommand = "mkdir -p /home/e2e/bin && cd /home/e2e"
 
 func WaitForSSMReady(session *session.Session, instanceId string) error {
 	err := retrier.Retry(10, 20*time.Second, func() error {
-		_, err := Run(session, instanceId, "ls")
-		return err
+		return Run(session, instanceId, "ls")
 	})
 	if err != nil {
 		return fmt.Errorf("error waiting for ssm to be ready: %v", err)
@@ -55,50 +53,28 @@ var nonFinalStatuses = map[string]struct{}{
 	ssm.CommandInvocationStatusInProgress: {}, ssm.CommandInvocationStatusDelayed: {}, ssm.CommandInvocationStatusPending: {},
 }
 
-// TODO: cleanup this method
-func Run(session *session.Session, instanceId, command string, opts ...CommandOpt) (commandId string, err error) {
+func Run(session *session.Session, instanceId, command string, opts ...CommandOpt) error {
+	o, err := RunCommand(session, instanceId, command, opts...)
+	if err != nil {
+		return err
+	}
+	if !o.Successful() {
+		return fmt.Errorf("ssm command returned not successful result %s: %s", *o.commandOut.Status, string(o.StdErr))
+	}
+
+	return nil
+}
+
+func RunCommand(session *session.Session, instanceId, command string, opts ...CommandOpt) (*RunOutput, error) {
 	service := ssm.New(session)
 
-	c := &ssm.SendCommandInput{
-		DocumentName: aws.String("AWS-RunShellScript"),
-		InstanceIds:  []*string{aws.String(instanceId)},
-		Parameters:   map[string][]*string{"commands": {aws.String(initE2EDirCommand), aws.String(command)}, "executionTimeout": {aws.String("10800")}},
-	}
-
-	for _, opt := range opts {
-		opt(c)
-	}
-	var result *ssm.SendCommandOutput
-	r := retrier.New(180*time.Minute, retrier.WithRetryPolicy(func(totalRetries int, err error) (retry bool, wait time.Duration) {
-		if request.IsErrorThrottle(err) && totalRetries < 60 {
-			return true, 60 * time.Second
-		}
-		return false, 0
-	}))
-	err = r.Retry(func() error {
-		var err error
-		logger.V(2).Info("Running ssm command", "cmd", command)
-		result, err = service.SendCommand(c)
-		if err != nil {
-			return err
-		}
-		return nil
-	})
+	result, err := sendCommand(service, instanceId, command, opts...)
 	if err != nil {
-		return "", fmt.Errorf("retries exhausted sending ssm command: %v", err)
+		return nil, err
 	}
 
-	logger.V(2).Info("SSM command started", "commandId", result.Command.CommandId)
-	if c.OutputS3BucketName != nil {
-		logger.V(4).Info(
-			"SSM command output to S3", "url",
-			fmt.Sprintf("s3://%s/%s/%s/%s/awsrunShellScript/0.awsrunShellScript/stderr", *c.OutputS3BucketName, *c.OutputS3KeyPrefix, *result.Command.CommandId, instanceId),
-		)
-	}
-
-	commandId = *result.Command.CommandId
 	commandIn := &ssm.GetCommandInvocationInput{
-		CommandId:  &commandId,
+		CommandId:  result.Command.CommandId,
 		InstanceId: aws.String(instanceId),
 	}
 
@@ -113,12 +89,12 @@ func Run(session *session.Session, instanceId, command string, opts ...CommandOp
 		return nil
 	})
 	if err != nil {
-		return commandId, fmt.Errorf("error waiting for ssm command to be registered: %v", err)
+		return nil, fmt.Errorf("error waiting for ssm command to be registered: %v", err)
 	}
 
 	logger.V(2).Info("Waiting for ssm command to finish")
 	var commandOut *ssm.GetCommandInvocationOutput
-	r = retrier.New(180*time.Minute, retrier.WithMaxRetries(2160, 60*time.Second))
+	r := retrier.New(180*time.Minute, retrier.WithMaxRetries(2160, 60*time.Second))
 	err = r.Retry(func() error {
 		var err error
 		commandOut, err = service.GetCommandInvocation(commandIn)
@@ -128,36 +104,62 @@ func Run(session *session.Session, instanceId, command string, opts ...CommandOp
 
 		status := *commandOut.Status
 		if isFinalStatus(status) {
-			logger.V(2).Info("SSM command finished", "status", status, "commandId", result.Command.CommandId)
-			// TODO: these outputs might be truncated (8000 chars max). Get the logs from s3 with StandardErrorUrl and StandardOutputContent instead
-			fmt.Println("Command stdout:")
-			fmt.Println(*commandOut.StandardOutputContent)
-			printDivider()
-			fmt.Println("Command stderr")
-			fmt.Println(*commandOut.StandardErrorContent)
-			printDivider()
-
+			logger.V(2).Info("SSM command finished", "status", status, "commandId", *result.Command.CommandId)
 			return nil
 		}
 
 		return fmt.Errorf("command still running with status %s", status)
 	})
 	if err != nil {
-		return commandId, fmt.Errorf("retries exhausted running ssm command: %v", err)
+		return nil, fmt.Errorf("retries exhausted running ssm command: %v", err)
 	}
 
-	if *commandOut.Status != ssm.CommandInvocationStatusSuccess {
-		return commandId, errors.New("failed to execute ssm command")
+	return buildRunOutput(commandOut), nil
+}
+
+func sendCommand(service *ssm.SSM, instanceId, command string, opts ...CommandOpt) (*ssm.SendCommandOutput, error) {
+	in := &ssm.SendCommandInput{
+		DocumentName: aws.String("AWS-RunShellScript"),
+		InstanceIds:  []*string{aws.String(instanceId)},
+		Parameters:   map[string][]*string{"commands": {aws.String(initE2EDirCommand), aws.String(command)}, "executionTimeout": {aws.String("10800")}},
 	}
 
-	return commandId, nil
+	for _, opt := range opts {
+		opt(in)
+	}
+
+	var result *ssm.SendCommandOutput
+	r := retrier.New(180*time.Minute, retrier.WithRetryPolicy(func(totalRetries int, err error) (retry bool, wait time.Duration) {
+		if request.IsErrorThrottle(err) && totalRetries < 60 {
+			return true, 60 * time.Second
+		}
+		return false, 0
+	}))
+	err := r.Retry(func() error {
+		var err error
+		logger.V(2).Info("Running ssm command", "cmd", command)
+		result, err = service.SendCommand(in)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("retries exhausted sending ssm command: %v", err)
+	}
+
+	logger.V(2).Info("SSM command started", "commandId", result.Command.CommandId)
+	if in.OutputS3BucketName != nil {
+		logger.V(4).Info(
+			"SSM command output to S3", "url",
+			fmt.Sprintf("s3://%s/%s/%s/%s/awsrunShellScript/0.awsrunShellScript/stderr", *in.OutputS3BucketName, *in.OutputS3KeyPrefix, *result.Command.CommandId, instanceId),
+		)
+	}
+
+	return result, nil
 }
 
 func isFinalStatus(status string) bool {
 	_, nonFinalStatus := nonFinalStatuses[status]
 	return !nonFinalStatus
-}
-
-func printDivider() {
-	fmt.Println("------")
 }

--- a/internal/pkg/ssm/run_output.go
+++ b/internal/pkg/ssm/run_output.go
@@ -1,0 +1,22 @@
+package ssm
+
+import "github.com/aws/aws-sdk-go/service/ssm"
+
+type RunOutput struct {
+	commandOut     *ssm.GetCommandInvocationOutput
+	CommandId      string
+	StdOut, StdErr []byte
+}
+
+func buildRunOutput(commandOut *ssm.GetCommandInvocationOutput) *RunOutput {
+	return &RunOutput{
+		commandOut: commandOut,
+		CommandId:  *commandOut.CommandId,
+		StdOut:     []byte(*commandOut.StandardOutputContent),
+		StdErr:     []byte(*commandOut.StandardErrorContent),
+	}
+}
+
+func (r *RunOutput) Successful() bool {
+	return *r.commandOut.Status == ssm.CommandInvocationStatusSuccess
+}

--- a/internal/test/e2e/oidc.go
+++ b/internal/test/e2e/oidc.go
@@ -114,8 +114,8 @@ func (e *E2ESession) downloadSignerKeyInInstance(folder string) (pathInInstance 
 	saSignerKey := filepath.Join(folder, saSignerPath)
 	logger.V(1).Info("Downloading from s3 in instance", "key", saSignerKey)
 	command := fmt.Sprintf("aws s3 cp s3://%s/%s ./%s", e.storageBucket, saSignerKey, saSignerPath)
-	_, err = ssm.Run(e.session, e.instanceId, command)
-	if err != nil {
+
+	if err = ssm.Run(e.session, e.instanceId, command); err != nil {
 		return "", fmt.Errorf("error downloading signer key in instance: %v", err)
 	}
 	logger.V(1).Info("Successfully downloaded signer key")

--- a/internal/test/e2e/registryMirror.go
+++ b/internal/test/e2e/registryMirror.go
@@ -35,8 +35,8 @@ func (e *E2ESession) setupRegistryMirrorEnv(testRegex string) error {
 
 func (e *E2ESession) mountRegistryCert(cert string, endpoint string) error {
 	command := fmt.Sprintf("sudo mkdir -p /etc/docker/certs.d/%s", endpoint)
-	_, err := ssm.Run(e.session, e.instanceId, command)
-	if err != nil {
+
+	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
 		return fmt.Errorf("error creating directory in instance: %v", err)
 	}
 	decodedCert, err := base64.StdEncoding.DecodeString(cert)
@@ -44,8 +44,8 @@ func (e *E2ESession) mountRegistryCert(cert string, endpoint string) error {
 		return fmt.Errorf("failed to decode certificate: %v", err)
 	}
 	command = fmt.Sprintf("sudo cat <<EOF>> /etc/docker/certs.d/%s/ca.crt\n%s\nEOF", endpoint, string(decodedCert))
-	_, err = ssm.Run(e.session, e.instanceId, command)
-	if err != nil {
+
+	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
 		return fmt.Errorf("error mounting certificate in instance: %v", err)
 	}
 

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -177,8 +177,8 @@ func (e *E2ESession) downloadRequiredFileInInstance(file string) error {
 	} else {
 		command = fmt.Sprintf("aws s3 cp s3://%s/%s/%[3]s ./bin/ && chmod 645 ./bin/%[3]s", e.storageBucket, e.jobId, file)
 	}
-	_, err := ssm.Run(e.session, e.instanceId, command)
-	if err != nil {
+
+	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
 		return fmt.Errorf("error downloading file in instance: %v", err)
 	}
 	logger.V(1).Info("Successfully downloaded file")
@@ -191,8 +191,7 @@ func (e *E2ESession) uploadGeneratedFilesFromInstance(testName string) {
 	command := fmt.Sprintf("aws s3 cp /home/e2e/%s/ %s/%s/ --recursive",
 		e.instanceId, e.generatedArtifactsBucketPath(), testName)
 
-	_, err := ssm.Run(e.session, e.instanceId, command)
-	if err != nil {
+	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
 		logger.Error(err, "error uploading log files from instance")
 	} else {
 		logger.V(1).Info("Successfully uploaded log files to S3")
@@ -205,8 +204,7 @@ func (e *E2ESession) uploadDiagnosticArchiveFromInstance(testName string) {
 	command := fmt.Sprintf("aws s3 cp /home/e2e/ %s/%s/ --recursive --exclude \"*\" --include \"%s\"",
 		e.generatedArtifactsBucketPath(), testName, bundleNameFormat)
 
-	_, err := ssm.Run(e.session, e.instanceId, command)
-	if err != nil {
+	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
 		logger.Error(err, "error uploading diagnostic bundle from instance")
 	} else {
 		logger.V(1).Info("Successfully uploaded diagnostic bundle files to S3")
@@ -229,8 +227,8 @@ func (e *E2ESession) downloadRequiredFilesInInstance() error {
 
 func (e *E2ESession) createTestNameFile(testName string) error {
 	command := fmt.Sprintf("echo %s > %s", testName, testNameFile)
-	_, err := ssm.Run(e.session, e.instanceId, command)
-	if err != nil {
+
+	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
 		return fmt.Errorf("error creating test name file in instance: %v", err)
 	}
 	logger.V(1).Info("Successfully created test name file")


### PR DESCRIPTION
*Description of changes:*
Minor changes to make the logs a bit more readable
* Avoid logging command output by default
* Allow caller to handle output manually
* Log e2e command output from main routine so they are all ordered
* Omit logs for commands like s3 upload and download

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
