### PR TITLE
Support bundle builds without br support for an eksd release

### DIFF
--- a/release/pkg/assets_eksd.go
+++ b/release/pkg/assets_eksd.go
@@ -182,7 +182,7 @@ func (r *ReleaseConfig) GetEksDChannelAssets(eksDReleaseChannel, kubeVer, eksDRe
 	return artifacts, nil
 }
 
-func (r *ReleaseConfig) GetEksDReleaseBundle(eksDReleaseChannel, kubeVer, eksDReleaseNumber string, imageDigests map[string]string) (anywherev1alpha1.EksDRelease, error) {
+func (r *ReleaseConfig) GetEksDReleaseBundle(eksDReleaseChannel, kubeVer, eksDReleaseNumber string, imageDigests map[string]string, dev bool) (anywherev1alpha1.EksDRelease, error) {
 	artifacts := r.BundleArtifactsTable[fmt.Sprintf("eks-d-%s", eksDReleaseChannel)]
 
 	tarballArtifacts := map[string][]Artifact{
@@ -193,7 +193,7 @@ func (r *ReleaseConfig) GetEksDReleaseBundle(eksDReleaseChannel, kubeVer, eksDRe
 	bundleArchiveArtifacts := map[string]anywherev1alpha1.Archive{}
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 
-	eksDManifestUrl := GetEksDReleaseManifestUrl(eksDReleaseChannel, eksDReleaseNumber)
+	eksDManifestUrl := GetEksDReleaseManifestUrl(eksDReleaseChannel, eksDReleaseNumber, dev)
 	for _, artifact := range artifacts {
 		if artifact.Archive != nil {
 			archiveArtifact := artifact.Archive

--- a/release/pkg/assets_eksd.go
+++ b/release/pkg/assets_eksd.go
@@ -22,11 +22,13 @@ import (
 	"github.com/pkg/errors"
 
 	anywherev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
+	"github.com/aws/eks-anywhere/release/pkg/utils"
 )
 
 const (
 	imageBuilderProjectPath = "projects/kubernetes-sigs/image-builder"
 	kindProjectPath         = "projects/kubernetes-sigs/kind"
+	releasePath             = "release"
 )
 
 // GetEksDChannelAssets returns the eks-d artifacts including OVAs and kind node image
@@ -45,10 +47,14 @@ func (r *ReleaseConfig) GetEksDChannelAssets(eksDReleaseChannel, kubeVer, eksDRe
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
+	bottlerocketSupportedK8sVersions, err := getBottlerocketSupportedK8sVersions(r)
+	if err != nil {
+		return nil, errors.Cause(err)
+	}
 
 	for _, osName := range osNames {
 		for _, imageFormat := range imageFormats {
-			if osName == "bottlerocket" && imageFormat == "raw" {
+			if osName == "bottlerocket" && (imageFormat == "raw" || !utils.SliceContains(bottlerocketSupportedK8sVersions, eksDReleaseChannel)) {
 				continue
 			}
 			var sourceS3Key string

--- a/release/pkg/file_reader.go
+++ b/release/pkg/file_reader.go
@@ -152,9 +152,11 @@ func (r *ReleaseConfig) getBottlerocketAdminContainerMetadata() (string, string,
 	return tag, imageDigest, nil
 }
 
-func GetEksDReleaseManifestUrl(releaseChannel, releaseNumber string) string {
-	manifestUrl := fmt.Sprintf("https://distro.eks.amazonaws.com/kubernetes-%[1]s/kubernetes-%[1]s-eks-%s.yaml", releaseChannel, releaseNumber)
-	return manifestUrl
+func GetEksDReleaseManifestUrl(releaseChannel, releaseNumber string, dev bool) string {
+	if dev {
+		return fmt.Sprintf("https://eks-d-postsubmit-artifacts.s3.us-west-2.amazonaws.com/kubernetes-%[1]s/kubernetes-%[1]s-eks-%s.yaml", releaseChannel, releaseNumber)
+	}
+	return fmt.Sprintf("https://distro.eks.amazonaws.com/kubernetes-%[1]s/kubernetes-%[1]s-eks-%s.yaml", releaseChannel, releaseNumber)
 }
 
 func (r *ReleaseConfig) GetCurrentEksADevReleaseVersion(releaseVersion string) (string, error) {
@@ -307,9 +309,9 @@ func (r *ReleaseConfig) readGitTag(projectPath, branch string) (string, error) {
 	return gitTag, nil
 }
 
-func getEksDKubeVersion(releaseChannel, releaseNumber string) (string, error) {
+func getEksDKubeVersion(releaseChannel, releaseNumber string, dev bool) (string, error) {
 	var kubeVersion string
-	eksDReleaseManifestUrl := GetEksDReleaseManifestUrl(releaseChannel, releaseNumber)
+	eksDReleaseManifestUrl := GetEksDReleaseManifestUrl(releaseChannel, releaseNumber, dev)
 
 	eksDRelease, err := getEksdRelease(eksDReleaseManifestUrl)
 	if err != nil {

--- a/release/pkg/file_reader.go
+++ b/release/pkg/file_reader.go
@@ -30,7 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/aws/eks-anywhere/release/pkg/aws/s3"
@@ -98,6 +98,19 @@ func readEksDReleases(r *ReleaseConfig) (map[string]interface{}, error) {
 		return nil, errors.Cause(err)
 	}
 	return eksDReleaseMap, nil
+}
+
+func getSupportedK8sVersions(r *ReleaseConfig) ([]string, error) {
+	// Read the eks-d latest release file to get all the releases
+	releaseFilePath := filepath.Join(r.BuildRepoSource, releasePath, "SUPPORTED_RELEASE_BRANCHES")
+
+	releaseFile, err := ioutil.ReadFile(releaseFilePath)
+	if err != nil {
+		return nil, errors.Cause(err)
+	}
+	supportedK8sVersions := strings.Split(strings.TrimRight(string(releaseFile), "\n"), "\n")
+
+	return supportedK8sVersions, nil
 }
 
 func getBottlerocketSupportedK8sVersions(r *ReleaseConfig) ([]string, error) {

--- a/release/pkg/file_reader_test.go
+++ b/release/pkg/file_reader_test.go
@@ -86,61 +86,77 @@ func TestGetEksDKubeVersion(t *testing.T) {
 		testName       string
 		releaseChannel string
 		releaseNumber  string
+		dev            bool
 		want           string
 	}{
 		{
 			testName:       "EKS Distro 1-18-1 release",
 			releaseChannel: "1-18",
 			releaseNumber:  "1",
+			dev:            false,
 			want:           "v1.18.9",
 		},
 		{
 			testName:       "EKS Distro 1-18-13 release",
 			releaseChannel: "1-18",
 			releaseNumber:  "13",
+			dev:            false,
 			want:           "v1.18.20",
 		},
 		{
 			testName:       "EKS Distro 1-19-1 release",
 			releaseChannel: "1-19",
 			releaseNumber:  "1",
+			dev:            false,
 			want:           "v1.19.6",
 		},
 		{
 			testName:       "EKS Distro 1-19-12 release",
 			releaseChannel: "1-19",
 			releaseNumber:  "12",
+			dev:            false,
 			want:           "v1.19.15",
 		},
 		{
 			testName:       "EKS Distro 1-20-1 release",
 			releaseChannel: "1-20",
 			releaseNumber:  "1",
+			dev:            false,
 			want:           "v1.20.4",
 		},
 		{
 			testName:       "EKS Distro 1-20-9 release",
 			releaseChannel: "1-20",
 			releaseNumber:  "9",
+			dev:            false,
 			want:           "v1.20.11",
 		},
 		{
 			testName:       "EKS Distro 1-21-1 release",
 			releaseChannel: "1-21",
 			releaseNumber:  "1",
+			dev:            false,
 			want:           "v1.21.2",
 		},
 		{
 			testName:       "EKS Distro 1-21-7 release",
 			releaseChannel: "1-21",
 			releaseNumber:  "7",
+			dev:            false,
 			want:           "v1.21.5",
+		},
+		{
+			testName:       "EKS Distro 1-22-1 dev release",
+			releaseChannel: "1-22",
+			releaseNumber:  "1",
+			dev:            true,
+			want:           "v1.22.4",
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			if got, err := getEksDKubeVersion(tt.releaseChannel, tt.releaseNumber); err != nil {
+			if got, err := getEksDKubeVersion(tt.releaseChannel, tt.releaseNumber, tt.dev); err != nil {
 				t.Fatalf("getEksDKubeVersion err = %s, want err = nil", err)
 			} else if got != tt.want {
 				t.Fatalf("getEksDKubeVersion kubeVersion = %s, want %s", got, tt.want)

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -154,13 +154,13 @@ func (r *ReleaseConfig) GetVersionsBundles(imageDigests map[string]string) ([]an
 		return nil, err
 	}
 
-	bottlerocketSupportedK8sVersions, err := getBottlerocketSupportedK8sVersions(r)
+	supportedK8sVersions, err := getSupportedK8sVersions(r)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error getting supported Kubernetes versions for bottlerocket")
 	}
 
 	for channel, release := range eksDReleaseMap {
-		if channel == "latest" || !utils.SliceContains(bottlerocketSupportedK8sVersions, channel) {
+		if channel == "latest" || !utils.SliceContains(supportedK8sVersions, channel) {
 			continue
 		}
 		releaseNumber := release.(map[interface{}]interface{})["number"]
@@ -280,12 +280,12 @@ func (r *ReleaseConfig) GenerateBundleArtifactsTable() (map[string][]Artifact, e
 		return nil, err
 	}
 
-	bottlerocketSupportedK8sVersions, err := getBottlerocketSupportedK8sVersions(r)
+	supportedK8sVersions, err := getSupportedK8sVersions(r)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error getting supported Kubernetes versions for bottlerocket")
 	}
 	for channel, release := range eksDReleaseMap {
-		if channel == "latest" || !utils.SliceContains(bottlerocketSupportedK8sVersions, channel) {
+		if channel == "latest" || !utils.SliceContains(supportedK8sVersions, channel) {
 			continue
 		}
 		releaseNumber := release.(map[interface{}]interface{})["number"]

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -323,6 +323,7 @@ func (r *ReleaseConfig) GenerateBundleArtifactsTable() (map[string][]Artifact, e
 	return artifactsTable, nil
 }
 
+// Retrieve values from https://github.com/aws/eks-anywhere-build-tooling/blob/main/EKSD_LATEST_RELEASES
 func getEksdReleaseValues(release interface{}) (string, bool) {
 	releaseNumber := release.(map[interface{}]interface{})["number"]
 	releaseNumberInt := releaseNumber.(int)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Change looping through the supported releases using the new supported branches file in the build tooling repo, as well as support being able to generate a bundle without having bottlerocket support for the respective eksd release. Also add support to be able to pull the dev release version of eksd from the appropriate s3 bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
