### PR TITLE
Delete TestEksa060LatestPatchDockerKubernetes121SimpleFlow test

### DIFF
--- a/test/e2e/simpleflow_test.go
+++ b/test/e2e/simpleflow_test.go
@@ -43,17 +43,6 @@ func TestDockerKubernetes121SimpleFlow(t *testing.T) {
 	runSimpleFlow(test)
 }
 
-func TestEksa060LatestPatchDockerKubernetes121SimpleFlow(t *testing.T) {
-
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithLatestMinorReleaseFromVersion(framework.Eksa060()),
-	)
-	runSimpleFlow(test)
-}
-
 func TestVSphereKubernetes120SimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,


### PR DESCRIPTION
because the new dns field makes new specs incompatible with old CLIs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
