### PR TITLE
Improvements for 'upgrades from latest release' e2e tests

### DIFF
--- a/pkg/networking/cilium/client.go
+++ b/pkg/networking/cilium/client.go
@@ -32,7 +32,7 @@ type retrierClient struct {
 func newRetrier(client Client) *retrierClient {
 	return &retrierClient{
 		Client:  client,
-		Retrier: retrier.New(1 * time.Minute),
+		Retrier: retrier.New(5 * time.Minute),
 	}
 }
 

--- a/test/e2e/upgrade_from_latest_test.go
+++ b/test/e2e/upgrade_from_latest_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package e2e
@@ -6,11 +7,11 @@ import (
 	"testing"
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
-	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-func runUpgradeFromLatestReleaseFlow(test *framework.ClusterE2ETest, wantVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
+func runUpgradeFromLatestReleaseFlow(test *framework.ClusterE2ETest, wantVersion anywherev1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
 	latestRelease, err := framework.GetLatestMinorReleaseFromTestBranch()
 	if err != nil {
 		test.T.Fatal(err)
@@ -27,58 +28,90 @@ func runUpgradeFromLatestReleaseFlow(test *framework.ClusterE2ETest, wantVersion
 }
 
 func TestVSphereKubernetes120BottlerocketUpgradeFromLatestMinorRelease(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket120())
+	provider := framework.NewVSphere(t, framework.WithVSphereFillers(
+		api.WithTemplate(""), // Use default template from bundle
+		api.WithOsFamily(anywherev1.Bottlerocket),
+	))
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+		framework.WithClusterFiller(api.WithKubernetesVersion(anywherev1.Kube120)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 	)
 	runUpgradeFromLatestReleaseFlow(
 		test,
-		v1alpha1.Kube120,
+		anywherev1.Kube120,
+		provider.WithProviderUpgrade(
+			framework.UpdateBottlerocketTemplate120(), // Set the template so it doesn't get autoimported
+		),
 	)
 }
 
 func TestVSphereKubernetes121BottlerocketUpgradeFromLatestMinorRelease(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket121())
+	provider := framework.NewVSphere(t, framework.WithVSphereFillers(
+		api.WithTemplate(""), // Use default template from bundle
+		api.WithOsFamily(anywherev1.Bottlerocket),
+	))
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+		framework.WithClusterFiller(api.WithKubernetesVersion(anywherev1.Kube121)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 	)
 	runUpgradeFromLatestReleaseFlow(
 		test,
-		v1alpha1.Kube121,
+		anywherev1.Kube121,
+		provider.WithProviderUpgrade(
+			framework.UpdateBottlerocketTemplate121(), // Set the template so it doesn't get autoimported
+		),
 	)
 }
 
 func TestVSphereKubernetes120UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu120())
+	provider := framework.NewVSphere(t, framework.WithVSphereFillers(
+		api.WithTemplate(""), // Use default template from bundle
+		api.WithOsFamily(anywherev1.Ubuntu),
+	))
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+		framework.WithClusterFiller(api.WithKubernetesVersion(anywherev1.Kube120)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 	)
 	runUpgradeFromLatestReleaseFlow(
 		test,
-		v1alpha1.Kube120,
+		anywherev1.Kube120,
+		provider.WithProviderUpgrade(
+			framework.UpdateUbuntuTemplate120Var(), // Set the template so it doesn't get autoimported
+		),
 	)
 }
 
 func TestVSphereKubernetes121UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu121())
+	provider := framework.NewVSphere(t, framework.WithVSphereFillers(
+		api.WithTemplate(""), // Use default template from bundle
+		api.WithOsFamily(anywherev1.Ubuntu),
+	))
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+		framework.WithClusterFiller(api.WithKubernetesVersion(anywherev1.Kube121)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 	)
 	runUpgradeFromLatestReleaseFlow(
 		test,
-		v1alpha1.Kube121,
+		anywherev1.Kube121,
+		provider.WithProviderUpgrade(
+			framework.UpdateUbuntuTemplate121Var(), // Set the template so it doesn't get autoimported
+		),
 	)
 }
 
@@ -87,11 +120,13 @@ func TestDockerKubernetes121UpgradeFromLatestMinorRelease(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+		framework.WithClusterFiller(api.WithKubernetesVersion(anywherev1.Kube121)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 	)
 	runUpgradeFromLatestReleaseFlow(
 		test,
-		v1alpha1.Kube121,
+		anywherev1.Kube121,
 	)
 }

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -90,6 +90,10 @@ func UpdateBottlerocketTemplate121() api.VSphereFiller {
 	return api.WithStringFromEnvVar(vsphereTemplateBR121Var, api.WithTemplate)
 }
 
+func UpdateBottlerocketTemplate120() api.VSphereFiller {
+	return api.WithStringFromEnvVar(vsphereTemplateBR120Var, api.WithTemplate)
+}
+
 func NewVSphere(t *testing.T, opts ...VSphereOpt) *VSphere {
 	checkRequiredEnvVars(t, requiredEnvVars)
 	c := buildGovc(t)

--- a/test/framework/wait.go
+++ b/test/framework/wait.go
@@ -9,7 +9,7 @@ import (
 
 func (e *ClusterE2ETest) WaitForControlPlaneReady() {
 	e.T.Log("Waiting for control plane to be ready")
-	err := retrier.New(1 * time.Minute).Retry(func() error {
+	err := retrier.New(5 * time.Minute).Retry(func() error {
 		return e.KubectlClient.ValidateControlPlaneNodes(context.Background(), e.cluster(), e.ClusterName)
 	})
 	if err != nil {


### PR DESCRIPTION
*Description of changes:*
* Fixes validation issues by using the default vsphere template
* Increases reliability by bumping up a timeout
* Makes tests faster by using less machines

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
