### PR TITLE
Avoid using bundles override with old CLI versions in e2e tests

### DIFF
--- a/test/framework/commands.go
+++ b/test/framework/commands.go
@@ -1,6 +1,8 @@
 package framework
 
 import (
+	"strings"
+
 	"github.com/aws/eks-anywhere/pkg/semver"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
@@ -60,6 +62,27 @@ func executeWithBinaryCommandOpt(fetcher binaryFetcher) CommandOpt {
 		if err = setEksctlVersionEnvVar(); err != nil {
 			return err
 		}
-		return err
+
+		// When bundles override is present, the manifest belongs to the current
+		// build of the CLI and it's intended to be used only with that version
+		removeFlag("--bundles-override", args)
+
+		return nil
+	}
+}
+
+func removeFlag(flag string, args *[]string) {
+	for i, a := range *args {
+		if a == flag {
+			elementsToDelete := 1
+			// If it's not the last arg and next arg is not a flag,
+			// that means it's the value for the current flag, remove it as well
+			if i < len(*args)-1 && !strings.HasPrefix((*args)[i+1], "-") {
+				elementsToDelete = 2
+			}
+
+			*args = append((*args)[:i], (*args)[i+elementsToDelete:]...)
+			break
+		}
 	}
 }


### PR DESCRIPTION
*Description of changes:*
When using `--bundles-override` in the e2e tests (configured by the env var `T_BUNDLES_OVERRIDE=true`), this was also being applied to old CLI versions.

That's a problem. first because the idea of running upgrade tests with old CLIs is to get an initial cluster that represents the current state of a possible user's cluster. Using a newer Bundles changes that cluster.

Second, because new Bundles might not be compatible with old CLIs.

This PR just remove that flag, if present, when using old CLIs.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
