### PR TITLE
Avoid eksctl download on e2e test instances

### DIFF
--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -15,12 +15,11 @@ import (
 	e2etests "github.com/aws/eks-anywhere/test/framework"
 )
 
-var requiredFiles = []string{cliBinary, e2eBinary, eksctlBinary}
+var requiredFiles = []string{cliBinary, e2eBinary}
 
 const (
 	cliBinary                  = "eksctl-anywhere"
 	e2eBinary                  = "e2e.test"
-	eksctlBinary               = "eksctl"
 	bundlesReleaseManifestFile = "local-bundle-release.yaml"
 	eksAComponentsManifestFile = "local-eksa-components.yaml"
 	testNameFile               = "e2e-test-name"
@@ -157,11 +156,9 @@ func (e *E2ESession) uploadRequiredFiles() error {
 		}
 	}
 	for _, file := range e.requiredFiles {
-		if file != "eksctl" {
-			err := e.uploadRequiredFile(file)
-			if err != nil {
-				return err
-			}
+		err := e.uploadRequiredFile(file)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -171,13 +168,7 @@ func (e *E2ESession) uploadRequiredFiles() error {
 func (e *E2ESession) downloadRequiredFileInInstance(file string) error {
 	logger.V(1).Info("Downloading from s3 in instance", "file", file)
 
-	var command string
-	if file == "eksctl" {
-		command = fmt.Sprintf("aws s3 cp s3://%s/eksctl/%[2]s ./bin/ && chmod 645 ./bin/%[2]s", e.storageBucket, file)
-	} else {
-		command = fmt.Sprintf("aws s3 cp s3://%s/%s/%[3]s ./bin/ && chmod 645 ./bin/%[3]s", e.storageBucket, e.jobId, file)
-	}
-
+	command := fmt.Sprintf("aws s3 cp s3://%s/%s/%[3]s ./bin/ && chmod 645 ./bin/%[3]s", e.storageBucket, e.jobId, file)
 	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
 		return fmt.Errorf("error downloading file in instance: %v", err)
 	}


### PR DESCRIPTION
*Description of changes:*
This is not needed anymore, now we include `eksctl` in the test image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
