### PR TITLE
Do not set annotation on machineconfig that belongs to a management cluster

### DIFF
--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1113,7 +1113,9 @@ func (p *vsphereProvider) MachineConfigs() []providers.MachineConfig {
 		p.machineConfigs[etcdMachineName].Annotations = map[string]string{p.clusterConfig.EtcdAnnotation(): "true"}
 		if etcdMachineName != controlPlaneMachineName {
 			configs[etcdMachineName] = p.machineConfigs[etcdMachineName]
-			p.machineConfigs[etcdMachineName].SetManagedBy(p.clusterConfig.ManagedBy())
+			if p.clusterConfig.IsManaged() {
+				p.machineConfigs[etcdMachineName].SetManagedBy(p.clusterConfig.ManagedBy())
+			}
 		}
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This will fix the code that sets the the "anywhere.eks.amazonaws.com/managed-by" on VSphereMachineConfig objects.
  
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
