### PR TITLE
E2E tests for multiple worker node groups

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -2,18 +2,29 @@ package api
 
 import (
 	"fmt"
+	"io/ioutil"
 
 	"sigs.k8s.io/yaml"
 
-	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
-type ClusterFiller func(c *v1alpha1.Cluster)
+type ClusterFiller func(c *anywherev1.Cluster)
 
-func AutoFillCluster(filename string, fillers ...ClusterFiller) ([]byte, error) {
-	clusterConfig, err := v1alpha1.GetAndValidateClusterConfig(filename)
+func AutoFillClusterFromFile(filename string, fillers ...ClusterFiller) ([]byte, error) {
+	content, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get cluster config from file: %v", err)
+		return nil, fmt.Errorf("unable to read file due to: %v", err)
+	}
+
+	return AutoFillClusterFromYaml(content, fillers...)
+}
+
+func AutoFillClusterFromYaml(yamlContent []byte, fillers ...ClusterFiller) ([]byte, error) {
+	clusterConfig, err := anywherev1.GetClusterConfigFromContent(yamlContent)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get cluster config from content: %v", err)
 	}
 
 	for _, f := range fillers {
@@ -28,83 +39,83 @@ func AutoFillCluster(filename string, fillers ...ClusterFiller) ([]byte, error) 
 	return clusterOutput, nil
 }
 
-func WithKubernetesVersion(v v1alpha1.KubernetesVersion) ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
+func WithKubernetesVersion(v anywherev1.KubernetesVersion) ClusterFiller {
+	return func(c *anywherev1.Cluster) {
 		c.Spec.KubernetesVersion = v
 	}
 }
 
 func WithClusterNamespace(ns string) ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
+	return func(c *anywherev1.Cluster) {
 		c.Namespace = ns
 	}
 }
 
 func WithControlPlaneCount(r int) ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
+	return func(c *anywherev1.Cluster) {
 		c.Spec.ControlPlaneConfiguration.Count = r
 	}
 }
 
 func WithControlPlaneEndpointIP(value string) ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
+	return func(c *anywherev1.Cluster) {
 		c.Spec.ControlPlaneConfiguration.Endpoint.Host = value
 	}
 }
 
 func WithPodCidr(podCidr string) ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
+	return func(c *anywherev1.Cluster) {
 		c.Spec.ClusterNetwork.Pods.CidrBlocks = []string{podCidr}
 	}
 }
 
 func WithServiceCidr(svcCidr string) ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
+	return func(c *anywherev1.Cluster) {
 		c.Spec.ClusterNetwork.Services.CidrBlocks = []string{svcCidr}
 	}
 }
 
 func WithWorkerNodeCount(r int) ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
+	return func(c *anywherev1.Cluster) {
 		if len(c.Spec.WorkerNodeGroupConfigurations) == 0 {
-			c.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 0}}
+			c.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{{Count: 0}}
 		}
 		c.Spec.WorkerNodeGroupConfigurations[0].Count = r
 	}
 }
 
 func WithOIDCIdentityProviderRef(name string) ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
+	return func(c *anywherev1.Cluster) {
 		c.Spec.IdentityProviderRefs = append(c.Spec.IdentityProviderRefs,
-			v1alpha1.Ref{Name: name, Kind: v1alpha1.OIDCConfigKind})
+			anywherev1.Ref{Name: name, Kind: anywherev1.OIDCConfigKind})
 	}
 }
 
 func WithGitOpsRef(name string) ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
-		c.Spec.GitOpsRef = &v1alpha1.Ref{Name: name, Kind: v1alpha1.GitOpsConfigKind}
+	return func(c *anywherev1.Cluster) {
+		c.Spec.GitOpsRef = &anywherev1.Ref{Name: name, Kind: anywherev1.GitOpsConfigKind}
 	}
 }
 
 func WithExternalEtcdTopology(count int) ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
+	return func(c *anywherev1.Cluster) {
 		if c.Spec.ExternalEtcdConfiguration == nil {
-			c.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{}
+			c.Spec.ExternalEtcdConfiguration = &anywherev1.ExternalEtcdConfiguration{}
 		}
 		c.Spec.ExternalEtcdConfiguration.Count = count
 	}
 }
 
 func WithStackedEtcdTopology() ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
