### PR TITLE
Worker node taints (#977)

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -238,6 +238,36 @@ spec:
                         name:
                           type: string
                       type: object
+                    taints:
+                      description: Taints define the set of taints to be applied on
+                        worker nodes
+                      items:
+                        description: The node this Taint is attached to has the "effect"
+                          on any pod that does not tolerate the Taint.
+                        properties:
+                          effect:
+                            description: Required. The effect of the taint on pods
+                              that do not tolerate the taint. Valid effects are NoSchedule,
+                              PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Required. The taint key to be applied to
+                              a node.
+                            type: string
+                          timeAdded:
+                            description: TimeAdded represents the time at which the
+                              taint was added. It is only written for NoExecute taints.
+                            format: date-time
+                            type: string
+                          value:
+                            description: The taint value corresponding to the taint
+                              key.
+                            type: string
+                        required:
+                        - effect
+                        - key
+                        type: object
+                      type: array
                     name:
                       description: Name refers to the name of the worker node group
                       type: string

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -2339,6 +2339,36 @@ spec:
                         name:
                           type: string
                       type: object
+                    taints:
+                      description: Taints define the set of taints to be applied on
+                        worker nodes
+                      items:
+                        description: The node this Taint is attached to has the "effect"
+                          on any pod that does not tolerate the Taint.
+                        properties:
+                          effect:
+                            description: Required. The effect of the taint on pods
+                              that do not tolerate the taint. Valid effects are NoSchedule,
+                              PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Required. The taint key to be applied to
+                              a node.
+                            type: string
+                          timeAdded:
+                            description: TimeAdded represents the time at which the
+                              taint was added. It is only written for NoExecute taints.
+                            format: date-time
+                            type: string
+                          value:
+                            description: The taint value corresponding to the taint
+                              key.
+                            type: string
+                        required:
+                        - effect
+                        - key
+                        type: object
+                      type: array
                     name:
                       description: Name refers to the name of the worker node group
                       type: string

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -193,6 +193,8 @@ type WorkerNodeGroupConfiguration struct {
 	Count int `json:"count,omitempty"`
 	// MachineGroupRef defines the machine group configuration for the worker nodes.
 	MachineGroupRef *Ref `json:"machineGroupRef,omitempty"`
+	// Taints define the set of taints to be applied on worker nodes
+	Taints []corev1.Taint `json:"taints,omitempty"`
 	// Labels define the labels to assign to the node
 	Labels map[string]string `json:"labels,omitempty"`
 }
@@ -222,7 +224,36 @@ func WorkerNodeGroupConfigurationsSliceEqual(a, b []WorkerNodeGroupConfiguration
 			delete(m, k)
 		}
 	}
