### PR TITLE
Revert "Create v1beta1 manifests for vsphere provider (#930)"

### DIFF
--- a/controllers/controllers/resource/testdata/etcdadmcluster.yaml
+++ b/controllers/controllers/resource/testdata/etcdadmcluster.yaml
@@ -1,5 +1,5 @@
 kind: EtcdadmCluster
-apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: test_cluster-etcd
   namespace: eksa-system
@@ -23,6 +23,6 @@ users:
       - 'ssh-rsa ssh_key_value'
     sudo: ALL=(ALL) NOPASSWD:ALL
 infrastructureTemplate:
-  apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+  apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
   kind: VSphereMachineTemplate
   name: test_cluster-etcd-template-v1.19.8-eks-1-19-4

--- a/controllers/controllers/resource/testdata/expectedMachineDeployment.yaml
+++ b/controllers/controllers/resource/testdata/expectedMachineDeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
@@ -17,12 +17,12 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test_cluster-md-0
       clusterName: test_cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: test_cluster-worker-node-template-1234567890000
       version: v1.19.8-eks-1-19-4

--- a/controllers/controllers/resource/testdata/expectedMachineDeploymentOnlyReplica.yaml
+++ b/controllers/controllers/resource/testdata/expectedMachineDeploymentOnlyReplica.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
@@ -17,12 +17,12 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test_cluster-md-0
       clusterName: test_cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: test_cluster-workload-template-1
       version: v1.19.8-eks-1-19-4

--- a/controllers/controllers/resource/testdata/kubeadmcontrolplane.yaml
+++ b/controllers/controllers/resource/testdata/kubeadmcontrolplane.yaml
@@ -1,14 +1,13 @@
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test_cluster
   namespace: default
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test_cluster-control-plane-template-v1.19.8-eks-1-19-4
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test_cluster-control-plane-template-v1.19.8-eks-1-19-4
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -17,6 +16,7 @@ spec:
           imageRepository: public.ecr.aws/eks-distro/etcd-io
           imageTag: v3.4.14-eks-1-19-4
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       apiServer:

--- a/controllers/controllers/resource/testdata/machineDeployment.yaml
+++ b/controllers/controllers/resource/testdata/machineDeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
@@ -17,12 +17,12 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test_cluster-md-0
       clusterName: test_cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: test_cluster-workload-template-1
       version: v1.19.8-eks-1-19-4

--- a/controllers/controllers/resource/testdata/vsphereMachineTemplate.yaml
+++ b/controllers/controllers/resource/testdata/vsphereMachineTemplate.yaml
@@ -1,4 +1,4 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test_cluster-worker-node-template-1234567890000

--- a/pkg/providers/vsphere/config/machine-health-check-template.yaml
+++ b/pkg/providers/vsphere/config/machine-health-check-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineHealthCheck
 metadata:
   name: {{.clusterName}}-node-unhealthy-5m
@@ -18,7 +18,7 @@ spec:
       status: "False"
       timeout: 300s
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineHealthCheck
 metadata:
   name: {{.clusterName}}-kcp-unhealthy-5m

--- a/pkg/providers/vsphere/config/secret.yaml
+++ b/pkg/providers/vsphere/config/secret.yaml
@@ -1,19 +1,45 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-credentials
-  namespace: {{.eksaSystemNamespace}}
-type: kubernetes.io/basic-auth
+  name: csi-vsphere-config
+  namespace: kube-system
 stringData:
-  username: "{{.vsphereUsername}}"
-  password: "{{.vspherePassword}}"
+  csi-vsphere.conf: |+
+    [Global]
+    cluster-id = "default/{{.clusterName}}"
+    thumbprint = "{{.thumbprint}}"
+
+    [VirtualCenter "{{.vsphereServer}}"]
+    user = "{{.vsphereUsername}}"
+    password = "{{.vspherePassword}}"
+    datacenters = "{{.vsphereDatacenter}}"
+    insecure-flag = "{{.insecure}}"
+
+    [Network]
+    public-network = "{{.vsphereNetwork}}"
+
+type: Opaque
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: eksa-license
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   license: "{{.eksaLicense}}"
 type: Opaque
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-credentials
+  namespace: eksa-system
+type: kubernetes.io/basic-auth
+stringData:
+  username: "{{.vsphereUsername}}"
+  password: "{{.vspherePassword}}"

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,36 +12,54 @@ spec:
     services:
       cidrBlocks: {{.serviceCidrs}}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: {{.clusterName}}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: {{.clusterName}}
 {{- if .externalEtcd }}
   managedExternalEtcdRef:
-    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
     name: {{.clusterName}}-etcd
 {{- end }}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: {{.clusterName}}
   namespace: {{.eksaSystemNamespace}}
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: '{{.thumbprint}}'
+      insecure: {{.insecure}}
+    network:
+      name: {{.vsphereNetwork}}
+    providerConfig:
+      cloud:
+        controllerImage: {{.managerImage}}
+    virtualCenter:
+      {{.vsphereServer}}:
+        datacenters: {{.vsphereDatacenter}}
+        thumbprint: '{{.thumbprint}}'
+    workspace:
+      datacenter: {{.vsphereDatacenter}}
+      datastore: {{.controlPlaneVsphereDatastore}}
+      folder: '{{.controlPlaneVsphereFolder}}'
+      resourcePool: '{{.controlPlaneVsphereResourcePool}}'
+      server: {{.vsphereServer}}
   controlPlaneEndpoint:
     host: {{.controlPlaneEndpointIp}}
     port: 6443
-  identityRef:
-    kind: Secret
-    name: {{.clusterName}}-vsphere-credentials
   server: {{.vsphereServer}}
   thumbprint: '{{.thumbprint}}'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: {{.controlPlaneTemplateName}}
@@ -68,17 +86,16 @@ spec:
       template: {{.vsphereTemplate}}
       thumbprint: '{{.thumbprint}}'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: {{.clusterName}}
   namespace: {{.eksaSystemNamespace}}
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: {{.controlPlaneTemplateName}}
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: {{.controlPlaneTemplateName}}
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: {{.kubernetesRepository}}
@@ -105,6 +122,7 @@ spec:
 {{- end }}
 {{- end }}
       dns:
+        type: CoreDNS
         imageRepository: {{.corednsRepository}}
         imageTag: {{.corednsVersion}}
 {{- if (eq .format "bottlerocket") }}
@@ -325,8 +343,7 @@ spec:
 {{- end }}
         name: '{{`{{ ds.meta_data.hostname }}`}}'
 {{- if .controlPlaneTaints }}
-        taints:
-{{- range .controlPlaneTaints}}
+        taints: {{ range .controlPlaneTaints}}
           - key: {{ .Key }}
             value: {{ .Value }}
             effect: {{ .Effect }}
@@ -370,8 +387,7 @@ spec:
 {{- end }}
         name: '{{`{{ ds.meta_data.hostname }}`}}'
 {{- if .controlPlaneTaints }}
-        taints:
-{{- range .controlPlaneTaints}}
+        taints: {{ range .controlPlaneTaints}}
           - key: {{ .Key }}
             value: {{ .Value }}
             effect: {{ .Effect }}
@@ -405,7 +421,7 @@ spec:
   replicas: {{.controlPlaneReplicas}}
   version: {{.kubernetesVersion}}
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -440,7 +456,7 @@ spec:
 ---
 {{- if .externalEtcd }}
 kind: EtcdadmCluster
-apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: {{.clusterName}}-etcd
   namespace: {{.eksaSystemNamespace}}
@@ -490,11 +506,11 @@ spec:
       {{- end }}
 {{- end }}
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
     name: {{.etcdTemplateName}}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: {{.etcdTemplateName}}
@@ -525,15 +541,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{.clusterName}}-vsphere-credentials
-  namespace: {{.eksaSystemNamespace}}
-stringData:
-  username: "{{.eksaVsphereUsername}}"
-  password: "{{.eksaVspherePassword}}"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: {{.eksaSystemNamespace}}
 stringData:
@@ -543,35 +550,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: {{.eksaSystemNamespace}}
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/{{.clusterName}}"
-        thumbprint = "{{.thumbprint}}"
-
-        [VirtualCenter "{{.vsphereServer}}"]
-        user = "{{.eksaVsphereUsername}}"
-        password = "{{.eksaVspherePassword}}"
-        datacenters = "{{.vsphereDatacenter}}"
-        insecure-flag = "{{.insecure}}"
-
-        [Network]
-        public-network = "{{.vsphereNetwork}}"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/providers/vsphere/config/template-md.yaml
+++ b/pkg/providers/vsphere/config/template-md.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: {{.clusterName}}-md-0
@@ -93,7 +93,7 @@ spec:
         sudo: ALL=(ALL) NOPASSWD:ALL
       format: {{.format}}
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
@@ -112,17 +112,17 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: {{.clusterName}}-md-0
       clusterName: {{.clusterName}}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: {{.workloadTemplateName}}
       version: {{.kubernetesVersion}}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: {{.workloadTemplateName}}

--- a/pkg/providers/vsphere/mocks/client.go
+++ b/pkg/providers/vsphere/mocks/client.go
@@ -572,20 +572,6 @@ func (mr *MockProviderKubectlClientMockRecorder) GetMachineDeployment(arg0, arg1
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineDeployment", reflect.TypeOf((*MockProviderKubectlClient)(nil).GetMachineDeployment), varargs...)
 }
 