+	return func(c *anywherev1.Cluster) {
 		c.Spec.ExternalEtcdConfiguration = nil
 	}
 }
 
 func WithProxyConfig(httpProxy, httpsProxy string, noProxy []string) ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
+	return func(c *anywherev1.Cluster) {
 		if c.Spec.ProxyConfiguration == nil {
-			c.Spec.ProxyConfiguration = &v1alpha1.ProxyConfiguration{}
+			c.Spec.ProxyConfiguration = &anywherev1.ProxyConfiguration{}
 		}
 		c.Spec.ProxyConfiguration.HttpProxy = httpProxy
 		c.Spec.ProxyConfiguration.HttpsProxy = httpProxy
@@ -113,9 +124,9 @@ func WithProxyConfig(httpProxy, httpsProxy string, noProxy []string) ClusterFill
 }
 
 func WithRegistryMirror(endpoint, caCert string) ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
+	return func(c *anywherev1.Cluster) {
 		if c.Spec.RegistryMirrorConfiguration == nil {
-			c.Spec.RegistryMirrorConfiguration = &v1alpha1.RegistryMirrorConfiguration{}
+			c.Spec.RegistryMirrorConfiguration = &anywherev1.RegistryMirrorConfiguration{}
 		}
 		c.Spec.RegistryMirrorConfiguration.Endpoint = endpoint
 		c.Spec.RegistryMirrorConfiguration.CACertContent = caCert
@@ -123,14 +134,59 @@ func WithRegistryMirror(endpoint, caCert string) ClusterFiller {
 }
 
 func WithManagementCluster(name string) ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
+	return func(c *anywherev1.Cluster) {
 		c.Spec.ManagementCluster.Name = name
 	}
 }
 
 func WithAWSIamIdentityProviderRef(name string) ClusterFiller {
-	return func(c *v1alpha1.Cluster) {
+	return func(c *anywherev1.Cluster) {
 		c.Spec.IdentityProviderRefs = append(c.Spec.IdentityProviderRefs,
-			v1alpha1.Ref{Name: name, Kind: v1alpha1.AWSIamConfigKind})
+			anywherev1.Ref{Name: name, Kind: anywherev1.AWSIamConfigKind})
+	}
+}
+
+func RemoveAllWorkerNodeGroups() ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		c.Spec.WorkerNodeGroupConfigurations = make([]anywherev1.WorkerNodeGroupConfiguration, 0)
+	}
+}
+
+func RemoveWorkerNodeGroup(name string) ClusterFiller {
+	logger.Info("removing", "name", name)
+	return func(c *anywherev1.Cluster) {
+		logger.Info("before deleting", "w", c.Spec.WorkerNodeGroupConfigurations)
+		for i, w := range c.Spec.WorkerNodeGroupConfigurations {
+			if w.Name == name {
+				copy(c.Spec.WorkerNodeGroupConfigurations[i:], c.Spec.WorkerNodeGroupConfigurations[i+1:])
+				c.Spec.WorkerNodeGroupConfigurations[len(c.Spec.WorkerNodeGroupConfigurations)-1] = anywherev1.WorkerNodeGroupConfiguration{}
+				c.Spec.WorkerNodeGroupConfigurations = c.Spec.WorkerNodeGroupConfigurations[:len(c.Spec.WorkerNodeGroupConfigurations)-1]
+				logger.Info("after deleting", "w", c.Spec.WorkerNodeGroupConfigurations)
+				return
+			}
+		}
+	}
+}
+
+func WithWorkerNodeGroup(name string, fillers ...WorkerNodeGroupFiller) ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		logger.Info("adding or updating", "name", name)
+		var nodeGroup *anywherev1.WorkerNodeGroupConfiguration
+		position := -1
+		for i, w := range c.Spec.WorkerNodeGroupConfigurations {
+			if w.Name == name {
+				nodeGroup = &w
+				position = i
+			}
+		}
+
+		if nodeGroup == nil {
+			nodeGroup = &anywherev1.WorkerNodeGroupConfiguration{Name: name}
+			c.Spec.WorkerNodeGroupConfigurations = append(c.Spec.WorkerNodeGroupConfigurations, *nodeGroup)
+			position = len(c.Spec.WorkerNodeGroupConfigurations) - 1
+		}
+
+		FillWorkerNodeGroup(nodeGroup, fillers...)
+		c.Spec.WorkerNodeGroupConfigurations[position] = *nodeGroup
 	}
 }

