### PR TITLE
Wrap kubectl delete call in a retrier for Cilium

### DIFF
--- a/pkg/networking/cilium/client.go
+++ b/pkg/networking/cilium/client.go
@@ -44,6 +44,14 @@ func (c *retrierClient) Apply(ctx context.Context, cluster *types.Cluster, data 
 	)
 }
 
+func (c *retrierClient) Delete(ctx context.Context, cluster *types.Cluster, data []byte) error {
+	return c.Retry(
+		func() error {
+			return c.DeleteKubeSpecFromBytes(ctx, cluster, data)
+		},
+	)
+}
+
 func (c *retrierClient) WaitForPreflightDaemonSet(ctx context.Context, cluster *types.Cluster) error {
 	return c.Retry(
 		func() error {

--- a/pkg/networking/cilium/mocks/upgrader.go
+++ b/pkg/networking/cilium/mocks/upgrader.go
@@ -49,18 +49,18 @@ func (mr *MockupgraderClientMockRecorder) Apply(ctx, cluster, data interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockupgraderClient)(nil).Apply), ctx, cluster, data)
 }
 
-// DeleteKubeSpecFromBytes mocks base method.
-func (m *MockupgraderClient) DeleteKubeSpecFromBytes(ctx context.Context, cluster *types.Cluster, data []byte) error {
+// Delete mocks base method.
+func (m *MockupgraderClient) Delete(ctx context.Context, cluster *types.Cluster, data []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteKubeSpecFromBytes", ctx, cluster, data)
+	ret := m.ctrl.Call(m, "Delete", ctx, cluster, data)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteKubeSpecFromBytes indicates an expected call of DeleteKubeSpecFromBytes.
-func (mr *MockupgraderClientMockRecorder) DeleteKubeSpecFromBytes(ctx, cluster, data interface{}) *gomock.Call {
+// Delete indicates an expected call of Delete.
+func (mr *MockupgraderClientMockRecorder) Delete(ctx, cluster, data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteKubeSpecFromBytes", reflect.TypeOf((*MockupgraderClient)(nil).DeleteKubeSpecFromBytes), ctx, cluster, data)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockupgraderClient)(nil).Delete), ctx, cluster, data)
 }
 
 // WaitForCiliumDaemonSet mocks base method.

--- a/pkg/networking/cilium/upgrader.go
+++ b/pkg/networking/cilium/upgrader.go
@@ -11,7 +11,7 @@ import (
 
 type upgraderClient interface {
 	Apply(ctx context.Context, cluster *types.Cluster, data []byte) error
-	DeleteKubeSpecFromBytes(ctx context.Context, cluster *types.Cluster, data []byte) error
+	Delete(ctx context.Context, cluster *types.Cluster, data []byte) error
 	WaitForPreflightDaemonSet(ctx context.Context, cluster *types.Cluster) error
 	WaitForPreflightDeployment(ctx context.Context, cluster *types.Cluster) error
 	WaitForCiliumDaemonSet(ctx context.Context, cluster *types.Cluster) error
@@ -55,7 +55,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentS
 	}
 
 	logger.V(3).Info("Deleting Cilium upgrade preflight")
-	if err := u.client.DeleteKubeSpecFromBytes(ctx, cluster, preflight); err != nil {
+	if err := u.client.Delete(ctx, cluster, preflight); err != nil {
 		return nil, fmt.Errorf("failed deleting cilium preflight check: %v", err)
 	}
 

--- a/pkg/networking/cilium/upgrader_test.go
+++ b/pkg/networking/cilium/upgrader_test.go
@@ -78,7 +78,7 @@ func TestUpgraderUpgradeSuccess(t *testing.T) {
 		tt.client.EXPECT().Apply(tt.ctx, tt.cluster, tt.manifestPre),
 		tt.client.EXPECT().WaitForPreflightDaemonSet(tt.ctx, tt.cluster),
 		tt.client.EXPECT().WaitForPreflightDeployment(tt.ctx, tt.cluster),
-		tt.client.EXPECT().DeleteKubeSpecFromBytes(tt.ctx, tt.cluster, tt.manifestPre),
+		tt.client.EXPECT().Delete(tt.ctx, tt.cluster, tt.manifestPre),
 		tt.expectTemplateManifest(),
 		tt.client.EXPECT().Apply(tt.ctx, tt.cluster, tt.manifest),
 		tt.client.EXPECT().WaitForCiliumDaemonSet(tt.ctx, tt.cluster),


### PR DESCRIPTION
*Description of changes:*
This should avoid transient errors like "connection reset by peer" when
talking to the api server.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
