### PR TITLE
Add `components` field to EKS-D bundle

### DIFF
--- a/release/api/v1alpha1/bundle_types.go
+++ b/release/api/v1alpha1/bundle_types.go
@@ -107,6 +107,9 @@ type EksDRelease struct {
 
 	// Raw points to a collection of Raw images built with this eks-d version
 	Raw OSImageBundle `json:"raw,omitempty"`
+
+	// Components refers to the url that points to the EKS-D release CRD
+	Components string `json:"components,omitempty"`
 }
 
 type OSImageBundle struct {

--- a/release/pkg/assets_eksd.go
+++ b/release/pkg/assets_eksd.go
@@ -26,9 +26,10 @@ import (
 )
 
 const (
-	imageBuilderProjectPath = "projects/kubernetes-sigs/image-builder"
-	kindProjectPath         = "projects/kubernetes-sigs/kind"
-	releasePath             = "release"
+	imageBuilderProjectPath  = "projects/kubernetes-sigs/image-builder"
+	kindProjectPath          = "projects/kubernetes-sigs/kind"
+	releasePath              = "release"
+	eksDReleaseComponentsUrl = "https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml"
 )
 
 // GetEksDChannelAssets returns the eks-d artifacts including OVAs and kind node image
@@ -290,6 +291,7 @@ func (r *ReleaseConfig) GetEksDReleaseBundle(eksDReleaseChannel, kubeVer, eksDRe
 				Crictl:  bundleArchiveArtifacts["cri-tools"],
 			},
 		},
+		Components: eksDReleaseComponentsUrl,
 	}
 
 	return bundle, nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Design doc: #1162 

This PR adds the `components` field to the EKS-D bundle. The `components` field points to the release CRD for EKS-D.
 
More details on these changes are in the design doc linked above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