--- a/internal/pkg/api/nodegroups.go
+++ b/internal/pkg/api/nodegroups.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+type WorkerNodeGroupFiller func(w *anywherev1.WorkerNodeGroupConfiguration)
+
+func FillWorkerNodeGroup(w *anywherev1.WorkerNodeGroupConfiguration, fillers ...WorkerNodeGroupFiller) {
+	for _, f := range fillers {
+		f(w)
+	}
+}
+
+func WithTaint(taint corev1.Taint) WorkerNodeGroupFiller {
+	return func(w *anywherev1.WorkerNodeGroupConfiguration) {
+		w.Taints = append(w.Taints, taint)
+	}
+}
+
+func WithLabel(key, value string) WorkerNodeGroupFiller {
+	return func(w *anywherev1.WorkerNodeGroupConfiguration) {
+		w.Labels[key] = value
+	}
+}
+
+func WithCount(count int) WorkerNodeGroupFiller {
+	return func(w *anywherev1.WorkerNodeGroupConfiguration) {
+		w.Count = count
+	}
+}
+
+func WithMachineGroupRef(name, kind string) WorkerNodeGroupFiller {
+	return func(w *anywherev1.WorkerNodeGroupConfiguration) {
+		w.MachineGroupRef = &anywherev1.Ref{
+			Name: name,
+			Kind: kind,
+		}
+	}
+}

--- a/internal/pkg/api/vspheremachines.go
+++ b/internal/pkg/api/vspheremachines.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+type VSphereMachineConfigFiller func(m *anywherev1.VSphereMachineConfig)
+
+func FillVSphereMachineConfig(m *anywherev1.VSphereMachineConfig, fillers ...VSphereMachineConfigFiller) {
+	for _, f := range fillers {
+		f(m)
+	}
+}
+
+func WithVSphereMachineDefaultValues() VSphereMachineConfigFiller {
+	return func(m *anywherev1.VSphereMachineConfig) {
+		m.Spec.DiskGiB = anywherev1.DefaultVSphereDiskGiB
+		m.Spec.NumCPUs = anywherev1.DefaultVSphereNumCPUs
+		m.Spec.MemoryMiB = anywherev1.DefaultVSphereMemoryMiB
+		m.Spec.OSFamily = anywherev1.DefaultVSphereOSFamily
+	}
+}
+
+func WithDatastore(value string) VSphereMachineConfigFiller {
+	return func(m *anywherev1.VSphereMachineConfig) {
+		m.Spec.Datastore = value
+	}
+}
+
+func WithFolder(value string) VSphereMachineConfigFiller {
+	return func(m *anywherev1.VSphereMachineConfig) {
+		m.Spec.Folder = value
+	}
+}
+
+func WithResourcePool(value string) VSphereMachineConfigFiller {
+	return func(m *anywherev1.VSphereMachineConfig) {
+		m.Spec.ResourcePool = value
+	}
+}
+
+func WithStoragePolicyName(value string) VSphereMachineConfigFiller {
+	return func(m *anywherev1.VSphereMachineConfig) {
+		m.Spec.StoragePolicyName = value
+	}
+}
+
+func WithTemplate(value string) VSphereMachineConfigFiller {
+	return func(m *anywherev1.VSphereMachineConfig) {
+		m.Spec.Template = value
+	}
+}
+
+func WithSSHKey(value string) VSphereMachineConfigFiller {
+	return func(m *anywherev1.VSphereMachineConfig) {
+		setSSHKeyForFirstUser(m, value)
+	}
+}
+
+func setSSHKeyForFirstUser(m *anywherev1.VSphereMachineConfig, key string) {
+	if len(m.Spec.Users) == 0 {
+		m.Spec.Users = []anywherev1.UserConfiguration{{}}
+	}
+
+	m.Spec.Users[0].SshAuthorizedKeys = []string{key}
+}

