### PR TITLE
Modifying eks-a controller error message

### DIFF
--- a/controllers/controllers/resource/fetcher.go
+++ b/controllers/controllers/resource/fetcher.go
@@ -162,7 +162,7 @@ func (r *CapiResourceFetcher) fetchClusterForRef(ctx context.Context, refId type
 			}
 		}
 	}
-	return nil, fmt.Errorf("eksa cluster not found for datacenterRef %v", refId)
+	return nil, fmt.Errorf("eksa cluster not found for %s: %v", kind, refId)
 }
 
 func (r *CapiResourceFetcher) machineDeploymentsMap(ctx context.Context, c *anywherev1.Cluster) (map[string]*clusterv1.MachineDeployment, error) {


### PR DESCRIPTION
*Description of changes:*
Nit fix.
Modifying error message to reflect the CRD kind that fetcher is trying to do an eksa cluster lookup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
