### PR TITLE
(#743) support passing multiple ips to cluster tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ eksa-test
 generated/
 eks-anywhere-downloads*
 hardware-manifests/
+*.env

--- a/internal/test/e2e/ipmanager.go
+++ b/internal/test/e2e/ipmanager.go
@@ -22,12 +22,28 @@ func newE2EIPManager(networkCidr, privateNetworkCidr string) *E2EIPManager {
 	return ipman
 }
 
-func (ipman *E2EIPManager) getIP() string {
+func (ipman *E2EIPManager) reserveIP() string {
 	return getUniqueIP(ipman.vspherenetworkCidr, ipman.vsphereNetworkIPs)
 }
 
-func (ipMan *E2EIPManager) getPrivateIP() string {
+func (ipMan *E2EIPManager) reservePrivateIP() string {
 	return getUniqueIP(ipMan.privateNetworkCidr, ipMan.privateNetworkIPs)
+}
+
+func (ipman *E2EIPManager) reservePrivateIPPool(count int) networkutils.IPPool {
+	pool := networkutils.NewIPPool()
+	for i := 0; i < count; i++ {
+		pool.AddIP(ipman.reservePrivateIP())
+	}
+	return pool
+}
+
+func (ipman *E2EIPManager) reserveIPPool(count int) networkutils.IPPool {
+	pool := networkutils.NewIPPool()
+	for i := 0; i < count; i++ {
+		pool.AddIP(ipman.reserveIP())
+	}
+	return pool
 }
 
 func getUniqueIP(cidr string, usedIPs map[string]bool) string {

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/pkg/s3"
 	"github.com/aws/eks-anywhere/internal/pkg/ssm"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/networkutils"
 	e2etests "github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -33,7 +34,7 @@ type E2ESession struct {
 	jobId               string
 	subnetId            string
 	instanceId          string
-	controlPlaneIP      string
+	ipPool              networkutils.IPPool
 	testEnvVars         map[string]string
 	bundlesOverride     bool
 	requiredFiles       []string
@@ -53,7 +54,7 @@ func newSessionFromConf(conf instanceRunConf) (*E2ESession, error) {
 		storageBucket:       conf.storageBucket,
 		jobId:               conf.jobId,
 		subnetId:            conf.subnetId,
-		controlPlaneIP:      conf.controlPlaneIP,
+		ipPool:              conf.ipPool,
 		testEnvVars:         make(map[string]string),
 		bundlesOverride:     conf.bundlesOverride,
 		requiredFiles:       requiredFiles,

--- a/internal/test/e2e/vsphere.go
+++ b/internal/test/e2e/vsphere.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	vsphereHostVar        = "T_VSPHERE_HOST"
 	cidrVar               = "T_VSPHERE_CIDR"
 	privateNetworkCidrVar = "T_VSPHERE_PRIVATE_NETWORK_CIDR"
 	vsphereRegex          = `^.*VSphere.*$`
@@ -32,9 +31,8 @@ func (e *E2ESession) setupVSphereEnv(testRegex string) error {
 			e.testEnvVars[eVar] = val
 		}
 	}
-	if e.controlPlaneIP != "" {
-		e.testEnvVars[vsphereHostVar] = e.controlPlaneIP
-	}
+
+	e.testEnvVars[e2etests.ClusterIPPoolEnvVar] = e.ipPool.ToString()
 
 	return nil
 }

--- a/pkg/networkutils/ippool.go
+++ b/pkg/networkutils/ippool.go
@@ -1,0 +1,61 @@
+package networkutils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type IPPool []string
+
+func NewIPPool() IPPool {
+	return IPPool{}
+}
+
+func NewIPPoolFromString(fromString string) IPPool {
+	return IPPool(strings.Split(fromString, ","))
+}
+
+func NewIPPoolFromEnv(ipPoolEnvVar string) (IPPool, error) {
+	value, ok := os.LookupEnv(ipPoolEnvVar)
+	if !ok {
+		return NewIPPool(), fmt.Errorf("%s environment ip pool does not exist", ipPoolEnvVar)
+	}
+	if value != "" {
+		return NewIPPoolFromString(value), nil
+	}
+	return NewIPPool(), nil
+}
+
+func (ipPool *IPPool) ToString() string {
+	return strings.Join(*ipPool, ",")
+}
+
+func (ipPool *IPPool) IsEmpty() bool {
+	return len(*ipPool) == 0
+}
+
+func (ipPool *IPPool) AddIP(ip string) {
+	*ipPool = append(*ipPool, ip)
+}
+
+func (ipPool *IPPool) PopIP() (string, error) {
+	if ipPool.IsEmpty() {
+		return "", errors.New("ip pool is empty")
+	} else {
+		index := len(*ipPool) - 1
+		ip := (*ipPool)[index]
+		*ipPool = (*ipPool)[:index]
+		return ip, nil
+	}
+}
+
+func (ipPool *IPPool) ToEnvVar(envVarName string) error {
+	s := ipPool.ToString()
+	err := os.Setenv(envVarName, s)
+	if err != nil {
+		return fmt.Errorf("failed to set the ip pool env var %s to value %s", envVarName, s)
+	}
+	return nil
+}

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -7,6 +7,16 @@ make e2e
 ```
 or
 ```sh
+# Create a .env file at the root of the repo with all the required envs vars listed below
+#
+# The makefile will include the .env file and export all the vars to the environment for you
+#
+# By default the local-e2e target will run TestDockerKubernetes121SimpleFlow. You can either 
+#   override LOCAL_E2E_TESTS in your .env file or pass it on the cli every time (i.e LOCAL_E2E_TESTS=TestDockerKubernetes121SimpleFlow)
+make local-e2e
+```
+or
+```sh
 go test -tags e2e -run [test name regex]
 ```
 
@@ -30,6 +40,7 @@ VSPHERE_USERNAME
 VSPHERE_PASSWORD
 T_VSPHERE_CIDR
 GOVC_URL
+T_CLUSTER_IP_POOL
 ```
 
 # OIDC tests requisites

--- a/test/e2e/upgrade_from_latest_test.go
+++ b/test/e2e/upgrade_from_latest_test.go
@@ -1,4 +1,3 @@
-//go:build e2e
 // +build e2e
 
 package e2e

--- a/test/e2e/workload_clusters_test.go
+++ b/test/e2e/workload_clusters_test.go
@@ -31,15 +31,15 @@ func runWorkloadClusterFlowWithGitOps(test *framework.MulticlusterE2ETest, clust
 	test.DeleteManagementCluster()
 }
 
-func TestVSphereKubernetes121WorkloadClusterDemo(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu120())
+func TestVSphereKubernetes121MulticlusterWorkloadClusterDemo(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithUbuntu121())
 	test := framework.NewMulticlusterE2ETest(
 		t,
 		framework.NewClusterE2ETest(
 			t,
 			provider,
 			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube120),
+				api.WithKubernetesVersion(v1alpha1.Kube121),
 				api.WithControlPlaneCount(1),
 				api.WithWorkerNodeCount(1),
 				api.WithStackedEtcdTopology(),
@@ -49,7 +49,7 @@ func TestVSphereKubernetes121WorkloadClusterDemo(t *testing.T) {
 			t,
 			provider,
 			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube120),
+				api.WithKubernetesVersion(v1alpha1.Kube121),
 				api.WithControlPlaneCount(1),
 				api.WithWorkerNodeCount(1),
 				api.WithStackedEtcdTopology(),
@@ -59,7 +59,7 @@ func TestVSphereKubernetes121WorkloadClusterDemo(t *testing.T) {
 	runWorkloadClusterFlow(test)
 }
 
-func TestVSphereUpgradeWorkloadClusterWithFlux(t *testing.T) {
+func TestVSphereUpgradeMulticlusterWorkloadClusterWithFlux(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu120())
 	test := framework.NewMulticlusterE2ETest(
 		t,

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -36,6 +36,7 @@ const (
 	eksctlVersionEnvVar              = "EKSCTL_VERSION"
 	eksctlVersionEnvVarDummyVal      = "ham sandwich"
 	ClusterNameVar                   = "T_CLUSTER_NAME"
+	ClusterIPPoolEnvVar              = "T_CLUSTER_IP_POOL"
 	JobIdVar                         = "T_JOB_ID"
 	BundlesOverrideVar               = "T_BUNDLES_OVERRIDE"
 )

--- a/test/framework/ippool.go
+++ b/test/framework/ippool.go
@@ -1,0 +1,28 @@
+package framework
+
+import (
+	"fmt"
+
+	"github.com/aws/eks-anywhere/pkg/networkutils"
+)
+
+func PopIPFromEnv(ipPoolEnvVar string) (string, error) {
+	ipPool, err := networkutils.NewIPPoolFromEnv(ipPoolEnvVar)
+	if err != nil {
+		return "", fmt.Errorf("error popping IP from environment: %v", err)
+	}
+
+	ip, popErr := ipPool.PopIP()
+	if popErr != nil {
+		return "", fmt.Errorf("failed to get an ip address from the cluster ip pool env var %s: %v", ipPoolEnvVar, popErr)
+	}
+
+	// PopIPFromEnv will remove the ip from the pool.
+	// Therefore, we rewrite the envvar to the system so the next caller can pick from remaining ips in the pool
+	err = ipPool.ToEnvVar(ipPoolEnvVar)
+	if err != nil {
+		return "", fmt.Errorf("error popping IP from environment: %v", err)
+	}
+
+	return ip, nil
+}


### PR DESCRIPTION
#743 

Update the test run to provide a pool of ips for cluster tests. Each test ec2 instance gets an ippool of ip addresses seeded via an env var reserved for the test clusters created by that e2e test session.

This PR is still in progress, but I needed to submit PR in order to get feedback from the CI to test e2e with ippool.






By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
