### PR TITLE
Update newly added GitOps e2e test name to include "Flux"

### DIFF
--- a/test/e2e/workload_clusters_test.go
+++ b/test/e2e/workload_clusters_test.go
@@ -59,7 +59,7 @@ func TestVSphereKubernetes121WorkloadClusterDemo(t *testing.T) {
 	runWorkloadClusterFlow(test)
 }
 
-func TestVSphereUpgradeWorkloadClusterWithGitOps(t *testing.T) {
+func TestVSphereUpgradeWorkloadClusterWithFlux(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu120())
 	test := framework.NewMulticlusterE2ETest(
 		t,
@@ -99,7 +99,7 @@ func TestVSphereUpgradeWorkloadClusterWithGitOps(t *testing.T) {
 	)
 }
 
-func TestDockerUpgradeWorkloadClusterWithGitOps(t *testing.T) {
+func TestDockerUpgradeWorkloadClusterWithFlux(t *testing.T) {
 	provider := framework.NewDocker(t)
 	test := framework.NewMulticlusterE2ETest(
 		t,


### PR DESCRIPTION
*Issue #, if available:*

The Flux e2e test envs are only set up when the test name includes "Flux" in it (https://github.com/aws/eks-anywhere/blob/main/internal/test/e2e/flux.go#L12). 

*Description of changes:*

Change the newly added GitOps test name to include "Flux" so that the envs can be properly set. Also to keep it consistent with the existing tests. Later we can change all flux tests name to "GitOps" which makes more sense.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
