### PR TITLE
Refactor preflight validations and change bool name for bypassing LogPass call

### DIFF
--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -1,0 +1,31 @@
+package validations
+
+import (
+	"fmt"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/features"
+)
+
+func ValidateTaintsSupport(clusterSpec *cluster.Spec) error {
+	if !features.IsActive(features.TaintsSupport()) {
+		if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints) > 0 {
+			return fmt.Errorf("Taints feature is not enabled. Please set the env variable TAINTS_SUPPORT.")
+		}
+	}
+	return nil
+}
+
+func ValidateNodeLabelsSupport(clusterSpec *cluster.Spec) error {
+	if !features.IsActive(features.NodeLabelsSupport()) {
+		if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Labels) > 0 {
+			return fmt.Errorf("Node labels feature is not enabled. Please set the env variable NODE_LABELS_SUPPORT.")
+		}
+		for _, workerNodeGroup := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
+			if len(workerNodeGroup.Labels) > 0 {
+				return fmt.Errorf("Node labels feature is not enabled. Please set the env variable NODE_LABELS_SUPPORT.")
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/validations/createvalidations/cluster.go
+++ b/pkg/validations/createvalidations/cluster.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
@@ -28,27 +26,4 @@ func ValidateManagementCluster(ctx context.Context, k validations.KubectlClient,
 		return err
 	}
 	return k.ValidateEKSAClustersCRD(ctx, cluster)
-}
-
-func ValidateTaintsSupport(clusterSpec *cluster.Spec) error {
-	if !features.IsActive(features.TaintsSupport()) {
-		if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints) > 0 {
-			return fmt.Errorf("Taints feature is not enabled. Please set the env variable TAINTS_SUPPORT.")
-		}
-	}
-	return nil
-}
-
-func ValidateNodeLabelsSupport(clusterSpec *cluster.Spec) error {
-	if !features.IsActive(features.NodeLabelsSupport()) {
-		if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Labels) > 0 {
-			return fmt.Errorf("Node labels feature is not enabled. Please set the env variable NODE_LABELS_SUPPORT.")
-		}
-		for _, workerNodeGroup := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
-			if len(workerNodeGroup.Labels) > 0 {
-				return fmt.Errorf("Node labels feature is not enabled. Please set the env variable NODE_LABELS_SUPPORT.")
-			}
-		}
-	}
-	return nil
 }

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -20,13 +20,13 @@ func (u *CreateValidations) PreflightValidations(ctx context.Context) (err error
 			Name:        "validate taints support",
 			Remediation: "ensure TAINTS_SUPPORT env variable is set",
 			Err:         ValidateTaintsSupport(u.Opts.Spec),
-			FeatureFlag: true,
+			Silent:      true,
 		},
 		{
 			Name:        "validate node labels support",
 			Remediation: "ensure NODE_LABELS_SUPPORT env variable is set",
 			Err:         ValidateNodeLabelsSupport(u.Opts.Spec),
-			FeatureFlag: true,
+			Silent:      true,
 		},
 	}
 
@@ -60,7 +60,7 @@ func (u *CreateValidations) PreflightValidations(ctx context.Context) (err error
 	for _, validation := range createValidations {
 		if validation.Err != nil {
 			errs = append(errs, validation.Err.Error())
-		} else if !validation.FeatureFlag {
+		} else if !validation.Silent {
 			validation.LogPass()
 		}
 	}

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -19,13 +19,13 @@ func (u *CreateValidations) PreflightValidations(ctx context.Context) (err error
 		{
 			Name:        "validate taints support",
 			Remediation: "ensure TAINTS_SUPPORT env variable is set",
-			Err:         ValidateTaintsSupport(u.Opts.Spec),
+			Err:         validations.ValidateTaintsSupport(u.Opts.Spec),
 			Silent:      true,
 		},
 		{
 			Name:        "validate node labels support",
 			Remediation: "ensure NODE_LABELS_SUPPORT env variable is set",
-			Err:         ValidateNodeLabelsSupport(u.Opts.Spec),
+			Err:         validations.ValidateNodeLabelsSupport(u.Opts.Spec),
 			Silent:      true,
 		},
 	}
@@ -56,17 +56,5 @@ func (u *CreateValidations) PreflightValidations(ctx context.Context) (err error
 		)
 	}
 
-	var errs []string
-	for _, validation := range createValidations {
-		if validation.Err != nil {
-			errs = append(errs, validation.Err.Error())
-		} else if !validation.Silent {
-			validation.LogPass()
-		}
-	}
-
-	if len(errs) > 0 {
-		return &validations.ValidationError{Errs: errs}
-	}
-	return nil
+	return validations.RunPreflightValidations(createValidations)
 }

