### PR TITLE
Make new bundle fields optional

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -1659,8 +1659,6 @@ spec:
                               description: The image repository, name, and tag
                               type: string
                           type: object
-                        version:
-                          type: string
                       required:
                       - image
                       type: object
@@ -2356,10 +2354,8 @@ spec:
                   - etcdadmBootstrap
                   - etcdadmController
                   - flux
-                  - haproxy
                   - kindnetd
                   - kubeVersion
-                  - tinkerbell
                   - vSphere
                   type: object
                 type: array

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -1827,8 +1827,6 @@ spec:
                               description: The image repository, name, and tag
                               type: string
                           type: object
-                        version:
-                          type: string
                       required:
                       - image
                       type: object
@@ -2524,10 +2522,8 @@ spec:
                   - etcdadmBootstrap
                   - etcdadmController
                   - flux
-                  - haproxy
                   - kindnetd
                   - kubeVersion
-                  - tinkerbell
                   - vSphere
                   type: object
                 type: array

--- a/release/api/v1alpha1/bundle_types.go
+++ b/release/api/v1alpha1/bundle_types.go
@@ -75,8 +75,8 @@ type VersionsBundle struct {
 	BottleRocketAdmin      BottlerocketAdminBundle     `json:"bottlerocketAdmin"`
 	ExternalEtcdBootstrap  EtcdadmBootstrapBundle      `json:"etcdadmBootstrap"`
 	ExternalEtcdController EtcdadmControllerBundle     `json:"etcdadmController"`
-	Tinkerbell             TinkerbellBundle            `json:"tinkerbell"`
-	Haproxy                HaproxyBundle               `json:"haproxy"`
+	Tinkerbell             TinkerbellBundle            `json:"tinkerbell,omitempty"`
+	Haproxy                HaproxyBundle               `json:"haproxy,omitempty"`
 }
 
 type EksDRelease struct {

--- a/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -1659,8 +1659,6 @@ spec:
                               description: The image repository, name, and tag
                               type: string
                           type: object
-                        version:
-                          type: string
                       required:
                       - image
                       type: object
@@ -2356,10 +2354,8 @@ spec:
                   - etcdadmBootstrap
                   - etcdadmController
                   - flux
-                  - haproxy
                   - kindnetd
                   - kubeVersion
-                  - tinkerbell
                   - vSphere
                   type: object
                 type: array


### PR DESCRIPTION
*Description of changes:*
Without this, old `Bundle`'s become invalid since the api server makes them required

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

