### PR TITLE
use staging assets for staging cli release e2e tests

### DIFF
--- a/scripts/get_bundle.sh
+++ b/scripts/get_bundle.sh
@@ -17,6 +17,6 @@ set -e
 set -x
 set -o pipefail
 
-bundle_number=$(cat "${CODEBUILD_SRC_DIR}/release/triggers/bundle-release/production/BUNDLE_NUMBER")
-bundle_url="https://anywhere-assets.eks.amazonaws.com/releases/bundles/${bundle_number}/manifest.yaml"
+bundle_number=$(cat "${CODEBUILD_SRC_DIR}/release/triggers/bundle-release/development/BUNDLE_NUMBER")
+bundle_url="https://beta-assets.eks-anywhere.model-rocket.aws.dev/releases/bundles/${bundle_number}/manifest.yaml"
 wget -O "${CODEBUILD_SRC_DIR}/bin/local-bundle-release.yaml" "${bundle_url}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Use the assets pushed by the staging release process to run the staging e2e tests during staging CLI release; this will allow us to run the following release flow:
- staging bundle build
- staging cli build
- prod bundle build
- prod cli build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
