### PR TITLE
Support node label reconciliation

### DIFF
--- a/controllers/controllers/resource/fetcher.go
+++ b/controllers/controllers/resource/fetcher.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
@@ -405,8 +406,21 @@ func MapMachineTemplateToVSphereMachineConfigSpec(vsMachineTemplate *vspherev1.V
 func MapKubeadmConfigTemplateToWorkerNodeGroupConfiguration(template kubeadmv1.KubeadmConfigTemplate) *anywherev1.WorkerNodeGroupConfiguration {
 	wnSpec := &anywherev1.WorkerNodeGroupConfiguration{}
 	wnSpec.Taints = template.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints
-	// TODO: map template.Spec.Template.Spec.JoinConfiguration.NodeRegestration.KubeletExtraArgs to wnSpec.Labels
+	wnSpec.Labels = convertStringToLabelsMap(template.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs["node-labels"])
 	return wnSpec
+}
+
+func convertStringToLabelsMap(labels string) map[string]string {
+	if labels == "" {
+		return nil
+	}
+	labelsList := strings.Split(labels, ",")
+	labelsMap := make(map[string]string, len(labelsList))
+	for _, label := range labelsList {
+		pair := strings.Split(label, "=")
+		labelsMap[pair[0]] = pair[1]
+	}
+	return labelsMap
 }
 
 func MapMachineTemplateToVSphereMachineConfigSpecWorkers(vsMachineTemplates []vspherev1.VSphereMachineTemplate) (map[string]anywherev1.VSphereMachineConfig, error) {

--- a/controllers/controllers/resource/reconciler_test.go
+++ b/controllers/controllers/resource/reconciler_test.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -394,8 +393,8 @@ func TestClusterReconcilerReconcile(t *testing.T) {
 				resourceUpdater.EXPECT().ForceApplyTemplate(ctx, gomock.Any(), gomock.Any()).Do(func(ctx context.Context, template *unstructured.Unstructured, dryRun bool) {
 					assert.Equal(t, false, dryRun, "Expected dryRun didn't match")
 					switch template.GetKind() {
-					case "KubeadmconfigTemplate":
-						existingKubeadmConfigTemplate := &v1beta1.KubeadmConfigTemplate{}
+					case "KubeadmConfigTemplate":
+						existingKubeadmConfigTemplate := &unstructured.Unstructured{}
 						if err := yaml.Unmarshal([]byte(kubeadmconfigTemplateSpecPath), existingKubeadmConfigTemplate); err != nil {
 							t.Errorf("unmarshal failed: %v", err)
 						}
@@ -513,8 +512,8 @@ func TestClusterReconcilerReconcile(t *testing.T) {
 				resourceUpdater.EXPECT().ForceApplyTemplate(ctx, gomock.Any(), gomock.Any()).Do(func(ctx context.Context, template *unstructured.Unstructured, dryRun bool) {
 					assert.Equal(t, false, dryRun, "Expected dryRun didn't match")
 					switch template.GetKind() {
-					case "KubeadmconfigTemplate":
-						existingKubeadmConfigTemplate := &v1beta1.KubeadmConfigTemplate{}
+					case "KubeadmConfigTemplate":
+						existingKubeadmConfigTemplate := &unstructured.Unstructured{}
 						if err := yaml.Unmarshal([]byte(kubeadmconfigTemplateSpecPath), existingKubeadmConfigTemplate); err != nil {
 							t.Errorf("unmarshal failed: %v", err)
 						}

--- a/controllers/controllers/resource/reconciler_test.go
+++ b/controllers/controllers/resource/reconciler_test.go
@@ -410,6 +410,125 @@ func TestClusterReconcilerReconcile(t *testing.T) {
 				}).AnyTimes().Return(nil)
 			},
 		},
+		{
+			name: "worker node reconcile (Vsphere provider) - worker node labels have changed",
+			args: args{
+				namespace: "namespaceA",
+				name:      "nameA",
+				objectKey: types.NamespacedName{
+					Name:      "nameA",
+					Namespace: "namespaceA",
+				},
+			},
+			want: controllerruntime.Result{},
+			prepare: func(ctx context.Context, fetcher *mocks.MockResourceFetcher, resourceUpdater *mocks.MockResourceUpdater, name string, namespace string) {
+				cluster := &anywherev1.Cluster{}
+				cluster.SetName(name)
+				cluster.SetNamespace(namespace)
+
+				fetcher.EXPECT().FetchCluster(gomock.Any(), gomock.Any()).Return(cluster, nil)
+
+				spec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
+				cluster.Spec = spec.Spec
+
+				fetcher.EXPECT().FetchAppliedSpec(ctx, gomock.Any()).Return(spec, nil)
+
+				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
+					clusterSpec := &anywherev1.VSphereDatacenterConfig{}
+					if err := yaml.Unmarshal([]byte(vsphereDatacenterConfigSpecPath), clusterSpec); err != nil {
+						t.Errorf("unmarshal failed: %v", err)
+					}
+					cluster := obj.(*anywherev1.VSphereDatacenterConfig)
+					cluster.SetName(objectKey.Name)
+					cluster.SetNamespace(objectKey.Namespace)
+					cluster.Spec = clusterSpec.Spec
+					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+				}).Return(nil)
+				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
+					clusterSpec := &anywherev1.VSphereMachineConfig{}
+					if err := yaml.Unmarshal([]byte(vsphereMachineConfigSpecPath), clusterSpec); err != nil {
+						t.Errorf("unmarshal failed: %v", err)
+					}
+					cluster := obj.(*anywherev1.VSphereMachineConfig)
+					cluster.SetName(objectKey.Name)
+					cluster.SetNamespace(objectKey.Namespace)
+					cluster.Spec = clusterSpec.Spec
+					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+				}).Return(nil)
+				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
+					clusterSpec := &anywherev1.VSphereMachineConfig{}
+					if err := yaml.Unmarshal([]byte(vsphereMachineConfigSpecPath), clusterSpec); err != nil {
+						t.Errorf("unmarshal failed: %v", err)
+					}
+					cluster := obj.(*anywherev1.VSphereMachineConfig)
+					cluster.SetName(objectKey.Name)
+					cluster.SetNamespace(objectKey.Namespace)
+					cluster.Spec = clusterSpec.Spec
+					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+				}).Return(nil)
+				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
+					clusterSpec := &anywherev1.VSphereMachineConfig{}
+					if err := yaml.Unmarshal([]byte(vsphereMachineConfigSpecPath), clusterSpec); err != nil {
+						t.Errorf("unmarshal failed: %v", err)
+					}
+					cluster := obj.(*anywherev1.VSphereMachineConfig)
+					cluster.SetName(objectKey.Name)
+					cluster.SetNamespace(objectKey.Namespace)
+					cluster.Spec = clusterSpec.Spec
+					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+				}).Return(nil)
+
+				kubeAdmControlPlane := &controlplanev1.KubeadmControlPlane{}
+				if err := yaml.Unmarshal([]byte(kubeadmcontrolplaneFile), kubeAdmControlPlane); err != nil {
+					t.Errorf("unmarshal failed: %v", err)
+				}
+
+				etcdadmCluster := &etcdv1.EtcdadmCluster{}
+				if err := yaml.Unmarshal([]byte(etcdadmclusterFile), etcdadmCluster); err != nil {
+					t.Errorf("unmarshal failed: %v", err)
+				}
+
+				existingWorkerNodeGroupConfiguration := &anywherev1.WorkerNodeGroupConfiguration{
+					Name:            "md-0",
+					Count:           3,
+					MachineGroupRef: nil,
+					Labels: map[string]string{
+						"Key1": "Val1",
+						"Key2": "Val2",
+					},
+				}
+
+				fetcher.EXPECT().Etcd(ctx, gomock.Any()).Return(etcdadmCluster, nil)
+				fetcher.EXPECT().ExistingVSphereDatacenterConfig(ctx, gomock.Any(), gomock.Any()).Return(&anywherev1.VSphereDatacenterConfig{}, nil)
+				fetcher.EXPECT().ExistingVSphereControlPlaneMachineConfig(ctx, gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
+				fetcher.EXPECT().ExistingVSphereEtcdMachineConfig(ctx, gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
+				fetcher.EXPECT().ExistingVSphereWorkerMachineConfig(ctx, gomock.Any(), gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
+				fetcher.EXPECT().ExistingWorkerNodeGroupConfig(ctx, gomock.Any(), gomock.Any()).Return(existingWorkerNodeGroupConfiguration, nil)
+				fetcher.EXPECT().VSphereCredentials(ctx).Return(&corev1.Secret{
+					Data: map[string][]byte{"username": []byte("username"), "password": []byte("password")},
+				}, nil)
+				fetcher.EXPECT().Fetch(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.NewNotFound(schema.GroupResource{Group: "testgroup", Resource: "testresource"}, ""))
+
+				resourceUpdater.EXPECT().ApplyPatch(ctx, gomock.Any(), false).Return(nil)
+				resourceUpdater.EXPECT().ForceApplyTemplate(ctx, gomock.Any(), gomock.Any()).Do(func(ctx context.Context, template *unstructured.Unstructured, dryRun bool) {
+					assert.Equal(t, false, dryRun, "Expected dryRun didn't match")
+					switch template.GetKind() {
+					case "KubeadmconfigTemplate":
+						existingKubeadmConfigTemplate := &v1beta1.KubeadmConfigTemplate{}
+						if err := yaml.Unmarshal([]byte(kubeadmconfigTemplateSpecPath), existingKubeadmConfigTemplate); err != nil {
+							t.Errorf("unmarshal failed: %v", err)
+						}
+						assert.Equal(t, existingKubeadmConfigTemplate, template, "values", existingKubeadmConfigTemplate, template)
+					case "MachineDeployment":
+						expectedMCDeployment := &unstructured.Unstructured{}
+						if err := yaml.Unmarshal([]byte(expectedMachineDeploymentTemplateChanged), expectedMCDeployment); err != nil {
+							t.Errorf("unmarshal failed: %v", err)
+						}
+						assert.Equal(t, expectedMCDeployment, template, "values", expectedMCDeployment, template)
+					}
+				}).AnyTimes().Return(nil)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/controllers/controllers/resource/testdata/kubeadmconfigTemplateSpec.yaml
+++ b/controllers/controllers/resource/testdata/kubeadmconfigTemplateSpec.yaml
@@ -1,17 +1,8 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  creationTimestamp: "2022-02-04T22:35:36Z"
-  generation: 2
-  name: test_cluster-md-0
+  name: test_cluster-md-0-template-1234567890000
   namespace: eksa-system
-  ownerReferences:
-    - apiVersion: cluster.x-k8s.io/v1beta1
-      kind: Cluster
-      name: taintstest4
-      uid: f3cd4d33-94cd-456b-8cf1-21f80d833af3
-  resourceVersion: "825197"
-  uid: 95717072-bfe7-4f98-9ec3-0bc8ee42beac
 spec:
   template:
     spec:
@@ -20,15 +11,12 @@ spec:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
-            cgroup-driver: systemd
+            anonymous-auth: "false"
             cloud-provider: external
+            read-only-port: "0"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-            node-labels: Key1=Val1
           name: '{{ ds.meta_data.hostname }}'
-          taints:
-            - effect: PreferNoSchedule
-              key: key1
-              value: PepperoniPizza
+          taints: []
       preKubeadmCommands:
         - hostname "{{ ds.meta_data.hostname }}"
         - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
@@ -36,7 +24,7 @@ spec:
         - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
         - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
-        - name: ec2-user
+        - name: capv
           sshAuthorizedKeys:
-            - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyjtLJZAGkn7Ibi9RW4QKGs+v/ltSE/vYMEX4+mixNF35rU3cFIiXYMut5hflzRRWlEHeNW9oNQ/WNOUiynFp9ySDmkjo81PkfUfYl2mXqkcwRFW0qVXSzLB5nsH68Y2mzfSVZ4UuUXs9fRSu8faYs/QjRkOLmaGFWzL8CVBvCSAT51dIppJ0lh+a9ZLiLLTpExL7tC32Q+TDuCIK3EpTBd+km58NUUrKBfML5u5LSehRTWzPxuOa4egYCCKa5uGfTjk1T2ycXbkaL6hn6KqpGI/aHvMIeP51cloa64ropRQ7XuGnpAACLh67FWz2tE+HwRg7VgdkwqDbrFNf6ONhwt4SPmRhOtkToEuV1U3z8YqnIButaGs8HYZV8DLAMre2hoAdnpsQhKyA2Q7ZmQw/YIOVsKuHQGz/OYGv4/gQxRDH+pduGTFFii9w7WaZSKAroBG3qJ/iLhFBKRYG1e0Pi+89Xf8Rg/011eNnR+aC4sIjFlSK1b9lrtOM767BoBPM5HJKSECuDCUhHnFZbFsTm7IFjlxVIKGiR/B8RTpycAdr+UdrLoCCSUYZnvqosgMneAq96QqCQscu9hDEbP3Dndyh3N6/VbVpl+eghFKvd4gdVD5FFy1nDC9Z/+rqeiiO+HUnksP9vTG8PEsp9Mi91mpdhBvkAYfPQQAHJazhnjQ==
+            - 'ssh-rsa ssh_key_value'
           sudo: ALL=(ALL) NOPASSWD:ALL

--- a/controllers/controllers/resource/testdata/kubeadmconfigTemplateSpec.yaml
+++ b/controllers/controllers/resource/testdata/kubeadmconfigTemplateSpec.yaml
@@ -23,6 +23,7 @@ spec:
             cgroup-driver: systemd
             cloud-provider: external
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+            node-labels: Key1=Val1
           name: '{{ ds.meta_data.hostname }}'
           taints:
             - effect: PreferNoSchedule

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -161,6 +161,22 @@ func TaintsSliceEqual(s1, s2 []corev1.Taint) bool {
 	return true
 }
 
+func LabelsMapEqual(s1, s2 map[string]string) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	for key, val := range s2 {
+		v, ok := s1[key]
+		if !ok {
+			return false
+		}
+		if val != v {
+			return false
+		}
+	}
+	return true
+}
+
 func (n *ControlPlaneConfiguration) Equal(o *ControlPlaneConfiguration) bool {
 	if n == o {
 		return true
@@ -168,7 +184,8 @@ func (n *ControlPlaneConfiguration) Equal(o *ControlPlaneConfiguration) bool {
 	if n == nil || o == nil {
 		return false
 	}
-	return n.Count == o.Count && n.Endpoint.Equal(o.Endpoint) && n.MachineGroupRef.Equal(o.MachineGroupRef) && TaintsSliceEqual(n.Taints, o.Taints)
+	return n.Count == o.Count && n.Endpoint.Equal(o.Endpoint) && n.MachineGroupRef.Equal(o.MachineGroupRef) &&
+		TaintsSliceEqual(n.Taints, o.Taints) && LabelsMapEqual(n.Labels, o.Labels)
 }
 
 type Endpoint struct {
@@ -229,7 +246,7 @@ func WorkerNodeGroupConfigurationsSliceEqual(a, b []WorkerNodeGroupConfiguration
 		return false
 	}
 
-	return WorkerNodeGroupConfigurationSliceTaintsEqual(a, b)
+	return WorkerNodeGroupConfigurationSliceTaintsEqual(a, b) && WorkerNodeGroupConfigurationsLabelsMapEqual(a, b)
 }
 
 func WorkerNodeGroupConfigurationSliceTaintsEqual(a, b []WorkerNodeGroupConfiguration) bool {
@@ -246,6 +263,27 @@ func WorkerNodeGroupConfigurationSliceTaintsEqual(a, b []WorkerNodeGroupConfigur
 			continue
 		} else {
 			if !TaintsSliceEqual(m[nodeGroup.Name], nodeGroup.Taints) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func WorkerNodeGroupConfigurationsLabelsMapEqual(a, b []WorkerNodeGroupConfiguration) bool {
+	m := make(map[string]map[string]string, len(a))
+	for _, nodeGroup := range a {
+		m[nodeGroup.Name] = nodeGroup.Labels
+	}
+
+	for _, nodeGroup := range b {
+		if _, ok := m[nodeGroup.Name]; !ok {
+			// this method is not concerned with added/removed node groups,
+			// only with the comparison of taints on existing node groups
+			// if a node group is present in a but not b, or vise versa, it's immaterial
+			continue
+		} else {
+			if !LabelsMapEqual(m[nodeGroup.Name], nodeGroup.Labels) {
 				return false
 			}
 		}

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -279,7 +279,7 @@ func WorkerNodeGroupConfigurationsLabelsMapEqual(a, b []WorkerNodeGroupConfigura
 	for _, nodeGroup := range b {
 		if _, ok := m[nodeGroup.Name]; !ok {
 			// this method is not concerned with added/removed node groups,
-			// only with the comparison of taints on existing node groups
+			// only with the comparison of labels on existing node groups
 			// if a node group is present in a but not b, or vise versa, it's immaterial
 			continue
 		} else {

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -154,16 +154,10 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 		)
 	}
 
-	if old.Spec.ControlPlaneConfiguration.Count != new.Spec.ControlPlaneConfiguration.Count {
+	if !old.Spec.ControlPlaneConfiguration.Equal(&new.Spec.ControlPlaneConfiguration) {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "ControlPlaneConfiguration.count"), new.Spec.ControlPlaneConfiguration.Count, "field is immutable"))
-	}
-
-	if !new.Spec.ControlPlaneConfiguration.MachineGroupRef.Equal(old.Spec.ControlPlaneConfiguration.MachineGroupRef) {
-		allErrs = append(
-			allErrs,
-			field.Invalid(field.NewPath("spec", "ControlPlaneConfiguration.machineGroupRef"), new.Spec.ControlPlaneConfiguration.MachineGroupRef, "field is immutable"))
+			field.Invalid(field.NewPath("spec", "ControlPlaneConfiguration"), new.Spec.ControlPlaneConfiguration, "field is immutable"))
 	}
 
 	return allErrs

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -215,6 +216,58 @@ func TestClusterValidateUpdateControlPlaneConfigurationNewEndpointNilImmutable(t
 	c := cOld.DeepCopy()
 	c.Spec.ControlPlaneConfiguration = v1alpha1.ControlPlaneConfiguration{
 		Endpoint: nil,
+	}
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(cOld)).NotTo(Succeed())
+}
+
+func TestManagementClusterValidateUpdateControlPlaneConfigurationTaintsImmutable(t *testing.T) {
+	cOld := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
+				Taints: []v1.Taint{
+					{
+						Key:    "Key1",
+						Value:  "Val1",
+						Effect: "PreferNoSchedule",
+					},
+				},
+			},
+		},
+	}
+	cOld.SetSelfManaged()
+	c := cOld.DeepCopy()
+	c.Spec.ControlPlaneConfiguration = v1alpha1.ControlPlaneConfiguration{
+		Taints: []v1.Taint{
+			{
+				Key:    "Key2",
+				Value:  "Val2",
+				Effect: "PreferNoSchedule",
+			},
+		},
+	}
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(cOld)).NotTo(Succeed())
+}
+
+func TestManagementClusterValidateUpdateControlPlaneConfigurationLabelsImmutable(t *testing.T) {
+	cOld := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
+				Labels: map[string]string{
+					"Key1": "Val1",
+				},
+			},
+		},
+	}
+	cOld.SetSelfManaged()
+	c := cOld.DeepCopy()
+	c.Spec.ControlPlaneConfiguration = v1alpha1.ControlPlaneConfiguration{
+		Labels: map[string]string{
+			"Key2": "Val2",
+		},
 	}
 
 	g := NewWithT(t)

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -538,14 +538,15 @@ func NeedsNewWorkloadTemplate(oldSpec, newSpec *cluster.Spec, oldVdc, newVdc *v1
 	if oldSpec.Bundles.Spec.Number != newSpec.Bundles.Spec.Number {
 		return true
 	}
-	if !v1alpha1.WorkerNodeGroupConfigurationSliceTaintsEqual(oldSpec.Spec.WorkerNodeGroupConfigurations, newSpec.Spec.WorkerNodeGroupConfigurations) {
+	if !v1alpha1.WorkerNodeGroupConfigurationSliceTaintsEqual(oldSpec.Spec.WorkerNodeGroupConfigurations, newSpec.Spec.WorkerNodeGroupConfigurations) ||
+		!v1alpha1.WorkerNodeGroupConfigurationsLabelsMapEqual(oldSpec.Spec.WorkerNodeGroupConfigurations, newSpec.Spec.WorkerNodeGroupConfigurations) {
 		return true
 	}
 	return AnyImmutableFieldChanged(oldVdc, newVdc, oldVmc, newVmc)
 }
 
 func NeedsNewKubeadmConfigTemplate(newWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration, oldWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration) bool {
-	return !v1alpha1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints)
+	return !v1alpha1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints) || !v1alpha1.LabelsMapEqual(newWorkerNodeGroup.Labels, oldWorkerNodeGroup.Labels)
 }
 
 func NeedsNewEtcdTemplate(oldSpec, newSpec *cluster.Spec, oldVdc, newVdc *v1alpha1.VSphereDatacenterConfig, oldVmc, newVmc *v1alpha1.VSphereMachineConfig) bool {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/1053

*Description of changes:*
Adding support for node labels upgrade through Flux and `upgrade`. This builds off of the changes from the taints work here https://github.com/aws/eks-anywhere/pull/1175 in leveraging replacing the `kubeadmconfigtemplate`. Also changing the `ControlPlaneConfiguration` validation in the webhook to leverage the `Equal` method for the struct.

*Testing (if applicable):*
Tested with modifying multiple labels both for control plane and worker nodes with `upgrade` and with Flux.

Also fixed the controller unit tests to properly test for taints and labels changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

