### PR TITLE
Deleting a cluster with GitOpsConfig enabled fails unless branch is set explicitly

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_gitopsconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_gitopsconfigs.yaml
@@ -44,6 +44,7 @@ spec:
                       Git repo.
                     properties:
                       branch:
+                        default: main
                         description: Git branch. Defaults to main.
                         type: string
                       clusterConfigPath:

--- a/pkg/api/v1alpha1/gitopsconfig_types.go
+++ b/pkg/api/v1alpha1/gitopsconfig_types.go
@@ -26,6 +26,7 @@ type Github struct {
 	FluxSystemNamespace string `json:"fluxSystemNamespace,omitempty"`
 
 	// Git branch. Defaults to main.
+	// +kubebuilder:default:="main"
 	Branch string `json:"branch,omitempty"`
 
 	// ClusterConfigPath relative to the repository root, when specified the cluster sync will be scoped to this path.


### PR DESCRIPTION
*Issue #, if available:* There is no issue filed for this report.

I just tried out eks-anywhere on ARM64 architecture with a Docker configuration and was able to make everything work, except for deleting the cluster cleanly at the end of the experiment.

I figured out that when I set a branch explicitly in the GitOpsConfig it succeeded. This change might help; the git clone is smart enough to pick the default branch, but my working hypothesis anyway is that the CR will not have that data and when it comes time to push a change representing the cluster delete, that's where it fails.

I have since lost track of where I found the code that emitted the branch error, but it was clear enough from reading it what happened. We just didn't have a string "main" and so whatever routine that expected the string branch name failed.

I guess it works up til that point because git repos have a default branch, and you can already clone them without naming it.

*Description of changes:*

I added a kubebuilder annotation that really makes the default mentioned in the adjacent comment official. I also ran `make generate-manifests` so it appears I did that correctly. I'm new at kubebuilder so, I wanted to mention that I don't know if this will solve the issue, or how to test it myself without running it through CI here.

---
(By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.)

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
