### PR TITLE
Modify the behavior of VSphereDatacenterConfig Webhook

### DIFF
--- a/pkg/api/v1alpha1/vspheredatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_webhook.go
@@ -23,6 +23,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/aws/eks-anywhere/pkg/features"
 )
 
 // log is for logging in this package.
@@ -48,7 +50,10 @@ func (r *VSphereDatacenterConfig) ValidateCreate() error {
 		vspheredatacenterconfiglog.Info("VSphereDatacenterConfig is paused, so allowing create", "name", r.Name)
 		return nil
 	}
-	return apierrors.NewBadRequest("Creating new VSphereDatacenterConfig on existing cluster is not supported")
+	if !features.IsActive(features.FullLifecycleAPI()) {
+		return apierrors.NewBadRequest("Creating new VSphereDatacenterConfig on existing cluster is not supported")
+	}
+	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_webhook_test.go
@@ -1,6 +1,7 @@
 package v1alpha1_test
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -123,4 +124,17 @@ func vsphereDatacenterConfig() v1alpha1.VSphereDatacenterConfig {
 		},
 		Status: v1alpha1.VSphereDatacenterConfigStatus{},
 	}
+}
+
+func TestVSphereDatacenterValidateCreateFullManagementCycleOn(t *testing.T) {
+	os.Setenv("FULL_LIFECYCLE_API", "true")
+	dataCenterConfig := vsphereDatacenterConfig()
+	dataCenterConfig.Spec.Network = "Network"
+	c := dataCenterConfig.DeepCopy()
+
+	c.Spec.Network = "Network"
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateCreate()).To(Succeed())
+	os.Unsetenv("FULL_LIFECYCLE_API")
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This will change the webhook to allow vspheredatacenterconfig objects to be
created if the FULL_LIFECYCLE_API is set to true.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
