### PR TITLE
Add cert-manager manifest from bundle

### DIFF
--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -74,6 +74,12 @@ func buildOverridesLayer(clusterSpec *cluster.Spec, clusterName string, provider
 
 	infraBundles := []types.InfrastructureBundle{
 		{
+			FolderName: filepath.Join("cert-manager", bundle.CertManager.Version),
+			Manifests: []v1alpha1.Manifest{
+				bundle.CertManager.Manifest,
+			},
+		},
+		{
 			FolderName: filepath.Join("bootstrap-kubeadm", bundle.Bootstrap.Version),
 			Manifests: []v1alpha1.Manifest{
 				bundle.Bootstrap.Components,

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -426,7 +426,10 @@ var versionBundle = &cluster.VersionsBundle{
 			Webhook: v1alpha1.Image{
 				URI: "public.ecr.aws/l0g8r8j6/jetstack/cert-manager-webhook:v1.1.0",
 			},
-			Version: "v1.1.0+88d7476",
+			Manifest: v1alpha1.Manifest{
+				URI: "testdata/fake_manifest.yaml",
+			},
+			Version: "v1.5.3",
 		},
 		ClusterAPI: v1alpha1.CoreClusterAPI{
 			Version: "v0.3.19",

--- a/pkg/executables/config/clusterctl.yaml
+++ b/pkg/executables/config/clusterctl.yaml
@@ -99,4 +99,5 @@ images:
     tag: {{ .EtcdadmControllerKubeRbacProxyTag }} #org one is v0.4.0
 cert-manager:
   timeout: 30m
+  url: "{{.dir}}/cert-manager/{{.CertManagerVersion}}/cert-manager.yaml"
 cert-manager-version: {{.CertManagerVersion}}

--- a/pkg/executables/testdata/clusterctl_expected.yaml
+++ b/pkg/executables/testdata/clusterctl_expected.yaml
@@ -93,4 +93,5 @@ images:
     tag: v0.8.0-25df7d96779e2a305a22c6e3f9425c3465a77244 #org one is v0.4.0
 cert-manager:
   timeout: 30m
-cert-manager-version: v1.1.0+88d7476
+  url: "{{.dir}}/cluster-name/generated/overrides/cert-manager/v1.5.3/cert-manager.yaml"
+cert-manager-version: v1.5.3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

These include the changes to actually consume the new cert-manager.yaml manifest file, following up from this PR: https://github.com/aws/eks-anywhere/pull/914

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
