### PR TITLE
Junit reports

### DIFF
--- a/cmd/integration_test/cmd/run.go
+++ b/cmd/integration_test/cmd/run.go
@@ -14,16 +14,17 @@ import (
 )
 
 const (
-	amiIdFlagName           = "ami-id"
-	storageBucketFlagName   = "storage-bucket"
-	jobIdFlagName           = "job-id"
-	instanceProfileFlagName = "instance-profile-name"
-	subnetIdFlagName        = "subnet-id"
-	regexFlagName           = "regex"
-	maxInstancesFlagName    = "max-instances"
-	skipFlagName            = "skip"
-	bundlesOverrideFlagName = "bundles-override"
-	cleanupVmsFlagName      = "cleanup-vms"
+	amiIdFlagName            = "ami-id"
+	storageBucketFlagName    = "storage-bucket"
+	jobIdFlagName            = "job-id"
+	instanceProfileFlagName  = "instance-profile-name"
+	subnetIdFlagName         = "subnet-id"
+	regexFlagName            = "regex"
+	maxInstancesFlagName     = "max-instances"
+	skipFlagName             = "skip"
+	bundlesOverrideFlagName  = "bundles-override"
+	cleanupVmsFlagName       = "cleanup-vms"
+	testReportFolderFlagName = "test-report-folder"
 )
 
 var runE2ECmd = &cobra.Command{
@@ -64,6 +65,7 @@ func init() {
 	runE2ECmd.Flags().StringSlice(skipFlagName, nil, "List of tests to skip")
 	runE2ECmd.Flags().Bool(bundlesOverrideFlagName, false, "Flag to indicate if the tests should run with a bundles override")
 	runE2ECmd.Flags().Bool(cleanupVmsFlagName, false, "Flag to indicate if VSphere VMs should be cleaned up automatically as tests complete")
+	runE2ECmd.Flags().String(testReportFolderFlagName, "", "Folder destination fo JUnit tests reports")
 
 	for _, flag := range requiredFlags {
 		if err := runE2ECmd.MarkFlagRequired(flag); err != nil {
@@ -83,6 +85,7 @@ func runE2E(ctx context.Context) error {
 	testsToSkip := viper.GetStringSlice(skipFlagName)
 	bundlesOverride := viper.GetBool(bundlesOverrideFlagName)
 	cleanupVms := viper.GetBool(cleanupVmsFlagName)
+	testReportFolder := viper.GetString(testReportFolderFlagName)
 
 	runConf := e2e.ParallelRunConf{
 		MaxInstances:        maxInstances,
@@ -95,6 +98,7 @@ func runE2E(ctx context.Context) error {
 		TestsToSkip:         testsToSkip,
 		BundlesOverride:     bundlesOverride,
 		CleanupVms:          cleanupVms,
+		TestReportFolder:    testReportFolder,
 	}
 
 	err := e2e.RunTestsInParallel(runConf)

--- a/internal/pkg/s3/download.go
+++ b/internal/pkg/s3/download.go
@@ -2,6 +2,8 @@ package s3
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -10,15 +12,37 @@ import (
 )
 
 func Download(session *session.Session, key, bucket string) ([]byte, error) {
-	d := s3manager.NewDownloader(session)
 	b := aws.NewWriteAtBuffer([]byte{})
-	_, err := d.Download(b, &s3.GetObjectInput{
+	if err := download(session, key, bucket, b); err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}
+
+func download(session *session.Session, key, bucket string, w io.WriterAt) error {
+	d := s3manager.NewDownloader(session)
+	_, err := d.Download(w, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error downloading [%s] from [%s] bucket: %v", key, bucket, err)
+		return fmt.Errorf("error downloading [%s] from [%s] bucket: %v", key, bucket, err)
 	}
 
-	return b.Bytes(), nil
+	return nil
+}
+
+func DownloadToDisk(session *session.Session, key, bucket, dst string) error {
+	file, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("unable to create destination file %s: %v", dst, err)
+	}
+	defer file.Close()
+
+	if err := download(session, key, bucket, file); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/test/e2e/artifacts.go
+++ b/internal/test/e2e/artifacts.go
@@ -1,0 +1,67 @@
+package e2e
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/aws/eks-anywhere/internal/pkg/s3"
+	"github.com/aws/eks-anywhere/internal/pkg/ssm"
+	"github.com/aws/eks-anywhere/pkg/logger"
+)
+
+func (e *E2ESession) uploadGeneratedFilesFromInstance(testName string) {
+	logger.V(1).Info("Uploading log files to s3 bucket")
+	command := fmt.Sprintf("aws s3 cp /home/e2e/%s/ %s/%s/ --recursive",
+		e.instanceId, e.generatedArtifactsBucketPath(), testName)
+
+	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
+		logger.Error(err, "error uploading log files from instance")
+	} else {
+		logger.V(1).Info("Successfully uploaded log files to S3")
+	}
+}
+
+func (e *E2ESession) uploadDiagnosticArchiveFromInstance(testName string) {
+	bundleNameFormat := "support-bundle-*.tar.gz"
+	logger.V(1).Info("Uploading diagnostic bundle to s3 bucket")
+	command := fmt.Sprintf("aws s3 cp /home/e2e/ %s/%s/ --recursive --exclude \"*\" --include \"%s\"",
+		e.generatedArtifactsBucketPath(), testName, bundleNameFormat)
+
+	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
+		logger.Error(err, "error uploading diagnostic bundle from instance")
+	} else {
+		logger.V(1).Info("Successfully uploaded diagnostic bundle files to S3")
+	}
+}
+
+func (e *E2ESession) uploadJUnitReport(testName string) {
+	junitFile := "junit-testing.xml"
+	logger.V(1).Info("Uploading JUnit report to s3 bucket")
+	command := fmt.Sprintf("aws s3 cp /home/e2e/ %s/%s/ --recursive --exclude \"*\" --include \"%s\"",
+		e.generatedArtifactsBucketPath(), testName, junitFile)
+
+	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
+		logger.Error(err, "error uploading JUnit report from instance")
+	} else {
+		logger.V(1).Info("Successfully uploaded JUnit report files to S3")
+	}
+}
+
+func (e *E2ESession) downloadJUnitReport(testName, destinationFolder string) {
+	junitFile := "junit-testing.xml"
+	key := filepath.Join(e.generatedArtifactsPath(), testName, junitFile)
+	dst := filepath.Join(destinationFolder, fmt.Sprintf("junit-testing-%s.xml", testName))
+
+	logger.V(1).Info("Downloading JUnit report to disk", "dst", dst)
+	if err := s3.DownloadToDisk(e.session, key, e.storageBucket, dst); err != nil {
+		logger.Error(err, "Error downloading JUnit report from s3")
+	}
+}
+
+func (e *E2ESession) generatedArtifactsBucketPath() string {
+	return fmt.Sprintf("s3://%s/%s", e.storageBucket, e.generatedArtifactsPath())
+}
+
+func (e *E2ESession) generatedArtifactsPath() string {
+	return filepath.Join(e.jobId, "generated-artifacts")
+}

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -127,7 +127,8 @@ func RunTests(conf instanceRunConf) (testInstanceID string, testCommandResult *t
 
 func (e *E2ESession) runTests(regex string) (testCommandResult *testCommandResult, err error) {
 	logger.V(1).Info("Running e2e tests", "regex", regex)
-	command := "./bin/e2e.test -test.v"
+	command := "GOVERSION=go1.16.6 gotestsum --junitfile=junit-testing.xml --raw-command --format=standard-verbose --ignore-non-json-output-lines -- test2json -t -p e2e ./bin/e2e.test -test.v"
+
 	if regex != "" {
 		command = fmt.Sprintf("%s -test.run %s", command, regex)
 	}
@@ -145,6 +146,8 @@ func (e *E2ESession) runTests(regex string) (testCommandResult *testCommandResul
 	if err != nil {
 		return nil, fmt.Errorf("error running e2e tests on instance %s: %v", e.instanceId, err)
 	}
+
+	e.uploadJUnitReport(regex)
 
 	if !testCommandResult.Successful() {
 		e.uploadGeneratedFilesFromInstance(regex)
@@ -223,7 +226,7 @@ func logTestGroups(instancesConf []instanceRunConf) {
 }
 
 func logResult(t *testCommandResult) {
-	// Go tests send non-test log output through stderr
-	// So stderr will have the cli output
-	fmt.Println(string(t.StdErr))
+	// Because of the way we run tests with gotestsum and test2json
+	// both cli output and test logs get conveniently combined in stdout
+	fmt.Println(string(t.StdOut))
 }

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -211,6 +211,19 @@ func (e *E2ESession) uploadDiagnosticArchiveFromInstance(testName string) {
 	}
 }
 
+func (e *E2ESession) uploadJUnitReport(testName string) {
+	junitFile := "junit-testing.xml"
+	logger.V(1).Info("Uploading JUnit report to s3 bucket")
+	command := fmt.Sprintf("aws s3 cp /home/e2e/ %s/%s/ --recursive --exclude \"*\" --include \"%s\"",
+		e.generatedArtifactsBucketPath(), testName, junitFile)
+
+	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
+		logger.Error(err, "error uploading JUnit report from instance")
+	} else {
+		logger.V(1).Info("Successfully uploaded JUnit report files to S3")
+	}
+}
+
 func (e *E2ESession) generatedArtifactsBucketPath() string {
 	return fmt.Sprintf("s3://%s/%s/generated-artifacts", e.storageBucket, e.jobId)
 }

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -186,48 +186,6 @@ func (e *E2ESession) downloadRequiredFileInInstance(file string) error {
 	return nil
 }
 
-func (e *E2ESession) uploadGeneratedFilesFromInstance(testName string) {
-	logger.V(1).Info("Uploading log files to s3 bucket")
-	command := fmt.Sprintf("aws s3 cp /home/e2e/%s/ %s/%s/ --recursive",
-		e.instanceId, e.generatedArtifactsBucketPath(), testName)
-
-	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
-		logger.Error(err, "error uploading log files from instance")
-	} else {
-		logger.V(1).Info("Successfully uploaded log files to S3")
-	}
-}
-
-func (e *E2ESession) uploadDiagnosticArchiveFromInstance(testName string) {
-	bundleNameFormat := "support-bundle-*.tar.gz"
-	logger.V(1).Info("Uploading diagnostic bundle to s3 bucket")
-	command := fmt.Sprintf("aws s3 cp /home/e2e/ %s/%s/ --recursive --exclude \"*\" --include \"%s\"",
-		e.generatedArtifactsBucketPath(), testName, bundleNameFormat)
-
-	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
-		logger.Error(err, "error uploading diagnostic bundle from instance")
-	} else {
-		logger.V(1).Info("Successfully uploaded diagnostic bundle files to S3")
-	}
-}
-
-func (e *E2ESession) uploadJUnitReport(testName string) {
-	junitFile := "junit-testing.xml"
-	logger.V(1).Info("Uploading JUnit report to s3 bucket")
-	command := fmt.Sprintf("aws s3 cp /home/e2e/ %s/%s/ --recursive --exclude \"*\" --include \"%s\"",
-		e.generatedArtifactsBucketPath(), testName, junitFile)
-
-	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
-		logger.Error(err, "error uploading JUnit report from instance")
-	} else {
-		logger.V(1).Info("Successfully uploaded JUnit report files to S3")
-	}
-}
-
-func (e *E2ESession) generatedArtifactsBucketPath() string {
-	return fmt.Sprintf("s3://%s/%s/generated-artifacts", e.storageBucket, e.jobId)
-}
-
 func (e *E2ESession) downloadRequiredFilesInInstance() error {
 	for _, file := range e.requiredFiles {
 		err := e.downloadRequiredFileInInstance(file)


### PR DESCRIPTION
*Description of changes:*
* Generate Junit reports per instance
* Upload reports to s3, under generated artifacts
* Optionally download artifacts locally, all in one folder and with unique names. We could use this to integrate with codebuild and prow reporting

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
