### PR TITLE
Avoid duplicated logs in failed e2e tests

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -139,7 +139,7 @@ func RunTests(conf instanceRunConf) (testInstanceID string, testCommandResult *t
 
 func (e *E2ESession) runTests(regex string) (testCommandResult *testCommandResult, err error) {
 	logger.V(1).Info("Running e2e tests", "regex", regex)
-	command := "GOVERSION=go1.16.6 gotestsum --junitfile=junit-testing.xml --raw-command --format=standard-verbose --ignore-non-json-output-lines -- test2json -t -p e2e ./bin/e2e.test -test.v"
+	command := "GOVERSION=go1.16.6 gotestsum --junitfile=junit-testing.xml --raw-command --format=standard-verbose --hide-summary=all --ignore-non-json-output-lines -- test2json -t -p e2e ./bin/e2e.test -test.v"
 
 	if regex != "" {
 		command = fmt.Sprintf("%s -test.run %s", command, regex)


### PR DESCRIPTION
*Description of changes:*
Hide all the summary sections from `gotestsum` and leave only the original
go test output

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