-// GetNamespace mocks base method.
-func (m *MockProviderKubectlClient) GetNamespace(arg0 context.Context, arg1, arg2 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNamespace", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// GetNamespace indicates an expected call of GetNamespace.
-func (mr *MockProviderKubectlClientMockRecorder) GetNamespace(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockProviderKubectlClient)(nil).GetNamespace), arg0, arg1, arg2)
-}
-
 // GetSecret mocks base method.
 func (m *MockProviderKubectlClient) GetSecret(arg0 context.Context, arg1 string, arg2 ...executables.KubectlOpt) (*v1.Secret, error) {
 	m.ctrl.T.Helper()

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,34 +12,52 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/16]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
   managedExternalEtcdRef:
-    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
     name: test-etcd
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
   namespace: eksa-system
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: 'ABCDEFG'
+      insecure: false
+    network:
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
+    providerConfig:
+      cloud:
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+    virtualCenter:
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
+    workspace:
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
     host: 1.2.3.4
     port: 6443
-  identityRef:
-    kind: Secret
-    name: test-vsphere-credentials
   server: vsphere_server
   thumbprint: 'ABCDEFG'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -64,17 +82,16 @@ spec:
       template: /SDDC-Datacenter/vm/Templates/bottlerocket-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
   namespace: eksa-system
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test-control-plane-template-1234567890000
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -85,6 +102,7 @@ spec:
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       pause:
@@ -387,7 +405,7 @@ spec:
   replicas: 3
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -421,7 +439,7 @@ spec:
     name: cpi-manifests
 ---
 kind: EtcdadmCluster
-apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: test-etcd
   namespace: eksa-system
@@ -440,11 +458,11 @@ spec:
           - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
     name: test-etcd-template-1234567890000
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000
@@ -472,15 +490,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-vsphere-credentials
-  namespace: eksa-system
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: eksa-system
 stringData:
@@ -490,35 +499,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: eksa-system
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/test"
-        thumbprint = "ABCDEFG"
-
-        [VirtualCenter "vsphere_server"]
-        user = "vsphere_username"
-        password = "vsphere_password"
-        datacenters = "SDDC-Datacenter"
-        insecure-flag = "false"
-
-        [Network]
-        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_md.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
@@ -32,7 +32,7 @@ spec:
         sudo: ALL=(ALL) NOPASSWD:ALL
       format: bottlerocket
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
@@ -51,17 +51,17 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test-md-0
       clusterName: test
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: test-worker-node-template-1234567890000
       version: v1.19.8-eks-1-19-4
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-worker-node-template-1234567890000

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,34 +12,52 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
   managedExternalEtcdRef:
-    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
     name: test-etcd
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
   namespace: eksa-system
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: 'ABCDEFG'
+      insecure: false
+    network:
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
+    providerConfig:
+      cloud:
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.21.0-eks-d-1-21-eks-a-v0.0.0-dev-build.158
+    virtualCenter:
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
+    workspace:
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
     host: 1.2.3.4
     port: 6443
-  identityRef:
-    kind: Secret
-    name: test-vsphere-credentials
   server: vsphere_server
   thumbprint: 'ABCDEFG'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -64,17 +82,16 @@ spec:
       template: /SDDC-Datacenter/vm/Templates/bottlerocket-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
   namespace: eksa-system
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test-control-plane-template-1234567890000
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -85,6 +102,7 @@ spec:
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.3-eks-1-21-4
       pause:
@@ -384,7 +402,7 @@ spec:
   replicas: 3
   version: v1.21.2-eks-1-21-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -418,7 +436,7 @@ spec:
     name: cpi-manifests
 ---
 kind: EtcdadmCluster
-apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: test-etcd
   namespace: eksa-system
@@ -439,11 +457,11 @@ spec:
     registryMirror:
       endpoint: 1.2.3.4:1234
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
     name: test-etcd-template-1234567890000
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000
@@ -471,15 +489,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-vsphere-credentials
-  namespace: eksa-system
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: eksa-system
 stringData:
@@ -489,35 +498,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: eksa-system
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/test"
-        thumbprint = "ABCDEFG"
-
-        [VirtualCenter "vsphere_server"]
-        user = "vsphere_username"
-        password = "vsphere_password"
-        datacenters = "SDDC-Datacenter"
-        insecure-flag = "false"
-
-        [Network]
-        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_md.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
@@ -34,7 +34,7 @@ spec:
         sudo: ALL=(ALL) NOPASSWD:ALL
       format: bottlerocket
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
@@ -53,17 +53,17 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test-md-0
       clusterName: test
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: test-worker-node-template-1234567890000
       version: v1.21.2-eks-1-21-4
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-worker-node-template-1234567890000

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,34 +12,52 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
   managedExternalEtcdRef:
