### PR TITLE
Remove unnecessary build tags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,9 +5,6 @@ run:
   skip-dirs:
   - ".*/mocks"
   - "controllers/tilt_modules"
-  build-tags:
-  - exclude_graphdriver_btrfs
-  - exclude_graphdriver_devicemapper
 linters:
   enable:
     - gofumpt

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ KUSTOMIZATION_CONFIG=./config/prod/kustomization.yaml
 CONTROLLER_MANIFEST_OUTPUT_DIR=$(OUTPUT_DIR)/manifests/cluster-controller
 
 # This removes the compile dependency on C libraries from github.com/containers/storage which is imported by github.com/replicatedhq/troubleshoot
-BUILD_TAGS := exclude_graphdriver_btrfs exclude_graphdriver_devicemapper
+BUILD_TAGS :=
 
 GO_ARCH:=$(shell go env GOARCH)
 GO_OS:=$(shell go env GOOS)


### PR DESCRIPTION
*Description of changes:*
This was only needed when importing throubleshoot as a module

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
