### PR TITLE
Taints cleanup

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -228,8 +228,8 @@ func WorkerNodeGroupConfigurationsSliceEqual(a, b []WorkerNodeGroupConfiguration
 		return false
 	}
 
-	for index, wngc := range a {
-		sameTaints := TaintsSliceEqual(wngc.Taints, b[index].Taints)
+	for index, nodeGroup := range a {
+		sameTaints := TaintsSliceEqual(nodeGroup.Taints, b[index].Taints)
 		if !sameTaints {
 			return false
 		}
@@ -240,15 +240,15 @@ func WorkerNodeGroupConfigurationsSliceEqual(a, b []WorkerNodeGroupConfiguration
 
 func WorkerNodeGroupConfigurationSliceTaintsEqual(a, b []WorkerNodeGroupConfiguration) bool {
 	m := make(map[string][]corev1.Taint, len(a))
-	for _, wngc := range a {
-		m[wngc.Name] = wngc.Taints
+	for _, nodeGroup := range a {
+		m[nodeGroup.Name] = nodeGroup.Taints
 	}
 
-	for _, wngc := range b {
-		if _, ok := m[wngc.Name]; !ok {
+	for _, nodeGroup := range b {
+		if _, ok := m[nodeGroup.Name]; !ok {
 			continue
 		} else {
-			if !TaintsSliceEqual(m[wngc.Name], wngc.Taints) {
+			if !TaintsSliceEqual(m[nodeGroup.Name], nodeGroup.Taints) {
 				return false
 			}
 		}

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -1122,7 +1122,7 @@ func TestControlPlaneConfigurationEqual(t *testing.T) {
 	taint1 := corev1.Taint{Key: "key1"}
 	taint2 := corev1.Taint{Key: "key2"}
 	taints1 := []corev1.Taint{taint1, taint2}
-	taintsOneDiffOrder := []corev1.Taint{taint2, taint1}
+	taints1DiffOrder := []corev1.Taint{taint2, taint1}
 	taints2 := []corev1.Taint{taint1}
 
 	testCases := []struct {
@@ -1256,7 +1256,7 @@ func TestControlPlaneConfigurationEqual(t *testing.T) {
 				Taints: taints1,
 			},
 			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{
-				Taints: taintsOneDiffOrder,
+				Taints: taints1DiffOrder,
 			},
 			want: true,
 		},

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -297,16 +297,12 @@ func TestClusterEqualKubernetesVersion(t *testing.T) {
 }
 
 func TestClusterEqualWorkerNodeGroupConfigurations(t *testing.T) {
-	var taints1, taints2, taints1DiffOrder, emptyTaints []corev1.Taint
-	var taint1, taint2 corev1.Taint
-
-	taint1.Key = "key1"
-	taint2.Key = "key2"
-	taints1 = append(taints1, taint1)
-	taints1 = append(taints1, taint2)
-	taints1DiffOrder = append(taints1DiffOrder, taint2)
-	taints1DiffOrder = append(taints1DiffOrder, taint1)
-	taints2 = append(taints2, taint1)
+	var emptyTaints []corev1.Taint
+	taint1 := corev1.Taint{Key: "key1"}
+	taint2 := corev1.Taint{Key: "key2"}
+	taints1 := []corev1.Taint{taint1, taint2}
+	taints1DiffOrder := []corev1.Taint{taint2, taint1}
+	taints2 := []corev1.Taint{taint1}
 
 	testCases := []struct {
 		testName                   string
@@ -1122,16 +1118,12 @@ func TestClusterEqualManagement(t *testing.T) {
 }
 
 func TestControlPlaneConfigurationEqual(t *testing.T) {
-	var taints1, taints2, taints1DiffOrder, emptyTaints []corev1.Taint
-	var taint1, taint2 corev1.Taint
-
-	taint1.Key = "key1"
-	taint2.Key = "key2"
-	taints1 = append(taints1, taint1)
-	taints1 = append(taints1, taint2)
-	taints1DiffOrder = append(taints1DiffOrder, taint2)
-	taints1DiffOrder = append(taints1DiffOrder, taint1)
-	taints2 = append(taints2, taint1)
+	var emptyTaints []corev1.Taint
+	taint1 := corev1.Taint{Key: "key1"}
+	taint2 := corev1.Taint{Key: "key2"}
+	taints1 := []corev1.Taint{taint1, taint2}
+	taintsOneDiffOrder := []corev1.Taint{taint2, taint1}
+	taints2 := []corev1.Taint{taint1}
 
 	testCases := []struct {
 		testName                           string
@@ -1264,7 +1256,7 @@ func TestControlPlaneConfigurationEqual(t *testing.T) {
 				Taints: taints1,
 			},
 			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{
-				Taints: taints1DiffOrder,
+				Taints: taintsOneDiffOrder,
 			},
 			want: true,
 		},

--- a/pkg/providers/docker/docker_test.go
+++ b/pkg/providers/docker/docker_test.go
@@ -174,7 +174,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 			wantMDFile: "testdata/valid_deployment_md_taints_expected.yaml",
 		},
 		{
-			testName: "valid config multiple wngc with md taints",
+			testName: "valid config multiple worker node groups with machine deplyoment taints",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.Name = "test-cluster"
 				s.Spec.KubernetesVersion = "1.19"

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -9,16 +9,16 @@ import (
 
 func ValidateTaintsSupport(clusterSpec *cluster.Spec) error {
 	if !features.IsActive(features.TaintsSupport()) {
-		wngcTaintsPresent := false
-		for _, wngc := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
-			if len(wngc.Taints) > 0 {
-				wngcTaintsPresent = true
+		workerNodeGroupTaintsPresent := false
+		for _, nodeGroup := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
+			if len(nodeGroup.Taints) > 0 {
+				workerNodeGroupTaintsPresent = true
 				break
 			}
 		}
 
 		if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints) > 0 ||
-			wngcTaintsPresent {
+			workerNodeGroupTaintsPresent {
 			return fmt.Errorf("Taints feature is not enabled. Please set the env variable TAINTS_SUPPORT.")
 		}
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

couple of cosmetic and legibility cleanups pertaining to the taints implementation --
- replacing var name `wngc` with `nodeGroup`; `wngc` was classified as "pure madness" by @g-gaston 😆 🧠 😵‍💫 
- clarify test setup by using struct and slice literals instead of chaining appends

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
