### PR TITLE
Automated cherry pick of #1066: Pass branch name from codebuild to e2e tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -67,6 +67,7 @@ phases:
       --bundles-override=${BUNDLES_OVERRIDE}
       --cleanup-vms=true
       --test-report-folder=reports
+      --branch-name=${BRANCH_NAME}
   post_build:
     commands:
     - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE

--- a/cmd/integration_test/cmd/run.go
+++ b/cmd/integration_test/cmd/run.go
@@ -25,6 +25,7 @@ const (
 	bundlesOverrideFlagName  = "bundles-override"
 	cleanupVmsFlagName       = "cleanup-vms"
 	testReportFolderFlagName = "test-report-folder"
+	branchNameFlagName       = "branch-name"
 )
 
 var runE2ECmd = &cobra.Command{
@@ -66,6 +67,7 @@ func init() {
 	runE2ECmd.Flags().Bool(bundlesOverrideFlagName, false, "Flag to indicate if the tests should run with a bundles override")
 	runE2ECmd.Flags().Bool(cleanupVmsFlagName, false, "Flag to indicate if VSphere VMs should be cleaned up automatically as tests complete")
 	runE2ECmd.Flags().String(testReportFolderFlagName, "", "Folder destination fo JUnit tests reports")
+	runE2ECmd.Flags().String(branchNameFlagName, "main", "EKS-A origin branch from where the tests are being run")
 
 	for _, flag := range requiredFlags {
 		if err := runE2ECmd.MarkFlagRequired(flag); err != nil {
@@ -86,6 +88,7 @@ func runE2E(ctx context.Context) error {
 	bundlesOverride := viper.GetBool(bundlesOverrideFlagName)
 	cleanupVms := viper.GetBool(cleanupVmsFlagName)
 	testReportFolder := viper.GetString(testReportFolderFlagName)
+	branchName := viper.GetString(branchNameFlagName)
 
 	runConf := e2e.ParallelRunConf{
 		MaxInstances:        maxInstances,
@@ -99,6 +102,7 @@ func runE2E(ctx context.Context) error {
 		BundlesOverride:     bundlesOverride,
 		CleanupVms:          cleanupVms,
 		TestReportFolder:    testReportFolder,
+		BranchName:          branchName,
 	}
 
 	err := e2e.RunTestsInParallel(runConf)

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -30,6 +30,7 @@ type ParallelRunConf struct {
 	BundlesOverride     bool
 	CleanupVms          bool
 	TestReportFolder    string
+	BranchName          string
 }
 
 type (
@@ -110,12 +111,12 @@ func RunTestsInParallel(conf ParallelRunConf) error {
 
 type instanceRunConf struct {
 	amiId, instanceProfileName, storageBucket, jobId, parentJobId, subnetId, regex, instanceId, controlPlaneIP string
-	testReportFolder                                                                                           string
+	testReportFolder, branchName                                                                               string
 	bundlesOverride                                                                                            bool
 }
 
 func RunTests(conf instanceRunConf) (testInstanceID string, testCommandResult *testCommandResult, err error) {
-	session, err := newSession(conf.amiId, conf.instanceProfileName, conf.storageBucket, conf.jobId, conf.subnetId, conf.controlPlaneIP, conf.bundlesOverride)
+	session, err := newSessionFromConf(conf)
 	if err != nil {
 		return "", nil, err
 	}
@@ -228,6 +229,7 @@ func splitTests(testsList []string, conf ParallelRunConf) []instanceRunConf {
 				bundlesOverride:     conf.BundlesOverride,
 				controlPlaneIP:      ip,
 				testReportFolder:    conf.TestReportFolder,
+				branchName:          conf.BranchName,
 			})
 
 			testsInCurrentInstance = make([]string, 0, testPerInstance)

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -37,9 +37,10 @@ type E2ESession struct {
 	testEnvVars         map[string]string
 	bundlesOverride     bool
 	requiredFiles       []string
+	branchName          string
 }
 
-func newSession(amiId, instanceProfileName, storageBucket, jobId, subnetId, controlPlaneIP string, bundlesOverride bool) (*E2ESession, error) {
+func newSessionFromConf(conf instanceRunConf) (*E2ESession, error) {
 	session, err := session.NewSession()
 	if err != nil {
 		return nil, fmt.Errorf("error creating session: %v", err)
@@ -47,15 +48,16 @@ func newSession(amiId, instanceProfileName, storageBucket, jobId, subnetId, cont
 
 	e := &E2ESession{
 		session:             session,
-		amiId:               amiId,
-		instanceProfileName: instanceProfileName,
-		storageBucket:       storageBucket,
-		jobId:               jobId,
-		subnetId:            subnetId,
-		controlPlaneIP:      controlPlaneIP,
+		amiId:               conf.amiId,
+		instanceProfileName: conf.instanceProfileName,
+		storageBucket:       conf.storageBucket,
+		jobId:               conf.jobId,
+		subnetId:            conf.subnetId,
+		controlPlaneIP:      conf.controlPlaneIP,
 		testEnvVars:         make(map[string]string),
-		bundlesOverride:     bundlesOverride,
+		bundlesOverride:     conf.bundlesOverride,
 		requiredFiles:       requiredFiles,
+		branchName:          conf.branchName,
 	}
 
 	return e, nil
@@ -128,6 +130,10 @@ func (e *E2ESession) setup(regex string) error {
 	e.testEnvVars[e2etests.JobIdVar] = e.jobId
 	e.testEnvVars[e2etests.BundlesOverrideVar] = strconv.FormatBool(e.bundlesOverride)
 	e.testEnvVars[e2etests.ClusterNameVar] = instanceId
+
+	if e.branchName != "" {
+		e.testEnvVars[e2etests.BranchNameEnvVar] = e.branchName
+	}
 	return nil
 }
 

--- a/test/framework/releaseVersions.go
+++ b/test/framework/releaseVersions.go
@@ -18,7 +18,7 @@ import (
 const (
 	prodReleasesManifest = "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml"
 	releaseBinaryName    = "eksctl-anywhere"
-	branchNameEnvVar     = "T_BRANCH_NAME"
+	BranchNameEnvVar     = "T_BRANCH_NAME"
 	defaultTestBranch    = "main"
 )
 
@@ -27,7 +27,7 @@ func GetLatestMinorReleaseBinaryFromTestBranch() (binaryPath string, err error) 
 }
 
 func GetLatestMinorReleaseFromTestBranch() (*releasev1alpha1.EksARelease, error) {
-	testBranch := getEnvWithDefault(branchNameEnvVar, defaultTestBranch)
+	testBranch := getEnvWithDefault(BranchNameEnvVar, defaultTestBranch)
 	if testBranch == "main" {
 		return GetLatestMinorReleaseFromMain()
 	}


### PR DESCRIPTION
Cherry pick of #1066 on release-0.7.

#1066: Pass branch name from codebuild to e2e tests