### PR TITLE
Delete worker node group name in old CLI E2E tests

### DIFF
--- a/internal/pkg/api/yaml.go
+++ b/internal/pkg/api/yaml.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+func CleanupPathsFromYaml(yamlContent []byte, paths []string) ([]byte, error) {
+	m := make(map[string]interface{})
+
+	if err := yaml.Unmarshal(yamlContent, &m); err != nil {
+		return nil, err
+	}
+
+	deletePaths(m, paths)
+
+	newYaml, err := yaml.Marshal(&m)
+	if err != nil {
+		return nil, err
+	}
+
+	return newYaml, nil
+}
+
+func deletePaths(m map[string]interface{}, paths []string) {
+	for _, p := range paths {
+		deletePath(m, strings.Split(p, "."))
+	}
+}
+
+func deletePath(m map[string]interface{}, path []string) {
+	currentElement := m
+	for i := 0; i < len(path)-1; i++ {
+		p := strings.TrimSuffix(path[i], "[]")
+		isArray := len(path[i]) != len(p)
+
+		e, ok := currentElement[p]
+		if !ok {
+			return
+		}
+
+		if isArray {
+			arrayElement, arrayOk := e.([]interface{})
+			if !arrayOk {
+				return
+			}
+
+			for _, o := range arrayElement {
+				currentElement, ok = o.(map[string]interface{})
+				if !ok {
+					continue
+				}
+
+				deletePath(currentElement, path[i+1:])
+			}
+			return
+		}
+
+		currentElement, ok = e.(map[string]interface{})
+		if !ok {
+			return
+		}
+	}
+
+	delete(currentElement, path[len(path)-1])
+}

--- a/internal/pkg/api/yaml_test.go
+++ b/internal/pkg/api/yaml_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestDeletePaths(t *testing.T) {
+	tests := []struct {
+		name         string
+		obj, wantObj map[string]interface{}
+		paths        []string
+	}{
+		{
+			name: "delete nested paths, array and property from array of objects",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"workers": []interface{}{
+						map[string]interface{}{
+							"name":  "name1",
+							"count": 1,
+						},
+						map[string]interface{}{
+							"name":  "name2",
+							"count": 2,
+						},
+					},
+					"controlPlane": map[string]interface{}{
+						"ip": "ip",
+						"apiServer": map[string]interface{}{
+							"cipher": "cipher1",
+							"flags": []string{
+								"flag1",
+								"flag2",
+							},
+						},
+					},
+				},
+			},
+			paths: []string{
+				"spec.controlPlane.apiServer.flags",
+				"spec.workers[].name",
+				"spec.controlPlane.ip",
+			},
+			wantObj: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"workers": []interface{}{
+						map[string]interface{}{
+							"count": 1,
+						},
+						map[string]interface{}{
+							"count": 2,
+						},
+					},
+					"controlPlane": map[string]interface{}{
+						"apiServer": map[string]interface{}{
+							"cipher": "cipher1",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			deletePaths(tt.obj, tt.paths)
+			g.Expect(tt.obj).To(Equal(tt.wantObj))
+		})
+	}
+}

--- a/test/framework/api.go
+++ b/test/framework/api.go
@@ -1,55 +1,16 @@
 package framework
 
 import (
-	"strings"
-
-	"sigs.k8s.io/yaml"
+	"github.com/aws/eks-anywhere/internal/pkg/api"
 )
 
 var incompatiblePathsForVersion = map[string][]string{
-	"v0.6.1": {"spec.clusterNetwork.dns"},
+	"v0.6.1": {
+		"spec.clusterNetwork.dns",
+		"spec.workerNodeGroupConfigurations[].name",
+	},
 }
 
 func cleanUpClusterForVersion(clusterYaml []byte, version string) ([]byte, error) {
-	return cleanupPathsFromYaml(clusterYaml, incompatiblePathsForVersion[version])
-}
-
-func cleanupPathsFromYaml(yamlContent []byte, paths []string) ([]byte, error) {
-	m := make(map[string]interface{})
-
-	if err := yaml.Unmarshal(yamlContent, &m); err != nil {
-		return nil, err
-	}
-
-	deletePaths(m, paths)
-
-	newYaml, err := yaml.Marshal(&m)
-	if err != nil {
-		return nil, err
-	}
-
-	return newYaml, nil
-}
-
-func deletePaths(m map[string]interface{}, paths []string) {
-	for _, p := range paths {
-		deletePath(m, strings.Split(p, "."))
-	}
-}
-
-func deletePath(m map[string]interface{}, path []string) {
-	currentElement := m
-	for i := 0; i < len(path)-1; i++ {
-		e, ok := currentElement[path[i]]
-		if !ok {
-			return
-		}
-
-		currentElement, ok = e.(map[string]interface{})
-		if !ok {
-			return
-		}
-	}
-
-	delete(currentElement, path[len(path)-1])
+	return api.CleanupPathsFromYaml(clusterYaml, incompatiblePathsForVersion[version])
 }


### PR DESCRIPTION
*Description of changes:*
The CLI does not allow extra fields in the cluster configuration file.
Old versions of the CLI don't support names for worker node groups,
since that a new field. This means we need to remove that field in the
E2E tests before passing the cluster config file to the old CLI.

Moved helpers to delete paths from a yaml object to the internal api
package and added tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
