### PR TITLE
Add cert-manager manifest to bundle

### DIFF
--- a/release/api/v1alpha1/bundle_types.go
+++ b/release/api/v1alpha1/bundle_types.go
@@ -126,11 +126,12 @@ type BottlerocketAdminBundle struct {
 }
 
 type CertManagerBundle struct {
-	Version    string `json:"version,omitempty"`
-	Acmesolver Image  `json:"acmesolver"`
-	Cainjector Image  `json:"cainjector"`
-	Controller Image  `json:"controller"`
-	Webhook    Image  `json:"webhook"`
+	Version    string   `json:"version,omitempty"`
+	Acmesolver Image    `json:"acmesolver"`
+	Cainjector Image    `json:"cainjector"`
+	Controller Image    `json:"controller"`
+	Webhook    Image    `json:"webhook"`
+	Manifest   Manifest `json:"manifest"`
 }
 
 type CoreClusterAPI struct {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Splitting up bundle release logic and actually consuming the manifest from the following PR: https://github.com/aws/eks-anywhere/pull/914

This can't be merged until the artifact gets uploaded from this: https://github.com/aws/eks-anywhere-build-tooling/pull/320

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
