### PR TITLE
Hardware to bmcRef validation

### DIFF
--- a/pkg/hardware/config.go
+++ b/pkg/hardware/config.go
@@ -1,0 +1,98 @@
+package hardware
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	pbnjv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/pbnj/api/v1alpha1"
+	tinkv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/tink/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+type HardwareConfig struct {
+	hardwareList []tinkv1alpha1.Hardware
+	bmcList      []pbnjv1alpha1.BMC
+	secretList   []corev1.Secret
+}
+
+func (hc *HardwareConfig) GetHardwareConfig(hardwareFileName string) error {
+	err := hc.parseHardwareConfig(hardwareFileName)
+	if err != nil {
+		return fmt.Errorf("unable to parse hardware file %s: %v", hardwareFileName, err)
+	}
+	return nil
+}
+
+func (hc *HardwareConfig) parseHardwareConfig(hardwareFileName string) error {
+	content, err := ioutil.ReadFile(hardwareFileName)
+	if err != nil {
+		return fmt.Errorf("unable to read file due to: %v", err)
+	}
+
+	for _, c := range strings.Split(string(content), v1alpha1.YamlSeparator) {
+		var resource unstructured.Unstructured
+		if err = yaml.Unmarshal([]byte(c), &resource); err != nil {
+			return fmt.Errorf("unable to parse %s\nyaml: %s\n %v", hardwareFileName, c, err)
+		}
+		switch resource.GetKind() {
+		case "Hardware":
+			var hardware tinkv1alpha1.Hardware
+			err = yaml.UnmarshalStrict([]byte(c), &hardware)
+			if err != nil {
+				return fmt.Errorf("unable to parse hardware CRD\n%s \n%v", c, err)
+			}
+			hc.hardwareList = append(hc.hardwareList, hardware)
+		case "BMC":
+			var bmc pbnjv1alpha1.BMC
+			err = yaml.UnmarshalStrict([]byte(c), &bmc)
+			if err != nil {
+				return fmt.Errorf("unable to parse bmc CRD\n%s \n%v", c, err)
+			}
+			hc.bmcList = append(hc.bmcList, bmc)
+		case "Secret":
+			var secret corev1.Secret
+			err = yaml.UnmarshalStrict([]byte(c), &secret)
+			if err != nil {
+				return fmt.Errorf("unable to parse k8s secret\n%s \n%v", c, err)
+			}
+			hc.secretList = append(hc.secretList, secret)
+		}
+	}
+
+	return nil
+}
+
+func (hc *HardwareConfig) ValidateBmcRefMapping() error {
+	bmcRefMap := hc.getBmcRefMap()
+	for _, hw := range hc.hardwareList {
+		if hw.Spec.BmcRef == "" {
+			return fmt.Errorf("bmcRef not present in hardware %s", hw.Name)
+		}
+
+		h, ok := bmcRefMap[hw.Spec.BmcRef]
+		if ok && h != nil {
+			return fmt.Errorf("bmcRef %s present in both hardware %s and hardware %s", hw.Spec.BmcRef, hw.Name, h.Name)
+		}
+		if !ok {
+			return fmt.Errorf("bmcRef %s not found in hardware config", hw.Spec.BmcRef)
+		}
+
+		bmcRefMap[hw.Spec.BmcRef] = &hw
+	}
+
+	return nil
+}
+
+func (hc *HardwareConfig) getBmcRefMap() map[string]*tinkv1alpha1.Hardware {
+	var bmcRefMap = make(map[string]*tinkv1alpha1.Hardware, len(hc.bmcList))
+	for _, bmc := range hc.bmcList {
+		bmcRefMap[bmc.Name] = nil
+	}
+
+	return bmcRefMap
+}

--- a/pkg/hardware/config.go
+++ b/pkg/hardware/config.go
@@ -20,15 +20,15 @@ type HardwareConfig struct {
 	secretList   []corev1.Secret
 }
 
