### PR TITLE
End to end tests for taints

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -174,7 +174,7 @@ func WithWorkerNodeGroup(name string, fillers ...WorkerNodeGroupFiller) ClusterF
 		position := -1
 		for i, w := range c.Spec.WorkerNodeGroupConfigurations {
 			if w.Name == name {
-				logger.Info("updating worker node group", "name", name)
+				logger.Info("Updating worker node group", "name", name)
 				nodeGroup = &w
 				position = i
 				break

--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -174,6 +174,7 @@ func WithWorkerNodeGroup(name string, fillers ...WorkerNodeGroupFiller) ClusterF
 		position := -1
 		for i, w := range c.Spec.WorkerNodeGroupConfigurations {
 			if w.Name == name {
+				logger.Info("updating worker node group", "name", name)
 				nodeGroup = &w
 				position = i
 				break
@@ -181,6 +182,7 @@ func WithWorkerNodeGroup(name string, fillers ...WorkerNodeGroupFiller) ClusterF
 		}
 
 		if nodeGroup == nil {
+			logger.Info("adding worker node group", "name", name)
 			nodeGroup = &anywherev1.WorkerNodeGroupConfiguration{Name: name}
 			c.Spec.WorkerNodeGroupConfigurations = append(c.Spec.WorkerNodeGroupConfigurations, *nodeGroup)
 			position = len(c.Spec.WorkerNodeGroupConfigurations) - 1

--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -182,7 +182,7 @@ func WithWorkerNodeGroup(name string, fillers ...WorkerNodeGroupFiller) ClusterF
 		}
 
 		if nodeGroup == nil {
-			logger.Info("adding worker node group", "name", name)
+			logger.Info("Adding worker node group", "name", name)
 			nodeGroup = &anywherev1.WorkerNodeGroupConfiguration{Name: name}
 			c.Spec.WorkerNodeGroupConfigurations = append(c.Spec.WorkerNodeGroupConfigurations, *nodeGroup)
 			position = len(c.Spec.WorkerNodeGroupConfigurations) - 1

--- a/internal/pkg/api/nodegroups.go
+++ b/internal/pkg/api/nodegroups.go
@@ -20,6 +20,12 @@ func WithTaint(taint corev1.Taint) WorkerNodeGroupFiller {
 	}
 }
 
+func WithNoTaints() WorkerNodeGroupFiller {
+	return func(w *anywherev1.WorkerNodeGroupConfiguration) {
+		w.Taints = nil
+	}
+}
+
 func WithLabel(key, value string) WorkerNodeGroupFiller {
 	return func(w *anywherev1.WorkerNodeGroupConfiguration) {
 		w.Labels[key] = value

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -293,6 +293,18 @@ func (k *Kubectl) ListCluster(ctx context.Context) error {
 	return nil
 }
 
+func (k *Kubectl) GetNodes(ctx context.Context, kubeconfig string) ([]corev1.Node, error) {
+	params := []string{"get", "nodes", "--kubeconfig", kubeconfig}
+	stdOut, err := k.Execute(ctx, params...)
+	if err != nil {
+		return nil, fmt.Errorf("error getting nodes: %v", err)
+	}
+	response := &corev1.NodeList{}
+	err = json.Unmarshal(stdOut.Bytes(), response)
+
+	return response.Items, err
+}
+
 func (k *Kubectl) ValidateNodes(ctx context.Context, kubeconfig string) error {
 	template := "{{range .items}}{{.metadata.name}}\n{{end}}"
 	params := []string{"get", "nodes", "-o", "go-template", "--template", template, "--kubeconfig", kubeconfig}

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -294,7 +294,7 @@ func (k *Kubectl) ListCluster(ctx context.Context) error {
 }
 
 func (k *Kubectl) GetNodes(ctx context.Context, kubeconfig string) ([]corev1.Node, error) {
-	params := []string{"get", "nodes", "--kubeconfig", kubeconfig}
+	params := []string{"get", "nodes", "-o", "json", "--kubeconfig", kubeconfig}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting nodes: %v", err)

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	addons "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -495,6 +496,31 @@ func (k *Kubectl) GetMachines(ctx context.Context, cluster *types.Cluster, clust
 	return response.Items, nil
 }
 
+type machineSetResponse struct {
+	Items []clusterv1.MachineSet `json:"items,omitempty"`
+}
+
+func (k *Kubectl) GetMachineSets(ctx context.Context, machineDeploymentName string, cluster *types.Cluster) ([]clusterv1.MachineSet, error) {
+	params := []string{
+		"get", "machinesets", "-o", "json", "--kubeconfig", cluster.KubeconfigFile,
+		"--selector=cluster.x-k8s.io/deployment-name=" + machineDeploymentName,
+		"--namespace", constants.EksaSystemNamespace,
+	}
+
+	stdOut, err := k.Execute(ctx, params...)
+	if err != nil {
+		return nil, fmt.Errorf("error getting machineset associated with deployment %s: %v", machineDeploymentName, err)
+	}
+
+	response := &machineSetResponse{}
+	err = json.Unmarshal(stdOut.Bytes(), response)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing get machinesets response: %v", err)
+	}
+
+	return response.Items, nil
+}
+
 type ClustersResponse struct {
 	Items []types.CAPICluster `json:"items,omitempty"`
 }
@@ -750,6 +776,23 @@ func (k *Kubectl) GetMachineDeployments(ctx context.Context, opts ...KubectlOpt)
 	}
 
 	return response.Items, nil
+}
+
+func (k *Kubectl) GetKubeadmConfigTemplate(ctx context.Context, kubeadmConfigTemplateName string, opts ...KubectlOpt) (*kubeadmv1.KubeadmConfigTemplate, error) {
+	params := []string{"get", fmt.Sprintf("kubeadmconfigtemplate.%s", kubeadmv1.GroupVersion.Group), kubeadmConfigTemplateName, "-o", "json"}
+	applyOpts(&params, opts...)
+	stdOut, err := k.Execute(ctx, params...)
+	if err != nil {
+		return nil, fmt.Errorf("error getting kubeadmconfigtemplate: %v", err)
+	}
+
+	response := &kubeadmv1.KubeadmConfigTemplate{}
+	err = json.Unmarshal(stdOut.Bytes(), response)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing get kubeadmconfigtemplate response: %v", err)
+	}
+
+	return response, nil
 }
 
 func (k *Kubectl) UpdateEnvironmentVariables(ctx context.Context, resourceType, resourceName string, envMap map[string]string, opts ...KubectlOpt) error {

--- a/test/e2e/taints_test.go
+++ b/test/e2e/taints_test.go
@@ -1,0 +1,1 @@
+package e2e

--- a/test/e2e/taints_test.go
+++ b/test/e2e/taints_test.go
@@ -60,13 +60,13 @@ func TestVSphereKubernetes121TaintsWorkerNodeGroups(t *testing.T) {
 	)
 
 	preUpgradeTaints := map[corev1.Taint]int{
-		noScheduleTaint(): 2,
-		preferNoScheduleTaint(): 1,
+		framework.NoScheduleTaint(): 2,
+		framework.PreferNoScheduleTaint(): 1,
 	}
 
 	postUpgradeTaints := map[corev1.Taint]int{
-		noExecuteTaint(): 3,
-		noScheduleTaint(): 2,
+		framework.NoExecuteTaint(): 3,
+		framework.NoScheduleTaint(): 2,
 	}
 
 	runTaintsUpgradeFlow(
@@ -75,41 +75,17 @@ func TestVSphereKubernetes121TaintsWorkerNodeGroups(t *testing.T) {
 		preUpgradeTaints,
 		postUpgradeTaints,
 		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(noExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(noExecuteTaint())),
+			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
 		),
 	)
 }
 
 func noScheduleWorkerNodeGroup(name string, count int) *framework.WorkerNodeGroup {
-		return framework.WithWorkerNodeGroup(name, api.WithCount(count), api.WithTaint(noScheduleTaint()))
+		return framework.WithWorkerNodeGroup(name, api.WithCount(count), api.WithTaint(framework.NoScheduleTaint()))
 }
 
 func preferNoScheduleWorkerNodeGroup(name string, count int) *framework.WorkerNodeGroup {
-	return framework.WithWorkerNodeGroup(name, api.WithCount(count), api.WithTaint(preferNoScheduleTaint()))
-}
-
-func noExecuteTaint() corev1.Taint {
-	return corev1.Taint{
-		Key:       "key1",
-		Value:     "value1",
-		Effect:    corev1.TaintEffectNoExecute,
-	}
-}
-
-func noScheduleTaint() corev1.Taint {
-	return corev1.Taint{
-		Key:       "key1",
-		Value:     "value1",
-		Effect:    corev1.TaintEffectNoSchedule,
-	}
-}
-
-func preferNoScheduleTaint() corev1.Taint {
-	return corev1.Taint{
-		Key:       "key1",
-		Value:     "value1",
-		Effect:    corev1.TaintEffectPreferNoSchedule,
-	}
+	return framework.WithWorkerNodeGroup(name, api.WithCount(count), api.WithTaint(framework.PreferNoScheduleTaint()))
 }

--- a/test/e2e/taints_test.go
+++ b/test/e2e/taints_test.go
@@ -15,10 +15,10 @@ import (
 func runTaintsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, preUpgradeNodeTaints, postUpgradeNodeTaints map[corev1.Taint]int, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
-	test.ValidateNodeTaints(preUpgradeNodeTaints)
+	test.VaidateWorkerNodeTaints()
 	test.UpgradeCluster(clusterOpts)
 	test.ValidateCluster(updateVersion)
-	test.ValidateNodeTaints(postUpgradeNodeTaints)
+	test.VaidateWorkerNodeTaints()
 	test.StopIfFailed()
 	test.DeleteCluster()
 }
@@ -60,12 +60,12 @@ func TestVSphereKubernetes121TaintsWorkerNodeGroups(t *testing.T) {
 	)
 
 	preUpgradeTaints := map[corev1.Taint]int{
-		framework.NoScheduleTaint(): 2,
+		framework.NoScheduleTaint():       2,
 		framework.PreferNoScheduleTaint(): 1,
 	}
 
 	postUpgradeTaints := map[corev1.Taint]int{
-		framework.NoExecuteTaint(): 3,
+		framework.NoExecuteTaint():  3,
 		framework.NoScheduleTaint(): 2,
 	}
 
@@ -83,7 +83,7 @@ func TestVSphereKubernetes121TaintsWorkerNodeGroups(t *testing.T) {
 }
 
 func noScheduleWorkerNodeGroup(name string, count int) *framework.WorkerNodeGroup {
-		return framework.WithWorkerNodeGroup(name, api.WithCount(count), api.WithTaint(framework.NoScheduleTaint()))
+	return framework.WithWorkerNodeGroup(name, api.WithCount(count), api.WithTaint(framework.NoScheduleTaint()))
 }
 
 func preferNoScheduleWorkerNodeGroup(name string, count int) *framework.WorkerNodeGroup {

--- a/test/e2e/taints_test.go
+++ b/test/e2e/taints_test.go
@@ -1,1 +1,115 @@
+// +build e2e
+
 package e2e
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/test/framework"
+)
+
+func runTaintsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, preUpgradeNodeTaints, postUpgradeNodeTaints map[corev1.Taint]int, clusterOpts ...framework.ClusterE2ETestOpt) {
+	test.GenerateClusterConfig()
+	test.CreateCluster()
+	test.ValidateNodeTaints(preUpgradeNodeTaints)
+	test.UpgradeCluster(clusterOpts)
+	test.ValidateCluster(updateVersion)
+	test.ValidateNodeTaints(postUpgradeNodeTaints)
+	test.StopIfFailed()
+	test.DeleteCluster()
+}
+
+// this test covers the following scenarios:
+// create a node with a taint
+// remove a taint from a node
+// add a taint to a node which already has another taint
+// add a taint to a node which had no taints
+func TestVSphereKubernetes121TaintsWorkerNodeGroups(t *testing.T) {
+	worker0 := "worker-0"
+	worker1 := "worker-1"
+	worker2 := "worker-2"
+
+	provider := framework.NewVSphere(t,
+		framework.WithVSphereWorkerNodeGroup(
+			worker0,
+			noScheduleWorkerNodeGroup(worker0, 2),
+		),
+		framework.WithVSphereWorkerNodeGroup(
+			worker1,
+			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+		),
+		framework.WithVSphereWorkerNodeGroup(
+			worker2,
+			preferNoScheduleWorkerNodeGroup(worker2, 1),
+		),
+		framework.WithUbuntu121(),
+	)
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube121),
+			api.WithExternalEtcdTopology(1),
+			api.WithControlPlaneCount(1),
+			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+		),
+	)
+
+	preUpgradeTaints := map[corev1.Taint]int{
+		noScheduleTaint(): 2,
+		preferNoScheduleTaint(): 1,
+	}
+
+	postUpgradeTaints := map[corev1.Taint]int{
+		noExecuteTaint(): 3,
+		noScheduleTaint(): 2,
+	}
+
+	runTaintsUpgradeFlow(
+		test,
+		v1alpha1.Kube121,
+		preUpgradeTaints,
+		postUpgradeTaints,
+		framework.WithClusterUpgrade(
+			api.WithWorkerNodeGroup(worker0, api.WithTaint(noExecuteTaint())),
+			api.WithWorkerNodeGroup(worker1, api.WithTaint(noExecuteTaint())),
+			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+		),
+	)
+}
+
+func noScheduleWorkerNodeGroup(name string, count int) *framework.WorkerNodeGroup {
+		return framework.WithWorkerNodeGroup(name, api.WithCount(count), api.WithTaint(noScheduleTaint()))
+}
+
+func preferNoScheduleWorkerNodeGroup(name string, count int) *framework.WorkerNodeGroup {
+	return framework.WithWorkerNodeGroup(name, api.WithCount(count), api.WithTaint(preferNoScheduleTaint()))
+}
+
+func noExecuteTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:       "key1",
+		Value:     "value1",
+		Effect:    corev1.TaintEffectNoExecute,
+	}
+}
+
+func noScheduleTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:       "key1",
+		Value:     "value1",
+		Effect:    corev1.TaintEffectNoSchedule,
+	}
+}
+
+func preferNoScheduleTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:       "key1",
+		Value:     "value1",
+		Effect:    corev1.TaintEffectPreferNoSchedule,
+	}
+}

