### PR TITLE
Add Tinkerbell assets only to dev release manifest

### DIFF
--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -254,13 +254,13 @@ func (r *ReleaseConfig) GenerateBundleArtifactsTable() (map[string][]Artifact, e
 		"etcdadm":                      r.GetEtcdadmAssets,
 		"cri-tools":                    r.GetCriToolsAssets,
 		"diagnostic-collector":         r.GetDiagnosticCollectorAssets,
-		"tink":                         r.GetTinkAssets,
-		"hegel":                        r.GetHegelAssets,
-		"cfssl":                        r.GetCfsslAssets,
 	}
 
 	if r.DevRelease && r.BuildRepoBranchName == "main" {
 		eksAArtifactsFuncs["cluster-api-provider-tinkerbell"] = r.GetCaptAssets
+		eksAArtifactsFuncs["tink"] = r.GetTinkAssets
+		eksAArtifactsFuncs["hegel"] = r.GetHegelAssets
+		eksAArtifactsFuncs["cfssl"] = r.GetCfsslAssets
 	}
 
 	for componentName, artifactFunc := range eksAArtifactsFuncs {


### PR DESCRIPTION
Tinkerbell is still in development phase behind feature flag, so we don't want these images to feature in the production bundle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