--- a/pkg/api/v1alpha1/vspheremachineconfig.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig.go
@@ -9,7 +9,13 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const VSphereMachineConfigKind = "VSphereMachineConfig"
+const (
+	VSphereMachineConfigKind = "VSphereMachineConfig"
+	DefaultVSphereDiskGiB    = 25
+	DefaultVSphereNumCPUs    = 2
+	DefaultVSphereMemoryMiB  = 8192
+	DefaultVSphereOSFamily   = Bottlerocket
+)
 
 // Used for generating yaml for generate clusterconfig command
 func NewVSphereMachineConfigGenerate(name string) *VSphereMachineConfigGenerate {
@@ -22,10 +28,10 @@ func NewVSphereMachineConfigGenerate(name string) *VSphereMachineConfigGenerate 
 			Name: name,
 		},
 		Spec: VSphereMachineConfigSpec{
-			DiskGiB:   25,
-			NumCPUs:   2,
-			MemoryMiB: 8192,
-			OSFamily:  Bottlerocket,
+			DiskGiB:   DefaultVSphereDiskGiB,
+			NumCPUs:   DefaultVSphereNumCPUs,
+			MemoryMiB: DefaultVSphereMemoryMiB,
+			OSFamily:  DefaultVSphereOSFamily,
 			Users: []UserConfiguration{{
 				Name:              "ec2-user",
 				SshAuthorizedKeys: []string{"ssh-rsa AAAA..."},

--- a/test/e2e/multiple_worker_node_groups_test.go
+++ b/test/e2e/multiple_worker_node_groups_test.go
@@ -1,0 +1,51 @@
+// +build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/test/framework"
+)
+
+func TestVSphereKubernetes121BottlerocketAndAndRemoveWorkerNodeGroups(t *testing.T) {
+	provider := framework.NewVSphere(t,
+		framework.WithVSphereWorkerNodeGroup(
+			"worker-1",
+			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
+		),
+		framework.WithVSphereWorkerNodeGroup(
+			"worker-1",
+			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
+		),
+		framework.WithBottleRocket121(),
+	)
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(
+			api.WithKubernetesVersion(anywherev1.Kube121),
+			api.WithExternalEtcdTopology(1),
+			api.WithControlPlaneCount(1),
+			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+		),
+	)
+
+	runSimpleUpgradeFlow(
+		test,
+		anywherev1.Kube121,
+		framework.WithClusterUpgrade(
+			api.RemoveWorkerNodeGroup("workers-2"),
+			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
+		),
+		provider.WithNewVSphereWorkerNodeGroup(
+			"worker-1",
+			framework.WithWorkerNodeGroup(
+				"workers-3",
+				api.WithCount(1),
+			),
+		),
+	)
+}

--- a/test/e2e/simpleflow_test.go
+++ b/test/e2e/simpleflow_test.go
@@ -75,7 +75,7 @@ func TestVSphereKubernetes121ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
 func TestVSphereKubernetes121DifferentNamespaceSimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
-		framework.NewVSphere(t, framework.WithUbuntu121(), framework.WithVSphereFillers(api.WithVSphereConfigNamespace(clusterNamespace))),
+		framework.NewVSphere(t, framework.WithUbuntu121(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
 	)
@@ -105,7 +105,7 @@ func TestVSphereKubernetes120BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *t
 func TestVSphereKubernetes120BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
-		framework.NewVSphere(t, framework.WithBottleRocket120(), framework.WithVSphereFillers(api.WithVSphereConfigNamespace(clusterNamespace))),
+		framework.NewVSphere(t, framework.WithBottleRocket120(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
 	)

--- a/test/e2e/upgrade_from_latest_test.go
+++ b/test/e2e/upgrade_from_latest_test.go
@@ -28,8 +28,8 @@ func runUpgradeFromLatestReleaseFlow(test *framework.ClusterE2ETest, wantVersion
 
 func TestVSphereKubernetes120BottlerocketUpgradeFromLatestMinorRelease(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithVSphereFillers(
-		api.WithTemplate(""), // Use default template from bundle
-		api.WithOsFamily(anywherev1.Bottlerocket),
+		api.WithTemplateForAllMachines(""), // Use default template from bundle
+		api.WithOsFamilyForAllMachines(anywherev1.Bottlerocket),
 	))
 	test := framework.NewClusterE2ETest(
 		t,
@@ -50,8 +50,8 @@ func TestVSphereKubernetes120BottlerocketUpgradeFromLatestMinorRelease(t *testin
 
 func TestVSphereKubernetes121BottlerocketUpgradeFromLatestMinorRelease(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithVSphereFillers(
-		api.WithTemplate(""), // Use default template from bundle
-		api.WithOsFamily(anywherev1.Bottlerocket),
+		api.WithTemplateForAllMachines(""), // Use default template from bundle
+		api.WithOsFamilyForAllMachines(anywherev1.Bottlerocket),
 	))
 	test := framework.NewClusterE2ETest(
 		t,
@@ -72,8 +72,8 @@ func TestVSphereKubernetes121BottlerocketUpgradeFromLatestMinorRelease(t *testin
 
 func TestVSphereKubernetes120UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithVSphereFillers(
-		api.WithTemplate(""), // Use default template from bundle
-		api.WithOsFamily(anywherev1.Ubuntu),
+		api.WithTemplateForAllMachines(""), // Use default template from bundle
+		api.WithOsFamilyForAllMachines(anywherev1.Ubuntu),
 	))
 	test := framework.NewClusterE2ETest(
 		t,
@@ -94,8 +94,8 @@ func TestVSphereKubernetes120UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
 
 func TestVSphereKubernetes121UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithVSphereFillers(
-		api.WithTemplate(""), // Use default template from bundle
-		api.WithOsFamily(anywherev1.Ubuntu),
+		api.WithTemplateForAllMachines(""), // Use default template from bundle
+		api.WithOsFamilyForAllMachines(anywherev1.Ubuntu),
 	))
 	test := framework.NewClusterE2ETest(
 		t,

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -60,10 +60,10 @@ func TestVSphereKubernetes120UbuntuTo121MultipleFieldsUpgrade(t *testing.T) {
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		provider.WithProviderUpgrade(
 			framework.UpdateUbuntuTemplate121Var(),
-			api.WithNumCPUs(vsphereCpVmNumCpuUpdateVar),
-			api.WithMemoryMiB(vsphereCpVmMemoryUpdate),
-			api.WithDiskGiB(vsphereCpDiskGiBUpdateVar),
-			api.WithFolder(vsphereFolderUpdateVar),
+			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
+			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
+			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
+			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
 			// Uncomment once we support tests with multiple machine configs
 			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
 			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
@@ -93,7 +93,7 @@ func TestVSphereKubernetes120UbuntuTo121WithFluxUpgrade(t *testing.T) {
 }
 
 func TestVSphereKubernetes120UbuntuTo121DifferentNamespaceWithFluxUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu120(), framework.WithVSphereFillers(api.WithVSphereConfigNamespace(clusterNamespace)))
+	provider := framework.NewVSphere(t, framework.WithUbuntu120(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace)))
 	test := framework.NewClusterE2ETest(t,
 		provider,
 		framework.WithFlux(api.WithGitOpsNamespace(clusterNamespace)),
@@ -171,10 +171,10 @@ func TestVSphereKubernetes120BottlerocketTo121MultipleFieldsUpgrade(t *testing.T
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		provider.WithProviderUpgrade(
 			framework.UpdateBottlerocketTemplate121(),
-			api.WithNumCPUs(vsphereCpVmNumCpuUpdateVar),
-			api.WithMemoryMiB(vsphereCpVmMemoryUpdate),
-			api.WithDiskGiB(vsphereCpDiskGiBUpdateVar),
-			api.WithFolder(vsphereFolderUpdateVar),
+			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
+			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
+			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
+			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
 			// Uncomment once we support tests with multiple machine configs
 			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
 			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
@@ -204,7 +204,7 @@ func TestVSphereKubernetes120BottlerocketTo121WithFluxUpgrade(t *testing.T) {
 }
 
 func TestVSphereKubernetes120BottlerocketTo121DifferentNamespaceWithFluxUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket120(), framework.WithVSphereFillers(api.WithVSphereConfigNamespace(clusterNamespace)))
+	provider := framework.NewVSphere(t, framework.WithBottleRocket120(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace)))
 	test := framework.NewClusterE2ETest(t,
 		provider,
 		framework.WithFlux(api.WithGitOpsNamespace(clusterNamespace)),

--- a/test/e2e/vsphere_autoimport_test.go
+++ b/test/e2e/vsphere_autoimport_test.go
@@ -44,8 +44,8 @@ func deleteTemplates(test *framework.ClusterE2ETest, provider *framework.VSphere
 func TestVSphereKubernetes120UbuntuAutoimport(t *testing.T) {
 	provider := framework.NewVSphere(t,
 		framework.WithVSphereFillers(
-			api.WithTemplate(""),
-			api.WithOsFamily(v1alpha1.Ubuntu),
+			api.WithTemplateForAllMachines(""),
+			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
 		),
 	)
 	test := framework.NewClusterE2ETest(
@@ -59,8 +59,8 @@ func TestVSphereKubernetes120UbuntuAutoimport(t *testing.T) {
 func TestVSphereKubernetes121UbuntuAutoimport(t *testing.T) {
 	provider := framework.NewVSphere(t,
 		framework.WithVSphereFillers(
-			api.WithTemplate(""),
-			api.WithOsFamily(v1alpha1.Ubuntu),
+			api.WithTemplateForAllMachines(""),
+			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
 		),
 	)
 	test := framework.NewClusterE2ETest(
@@ -74,8 +74,8 @@ func TestVSphereKubernetes121UbuntuAutoimport(t *testing.T) {
 func TestVSphereKubernetes120BottlerocketAutoimport(t *testing.T) {
 	provider := framework.NewVSphere(t,
 		framework.WithVSphereFillers(
-			api.WithTemplate(""),
-			api.WithOsFamily(v1alpha1.Bottlerocket),
+			api.WithTemplateForAllMachines(""),
+			api.WithOsFamilyForAllMachines(v1alpha1.Bottlerocket),
 		),
 	)
 	test := framework.NewClusterE2ETest(
@@ -89,8 +89,8 @@ func TestVSphereKubernetes120BottlerocketAutoimport(t *testing.T) {
 func TestVSphereKubernetes121BottlerocketAutoimport(t *testing.T) {
 	provider := framework.NewVSphere(t,
 		framework.WithVSphereFillers(
-			api.WithTemplate(""),
-			api.WithOsFamily(v1alpha1.Bottlerocket),
+			api.WithTemplateForAllMachines(""),
+			api.WithOsFamilyForAllMachines(v1alpha1.Bottlerocket),
 		),
 	)
 	test := framework.NewClusterE2ETest(

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -366,7 +366,7 @@ func (e *ClusterE2ETest) StopIfFailed() {
 }
 
 func (e *ClusterE2ETest) customizeClusterConfig(clusterConfigLocation string, fillers ...api.ClusterFiller) []byte {
-	b, err := api.AutoFillCluster(clusterConfigLocation, fillers...)
+	b, err := api.AutoFillClusterFromFile(clusterConfigLocation, fillers...)
 	if err != nil {
 		e.T.Fatalf("Error filling cluster config: %v", err)
 	}

--- a/test/framework/workergroups.go
+++ b/test/framework/workergroups.go
@@ -1,0 +1,24 @@
+package framework
+
+import "github.com/aws/eks-anywhere/internal/pkg/api"
+
+type WorkerNodeGroup struct {
+	Name                                 string
+	Fillers                              []api.WorkerNodeGroupFiller
+	MachineConfigKind, MachineConfigName string
+}
+
+func WithWorkerNodeGroup(name string, fillers ...api.WorkerNodeGroupFiller) *WorkerNodeGroup {
+	return &WorkerNodeGroup{
+		Name:    name,
+		Fillers: fillers,
+	}
+}
+
+func (w *WorkerNodeGroup) clusterFiller() api.ClusterFiller {
+	wf := make([]api.WorkerNodeGroupFiller, 0, len(w.Fillers)+1)
+	wf = append(wf, api.WithMachineGroupRef(w.MachineConfigName, w.MachineConfigKind))
+	wf = append(wf, w.Fillers...)
+
+	return api.WithWorkerNodeGroup(w.Name, wf...)
+}


### PR DESCRIPTION
*Description of changes:*
Expands current e2e testing framework to support multiple worker node
groups. It allows to add/remove/update worker node groups to the initial
spec and during upgrades.

Adds one simple vSphere tests that starts with two worker node groups.
During the upgrade, it scales down one of them to 1 replica, it deletes
the other one and creates a new one.

This will need to be refactored eventually. The framework api is becoming a bit convoluted and expanding the framework itself is quite difficult. We will create tickets to refactor this in the near future. We don't do it now because it requires to rethink a bit the framework internals and in particular the way we apply api object updates and that will take some time.

We are postponing that refactor because at least this adds the ability to test multiple worker node groups and unblocks subsequent work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
