### PR TITLE
Use Kind Haproxy image for CAPD loadbalancing

### DIFF
--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -33,6 +33,10 @@ kind: DockerCluster
 metadata:
   name: {{.clusterName}}
   namespace: {{.eksaSystemNamespace}}
+spec:
+  loadBalancer:
+    imageRepository: {{.haproxyImageRepository}}
+    imageTag: {{.haproxyImageTag}}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -212,6 +212,8 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) map[string]interface{} {
 		"auditPolicy":                common.GetAuditPolicy(),
 		"podCidrs":                   clusterSpec.Spec.ClusterNetwork.Pods.CidrBlocks,
 		"serviceCidrs":               clusterSpec.Spec.ClusterNetwork.Services.CidrBlocks,
+		"haproxyImageRepository":     getHAProxyImageRepo(bundle.Haproxy.Image),
+		"haproxyImageTag":            bundle.Haproxy.Image.Tag(),
 	}
 
 	if clusterSpec.Spec.ExternalEtcdConfiguration != nil {
@@ -483,4 +485,17 @@ func (p *provider) MachineDeploymentsToDelete(workloadCluster *types.Cluster, cu
 		machineDeployments = append(machineDeployments, mdName)
 	}
 	return machineDeployments
+}
+
+func getHAProxyImageRepo(haProxyImage releasev1alpha1.Image) string {
+	var haproxyImageRepo string
+
+	regexStr := `(?P<HAProxyImageRepoPrefix>public.ecr.aws/[a-z0-9._-]+/kubernetes-sigs/kind)/haproxy`
+	regex := regexp.MustCompile(regexStr)
+	matches := regex.FindStringSubmatch(haProxyImage.Image())
+	if len(matches) > 0 {
+		haproxyImageRepo = matches[regex.SubexpIndex("HAProxyImageRepoPrefix")]
+	}
+
+	return haproxyImageRepo
 }

--- a/pkg/providers/docker/docker_test.go
+++ b/pkg/providers/docker/docker_test.go
@@ -470,6 +470,11 @@ var versionsBundle = &cluster.VersionsBundle{
 				URI: "embed:///config/clusterctl/overrides/infrastructure-docker/v0.3.19/metadata.yaml",
 			},
 		},
+		Haproxy: releasev1alpha1.HaproxyBundle{
+			Image: releasev1alpha1.Image{
+				URI: "public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind/haproxy:v0.11.1-eks-a-v0.0.0-dev-build.1464",
+			},
+		},
 	},
 }
 

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
@@ -31,6 +31,10 @@ kind: DockerCluster
 metadata:
   name: test-cluster
   namespace: eksa-system
+spec:
+  loadBalancer:
+    imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
+    imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
@@ -31,6 +31,10 @@ kind: DockerCluster
 metadata:
   name: test-cluster
   namespace: eksa-system
+spec:
+  loadBalancer:
+    imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
+    imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/pkg/providers/docker/testdata/no_machinetemplate_update_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/no_machinetemplate_update_cp_expected.yaml
@@ -26,6 +26,10 @@ kind: DockerCluster
 metadata:
   name: fluxAddonTestCluster
   namespace: eksa-system
+spec:
+  loadBalancer:
+    imageRepository: 
+    imageTag: 
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
@@ -31,6 +31,10 @@ kind: DockerCluster
 metadata:
   name: test-cluster
   namespace: eksa-system
+spec:
+  loadBalancer:
+    imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
+    imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
@@ -31,6 +31,10 @@ kind: DockerCluster
 metadata:
   name: test-cluster
   namespace: eksa-system
+spec:
+  loadBalancer:
+    imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
+    imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/pkg/providers/docker/testdata/valid_deployment_cp_stacked_etcd_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_stacked_etcd_expected.yaml
@@ -26,6 +26,10 @@ kind: DockerCluster
 metadata:
   name: test-cluster
   namespace: eksa-system
+spec:
+  loadBalancer:
+    imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
+    imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
@@ -31,6 +31,10 @@ kind: DockerCluster
 metadata:
   name: test-cluster
   namespace: eksa-system
+spec:
+  loadBalancer:
+    imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
+    imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
@@ -31,6 +31,10 @@ kind: DockerCluster
 metadata:
   name: test-cluster
   namespace: eksa-system
+spec:
+  loadBalancer:
+    imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
+    imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
@@ -31,6 +31,10 @@ kind: DockerCluster
 metadata:
   name: test-cluster
   namespace: eksa-system
+spec:
+  loadBalancer:
+    imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
+    imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -101,6 +101,7 @@ func (vb *VersionsBundle) SharedImages() []Image {
 		vb.ExternalEtcdBootstrap.KubeProxy,
 		vb.ExternalEtcdController.Controller,
 		vb.ExternalEtcdController.KubeProxy,
+		vb.Haproxy.Image,
 	}
 }
 


### PR DESCRIPTION
CAPD was initially hardcoded to use `kindest/haproxy` as the loadbalancer image. They made this configurable in `v1alpha4` by adding a `LoadBalancer` field to the `DockerClusterSpec` type. This PR sets this field to use the HAProxy image we build and distribute.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

