### PR TITLE
Cleanup s3 copy commands in e2e setup code

### DIFF
--- a/internal/test/e2e/commands.go
+++ b/internal/test/e2e/commands.go
@@ -1,0 +1,40 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+)
+
+type copyCommand string
+
+func newCopyCommand() copyCommand {
+	return "aws s3 cp"
+}
+
+func (c copyCommand) String() string {
+	return string(c)
+}
+
+func (c copyCommand) addOption(opt string) copyCommand {
+	return copyCommand(fmt.Sprintf("%s %s", string(c), opt))
+}
+
+func (c copyCommand) from(p ...string) copyCommand {
+	return c.addOption(strings.Join(p, "/"))
+}
+
+func (c copyCommand) to(p ...string) copyCommand {
+	return c.addOption(strings.Join(p, "/"))
+}
+
+func (c copyCommand) recursive() copyCommand {
+	return c.addOption("--recursive")
+}
+
+func (c copyCommand) exclude(v string) copyCommand {
+	return c.addOption(fmt.Sprintf("--exclude \"%s\"", v))
+}
+
+func (c copyCommand) include(v string) copyCommand {
+	return c.addOption(fmt.Sprintf("--include \"%s\"", v))
+}

--- a/internal/test/e2e/commands_test.go
+++ b/internal/test/e2e/commands_test.go
@@ -1,0 +1,43 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCopyCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		c    copyCommand
+		want string
+	}{
+		{
+			name: "simple upload",
+			c: newCopyCommand().from(
+				"/home/path", "user",
+			).to("s3://bucket", "path"),
+			want: "aws s3 cp /home/path/user s3://bucket/path",
+		},
+		{
+			name: "simple download",
+			c: newCopyCommand().from(
+				"s3://bucket", "path",
+			).to("/home/path", "user"),
+			want: "aws s3 cp s3://bucket/path /home/path/user",
+		},
+		{
+			name: "recursive upload exclude everything include file pattern",
+			c: newCopyCommand().from("/home/e2e/").to(
+				"s3://bucket", "path", "path2/",
+			).recursive().exclude("*").include("support-bundle-*.tar.gz"),
+			want: "aws s3 cp /home/e2e/ s3://bucket/path/path2/ --recursive --exclude \"*\" --include \"support-bundle-*.tar.gz\"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.c.String()).To(Equal(tt.want), "String() should return the proper built s3 copy command")
+		})
+	}
+}

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -163,9 +163,9 @@ func (e *E2ESession) runTests(regex string) (testCommandResult *testCommandResul
 }
 
 func (c instanceRunConf) runPostTestsProcessing(e *E2ESession, testCommandResult *testCommandResult) error {
-	e.uploadJUnitReport(c.regex)
+	e.uploadJUnitReportFromInstance(c.regex)
 	if c.testReportFolder != "" {
-		e.downloadJUnitReport(c.regex, c.testReportFolder)
+		e.downloadJUnitReportToLocalDisk(c.regex, c.testReportFolder)
 	}
 
 	if !testCommandResult.Successful() {


### PR DESCRIPTION
*Description of changes:*
Following up on [this](https://github.com/aws/eks-anywhere/pull/901#discussion_r778315004)
Just minor refactor, dry a bit constants and add a builder for the s3 copy commands

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
