### PR TITLE
Remove analyzers for `capi-webhook-system` namespace, as it's been re…

### DIFF
--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -52,10 +52,6 @@ func (a *analyzerFactory) managementClusterDeploymentAnalyzers() []*Analyze {
 	d := []eksaDeployment{
 		{
 			Name:             "capv-controller-manager",
-			Namespace:        constants.CapiWebhookSystemNamespace,
-			ExpectedReplicas: 1,
-		}, {
-			Name:             "capv-controller-manager",
 			Namespace:        constants.CapvSystemNamespace,
 			ExpectedReplicas: 1,
 		}, {
@@ -69,18 +65,6 @@ func (a *analyzerFactory) managementClusterDeploymentAnalyzers() []*Analyze {
 		}, {
 			Name:             "cert-manager",
 			Namespace:        constants.CertManagerNamespace,
-			ExpectedReplicas: 1,
-		}, {
-			Name:             "capi-kubeadm-control-plane-controller-manager",
-			Namespace:        constants.CapiWebhookSystemNamespace,
-			ExpectedReplicas: 1,
-		}, {
-			Name:             "capi-kubeadm-bootstrap-controller-manager",
-			Namespace:        constants.CapiWebhookSystemNamespace,
-			ExpectedReplicas: 1,
-		}, {
-			Name:             "capi-controller-manager",
-			Namespace:        constants.CapiWebhookSystemNamespace,
 			ExpectedReplicas: 1,
 		}, {
 			Name:             "capi-controller-manager",


### PR DESCRIPTION
…moved in CAPI v1beta1

Additionally, there is a bug in upstream Troubleshoot which casues a panic if the namespace for a deplyoment it's analyzing does not exist. This issue was revealed by the removal of the `capi-webhook-system` namespace by the migration to v1beta1 CAPI.
Working on an upstream fix to Troubleshoot support-bundle.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