-    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
     name: test-etcd
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
   namespace: eksa-system
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: 'ABCDEFG'
+      insecure: false
+    network:
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
+    providerConfig:
+      cloud:
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.21.0-eks-d-1-21-eks-a-v0.0.0-dev-build.158
+    virtualCenter:
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
+    workspace:
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
     host: 1.2.3.4
     port: 6443
-  identityRef:
-    kind: Secret
-    name: test-vsphere-credentials
   server: vsphere_server
   thumbprint: 'ABCDEFG'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -64,17 +82,16 @@ spec:
       template: /SDDC-Datacenter/vm/Templates/bottlerocket-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
   namespace: eksa-system
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test-control-plane-template-1234567890000
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -85,6 +102,7 @@ spec:
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.3-eks-1-21-4
       pause:
@@ -420,7 +438,7 @@ spec:
   replicas: 3
   version: v1.21.2-eks-1-21-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -454,7 +472,7 @@ spec:
     name: cpi-manifests
 ---
 kind: EtcdadmCluster
-apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: test-etcd
   namespace: eksa-system
@@ -493,11 +511,11 @@ spec:
         9n5t2E4AHPen+YrGeLY1qEn9WMv0XRGWrgJyLW9VSX8T3SlWO2w3okcw
         -----END CERTIFICATE-----
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
     name: test-etcd-template-1234567890000
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000
@@ -525,15 +543,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-vsphere-credentials
-  namespace: eksa-system
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: eksa-system
 stringData:
@@ -543,35 +552,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: eksa-system
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/test"
-        thumbprint = "ABCDEFG"
-
-        [VirtualCenter "vsphere_server"]
-        user = "vsphere_username"
-        password = "vsphere_password"
-        datacenters = "SDDC-Datacenter"
-        insecure-flag = "false"
-
-        [Network]
-        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_md.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
@@ -52,7 +52,7 @@ spec:
         sudo: ALL=(ALL) NOPASSWD:ALL
       format: bottlerocket
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
@@ -71,17 +71,17 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test-md-0
       clusterName: test
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: test-worker-node-template-1234567890000
       version: v1.21.2-eks-1-21-4
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-worker-node-template-1234567890000

--- a/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,34 +12,52 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
   managedExternalEtcdRef:
-    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
     name: test-etcd
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
   namespace: eksa-system
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: 'ABCDEFG'
+      insecure: false
+    network:
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
+    providerConfig:
+      cloud:
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+    virtualCenter:
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
+    workspace:
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
     host: 1.2.3.4
     port: 6443
-  identityRef:
-    kind: Secret
-    name: test-vsphere-credentials
   server: vsphere_server
   thumbprint: 'ABCDEFG'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -64,17 +82,16 @@ spec:
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
   namespace: eksa-system
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test-control-plane-template-1234567890000
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -85,6 +102,7 @@ spec:
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       apiServer:
@@ -357,7 +375,7 @@ spec:
   replicas: 3
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -391,7 +409,7 @@ spec:
     name: cpi-manifests
 ---
 kind: EtcdadmCluster
-apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: test-etcd
   namespace: eksa-system
@@ -416,11 +434,11 @@ spec:
           - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
     name: test-etcd-template-1234567890000
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000
@@ -448,15 +466,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-vsphere-credentials
-  namespace: eksa-system
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: eksa-system
 stringData:
@@ -466,35 +475,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: eksa-system
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/test"
-        thumbprint = "ABCDEFG"
-
-        [VirtualCenter "vsphere_server"]
-        user = "vsphere_username"
-        password = "vsphere_password"
-        datacenters = "SDDC-Datacenter"
-        insecure-flag = "false"
-
-        [Network]
-        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,30 +12,48 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/16]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
   namespace: eksa-system
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: 'ABCDEFG'
+      insecure: false
+    network:
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
+    providerConfig:
+      cloud:
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+    virtualCenter:
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
+    workspace:
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
     host: 1.2.3.4
     port: 6443
-  identityRef:
-    kind: Secret
-    name: test-vsphere-credentials
   server: vsphere_server
   thumbprint: 'ABCDEFG'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -60,17 +78,16 @@ spec:
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
   namespace: eksa-system
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test-control-plane-template-1234567890000
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -81,6 +98,7 @@ spec:
           extraArgs:
             cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       apiServer:
@@ -358,7 +376,7 @@ spec:
   replicas: 3
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -394,15 +412,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-vsphere-credentials
-  namespace: eksa-system
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: eksa-system
 stringData:
@@ -412,35 +421,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: eksa-system
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/test"
-        thumbprint = "ABCDEFG"
-
-        [VirtualCenter "vsphere_server"]
-        user = "vsphere_username"
-        password = "vsphere_password"
-        datacenters = "SDDC-Datacenter"
-        insecure-flag = "false"
-
-        [Network]
-        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,34 +12,52 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
   managedExternalEtcdRef:
