### PR TITLE
Update vsphere.md

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/vsphere.md
+++ b/docs/content/en/docs/reference/clusterspec/vsphere.md
@@ -142,7 +142,7 @@ The Kubernetes version you want to use for your cluster. Supported values: `1.20
 ## VSphereDatacenterConfig Fields
 
 ### datacenter (required)
-The vSphere datacenter to deploy the EKS Anywhere cluster on. For example `SDDC-Datacenter`.
+The vSphere datacenter to deploy the EKS Anywhere cluster on. For example `SDDC-Datacenter`. Note: It's required to add double quotes around the datacenter name in case it has a space in the name of it, example "datacenter one".
 
 ### network (required)
 The VM network to deploy your EKS Anywhere cluster on.

--- a/docs/content/en/docs/reference/clusterspec/vsphere.md
+++ b/docs/content/en/docs/reference/clusterspec/vsphere.md
@@ -142,7 +142,7 @@ The Kubernetes version you want to use for your cluster. Supported values: `1.20
 ## VSphereDatacenterConfig Fields
 
 ### datacenter (required)
-The vSphere datacenter to deploy the EKS Anywhere cluster on. For example `SDDC-Datacenter`. Note: It's required to add double quotes around the datacenter name in case it has a space in the name of it, example "datacenter one".
+The vSphere datacenter to deploy the EKS Anywhere cluster on. For example `SDDC-Datacenter`. Add double quotes around the datacenter name if there is a space in its name, such as "datacenter one".
 
 ### network (required)
 The VM network to deploy your EKS Anywhere cluster on.


### PR DESCRIPTION
It's required to add double quotes around the datacenter name in case it has a space in the name of it, example "datacenter one".

*Issue #, if available:*

*Description of changes:*
It's required to add double quotes around the datacenter name in case it has a space in the name of it, example "datacenter one".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
