### PR TITLE
Adding kubectl for cloudstack

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -33,22 +33,112 @@ const (
 )
 
 var (
-	capiClustersResourceType          = fmt.Sprintf("clusters.%s", clusterv1.GroupVersion.Group)
-	eksaClusterResourceType           = fmt.Sprintf("clusters.%s", v1alpha1.GroupVersion.Group)
-	eksaVSphereDatacenterResourceType = fmt.Sprintf("vspheredatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
-	eksaVSphereMachineResourceType    = fmt.Sprintf("vspheremachineconfigs.%s", v1alpha1.GroupVersion.Group)
-	eksaAwsResourceType               = fmt.Sprintf("awsdatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
-	eksaGitOpsResourceType            = fmt.Sprintf("gitopsconfigs.%s", v1alpha1.GroupVersion.Group)
-	eksaOIDCResourceType              = fmt.Sprintf("oidcconfigs.%s", v1alpha1.GroupVersion.Group)
-	eksaAwsIamResourceType            = fmt.Sprintf("awsiamconfigs.%s", v1alpha1.GroupVersion.Group)
-	etcdadmClustersResourceType       = fmt.Sprintf("etcdadmclusters.%s", etcdv1.GroupVersion.Group)
-	bundlesResourceType               = fmt.Sprintf("bundles.%s", releasev1alpha1.GroupVersion.Group)
-	clusterResourceSetResourceType    = fmt.Sprintf("clusterresourcesets.%s", addons.GroupVersion.Group)
-	kubeadmControlPlaneResourceType   = fmt.Sprintf("kubeadmcontrolplanes.controlplane.%s", clusterv1.GroupVersion.Group)
+	capiClustersResourceType             = fmt.Sprintf("clusters.%s", clusterv1.GroupVersion.Group)
+	eksaClusterResourceType              = fmt.Sprintf("clusters.%s", v1alpha1.GroupVersion.Group)
+	eksaVSphereDatacenterResourceType    = fmt.Sprintf("vspheredatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
+	eksaVSphereMachineResourceType       = fmt.Sprintf("vspheremachineconfigs.%s", v1alpha1.GroupVersion.Group)
+	eksaCloudStackDatacenterResourceType = fmt.Sprintf("cloudstackdeploymentconfigs.%s", v1alpha1.GroupVersion.Group)
+	eksaCloudStackMachineResourceType    = fmt.Sprintf("cloudstackmachineconfigs.%s", v1alpha1.GroupVersion.Group)
+	eksaAwsResourceType                  = fmt.Sprintf("awsdatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
+	eksaGitOpsResourceType               = fmt.Sprintf("gitopsconfigs.%s", v1alpha1.GroupVersion.Group)
+	eksaOIDCResourceType                 = fmt.Sprintf("oidcconfigs.%s", v1alpha1.GroupVersion.Group)
+	eksaAwsIamResourceType               = fmt.Sprintf("awsiamconfigs.%s", v1alpha1.GroupVersion.Group)
+	etcdadmClustersResourceType          = fmt.Sprintf("etcdadmclusters.%s", etcdv1.GroupVersion.Group)
+	bundlesResourceType                  = fmt.Sprintf("bundles.%s", releasev1alpha1.GroupVersion.Group)
+	clusterResourceSetResourceType       = fmt.Sprintf("clusterresourcesets.%s", addons.GroupVersion.Group)
+	kubeadmControlPlaneResourceType      = fmt.Sprintf("kubeadmcontrolplanes.controlplane.%s", clusterv1.GroupVersion.Group)
 )
 
 type Kubectl struct {
 	Executable
+}
+
+func (k *Kubectl) SearchCloudStackMachineConfig(ctx context.Context, name string, kubeconfigFile string, namespace string) ([]*v1alpha1.CloudStackMachineConfig, error) {
+	params := []string{
+		"get", eksaCloudStackMachineResourceType, "-o", "json", "--kubeconfig",
+		kubeconfigFile, "--namespace", namespace, "--field-selector=metadata.name=" + name,
+	}
+	stdOut, err := k.Execute(ctx, params...)
+	if err != nil {
+		return nil, fmt.Errorf("error searching eksa CloudStackMachineConfigResponse: %v", err)
+	}
+
+	response := &CloudStackMachineConfigResponse{}
+	err = json.Unmarshal(stdOut.Bytes(), response)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing CloudStackMachineConfigResponse response: %v", err)
+	}
+
+	return response.Items, nil
+}
+
+func (k *Kubectl) DeleteEksaCloudStackDatacenterConfig(ctx context.Context, cloudstackDeploymentConfigName string, kubeconfigFile string, namespace string) error {
+	params := []string{"delete", eksaCloudStackDatacenterResourceType, cloudstackDeploymentConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace, "--ignore-not-found=true"}
+	_, err := k.Execute(ctx, params...)
+	if err != nil {
+		return fmt.Errorf("error deleting cloudstackdeploymentconfig cluster %s apply: %v", cloudstackDeploymentConfigName, err)
+	}
+	return nil
+}
+
+func (k *Kubectl) GetEksaCloudStackDatacenterConfig(ctx context.Context, cloudstackDatacenterConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.CloudStackDatacenterConfig, error) {
+	params := []string{"get", eksaVSphereDatacenterResourceType, cloudstackDatacenterConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
+	stdOut, err := k.Execute(ctx, params...)
+	if err != nil {
+		return nil, fmt.Errorf("error getting eksa vsphere cluster %v", err)
+	}
+
+	response := &v1alpha1.CloudStackDatacenterConfig{}
+	err = json.Unmarshal(stdOut.Bytes(), response)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing get eksa vsphere cluster response: %v", err)
+	}
+
+	return response, nil
+}
+
+func (k *Kubectl) GetEksaCloudStackMachineConfig(ctx context.Context, cloudstackMachineConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.CloudStackMachineConfig, error) {
+	params := []string{"get", eksaVSphereMachineResourceType, cloudstackMachineConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
+	stdOut, err := k.Execute(ctx, params...)
+	if err != nil {
+		return nil, fmt.Errorf("error getting eksa vsphere cluster %v", err)
+	}
+
+	response := &v1alpha1.CloudStackMachineConfig{}
+	err = json.Unmarshal(stdOut.Bytes(), response)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing get eksa vsphere cluster response: %v", err)
+	}
+
+	return response, nil
+}
+
+func (k *Kubectl) SearchCloudStackDatacenterConfig(ctx context.Context, name string, kubeconfigFile string, namespace string) ([]*v1alpha1.CloudStackDatacenterConfig, error) {
+	params := []string{
+		"get", eksaCloudStackDatacenterResourceType, "-o", "json", "--kubeconfig",
+		kubeconfigFile, "--namespace", namespace, "--field-selector=metadata.name=" + name,
+	}
+	stdOut, err := k.Execute(ctx, params...)
+	if err != nil {
+		return nil, fmt.Errorf("error searching eksa CloudStackDatacenterConfigResponse: %v", err)
+	}
+
+	response := &CloudStackDatacenterConfigResponse{}
+	err = json.Unmarshal(stdOut.Bytes(), response)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing CloudStackDatacenterConfigResponse response: %v", err)
+	}
+
+	return response.Items, nil
+}
+
+func (k *Kubectl) DeleteEksaCloudStackMachineConfig(ctx context.Context, cloudstackMachineConfigName string, kubeconfigFile string, namespace string) error {
+	params := []string{"delete", eksaCloudStackMachineResourceType, cloudstackMachineConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace, "--ignore-not-found=true"}
+	_, err := k.Execute(ctx, params...)
+	if err != nil {
+		return fmt.Errorf("error deleting cloudstackmachineconfig cluster %s apply: %v", cloudstackMachineConfigName, err)
+	}
+	return nil
 }
 
 type VersionResponse struct {
@@ -491,6 +581,10 @@ type GitOpsConfigResponse struct {
 	Items []*v1alpha1.GitOpsConfig `json:"items,omitempty"`
 }
 
+type CloudStackDatacenterConfigResponse struct {
+	Items []*v1alpha1.CloudStackDatacenterConfig `json:"items,omitempty"`
+}
+
 type VSphereDatacenterConfigResponse struct {
 	Items []*v1alpha1.VSphereDatacenterConfig `json:"items,omitempty"`
 }
@@ -501,6 +595,10 @@ type IdentityProviderConfigResponse struct {
 
 type VSphereMachineConfigResponse struct {
 	Items []*v1alpha1.VSphereMachineConfig `json:"items,omitempty"`
+}
+
+type CloudStackMachineConfigResponse struct {
+	Items []*v1alpha1.CloudStackMachineConfig `json:"items,omitempty"`
 }
 
 func (k *Kubectl) ValidateClustersCRD(ctx context.Context, cluster *types.Cluster) error {

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -53,83 +53,33 @@ type Kubectl struct {
 	Executable
 }
 
-func (k *Kubectl) SearchCloudStackMachineConfig(ctx context.Context, name string, kubeconfigFile string, namespace string) ([]*v1alpha1.CloudStackMachineConfig, error) {
-	params := []string{
-		"get", eksaCloudStackMachineResourceType, "-o", "json", "--kubeconfig",
-		kubeconfigFile, "--namespace", namespace, "--field-selector=metadata.name=" + name,
-	}
-	stdOut, err := k.Execute(ctx, params...)
+func (k *Kubectl) GetEksaCloudStackMachineConfig(ctx context.Context, cloudstackMachineConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.CloudStackMachineConfig, error) {
+	response := &v1alpha1.CloudStackMachineConfig{}
+	err := k.getObject(ctx, eksaCloudStackMachineResourceType, cloudstackMachineConfigName, namespace, kubeconfigFile, response)
 	if err != nil {
-		return nil, fmt.Errorf("error searching eksa CloudStackMachineConfigResponse: %v", err)
+		return nil, fmt.Errorf("error getting eksa cloudstack machineconfig: %v", err)
 	}
 
-	response := &CloudStackMachineConfigResponse{}
-	err = json.Unmarshal(stdOut.Bytes(), response)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing CloudStackMachineConfigResponse response: %v", err)
-	}
-
-	return response.Items, nil
+	return response, nil
 }
 
-func (k *Kubectl) DeleteEksaCloudStackDatacenterConfig(ctx context.Context, cloudstackDeploymentConfigName string, kubeconfigFile string, namespace string) error {
-	params := []string{"delete", eksaCloudStackDatacenterResourceType, cloudstackDeploymentConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace, "--ignore-not-found=true"}
+func (k *Kubectl) DeleteEksaCloudStackDatacenterConfig(ctx context.Context, cloudstackDatacenterConfigName string, kubeconfigFile string, namespace string) error {
+	params := []string{"delete", eksaCloudStackDatacenterResourceType, cloudstackDatacenterConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace, "--ignore-not-found=true"}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error deleting cloudstackdeploymentconfig cluster %s apply: %v", cloudstackDeploymentConfigName, err)
+		return fmt.Errorf("error deleting cloudstackdatacenterconfig cluster %s apply: %v", cloudstackDatacenterConfigName, err)
 	}
 	return nil
 }
 
 func (k *Kubectl) GetEksaCloudStackDatacenterConfig(ctx context.Context, cloudstackDatacenterConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.CloudStackDatacenterConfig, error) {
-	params := []string{"get", eksaCloudStackDatacenterResourceType, cloudstackDatacenterConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
-	stdOut, err := k.Execute(ctx, params...)
-	if err != nil {
-		return nil, fmt.Errorf("error getting eksa cloudstack datacenter config: %v", err)
-	}
-
 	response := &v1alpha1.CloudStackDatacenterConfig{}
-	err = json.Unmarshal(stdOut.Bytes(), response)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing get eksa cloudstack cluster response: %v", err)
-	}
-
-	return response, nil
-}
-
-func (k *Kubectl) GetEksaCloudStackMachineConfig(ctx context.Context, cloudstackMachineConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.CloudStackMachineConfig, error) {
-	params := []string{"get", eksaCloudStackMachineResourceType, cloudstackMachineConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
-	stdOut, err := k.Execute(ctx, params...)
+	err := k.getObject(ctx, eksaCloudStackDatacenterResourceType, cloudstackDatacenterConfigName, namespace, kubeconfigFile, response)
 	if err != nil {
 		return nil, fmt.Errorf("error getting eksa cloudstack machineconfig: %v", err)
 	}
 
-	response := &v1alpha1.CloudStackMachineConfig{}
-	err = json.Unmarshal(stdOut.Bytes(), response)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing get eksa cloudstack cluster response: %v", err)
-	}
-
 	return response, nil
-}
-
-func (k *Kubectl) SearchCloudStackDatacenterConfig(ctx context.Context, name string, kubeconfigFile string, namespace string) ([]*v1alpha1.CloudStackDatacenterConfig, error) {
-	params := []string{
-		"get", eksaCloudStackDatacenterResourceType, "-o", "json", "--kubeconfig",
-		kubeconfigFile, "--namespace", namespace, "--field-selector=metadata.name=" + name,
-	}
-	stdOut, err := k.Execute(ctx, params...)
-	if err != nil {
-		return nil, fmt.Errorf("error searching eksa CloudStackDatacenterConfigResponse: %v", err)
-	}
-
-	response := &CloudStackDatacenterConfigResponse{}
-	err = json.Unmarshal(stdOut.Bytes(), response)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing CloudStackDatacenterConfigResponse response: %v", err)
-	}
-
-	return response.Items, nil
 }
 
 func (k *Kubectl) DeleteEksaCloudStackMachineConfig(ctx context.Context, cloudstackMachineConfigName string, kubeconfigFile string, namespace string) error {
@@ -581,10 +531,6 @@ type GitOpsConfigResponse struct {
 	Items []*v1alpha1.GitOpsConfig `json:"items,omitempty"`
 }
 
-type CloudStackDatacenterConfigResponse struct {
-	Items []*v1alpha1.CloudStackDatacenterConfig `json:"items,omitempty"`
-}
-
 type VSphereDatacenterConfigResponse struct {
 	Items []*v1alpha1.VSphereDatacenterConfig `json:"items,omitempty"`
 }
@@ -595,10 +541,6 @@ type IdentityProviderConfigResponse struct {
 
 type VSphereMachineConfigResponse struct {
 	Items []*v1alpha1.VSphereMachineConfig `json:"items,omitempty"`
-}
-
-type CloudStackMachineConfigResponse struct {
-	Items []*v1alpha1.CloudStackMachineConfig `json:"items,omitempty"`
 }
 
 func (k *Kubectl) ValidateClustersCRD(ctx context.Context, cluster *types.Cluster) error {

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -37,7 +37,7 @@ var (
 	eksaClusterResourceType              = fmt.Sprintf("clusters.%s", v1alpha1.GroupVersion.Group)
 	eksaVSphereDatacenterResourceType    = fmt.Sprintf("vspheredatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaVSphereMachineResourceType       = fmt.Sprintf("vspheremachineconfigs.%s", v1alpha1.GroupVersion.Group)
-	eksaCloudStackDatacenterResourceType = fmt.Sprintf("cloudstackdeploymentconfigs.%s", v1alpha1.GroupVersion.Group)
+	eksaCloudStackDatacenterResourceType = fmt.Sprintf("cloudstackdatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaCloudStackMachineResourceType    = fmt.Sprintf("cloudstackmachineconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaAwsResourceType                  = fmt.Sprintf("awsdatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaGitOpsResourceType               = fmt.Sprintf("gitopsconfigs.%s", v1alpha1.GroupVersion.Group)
@@ -82,32 +82,32 @@ func (k *Kubectl) DeleteEksaCloudStackDatacenterConfig(ctx context.Context, clou
 }
 
 func (k *Kubectl) GetEksaCloudStackDatacenterConfig(ctx context.Context, cloudstackDatacenterConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.CloudStackDatacenterConfig, error) {
-	params := []string{"get", eksaVSphereDatacenterResourceType, cloudstackDatacenterConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
+	params := []string{"get", eksaCloudStackDatacenterResourceType, cloudstackDatacenterConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting eksa vsphere cluster %v", err)
+		return nil, fmt.Errorf("error getting eksa cloudstack datacenter config: %v", err)
 	}
 
 	response := &v1alpha1.CloudStackDatacenterConfig{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get eksa vsphere cluster response: %v", err)
+		return nil, fmt.Errorf("error parsing get eksa cloudstack cluster response: %v", err)
 	}
 
 	return response, nil
 }
 
 func (k *Kubectl) GetEksaCloudStackMachineConfig(ctx context.Context, cloudstackMachineConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.CloudStackMachineConfig, error) {
-	params := []string{"get", eksaVSphereMachineResourceType, cloudstackMachineConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
+	params := []string{"get", eksaCloudStackMachineResourceType, cloudstackMachineConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting eksa vsphere cluster %v", err)
+		return nil, fmt.Errorf("error getting eksa cloudstack machineconfig: %v", err)
 	}
 
 	response := &v1alpha1.CloudStackMachineConfig{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get eksa vsphere cluster response: %v", err)
+		return nil, fmt.Errorf("error parsing get eksa cloudstack cluster response: %v", err)
 	}
 
 	return response, nil

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -630,16 +630,16 @@ func TestKubectlGetEksaCloudStackMachineConfig(t *testing.T) {
 		{
 			testName:         "no machines",
 			jsonResponseFile: "testdata/kubectl_no_cs_machineconfigs.json",
-			wantMachines:     &v1alpha1.CloudStackMachineConfig{
+			wantMachines: &v1alpha1.CloudStackMachineConfig{
 				TypeMeta: metav1.TypeMeta{APIVersion: "v1"},
 			},
 		},
 		{
 			testName:         "one machineconfig",
 			jsonResponseFile: "testdata/kubectl_eksa_cs_machineconfig.json",
-			wantMachines:     &v1alpha1.CloudStackMachineConfig{
+			wantMachines: &v1alpha1.CloudStackMachineConfig{
 				TypeMeta: metav1.TypeMeta{
-					Kind: "CloudStackMachineConfig",
+					Kind:       "CloudStackMachineConfig",
 					APIVersion: "anywhere.eks.amazonaws.com/v1alpha1",
 				},
 				ObjectMeta: metav1.ObjectMeta{Name: "test-etcd"},
@@ -654,14 +654,13 @@ func TestKubectlGetEksaCloudStackMachineConfig(t *testing.T) {
 					},
 					Users: []v1alpha1.UserConfiguration{
 						{
-							Name: "maxdrib",
+							Name:              "maxdrib",
 							SshAuthorizedKeys: []string{"ssh-rsa test123 hi"},
 						},
 					},
 				},
 			},
 		},
-
 	}
 
 	for _, tt := range tests {
@@ -697,16 +696,16 @@ func TestKubectlGetEksaCloudStackDatacenterConfig(t *testing.T) {
 		{
 			testName:         "no datacenter",
 			jsonResponseFile: "testdata/kubectl_no_cs_datacenterconfigs.json",
-			wantDatacenter:     &v1alpha1.CloudStackDatacenterConfig{
+			wantDatacenter: &v1alpha1.CloudStackDatacenterConfig{
 				TypeMeta: metav1.TypeMeta{APIVersion: "v1"},
 			},
 		},
 		{
 			testName:         "one datacenter",
 			jsonResponseFile: "testdata/kubectl_eksa_cs_datacenterconfig.json",
-			wantDatacenter:     &v1alpha1.CloudStackDatacenterConfig{
+			wantDatacenter: &v1alpha1.CloudStackDatacenterConfig{
 				TypeMeta: metav1.TypeMeta{
-					Kind: "CloudStackDatacenterConfig",
+					Kind:       "CloudStackDatacenterConfig",
 					APIVersion: "anywhere.eks.amazonaws.com/v1alpha1",
 				},
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
@@ -720,7 +719,7 @@ func TestKubectlGetEksaCloudStackDatacenterConfig(t *testing.T) {
 						Type:  "name",
 						Value: "testZone",
 					},
-					Domain: "testDomain",
+					Domain:  "testDomain",
 					Account: "testAccount",
 				},
 			},

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -621,6 +621,136 @@ func TestKubectlGetMachines(t *testing.T) {
 	}
 }
 
+func TestKubectlGetEksaCloudStackMachineConfig(t *testing.T) {
+	tests := []struct {
+		testName         string
+		jsonResponseFile string
+		wantMachines     *v1alpha1.CloudStackMachineConfig
+	}{
+		{
+			testName:         "no machines",
+			jsonResponseFile: "testdata/kubectl_no_cs_machineconfigs.json",
+			wantMachines:     &v1alpha1.CloudStackMachineConfig{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1"},
+			},
+		},
+		{
+			testName:         "one machineconfig",
+			jsonResponseFile: "testdata/kubectl_eksa_cs_machineconfig.json",
+			wantMachines:     &v1alpha1.CloudStackMachineConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "CloudStackMachineConfig",
+					APIVersion: "anywhere.eks.amazonaws.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: "test-etcd"},
+				Spec: v1alpha1.CloudStackMachineConfigSpec{
+					Template: v1alpha1.CloudStackResourceRef{
+						Type:  "name",
+						Value: "testTemplate",
+					},
+					ComputeOffering: v1alpha1.CloudStackResourceRef{
+						Type:  "name",
+						Value: "testOffering",
+					},
+					Users: []v1alpha1.UserConfiguration{
+						{
+							Name: "maxdrib",
+							SshAuthorizedKeys: []string{"ssh-rsa test123 hi"},
+						},
+					},
+				},
+			},
+		},
+
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			fileContent := test.ReadFile(t, tt.jsonResponseFile)
+			k, ctx, cluster, e := newKubectl(t)
+			machineConfigName := "testMachineConfig"
+			e.EXPECT().Execute(ctx, []string{
+				"get", "--namespace", constants.EksaSystemNamespace,
+				"cloudstackmachineconfigs.anywhere.eks.amazonaws.com",
+				machineConfigName,
+				"-o", "json", "--kubeconfig", cluster.KubeconfigFile,
+			}).Return(*bytes.NewBufferString(fileContent), nil)
+
+			gotMachines, err := k.GetEksaCloudStackMachineConfig(ctx, machineConfigName, cluster.KubeconfigFile, constants.EksaSystemNamespace)
+			if err != nil {
+				t.Fatalf("Kubectl.GetEksaCloudStackMachineConfig() error = %v, want nil", err)
+			}
+
+			if !reflect.DeepEqual(gotMachines, tt.wantMachines) {
+				t.Fatalf("Kubectl.GetEksaCloudStackMachineConfig() machines = %+v, want %+v", gotMachines, tt.wantMachines)
+			}
+		})
+	}
+}
+
+func TestKubectlGetEksaCloudStackDatacenterConfig(t *testing.T) {
+	tests := []struct {
+		testName         string
+		jsonResponseFile string
+		wantDatacenter   *v1alpha1.CloudStackDatacenterConfig
+	}{
+		{
+			testName:         "no datacenter",
+			jsonResponseFile: "testdata/kubectl_no_cs_datacenterconfigs.json",
+			wantDatacenter:     &v1alpha1.CloudStackDatacenterConfig{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1"},
+			},
+		},
+		{
+			testName:         "one datacenter",
+			jsonResponseFile: "testdata/kubectl_eksa_cs_datacenterconfig.json",
+			wantDatacenter:     &v1alpha1.CloudStackDatacenterConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "CloudStackDatacenterConfig",
+					APIVersion: "anywhere.eks.amazonaws.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: v1alpha1.CloudStackDatacenterConfigSpec{
+					Insecure: true,
+					Network: v1alpha1.CloudStackResourceRef{
+						Type:  "name",
+						Value: "testNetwork",
+					},
+					Zone: v1alpha1.CloudStackResourceRef{
+						Type:  "name",
+						Value: "testZone",
+					},
+					Domain: "testDomain",
+					Account: "testAccount",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			fileContent := test.ReadFile(t, tt.jsonResponseFile)
+			k, ctx, cluster, e := newKubectl(t)
+			datacenterConfigName := "testDatacenterConfig"
+			e.EXPECT().Execute(ctx, []string{
+				"get", "--namespace", constants.EksaSystemNamespace,
+				"cloudstackdatacenterconfigs.anywhere.eks.amazonaws.com",
+				datacenterConfigName,
+				"-o", "json", "--kubeconfig", cluster.KubeconfigFile,
+			}).Return(*bytes.NewBufferString(fileContent), nil)
+
+			gotDatacenter, err := k.GetEksaCloudStackDatacenterConfig(ctx, datacenterConfigName, cluster.KubeconfigFile, constants.EksaSystemNamespace)
+			if err != nil {
+				t.Fatalf("Kubectl.GetEksaCloudStackDatacenterConfig() error = %v, want nil", err)
+			}
+
+			if !reflect.DeepEqual(gotDatacenter, tt.wantDatacenter) {
+				t.Fatalf("Kubectl.GetEksaCloudStackDatacenterConfig() machines = %+v, want %+v", gotDatacenter, tt.wantDatacenter)
+			}
+		})
+	}
+}
+
 func TestKubectlLoadSecret(t *testing.T) {
 	tests := []struct {
 		testName string

--- a/pkg/executables/testdata/kubectl_eksa_cs_datacenterconfig.json
+++ b/pkg/executables/testdata/kubectl_eksa_cs_datacenterconfig.json
@@ -1,0 +1,20 @@
+{
+  "apiVersion": "anywhere.eks.amazonaws.com/v1alpha1",
+  "kind": "CloudStackDatacenterConfig",
+  "metadata": {
+    "name": "test"
+  },
+  "spec": {
+    "insecure": true,
+    "network": {
+      "value": "testNetwork",
+      "type": "name"
+    },
+    "domain": "testDomain",
+    "account": "testAccount",
+    "zone": {
+      "value": "testZone",
+      "type": "name"
+    }
+  }
+}

--- a/pkg/executables/testdata/kubectl_eksa_cs_machineconfig.json
+++ b/pkg/executables/testdata/kubectl_eksa_cs_machineconfig.json
@@ -1,0 +1,21 @@
+{
+  "apiVersion": "anywhere.eks.amazonaws.com/v1alpha1",
+  "kind": "CloudStackMachineConfig",
+  "metadata": {
+    "name": "test-etcd"
+  },
+  "spec": {
+    "computeOffering": {
+      "value": "testOffering",
+      "type": "name"
+    },
+    "users": [{
+      "name": "maxdrib",
+      "sshAuthorizedKeys": ["ssh-rsa test123 hi"]
+    }],
+    "template": {
+      "value": "testTemplate",
+      "type": "name"
+    }
+  }
+}

--- a/pkg/executables/testdata/kubectl_no_cs_datacenterconfigs.json
+++ b/pkg/executables/testdata/kubectl_no_cs_datacenterconfigs.json
@@ -1,0 +1,8 @@
+{
+  "apiVersion": "v1",
+  "items": [],
+  "metadata": {
+    "resourceVersion": "",
+    "selfLink": ""
+  }
+}

--- a/pkg/executables/testdata/kubectl_no_cs_machineconfigs.json
+++ b/pkg/executables/testdata/kubectl_no_cs_machineconfigs.json
@@ -1,0 +1,8 @@
+{
+  "apiVersion": "v1",
+  "items": [],
+  "metadata": {
+    "resourceVersion": "",
+    "selfLink": ""
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR is a continuation of the integration of the CloudStack provider into EKS-A. It adds support for querying cloudstack items using the kubectl executable. Most of the code is copied/pasted from vsphere.

*Testing (if applicable):*
Cluster creation succeeded locally (with other changes). EKS-A builds, and all older unit tests succeed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