-	return len(m) == 0
+	if len(m) != 0 {
+		return false
+	}
+
+	for index, wngc := range a {
+		sameTaints := TaintsSliceEqual(wngc.Taints, b[index].Taints)
+		if !sameTaints {
+			return false
+		}
+	}
+
+	return true
+}
+
+func WorkerNodeGroupConfigurationSliceTaintsEqual(a, b []WorkerNodeGroupConfiguration) bool {
+	m := make(map[string][]corev1.Taint, len(a))
+	for _, wngc := range a {
+		m[wngc.Name] = wngc.Taints
+	}
+
+	for _, wngc := range b {
+		if _, ok := m[wngc.Name]; !ok {
+			continue
+		} else {
+			if !TaintsSliceEqual(m[wngc.Name], wngc.Taints) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 type ClusterNetwork struct {

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -296,6 +297,17 @@ func TestClusterEqualKubernetesVersion(t *testing.T) {
 }
 
 func TestClusterEqualWorkerNodeGroupConfigurations(t *testing.T) {
+	var taints1, taints2, taints1DiffOrder, emptyTaints []corev1.Taint
+	var taint1, taint2 corev1.Taint
+
+	taint1.Key = "key1"
+	taint2.Key = "key2"
+	taints1 = append(taints1, taint1)
+	taints1 = append(taints1, taint2)
+	taints1DiffOrder = append(taints1DiffOrder, taint2)
+	taints1DiffOrder = append(taints1DiffOrder, taint1)
+	taints2 = append(taints2, taint1)
+
 	testCases := []struct {
 		testName                   string
 		cluster1Wngs, cluster2Wngs []v1alpha1.WorkerNodeGroupConfiguration
@@ -407,6 +419,88 @@ func TestClusterEqualWorkerNodeGroupConfigurations(t *testing.T) {
 				},
 			},
 			want: false,
+		},
+		{
+			testName: "both exist, same taints",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Taints: taints1,
+				},
+			},
+			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Taints: taints1,
+				},
+			},
+			want: true,
+		},
+		{
+			testName: "both exist, same taints in different order",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Taints: taints1,
+				},
+			},
+			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Taints: taints1DiffOrder,
+				},
+			},
+			want: true,
+		},
+		{
+			testName: "both exist, taints diff",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Taints: taints1,
+				},
+			},
+			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Taints: taints2,
+				},
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, one with no taints",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Taints: taints1,
+				},
+			},
+			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{},
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, one with empty taints",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Taints: taints1,
+				},
+			},
+			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Taints: emptyTaints,
+				},
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, both with empty taints",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Taints: emptyTaints,
+				},
+			},
+			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Taints: emptyTaints,
+				},
+			},
+			want: true,
 		},
 	}
 	for _, tt := range testCases {
@@ -1028,6 +1122,17 @@ func TestClusterEqualManagement(t *testing.T) {
 }
 
 func TestControlPlaneConfigurationEqual(t *testing.T) {
+	var taints1, taints2, taints1DiffOrder, emptyTaints []corev1.Taint
+	var taint1, taint2 corev1.Taint
+
+	taint1.Key = "key1"
+	taint2.Key = "key2"
+	taints1 = append(taints1, taint1)
+	taints1 = append(taints1, taint2)
+	taints1DiffOrder = append(taints1DiffOrder, taint2)
+	taints1DiffOrder = append(taints1DiffOrder, taint1)
+	taints2 = append(taints2, taint1)
+
 	testCases := []struct {
 		testName                           string
 		cluster1CPConfig, cluster2CPConfig *v1alpha1.ControlPlaneConfiguration
@@ -1140,6 +1245,64 @@ func TestControlPlaneConfigurationEqual(t *testing.T) {
 			},
 			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{
 				Endpoint: &v1alpha1.Endpoint{},
+			},
+			want: true,
+		},
+		{
+			testName: "both taints equal",
+			cluster1CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Taints: taints1,
+			},
+			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Taints: taints1,
+			},
+			want: true,
+		},
+		{
+			testName: "taints in different orders",
+			cluster1CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Taints: taints1,
+			},
+			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Taints: taints1DiffOrder,
+			},
+			want: true,
+		},
+		{
+			testName: "different taints",
+			cluster1CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Taints: taints1,
+			},
+			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Taints: taints2,
+			},
+			want: false,
+		},
+		{
+			testName: "One taints set empty",
+			cluster1CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Taints: taints1,
+			},
+			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Taints: emptyTaints,
+			},
+			want: false,
+		},
+		{
+			testName: "one taints set not present",
+			cluster1CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Taints: taints1,
+			},
+			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{},
+			want:             false,
+		},
+		{
+			testName: "both taints set empty",
+			cluster1CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Taints: emptyTaints,
+			},
+			cluster2CPConfig: &v1alpha1.ControlPlaneConfiguration{
+				Taints: emptyTaints,
 			},
 			want: true,
 		},

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -1136,9 +1136,11 @@ func (k *Kubectl) ApplyTolerationsFromTaints(ctx context.Context, oldTaints []co
 		return err
 	}
 	var appliedTolerations []Toleration
-	err = json.Unmarshal(output.Bytes(), &appliedTolerations)
-	if err != nil {
-		return fmt.Errorf("error parsing toleration response: %v", err)
+	if len(output.String()) > 0 {
+		err = json.Unmarshal(output.Bytes(), &appliedTolerations)
+		if err != nil {
+			return fmt.Errorf("error parsing toleration response: %v", err)
+		}
 	}
 
 	oldTolerationSet := make(map[Toleration]bool)

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -1483,3 +1483,16 @@ func TestKubectlGetDaemonSetError(t *testing.T) {
 		return tt.k.GetDaemonSet(tt.ctx, tt.name, tt.namespace, tt.kubeconfig)
 	}).testError()
 }
