### PR TITLE
Nodes ready total count issue for the tinkerbell workernodes

### DIFF
--- a/pkg/providers/tinkerbell/config/template-md.yaml
+++ b/pkg/providers/tinkerbell/config/template-md.yaml
@@ -10,9 +10,7 @@ spec:
   clusterName: {{.clusterName}}
   replicas: {{.workerReplicas}}
   selector:
-    matchLabels:
-      cluster.x-k8s.io/cluster-name: {{.clusterName}}
-      pool: {{.workerPoolName}}
+    matchLabels: {}
   template:
     metadata:
       labels:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md.yaml
@@ -10,9 +10,7 @@ spec:
   clusterName: test
   replicas: 1
   selector:
-    matchLabels:
-      cluster.x-k8s.io/cluster-name: test
-      pool: md-0
+    matchLabels: {}
   template:
     metadata:
       labels:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Our CLI was showing wrong count for the total Nodes (CP + worker). It was not taking workernodes into consideration for tinkerbell provider. This PR is for solving this error. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
