### PR TITLE
Fix e2e test docker script: move comment out of multiline command

### DIFF
--- a/scripts/e2e_test_docker.sh
+++ b/scripts/e2e_test_docker.sh
@@ -49,6 +49,11 @@ BUNDLES_OVERRIDE=false
 if [ -f "$BIN_FOLDER/local-bundle-release.yaml" ]; then
     BUNDLES_OVERRIDE=true
 fi
+
+# In order to be uploaded from the sidecar and used by the junit lens
+# the junit reports need to be in /logs/*/junit*.xml
+TEST_REPORT_FOLDER=/logs/artifacts
+
 $BIN_FOLDER/test e2e run \
     -a ${INTEGRATION_TEST_AL2_AMI_ID} \
     -s ${INTEGRATION_TEST_STORAGE_BUCKET} \
@@ -56,10 +61,8 @@ $BIN_FOLDER/test e2e run \
     -i ${INTEGRATION_TEST_INSTANCE_PROFILE} \
     -r ${TEST_REGEX} \
     --bundles-override=${BUNDLES_OVERRIDE} \
-    # in order to be uploaded from the sidecar and used by the junit lens
-    # the junit reports need to be in /logs/*/junit*.xml
-    --test-report-folder=/logs/artifacts \
-    -v 4
+    --test-report-folder=${TEST_REPORT_FOLDER} \
+    -v4
 
 # Faking cross-platform versioned folders for dry-run
 mkdir -p $BIN_FOLDER/linux/amd64


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