+
+func TestApplyTolerationsFromTaints(t *testing.T) {
+	tt := newKubectlTest(t)
+	params := []string{
+		"get", "ds", "test",
+		"-o", "jsonpath={range .spec.template.spec}{.tolerations} {end}",
+		"-n", "testNs", "--kubeconfig", tt.cluster.KubeconfigFile,
+	}
+	tt.e.EXPECT().Execute(
+		tt.ctx, gomock.Eq(params)).Return(bytes.Buffer{}, nil)
+	var taints []corev1.Taint
+	tt.Expect(tt.k.ApplyTolerationsFromTaints(tt.ctx, taints, taints, "ds", "test", tt.cluster.KubeconfigFile, "testNs", "/test")).To(Succeed())
+}

--- a/pkg/providers/docker/config/template-md.yaml
+++ b/pkg/providers/docker/config/template-md.yaml
@@ -9,6 +9,18 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+{{- if .workerNodeGroupTaints }}
+          taints:{{ range .workerNodeGroupTaints}}
+            - key: {{ .Key }}
+              value: {{ .Value }}
+              effect: {{ .Effect }}
+{{- if .TimeAdded }}
+              timeAdded: {{ .TimeAdded }}
+{{- end }}
+{{- end }}
+{{- else}}
+          taints: []
+{{- end }}
           kubeletExtraArgs:
             cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_md_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_md_expected.yaml
@@ -9,6 +9,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
@@ -52,4 +53,5 @@ spec:
       - containerPath: /var/run/docker.sock
         hostPath: /var/run/docker.sock
       customImage: public.ecr.aws/eks-distro/kubernetes-sigs/kind/node:v1.18.16-eks-1-18-4-216edda697a37f8bf16651af6c23b7e2bb7ef42f-62681885fe3a97ee4f2b110cc277e084e71230fa
+
 ---

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_md_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_md_expected.yaml
@@ -9,6 +9,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
@@ -52,4 +53,5 @@ spec:
       - containerPath: /var/run/docker.sock
         hostPath: /var/run/docker.sock
       customImage: public.ecr.aws/eks-distro/kubernetes-sigs/kind/node:v1.18.16-eks-1-18-4-216edda697a37f8bf16651af6c23b7e2bb7ef42f-62681885fe3a97ee4f2b110cc277e084e71230fa
+
 ---

--- a/pkg/providers/docker/testdata/no_machinetemplate_update_md_expected.yaml
+++ b/pkg/providers/docker/testdata/no_machinetemplate_update_md_expected.yaml
@@ -9,6 +9,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
@@ -52,4 +53,5 @@ spec:
       - containerPath: /var/run/docker.sock
         hostPath: /var/run/docker.sock
       customImage: 
+
 ---

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_md_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_md_expected.yaml
@@ -9,6 +9,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
@@ -53,4 +54,5 @@ spec:
       - containerPath: /var/run/docker.sock
         hostPath: /var/run/docker.sock
       customImage: public.ecr.aws/eks-distro/kubernetes-sigs/kind/node:v1.18.16-eks-1-18-4-216edda697a37f8bf16651af6c23b7e2bb7ef42f-62681885fe3a97ee4f2b110cc277e084e71230fa
+
 ---

--- a/pkg/providers/docker/testdata/valid_deployment_md_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_md_expected.yaml
@@ -9,6 +9,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
@@ -52,4 +53,5 @@ spec:
       - containerPath: /var/run/docker.sock
         hostPath: /var/run/docker.sock
       customImage: public.ecr.aws/eks-distro/kubernetes-sigs/kind/node:v1.18.16-eks-1-18-4-216edda697a37f8bf16651af6c23b7e2bb7ef42f-62681885fe3a97ee4f2b110cc277e084e71230fa
+
 ---

