### PR TITLE
Backport taints support ancillary

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -148,9 +148,9 @@ func TaintsSliceEqual(s1, s2 []corev1.Taint) bool {
 	if len(s1) != len(s2) {
 		return false
 	}
-	taints := make(map[corev1.Taint]bool)
+	taints := make(map[corev1.Taint]struct{})
 	for _, taint := range s1 {
-		taints[taint] = true
+		taints[taint] = struct{}{}
 	}
 	for _, taint := range s2 {
 		_, ok := taints[taint]
@@ -200,6 +200,7 @@ type WorkerNodeGroupConfiguration struct {
 }
 
 func generateWorkerNodeGroupKey(c WorkerNodeGroupConfiguration) (key string) {
+	key = c.Name
 	if c.MachineGroupRef != nil {
 		key = c.MachineGroupRef.Kind + c.MachineGroupRef.Name
 	}
@@ -228,14 +229,7 @@ func WorkerNodeGroupConfigurationsSliceEqual(a, b []WorkerNodeGroupConfiguration
 		return false
 	}
 
-	for index, nodeGroup := range a {
-		sameTaints := TaintsSliceEqual(nodeGroup.Taints, b[index].Taints)
-		if !sameTaints {
-			return false
-		}
-	}
-
-	return true
+	return WorkerNodeGroupConfigurationSliceTaintsEqual(a, b)
 }
 
 func WorkerNodeGroupConfigurationSliceTaintsEqual(a, b []WorkerNodeGroupConfiguration) bool {
@@ -246,6 +240,9 @@ func WorkerNodeGroupConfigurationSliceTaintsEqual(a, b []WorkerNodeGroupConfigur
 
 	for _, nodeGroup := range b {
 		if _, ok := m[nodeGroup.Name]; !ok {
+			// this method is not concerned with added/removed node groups,
+			// only with the comparison of taints on existing node groups
+			// if a node group is present in a but not b, or vise versa, it's immaterial
 			continue
 		} else {
 			if !TaintsSliceEqual(m[nodeGroup.Name], nodeGroup.Taints) {

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -228,8 +228,8 @@ func WorkerNodeGroupConfigurationsSliceEqual(a, b []WorkerNodeGroupConfiguration
 		return false
 	}
 
-	for index, wngc := range a {
-		sameTaints := TaintsSliceEqual(wngc.Taints, b[index].Taints)
+	for index, nodeGroup := range a {
+		sameTaints := TaintsSliceEqual(nodeGroup.Taints, b[index].Taints)
 		if !sameTaints {
 			return false
 		}
@@ -240,15 +240,15 @@ func WorkerNodeGroupConfigurationsSliceEqual(a, b []WorkerNodeGroupConfiguration
 
 func WorkerNodeGroupConfigurationSliceTaintsEqual(a, b []WorkerNodeGroupConfiguration) bool {
 	m := make(map[string][]corev1.Taint, len(a))
-	for _, wngc := range a {
-		m[wngc.Name] = wngc.Taints
+	for _, nodeGroup := range a {
+		m[nodeGroup.Name] = nodeGroup.Taints
 	}
 
-	for _, wngc := range b {
-		if _, ok := m[wngc.Name]; !ok {
+	for _, nodeGroup := range b {
+		if _, ok := m[nodeGroup.Name]; !ok {
 			continue
 		} else {
-			if !TaintsSliceEqual(m[wngc.Name], wngc.Taints) {
+			if !TaintsSliceEqual(m[nodeGroup.Name], nodeGroup.Taints) {
 				return false
 			}
 		}

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -297,16 +297,12 @@ func TestClusterEqualKubernetesVersion(t *testing.T) {
 }
 
 func TestClusterEqualWorkerNodeGroupConfigurations(t *testing.T) {
-	var taints1, taints2, taints1DiffOrder, emptyTaints []corev1.Taint
-	var taint1, taint2 corev1.Taint
-
-	taint1.Key = "key1"
-	taint2.Key = "key2"
-	taints1 = append(taints1, taint1)
-	taints1 = append(taints1, taint2)
-	taints1DiffOrder = append(taints1DiffOrder, taint2)
-	taints1DiffOrder = append(taints1DiffOrder, taint1)
-	taints2 = append(taints2, taint1)
+	var emptyTaints []corev1.Taint
+	taint1 := corev1.Taint{Key: "key1"}
+	taint2 := corev1.Taint{Key: "key2"}
+	taints1 := []corev1.Taint{taint1, taint2}
+	taints1DiffOrder := []corev1.Taint{taint2, taint1}
+	taints2 := []corev1.Taint{taint1}
 
 	testCases := []struct {
 		testName                   string
@@ -1122,16 +1118,12 @@ func TestClusterEqualManagement(t *testing.T) {
 }
 
 func TestControlPlaneConfigurationEqual(t *testing.T) {
-	var taints1, taints2, taints1DiffOrder, emptyTaints []corev1.Taint
-	var taint1, taint2 corev1.Taint
-
-	taint1.Key = "key1"
-	taint2.Key = "key2"
-	taints1 = append(taints1, taint1)
-	taints1 = append(taints1, taint2)
-	taints1DiffOrder = append(taints1DiffOrder, taint2)
-	taints1DiffOrder = append(taints1DiffOrder, taint1)
-	taints2 = append(taints2, taint1)
+	var emptyTaints []corev1.Taint
+	taint1 := corev1.Taint{Key: "key1"}
+	taint2 := corev1.Taint{Key: "key2"}
+	taints1 := []corev1.Taint{taint1, taint2}
+	taints1DiffOrder := []corev1.Taint{taint2, taint1}
+	taints2 := []corev1.Taint{taint1}
 
 	testCases := []struct {
 		testName                           string

--- a/pkg/api/v1alpha1/testdata/cluster_invalid_taints.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_invalid_taints.yaml
@@ -1,0 +1,73 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: VSphereMachineConfig
+  kubernetesVersion: "1.19"
+  workerNodeGroupConfigurations:
+    - count: 3
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: VSphereMachineConfig
+      name: md-0
+      taints:
+        - key: key1
+          value: value1
+          effect: NoExecute
+    - count: 3
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: VSphereMachineConfig
+      name: md-1
+      taints:
+        - key: key1
+          value: value1
+          effect: NoSchedule
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  diskGiB: 25
+  datastore: "myDatastore"
+  folder: "myFolder"
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: "ubuntu"
+  resourcePool: "myResourcePool"
+  storagePolicyName: "myStoragePolicyName"
+  template: "myTemplate"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  datacenter: "myDatacenter"
+  network: "myNetwork"
+  server: "myServer"
+  thumbprint: "myTlsThumbprint"
+  insecure: false

--- a/pkg/api/v1alpha1/testdata/cluster_valid_taints_multiple_worker_node_groups.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_valid_taints_multiple_worker_node_groups.yaml
@@ -1,0 +1,92 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: VSphereMachineConfig
+  kubernetesVersion: "1.19"
+  workerNodeGroupConfigurations:
+    - count: 3
+      machineGroupRef:
+        name: eksa-unit-test-2
+        kind: VSphereMachineConfig
+      name: "md-0"
+      taints:
+        - key: key1
+          value: val1
+          effect: NoSchedule
+    - count: 3
+      machineGroupRef:
+        name: eksa-unit-test-2
+        kind: VSphereMachineConfig
+      name: "md-1"
+      taints:
+        - key: key1
+          value: val1
+          effect: PreferNoSchedule
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  diskGiB: 25
+  datastore: "myDatastore"
+  folder: "myFolder"
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: "ubuntu"
+  resourcePool: "myResourcePool"
+  storagePolicyName: "myStoragePolicyName"
+  template: "myTemplate"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test-2
+spec:
+  diskGiB: 20
+  datastore: "myDatastore2"
+  folder: "myFolder2"
+  memoryMiB: 2048
+  numCPUs: 4
+  osFamily: "bottlerocket"
+  resourcePool: "myResourcePool2"
+  storagePolicyName: "myStoragePolicyName2"
+  template: "myTemplate2"
+  users:
+    - name: "mySshUsername2"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey2"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  datacenter: "myDatacenter"
+  network: "myNetwork"
+  server: "myServer"
+  thumbprint: "myTlsThumbprint"
+  insecure: false

--- a/pkg/providers/docker/docker_test.go
+++ b/pkg/providers/docker/docker_test.go
@@ -174,7 +174,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 			wantMDFile: "testdata/valid_deployment_md_taints_expected.yaml",
 		},
 		{
-			testName: "valid config multiple wngc with md taints",
+			testName: "valid config multiple worker node groups with machine deplyoment taints",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.Name = "test-cluster"
 				s.Spec.KubernetesVersion = "1.19"

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -21,18 +21,6 @@ func ValidateTaintsSupport(clusterSpec *cluster.Spec) error {
 			wngcTaintsPresent {
 			return fmt.Errorf("Taints feature is not enabled. Please set the env variable TAINTS_SUPPORT.")
 		}
-	} else if len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Taints) > 0 {
-		invalidWorkerNodeGroupTaints := false
-		for _, slice := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Taints {
-			if slice.Effect == "NoExecute" || slice.Effect == "NoSchedule" {
-				invalidWorkerNodeGroupTaints = true
-				break
-			}
-		}
-
-		if invalidWorkerNodeGroupTaints {
-			return fmt.Errorf("The first worker node group does not support NoExecute or NoSchedule taints.")
-		}
 	}
 	return nil
 }

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -9,16 +9,16 @@ import (
 
 func ValidateTaintsSupport(clusterSpec *cluster.Spec) error {
 	if !features.IsActive(features.TaintsSupport()) {
-		wngcTaintsPresent := false
-		for _, wngc := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
-			if len(wngc.Taints) > 0 {
-				wngcTaintsPresent = true
+		workerNodeGroupTaintsPresent := false
+		for _, nodeGroup := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
+			if len(nodeGroup.Taints) > 0 {
+				workerNodeGroupTaintsPresent = true
 				break
 			}
 		}
 
 		if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints) > 0 ||
-			wngcTaintsPresent {
+			workerNodeGroupTaintsPresent {
 			return fmt.Errorf("Taints feature is not enabled. Please set the env variable TAINTS_SUPPORT.")
 		}
 	}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/commit/cbf03fd2a76be81076724321f31b15ecbf50c07f
https://github.com/aws/eks-anywhere/commit/71b969705dd2ef8275ffc4a3e54f61b4bd61f2c4
https://github.com/aws/eks-anywhere/commit/249cf6c62f4eec888220877aa7c80fa85bb7c5c3

*Description of changes:*
Backport three ancillary cleanup commits pertaining to the taints support to release-0.7

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

