### PR TITLE
Specify version for cert-manager overrides

### DIFF
--- a/pkg/executables/config/clusterctl.yaml
+++ b/pkg/executables/config/clusterctl.yaml
@@ -100,4 +100,4 @@ images:
 cert-manager:
   timeout: 30m
   url: "{{.dir}}/cert-manager/{{.CertManagerVersion}}/cert-manager.yaml"
-cert-manager-version: {{.CertManagerVersion}}
+  version: {{.CertManagerVersion}}

--- a/pkg/executables/testdata/clusterctl_expected.yaml
+++ b/pkg/executables/testdata/clusterctl_expected.yaml
@@ -94,4 +94,4 @@ images:
 cert-manager:
   timeout: 30m
   url: "{{.dir}}/cluster-name/generated/overrides/cert-manager/v1.5.3/cert-manager.yaml"
-cert-manager-version: v1.5.3
+  version: v1.5.3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
cert-manager.yaml gets downloaded at path `"{{.dir}}/cert-manager/{{.CertManagerVersion}}/cert-manager.yaml"`, where CertManagerVersion is the one from bundle-release so it ends up being a semver tag instead of the git tag. This PR specifies the cert manager version in the overrides section for clusterctl as per [the docs](https://cluster-api.sigs.k8s.io/clusterctl/configuration.html#cert-manager-configuration)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