--- a/pkg/providers/docker/testdata/valid_deployment_md_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_md_taints_expected.yaml
@@ -9,11 +9,13 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
-          taints: []
+          taints:
+            - key: key2
+              value: val2
+              effect: PreferNoSchedule
           kubeletExtraArgs:
             cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-            node-labels: label1=foo,label2=bar
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_multiple_md_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_multiple_md_taints_expected.yaml
@@ -1,0 +1,120 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: test-cluster-md-0
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          taints:
+            - key: key2
+              value: val2
+              effect: PreferNoSchedule
+          kubeletExtraArgs:
+            cgroup-driver: cgroupfs
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: test-cluster-md-0
+  namespace: eksa-system
+spec:
+  clusterName: test-cluster
+  replicas: 3
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test-cluster-md-0
+          namespace: eksa-system
+      clusterName: test-cluster
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        name: test-cluster-md-0-1234567890000
+        namespace: eksa-system
+      version: v1.19.6-eks-1-19-2
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: test-cluster-md-0-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      extraMounts:
+      - containerPath: /var/run/docker.sock
+        hostPath: /var/run/docker.sock
+      customImage: public.ecr.aws/eks-distro/kubernetes-sigs/kind/node:v1.18.16-eks-1-18-4-216edda697a37f8bf16651af6c23b7e2bb7ef42f-62681885fe3a97ee4f2b110cc277e084e71230fa
+
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: test-cluster-md-1
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          taints:
+            - key: wnTaitns2
+              value: true
+              effect: PreferNoSchedule
+          kubeletExtraArgs:
+            cgroup-driver: cgroupfs
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: test-cluster-md-1
+  namespace: eksa-system
+spec:
+  clusterName: test-cluster
+  replicas: 3
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test-cluster-md-1
+          namespace: eksa-system
+      clusterName: test-cluster
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        name: test-cluster-md-1-1234567890000
+        namespace: eksa-system
+      version: v1.19.6-eks-1-19-2
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: test-cluster-md-1-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      extraMounts:
+      - containerPath: /var/run/docker.sock
+        hostPath: /var/run/docker.sock
+      customImage: public.ecr.aws/eks-distro/kubernetes-sigs/kind/node:v1.18.16-eks-1-18-4-216edda697a37f8bf16651af6c23b7e2bb7ef42f-62681885fe3a97ee4f2b110cc277e084e71230fa
+
+---

--- a/pkg/providers/vsphere/config/template-md.yaml
+++ b/pkg/providers/vsphere/config/template-md.yaml
@@ -32,6 +32,18 @@ spec:
 {{- end }}
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+{{- if .workerNodeGroupTaints }}
+          taints:{{ range .workerNodeGroupTaints}}
+            - key: {{ .Key }}
+              value: {{ .Value }}
+              effect: {{ .Effect }}
+{{- if .TimeAdded }}
+              timeAdded: {{ .TimeAdded }}
+{{- end }}
+{{- end }}
+{{- else}}
+          taints: []
+{{- end }}
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"

--- a/pkg/providers/vsphere/testdata/cluster_main_multiple_worker_node_groups.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_main_multiple_worker_node_groups.yaml
@@ -18,11 +18,24 @@ spec:
         name: test-wn
         kind: VSphereMachineConfig
       name: md-0
+      taints:
+      - key: key2
+        value: val2
+        effect: PreferNoSchedule
     - count: 2
       machineGroupRef:
         name: test-wn
         kind: VSphereMachineConfig
       name: md-1
+      taints:
+      - key: key2
+        value: val2
+        effect: PreferNoSchedule
+  externalEtcdConfiguration:
+    count: 3
+    machineGroupRef:
+      name: test-etcd
+      kind: VSphereMachineConfig
   datacenterRef:
     kind: VSphereDatacenterConfig
     name: test
@@ -86,3 +99,24 @@ spec:
   server: "vsphere_server"
   thumbprint: "ABCDEFG"
   insecure: false
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-etcd
+  namespace: test-namespace
+spec:
+  diskGiB: 25
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 4096
+  numCPUs: 3
+  osFamily: ubuntu
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---

--- a/pkg/providers/vsphere/testdata/cluster_main_with_taints.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_main_with_taints.yaml
@@ -27,6 +27,10 @@ spec:
       machineGroupRef:
         name: test-wn
         kind: VSphereMachineConfig