--- a/test/framework/taints.go
+++ b/test/framework/taints.go
@@ -1,0 +1,1 @@
+package framework

--- a/test/framework/taints.go
+++ b/test/framework/taints.go
@@ -3,53 +3,55 @@ package framework
 import (
 	"context"
 	"fmt"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/aws/eks-anywhere/pkg/retrier"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
-func (e *ClusterE2ETest) ValidateNodeTaints(expectedTaints map[corev1.Taint]int) {
+const ownerAnnotation = "cluster.x-k8s.io/owner-name"
+
+func (e *ClusterE2ETest) VaidateWorkerNodeTaints() {
+	wn := e.ClusterConfig.Spec.WorkerNodeGroupConfigurations
 	ctx := context.Background()
-	e.T.Log("Validating cluster node taints")
-	r := retrier.New(time.Minute)
-	var nodes []corev1.Node
-	var err error
-	err = r.Retry(func() error {
-		nodes, err = e.KubectlClient.GetNodes(ctx, e.cluster().KubeconfigFile)
-		if err != nil {
-			return fmt.Errorf("error validating nodes taint presence: %v", err)
-		}
-		return nil
-	})
+	nodes, err := e.KubectlClient.GetNodes(ctx, e.cluster().KubeconfigFile)
 	if err != nil {
 		e.T.Fatal(err)
 	}
-	for _, node := range nodes {
-		for _, taint := range node.Spec.Taints {
-			if taint == MasterNodeTaint() {
-				continue
-			}
-			_, ok := expectedTaints[taint]
-			if !ok {
-				e.T.Fatal(fmt.Errorf("node %s has taint %v, but none are expected", node.Name, taint))
-			}
-			expectedTaints[taint] -= 1
-			if expectedTaints[taint] == 0 {
-				delete(expectedTaints, taint)
+	for _, w := range wn {
+		md, err := e.KubectlClient.GetMachineDeployment(ctx, w.Name)
+		if err != nil {
+			e.T.Fatal(fmt.Errorf("failed to get machine deployment for worker node %s when validating taints: %v", w.Name, err))
+		}
+		templateName := md.Spec.Template.Spec.Bootstrap.ConfigRef.Name
+		template, err := e.KubectlClient.GetKubeadmConfigTemplate(ctx, templateName)
+		if err != nil {
+			e.T.Fatal(fmt.Errorf("failed to get kubeadmconfigtemplate for worker node %s when validating taints: %v", w.Name, err))
+		}
+		nodeTaints := template.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints
+		if !v1alpha1.TaintsSliceEqual(w.Taints, nodeTaints) {
+			e.T.Fatal(fmt.Errorf("failed to validate taints for node %v: taints in kubeadmconfigtemplate are not equal to taints in worker node group configuration spec. Expected %v, got %v", w.Name, w.Taints, nodeTaints))
+		}
+
+		ms, err := e.KubectlClient.GetMachineSets(ctx, md.Name, e.cluster())
+		if err != nil {
+			e.T.Fatal(fmt.Errorf("failed to get machine sets when validating taints: %v", err))
+		}
+
+		if len(ms) != 1 {
+			e.T.Fatal(fmt.Errorf("invalid number of machine sets associated with worker node %v", w.Name))
+		}
+
+		for _, node := range nodes {
+			ownerName, ok := node.Annotations[ownerAnnotation]
+			if ok {
+				if ownerName == ms[0].Name {
+					if !v1alpha1.TaintsSliceEqual(node.Spec.Taints, w.Taints) {
+						e.T.Fatal(fmt.Errorf("taints on node %v and corresponding worker node group configuration %v do not match", node.Name, w.Name))
+					}
+				}
 			}
 		}
-	}
-	if len(expectedTaints) > 0 {
-		e.T.Fatal(fmt.Errorf("expected taints %v missing from cluster", expectedTaints))
-	}
-}
-
-func MasterNodeTaint() corev1.Taint {
-	return corev1.Taint{
-		Key:    "node-role.kubernetes.io/master",
-		Effect: "NoSchedule",
 	}
 }
 

--- a/test/framework/taints.go
+++ b/test/framework/taints.go
@@ -1,1 +1,54 @@
 package framework
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/eks-anywhere/pkg/retrier"
+)
+
+func (e *ClusterE2ETest) ValidateNodeTaints(expectedTaints map[corev1.Taint]int) {
+	ctx := context.Background()
+	e.T.Log("Validating cluster node taints")
+	r := retrier.New(time.Minute)
+	var nodes []corev1.Node
+	var err error
+	err = r.Retry(func() error {
+		nodes, err = e.KubectlClient.GetNodes(ctx, e.cluster().KubeconfigFile)
+		if err != nil {
+			return fmt.Errorf("error validating nodes taint presence: %v", err)
+		}
+		return nil
+	})
+	if err != nil {
+		e.T.Fatal(err)
+	}
+	for _, node := range nodes {
+		for _, taint := range node.Spec.Taints {
+			if taint == masterNodeTaint() {
+				continue
+			}
+			_, ok := expectedTaints[taint]
+			if !ok {
+				e.T.Fatal(fmt.Errorf("node %s has taint %v, but none are expected", node.Name, taint))
+			}
+			expectedTaints[taint] -= 1
+			if expectedTaints[taint] == 0 {
+				delete(expectedTaints, taint)
+			}
+		}
+	}
+	if len(expectedTaints) > 0 {
+		e.T.Fatal(fmt.Errorf("expected taints %v missing from cluster", expectedTaints))
+	}
+}
+
+func masterNodeTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    "node-role.kubernetes.io/master",
+		Effect: "NoSchedule",
+	}
+}

--- a/test/framework/taints.go
+++ b/test/framework/taints.go
@@ -28,7 +28,7 @@ func (e *ClusterE2ETest) ValidateNodeTaints(expectedTaints map[corev1.Taint]int)
 	}
 	for _, node := range nodes {
 		for _, taint := range node.Spec.Taints {
-			if taint == masterNodeTaint() {
+			if taint == MasterNodeTaint() {
 				continue
 			}
 			_, ok := expectedTaints[taint]
@@ -46,9 +46,33 @@ func (e *ClusterE2ETest) ValidateNodeTaints(expectedTaints map[corev1.Taint]int)
 	}
 }
 
-func masterNodeTaint() corev1.Taint {
+func MasterNodeTaint() corev1.Taint {
 	return corev1.Taint{
 		Key:    "node-role.kubernetes.io/master",
 		Effect: "NoSchedule",
+	}
+}
+
+func NoExecuteTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    "key1",
+		Value:  "value1",
+		Effect: corev1.TaintEffectNoExecute,
+	}
+}
+
+func NoScheduleTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    "key1",
+		Value:  "value1",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+}
+
+func PreferNoScheduleTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    "key1",
+		Value:  "value1",
+		Effect: corev1.TaintEffectPreferNoSchedule,
 	}
 }

