### PR TITLE
Add necessary controller permissions for v1beta1 capi manifests

### DIFF
--- a/config/rbac/manager_extraroles_patch.yaml
+++ b/config/rbac/manager_extraroles_patch.yaml
@@ -2,16 +2,16 @@
   path: /rules/-
   value:
     apiGroups:
-    - cluster.x-k8s.io
+      - cluster.x-k8s.io
     resources:
-    - clusters
-    - clusters/status
+      - clusters
+      - clusters/status
     verbs:
-    - get
-    - list
-    - patch
-    - update
-    - watch
+      - get
+      - list
+      - patch
+      - update
+      - watch
 - op: add
   path: /rules/-
   value:
@@ -114,10 +114,127 @@
       - configmaps/status
       - namespaces
       - namespaces/status
+      - services
+      - services/status
     verbs:
       - get
       - list
       - patch
       - update
       - watch
+      - create
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterroles/status
+      - clusterrolebindings
+      - clusterrolebindings/status
+      - rolebindings
+      - rolebindings/status
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - create
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - daemonsets/status
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - create
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - '*'
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
       - create

--- a/config/rbac/manager_extraroles_patch.yaml
+++ b/config/rbac/manager_extraroles_patch.yaml
@@ -193,6 +193,7 @@
       - ""
     resources:
       - serviceaccounts
+      - endpoints
     verbs:
       - create
       - get
@@ -207,19 +208,6 @@
     resources:
       - persistentvolumes
     verbs:
-      - get
-      - list
-      - watch
-      - update
-- op: add
-  path: /rules/-
-  value:
-    apiGroups:
-      - ""
-    resources:
-      - endpoints
-    verbs:
-      - create
       - get
       - list
       - watch


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Controller needs additional permissions based on the new v1beta1 cpi manifest changes for capi.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
