### PR TITLE
Add PBNJ assets to bundle manifest

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -1779,6 +1779,35 @@ spec:
                               description: URI points to the manifest yaml file
                               type: string
                           type: object
+                        pbnj:
+                          properties:
+                            arch:
+                              description: Architectures of the asset
+                              items:
+                                type: string
+                              type: array
+                            description:
+                              type: string
+                            imageDigest:
+                              description: The SHA256 digest of the image manifest
+                              type: string
+                            name:
+                              description: The asset name
+                              type: string
+                            os:
+                              description: Operating system of the asset
+                              enum:
+                              - linux
+                              - darwin
+                              - windows
+                              type: string
+                            osName:
+                              description: Name of the OS like ubuntu, bottlerocket
+                              type: string
+                            uri:
+                              description: The image repository, name, and tag
+                              type: string
+                          type: object
                         tinkCli:
                           properties:
                             arch:
@@ -1876,6 +1905,7 @@ spec:
                       - hegel
                       - kubeVip
                       - metadata
+                      - pbnj
                       - tinkCli
                       - tinkServer
                       - tinkWorker

--- a/release/api/v1alpha1/bundle_types.go
+++ b/release/api/v1alpha1/bundle_types.go
@@ -246,6 +246,7 @@ type TinkerbellBundle struct {
 	TinkCli              Image    `json:"tinkCli"`
 	Hegel                Image    `json:"hegel"`
 	Cfssl                Image    `json:"cfssl"`
+	Pbnj                 Image    `json:"pbnj"`
 	Components           Manifest `json:"components"`
 	Metadata             Manifest `json:"metadata"`
 	ClusterTemplate      Manifest `json:"clusterTemplate"`

--- a/release/api/v1alpha1/zz_generated.deepcopy.go
+++ b/release/api/v1alpha1/zz_generated.deepcopy.go
@@ -626,6 +626,7 @@ func (in *TinkerbellBundle) DeepCopyInto(out *TinkerbellBundle) {
 	in.TinkCli.DeepCopyInto(&out.TinkCli)
 	in.Hegel.DeepCopyInto(&out.Hegel)
 	in.Cfssl.DeepCopyInto(&out.Cfssl)
+	in.Pbnj.DeepCopyInto(&out.Pbnj)
 	out.Components = in.Components
 	out.Metadata = in.Metadata
 	out.ClusterTemplate = in.ClusterTemplate

--- a/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -1779,6 +1779,35 @@ spec:
                               description: URI points to the manifest yaml file
                               type: string
                           type: object
+                        pbnj:
+                          properties:
+                            arch:
+                              description: Architectures of the asset
+                              items:
+                                type: string
+                              type: array
+                            description:
+                              type: string
+                            imageDigest:
+                              description: The SHA256 digest of the image manifest
+                              type: string
+                            name:
+                              description: The asset name
+                              type: string
+                            os:
+                              description: Operating system of the asset
+                              enum:
+                              - linux
+                              - darwin
+                              - windows
+                              type: string
+                            osName:
+                              description: Name of the OS like ubuntu, bottlerocket
+                              type: string
+                            uri:
+                              description: The image repository, name, and tag
+                              type: string
+                          type: object
                         tinkCli:
                           properties:
                             arch:
@@ -1876,6 +1905,7 @@ spec:
                       - hegel
                       - kubeVip
                       - metadata
+                      - pbnj
                       - tinkCli
                       - tinkServer
                       - tinkWorker

--- a/release/pkg/assets_pbnj.go
+++ b/release/pkg/assets_pbnj.go
@@ -1,0 +1,61 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+const pbnjProjectPath = "projects/tinkerbell/pbnj"
+
+// GetPbnjAssets returns the eks a artifacts for pbnj
+func (r *ReleaseConfig) GetPbnjAssets() ([]Artifact, error) {
+	gitTag, err := r.readGitTag(pbnjProjectPath, r.BuildRepoBranchName)
+	if err != nil {
+		return nil, errors.Cause(err)
+	}
+
+	name := "pbnj"
+	repoName := fmt.Sprintf("tinkerbell/%s", name)
+	tagOptions := map[string]string{
+		"gitTag":      gitTag,
+		"projectPath": pbnjProjectPath,
+	}
+
+	sourceImageUri, sourcedFromBranch, err := r.GetSourceImageURI(name, repoName, tagOptions)
+	if err != nil {
+		return nil, errors.Cause(err)
+	}
+	releaseImageUri, err := r.GetReleaseImageURI(name, repoName, tagOptions)
+	if err != nil {
+		return nil, errors.Cause(err)
+	}
+
+	imageArtifact := &ImageArtifact{
+		AssetName:         name,
+		SourceImageURI:    sourceImageUri,
+		ReleaseImageURI:   releaseImageUri,
+		Arch:              []string{"amd64"},
+		OS:                "linux",
+		GitTag:            gitTag,
+		ProjectPath:       pbnjProjectPath,
+		SourcedFromBranch: sourcedFromBranch,
+	}
+	artifacts := []Artifact{{Image: imageArtifact}}
+
+	return artifacts, nil
+}

--- a/release/pkg/assets_tinkerbell.go
+++ b/release/pkg/assets_tinkerbell.go
@@ -31,6 +31,7 @@ func (r *ReleaseConfig) GetTinkerbellBundle(imageDigests map[string]string) (any
 		"tink":                            r.BundleArtifactsTable["tink"],
 		"hegel":                           r.BundleArtifactsTable["hegel"],
 		"cfssl":                           r.BundleArtifactsTable["cfssl"],
+		"pbnj":                            r.BundleArtifactsTable["pbnj"],
 	}
 	sortedComponentNames := sortArtifactsMap(tinkerbellBundleArtifacts)
 
@@ -94,6 +95,7 @@ func (r *ReleaseConfig) GetTinkerbellBundle(imageDigests map[string]string) (any
 		TinkCli:              bundleImageArtifacts["tink-cli"],
 		Hegel:                bundleImageArtifacts["hegel"],
 		Cfssl:                bundleImageArtifacts["cfssl"],
+		Pbnj:                 bundleImageArtifacts["pbnj"],
 		Components:           bundleManifestArtifacts["infrastructure-components.yaml"],
 		ClusterTemplate:      bundleManifestArtifacts["cluster-template.yaml"],
 		Metadata:             bundleManifestArtifacts["metadata.yaml"],

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -261,6 +261,7 @@ func (r *ReleaseConfig) GenerateBundleArtifactsTable() (map[string][]Artifact, e
 		eksAArtifactsFuncs["tink"] = r.GetTinkAssets
 		eksAArtifactsFuncs["hegel"] = r.GetHegelAssets
 		eksAArtifactsFuncs["cfssl"] = r.GetCfsslAssets
+		eksAArtifactsFuncs["pbnj"] = r.GetPbnjAssets
 	}
 
 	for componentName, artifactFunc := range eksAArtifactsFuncs {


### PR DESCRIPTION
Adding PBNJ image to the bundle manifest.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
