### PR TITLE
Adding mirroring of helm chart `cert-manager` to release tool

### DIFF
--- a/release/api/v1alpha1/bundle_types.go
+++ b/release/api/v1alpha1/bundle_types.go
@@ -132,6 +132,7 @@ type CertManagerBundle struct {
 	Controller Image    `json:"controller"`
 	Webhook    Image    `json:"webhook"`
 	Manifest   Manifest `json:"manifest"`
+	HelmChart  Image    `json:"helmChart,omitempty"`
 }
 
 type CoreClusterAPI struct {


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

*Description of changes:*
Adding in mirroring of the cert-manager helm chart. Noticed it was actually empty on ecr gallery. https://gallery.ecr.aws/l0g8r8j6/jetstack/cert-manager

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
