### PR TITLE
Replace EKS with EKS-A in docs

### DIFF
--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -38,7 +38,7 @@ It currently will not work on computers with Apple Silicon or Arm based processo
 {{% /alert %}}
 
 You can install `eksctl` and `eksctl-anywhere` with [homebrew](http://brew.sh/).
-This package will also install `kubectl` and the `aws-iam-authenticator` which will be helpful to test EKS clusters.
+This package will also install `kubectl` and the `aws-iam-authenticator` which will be helpful to test EKS Anywhere clusters.
 
 ```bash
 brew install aws/tap/eks-anywhere

--- a/docs/content/en/docs/overview/_index.md
+++ b/docs/content/en/docs/overview/_index.md
@@ -10,7 +10,7 @@ EKS Anywhere uses the `eksctl` executable to create a Kubernetes cluster in your
 Currently it allows you to create and delete clusters in a vSphere environment.
 You can run cluster create and delete commands from an Ubuntu or Mac administrative machine.
 
-To create a cluster, you need to create a specification file that includes all of your vSphere details and information about your EKS cluster.
+To create a cluster, you need to create a specification file that includes all of your vSphere details and information about your EKS Anywhere cluster.
 Running the `eksctl anywhere create cluster` command from your admin machine creates the workload cluster in vSphere.
 It does this by first creating a temporary bootstrap cluster to direct the workload cluster creation.
 Once the workload cluster is created, the cluster management resources are moved to your workload cluster and the local bootstrap cluster is deleted.


### PR DESCRIPTION
Using EKS in these contexts (atleast the second) would be a bit misleading.

