### PR TITLE
Update the docs to link the demo

### DIFF
--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -39,9 +39,8 @@ Amazon EKS Anywhere gives you on-premises Kubernetes operational tooling that’
         style="max-width: 1000px;">
         <div>
             <h4><i style="color: orange;" class="fas fa-couch display-4"></i> Containers from the Couch</h4>
-            <h3 class="card-title pt-2 mb-1"><strong>Join us for a live demo</strong></h3>
-			<p>Monday, September 13th at 1200 PT/1500 ET</p>
-            <p class="display-5 py-1">Come see EKS Anywhere in action with a live demo and Q&A. We will create a cluster and show admin workflows for scaling, upgrading the cluster version, and GitOps management.</p>
+            <a target="_blank" href="https://www.youtube.com/watch?v=n7Qh7ha5MG0"><h3 class="card-title pt-2 mb-1"><strong>Check out the EKS Anywhere demo</strong></h3></a>
+            <p class="display-5 py-1">See EKS Anywhere in action. We create a cluster and show admin workflows for scaling, upgrading the cluster version, and GitOps management.</p>
 			<a class="btn rounded-lg btn-primary card-link" target="_blank" href="https://containersfromthecouch.com">Subscribe on YouTube</a>
         </div>
     </div>


### PR DESCRIPTION
The docs still link to a live demo that happened four months ago. New look:

![Screen Shot 2022-02-04 at 05 13 51](https://user-images.githubusercontent.com/104113/152527514-4b667156-bc4d-4dad-b541-398207f680dc.png)

