### PR TITLE
Backport Controller Support for Reconciling Taints (#1175)

### DIFF
--- a/controllers/controllers/clusters/vsphere.go
+++ b/controllers/controllers/clusters/vsphere.go
@@ -134,6 +134,5 @@ func (v *VSphereClusterReconciler) Reconcile(ctx context.Context, cluster *anywh
 	if err := v.Validator.ValidateClusterMachineConfigs(ctx, vshepreClusterSpec); err != nil {
 		return reconciler.Result{}, err
 	}
-
 	return reconciler.Result{}, nil
 }

--- a/controllers/controllers/resource/fetcher.go
+++ b/controllers/controllers/resource/fetcher.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -26,6 +27,7 @@ import (
 
 type ResourceFetcher interface {
 	MachineDeployment(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*clusterv1.MachineDeployment, error)
+	KubeadmConfigTemplate(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*kubeadmv1.KubeadmConfigTemplate, error)
 	VSphereWorkerMachineTemplate(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*vspherev1.VSphereMachineTemplate, error)
 	VSphereCredentials(ctx context.Context) (*corev1.Secret, error)
 	FetchObject(ctx context.Context, objectKey types.NamespacedName, obj client.Object) error
@@ -36,6 +38,7 @@ type ResourceFetcher interface {
 	ExistingVSphereControlPlaneMachineConfig(ctx context.Context, cs *anywherev1.Cluster) (*anywherev1.VSphereMachineConfig, error)
 	ExistingVSphereEtcdMachineConfig(ctx context.Context, cs *anywherev1.Cluster) (*anywherev1.VSphereMachineConfig, error)
 	ExistingVSphereWorkerMachineConfig(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*anywherev1.VSphereMachineConfig, error)
+	ExistingWorkerNodeGroupConfig(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*anywherev1.WorkerNodeGroupConfiguration, error)
 	ControlPlane(ctx context.Context, cs *anywherev1.Cluster) (*controlplanev1.KubeadmControlPlane, error)
 	Etcd(ctx context.Context, cs *anywherev1.Cluster) (*etcdv1.EtcdadmCluster, error)
 	FetchAppliedSpec(ctx context.Context, cs *anywherev1.Cluster) (*cluster.Spec, error)
@@ -251,6 +254,19 @@ func (r *CapiResourceFetcher) VSphereEtcdMachineTemplate(ctx context.Context, cs
 	return vsphereMachineTemplate, nil
 }
 
+func (r *CapiResourceFetcher) KubeadmConfigTemplate(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*kubeadmv1.KubeadmConfigTemplate, error) {
+	machineDeployment, err := r.MachineDeployment(ctx, cs, wnc)
+	if err != nil {
+		return nil, err
+	}
+	kubeadmConfigTemplate := &kubeadmv1.KubeadmConfigTemplate{}
+	err = r.FetchObjectByName(ctx, machineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef.Name, constants.EksaSystemNamespace, kubeadmConfigTemplate)
+	if err != nil {
+		return nil, err
+	}
+	return kubeadmConfigTemplate, nil
+}
+
 func (r *CapiResourceFetcher) VSphereCredentials(ctx context.Context) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	err := r.FetchObjectByName(ctx, constants.VSphereCredentialsName, constants.EksaSystemNamespace, secret)
@@ -349,6 +365,14 @@ func (r *CapiResourceFetcher) ExistingVSphereWorkerMachineConfig(ctx context.Con
 	return MapMachineTemplateToVSphereMachineConfigSpec(vsMachineTemplate)
 }
 
+func (r *CapiResourceFetcher) ExistingWorkerNodeGroupConfig(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*anywherev1.WorkerNodeGroupConfiguration, error) {
+	existingKubeadmConfigTemplate, err := r.KubeadmConfigTemplate(ctx, cs, wnc)
+	if err != nil {
+		return nil, err
+	}
+	return MapKubeadmConfigTemplateToWorkerNodeGroupConfiguration(*existingKubeadmConfigTemplate), nil
+}
+
 func MapMachineTemplateToVSphereDatacenterConfigSpec(vsMachineTemplate *vspherev1.VSphereMachineTemplate) (*anywherev1.VSphereDatacenterConfig, error) {
 	vsSpec := &anywherev1.VSphereDatacenterConfig{}
 	vsSpec.Spec.Thumbprint = vsMachineTemplate.Spec.Template.Spec.Thumbprint
@@ -376,6 +400,13 @@ func MapMachineTemplateToVSphereMachineConfigSpec(vsMachineTemplate *vspherev1.V
 
 	// TODO: OSFamily, Users (these fields are immutable)
 	return vsSpec, nil
+}
+
+func MapKubeadmConfigTemplateToWorkerNodeGroupConfiguration(template kubeadmv1.KubeadmConfigTemplate) *anywherev1.WorkerNodeGroupConfiguration {
+	wnSpec := &anywherev1.WorkerNodeGroupConfiguration{}
+	wnSpec.Taints = template.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints
+	// TODO: map template.Spec.Template.Spec.JoinConfiguration.NodeRegestration.KubeletExtraArgs to wnSpec.Labels
+	return wnSpec
 }
 
 func MapMachineTemplateToVSphereMachineConfigSpecWorkers(vsMachineTemplates []vspherev1.VSphereMachineTemplate) (map[string]anywherev1.VSphereMachineConfig, error) {

--- a/controllers/controllers/resource/mocks/resource.go
+++ b/controllers/controllers/resource/mocks/resource.go
@@ -17,7 +17,8 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	v1beta10 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
 	v1beta11 "sigs.k8s.io/cluster-api/api/v1beta1"
-	v1beta12 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	v1beta12 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	v1beta13 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -60,10 +61,10 @@ func (mr *MockResourceFetcherMockRecorder) AWSIamConfig(arg0, arg1, arg2 interfa
 }
 
 // ControlPlane mocks base method.
-func (m *MockResourceFetcher) ControlPlane(arg0 context.Context, arg1 *v1alpha1.Cluster) (*v1beta12.KubeadmControlPlane, error) {
+func (m *MockResourceFetcher) ControlPlane(arg0 context.Context, arg1 *v1alpha1.Cluster) (*v1beta13.KubeadmControlPlane, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControlPlane", arg0, arg1)
-	ret0, _ := ret[0].(*v1beta12.KubeadmControlPlane)
+	ret0, _ := ret[0].(*v1beta13.KubeadmControlPlane)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -149,6 +150,21 @@ func (mr *MockResourceFetcherMockRecorder) ExistingVSphereWorkerMachineConfig(ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExistingVSphereWorkerMachineConfig", reflect.TypeOf((*MockResourceFetcher)(nil).ExistingVSphereWorkerMachineConfig), arg0, arg1, arg2)
 }
 
+// ExistingWorkerNodeGroupConfig mocks base method.
+func (m *MockResourceFetcher) ExistingWorkerNodeGroupConfig(arg0 context.Context, arg1 *v1alpha1.Cluster, arg2 v1alpha1.WorkerNodeGroupConfiguration) (*v1alpha1.WorkerNodeGroupConfiguration, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExistingWorkerNodeGroupConfig", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*v1alpha1.WorkerNodeGroupConfiguration)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExistingWorkerNodeGroupConfig indicates an expected call of ExistingWorkerNodeGroupConfig.
+func (mr *MockResourceFetcherMockRecorder) ExistingWorkerNodeGroupConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExistingWorkerNodeGroupConfig", reflect.TypeOf((*MockResourceFetcher)(nil).ExistingWorkerNodeGroupConfig), arg0, arg1, arg2)
+}
+
 // Fetch mocks base method.
 func (m *MockResourceFetcher) Fetch(arg0 context.Context, arg1, arg2, arg3, arg4 string) (*unstructured.Unstructured, error) {
 	m.ctrl.T.Helper()
@@ -220,6 +236,21 @@ func (m *MockResourceFetcher) FetchObjectByName(arg0 context.Context, arg1, arg2
 func (mr *MockResourceFetcherMockRecorder) FetchObjectByName(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchObjectByName", reflect.TypeOf((*MockResourceFetcher)(nil).FetchObjectByName), arg0, arg1, arg2, arg3)
+}
+
+// KubeadmConfigTemplate mocks base method.
+func (m *MockResourceFetcher) KubeadmConfigTemplate(arg0 context.Context, arg1 *v1alpha1.Cluster, arg2 v1alpha1.WorkerNodeGroupConfiguration) (*v1beta12.KubeadmConfigTemplate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "KubeadmConfigTemplate", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*v1beta12.KubeadmConfigTemplate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// KubeadmConfigTemplate indicates an expected call of KubeadmConfigTemplate.
+func (mr *MockResourceFetcherMockRecorder) KubeadmConfigTemplate(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KubeadmConfigTemplate", reflect.TypeOf((*MockResourceFetcher)(nil).KubeadmConfigTemplate), arg0, arg1, arg2)
 }
 
 // MachineDeployment mocks base method.

--- a/controllers/controllers/resource/reconciler_test.go
+++ b/controllers/controllers/resource/reconciler_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,11 +46,17 @@ var expectedMachineDeploymentFile string
 //go:embed testdata/expectedMachineDeploymentOnlyReplica.yaml
 var expectedMachineDeploymentOnlyReplica string
 
+//go:embed testdata/expectedMachineDeploymentTemplateChanged.yaml
+var expectedMachineDeploymentTemplateChanged string
+
 //go:embed testdata/vsphereDatacenterConfigSpec.yaml
 var vsphereDatacenterConfigSpecPath string
 
 //go:embed testdata/vsphereMachineConfigSpec.yaml
 var vsphereMachineConfigSpecPath string
+
+//go:embed testdata/kubeadmconfigTemplateSpec.yaml
+var kubeadmconfigTemplateSpecPath string
 
 func TestClusterReconcilerReconcile(t *testing.T) {
 	type args struct {
@@ -142,11 +149,18 @@ func TestClusterReconcilerReconcile(t *testing.T) {
 					t.Errorf("unmarshal failed: %v", err)
 				}
 
+				machineDeployment := &clusterv1.MachineDeployment{}
+				if err := yaml.Unmarshal([]byte(machineDeploymentFile), machineDeployment); err != nil {
+					t.Errorf("unmarshalling machinedeployment failed: %v", err)
+				}
+				fetcher.EXPECT().MachineDeployment(ctx, gomock.Any(), gomock.Any()).Return(machineDeployment, nil)
+
 				fetcher.EXPECT().Etcd(ctx, gomock.Any()).Return(etcdadmCluster, nil)
 				fetcher.EXPECT().ExistingVSphereDatacenterConfig(ctx, gomock.Any(), gomock.Any()).Return(&anywherev1.VSphereDatacenterConfig{}, nil)
 				fetcher.EXPECT().ExistingVSphereControlPlaneMachineConfig(ctx, gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
 				fetcher.EXPECT().ExistingVSphereEtcdMachineConfig(ctx, gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
 				fetcher.EXPECT().ExistingVSphereWorkerMachineConfig(ctx, gomock.Any(), gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
+				fetcher.EXPECT().ExistingWorkerNodeGroupConfig(ctx, gomock.Any(), gomock.Any()).Return(&anywherev1.WorkerNodeGroupConfiguration{}, nil)
 				fetcher.EXPECT().VSphereCredentials(ctx).Return(&corev1.Secret{
 					Data: map[string][]byte{"username": []byte("username"), "password": []byte("password")},
 				}, nil)
@@ -232,6 +246,13 @@ func TestClusterReconcilerReconcile(t *testing.T) {
 					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
 				}).Return(nil)
 
+				existingWorkerNodeGroupConfiguration := &anywherev1.WorkerNodeGroupConfiguration{
+					Name:            "md-0",
+					Count:           3,
+					MachineGroupRef: nil,
+				}
+				fetcher.EXPECT().ExistingWorkerNodeGroupConfig(ctx, gomock.Any(), gomock.Any()).Return(existingWorkerNodeGroupConfiguration, nil)
+
 				existingVSMachine := &anywherev1.VSphereMachineConfig{}
 				existingVSMachine.Spec = machineSpec.Spec
 				fetcher.EXPECT().ExistingVSphereControlPlaneMachineConfig(ctx, gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
@@ -242,10 +263,11 @@ func TestClusterReconcilerReconcile(t *testing.T) {
 					t.Errorf("unmarshal failed: %v", err)
 				}
 
-				mcDeployment := &clusterv1.MachineDeployment{}
-				if err := yaml.Unmarshal([]byte(machineDeploymentFile), mcDeployment); err != nil {
+				machineDeployment := &clusterv1.MachineDeployment{}
+				if err := yaml.Unmarshal([]byte(machineDeploymentFile), machineDeployment); err != nil {
 					t.Errorf("unmarshal failed: %v", err)
 				}
+				fetcher.EXPECT().MachineDeployment(ctx, gomock.Any(), gomock.Any()).Return(machineDeployment, nil)
 
 				fetcher.EXPECT().VSphereCredentials(ctx).Return(&corev1.Secret{
 					Data: map[string][]byte{"username": []byte("username"), "password": []byte("password")},
@@ -259,6 +281,128 @@ func TestClusterReconcilerReconcile(t *testing.T) {
 					case "MachineDeployment":
 						expectedMCDeployment := &unstructured.Unstructured{}
 						if err := yaml.Unmarshal([]byte(expectedMachineDeploymentOnlyReplica), expectedMCDeployment); err != nil {
+							t.Errorf("unmarshal failed: %v", err)
+						}
+						assert.Equal(t, expectedMCDeployment, template, "values", expectedMCDeployment, template)
+					}
+				}).AnyTimes().Return(nil)
+			},
+		},
+		{
+			name: "worker node reconcile (Vsphere provider) - worker node taints have changed",
+			args: args{
+				namespace: "namespaceA",
+				name:      "nameA",
+				objectKey: types.NamespacedName{
+					Name:      "nameA",
+					Namespace: "namespaceA",
+				},
+			},
+			want: controllerruntime.Result{},
+			prepare: func(ctx context.Context, fetcher *mocks.MockResourceFetcher, resourceUpdater *mocks.MockResourceUpdater, name string, namespace string) {
+				cluster := &anywherev1.Cluster{}
+				cluster.SetName(name)
+				cluster.SetNamespace(namespace)
+
+				fetcher.EXPECT().FetchCluster(gomock.Any(), gomock.Any()).Return(cluster, nil)
+
+				spec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
+				cluster.Spec = spec.Spec
+
+				fetcher.EXPECT().FetchAppliedSpec(ctx, gomock.Any()).Return(spec, nil)
+
+				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
+					clusterSpec := &anywherev1.VSphereDatacenterConfig{}
+					if err := yaml.Unmarshal([]byte(vsphereDatacenterConfigSpecPath), clusterSpec); err != nil {
+						t.Errorf("unmarshal failed: %v", err)
+					}
+					cluster := obj.(*anywherev1.VSphereDatacenterConfig)
+					cluster.SetName(objectKey.Name)
+					cluster.SetNamespace(objectKey.Namespace)
+					cluster.Spec = clusterSpec.Spec
+					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+				}).Return(nil)
+				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
+					clusterSpec := &anywherev1.VSphereMachineConfig{}
+					if err := yaml.Unmarshal([]byte(vsphereMachineConfigSpecPath), clusterSpec); err != nil {
+						t.Errorf("unmarshal failed: %v", err)
+					}
+					cluster := obj.(*anywherev1.VSphereMachineConfig)
+					cluster.SetName(objectKey.Name)
+					cluster.SetNamespace(objectKey.Namespace)
+					cluster.Spec = clusterSpec.Spec
+					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+				}).Return(nil)
+				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
+					clusterSpec := &anywherev1.VSphereMachineConfig{}
+					if err := yaml.Unmarshal([]byte(vsphereMachineConfigSpecPath), clusterSpec); err != nil {
+						t.Errorf("unmarshal failed: %v", err)
+					}
+					cluster := obj.(*anywherev1.VSphereMachineConfig)
+					cluster.SetName(objectKey.Name)
+					cluster.SetNamespace(objectKey.Namespace)
+					cluster.Spec = clusterSpec.Spec
+					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+				}).Return(nil)
+				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
+					clusterSpec := &anywherev1.VSphereMachineConfig{}
+					if err := yaml.Unmarshal([]byte(vsphereMachineConfigSpecPath), clusterSpec); err != nil {
+						t.Errorf("unmarshal failed: %v", err)
+					}
+					cluster := obj.(*anywherev1.VSphereMachineConfig)
+					cluster.SetName(objectKey.Name)
+					cluster.SetNamespace(objectKey.Namespace)
+					cluster.Spec = clusterSpec.Spec
+					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+				}).Return(nil)
+
+				kubeAdmControlPlane := &controlplanev1.KubeadmControlPlane{}
+				if err := yaml.Unmarshal([]byte(kubeadmcontrolplaneFile), kubeAdmControlPlane); err != nil {
+					t.Errorf("unmarshal failed: %v", err)
+				}
+
+				etcdadmCluster := &etcdv1.EtcdadmCluster{}
+				if err := yaml.Unmarshal([]byte(etcdadmclusterFile), etcdadmCluster); err != nil {
+					t.Errorf("unmarshal failed: %v", err)
+				}
+
+				existingWorkerNodeGroupConfiguration := &anywherev1.WorkerNodeGroupConfiguration{
+					Name:            "md-0",
+					Count:           3,
+					MachineGroupRef: nil,
+					Taints: []corev1.Taint{
+						{
+							Key:    "key1",
+							Value:  "val1",
+							Effect: "PreferNoSchedule",
+						},
+					},
+				}
+
+				fetcher.EXPECT().Etcd(ctx, gomock.Any()).Return(etcdadmCluster, nil)
+				fetcher.EXPECT().ExistingVSphereDatacenterConfig(ctx, gomock.Any(), gomock.Any()).Return(&anywherev1.VSphereDatacenterConfig{}, nil)
+				fetcher.EXPECT().ExistingVSphereControlPlaneMachineConfig(ctx, gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
+				fetcher.EXPECT().ExistingVSphereEtcdMachineConfig(ctx, gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
+				fetcher.EXPECT().ExistingVSphereWorkerMachineConfig(ctx, gomock.Any(), gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
+				fetcher.EXPECT().ExistingWorkerNodeGroupConfig(ctx, gomock.Any(), gomock.Any()).Return(existingWorkerNodeGroupConfiguration, nil)
+				fetcher.EXPECT().VSphereCredentials(ctx).Return(&corev1.Secret{
+					Data: map[string][]byte{"username": []byte("username"), "password": []byte("password")},
+				}, nil)
+				fetcher.EXPECT().Fetch(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.NewNotFound(schema.GroupResource{Group: "testgroup", Resource: "testresource"}, ""))
+
+				resourceUpdater.EXPECT().ApplyPatch(ctx, gomock.Any(), false).Return(nil)
+				resourceUpdater.EXPECT().ForceApplyTemplate(ctx, gomock.Any(), gomock.Any()).Do(func(ctx context.Context, template *unstructured.Unstructured, dryRun bool) {
+					assert.Equal(t, false, dryRun, "Expected dryRun didn't match")
+					switch template.GetKind() {
+					case "KubeadmconfigTemplate":
+						existingKubeadmConfigTemplate := &v1beta1.KubeadmConfigTemplate{}
+						if err := yaml.Unmarshal([]byte(kubeadmconfigTemplateSpecPath), existingKubeadmConfigTemplate); err != nil {
+							t.Errorf("unmarshal failed: %v", err)
+						}
+						assert.Equal(t, existingKubeadmConfigTemplate, template, "values", existingKubeadmConfigTemplate, template)
+					case "MachineDeployment":
+						expectedMCDeployment := &unstructured.Unstructured{}
+						if err := yaml.Unmarshal([]byte(expectedMachineDeploymentTemplateChanged), expectedMCDeployment); err != nil {
 							t.Errorf("unmarshal failed: %v", err)
 						}
 						assert.Equal(t, expectedMCDeployment, template, "values", expectedMCDeployment, template)

--- a/controllers/controllers/resource/testdata/expectedMachineDeploymentTemplateChanged.yaml
+++ b/controllers/controllers/resource/testdata/expectedMachineDeploymentTemplateChanged.yaml
@@ -1,0 +1,28 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test_cluster
+  name: test_cluster-md-0
+  namespace: eksa-system
+spec:
+  clusterName: test_cluster
+  replicas: 4
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: test_cluster
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test_cluster-md-0-template-1234567890000
+      clusterName: test_cluster
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        name: test_cluster-md-0-1234567890000
+      version: v1.19.8-eks-1-19-4

--- a/controllers/controllers/resource/testdata/kubeadmconfigTemplateSpec.yaml
+++ b/controllers/controllers/resource/testdata/kubeadmconfigTemplateSpec.yaml
@@ -1,0 +1,41 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  creationTimestamp: "2022-02-04T22:35:36Z"
+  generation: 2
+  name: test_cluster-md-0
+  namespace: eksa-system
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      kind: Cluster
+      name: taintstest4
+      uid: f3cd4d33-94cd-456b-8cf1-21f80d833af3
+  resourceVersion: "825197"
+  uid: 95717072-bfe7-4f98-9ec3-0bc8ee42beac
+spec:
+  template:
+    spec:
+      format: cloud-config
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          kubeletExtraArgs:
+            cgroup-driver: systemd
+            cloud-provider: external
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          name: '{{ ds.meta_data.hostname }}'
+          taints:
+            - effect: PreferNoSchedule
+              key: key1
+              value: PepperoniPizza
+      preKubeadmCommands:
+        - hostname "{{ ds.meta_data.hostname }}"
+        - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+        - echo "127.0.0.1   localhost" >>/etc/hosts
+        - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+        - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+      users:
+        - name: ec2-user
+          sshAuthorizedKeys:
+            - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyjtLJZAGkn7Ibi9RW4QKGs+v/ltSE/vYMEX4+mixNF35rU3cFIiXYMut5hflzRRWlEHeNW9oNQ/WNOUiynFp9ySDmkjo81PkfUfYl2mXqkcwRFW0qVXSzLB5nsH68Y2mzfSVZ4UuUXs9fRSu8faYs/QjRkOLmaGFWzL8CVBvCSAT51dIppJ0lh+a9ZLiLLTpExL7tC32Q+TDuCIK3EpTBd+km58NUUrKBfML5u5LSehRTWzPxuOa4egYCCKa5uGfTjk1T2ycXbkaL6hn6KqpGI/aHvMIeP51cloa64ropRQ7XuGnpAACLh67FWz2tE+HwRg7VgdkwqDbrFNf6ONhwt4SPmRhOtkToEuV1U3z8YqnIButaGs8HYZV8DLAMre2hoAdnpsQhKyA2Q7ZmQw/YIOVsKuHQGz/OYGv4/gQxRDH+pduGTFFii9w7WaZSKAroBG3qJ/iLhFBKRYG1e0Pi+89Xf8Rg/011eNnR+aC4sIjFlSK1b9lrtOM767BoBPM5HJKSECuDCUhHnFZbFsTm7IFjlxVIKGiR/B8RTpycAdr+UdrLoCCSUYZnvqosgMneAq96QqCQscu9hDEbP3Dndyh3N6/VbVpl+eghFKvd4gdVD5FFy1nDC9Z/+rqeiiO+HUnksP9vTG8PEsp9Mi91mpdhBvkAYfPQQAHJazhnjQ==
+          sudo: ALL=(ALL) NOPASSWD:ALL

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -13,6 +13,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -44,6 +45,7 @@ func init() {
 	utilruntime.Must(controlplanev1.AddToScheme(scheme))
 	utilruntime.Must(vspherev1.AddToScheme(scheme))
 	utilruntime.Must(etcdv1.AddToScheme(scheme))
+	utilruntime.Must(kubeadmv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -50,9 +50,10 @@ type BuildMapOption func(map[string]interface{})
 
 type TemplateBuilder interface {
 	GenerateCAPISpecControlPlane(clusterSpec *cluster.Spec, buildOptions ...BuildMapOption) (content []byte, err error)
-	GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, templateNames map[string]string) (content []byte, err error)
+	GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, workloadTemplateNames, kubeadmconfigTemplateNames map[string]string) (content []byte, err error)
 	WorkerMachineTemplateName(clusterName, workerNodeGroupName string) string
 	CPMachineTemplateName(clusterName string) string
+	KubeadmConfigTemplateName(clusterName, workerNodeGroupName string) string
 	EtcdMachineTemplateName(clusterName string) string
 }
 

--- a/pkg/providers/vsphere/config/template-md.yaml
+++ b/pkg/providers/vsphere/config/template-md.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: {{.workerNodeGroupName}}
+  name: {{.workloadkubeadmconfigTemplateName}}
   namespace: {{.eksaSystemNamespace}}
 spec:
   template:
@@ -128,7 +128,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: {{.workerNodeGroupName}}
+          name: {{.workloadkubeadmconfigTemplateName}}
       clusterName: {{.clusterName}}
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_md.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-0
+  name: test-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -56,7 +56,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-0
+          name: test-md-0-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_md.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-0
+  name: test-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -58,7 +58,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-0
+          name: test-md-0-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_md.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-0
+  name: test-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -76,7 +76,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-0
+          name: test-md-0-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_controller_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_controller_md.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-0
+  name: test-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -51,7 +51,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-0
+          name: test-md-0-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_md.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-0
+  name: test-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -50,7 +50,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-0
+          name: test-md-0-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/testdata/expected_results_main_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_md.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-0
+  name: test-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -50,7 +50,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-0
+          name: test-md-0-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/testdata/expected_results_main_multiple_worker_node_groups.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_multiple_worker_node_groups.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-0
+  name: test-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -53,7 +53,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-0
+          name: test-md-0-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -90,7 +90,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-1
+  name: test-md-1-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -142,7 +142,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-1
+          name: test-md-1-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_md.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-0
+  name: test-md-0-template-original
   namespace: eksa-system
 spec:
   template:
@@ -50,7 +50,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-0
+          name: test-md-0-template-original
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_md.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-0
+  name: test-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -51,7 +51,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-0
+          name: test-md-0-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_md.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-0
+  name: test-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -53,7 +53,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-0
+          name: test-md-0-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_add_worker_node_group.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_add_worker_node_group.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-0
+  name: test-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -53,7 +53,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-0
+          name: test-md-0-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -90,7 +90,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-1
+  name: test-md-1-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -142,7 +142,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-1
+          name: test-md-1-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -179,7 +179,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-2
+  name: test-md-2-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -228,7 +228,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-2
+          name: test-md-2-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_md.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-0
+  name: test-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -50,7 +50,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-0
+          name: test-md-0-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_md.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-0
+  name: test-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -60,7 +60,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-0
+          name: test-md-0-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-md-0
+  name: test-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -82,7 +82,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-md-0
+          name: test-md-0-template-1234567890000
       clusterName: test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -544,6 +544,10 @@ func NeedsNewWorkloadTemplate(oldSpec, newSpec *cluster.Spec, oldVdc, newVdc *v1
 	return AnyImmutableFieldChanged(oldVdc, newVdc, oldVmc, newVmc)
 }
 
+func NeedsNewKubeadmConfigTemplate(newWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration, oldWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration) bool {
+	return !v1alpha1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints)
+}
+
 func NeedsNewEtcdTemplate(oldSpec, newSpec *cluster.Spec, oldVdc, newVdc *v1alpha1.VSphereDatacenterConfig, oldVmc, newVmc *v1alpha1.VSphereMachineConfig) bool {
 	if oldSpec.Cluster.Spec.KubernetesVersion != newSpec.Cluster.Spec.KubernetesVersion {
 		return true
@@ -620,6 +624,11 @@ func (vs *VsphereTemplateBuilder) EtcdMachineTemplateName(clusterName string) st
 	return fmt.Sprintf("%s-etcd-template-%d", clusterName, t)
 }
 
+func (vs *VsphereTemplateBuilder) KubeadmConfigTemplateName(clusterName, workerNodeGroupName string) string {
+	t := vs.now().UnixNano() / int64(time.Millisecond)
+	return fmt.Sprintf("%s-%s-template-%d", clusterName, workerNodeGroupName, t)
+}
+
 func (vs *VsphereTemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spec, buildOptions ...providers.BuildMapOption) (content []byte, err error) {
 	var etcdMachineSpec v1alpha1.VSphereMachineConfigSpec
 	if clusterSpec.Spec.ExternalEtcdConfiguration != nil {
@@ -651,7 +660,7 @@ func (vs *VsphereTemplateBuilder) isCgroupDriverSystemd(clusterSpec *cluster.Spe
 	return false, nil
 }
 
-func (vs *VsphereTemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, templateNames map[string]string) (content []byte, err error) {
+func (vs *VsphereTemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, workloadTemplateNames, kubeadmconfigTemplateNames map[string]string) (content []byte, err error) {
 	// pin cgroupDriver to systemd for k8s >= 1.21 when generating template in controller
 	// remove this check once the controller supports order upgrade.
 	// i.e. control plane, etcd upgrade before worker nodes.
@@ -663,12 +672,8 @@ func (vs *VsphereTemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.S
 	workerSpecs := make([][]byte, 0, len(clusterSpec.Spec.WorkerNodeGroupConfigurations))
 	for _, workerNodeGroupConfiguration := range clusterSpec.Spec.WorkerNodeGroupConfigurations {
 		values := buildTemplateMapMD(clusterSpec, *vs.datacenterSpec, vs.workerNodeGroupMachineSpecs[workerNodeGroupConfiguration.MachineGroupRef.Name], workerNodeGroupConfiguration)
-		_, ok := templateNames[workerNodeGroupConfiguration.Name]
-		if templateNames != nil && ok {
-			values["workloadTemplateName"] = templateNames[workerNodeGroupConfiguration.Name]
-		} else {
-			values["workloadTemplateName"] = vs.WorkerMachineTemplateName(clusterSpec.Name, workerNodeGroupConfiguration.Name)
-		}
+		values["workloadTemplateName"] = workloadTemplateNames[workerNodeGroupConfiguration.Name]
+		values["workloadkubeadmconfigTemplateName"] = kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name]
 
 		values["cgroupDriverSystemd"] = cgroupDriverSystemd
 
@@ -880,7 +885,7 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 
 func (p *vsphereProvider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currentSpec, newClusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	clusterName := newClusterSpec.ObjectMeta.Name
-	var controlPlaneTemplateName, workloadTemplateName, etcdTemplateName string
+	var controlPlaneTemplateName, workloadTemplateName, kubeadmconfigTemplateName, etcdTemplateName string
 	var needsNewEtcdTemplate bool
 
 	c, err := p.providerKubectlClient.GetEksaCluster(ctx, workloadCluster, newClusterSpec.Name)
@@ -910,11 +915,30 @@ func (p *vsphereProvider) generateCAPISpecForUpgrade(ctx context.Context, bootst
 	previousWorkerNodeGroupConfigs := cluster.BuildMapForWorkerNodeGroupsByName(currentSpec.Spec.WorkerNodeGroupConfigurations)
 
 	workloadTemplateNames := make(map[string]string, len(newClusterSpec.Spec.WorkerNodeGroupConfigurations))
+	kubeadmconfigTemplateNames := make(map[string]string, len(newClusterSpec.Spec.WorkerNodeGroupConfigurations))
 	for _, workerNodeGroupConfiguration := range newClusterSpec.Spec.WorkerNodeGroupConfigurations {
 		needsNewWorkloadTemplate, err := p.needsNewMachineTemplate(ctx, workloadCluster, currentSpec, newClusterSpec, workerNodeGroupConfiguration, vdc, previousWorkerNodeGroupConfigs)
 		if err != nil {
 			return nil, nil, err
 		}
+
+		needsNewKubeadmConfigTemplate, err := p.needsNewKubeadmConfigTemplate(workerNodeGroupConfiguration, previousWorkerNodeGroupConfigs)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !needsNewKubeadmConfigTemplate {
+			mdName := machineDeploymentName(newClusterSpec.Name, workerNodeGroupConfiguration.Name)
+			md, err := p.providerKubectlClient.GetMachineDeployment(ctx, mdName, executables.WithCluster(bootstrapCluster), executables.WithNamespace(constants.EksaSystemNamespace))
+			if err != nil {
+				return nil, nil, err
+			}
+			kubeadmconfigTemplateName = md.Spec.Template.Spec.Bootstrap.ConfigRef.Name
+			kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name] = kubeadmconfigTemplateName
+		} else {
+			kubeadmconfigTemplateName = p.templateBuilder.KubeadmConfigTemplateName(clusterName, workerNodeGroupConfiguration.Name)
+			kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name] = kubeadmconfigTemplateName
+		}
+
 		if !needsNewWorkloadTemplate {
 			mdName := machineDeploymentName(newClusterSpec.Name, workerNodeGroupConfiguration.Name)
 			md, err := p.providerKubectlClient.GetMachineDeployment(ctx, mdName, executables.WithCluster(bootstrapCluster), executables.WithNamespace(constants.EksaSystemNamespace))
@@ -970,7 +994,7 @@ func (p *vsphereProvider) generateCAPISpecForUpgrade(ctx context.Context, bootst
 		return nil, nil, err
 	}
 
-	workersSpec, err = p.templateBuilder.GenerateCAPISpecWorkers(newClusterSpec, workloadTemplateNames)
+	workersSpec, err = p.templateBuilder.GenerateCAPISpecWorkers(newClusterSpec, workloadTemplateNames, kubeadmconfigTemplateNames)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -990,10 +1014,15 @@ func (p *vsphereProvider) generateCAPISpecForCreate(ctx context.Context, cluster
 	if err != nil {
 		return nil, nil, err
 	}
+
+	workloadTemplateNames := make(map[string]string, len(clusterSpec.Spec.WorkerNodeGroupConfigurations))
+	kubeadmconfigTemplateNames := make(map[string]string, len(clusterSpec.Spec.WorkerNodeGroupConfigurations))
 	for _, workerNodeGroupConfiguration := range clusterSpec.Spec.WorkerNodeGroupConfigurations {
+		workloadTemplateNames[workerNodeGroupConfiguration.Name] = p.templateBuilder.WorkerMachineTemplateName(clusterSpec.Name, workerNodeGroupConfiguration.Name)
+		kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name] = p.templateBuilder.KubeadmConfigTemplateName(clusterSpec.Name, workerNodeGroupConfiguration.Name)
 		p.templateBuilder.workerNodeGroupMachineSpecs[workerNodeGroupConfiguration.MachineGroupRef.Name] = p.machineConfigs[workerNodeGroupConfiguration.MachineGroupRef.Name].Spec
 	}
-	workersSpec, err = p.templateBuilder.GenerateCAPISpecWorkers(clusterSpec, nil)
+	workersSpec, err = p.templateBuilder.GenerateCAPISpecWorkers(clusterSpec, workloadTemplateNames, kubeadmconfigTemplateNames)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1198,14 +1227,22 @@ func (p *vsphereProvider) ValidateNewSpec(ctx context.Context, cluster *types.Cl
 }
 
 func (p *vsphereProvider) needsNewMachineTemplate(ctx context.Context, workloadCluster *types.Cluster, currentSpec, newClusterSpec *cluster.Spec, workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration, vdc *v1alpha1.VSphereDatacenterConfig, prevWorkerNodeGroupConfigs map[string]v1alpha1.WorkerNodeGroupConfiguration) (bool, error) {
-	workerMachineConfig := p.machineConfigs[workerNodeGroupConfiguration.MachineGroupRef.Name]
 	if _, ok := prevWorkerNodeGroupConfigs[workerNodeGroupConfiguration.Name]; ok {
+		workerMachineConfig := p.machineConfigs[workerNodeGroupConfiguration.MachineGroupRef.Name]
 		workerVmc, err := p.providerKubectlClient.GetEksaVSphereMachineConfig(ctx, workerNodeGroupConfiguration.MachineGroupRef.Name, workloadCluster.KubeconfigFile, newClusterSpec.Namespace)
 		if err != nil {
 			return false, err
 		}
 		needsNewWorkloadTemplate := NeedsNewWorkloadTemplate(currentSpec, newClusterSpec, vdc, p.datacenterConfig, workerVmc, workerMachineConfig)
 		return needsNewWorkloadTemplate, nil
+	}
+	return true, nil
+}
+
+func (p *vsphereProvider) needsNewKubeadmConfigTemplate(workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration, prevWorkerNodeGroupConfigs map[string]v1alpha1.WorkerNodeGroupConfiguration) (bool, error) {
+	if _, ok := prevWorkerNodeGroupConfigs[workerNodeGroupConfiguration.Name]; ok {
+		existingWorkerNodeGroupConfig := prevWorkerNodeGroupConfigs[workerNodeGroupConfiguration.Name]
+		return NeedsNewKubeadmConfigTemplate(&workerNodeGroupConfiguration, &existingWorkerNodeGroupConfig), nil
 	}
 	return true, nil
 }

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -234,6 +234,38 @@ type testContext struct {
 	isExpClusterResourceSetSet bool
 }
 
+func workerNodeGroup1MachineDeployment() *clusterv1.MachineDeployment {
+	return &clusterv1.MachineDeployment{
+		Spec: clusterv1.MachineDeploymentSpec{
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &v1.ObjectReference{
+							Name: "test-md-0-template-1234567890000",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func workerNodeGroup2MachineDeployment() *clusterv1.MachineDeployment {
+	return &clusterv1.MachineDeployment{
+		Spec: clusterv1.MachineDeploymentSpec{
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &v1.ObjectReference{
+							Name: "test-md-1-template-1234567890000",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func (tctx *testContext) SaveContext() {
 	tctx.oldUsername, tctx.isUsernameSet = os.LookupEnv(EksavSphereUsernameKey)
 	tctx.oldPassword, tctx.isPasswordSet = os.LookupEnv(EksavSpherePasswordKey)
@@ -448,6 +480,7 @@ func TestProviderGenerateCAPISpecForUpgradeUpdateMachineTemplate(t *testing.T) {
 				Spec: v1alpha1.VSphereMachineConfigSpec{},
 			}
 
+			kubectl.EXPECT().GetMachineDeployment(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(workerNodeGroup1MachineDeployment(), nil)
 			kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Name).Return(clusterSpec.Cluster, nil)
 			kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereDatacenter, nil)
 			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
@@ -515,6 +548,7 @@ func TestProviderGenerateCAPISpecForUpgradeOIDC(t *testing.T) {
 				Spec: v1alpha1.VSphereMachineConfigSpec{},
 			}
 
+			kubectl.EXPECT().GetMachineDeployment(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(workerNodeGroup1MachineDeployment(), nil)
 			kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Name).Return(clusterSpec.Cluster, nil)
 			kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereDatacenter, nil)
 			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
@@ -578,6 +612,8 @@ func TestProviderGenerateCAPISpecForUpgradeMultipleWorkerNodeGroups(t *testing.T
 			newConfig := v1alpha1.WorkerNodeGroupConfiguration{Count: 1, MachineGroupRef: &v1alpha1.Ref{Name: "test-wn", Kind: "VSphereMachineConfig"}, Name: "md-2"}
 			newClusterSpec.Spec.WorkerNodeGroupConfigurations = append(newClusterSpec.Spec.WorkerNodeGroupConfigurations, newConfig)
 
+			kubectl.EXPECT().GetMachineDeployment(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(workerNodeGroup1MachineDeployment(), nil)
+			kubectl.EXPECT().GetMachineDeployment(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(workerNodeGroup2MachineDeployment(), nil)
 			kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Name).Return(clusterSpec.Cluster, nil)
 			kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereDatacenter, nil)
 			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
@@ -661,6 +697,7 @@ func TestProviderGenerateCAPISpecForUpgradeUpdateMachineTemplateExternalEtcd(t *
 				Spec: v1alpha1.VSphereMachineConfigSpec{},
 			}
 
+			kubectl.EXPECT().GetMachineDeployment(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(workerNodeGroup1MachineDeployment(), nil)
 			kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Name).Return(clusterSpec.Cluster, nil)
 			kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereDatacenter, nil)
 			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
@@ -721,6 +758,11 @@ func TestProviderGenerateCAPISpecForUpgradeNotUpdateMachineTemplate(t *testing.T
 					InfrastructureRef: v1.ObjectReference{
 						Name: "test-md-0-original",
 					},
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &v1.ObjectReference{
+							Name: "test-md-0-template-original",
+						},
+					},
 				},
 			},
 		},
@@ -755,7 +797,7 @@ func TestProviderGenerateCAPISpecForUpgradeNotUpdateMachineTemplate(t *testing.T
 	kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, workerNodeMachineConfigName, cluster.KubeconfigFile, clusterSpec.Namespace).Return(machineConfigs[workerNodeMachineConfigName], nil)
 	kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, etcdMachineConfigName, cluster.KubeconfigFile, clusterSpec.Namespace).Return(machineConfigs[etcdMachineConfigName], nil)
 	kubectl.EXPECT().GetKubeadmControlPlane(ctx, cluster, clusterSpec.Name, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(oldCP, nil)
-	kubectl.EXPECT().GetMachineDeployment(ctx, machineDeploymentName, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(oldMD, nil)
+	kubectl.EXPECT().GetMachineDeployment(ctx, machineDeploymentName, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(oldMD, nil).Times(2)
 	kubectl.EXPECT().GetEtcdadmCluster(ctx, cluster, clusterSpec.Name, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(etcdadmCluster, nil)
 	cp, md, err := provider.GenerateCAPISpecForUpgrade(context.Background(), bootstrapCluster, cluster, clusterSpec, clusterSpec.DeepCopy())
 	if err != nil {


### PR DESCRIPTION
* vsphere provider checks if new kubeadmconfig template is needed based on WN config

* method to fetch kubeadmconfigtemplate

* regenerate kubeadmconfigtemplate spec if neccessary

* controller tests, testdata, and mocks

* update vsphere md template to accomodate mutable kubeadmconfigtemplate name

* vsphere provider tests, testdata, and mocks

* docker, tink and generic provider methods to support kubeadmconfigtemplate changes

* gofmt controller tests

* add kubeadmconfigtemplate to scheme

* check if new kubeadmconfigtemplate is needed during upgrade

* standardize method calls in templater

* update tests, mocks

* shorten kubeadmconfigtemplate generated name

* make sure to pass kubeadmconfigtemplate during upgrade

* update vsphere multiworkernode tests to properly pull the machine deployment associated with the wngc

* remove redundant defaulting behavior in vsphere template builder

* fix mock method signatures after merge

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

