### PR TITLE
Validate requested node provisioninging against available cr hardware

### DIFF
--- a/pkg/hardware/config.go
+++ b/pkg/hardware/config.go
@@ -17,9 +17,9 @@ import (
 )
 
 type HardwareConfig struct {
-	hardwareList []tinkv1alpha1.Hardware
-	bmcList      []pbnjv1alpha1.BMC
-	secretList   []corev1.Secret
+	Hardwares []tinkv1alpha1.Hardware
+	Bmcs      []pbnjv1alpha1.BMC
+	Secrets   []corev1.Secret
 }
 
 func (hc *HardwareConfig) ParseHardwareConfig(hardwareFileName string) error {
@@ -48,21 +48,21 @@ func (hc *HardwareConfig) setHardwareConfigFromFile(hardwareFileName string) err
 			if err != nil {
 				return fmt.Errorf("unable to parse hardware CRD\n%s \n%v", c, err)
 			}
-			hc.hardwareList = append(hc.hardwareList, hardware)
+			hc.Hardwares = append(hc.Hardwares, hardware)
 		case "BMC":
 			var bmc pbnjv1alpha1.BMC
 			err = yaml.UnmarshalStrict([]byte(c), &bmc)
 			if err != nil {
 				return fmt.Errorf("unable to parse bmc CRD\n%s \n%v", c, err)
 			}
-			hc.bmcList = append(hc.bmcList, bmc)
+			hc.Bmcs = append(hc.Bmcs, bmc)
 		case "Secret":
 			var secret corev1.Secret
 			err = yaml.UnmarshalStrict([]byte(c), &secret)
 			if err != nil {
 				return fmt.Errorf("unable to parse k8s secret\n%s \n%v", c, err)
 			}
-			hc.secretList = append(hc.secretList, secret)
+			hc.Secrets = append(hc.Secrets, secret)
 		}
 	}
 