--- a/test/framework/taints.go
+++ b/test/framework/taints.go
@@ -6,42 +6,40 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/executables"
 )
 
 const ownerAnnotation = "cluster.x-k8s.io/owner-name"
 
 func (e *ClusterE2ETest) VaidateWorkerNodeTaints() {
-	wn := e.ClusterConfig.Spec.WorkerNodeGroupConfigurations
 	ctx := context.Background()
 	nodes, err := e.KubectlClient.GetNodes(ctx, e.cluster().KubeconfigFile)
 	if err != nil {
 		e.T.Fatal(err)
 	}
+
+	c, err := v1alpha1.GetClusterConfigFromContent(e.ClusterConfigB)
+	if err != nil {
+		e.T.Fatal(err)
+	}
+	wn := c.Spec.WorkerNodeGroupConfigurations
+	// deduce the worker node group configuration to node mapping via the machine deployment and machine set
 	for _, w := range wn {
-		md, err := e.KubectlClient.GetMachineDeployment(ctx, w.Name)
+		mdName := fmt.Sprintf("%v-%v", e.ClusterName, w.Name)
+		md, err := e.KubectlClient.GetMachineDeployment(ctx, mdName, executables.WithKubeconfig(e.cluster().KubeconfigFile), executables.WithNamespace(constants.EksaSystemNamespace))
 		if err != nil {
 			e.T.Fatal(fmt.Errorf("failed to get machine deployment for worker node %s when validating taints: %v", w.Name, err))
 		}
-		templateName := md.Spec.Template.Spec.Bootstrap.ConfigRef.Name
-		template, err := e.KubectlClient.GetKubeadmConfigTemplate(ctx, templateName)
-		if err != nil {
-			e.T.Fatal(fmt.Errorf("failed to get kubeadmconfigtemplate for worker node %s when validating taints: %v", w.Name, err))
-		}
-		nodeTaints := template.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints
-		if !v1alpha1.TaintsSliceEqual(w.Taints, nodeTaints) {
-			e.T.Fatal(fmt.Errorf("failed to validate taints for node %v: taints in kubeadmconfigtemplate are not equal to taints in worker node group configuration spec. Expected %v, got %v", w.Name, w.Taints, nodeTaints))
-		}
-
 		ms, err := e.KubectlClient.GetMachineSets(ctx, md.Name, e.cluster())
 		if err != nil {
 			e.T.Fatal(fmt.Errorf("failed to get machine sets when validating taints: %v", err))
 		}
-
 		if len(ms) != 1 {
-			e.T.Fatal(fmt.Errorf("invalid number of machine sets associated with worker node %v", w.Name))
+			e.T.Fatal(fmt.Errorf("invalid number of machine sets associated with worker node configuration %v", w.Name))
 		}
-
 		for _, node := range nodes {
 			ownerName, ok := node.Annotations[ownerAnnotation]
 			if ok {
@@ -53,6 +51,7 @@ func (e *ClusterE2ETest) VaidateWorkerNodeTaints() {
 			}
 		}
 	}
+	e.T.Log("validated that expected taints are present on the workload cluster nodes")
 }
 
 func NoExecuteTaint() corev1.Taint {
@@ -77,4 +76,12 @@ func PreferNoScheduleTaint() corev1.Taint {
 		Value:  "value1",
 		Effect: corev1.TaintEffectPreferNoSchedule,
 	}
+}
+
+func NoScheduleWorkerNodeGroup(name string, count int) *WorkerNodeGroup {
+	return WithWorkerNodeGroup(name, api.WithCount(count), api.WithTaint(NoScheduleTaint()))
+}
+
+func PreferNoScheduleWorkerNodeGroup(name string, count int) *WorkerNodeGroup {
+	return WithWorkerNodeGroup(name, api.WithCount(count), api.WithTaint(PreferNoScheduleTaint()))
 }

--- a/test/framework/taints.go
+++ b/test/framework/taints.go
@@ -56,7 +56,7 @@ func (e *ClusterE2ETest) VaidateWorkerNodeTaints() {
 			}
 		}
 	}
