### PR TITLE
Accept insecure flag for vsphere cloud-controller-manager config

### DIFF
--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -1136,6 +1136,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "{{.thumbprint}}"
+          insecureFlag: {{.insecure}}
         vcenter:
           {{.vsphereServer}}:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
@@ -1084,6 +1084,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
@@ -1083,6 +1083,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -1137,6 +1137,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
@@ -1059,6 +1059,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
@@ -1005,6 +1005,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
@@ -1057,6 +1057,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -1057,6 +1057,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -1057,6 +1057,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
@@ -1059,6 +1059,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -1075,6 +1075,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
@@ -997,6 +997,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
@@ -1000,6 +1000,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -1068,6 +1068,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -1108,6 +1108,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -1058,6 +1058,7 @@ data:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
           thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
           vsphere_server:
             datacenters:


### PR DESCRIPTION
When migrating to v1beta1 the insecure option got removed. This PR
adds it back
The way cloud-controller-manager is launched has changed when moving to capv v1.0.1, it is now deployed through the manifest through CRS. So we directly create the configmap containing vsphere.conf file, which has the field named `insecureFlag` as per the [documentation](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-0C202FC5-F973-4D24-B383-DDA27DA49BFA.html)

*Issue #, if available:* https://github.com/aws/eks-anywhere/issues/1117

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