@@ -71,7 +71,7 @@ func (hc *HardwareConfig) setHardwareConfigFromFile(hardwareFileName string) err
 
 func (hc *HardwareConfig) ValidateHardware() error {
 	bmcRefMap := hc.initBmcRefMap()
-	for _, hw := range hc.hardwareList {
+	for _, hw := range hc.Hardwares {
 		if hw.Name == "" {
 			return fmt.Errorf("hardware name is required")
 		}
@@ -100,8 +100,8 @@ func (hc *HardwareConfig) ValidateHardware() error {
 
 func (hc *HardwareConfig) ValidateBMC() error {
 	secretRefMap := hc.initSecretRefMap()
-	bmcIpMap := make(map[string]struct{}, len(hc.bmcList))
-	for _, bmc := range hc.bmcList {
+	bmcIpMap := make(map[string]struct{}, len(hc.Bmcs))
+	for _, bmc := range hc.Bmcs {
 		if bmc.Name == "" {
 			return fmt.Errorf("bmc name is required")
 		}
@@ -137,7 +137,7 @@ func (hc *HardwareConfig) ValidateBMC() error {
 }
 
 func (hc *HardwareConfig) ValidateBmcSecretRefs() error {
-	for _, s := range hc.secretList {
+	for _, s := range hc.Secrets {
 		if s.Name == "" {
 			return fmt.Errorf("secret name is required")
 		}
@@ -167,8 +167,8 @@ func (hc *HardwareConfig) ValidateBmcSecretRefs() error {
 }
 
 func (hc *HardwareConfig) initBmcRefMap() map[string]*tinkv1alpha1.Hardware {
-	bmcRefMap := make(map[string]*tinkv1alpha1.Hardware, len(hc.bmcList))
-	for _, bmc := range hc.bmcList {
+	bmcRefMap := make(map[string]*tinkv1alpha1.Hardware, len(hc.Bmcs))
+	for _, bmc := range hc.Bmcs {
 		bmcRefMap[bmc.Name] = nil
 	}
 
@@ -176,8 +176,8 @@ func (hc *HardwareConfig) initBmcRefMap() map[string]*tinkv1alpha1.Hardware {
 }
 
 func (hc *HardwareConfig) initSecretRefMap() map[string]struct{} {
-	secretRefMap := make(map[string]struct{}, len(hc.secretList))
-	for _, s := range hc.secretList {
+	secretRefMap := make(map[string]struct{}, len(hc.Secrets))
+	for _, s := range hc.Secrets {
 		secretRefMap[s.Name] = struct{}{}
 	}
 

--- a/pkg/providers/tinkerbell/testdata/hardware_config.yaml
+++ b/pkg/providers/tinkerbell/testdata/hardware_config.yaml
@@ -36,6 +36,8 @@ metadata:
   name: bmc-worker1-auth
   namespace: eksa-system
 type: kubernetes.io/basic-auth
+
+
 ---
 apiVersion: tinkerbell.org/v1alpha1
 kind: Hardware
@@ -73,6 +75,88 @@ metadata:
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
   name: bmc-worker2-auth
+  namespace: eksa-system
+type: kubernetes.io/basic-auth
+
+
+---
+apiVersion: tinkerbell.org/v1alpha1
+kind: Hardware
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: worker3
+  namespace: eksa-system
+spec:
+  bmcRef: bmc-worker3
+  id: d2c14d26-640a-48f0-baee-a737c68a75f5
+status: {}
+---
+apiVersion: tinkerbell.org/v1alpha1
+kind: BMC
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: bmc-worker3
+  namespace: eksa-system
+spec:
+  authSecretRef:
+    name: bmc-worker3-auth
+    namespace: eksa-system
+  host: 192.168.0.12
+  vendor: supermicro
+status: {}
+---
+apiVersion: v1
+data:
+  password: QWRtaW4=
+  username: YWRtaW4=
+kind: Secret
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: bmc-worker3-auth
+  namespace: eksa-system
+type: kubernetes.io/basic-auth
+
+
+---
+apiVersion: tinkerbell.org/v1alpha1
+kind: Hardware
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: worker4
+  namespace: eksa-system
+spec:
+  bmcRef: bmc-worker4
+  id: 0c9d1701-f884-499e-80b8-6dcfc0973e85
+status: {}
+---
+apiVersion: tinkerbell.org/v1alpha1
+kind: BMC
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: bmc-worker4
+  namespace: eksa-system
+spec:
+  authSecretRef:
+    name: bmc-worker4-auth
+    namespace: eksa-system
+  host: 192.168.0.13
+  vendor: supermicro
+status: {}
+---
+apiVersion: v1
+data:
+  password: QWRtaW4=
+  username: YWRtaW4=
+kind: Secret
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: bmc-worker4-auth
   namespace: eksa-system
 type: kubernetes.io/basic-auth
 ---

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/hardware"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
@@ -25,7 +25,7 @@ func NewValidator(tink ProviderTinkClient, netClient networkutils.NetClient, har
 	}
 }
 
-func (v *Validator) ValidateTinkerbellConfig(ctx context.Context, datacenterConfig *anywherev1.TinkerbellDatacenterConfig) error {
+func (v *Validator) ValidateTinkerbellConfig(ctx context.Context, datacenterConfig *v1alpha1.TinkerbellDatacenterConfig) error {
 	if err := v.validateTinkerbellIP(ctx, datacenterConfig.Spec.TinkerbellIP); err != nil {
 		return err
 	}
@@ -88,12 +88,12 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, tinkerbel
 		return fmt.Errorf("cluster controlPlaneConfiguration.Endpoint.Host %s", err)
 	}
 
-	if controlPlaneMachineConfig.Spec.OSFamily != anywherev1.Ubuntu {
-		return fmt.Errorf("control plane osFamily: %s is not supported, please use %s", controlPlaneMachineConfig.Spec.OSFamily, anywherev1.Ubuntu)
+	if controlPlaneMachineConfig.Spec.OSFamily != v1alpha1.Ubuntu {
+		return fmt.Errorf("control plane osFamily: %s is not supported, please use %s", controlPlaneMachineConfig.Spec.OSFamily, v1alpha1.Ubuntu)
 	}
 
-	if workerNodeGroupMachineConfig.Spec.OSFamily != anywherev1.Ubuntu {
-		return fmt.Errorf("worker node osFamily: %s is not supported, please use %s", workerNodeGroupMachineConfig.Spec.OSFamily, anywherev1.Ubuntu)
+	if workerNodeGroupMachineConfig.Spec.OSFamily != v1alpha1.Ubuntu {
+		return fmt.Errorf("worker node osFamily: %s is not supported, please use %s", workerNodeGroupMachineConfig.Spec.OSFamily, v1alpha1.Ubuntu)
 	}
 
 	if controlPlaneMachineConfig.Spec.OSFamily != workerNodeGroupMachineConfig.Spec.OSFamily {
@@ -109,6 +109,7 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, tinkerbel
 	if tinkerbellClusterSpec.datacenterConfig.Namespace != tinkerbellClusterSpec.Cluster.Namespace {
 		return errors.New("TinkerbellDatacenterConfig and Cluster objects must have the same namespace specified")
 	}
+
 	logger.MarkPass("Machine Configs are valid")
 
 	return nil
@@ -132,6 +133,31 @@ func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFi
 	}
 
 	logger.MarkPass("Hardware Config is valid")
+	return nil
+}
+
+// ValidateMinimumRequiredTinkerbellHardwareAvailable ensures there is sufficient hardware registered relative to the
+// sum of requested control plane, etcd and worker node counts.
+// The system requires hardware >= to requested provisioning.
+// ValidateMinimumRequiredTinkerbellHardwareAvailable requires v.ValidateHardwareConfig() to be called first.
+func (v *Validator) ValidateMinimumRequiredTinkerbellHardwareAvailable(spec v1alpha1.ClusterSpec) error {
+	// ValidateMinimumRequiredTinkerbellHardwareAvailable relies on v.hardwareConfig being valid. A call to
+	// v.ValidateHardwareConfig parses the hardware config file. Consequently, we need to validate the hardware config
+	// prior to calling ValidateMinimumRequiredTinkerbellHardwareAvailable. We should decouple validation including
+	// isolation of io in the parsing of hardware config.
+
+	requestedNodesCount := spec.ControlPlaneConfiguration.Count +
+		spec.ExternalEtcdConfiguration.Count +
+		sumWorkerNodeCounts(spec.WorkerNodeGroupConfigurations)
+
+	if len(v.hardwareConfig.Hardwares) < requestedNodesCount {
+		return fmt.Errorf(
+			"have %v tinkerbell hardware; cluster spec requires >= %v hardware",
+			len(v.hardwareConfig.Hardwares),
+			requestedNodesCount,
+		)
+	}
+
 	return nil
 }
 
@@ -182,4 +208,12 @@ func (v *Validator) validatetinkerbellPBnJGRPCAuth(ctx context.Context, tinkerbe
 	}
 
 	return nil
+}
+
+func sumWorkerNodeCounts(nodes []v1alpha1.WorkerNodeGroupConfiguration) int {
+	var requestedNodesCount int
+	for _, workerSpec := range nodes {
+		requestedNodesCount += workerSpec.Count
+	}
+	return requestedNodesCount
 }

--- a/pkg/providers/tinkerbell/validator_helper_test.go
+++ b/pkg/providers/tinkerbell/validator_helper_test.go
@@ -1,0 +1,8 @@
+package tinkerbell
+
+import "github.com/aws/eks-anywhere/pkg/hardware"
+
+// SetValidatorHardwareConfig sets v internal hardwareConfig member to cfg.
+func SetValidatorHardwareConfig(v *Validator, cfg hardware.HardwareConfig) {
+	v.hardwareConfig = cfg
+}

--- a/pkg/providers/tinkerbell/validator_test.go
+++ b/pkg/providers/tinkerbell/validator_test.go
@@ -1,0 +1,65 @@
+package tinkerbell_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	tinkv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/tink/api/v1alpha1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/hardware"
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
+)
+
+func TestValidateMinimumRequiredTinkerbellHardwareAvailable_SufficientHardware(t *testing.T) {
+	for name, tt := range map[string]struct {
+		AvailableHardware int
+		ClusterSpec       v1alpha1.ClusterSpec
+	}{
+		"SufficientHardware":  {3, newValidClusterSpec(1, 1, 1)},
+		"SuperfluousHardware": {5, newValidClusterSpec(1, 1, 1)},
+	} {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			hardwareConfig := newHardwareConfigWithHardware(tt.AvailableHardware)
+
+			var validator tinkerbell.Validator
+			tinkerbell.SetValidatorHardwareConfig(&validator, hardwareConfig)
+
+			assert.NoError(t, validator.ValidateMinimumRequiredTinkerbellHardwareAvailable(tt.ClusterSpec))
+		})
+	}
+}
+
+func TestValidateMinimumRequiredTinkerbellHardwareAvailable_InsufficientHardware(t *testing.T) {
+	clusterSpec := newValidClusterSpec(1, 1, 1)
+
+	hardwareConfig := newHardwareConfigWithHardware(2)
+
+	var validator tinkerbell.Validator
+	tinkerbell.SetValidatorHardwareConfig(&validator, hardwareConfig)
+
+	assert.Error(t, validator.ValidateMinimumRequiredTinkerbellHardwareAvailable(clusterSpec))
+}
+
+func newValidClusterSpec(cp, etcd, worker int) v1alpha1.ClusterSpec {
+	return v1alpha1.ClusterSpec{
+		ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
+			Count: cp,
+		},
+		ExternalEtcdConfiguration: &v1alpha1.ExternalEtcdConfiguration{
+			Count: etcd,
+		},
+		WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{
+			{Count: worker},
+		},
+	}
+}
+
+func newHardwareConfigWithHardware(hardwareCount int) hardware.HardwareConfig {
+	return hardware.HardwareConfig{
+		Hardwares: make([]tinkv1alpha1.Hardware, hardwareCount),
+	}
+}


### PR DESCRIPTION
## Description
Add pre-flight validation to assert there are sufficient Tinkerbell CRs to satisfy the requested provisioning of control plane, etcd and worker nodes.

## Future work

There is a tight coupling between a few methods as the `ValidateHardwareConfig()` assumes responsibility for loading and parsing the hardware config that's required by `ValidateMinimumRequiredTinkerbellHardwareAvailable()`. This made it difficult to declare the `ValidateMinimumRequiredTinkerbellHardwareAvailable()` dependencies explicitly as parameters; we should really decoupled that to create much better testability.