### PR TITLE
Readd cilium helm chart to bundle

### DIFF
--- a/release/pkg/assets_cilium.go
+++ b/release/pkg/assets_cilium.go
@@ -17,6 +17,7 @@ package pkg
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -27,7 +28,10 @@ const (
 	ciliumProjectPath       = "projects/cilium/cilium"
 	ciliumImageName         = "cilium"
 	ciliumOperatorImageName = "operator-generic"
-	ciliumHelmChartName     = "cilium"
+	ciliumHelmChartName     = "cilium-chart"
+	ciliumHelmChart         = "cilium"
+	ciliumImage             = "cilium"
+	ciliumOperatorImage     = "operator-generic"
 )
 
 // GetCiliumAssets returns the eks-a artifacts for Cilium
@@ -89,11 +93,11 @@ func (r *ReleaseConfig) GetCiliumBundle() (anywherev1alpha1.CiliumBundle, error)
 		return anywherev1alpha1.CiliumBundle{}, errors.Cause(err)
 	}
 	ciliumImages := []imageDefinition{
-		containerImage(ciliumImageName, ciliumContainerRegistry, ciliumGitTag),
-		containerImage(ciliumOperatorImageName, ciliumContainerRegistry, ciliumGitTag),
+		containerImage(ciliumImageName, ciliumImage, ciliumContainerRegistry, ciliumGitTag),
+		containerImage(ciliumOperatorImageName, ciliumOperatorImage, ciliumContainerRegistry, ciliumGitTag),
 		// Helm charts are in the same repository and have the same
 		// sem version as the corresponding container image but omiting the initial "v"
-		// chart(ciliumHelmChartName, ciliumContainerRegistry, strings.TrimPrefix(ciliumGitTag, "v")),
+		chart(ciliumHelmChartName, ciliumHelmChart, ciliumContainerRegistry, strings.TrimPrefix(ciliumGitTag, "v")),
 	}
 
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
@@ -120,11 +124,11 @@ func (r *ReleaseConfig) GetCiliumBundle() (anywherev1alpha1.CiliumBundle, error)
 	}
 
 	bundle := anywherev1alpha1.CiliumBundle{
-		Version:  ciliumGitTag,
-		Cilium:   bundleImageArtifacts[ciliumImageName],
-		Operator: bundleImageArtifacts[ciliumOperatorImageName],
-		Manifest: bundleManifestArtifacts["cilium.yaml"],
-		// HelmChart: bundleImageArtifacts[ciliumHelmChartName],
+		Version:   ciliumGitTag,
+		Cilium:    bundleImageArtifacts[ciliumImageName],
+		Operator:  bundleImageArtifacts[ciliumOperatorImageName],
+		Manifest:  bundleManifestArtifacts["cilium.yaml"],
+		HelmChart: bundleImageArtifacts[ciliumHelmChartName],
 	}
 
 	return bundle, nil
@@ -143,15 +147,16 @@ func (r *ReleaseConfig) getCiliumImageDigest(imageName string) (string, error) {
 }
 
 type imageDefinition struct {
-	name, registry, tag string
-	builder             imageBuilder
+	name, image, registry, tag string
+	builder                    imageBuilder
 }
 
 type imageBuilder func(digest string) anywherev1alpha1.Image
 
-func containerImage(name, registry, tag string) imageDefinition {
+func containerImage(name, image, registry, tag string) imageDefinition {
 	return imageDefinition{
 		name:     name,
+		image:    image,
 		registry: registry,
 		tag:      tag,
 		builder: func(digest string) anywherev1alpha1.Image {
@@ -160,23 +165,24 @@ func containerImage(name, registry, tag string) imageDefinition {
 				Description: fmt.Sprintf("Container image for %s image", name),
 				OS:          "linux",
 				Arch:        []string{"amd64"},
-				URI:         fmt.Sprintf("%s/%s:%s", registry, name, tag),
+				URI:         fmt.Sprintf("%s/%s:%s", registry, image, tag),
 				ImageDigest: digest,
 			}
 		},
 	}
 }
 
-func chart(name, registry, tag string) imageDefinition {
+func chart(name, image, registry, tag string) imageDefinition {
 	return imageDefinition{
 		name:     name,
+		image:    image,
 		registry: registry,
 		tag:      tag,
 		builder: func(digest string) anywherev1alpha1.Image {
 			return anywherev1alpha1.Image{
 				Name:        name,
 				Description: fmt.Sprintf("Helm chart for %s", name),
-				URI:         fmt.Sprintf("%s/%s:%s", registry, name, tag),
+				URI:         fmt.Sprintf("%s/%s:%s", registry, image, tag),
 				ImageDigest: digest,
 			}
 		},


### PR DESCRIPTION
*Description of changes:*
Readds the chart to the bundle after the build tooling repo has been updated with support for it

Also make a distcition between name and image for the image artifacts since the chart and the cilium image have the same image name (just a different tag). When using the image as the map key, we got some overlapping.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
