### PR TITLE
Adding replace for patched CAPT in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,4 +42,5 @@ replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.5.9
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc95
+	github.com/tinkerbell/cluster-api-provider-tinkerbell => github.com/pokearu/cluster-api-provider-tinkerbell v0.0.0-20220128001529-79d851d0861f
 )


### PR DESCRIPTION
*Description of changes:*
We are maintaining a patched version of [CAPT](https://github.com/pokearu/cluster-api-provider-tinkerbell/tree/release-v0.1.0) which has modified APIs. 
Added a replace and ran `go mod tidy`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
