### PR TITLE
Remove usage of deprecated clusterctl flag management-group

### DIFF
--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -316,7 +316,6 @@ func (c *Clusterctl) Upgrade(ctx context.Context, managementCluster *types.Clust
 	upgradeCommand := []string{
 		"upgrade", "apply",
 		"--config", clusterctlConfig.configFile,
-		"--management-group", "capi-system/cluster-api",
 		"--kubeconfig", managementCluster.KubeconfigFile,
 	}
 

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -328,7 +328,6 @@ func TestClusterctlUpgradeAllProvidersSucess(t *testing.T) {
 	tt.e.EXPECT().ExecuteWithEnv(tt.ctx, tt.providerEnvMap,
 		"upgrade", "apply",
 		"--config", test.OfType("string"),
-		"--management-group", "capi-system/cluster-api",
 		"--kubeconfig", tt.cluster.KubeconfigFile,
 		"--control-plane", "capi-kubeadm-control-plane-system/kubeadm:v0.3.19",
 		"--core", "capi-system/cluster-api:v0.3.19",
@@ -356,7 +355,6 @@ func TestClusterctlUpgradeInfrastructureProvidersSucess(t *testing.T) {
 	tt.e.EXPECT().ExecuteWithEnv(tt.ctx, tt.providerEnvMap,
 		"upgrade", "apply",
 		"--config", test.OfType("string"),
-		"--management-group", "capi-system/cluster-api",
 		"--kubeconfig", tt.cluster.KubeconfigFile,
 		"--infrastructure", "capv-system/vsphere:v0.4.1",
 	)
@@ -379,7 +377,6 @@ func TestClusterctlUpgradeInfrastructureProvidersError(t *testing.T) {
 	tt.e.EXPECT().ExecuteWithEnv(tt.ctx, tt.providerEnvMap,
 		"upgrade", "apply",
 		"--config", test.OfType("string"),
-		"--management-group", "capi-system/cluster-api",
 		"--kubeconfig", tt.cluster.KubeconfigFile,
 		"--infrastructure", "capv-system/vsphere:v0.4.1",
 	).Return(bytes.Buffer{}, errors.New("error in exec"))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cluster API 1.0.1 removes usage of management-group flag from clusterctl as a part of [this](https://github.com/kubernetes-sigs/cluster-api/pull/4668) PR.
Earlier eks-a was setting management-group to capi-system/cluster-api to indicate that's the core provider group that should be updated. The above linked PR from capi does it by default, so there's no replacement needed for this flag

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
