### PR TITLE
add default cluster name for cases where no cluster spec is provided

### DIFF
--- a/pkg/diagnostics/diagnostic_bundle.go
+++ b/pkg/diagnostics/diagnostic_bundle.go
@@ -29,6 +29,7 @@ const (
 	generatedAnalysisNameFormat = "%s-%s-analysis.yaml"
 	maxRetries                  = 5
 	backOffPeriod               = 5 * time.Second
+	defaultClusterName          = "eksa-cluster"
 )
 
 type EksaDiagnosticBundle struct {
@@ -372,5 +373,8 @@ func ParseTimeOptions(since string, sinceTime string) (*time.Time, error) {
 }
 
 func (e *EksaDiagnosticBundle) clusterName() string {
-	return e.bundle.Name
+	if e.bundle != nil {
+		return e.bundle.Name
+	}
+	return defaultClusterName
 }

--- a/pkg/diagnostics/diagnostic_bundle.go
+++ b/pkg/diagnostics/diagnostic_bundle.go
@@ -138,7 +138,7 @@ func newDiagnosticBundleDefault(af AnalyzerFactory, cf CollectorFactory) *EksaDi
 	return b.WithDefaultAnalyzers().WithDefaultCollectors().WithManagementCluster(true)
 }
 
-func newDiagnosticBundleCustom(af AnalyzerFactory, cf CollectorFactory, client BundleClient, kubectl *executables.Kubectl, bundlePath string, kubeconfig string) *EksaDiagnosticBundle {
+func newDiagnosticBundleCustom(af AnalyzerFactory, cf CollectorFactory, client BundleClient, kubectl *executables.Kubectl, bundlePath string, kubeconfig string, writer filewriter.FileWriter) *EksaDiagnosticBundle {
 	return &EksaDiagnosticBundle{
 		bundlePath:       bundlePath,
 		analyzerFactory:  af,
@@ -147,6 +147,7 @@ func newDiagnosticBundleCustom(af AnalyzerFactory, cf CollectorFactory, client B
 		kubeconfig:       kubeconfig,
 		kubectl:          kubectl,
 		retrier:          retrier.NewWithMaxRetries(maxRetries, backOffPeriod),
+		writer:           writer,
 	}
 }
 

--- a/pkg/diagnostics/factory.go
+++ b/pkg/diagnostics/factory.go
@@ -56,5 +56,5 @@ func (f *eksaDiagnosticBundleFactory) DiagnosticBundleDefault() DiagnosticBundle
 }
 
 func (f *eksaDiagnosticBundleFactory) DiagnosticBundleCustom(kubeconfig string, bundlePath string) DiagnosticBundle {
-	return newDiagnosticBundleCustom(f.analyzerFactory, f.collectorFactory, f.client, f.kubectl, bundlePath, kubeconfig)
+	return newDiagnosticBundleCustom(f.analyzerFactory, f.collectorFactory, f.client, f.kubectl, bundlePath, kubeconfig, f.writer)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A user supplied support-bundle config caused a nil pointer when we attempted to access the non-existent 'bundle' in the diagnostic bundle struct; adding a default name to prevent this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
