### PR TITLE
Bmc Secret validations for hardware config

### DIFF
--- a/pkg/hardware/config.go
+++ b/pkg/hardware/config.go
@@ -144,21 +144,21 @@ func (hc *HardwareConfig) ValidateBmcSecretRefs() error {
 		if s.Namespace != constants.EksaSystemNamespace {
 			return fmt.Errorf("invalid secret namespace: %s for secret: %s expected: %s", s.Namespace, s.Name, constants.EksaSystemNamespace)
 		}
-		du, dOk := s.Data["username"]
-		sdu, sdOk := s.StringData["username"]
+		dUsr, dOk := s.Data["username"]
+		sdUsr, sdOk := s.StringData["username"]
 		if !dOk && !sdOk {
 			return fmt.Errorf("secret: %s must contain key username", s.Name)
 		}
-		if (dOk && len(du) == 0) || (sdOk && sdu == "") {
+		if (dOk && len(dUsr) == 0) || (sdOk && sdUsr == "") {
 			return fmt.Errorf("username can not be empty for secret: %s", s.Name)
 		}
 
-		dp, dOk := s.Data["password"]
-		sdp, sdOk := s.StringData["password"]
+		dPwd, dOk := s.Data["password"]
+		sdPwd, sdOk := s.StringData["password"]
 		if !dOk && !sdOk {
 			return fmt.Errorf("secret: %s must contain key password", s.Name)
 		}
-		if (dOk && len(dp) == 0) || (sdOk && sdp == "") {
+		if (dOk && len(dPwd) == 0) || (sdOk && sdPwd == "") {
 			return fmt.Errorf("password can not be empty for secret: %s", s.Name)
 		}
 	}

--- a/pkg/hardware/config.go
+++ b/pkg/hardware/config.go
@@ -69,9 +69,17 @@ func (hc *HardwareConfig) setHardwareConfigFromFile(hardwareFileName string) err
 	return nil
 }
 
-func (hc *HardwareConfig) ValidateBmcRefMapping() error {
+func (hc *HardwareConfig) ValidateHardware() error {
 	bmcRefMap := hc.initBmcRefMap()
 	for _, hw := range hc.hardwareList {
+		if hw.Name == "" {
+			return fmt.Errorf("hardware name is required")
+		}
+
+		if hw.Spec.ID == "" {
+			return fmt.Errorf("hardware: %s ID is required", hw.Name)
+		}
+
 		if hw.Spec.BmcRef == "" {
 			return fmt.Errorf("bmcRef not present in hardware %s", hw.Name)
 		}
@@ -94,6 +102,10 @@ func (hc *HardwareConfig) ValidateBMC() error {
 	secretRefMap := hc.initSecretRefMap()
 	bmcIpMap := make(map[string]struct{}, len(hc.bmcList))
 	for _, bmc := range hc.bmcList {
+		if bmc.Name == "" {
+			return fmt.Errorf("bmc name is required")
+		}
+
 		if bmc.Spec.AuthSecretRef.Name == "" {
 			return fmt.Errorf("authSecretRef name required for bmc %s", bmc.Name)
 		}
@@ -114,6 +126,10 @@ func (hc *HardwareConfig) ValidateBMC() error {
 
 		if err := networkutils.ValidateIP(bmc.Spec.Host); err != nil {
 			return fmt.Errorf("bmc host IP: %v", err)
+		}
+
+		if bmc.Spec.Vendor == "" {
+			return fmt.Errorf("bmc: %s vendor is required", bmc.Name)
 		}
 	}
 

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -121,6 +121,10 @@ func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFi
 		return fmt.Errorf("failed validating Hardware BMC refs in hardware config: %v", err)
 	}
 
+	if err := v.hardwareConfig.ValidateBMC(); err != nil {
+		return fmt.Errorf("failed validating BMCs in hardware config: %v", err)
+	}
+
 	logger.MarkPass("Hardware Config file validated")
 	return nil
 }

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -119,7 +119,7 @@ func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFi
 		return fmt.Errorf("failed to get hardware Config: %v", err)
 	}
 
-	if err := v.hardwareConfig.ValidateBmcRefMapping(); err != nil {
+	if err := v.hardwareConfig.ValidateHardware(); err != nil {
 		return fmt.Errorf("failed validating Hardware BMC refs in hardware config: %v", err)
 	}
 

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -46,6 +46,7 @@ func (v *Validator) ValidateTinkerbellConfig(ctx context.Context, datacenterConf
 	if err := v.validatetinkerbellPBnJGRPCAuth(ctx, datacenterConfig.Spec.TinkerbellPBnJGRPCAuth); err != nil {
 		return err
 	}
+	logger.MarkPass("Tinkerbell Config is valid")
 
 	return nil
 }
@@ -108,6 +109,7 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, tinkerbel
 	if tinkerbellClusterSpec.datacenterConfig.Namespace != tinkerbellClusterSpec.Cluster.Namespace {
 		return errors.New("TinkerbellDatacenterConfig and Cluster objects must have the same namespace specified")
 	}
+	logger.MarkPass("Machine Configs are valid")
 
 	return nil
 }
@@ -129,7 +131,7 @@ func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFi
 		return fmt.Errorf("failed validating Secrets in hardware config: %v", err)
 	}
 
-	logger.MarkPass("Hardware Config file validated")
+	logger.MarkPass("Hardware Config is valid")
 	return nil
 }
 
@@ -145,6 +147,8 @@ func (v *Validator) validateControlPlaneIpUniqueness(tinkerBellClusterSpec *spec
 	if !networkutils.NewIPGenerator(v.netClient).IsIPUnique(ip) {
 		return fmt.Errorf("cluster controlPlaneConfiguration.Endpoint.Host <%s> is already in use, please provide a unique IP", ip)
 	}
+
+	logger.MarkPass("Cluster  controlPlaneConfiguration host IP available")
 	return nil
 }
 

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -125,6 +125,10 @@ func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFi
 		return fmt.Errorf("failed validating BMCs in hardware config: %v", err)
 	}
 
+	if err := v.hardwareConfig.ValidateBmcSecretRefs(); err != nil {
+		return fmt.Errorf("failed validating Secrets in hardware config: %v", err)
+	}
+
 	logger.MarkPass("Hardware Config file validated")
 	return nil
 }


### PR DESCRIPTION
*Description of changes:*
Added validations for BMC and Secret CRDs in hardware config. Main validations are

- BMC's secretRef is present in the hardwareConfig
- BMC's have unique IPs
- BMC IP format is valid
- Secrets have keys username, password
- Non empty fields validations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

