### PR TITLE
Fix taints validations

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -318,6 +318,7 @@ func validateWorkerNodeGroups(clusterConfig *Cluster) error {
 		return errors.New("worker node group must be specified")
 	}
 	workerNodeGroupNames := make(map[string]bool, len(workerNodeGroupConfigs))
+	noExecuteNoScheduleTaintedNodeGroups := make(map[string]struct{})
 	for _, workerNodeGroupConfig := range workerNodeGroupConfigs {
 		if workerNodeGroupConfig.Name == "" {
 			return errors.New("must specify name for worker nodes")
@@ -325,7 +326,17 @@ func validateWorkerNodeGroups(clusterConfig *Cluster) error {
 		if workerNodeGroupNames[workerNodeGroupConfig.Name] {
 			return errors.New("worker node group names must be unique")
 		}
+		if len(workerNodeGroupConfig.Taints) != 0 {
+			for _, taint := range workerNodeGroupConfig.Taints {
+				if taint.Effect == "NoExecute" || taint.Effect == "NoSchedule" {
+					noExecuteNoScheduleTaintedNodeGroups[workerNodeGroupConfig.Name] = struct{}{}
+				}
+			}
+		}
 		workerNodeGroupNames[workerNodeGroupConfig.Name] = true
+	}
+	if len(noExecuteNoScheduleTaintedNodeGroups) == len(workerNodeGroupConfigs) {
+		return errors.New("at least one WorkerNodeGroupConfiguration must not have NoExecute and/or NoSchedule taints")
 	}
 	return nil
 }

--- a/pkg/api/v1alpha1/testdata/cluster_invalid_taints.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_invalid_taints.yaml
@@ -1,0 +1,73 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: VSphereMachineConfig
+  kubernetesVersion: "1.19"
+  workerNodeGroupConfigurations:
+    - count: 3
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: VSphereMachineConfig
+      name: md-0
+      taints:
+        - key: key1
+          value: value1
+          effect: NoExecute
+    - count: 3
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: VSphereMachineConfig
+      name: md-1
+      taints:
+        - key: key1
+          value: value1
+          effect: NoSchedule
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  diskGiB: 25
+  datastore: "myDatastore"
+  folder: "myFolder"
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: "ubuntu"
+  resourcePool: "myResourcePool"
+  storagePolicyName: "myStoragePolicyName"
+  template: "myTemplate"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  datacenter: "myDatacenter"
+  network: "myNetwork"
+  server: "myServer"
+  thumbprint: "myTlsThumbprint"
+  insecure: false

--- a/pkg/api/v1alpha1/testdata/cluster_valid_taints_multiple_worker_node_groups.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_valid_taints_multiple_worker_node_groups.yaml
@@ -1,0 +1,92 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: VSphereMachineConfig
+  kubernetesVersion: "1.19"
+  workerNodeGroupConfigurations:
+    - count: 3
+      machineGroupRef:
+        name: eksa-unit-test-2
+        kind: VSphereMachineConfig
+      name: "md-0"
+      taints:
+        - key: key1
+          value: val1
+          effect: NoSchedule
+    - count: 3
+      machineGroupRef:
+        name: eksa-unit-test-2
+        kind: VSphereMachineConfig
+      name: "md-1"
+      taints:
+        - key: key1
+          value: val1
+          effect: PreferNoSchedule
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  diskGiB: 25
+  datastore: "myDatastore"
+  folder: "myFolder"
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: "ubuntu"
+  resourcePool: "myResourcePool"
+  storagePolicyName: "myStoragePolicyName"
+  template: "myTemplate"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test-2
+spec:
+  diskGiB: 20
+  datastore: "myDatastore2"
+  folder: "myFolder2"
+  memoryMiB: 2048
+  numCPUs: 4
+  osFamily: "bottlerocket"
+  resourcePool: "myResourcePool2"
+  storagePolicyName: "myStoragePolicyName2"
+  template: "myTemplate2"
+  users:
+    - name: "mySshUsername2"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey2"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  datacenter: "myDatacenter"
+  network: "myNetwork"
+  server: "myServer"
+  thumbprint: "myTlsThumbprint"
+  insecure: false

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -21,18 +21,6 @@ func ValidateTaintsSupport(clusterSpec *cluster.Spec) error {
 			wngcTaintsPresent {
 			return fmt.Errorf("Taints feature is not enabled. Please set the env variable TAINTS_SUPPORT.")
 		}
-	} else if len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Taints) > 0 {
-		invalidWorkerNodeGroupTaints := false
-		for _, slice := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Taints {
-			if slice.Effect == "NoExecute" || slice.Effect == "NoSchedule" {
-				invalidWorkerNodeGroupTaints = true
-				break
-			}
-		}
-
-		if invalidWorkerNodeGroupTaints {
-			return fmt.Errorf("The first worker node group does not support NoExecute or NoSchedule taints.")
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
https://github.com/aws/eks-anywhere/issues/1126

Validate that at least one worker node group configuration is free from `NoSchedule` or `NoExecute` taints.
If all worker node groups are tainted with `NoSchedule` and/or `NoExecute`, the cluster fails to come up.