+      taints:
+      - key: key1
+        value: val1
+        effect: PreferNoSchedule
       name: md-0
   externalEtcdConfiguration:
     count: 3

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_md.yaml
@@ -15,6 +15,7 @@ spec:
           imageTag: v1-19-6-51a138f2cb28ccc98ced838ffc6ab984110123b
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -87,4 +88,5 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/bottlerocket-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
+
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_md.yaml
@@ -17,6 +17,7 @@ spec:
           endpoint: 1.2.3.4:1234
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -89,4 +90,5 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/bottlerocket-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
+
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_md.yaml
@@ -35,6 +35,7 @@ spec:
             -----END CERTIFICATE-----
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -107,4 +108,5 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/bottlerocket-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
+
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_controller_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_controller_md.yaml
@@ -9,6 +9,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -82,4 +83,5 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.21.2
       thumbprint: 'ABCDEFG'
+
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_md.yaml
@@ -9,6 +9,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -81,4 +82,5 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.21.2
       thumbprint: 'ABCDEFG'
+
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_main_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_md.yaml
@@ -9,6 +9,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -81,4 +82,5 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
+
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_main_multiple_worker_node_groups.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_multiple_worker_node_groups.yaml
@@ -9,6 +9,10 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints:
+            - key: key2
+              value: val2
+              effect: PreferNoSchedule
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -81,6 +85,7 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
+
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -93,6 +98,10 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints:
+            - key: key2
+              value: val2
+              effect: PreferNoSchedule
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -165,4 +174,5 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
+
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_md.yaml
@@ -9,6 +9,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -81,4 +82,5 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
+
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_md.yaml
@@ -9,6 +9,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -82,4 +83,5 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
+
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_md.yaml
@@ -15,6 +15,8 @@ spec:
               effect: PreferNoSchedule
           kubeletExtraArgs:
             cloud-provider: external
+            read-only-port: "0"
+            anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
           name: '{{ ds.meta_data.hostname }}'
       preKubeadmCommands:

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_md.yaml
@@ -9,11 +9,12 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
-          taints: []
+          taints:
+            - key: key1
+              value: val1
+              effect: PreferNoSchedule
           kubeletExtraArgs:
             cloud-provider: external
-            read-only-port: "0"
-            anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
           name: '{{ ds.meta_data.hostname }}'
       preKubeadmCommands:
@@ -71,14 +72,15 @@ spec:
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
-      memoryMiB: 8192
+      memoryMiB: 4096
       network:
         devices:
         - dhcp4: true
           networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
-      numCPUs: 2
+      numCPUs: 3
       resourcePool: '*/Resources'
       server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
 

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_add_worker_node_group.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_add_worker_node_group.yaml
@@ -9,6 +9,10 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints:
+            - key: key2
+              value: val2
+              effect: PreferNoSchedule
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -81,6 +85,7 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
+
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -93,6 +98,10 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints:
+            - key: key2
+              value: val2
+              effect: PreferNoSchedule
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -165,6 +174,7 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
+
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -177,6 +187,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -249,4 +260,5 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
+
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_md.yaml
@@ -9,6 +9,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -91,4 +92,5 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
+
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
@@ -9,6 +9,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+          taints: []
           kubeletExtraArgs:
             cloud-provider: external
             read-only-port: "0"
@@ -113,4 +114,5 @@ spec:
       storagePolicyName: "vSAN Default Storage Policy"
       template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
       thumbprint: 'ABCDEFG'
+
 ---

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -538,6 +538,9 @@ func NeedsNewWorkloadTemplate(oldSpec, newSpec *cluster.Spec, oldVdc, newVdc *v1
 	if oldSpec.Bundles.Spec.Number != newSpec.Bundles.Spec.Number {
 		return true
 	}
+	if !v1alpha1.WorkerNodeGroupConfigurationSliceTaintsEqual(oldSpec.Spec.WorkerNodeGroupConfigurations, newSpec.Spec.WorkerNodeGroupConfigurations) {
+		return true
+	}
 	return AnyImmutableFieldChanged(oldVdc, newVdc, oldVmc, newVmc)
 }
 
@@ -832,6 +835,7 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		"vsphereWorkerSshAuthorizedKey":  workerNodeGroupMachineSpec.Users[0].SshAuthorizedKeys[0],
 		"workerReplicas":                 workerNodeGroupConfiguration.Count,
 		"workerNodeGroupName":            fmt.Sprintf("%s-%s", clusterSpec.Name, workerNodeGroupConfiguration.Name),
