### PR TITLE
Move eks-a components and kindnetd manifests to versioned folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ KUBE_RBAC_PROXY_IMAGE_NAME_OVERRIDE="${IMAGE_REPO}/brancz/kube-rbac-proxy"
 KUBE_RBAC_PROXY_IMAGE_TAG_OVERRIDE="latest"
 KUSTOMIZATION_CONFIG=./config/prod/kustomization.yaml
 
-CONTROLLER_MANIFEST_OUTPUT_DIR=$(OUTPUT_DIR)/manifests/cluster-controller
+CONTROLLER_MANIFEST_OUTPUT_DIR=$(OUTPUT_DIR)/manifests/cluster-controller/$(GIT_TAG)
 
 # This removes the compile dependency on C libraries from github.com/containers/storage which is imported by github.com/replicatedhq/troubleshoot
 BUILD_TAGS :=

--- a/controllers/build/upload_artifacts.sh
+++ b/controllers/build/upload_artifacts.sh
@@ -25,7 +25,6 @@ BUILD_IDENTIFIER="${4? Specify fourth argument - build identifier}"
 GIT_HASH="${5?Specify fifth argument - git hash of the tar builds}"
 LATEST_PATH="${6?Specify sixth argument - latest S3 folder path for artifacts}"
 
-
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 source "$REPO_ROOT/scripts/common.sh"
 

--- a/release/pkg/assets_cluster_controller.go
+++ b/release/pkg/assets_cluster_controller.go
@@ -114,7 +114,7 @@ func (r *ReleaseConfig) GetClusterControllerAssets() ([]Artifact, error) {
 	latestPath := getLatestUploadDestination(sourcedFromBranch)
 
 	if r.DevRelease || r.ReleaseEnvironment == "development" {
-		sourceS3Prefix = fmt.Sprintf("%s/%s/manifests/cluster-controller", eksAnywhereProjectPath, latestPath)
+		sourceS3Prefix = fmt.Sprintf("%s/%s/manifests/cluster-controller/%s", eksAnywhereProjectPath, latestPath, gitTag)
 	} else {
 		sourceS3Prefix = fmt.Sprintf("releases/bundles/%d/artifacts/eks-anywhere-cluster-controller/manifests/%s", r.BundleNumber, gitTag)
 	}

--- a/release/pkg/assets_kindnetd.go
+++ b/release/pkg/assets_kindnetd.go
@@ -69,15 +69,15 @@ func (r *ReleaseConfig) GetKindnetdAssets() ([]Artifact, error) {
 		latestPath := getLatestUploadDestination(sourcedFromBranch)
 
 		if r.DevRelease || r.ReleaseEnvironment == "development" {
-			sourceS3Prefix = fmt.Sprintf("%s/%s/manifests", kindProjectPath, latestPath)
+			sourceS3Prefix = fmt.Sprintf("%s/%s/manifests/kindnetd/%s", kindProjectPath, latestPath, gitTag)
 		} else {
-			sourceS3Prefix = fmt.Sprintf("releases/bundles/%d/artifacts/kind/manifests", r.BundleNumber)
+			sourceS3Prefix = fmt.Sprintf("releases/bundles/%d/artifacts/kind/manifests/kindnetd/%s", r.BundleNumber, gitTag)
 		}
 
 		if r.DevRelease {
-			releaseS3Path = fmt.Sprintf("artifacts/%s/kind/manifests", r.DevReleaseUriVersion)
+			releaseS3Path = fmt.Sprintf("artifacts/%s/kind/manifests/kindnetd/%s", r.DevReleaseUriVersion, gitTag)
 		} else {
-			releaseS3Path = fmt.Sprintf("releases/bundles/%d/artifacts/kind/manifests", r.BundleNumber)
+			releaseS3Path = fmt.Sprintf("releases/bundles/%d/artifacts/kind/manifests/kindnetd/%s", r.BundleNumber, gitTag)
 		}
 
 		cdnURI, err := r.GetURI(filepath.Join(releaseS3Path, manifest))


### PR DESCRIPTION
Release tool changes for aws/eks-anywhere-build-tooling#406


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
