### PR TITLE
Removing IAM Auth ClusterID references in docs

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/iamauth.md
+++ b/docs/content/en/docs/reference/clusterspec/iamauth.md
@@ -28,7 +28,6 @@ metadata:
    name: aws-iam-auth-config
 spec:
     awsRegion: ""
-    clusterID: ""
     backendMode:
         - ""
     mapRoles:
@@ -49,10 +48,6 @@ This would include a reference to the `AWSIamConfig` object with the configurati
 
 ### __awsRegion__ (required)
 * __Description__: awsRegion can be any region in the aws partition that the IAM roles exist in.
-* __Type__: string
-
-### __clusterID__
-* __Description__: clusterID is set as part of the role mapping config that is used by the IAM authenticator server. The default value is set to the cluster name. For more details refer [clusterID](https://github.com/kubernetes-sigs/aws-iam-authenticator#what-is-a-cluster-id).
 * __Type__: string
 
 ### __backendMode__ (required)

--- a/docs/content/en/docs/tasks/cluster/cluster-iam-auth.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-iam-auth.md
@@ -25,10 +25,10 @@ Generate your cluster configuration and add the necessary IAM Authenticator conf
 
 Create an EKS Anywhere cluster as follows:
 
-    ```bash
-    CLUSTER_NAME=my-cluster-name
-    eksctl anywhere create cluster -f ${CLUSTER_NAME}.yaml
-    ```
+```bash
+CLUSTER_NAME=my-cluster-name
+eksctl anywhere create cluster -f ${CLUSTER_NAME}.yaml
+```
 
 #### Example AWSIamConfig configuration
 This example uses a region in the default aws partition and `EKSConfigMap` as `backendMode`. Also, the IAM ARNs are mapped to the kubernetes `system:masters` group.
@@ -50,7 +50,6 @@ metadata:
    name: aws-iam-auth-config
 spec:
     awsRegion: us-west-1
-    clusterID: my-cluster-name
     backendMode:
         - EKSConfigMap
     mapRoles:
@@ -67,7 +66,7 @@ spec:
 ```
 
 {{% alert title="Note" color="primary" %}}
-When using backend mode `CRD`, the `mapRoles` and `mapUsers` are not required. For more details on configuring CRD mode, refer to [CRD](https://github.com/kubernetes-sigs/aws-iam-authenticator#crd-alpha).
+When using backend mode `CRD`, the `mapRoles` and `mapUsers` are not required. For more details on configuring CRD mode, refer to [CRD](https://github.com/kubernetes-sigs/aws-iam-authenticator#crd-alpha)
 {{% /alert %}}
 
 ### Authenticating with IAM Authenticator


### PR DESCRIPTION
*Description of changes:*
EKS-A does not support configuring clusterID value for IAM Authenticator. Updating docs accordingly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