-func (hc *HardwareConfig) GetHardwareConfig(hardwareFileName string) error {
-	err := hc.parseHardwareConfig(hardwareFileName)
+func (hc *HardwareConfig) ParseHardwareConfig(hardwareFileName string) error {
+	err := hc.setHardwareConfigFromFile(hardwareFileName)
 	if err != nil {
 		return fmt.Errorf("unable to parse hardware file %s: %v", hardwareFileName, err)
 	}
 	return nil
 }
 
-func (hc *HardwareConfig) parseHardwareConfig(hardwareFileName string) error {
+func (hc *HardwareConfig) setHardwareConfigFromFile(hardwareFileName string) error {
 	content, err := ioutil.ReadFile(hardwareFileName)
 	if err != nil {
 		return fmt.Errorf("unable to read file due to: %v", err)
@@ -68,7 +68,7 @@ func (hc *HardwareConfig) parseHardwareConfig(hardwareFileName string) error {
 }
 
 func (hc *HardwareConfig) ValidateBmcRefMapping() error {
-	bmcRefMap := hc.getBmcRefMap()
+	bmcRefMap := hc.initBmcRefMap()
 	for _, hw := range hc.hardwareList {
 		if hw.Spec.BmcRef == "" {
 			return fmt.Errorf("bmcRef not present in hardware %s", hw.Name)
@@ -88,7 +88,7 @@ func (hc *HardwareConfig) ValidateBmcRefMapping() error {
 	return nil
 }
 
-func (hc *HardwareConfig) getBmcRefMap() map[string]*tinkv1alpha1.Hardware {
+func (hc *HardwareConfig) initBmcRefMap() map[string]*tinkv1alpha1.Hardware {
 	bmcRefMap := make(map[string]*tinkv1alpha1.Hardware, len(hc.bmcList))
 	for _, bmc := range hc.bmcList {
 		bmcRefMap[bmc.Name] = nil

--- a/pkg/hardware/config.go
+++ b/pkg/hardware/config.go
@@ -89,7 +89,7 @@ func (hc *HardwareConfig) ValidateBmcRefMapping() error {
 }
 
 func (hc *HardwareConfig) getBmcRefMap() map[string]*tinkv1alpha1.Hardware {
-	var bmcRefMap = make(map[string]*tinkv1alpha1.Hardware, len(hc.bmcList))
+	bmcRefMap := make(map[string]*tinkv1alpha1.Hardware, len(hc.bmcList))
 	for _, bmc := range hc.bmcList {
 		bmcRefMap[bmc.Name] = nil
 	}

--- a/pkg/providers/tinkerbell/testdata/hardware_config.yaml
+++ b/pkg/providers/tinkerbell/testdata/hardware_config.yaml
@@ -1,0 +1,78 @@
+apiVersion: tinkerbell.org/v1alpha1
+kind: Hardware
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: worker1
+  namespace: eksa-system
+spec:
+  bmcRef: bmc-worker1
+  id: b14d7f5b-8903-4a4c-b38d-55889ba820ba
+status: {}
+---
+apiVersion: tinkerbell.org/v1alpha1
+kind: BMC
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: bmc-worker1
+  namespace: eksa-system
+spec:
+  authSecretRef:
+    name: bmc-worker1-auth
+    namespace: eksa-system
+  host: 192.168.0.10
+  vendor: supermicro
+status: {}
+---
+apiVersion: v1
+data:
+  password: QWRtaW4=
+  username: YWRtaW4=
+kind: Secret
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: bmc-worker1-auth
+  namespace: eksa-system
+type: kubernetes.io/basic-auth
+---
+apiVersion: tinkerbell.org/v1alpha1
+kind: Hardware
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: worker2
+  namespace: eksa-system
+spec:
+  bmcRef: bmc-worker2
+  id: b14d7f5b-8903-4a4c-b38d-55889ba820bb
+status: {}
+---
+apiVersion: tinkerbell.org/v1alpha1
+kind: BMC
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: bmc-worker2
+  namespace: eksa-system
+spec:
+  authSecretRef:
+    name: bmc-worker2-auth
+    namespace: eksa-system
+  host: 192.168.0.11
+  vendor: supermicro
+status: {}
+---
+apiVersion: v1
+data:
+  password: QWRtaW4=
+  username: YWRtaW4=
+kind: Secret
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: bmc-worker2-auth
+  namespace: eksa-system
+type: kubernetes.io/basic-auth
+---

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -65,7 +65,7 @@ func newProvider(t *testing.T, datacenterConfig *v1alpha1.TinkerbellDatacenterCo
 		tink,
 		test.FakeNow,
 		true,
-		"some-hardware-config",
+		"testdata/hardware_config.yaml",
 	)
 }
 

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -113,7 +113,7 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, tinkerbel
 }
 
 func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFile string) error {
-	if err := v.hardwareConfig.GetHardwareConfig(hardwareConfigFile); err != nil {
+	if err := v.hardwareConfig.ParseHardwareConfig(hardwareConfigFile); err != nil {
 		return fmt.Errorf("failed to get hardware Config: %v", err)
 	}
 


### PR DESCRIPTION
*Description of changes:*
Adding support to parse tinkerbell hardware config file and perform hardware to bmc validations.

1. Every hardware has a unique BmcRef
2. Hardware's BmcRef is present in the hardwareConfig

*Testing:*
Tested by running `eksctl-anywhere create cluster`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->