### PR TITLE
Update kubectl ValidateWorkerNodes arg to pass in kubeconfig

### DIFF
--- a/cmd/eks-a-tool/cmd/validatecluster.go
+++ b/cmd/eks-a-tool/cmd/validatecluster.go
@@ -59,7 +59,7 @@ func validateCluster(ctx context.Context, cluster *types.Cluster, clusterName st
 	if err != nil {
 		return err
 	}
-	err = kubectl.ValidateWorkerNodes(ctx, cluster, clusterName)
+	err = kubectl.ValidateWorkerNodes(ctx, clusterName, cluster.KubeconfigFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -79,7 +79,7 @@ type ClusterClient interface {
 	CreateNamespace(ctx context.Context, kubeconfig string, namespace string) error
 	GetNamespace(ctx context.Context, kubeconfig string, namespace string) error
 	ValidateControlPlaneNodes(ctx context.Context, cluster *types.Cluster, clusterName string) error
-	ValidateWorkerNodes(ctx context.Context, cluster *types.Cluster, clusterName string) error
+	ValidateWorkerNodes(ctx context.Context, clusterName string, kubeconfigFile string) error
 	GetBundles(ctx context.Context, kubeconfigFile, name, namespace string) (*releasev1alpha1.Bundles, error)
 	GetApiServerUrl(ctx context.Context, cluster *types.Cluster) (string, error)
 	GetClusterCATlsCert(ctx context.Context, clusterName string, cluster *types.Cluster, namespace string) ([]byte, error)
@@ -728,7 +728,7 @@ func (c *ClusterManager) waitForMachineDeploymentReplicasReady(ctx context.Conte
 	}
 
 	isMdReady := func() error {
-		return c.clusterClient.ValidateWorkerNodes(ctx, managementCluster, clusterSpec.Name)
+		return c.clusterClient.ValidateWorkerNodes(ctx, clusterSpec.Name, managementCluster.KubeconfigFile)
 	}
 
 	err := isMdReady()

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -479,7 +479,7 @@ func TestClusterManagerUpgradeWorkloadClusterSuccess(t *testing.T) {
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
 	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, wCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, wCluster.Name).Return(nil)
-	tt.mocks.client.EXPECT().ValidateWorkerNodes(tt.ctx, mCluster, wCluster.Name).Return(nil)
+	tt.mocks.client.EXPECT().ValidateWorkerNodes(tt.ctx, wCluster.Name, mCluster.KubeconfigFile).Return(nil)
 	tt.mocks.provider.EXPECT().GetDeployments()
 	tt.mocks.writer.EXPECT().Write(clusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
 
@@ -577,7 +577,7 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForCAPITimeout(t *testing.T) {
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
 	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, wCluster, "30m", "Available", gomock.Any(), gomock.Any()).Return(errors.New("time out"))
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, wCluster.Name).Return(nil)
-	tt.mocks.client.EXPECT().ValidateWorkerNodes(tt.ctx, mCluster, wCluster.Name).Return(nil)
+	tt.mocks.client.EXPECT().ValidateWorkerNodes(tt.ctx, wCluster.Name, mCluster.KubeconfigFile).Return(nil)
 	tt.mocks.writer.EXPECT().Write(clusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
 
 	if err := tt.clusterManager.UpgradeCluster(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.mocks.provider); err == nil {
@@ -607,7 +607,7 @@ func TestClusterManagerMoveCAPISuccess(t *testing.T) {
 	m.client.EXPECT().GetClusters(ctx, to).Return(clusters, nil)
 	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "15m0s", capiClusterName)
 	m.client.EXPECT().ValidateControlPlaneNodes(ctx, to, to.Name)
-	m.client.EXPECT().ValidateWorkerNodes(ctx, to, to.Name)
+	m.client.EXPECT().ValidateWorkerNodes(ctx, to.Name, to.KubeconfigFile)
 	m.client.EXPECT().GetMachines(ctx, to, to.Name)
 
 	if err := c.MoveCAPI(ctx, from, to, to.Name, clusterSpec); err != nil {
@@ -708,7 +708,7 @@ func TestClusterManagerMoveCAPIErrorGetMachines(t *testing.T) {
 	m.client.EXPECT().MoveManagement(ctx, from, to)
 	m.client.EXPECT().GetClusters(ctx, to)
 	m.client.EXPECT().ValidateControlPlaneNodes(ctx, to, to.Name)
-	m.client.EXPECT().ValidateWorkerNodes(ctx, to, to.Name)
+	m.client.EXPECT().ValidateWorkerNodes(ctx, to.Name, to.KubeconfigFile)
 	m.client.EXPECT().GetMachines(ctx, to, from.Name).Return(nil, errors.New("error getting machines")).AnyTimes()
 
 	if err := c.MoveCAPI(ctx, from, to, from.Name, clusterSpec); err == nil {

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -444,7 +444,7 @@ func (mr *MockClusterClientMockRecorder) ValidateControlPlaneNodes(arg0, arg1, a
 }
 
 // ValidateWorkerNodes mocks base method.
-func (m *MockClusterClient) ValidateWorkerNodes(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
+func (m *MockClusterClient) ValidateWorkerNodes(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateWorkerNodes", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -344,9 +344,9 @@ func (k *Kubectl) ValidateControlPlaneNodes(ctx context.Context, cluster *types.
 	return nil
 }
 
-func (k *Kubectl) ValidateWorkerNodes(ctx context.Context, cluster *types.Cluster, clusterName string) error {
+func (k *Kubectl) ValidateWorkerNodes(ctx context.Context, clusterName string, kubeconfig string) error {
 	logger.V(6).Info("waiting for nodes", "cluster", clusterName)
-	deployments, err := k.GetMachineDeployments(ctx, WithCluster(cluster), WithNamespace(constants.EksaSystemNamespace))
+	deployments, err := k.GetMachineDeployments(ctx, WithKubeconfig(kubeconfig), WithNamespace(constants.EksaSystemNamespace))
 	if err != nil {
 		return err
 	}

--- a/pkg/validations/kubectl.go
+++ b/pkg/validations/kubectl.go
@@ -14,7 +14,7 @@ import (
 
 type KubectlClient interface {
 	ValidateControlPlaneNodes(ctx context.Context, cluster *types.Cluster, clusterName string) error
-	ValidateWorkerNodes(ctx context.Context, cluster *types.Cluster, clusterName string) error
+	ValidateWorkerNodes(ctx context.Context, clusterName string, kubeconfig string) error
 	ValidateNodes(ctx context.Context, kubeconfig string) error
 	ValidateClustersCRD(ctx context.Context, cluster *types.Cluster) error
 	ValidateEKSAClustersCRD(ctx context.Context, cluster *types.Cluster) error

--- a/pkg/validations/mocks/kubectl.go
+++ b/pkg/validations/mocks/kubectl.go
@@ -214,17 +214,17 @@ func (mr *MockKubectlClientMockRecorder) ValidateNodes(ctx, kubeconfig interface
 }
 
 // ValidateWorkerNodes mocks base method.
-func (m *MockKubectlClient) ValidateWorkerNodes(ctx context.Context, cluster *types.Cluster, clusterName string) error {
+func (m *MockKubectlClient) ValidateWorkerNodes(ctx context.Context, clusterName, kubeconfig string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateWorkerNodes", ctx, cluster, clusterName)
+	ret := m.ctrl.Call(m, "ValidateWorkerNodes", ctx, clusterName, kubeconfig)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ValidateWorkerNodes indicates an expected call of ValidateWorkerNodes.
-func (mr *MockKubectlClientMockRecorder) ValidateWorkerNodes(ctx, cluster, clusterName interface{}) *gomock.Call {
+func (mr *MockKubectlClientMockRecorder) ValidateWorkerNodes(ctx, clusterName, kubeconfig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateWorkerNodes", reflect.TypeOf((*MockKubectlClient)(nil).ValidateWorkerNodes), ctx, cluster, clusterName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateWorkerNodes", reflect.TypeOf((*MockKubectlClient)(nil).ValidateWorkerNodes), ctx, clusterName, kubeconfig)
 }
 
 // Version mocks base method.

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -40,7 +40,7 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) (err erro
 		validations.ValidationResult{
 			Name:        "worker nodes ready",
 			Remediation: fmt.Sprintf("ensure machine deployments for cluster %s are Ready", u.Opts.WorkloadCluster.Name),
-			Err:         k.ValidateWorkerNodes(ctx, targetCluster, u.Opts.Spec.Name),
+			Err:         k.ValidateWorkerNodes(ctx, u.Opts.Spec.Name, targetCluster.KubeconfigFile),
 		},
 		validations.ValidationResult{
 			Name:        "nodes ready",

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -601,7 +601,7 @@ func TestPreflightValidations(t *testing.T) {
 			provider.EXPECT().ValidateNewSpec(ctx, workloadCluster, clusterSpec).Return(nil).MaxTimes(1)
 			k.EXPECT().GetEksaVSphereDatacenterConfig(ctx, clusterSpec.Spec.DatacenterRef.Name, gomock.Any(), gomock.Any()).Return(existingProviderSpec, nil).MaxTimes(1)
 			k.EXPECT().ValidateControlPlaneNodes(ctx, workloadCluster, clusterSpec.Name).Return(tc.cpResponse)
-			k.EXPECT().ValidateWorkerNodes(ctx, workloadCluster, workloadCluster.Name).Return(tc.workerResponse)
+			k.EXPECT().ValidateWorkerNodes(ctx, workloadCluster.Name, workloadCluster.KubeconfigFile).Return(tc.workerResponse)
 			k.EXPECT().ValidateNodes(ctx, kubeconfigFilePath).Return(tc.nodeResponse)
 			k.EXPECT().ValidateClustersCRD(ctx, workloadCluster).Return(tc.crdResponse)
 			k.EXPECT().GetClusters(ctx, workloadCluster).Return(tc.getClusterResponse, nil)

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -411,7 +411,7 @@ func (e *ClusterE2ETest) waitForWorkerNodeValidation() error {
 	ctx := context.Background()
 	return retrier.Retry(10, time.Second*10, func() error {
 		e.T.Log("Attempting to validate worker nodes...")
-		if err := e.KubectlClient.ValidateWorkerNodes(ctx, e.cluster(), e.ClusterConfig.Name); err != nil {
+		if err := e.KubectlClient.ValidateWorkerNodes(ctx, e.ClusterConfig.Name, e.cluster().KubeconfigFile); err != nil {
 			e.T.Logf("Worker node validation failed: %v", err)
 			return fmt.Errorf("error while validating worker nodes: %v", err)
 		}


### PR DESCRIPTION
*Issue #, if available:*

Prep for #396 

*Description of changes:*

Update the kubectl exec `ValidateWorkerNodes` method to use kubeconfig as arg directly instead of passing the `types.cluster`. It's easier to validate workload cluster's nodes in management cluster for Flux e2e tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
