### PR TITLE
Make cilium checks more reliable

### DIFF
--- a/pkg/networking/cilium/ready.go
+++ b/pkg/networking/cilium/ready.go
@@ -7,6 +7,10 @@ import (
 )
 
 func checkDaemonSetReady(daemonSet *v1.DaemonSet) error {
+	if err := checkDaemonSetObservedGeneration(daemonSet); err != nil {
+		return err
+	}
+
 	if daemonSet.Status.DesiredNumberScheduled != daemonSet.Status.NumberReady {
 		return fmt.Errorf("daemonSet %s is not ready: %d/%d ready", daemonSet.Name, daemonSet.Status.NumberReady, daemonSet.Status.DesiredNumberScheduled)
 	}
@@ -14,6 +18,13 @@ func checkDaemonSetReady(daemonSet *v1.DaemonSet) error {
 }
 
 func checkPreflightDaemonSetReady(ciliumDaemonSet, preflightDaemonSet *v1.DaemonSet) error {
+	if err := checkDaemonSetObservedGeneration(ciliumDaemonSet); err != nil {
+		return err
+	}
+	if err := checkDaemonSetObservedGeneration(preflightDaemonSet); err != nil {
+		return err
+	}
+
 	if ciliumDaemonSet.Status.NumberReady != preflightDaemonSet.Status.NumberReady {
 		return fmt.Errorf("cilium preflight check DS is not ready: %d want and %d ready", ciliumDaemonSet.Status.NumberReady, preflightDaemonSet.Status.NumberReady)
 	}
@@ -21,8 +32,32 @@ func checkPreflightDaemonSetReady(ciliumDaemonSet, preflightDaemonSet *v1.Daemon
 }
 
 func checkDeploymentReady(deployment *v1.Deployment) error {
+	if err := checkDeploymentObservedGeneration(deployment); err != nil {
+		return err
+	}
+
 	if deployment.Status.Replicas != deployment.Status.ReadyReplicas {
 		return fmt.Errorf("deployment %s is not ready: %d/%d ready", deployment.Name, deployment.Status.ReadyReplicas, deployment.Status.Replicas)
 	}
+	return nil
+}
+
+func checkDaemonSetObservedGeneration(daemonSet *v1.DaemonSet) error {
+	observedGeneration := daemonSet.Status.ObservedGeneration
+	generation := daemonSet.Generation
+	if observedGeneration != generation {
+		return fmt.Errorf("daemonSet %s status needs to be refreshed: observed generation is %d, want %d", daemonSet.Name, observedGeneration, generation)
+	}
+
+	return nil
+}
+
+func checkDeploymentObservedGeneration(deployment *v1.Deployment) error {
+	observedGeneration := deployment.Status.ObservedGeneration
+	generation := deployment.Generation
+	if observedGeneration != generation {
+		return fmt.Errorf("deployment %s status needs to be refreshed: observed generation is %d, want %d", deployment.Name, observedGeneration, generation)
+	}
+
 	return nil
 }

--- a/pkg/networking/cilium/ready_test.go
+++ b/pkg/networking/cilium/ready_test.go
@@ -16,6 +16,21 @@ func TestCheckDaemonSetReady(t *testing.T) {
 		wantErr   error
 	}{
 		{
+			name: "old status",
+			daemonSet: &v1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "ds",
+					Generation: 2,
+				},
+				Status: v1.DaemonSetStatus{
+					ObservedGeneration:     1,
+					DesiredNumberScheduled: 5,
+					NumberReady:            5,
+				},
+			},
+			wantErr: errors.New("daemonSet ds status needs to be refreshed: observed generation is 1, want 2"),
+		},
+		{
 			name: "ready",
 			daemonSet: &v1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{
@@ -60,6 +75,54 @@ func TestCheckPreflightDaemonSetReady(t *testing.T) {
 		cilium, preflight *v1.DaemonSet
 		wantErr           error
 	}{
+		{
+			name: "cilium old status",
+			cilium: &v1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "ds",
+					Generation: 2,
+				},
+				Status: v1.DaemonSetStatus{
+					ObservedGeneration:     1,
+					DesiredNumberScheduled: 5,
+					NumberReady:            5,
+				},
+			},
+			preflight: &v1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ds-pre",
+				},
+				Status: v1.DaemonSetStatus{
+					DesiredNumberScheduled: 5,
+					NumberReady:            5,
+				},
+			},
+			wantErr: errors.New("daemonSet ds status needs to be refreshed: observed generation is 1, want 2"),
+		},
+		{
+			name: "pre-check old status",
+			cilium: &v1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ds",
+				},
+				Status: v1.DaemonSetStatus{
+					DesiredNumberScheduled: 5,
+					NumberReady:            5,
+				},
+			},
+			preflight: &v1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "ds-pre",
+					Generation: 2,
+				},
+				Status: v1.DaemonSetStatus{
+					ObservedGeneration:     1,
+					DesiredNumberScheduled: 5,
+					NumberReady:            5,
+				},
+			},
+			wantErr: errors.New("daemonSet ds-pre status needs to be refreshed: observed generation is 1, want 2"),
+		},
 		{
 			name: "ready",
 			cilium: &v1.DaemonSet{
@@ -123,6 +186,21 @@ func TestCheckDeploymentReady(t *testing.T) {
 		deployment *v1.Deployment
 		wantErr    error
 	}{
+		{
+			name: "old status",
+			deployment: &v1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "dep",
+					Generation: 2,
+				},
+				Status: v1.DeploymentStatus{
+					Replicas:           5,
+					ReadyReplicas:      5,
+					ObservedGeneration: 1,
+				},
+			},
+			wantErr: errors.New("deployment dep status needs to be refreshed: observed generation is 1, want 2"),
+		},
 		{
 			name: "ready",
 			deployment: &v1.Deployment{


### PR DESCRIPTION
*Description of changes:*
By using by using `observedGeneration` we make sure we are always looking
to a refreshed status. This should avoid a few race conditions when checking
and object that has just been updated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
