### PR TITLE
Kubectl executable improvements

### DIFF
--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -782,7 +782,7 @@ func TestKubectlGetEKSAClusters(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			fileContent := test.ReadFile(t, tt.jsonResponseFile)
 			k, ctx, cluster, e := newKubectl(t)
-			e.EXPECT().Execute(ctx, []string{"get", "clusters", "-A", "-o", "jsonpath={.items[0]}", "--kubeconfig", cluster.KubeconfigFile, "--field-selector=metadata.name=" + tt.clusterName}).Return(*bytes.NewBufferString(fileContent), nil)
+			e.EXPECT().Execute(ctx, []string{"get", "clusters.anywhere.eks.amazonaws.com", "-A", "-o", "jsonpath={.items[0]}", "--kubeconfig", cluster.KubeconfigFile, "--field-selector=metadata.name=" + tt.clusterName}).Return(*bytes.NewBufferString(fileContent), nil)
 
 			gotCluster, err := k.GetEksaCluster(ctx, cluster, tt.clusterName)
 			if err != nil {

--- a/pkg/validations/createvalidations/gitops_test.go
+++ b/pkg/validations/createvalidations/gitops_test.go
@@ -143,7 +143,7 @@ func TestValidateGitopsForWorkloadClustersPath(t *testing.T) {
 
 			e.EXPECT().Execute(
 				ctx, []string{
-					"get", "clusters", "-A", "-o", "jsonpath={.items[0]}", "--kubeconfig",
+					"get", "clusters.anywhere.eks.amazonaws.com", "-A", "-o", "jsonpath={.items[0]}", "--kubeconfig",
 					cluster.KubeconfigFile,
 					"--field-selector=metadata.name=management-cluster",
 				}).Return(*bytes.NewBufferString(eksaClusterContent), nil)


### PR DESCRIPTION
*Description of changes:*
 * Check observedGeneration when validating kubeadm control plane
 * Use full eksa cluster resource type when retrieving it

Related with errors I have seen in the e2e tests:
```
2022-01-18T22:58:59.077Z        V0      ❌ Validation failed    {"validation": "vsphere Provider setup is valid", "error": "failed validate machineconfig uniqueness: error getting eksa cluster: error: the server doesn't have a resource type \"clusters\"\n", "remediation": ""}
```

```
2022-01-18T22:55:08.619Z        V0      ❌ Validation failed    {"validation": "upgrade preflight validations pass", "error": "validation failed with 1 errors: 1 control plane replicas are unavailable", "remediation": ""}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
