### PR TITLE
Update build-eks-a-cli.yml

### DIFF
--- a/cmd/integration_test/build/buildspecs/build-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/build-eks-a-cli.yml
@@ -4,6 +4,7 @@ phases:
   build:
     commands:
     - make e2e
+    - make get-override-bundle
     - echo "$CODEBUILD_RESOLVED_SOURCE_VERSION" >> bin/githash
 
 artifacts:


### PR DESCRIPTION
add release branch bundle override to the `0.7.0` test build

*Issue #, if available:*

*Description of changes:*
Use the `release-0.7` bundle from build tooling for the test execution on this branch


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
