### PR TITLE
Do not push tag to ECR public if it already exists

### DIFF
--- a/release/pkg/prepare_release.go
+++ b/release/pkg/prepare_release.go
@@ -379,9 +379,15 @@ func (r *ReleaseConfig) UploadArtifacts(eksArtifacts map[string][]Artifact) erro
 				releaseImageUri := artifact.Image.ReleaseImageURI
 				fmt.Printf("Source Image - %s\n", sourceImageUri)
 				fmt.Printf("Destination Image - %s\n", releaseImageUri)
-				err := images.CopyToDestination(sourceEcrAuthConfig, releaseEcrAuthConfig, sourceImageUri, releaseImageUri)
+				exists, err := ecrpublic.CheckImageExistence(releaseImageUri, r.ReleaseContainerRegistry, r.ReleaseClients.ECRPublic.Client)
 				if err != nil {
 					return errors.Cause(err)
+				}
+				if !exists {
+					err := images.CopyToDestination(sourceEcrAuthConfig, releaseEcrAuthConfig, sourceImageUri, releaseImageUri)
+					if err != nil {
+						return errors.Cause(err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR adds logic to prevent an existing image tag from being inadvertently pushed to ECR Public.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
