### PR TITLE
Use management clusters bundle

### DIFF
--- a/controllers/controllers/cluster_controller_test.go
+++ b/controllers/controllers/cluster_controller_test.go
@@ -10,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -159,12 +158,6 @@ func TestClusterReconcilerFailToSetUpMachineConfigCP(t *testing.T) {
 	machineConfigWN := createWNMachineConfig()
 
 	objs := []runtime.Object{cluster, datacenterConfig, secret, bundle, machineConfigCP, machineConfigWN, managementCluster}
-
-	s := scheme.Scheme
-	s.AddKnownTypes(anywherev1.GroupVersion, cluster)
-	s.AddKnownTypes(anywherev1.GroupVersion, datacenterConfig)
-	s.AddKnownTypes(anywherev1.GroupVersion, bundle)
-	s.AddKnownTypes(anywherev1.GroupVersion, machineConfigCP)
 
 	cb := fake.NewClientBuilder()
 	cl := cb.WithRuntimeObjects(objs...).Build()

--- a/controllers/controllers/cluster_controller_test.go
+++ b/controllers/controllers/cluster_controller_test.go
@@ -88,15 +88,17 @@ func TestClusterReconcilerSuccess(t *testing.T) {
 	govcClient := mocks.NewMockProviderGovcClient(ctrl)
 
 	secret := createSecret()
+	managementCluster := createCluster()
+	managementCluster.Name = "management-cluster"
 	cluster := createCluster()
 	cluster.Spec.ManagementCluster = anywherev1.ManagementCluster{Name: "management-cluster"}
 
 	datacenterConfig := createDataCenter(cluster)
-	bundle := createBundle(cluster)
+	bundle := createBundle(managementCluster)
 	machineConfigCP := createCPMachineConfig()
 	machineConfigWN := createWNMachineConfig()
 
-	objs := []runtime.Object{cluster, datacenterConfig, secret, bundle, machineConfigCP, machineConfigWN}
+	objs := []runtime.Object{cluster, datacenterConfig, secret, bundle, machineConfigCP, machineConfigWN, managementCluster}
 
 	cb := fake.NewClientBuilder()
 	cl := cb.WithRuntimeObjects(objs...).Build()
@@ -146,15 +148,17 @@ func TestClusterReconcilerFailToSetUpMachineConfigCP(t *testing.T) {
 	govcClient := mocks.NewMockProviderGovcClient(ctrl)
 
 	secret := createSecret()
+	managementCluster := createCluster()
+	managementCluster.Name = "management-cluster"
 	cluster := createCluster()
 	cluster.Spec.ManagementCluster = anywherev1.ManagementCluster{Name: "management-cluster"}
 
 	datacenterConfig := createDataCenter(cluster)
-	bundle := createBundle(cluster)
+	bundle := createBundle(managementCluster)
 	machineConfigCP := createCPMachineConfig()
 	machineConfigWN := createWNMachineConfig()
 
-	objs := []runtime.Object{cluster, datacenterConfig, secret, bundle, machineConfigCP, machineConfigWN}
+	objs := []runtime.Object{cluster, datacenterConfig, secret, bundle, machineConfigCP, machineConfigWN, managementCluster}
 
 	s := scheme.Scheme
 	s.AddKnownTypes(anywherev1.GroupVersion, cluster)

--- a/controllers/controllers/clusters/vsphere.go
+++ b/controllers/controllers/clusters/vsphere.go
@@ -131,7 +131,7 @@ func (v *VSphereClusterReconciler) Reconcile(ctx context.Context, cluster *anywh
 		return reconciler.Result{}, err
 	}
 
-	specWithBundles, err := c.BuildSpecFromBundles(cluster,clusterSpec.Bundles)
+	specWithBundles, err := c.BuildSpecFromBundles(cluster, clusterSpec.Bundles)
 	if err != nil {
 		return reconciler.Result{}, err
 	}

--- a/controllers/controllers/clusters/vsphere.go
+++ b/controllers/controllers/clusters/vsphere.go
@@ -120,12 +120,6 @@ func (v *VSphereClusterReconciler) Reconcile(ctx context.Context, cluster *anywh
 		machineConfigMap[ref.Name] = machineConfig
 	}
 
-	managementCluster := &anywherev1.Cluster{}
-	managementClusterName := types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Spec.ManagementCluster.Name}
-	if err := v.Client.Get(ctx, managementClusterName, managementCluster); err != nil {
-		return reconciler.Result{}, err
-	}
-
 	bundles, err := v.bundles(ctx, cluster.Spec.ManagementCluster.Name, cluster.Namespace)
 	if err != nil {
 		return reconciler.Result{}, err

--- a/controllers/controllers/clusters/vsphere.go
+++ b/controllers/controllers/clusters/vsphere.go
@@ -126,12 +126,12 @@ func (v *VSphereClusterReconciler) Reconcile(ctx context.Context, cluster *anywh
 		return reconciler.Result{}, err
 	}
 
-	clusterSpec, err := v.FetchAppliedSpec(ctx, managementCluster)
+	bundles, err := v.bundles(ctx, cluster.Spec.ManagementCluster.Name, cluster.Namespace)
 	if err != nil {
 		return reconciler.Result{}, err
 	}
 
-	specWithBundles, err := c.BuildSpecFromBundles(cluster, clusterSpec.Bundles)
+	specWithBundles, err := c.BuildSpecFromBundles(cluster, bundles)
 	if err != nil {
 		return reconciler.Result{}, err
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This will change the controller to use a bundle linked to a management cluster when creating workload clusters  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