-	e.T.Log("validated that expected taints are present on the workload cluster nodes")
+	e.T.Log("Validated that expected taints are present on the workload cluster nodes")
 }
 
 func NoExecuteTaint() corev1.Taint {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/1121

*Update*
Ok, so after discussion with @jiayiwang7 , I've improved the validation logic.

We're now going through the whole process of deducing the `node` from the `workerNodeGroupConfiguraton`, by:
- map wngc to machine deployment
- map machineDeployment to machineSpec
- iterate through the nodes, checking their 'owner' annotations, and mapping that back to the mahcineSpec.

This way, we get a robust 1-1 validation of taint to node.  This mapping should be trivial but is not (espeically on BR, where the node names are the IP of the hosts, and not related to the node group configuration name), so I've filed a ticket to simplify it (perhaps by putting an annotation on the nodes which has their wngc?) -- https://github.com/aws/eks-anywhere/issues/1236

So this means we get a better validation of node-to-wngc taints mapping than the original implementation.

*Description of changes:*
Add an initial end-to-end test which validates the taints feature works.

We add taints to worker nodes, validate that the taints we expect to be present are present after cluster creation; then, we update the cluster, removing one taint, and adding two more -- one to a node that had no taints, and one to a node that already had taints. After the upgrade finishes, we then validate once again that the taints we expect to be present are present on the set of nodes.

Due to the relative complexity of converting a given worker-node-group name to a node name, we're deducing the taints present by creating a map of `taint` to expected number of that taint, and using that to confirm the expected taints are present in the cluster.

So, this test covers:
- create a node with a taint
- remove a taint from a node
- add a taint to a node which already has another taint
- add a taint to a node which had no taints

Currently running into some snags with BR, so that test coverage will come at a later time.

*Testing (if applicable):*
Ran the tests and they work as expected.

*Follow Up Work*

https://github.com/aws/eks-anywhere/issues/1225 unit tests for new methods of kubectl
https://github.com/aws/eks-anywhere/issues/1226 e2e tests for CP node taints
https://github.com/aws/eks-anywhere/issues/1227 e2e tests for BR node taints

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