-    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
     name: test-etcd
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
   namespace: eksa-system
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: 'ABCDEFG'
+      insecure: false
+    network:
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
+    providerConfig:
+      cloud:
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+    virtualCenter:
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
+    workspace:
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
     host: 1.2.3.4
     port: 6443
-  identityRef:
-    kind: Secret
-    name: test-vsphere-credentials
   server: vsphere_server
   thumbprint: 'ABCDEFG'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -64,17 +82,16 @@ spec:
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
   namespace: eksa-system
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test-control-plane-template-1234567890000
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -85,6 +102,7 @@ spec:
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       apiServer:
@@ -355,7 +373,7 @@ spec:
   replicas: 3
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -389,7 +407,7 @@ spec:
     name: cpi-manifests
 ---
 kind: EtcdadmCluster
-apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: test-etcd
   namespace: eksa-system
@@ -414,11 +432,11 @@ spec:
           - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
     name: test-etcd-template-1234567890000
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000
@@ -446,15 +464,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-vsphere-credentials
-  namespace: eksa-system
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: eksa-system
 stringData:
@@ -464,35 +473,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: eksa-system
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/test"
-        thumbprint = "ABCDEFG"
-
-        [VirtualCenter "vsphere_server"]
-        user = "vsphere_username"
-        password = "vsphere_password"
-        datacenters = "SDDC-Datacenter"
-        insecure-flag = "false"
-
-        [Network]
-        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/providers/vsphere/testdata/expected_results_main_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_md.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
@@ -26,7 +26,7 @@ spec:
         sudo: ALL=(ALL) NOPASSWD:ALL
       format: cloud-config
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
@@ -45,17 +45,17 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test-md-0
       clusterName: test
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: test-worker-node-template-1234567890000
       version: v1.19.8-eks-1-19-4
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-worker-node-template-1234567890000

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,34 +12,52 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
   managedExternalEtcdRef:
-    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
     name: test-etcd
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
   namespace: eksa-system
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: 'ABCDEFG'
+      insecure: false
+    network:
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
+    providerConfig:
+      cloud:
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+    virtualCenter:
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
+    workspace:
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
     host: 1.2.3.4
     port: 6443
-  identityRef:
-    kind: Secret
-    name: test-vsphere-credentials
   server: vsphere_server
   thumbprint: 'ABCDEFG'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-original
@@ -64,17 +82,16 @@ spec:
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
   namespace: eksa-system
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test-control-plane-template-original
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-control-plane-template-original
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -85,6 +102,7 @@ spec:
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       apiServer:
@@ -355,7 +373,7 @@ spec:
   replicas: 3
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -389,7 +407,7 @@ spec:
     name: cpi-manifests
 ---
 kind: EtcdadmCluster
-apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: test-etcd
   namespace: eksa-system
@@ -414,11 +432,11 @@ spec:
           - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
     name: test-etcd-template-original
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-etcd-template-original
@@ -446,15 +464,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-vsphere-credentials
-  namespace: eksa-system
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: eksa-system
 stringData:
@@ -464,35 +473,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: eksa-system
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/test"
-        thumbprint = "ABCDEFG"
-
-        [VirtualCenter "vsphere_server"]
-        user = "vsphere_username"
-        password = "vsphere_password"
-        datacenters = "SDDC-Datacenter"
-        insecure-flag = "false"
-
-        [Network]
-        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_md.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
@@ -26,7 +26,7 @@ spec:
         sudo: ALL=(ALL) NOPASSWD:ALL
       format: cloud-config
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
@@ -45,17 +45,17 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test-md-0
       clusterName: test
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: test-worker-node-template-original
       version: v1.19.8-eks-1-19-4
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-worker-node-template-original

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,34 +12,52 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
   managedExternalEtcdRef:
-    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
     name: test-etcd
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
   namespace: eksa-system
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: 'ABCDEFG'
+      insecure: false
+    network:
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
+    providerConfig:
+      cloud:
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+    virtualCenter:
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
+    workspace:
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
     host: 1.2.3.4
     port: 6443
-  identityRef:
-    kind: Secret
-    name: test-vsphere-credentials
   server: vsphere_server
   thumbprint: 'ABCDEFG'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -64,17 +82,16 @@ spec:
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
   namespace: eksa-system
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test-control-plane-template-1234567890000
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -85,6 +102,7 @@ spec:
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       apiServer:
@@ -357,7 +375,7 @@ spec:
   replicas: 3
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -391,7 +409,7 @@ spec:
     name: cpi-manifests
 ---
 kind: EtcdadmCluster
-apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: test-etcd
   namespace: eksa-system
