### PR TITLE
Make eksdReleaseRef a pointer to support previous releases

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -374,7 +374,7 @@ type ClusterStatus struct {
 	// +optional
 	FailureMessage *string `json:"failureMessage,omitempty"`
 	// EksdReleaseRef defines the properties of the EKS-D object on the cluster
-	EksdReleaseRef EksdReleaseRef `json:"eksdReleaseRef,omitempty"`
+	EksdReleaseRef *EksdReleaseRef `json:"eksdReleaseRef,omitempty"`
 }
 
 type EksdReleaseRef struct {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make this field a pointer support backwards compatibility with previous releases

*Testing (if applicable):*
Ran e2e tests with latest minor release for docker & vsphere

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

