### PR TITLE
Add warning in docs to warn users to not power on the OVA directly

### DIFF
--- a/docs/content/en/docs/reference/vsphere/customize-ovas.md
+++ b/docs/content/en/docs/reference/vsphere/customize-ovas.md
@@ -97,7 +97,17 @@ Once the VM is powered on and fetches an IP address, ssh into the VM using your 
 ssh -i <private-key-file> username@<VM-IP>
 ```
 
-Make desired config changes on the VM 
+Make desired config changes on the VM
+
+### Reset the machine-id and power off the VM
+
+This step in needed because of a [known issue in Ubuntu](https://kb.vmware.com/s/article/82229) which results in the clone VMs getting the same DHCP IP
+
+```
+echo -n > /etc/machine-id
+rm /var/lib/dbus/machine-id
+ln -s /etc/machine-id /var/lib/dbus/machine-id
+```
 
 Power the VM down
 
@@ -105,13 +115,18 @@ Power the VM down
 govc vm.power -off "$VM"
 ```
 
-Take a snapshot of the VM (It is highly recommended that you snapshot the VM. This will reduce the time it takes to provision machines and cluster creation will be faster. If you prefer not to take snapshot, skip this step. If you do not snapshot the VM, you will not be able to customize the disk size on your cluster VMs)
+### Take a snapshot of the VM 
+
+It is recommended to take a snapshot the VM as it reduces the provisioning time for the machines and makes cluster creation faster.
+
+If you do snapshot the VM, you will not be able to customize the disk size of your cluster VMs. If you prefer not to take a snapshot, skip this step.
+
 
 ```
 govc snapshot.create -vm "$VM" root
 ```
 
-Convert VM to template
+### Convert VM to template
 
 ```
 govc vm.markastemplate $VM

--- a/docs/content/en/docs/reference/vsphere/customize-ovas.md
+++ b/docs/content/en/docs/reference/vsphere/customize-ovas.md
@@ -117,7 +117,7 @@ govc vm.power -off "$VM"
 
 ### Take a snapshot of the VM 
 
-It is recommended to take a snapshot the VM as it reduces the provisioning time for the machines and makes cluster creation faster.
+It is recommended to take a snapshot of the VM as it reduces the provisioning time for the machines and makes cluster creation faster.
 
 If you do snapshot the VM, you will not be able to customize the disk size of your cluster VMs. If you prefer not to take a snapshot, skip this step.
 

--- a/docs/content/en/docs/reference/vsphere/customize-ovas.md
+++ b/docs/content/en/docs/reference/vsphere/customize-ovas.md
@@ -101,7 +101,7 @@ Make desired config changes on the VM
 
 ### Reset the machine-id and power off the VM
 
-This step in needed because of a [known issue in Ubuntu](https://kb.vmware.com/s/article/82229) which results in the clone VMs getting the same DHCP IP
+This step is needed because of a [known issue in Ubuntu](https://kb.vmware.com/s/article/82229) which results in the clone VMs getting the same DHCP IP
 
 ```
 echo -n > /etc/machine-id

--- a/docs/content/en/docs/reference/vsphere/vsphere-ovas.md
+++ b/docs/content/en/docs/reference/vsphere/vsphere-ovas.md
@@ -6,7 +6,7 @@ description: >
   Importing EKS Anywhere OVAs to vSphere
 ---
 
-If you want to specify an OVF template, you will need to import OVA files into vSphere before you can use it in your EKS Anywhere cluster.
+If you want to specify an OVA template, you will need to import OVA files into vSphere before you can use it in your EKS Anywhere cluster.
 This guide was written using VMware Cloud on AWS,
 but the [VMware OVA import guide can be found here](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-17BEDA21-43F6-41F4-8FB2-E01D275FE9B4.html).
 
@@ -15,6 +15,10 @@ If you don't specify a template in the cluster spec file, EKS Anywhere will use 
 If the template doesn't exist, it will import the appropriate OVA into vSphere and add the necessary tags.
 
 The default OVA for a Kubernetes minor version + OS family will change over time, for example, when a new EKS Distro version is released. In that case, new clusters will use the new OVA (EKS Anywhere will import it automatically).
+{{% /alert %}}
+
+{{% alert title="Warning" color="warning" %}}
+Do not power on the imported OVA directly as it can cause some undesired configurations on the OS template and affect cluster creation. If you want to explore or modify the OS, please follow the instructions to [customize the OVA.]({{< relref "/customize-ovas" >}})
 {{% /alert %}}
 
 EKS Anywhere supports the following operating system families


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/940

*Description of changes:*
- Add warning in docs to warn users to not power on the OVA directly
- Add steps to reset the machine-id if users customize the OVA template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
