### PR TITLE
Add watch permission for OIDCConfig to controller

### DIFF
--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -3227,6 +3227,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - cluster.x-k8s.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -54,3 +54,4 @@ rules:
   verbs:
   - get
   - list
+  - watch

--- a/controllers/controllers/cluster_controller_legacy.go
+++ b/controllers/controllers/cluster_controller_legacy.go
@@ -44,7 +44,7 @@ func NewClusterReconcilerLegacy(client client.Client, log logr.Logger, scheme *r
 }
 
 //+kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=clusters;vspheredatacenterconfigs;vspheremachineconfigs;dockerdatacenterconfigs;bundles;awsiamconfigs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=oidcconfigs,verbs=get;list
+//+kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=oidcconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=clusters/status;vspheredatacenterconfigs/status;vspheremachineconfigs/status;dockerdatacenterconfigs/status;bundles/status;awsiamconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=clusters/finalizers;vspheredatacenterconfigs/finalizers;vspheremachineconfigs/finalizers;dockerdatacenterconfigs/finalizers;bundles/finalizers;awsiamconfigs/finalizers,verbs=update
 


### PR DESCRIPTION
Fixes #1087 

*Description of changes:*
This avoids a error log from the cached client after retrieving an
OIDCConfig object from the controller.

More info about why this was happening in the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
