### PR TITLE
Add cipherSuites arg to bottlerocket etcdadm

### DIFF
--- a/docs/content/en/docs/reference/changelog.md
+++ b/docs/content/en/docs/reference/changelog.md
@@ -17,7 +17,7 @@ menu:
 
 - Kubernetes components and etcd now use TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 as the
   configured TLS cipher suite [#657](https://github.com/aws/eks-anywhere/pull/657), 
-  [#759](https://github.com/aws/eks-anywhere/pull/759)
+  [#759](https://github.com/aws/eks-anywhere/pull/759), [#1019](https://github.com/aws/eks-anywhere/pull/1019)
 
 ## v0.6.0 - 2021-10-29
 

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -464,9 +464,9 @@ spec:
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
       - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
+{{- end }}
 {{- if .etcdCipherSuites }}
     cipherSuites: {{.etcdCipherSuites}}
-{{- end }}
 {{- end }}
     users:
       - name: {{.etcdSshUsername}}

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
@@ -434,6 +434,7 @@ spec:
       etcdImage: public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.14-eks-1-19-4
       bootstrapImage: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap:v1-19-6-51a138f2cb28ccc98ced838ffc6ab984110123b
       pauseImage: public.ecr.aws/eks-distro/kubernetes/pause:v1.19.8-eks-1-19-4
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
       - name: ec2-user
         sshAuthorizedKeys:

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
@@ -431,6 +431,7 @@ spec:
       etcdImage: public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.16-eks-1-21-4
       bootstrapImage: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap:v1-21-4-eks-a-v0.0.0-dev-build.158
       pauseImage: public.ecr.aws/eks-distro/kubernetes/pause:v1.21.2-eks-1-21-4
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
       - name: ec2-user
         sshAuthorizedKeys:

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -467,6 +467,7 @@ spec:
       etcdImage: public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.16-eks-1-21-4
       bootstrapImage: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap:v1-21-4-eks-a-v0.0.0-dev-build.158
       pauseImage: public.ecr.aws/eks-distro/kubernetes/pause:v1.21.2-eks-1-21-4
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
       - name: ec2-user
         sshAuthorizedKeys:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/937

*Description of changes:*

Adding support for passing in cipherSuites to cluster-api spec for etcdadm in bottlerocket. For bottlerocket to actually spin up nodes with these change, changes need to be made to https://github.com/mrajashree/etcdadm-bootstrap-provider and the bottlerocket-bootstrap code in https://github.com/aws/eks-anywhere-build-tooling as well, which will come as a follow-up

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