--- a/pkg/validations/preflightvalidations.go
+++ b/pkg/validations/preflightvalidations.go
@@ -1,0 +1,17 @@
+package validations
+
+func RunPreflightValidations(validations []ValidationResult) error {
+	var errs []string
+	for _, validation := range validations {
+		if validation.Err != nil {
+			errs = append(errs, validation.Err.Error())
+		} else if !validation.Silent {
+			validation.LogPass()
+		}
+	}
+
+	if len(errs) > 0 {
+		return &ValidationError{Errs: errs}
+	}
+	return nil
+}

--- a/pkg/validations/upgradevalidations/cluster.go
+++ b/pkg/validations/upgradevalidations/cluster.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
@@ -24,27 +22,4 @@ func ValidateClusterObjectExists(ctx context.Context, k validations.KubectlClien
 		}
 	}
 	return fmt.Errorf("couldn't find CAPI cluster object for cluster with name %s", cluster.Name)
-}
-
-func ValidateTaintsSupport(clusterSpec *cluster.Spec) error {
-	if !features.IsActive(features.TaintsSupport()) {
-		if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints) > 0 {
-			return fmt.Errorf("Taints feature is not enabled.")
-		}
-	}
-	return nil
-}
-
-func ValidateNodeLabelsSupport(clusterSpec *cluster.Spec) error {
-	if !features.IsActive(features.NodeLabelsSupport()) {
-		if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Labels) > 0 {
-			return fmt.Errorf("Node labels feature is not enabled. Please set the env variable NODE_LABELS_SUPPORT.")
-		}
-		for _, workerNodeGroup := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
-			if len(workerNodeGroup.Labels) > 0 {
-				return fmt.Errorf("Node labels feature is not enabled. Please set the env variable NODE_LABELS_SUPPORT.")
-			}
-		}
-	}
-	return nil
 }

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -24,13 +24,13 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) (err erro
 			Name:        "validate taints support",
 			Remediation: "ensure TAINTS_SUPPORT env variable is set",
 			Err:         ValidateTaintsSupport(u.Opts.Spec),
-			FeatureFlag: true,
+			Silent:      true,
 		},
 		validations.ValidationResult{
 			Name:        "validate node labels support",
 			Remediation: "ensure NODE_LABELS_SUPPORT env variable is set",
 			Err:         ValidateNodeLabelsSupport(u.Opts.Spec),
-			FeatureFlag: true,
+			Silent:      true,
 		},
 		validations.ValidationResult{
 			Name:        "control plane ready",
@@ -73,7 +73,7 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) (err erro
 	for _, validation := range upgradeValidations {
 		if validation.Err != nil {
 			errs = append(errs, validation.Err.Error())
-		} else if !validation.FeatureFlag {
+		} else if !validation.Silent {
 			validation.LogPass()
 		}
 	}

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -23,13 +23,13 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) (err erro
 		validations.ValidationResult{
 			Name:        "validate taints support",
 			Remediation: "ensure TAINTS_SUPPORT env variable is set",
-			Err:         ValidateTaintsSupport(u.Opts.Spec),
+			Err:         validations.ValidateTaintsSupport(u.Opts.Spec),
 			Silent:      true,
 		},
 		validations.ValidationResult{
 			Name:        "validate node labels support",
 			Remediation: "ensure NODE_LABELS_SUPPORT env variable is set",
-			Err:         ValidateNodeLabelsSupport(u.Opts.Spec),
+			Err:         validations.ValidateNodeLabelsSupport(u.Opts.Spec),
 			Silent:      true,
 		},
 		validations.ValidationResult{
@@ -69,17 +69,5 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) (err erro
 		},
 	)
 
-	var errs []string
-	for _, validation := range upgradeValidations {
-		if validation.Err != nil {
-			errs = append(errs, validation.Err.Error())
-		} else if !validation.Silent {
-			validation.LogPass()
-		}
-	}
-
-	if len(errs) > 0 {
-		return &validations.ValidationError{Errs: errs}
-	}
-	return nil
+	return validations.RunPreflightValidations(upgradeValidations)
 }

--- a/pkg/validations/utils.go
+++ b/pkg/validations/utils.go
@@ -10,7 +10,7 @@ type ValidationResult struct {
 	Name        string
 	Err         error
 	Remediation string
-	FeatureFlag bool
+	Silent      bool
 }
 
 func (v *ValidationResult) Report() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Refactoring preflight validations so we have common code instead of repeating validation code in both create and upgrade. Also changed bool name to `Silent` so that it can be more flexible than just for feature flags and explains what is actually happening. 

This PR addresses comments from https://github.com/aws/eks-anywhere/pull/1036

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
