### PR TITLE
Update e2e test flow so cluster ip pool is not required

### DIFF
--- a/internal/test/e2e/vsphere.go
+++ b/internal/test/e2e/vsphere.go
@@ -32,7 +32,10 @@ func (e *E2ESession) setupVSphereEnv(testRegex string) error {
 		}
 	}
 
-	e.testEnvVars[e2etests.ClusterIPPoolEnvVar] = e.ipPool.ToString()
+	ipPool := e.ipPool.ToString()
+	if ipPool != "" {
+		e.testEnvVars[e2etests.ClusterIPPoolEnvVar] = ipPool
+	}
 
 	return nil
 }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -41,7 +41,7 @@ VSPHERE_USERNAME
 VSPHERE_PASSWORD
 T_VSPHERE_CIDR
 GOVC_URL
-T_CLUSTER_IP_POOL
+T_CLUSTER_IP_POOL # comma-separated list of CP ip addresses
 ```
 
 # OIDC tests requisites


### PR DESCRIPTION
no issue

Update e2e test flow so cluster ip pool is not required

Ran local e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

