### PR TITLE
Fix URLs for CAPI manifests

### DIFF
--- a/release/pkg/artifacts_types.go
+++ b/release/pkg/artifacts_types.go
@@ -56,6 +56,7 @@ type ManifestArtifact struct {
 	GitTag            string
 	ProjectPath       string
 	SourcedFromBranch string
+	Component         string
 }
 
 type Artifact struct {

--- a/release/pkg/assets_capi.go
+++ b/release/pkg/assets_capi.go
@@ -19,7 +19,6 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -145,6 +144,7 @@ func (r *ReleaseConfig) GetCAPIAssets() ([]Artifact, error) {
 				GitTag:            gitTag,
 				ProjectPath:       capiProjectPath,
 				SourcedFromBranch: sourcedFromBranch,
+				Component:         component,
 			}
 			artifacts = append(artifacts, Artifact{Manifest: manifestArtifact})
 		}
@@ -190,14 +190,13 @@ func (r *ReleaseConfig) GetCoreClusterAPIBundle(imageDigests map[string]string) 
 
 			if artifact.Manifest != nil {
 				manifestArtifact := artifact.Manifest
-				if !strings.Contains(manifestArtifact.ReleaseName, "core") && !strings.Contains(manifestArtifact.ReleaseName, "metadata") {
+				if manifestArtifact.Component != "cluster-api" {
 					continue
 				}
 
 				bundleManifestArtifact := anywherev1alpha1.Manifest{
 					URI: manifestArtifact.ReleaseCdnURI,
 				}
-
 				bundleManifestArtifacts[manifestArtifact.ReleaseName] = bundleManifestArtifact
 
 				manifestContents, err := ioutil.ReadFile(filepath.Join(manifestArtifact.ArtifactPath, manifestArtifact.ReleaseName))
@@ -267,14 +266,13 @@ func (r *ReleaseConfig) GetKubeadmBootstrapBundle(imageDigests map[string]string
 
 			if artifact.Manifest != nil {
 				manifestArtifact := artifact.Manifest
-				if !strings.Contains(manifestArtifact.ReleaseName, "bootstrap") && !strings.Contains(manifestArtifact.ReleaseName, "metadata") {
+				if manifestArtifact.Component != "bootstrap-kubeadm" {
 					continue
 				}
 
 				bundleManifestArtifact := anywherev1alpha1.Manifest{
 					URI: manifestArtifact.ReleaseCdnURI,
 				}
-
 				bundleManifestArtifacts[manifestArtifact.ReleaseName] = bundleManifestArtifact
 
 				manifestContents, err := ioutil.ReadFile(filepath.Join(manifestArtifact.ArtifactPath, manifestArtifact.ReleaseName))
@@ -344,14 +342,13 @@ func (r *ReleaseConfig) GetKubeadmControlPlaneBundle(imageDigests map[string]str
 
 			if artifact.Manifest != nil {
 				manifestArtifact := artifact.Manifest
-				if !strings.Contains(manifestArtifact.ReleaseName, "control-plane") && !strings.Contains(manifestArtifact.ReleaseName, "metadata") {
+				if manifestArtifact.Component != "control-plane-kubeadm" {
 					continue
 				}
 
 				bundleManifestArtifact := anywherev1alpha1.Manifest{
 					URI: manifestArtifact.ReleaseCdnURI,
 				}
-
 				bundleManifestArtifacts[manifestArtifact.ReleaseName] = bundleManifestArtifact
 
 				manifestContents, err := ioutil.ReadFile(filepath.Join(manifestArtifact.ArtifactPath, manifestArtifact.ReleaseName))

--- a/release/pkg/assets_cluster_controller.go
+++ b/release/pkg/assets_cluster_controller.go
@@ -31,13 +31,13 @@ func (r *ReleaseConfig) GetClusterControllerAssets() ([]Artifact, error) {
 	var gitTag string
 	if r.DevRelease {
 		// Get git tag
-		out, err := git.DescribeTag(r.CliRepoSource)
+		out, err := git.GetRepoTags(r.CliRepoSource)
 		if err != nil {
 			return nil, errors.Cause(err)
 		}
 
-		gitVersion := strings.Split(out, "-")
-		gitTag = gitVersion[0]
+		gitTags := strings.Split(out, "\n")
+		gitTag = gitTags[len(gitTags)-2]
 		if err != nil {
 			return nil, errors.Cause(err)
 		}

--- a/release/pkg/git/git.go
+++ b/release/pkg/git/git.go
@@ -35,6 +35,11 @@ func DescribeTag(gitRoot string) (string, error) {
 	return utils.ExecCommand(cmd)
 }
 
+func GetRepoTags(gitRoot string) (string, error) {
+	cmd := exec.Command("git", "-C", gitRoot, "tag")
+	return utils.ExecCommand(cmd)
+}
+
 func GetLatestCommitForPath(gitRoot, path string) (string, error) {
 	cmd := exec.Command("git", "-C", gitRoot, "log", "--pretty=format:%h", "-n1", path)
 	return utils.ExecCommand(cmd)


### PR DESCRIPTION
This check was causing the incorrect URL to be assigned to CAPI metadata manifests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
