### PR TITLE
Improve and fix API Cluster validations/defaults

### DIFF
--- a/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
@@ -69,7 +69,7 @@ func (gsbo *generateSupportBundleOptions) validateCmdInput() error {
 		if !clusterConfigFileExist {
 			return fmt.Errorf("the cluster config file %s does not exist", f)
 		}
-		_, err := v1alpha1.ValidateClusterConfig(f)
+		_, err := v1alpha1.GetAndValidateClusterConfig(f)
 		if err != nil {
 			return fmt.Errorf("unable to get cluster config from file: %v", err)
 		}

--- a/cmd/eksctl-anywhere/cmd/validations.go
+++ b/cmd/eksctl-anywhere/cmd/validations.go
@@ -27,7 +27,7 @@ func commonValidation(ctx context.Context, clusterConfigFile string) (*v1alpha1.
 	if !clusterConfigFileExist {
 		return nil, fmt.Errorf("the cluster config file %s does not exist", clusterConfigFile)
 	}
-	clusterConfig, err := v1alpha1.ValidateClusterConfig(clusterConfigFile)
+	clusterConfig, err := v1alpha1.GetAndValidateClusterConfig(clusterConfigFile)
 	if err != nil {
 		return nil, fmt.Errorf("the cluster config file provided is invalid: %v", err)
 	}

--- a/pkg/api/v1alpha1/cluster_defaults.go
+++ b/pkg/api/v1alpha1/cluster_defaults.go
@@ -1,0 +1,50 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/logger"
+)
+
+var clusterDefaults = []func(*Cluster) error{
+	setRegistryMirrorConfigDefaults,
+	setWorkerNodeGroupDefaults,
+}
+
+func setClusterDefaults(cluster *Cluster) error {
+	for _, d := range clusterDefaults {
+		if err := d(cluster); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setRegistryMirrorConfigDefaults(clusterConfig *Cluster) error {
+	if clusterConfig.Spec.RegistryMirrorConfiguration == nil {
+		return nil
+	}
+	if clusterConfig.Spec.RegistryMirrorConfiguration.Port == "" {
+		logger.V(1).Info("RegistryMirrorConfiguration.Port is not specified, default port will be used", "Default Port", constants.DefaultHttpsPort)
+		clusterConfig.Spec.RegistryMirrorConfiguration.Port = constants.DefaultHttpsPort
+	}
+	if clusterConfig.Spec.RegistryMirrorConfiguration.CACertContent == "" {
+		if caCert, set := os.LookupEnv(RegistryMirrorCAKey); set && len(caCert) > 0 {
+			content, err := ioutil.ReadFile(caCert)
+			if err != nil {
+				return fmt.Errorf("error reading the cert file %s: %v", caCert, err)
+			}
+			logger.V(4).Info(fmt.Sprintf("%s is set, using %s as ca cert for registry", RegistryMirrorCAKey, caCert))
+			clusterConfig.Spec.RegistryMirrorConfiguration.CACertContent = string(content)
+		}
+	}
+	return nil
+}
+
+func setWorkerNodeGroupDefaults(cluster *Cluster) error {
+	// TODO: add default worker node group name when it becomes available
+	return nil
+}

--- a/pkg/api/v1alpha1/cluster_defaults_test.go
+++ b/pkg/api/v1alpha1/cluster_defaults_test.go
@@ -1,0 +1,29 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestSetClusterDefaults(t *testing.T) {
+	tests := []struct {
+		name            string
+		in, wantCluster *Cluster
+		wantErr         string
+	}{}
+	// TODO: add tests for default worker node group name when it becomes available
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			gotErr := setClusterDefaults(tt.in)
+			if tt.wantErr == "" {
+				g.Expect(gotErr).To(BeNil())
+			} else {
+				g.Expect(gotErr).To(MatchError(ContainSubstring(tt.wantErr)))
+			}
+
+			g.Expect(tt.in).To(Equal(tt.wantCluster))
+		})
+	}
+}


### PR DESCRIPTION
*Description of changes:*
Separated cluster defaults from validations. Now validations don't have
side effects and don't modify the Cluster object.

Simplified the api package interface to have one method for parsing, one
for parsing + defaults and one for parsing, defaults and validation. The
all build on top of each other so that should prevent us from "missing"
parts of the logic in some flows in the future.

Added doc comments to api package public methods to get a Cluster
object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