@@ -416,11 +434,11 @@ spec:
           - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
     name: test-etcd-template-1234567890000
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000
@@ -448,15 +466,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-vsphere-credentials
-  namespace: eksa-system
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: eksa-system
 stringData:
@@ -466,35 +475,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: eksa-system
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/test"
-        thumbprint = "ABCDEFG"
-
-        [VirtualCenter "vsphere_server"]
-        user = "vsphere_username"
-        password = "vsphere_password"
-        datacenters = "SDDC-Datacenter"
-        insecure-flag = "false"
-
-        [Network]
-        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_md.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
@@ -27,7 +27,7 @@ spec:
         sudo: ALL=(ALL) NOPASSWD:ALL
       format: cloud-config
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
@@ -46,17 +46,17 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test-md-0
       clusterName: test
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: test-worker-node-template-1234567890000
       version: v1.19.8-eks-1-19-4
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-worker-node-template-1234567890000

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,34 +12,52 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
   managedExternalEtcdRef:
-    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
     name: test-etcd
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
   namespace: eksa-system
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: 'ABCDEFG'
+      insecure: false
+    network:
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
+    providerConfig:
+      cloud:
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+    virtualCenter:
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
+    workspace:
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
     host: 1.2.3.4
     port: 6443
-  identityRef:
-    kind: Secret
-    name: test-vsphere-credentials
   server: vsphere_server
   thumbprint: 'ABCDEFG'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -64,17 +82,16 @@ spec:
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
   namespace: eksa-system
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test-control-plane-template-1234567890000
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -85,6 +102,7 @@ spec:
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       apiServer:
@@ -330,7 +348,7 @@ spec:
           cloud-provider: external
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
-        taints:
+        taints: 
           - key: key1
             value: val1
             effect: PreferNoSchedule
@@ -347,7 +365,7 @@ spec:
           cloud-provider: external
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
-        taints:
+        taints: 
           - key: key1
             value: val1
             effect: PreferNoSchedule
@@ -373,7 +391,7 @@ spec:
   replicas: 3
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -407,7 +425,7 @@ spec:
     name: cpi-manifests
 ---
 kind: EtcdadmCluster
-apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: test-etcd
   namespace: eksa-system
@@ -432,11 +450,11 @@ spec:
           - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
     name: test-etcd-template-1234567890000
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000
@@ -464,15 +482,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-vsphere-credentials
-  namespace: eksa-system
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: eksa-system
 stringData:
@@ -482,35 +491,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: eksa-system
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/test"
-        thumbprint = "ABCDEFG"
-
-        [VirtualCenter "vsphere_server"]
-        user = "vsphere_username"
-        password = "vsphere_password"
-        datacenters = "SDDC-Datacenter"
-        insecure-flag = "false"
-
-        [Network]
-        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,30 +12,48 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
   namespace: eksa-system
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: 'ABCDEFG'
+      insecure: false
+    network:
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
+    providerConfig:
+      cloud:
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+    virtualCenter:
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
+    workspace:
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
     host: 1.2.3.4
     port: 6443
-  identityRef:
-    kind: Secret
-    name: test-vsphere-credentials
   server: vsphere_server
   thumbprint: 'ABCDEFG'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -59,17 +77,16 @@ spec:
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
   namespace: eksa-system
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test-control-plane-template-1234567890000
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -80,6 +97,7 @@ spec:
           extraArgs:
             cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       apiServer:
@@ -350,7 +368,7 @@ spec:
   replicas: 3
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -386,15 +404,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-vsphere-credentials
-  namespace: eksa-system
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: eksa-system
 stringData:
@@ -404,35 +413,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: eksa-system
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/test"
-        thumbprint = "ABCDEFG"
-
-        [VirtualCenter "vsphere_server"]
-        user = "vsphere_username"
-        password = "vsphere_password"
-        datacenters = "SDDC-Datacenter"
-        insecure-flag = "false"
-
-        [Network]
-        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_md.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
@@ -26,7 +26,7 @@ spec:
         sudo: ALL=(ALL) NOPASSWD:ALL
       format: cloud-config
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
@@ -45,17 +45,17 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test-md-0
       clusterName: test
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: test-worker-node-template-1234567890000
       version: v1.19.8-eks-1-19-4
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-worker-node-template-1234567890000

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,30 +12,48 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
   namespace: eksa-system
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: 'ABCDEFG'
+      insecure: false
+    network:
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
+    providerConfig:
+      cloud:
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+    virtualCenter:
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
+    workspace:
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
     host: 1.2.3.4
     port: 6443
-  identityRef:
-    kind: Secret
-    name: test-vsphere-credentials
   server: vsphere_server
   thumbprint: 'ABCDEFG'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -60,17 +78,16 @@ spec:
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
   namespace: eksa-system
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test-control-plane-template-1234567890000
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -81,6 +98,7 @@ spec:
           extraArgs:
             cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       apiServer:
@@ -353,7 +371,7 @@ spec:
   replicas: 3
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -389,15 +407,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-vsphere-credentials
-  namespace: eksa-system
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: eksa-system
 stringData:
@@ -407,35 +416,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: eksa-system
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/test"
-        thumbprint = "ABCDEFG"
-
-        [VirtualCenter "vsphere_server"]
-        user = "vsphere_username"
-        password = "vsphere_password"
-        datacenters = "SDDC-Datacenter"
-        insecure-flag = "false"
-
-        [Network]
-        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,34 +12,52 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
   managedExternalEtcdRef:
-    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
     name: test-etcd
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
   namespace: eksa-system
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: 'ABCDEFG'
+      insecure: false
+    network:
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
+    providerConfig:
+      cloud:
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.21.0-eks-d-1-21-eks-a-v0.0.0-dev-build.158
+    virtualCenter:
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
+    workspace:
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
     host: 1.2.3.4
     port: 6443
-  identityRef:
-    kind: Secret
-    name: test-vsphere-credentials
   server: vsphere_server
   thumbprint: 'ABCDEFG'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -64,17 +82,16 @@ spec:
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
   namespace: eksa-system
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test-control-plane-template-1234567890000
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -85,6 +102,7 @@ spec:
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.3-eks-1-21-4
       apiServer:
@@ -364,7 +382,7 @@ spec:
   replicas: 3
   version: v1.21.2-eks-1-21-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -398,7 +416,7 @@ spec:
     name: cpi-manifests
 ---
 kind: EtcdadmCluster
-apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: test-etcd
   namespace: eksa-system
@@ -425,11 +443,11 @@ spec:
     registryMirror:
       endpoint: 1.2.3.4:1234
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
     name: test-etcd-template-1234567890000
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000
@@ -457,15 +475,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-vsphere-credentials
-  namespace: eksa-system
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: eksa-system
 stringData:
@@ -475,35 +484,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: eksa-system
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/test"
-        thumbprint = "ABCDEFG"
-
-        [VirtualCenter "vsphere_server"]
-        user = "vsphere_username"
-        password = "vsphere_password"
-        datacenters = "SDDC-Datacenter"
-        insecure-flag = "false"
-
-        [Network]
-        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_md.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
@@ -36,7 +36,7 @@ spec:
         sudo: ALL=(ALL) NOPASSWD:ALL
       format: cloud-config
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
@@ -55,17 +55,17 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test-md-0
       clusterName: test
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: test-worker-node-template-1234567890000
       version: v1.21.2-eks-1-21-4
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-worker-node-template-1234567890000

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,34 +12,52 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
   managedExternalEtcdRef:
-    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
     name: test-etcd
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
   namespace: eksa-system
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: 'ABCDEFG'
+      insecure: false
+    network:
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
+    providerConfig:
+      cloud:
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.21.0-eks-d-1-21-eks-a-v0.0.0-dev-build.158
+    virtualCenter:
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
+    workspace:
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
     host: 1.2.3.4
     port: 6443
-  identityRef:
-    kind: Secret
-    name: test-vsphere-credentials
   server: vsphere_server
   thumbprint: 'ABCDEFG'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -64,17 +82,16 @@ spec:
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
   namespace: eksa-system
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test-control-plane-template-1234567890000
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -85,6 +102,7 @@ spec:
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.3-eks-1-21-4
       apiServer:
@@ -386,7 +404,7 @@ spec:
   replicas: 3
   version: v1.21.2-eks-1-21-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -420,7 +438,7 @@ spec:
     name: cpi-manifests
 ---
 kind: EtcdadmCluster
-apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: test-etcd
   namespace: eksa-system
@@ -465,11 +483,11 @@ spec:
         9n5t2E4AHPen+YrGeLY1qEn9WMv0XRGWrgJyLW9VSX8T3SlWO2w3okcw
         -----END CERTIFICATE-----
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
     name: test-etcd-template-1234567890000
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000
@@ -497,15 +515,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-vsphere-credentials
-  namespace: eksa-system
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: eksa-system
 stringData:
@@ -515,35 +524,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: eksa-system
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/test"
-        thumbprint = "ABCDEFG"
-
-        [VirtualCenter "vsphere_server"]
-        user = "vsphere_username"
-        password = "vsphere_password"
-        datacenters = "SDDC-Datacenter"
-        insecure-flag = "false"
-
-        [Network]
-        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: test-md-0
@@ -58,7 +58,7 @@ spec:
         sudo: ALL=(ALL) NOPASSWD:ALL
       format: cloud-config
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   labels:
@@ -77,17 +77,17 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: test-md-0
       clusterName: test
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: test-worker-node-template-1234567890000
       version: v1.21.2-eks-1-21-4
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-worker-node-template-1234567890000

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   labels:
@@ -12,34 +12,52 @@ spec:
     services:
       cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: KubeadmControlPlane
     name: test
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: test
   managedExternalEtcdRef:
-    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
     kind: EtcdadmCluster
     name: test-etcd
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: test
   namespace: eksa-system
 spec:
+  cloudProviderConfiguration:
+    global:
+      secretName: cloud-provider-vsphere-credentials
+      secretNamespace: kube-system
+      thumbprint: 'ABCDEFG'
+      insecure: false
+    network:
+      name: /SDDC-Datacenter/network/sddc-cgw-network-1
+    providerConfig:
+      cloud:
+        controllerImage: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+    virtualCenter:
+      vsphere_server:
+        datacenters: SDDC-Datacenter
+        thumbprint: 'ABCDEFG'
+    workspace:
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      folder: '/SDDC-Datacenter/vm'
+      resourcePool: '*/Resources'
+      server: vsphere_server
   controlPlaneEndpoint:
     host: 1.2.3.4
     port: 6443
-  identityRef:
-    kind: Secret
-    name: test-vsphere-credentials
   server: vsphere_server
   thumbprint: 'ABCDEFG'
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -64,17 +82,16 @@ spec:
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: test
   namespace: eksa-system
 spec:
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: test-control-plane-template-1234567890000
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: VSphereMachineTemplate
+    name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
@@ -85,6 +102,7 @@ spec:
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
       dns:
+        type: CoreDNS
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       apiServer:
@@ -356,7 +374,7 @@ spec:
   replicas: 3
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -390,7 +408,7 @@ spec:
     name: cpi-manifests
 ---
 kind: EtcdadmCluster
-apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+apiVersion: etcdcluster.cluster.x-k8s.io/v1alpha3
 metadata:
   name: test-etcd
   namespace: eksa-system
@@ -415,11 +433,11 @@ spec:
           - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachineTemplate
     name: test-etcd-template-1234567890000
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000
@@ -447,15 +465,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-vsphere-credentials
-  namespace: eksa-system
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: vsphere-csi-controller
   namespace: eksa-system
 stringData:
@@ -465,35 +474,6 @@ stringData:
     metadata:
       name: vsphere-csi-controller
       namespace: kube-system
-type: addons.cluster.x-k8s.io/resource-set
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: csi-vsphere-config
-  namespace: eksa-system
-stringData:
-  data: |
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: csi-vsphere-config
-      namespace: kube-system
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        cluster-id = "default/test"
-        thumbprint = "ABCDEFG"
-
-        [VirtualCenter "vsphere_server"]
-        user = "vsphere_username"
-        password = "vsphere_password"
-        datacenters = "SDDC-Datacenter"
-        insecure-flag = "false"
-
-        [Network]
-        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
-    type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
 apiVersion: v1

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -214,13 +214,6 @@ func (s *CreateWorkloadClusterTask) Run(ctx context.Context, commandContext *tas
 			commandContext.SetError(err)
 			return &CollectDiagnosticsTask{}
 		}
-
-		logger.Info("Installing EKS-A secrets on workload cluster")
-		err := commandContext.Provider.UpdateSecrets(ctx, commandContext.WorkloadCluster)
-		if err != nil {
-			commandContext.SetError(err)
-			return &CollectDiagnosticsTask{}
-		}
 	}
 
 	logger.V(4).Info("Installing machine health checks on bootstrap cluster")

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -105,7 +105,6 @@ func (c *createTestSetup) expectCreateWorkload() {
 		c.clusterManager.EXPECT().InstallCAPI(
 			c.ctx, c.clusterSpec, c.workloadCluster, c.provider,
 		),
-		c.provider.EXPECT().UpdateSecrets(c.ctx, c.workloadCluster),
 	)
 }
 
@@ -125,7 +124,6 @@ func (c *createTestSetup) expectCreateWorkloadSkipCAPI() {
 	c.clusterManager.EXPECT().InstallCAPI(
 		c.ctx, c.clusterSpec, c.workloadCluster, c.provider,
 	).Times(0)
-	c.provider.EXPECT().UpdateSecrets(c.ctx, c.workloadCluster).Times(0)
 }
 
 func (c *createTestSetup) expectMoveManagement() {


### PR DESCRIPTION
This reverts commit 1f90618c94d61efd8cdd985dffd2c9cd57146040.

*Issue #, if available:*

*Description of changes:*

This is causing issues with upgrades/scaling because the vsphere username and password is not accessible by the controller, so it is filling up the values as empty strings, causing the capv integration to break. Will need to move the secrets back to a separate step or retrieve those values through the controller, but because that would require some rework on these changes, I will revert this for now.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