+		"workerNodeGroupTaints":          workerNodeGroupConfiguration.Taints,
 	}
 
 	if clusterSpec.Spec.RegistryMirrorConfiguration != nil {

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -582,6 +582,9 @@ func TestProviderGenerateCAPISpecForUpgradeMultipleWorkerNodeGroups(t *testing.T
 			kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereDatacenter, nil)
 			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
 			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil).AnyTimes()
+			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
+			kubectl.EXPECT().UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", cluster.Name), map[string]string{etcdv1.UpgradeInProgressAnnotation: "true"}, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster)))
+
 			datacenterConfig := givenDatacenterConfig(t, tt.clusterconfigFile)
 			machineConfigs := givenMachineConfigs(t, tt.clusterconfigFile)
 			provider := newProviderWithKubectl(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, kubectl)
@@ -621,7 +624,7 @@ func TestProviderGenerateCAPISpecForUpgradeUpdateMachineTemplateExternalEtcd(t *
 			testName:          "main_with_taints",
 			clusterconfigFile: "cluster_main_with_taints.yaml",
 			wantCPFile:        "testdata/expected_results_main_with_taints_cp.yaml",
-			wantMDFile:        "testdata/expected_results_main_md.yaml",
+			wantMDFile:        "testdata/expected_results_main_with_taints_md.yaml",
 		},
 		{
 			testName:          "main with node labels",

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -1,0 +1,52 @@
+package validations
+
+import (
+	"fmt"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/features"
+)
+
+func ValidateTaintsSupport(clusterSpec *cluster.Spec) error {
+	if !features.IsActive(features.TaintsSupport()) {
+		wngcTaintsPresent := false
+		for _, wngc := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
+			if len(wngc.Taints) > 0 {
+				wngcTaintsPresent = true
+				break
+			}
+		}
+
+		if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints) > 0 ||
+			wngcTaintsPresent {
+			return fmt.Errorf("Taints feature is not enabled. Please set the env variable TAINTS_SUPPORT.")
+		}
+	} else if len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Taints) > 0 {
+		invalidWorkerNodeGroupTaints := false
+		for _, slice := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Taints {
+			if slice.Effect == "NoExecute" || slice.Effect == "NoSchedule" {
+				invalidWorkerNodeGroupTaints = true
+				break
+			}
+		}
+
+		if invalidWorkerNodeGroupTaints {
+			return fmt.Errorf("The first worker node group does not support NoExecute or NoSchedule taints.")
+		}
+	}
+	return nil
+}
+
+func ValidateNodeLabelsSupport(clusterSpec *cluster.Spec) error {
+	if !features.IsActive(features.NodeLabelsSupport()) {
+		if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Labels) > 0 {
+			return fmt.Errorf("Node labels feature is not enabled. Please set the env variable NODE_LABELS_SUPPORT.")
+		}
+		for _, workerNodeGroup := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
+			if len(workerNodeGroup.Labels) > 0 {
+				return fmt.Errorf("Node labels feature is not enabled. Please set the env variable NODE_LABELS_SUPPORT.")
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Backporting https://github.com/aws/eks-anywhere/pull/977 to release-0.7 in preparation for a patch release this week.

This is a cherry-pick of e105a28543c542243a902726ca949d3222ce11b9

> * Support worker node taints

* Support worker node taints (Review 1)

* Support worker node taints (Review 2)

* update testdata for nodelabels tests to incorporate addition of taints to spec

* fix CRD description to indicate worker nodes, not control plane nodes, for taints

* fix comment to correctly refer to worker, not cp, node

* remove extraneous validation of taint slice len in docker provider

* update tests to use v1beta1 capi version

* populate CAPV  wngc template with taints

* populate CAPD wngc template with taints

* remove unneeded assignment of wngc taints

* vsphere multi wngc tests now test taints

* docker multi wngc tests now test taints

* update testdata withe expected configuration based on taints support

* update refactored validations to include feature flag for worker node taints

* adjust worker node group tests to account for external etcd configuration present in config

* set taints in buildTemplateMapMD method

* set taints in buildTemplateMapMD method in docker provider

* add method to compare wngc slices based soley on their taint slices

* ensure docker machine templates are re-created if wngc taints change

* remove redundant mapping of workerNodeGroupTaints key in template

Co-authored-by: Abhisek Banerjee <bnrjee@amazon.com>

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

