### PR TITLE
Remove expired CNCF cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Its goal is to include full lifecycle management of multiple Kubernetes clusters
 Here are the steps for [getting started](https://anywhere.eks.amazonaws.com/docs/getting-started/) with EKS Anywhere.
 Full documentation for releases can be found on [https://anywhere.eks.amazonaws.com](https://anywhere.eks.amazonaws.com/).
 
-[<img src="docs/static/certified-kubernetes-1.20-color.svg" height=150>](https://github.com/cncf/k8s-conformance/pull/1617)
 [<img src="docs/static/certified-kubernetes-1.21-color.svg" height=150>](https://github.com/cncf/k8s-conformance/pull/1605)
 <!-- 
 Source: https://github.com/cncf/artwork/tree/master/projects/kubernetes/certified-kubernetes


### PR DESCRIPTION
K8s 1.20 certificates expire 1/8/2022
