### PR TITLE
Add snow provider to generate clusterconfig command

### DIFF
--- a/cmd/eksctl-anywhere/cmd/generateclusterconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generateclusterconfig.go
@@ -123,8 +123,8 @@ func generateClusterConfig(clusterName string) error {
 		datacenterConfig := v1alpha1.NewSnowDatacenterConfigGenerate(clusterName)
 		clusterConfigOpts = append(clusterConfigOpts, v1alpha1.WithDatacenterRef(datacenterConfig))
 		clusterConfigOpts = append(clusterConfigOpts,
-			v1alpha1.ControlPlaneConfigCount(2),
-			v1alpha1.WorkerNodeConfigCount(2),
+			v1alpha1.ControlPlaneConfigCount(3),
+			v1alpha1.WorkerNodeConfigCount(3),
 			v1alpha1.WorkerNodeConfigName(constants.DefaultWorkerNodeGroupName),
 		)
 		dcyaml, err := yaml.Marshal(datacenterConfig)

--- a/pkg/api/v1alpha1/snowdatacenterconfig.go
+++ b/pkg/api/v1alpha1/snowdatacenterconfig.go
@@ -1,0 +1,42 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const SnowDatacenterKind = "SnowDatacenterConfig"
+
+// Used for generating yaml for generate clusterconfig command
+func NewSnowDatacenterConfigGenerate(clusterName string) *SnowDatacenterConfigGenerate {
+	return &SnowDatacenterConfigGenerate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       SnowDatacenterKind,
+			APIVersion: SchemeBuilder.GroupVersion.String(),
+		},
+		ObjectMeta: ObjectMeta{
+			Name: clusterName,
+		},
+		Spec: SnowDatacenterConfigSpec{},
+	}
+}
+
+func (s *SnowDatacenterConfigGenerate) APIVersion() string {
+	return s.TypeMeta.APIVersion
+}
+
+func (s *SnowDatacenterConfigGenerate) Kind() string {
+	return s.TypeMeta.Kind
+}
+
+func (s *SnowDatacenterConfigGenerate) Name() string {
+	return s.ObjectMeta.Name
+}
+
+func GetSnowDatacenterConfig(fileName string) (*SnowDatacenterConfig, error) {
+	var clusterConfig SnowDatacenterConfig
+	err := ParseClusterConfig(fileName, &clusterConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &clusterConfig, nil
+}

--- a/pkg/api/v1alpha1/snowdatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/snowdatacenterconfig_types.go
@@ -19,3 +19,21 @@ type SnowDatacenterConfig struct {
 	Spec   SnowDatacenterConfigSpec   `json:"spec,omitempty"`
 	Status SnowDatacenterConfigStatus `json:"status,omitempty"`
 }
+
+func (s *SnowDatacenterConfig) Kind() string {
+	return s.TypeMeta.Kind
+}
+
+func (s *SnowDatacenterConfig) ExpectedKind() string {
+	return VSphereDatacenterKind
+}
+
+// +kubebuilder:object:generate=false
+
+// Same as SnowDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig
+type SnowDatacenterConfigGenerate struct {
+	metav1.TypeMeta `json:",inline"`
+	ObjectMeta      `json:"metadata,omitempty"`
+
+	Spec SnowDatacenterConfigSpec `json:"spec,omitempty"`
+}

--- a/pkg/api/v1alpha1/snowmachineconfig.go
+++ b/pkg/api/v1alpha1/snowmachineconfig.go
@@ -4,7 +4,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 const (
 	SnowMachineConfigKind   = "SnowMachineConfig"
-	DefaultSnowInstanceType = "sbe-c.xlarge"
+	DefaultSnowInstanceType = "sbe-c.large"
 	DefaultSnowSshKeyName   = "default"
 )
 

--- a/pkg/api/v1alpha1/snowmachineconfig.go
+++ b/pkg/api/v1alpha1/snowmachineconfig.go
@@ -1,0 +1,39 @@
+package v1alpha1
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+const (
+	SnowMachineConfigKind   = "SnowMachineConfig"
+	DefaultSnowInstanceType = "sbe-c.xlarge"
+	DefaultSnowSshKeyName   = "default"
+)
+
+// Used for generating yaml for generate clusterconfig command
+func NewSnowMachineConfigGenerate(name string) *SnowMachineConfigGenerate {
+	return &SnowMachineConfigGenerate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       SnowMachineConfigKind,
+			APIVersion: SchemeBuilder.GroupVersion.String(),
+		},
+		ObjectMeta: ObjectMeta{
+			Name: name,
+		},
+		Spec: SnowMachineConfigSpec{
+			AMIID:        "",
+			InstanceType: DefaultSnowInstanceType,
+			SshKeyName:   DefaultSnowSshKeyName,
+		},
+	}
+}
+
+func (s *SnowMachineConfigGenerate) APIVersion() string {
+	return s.TypeMeta.APIVersion
+}
+
+func (s *SnowMachineConfigGenerate) Kind() string {
+	return s.TypeMeta.Kind
+}
+
+func (s *SnowMachineConfigGenerate) Name() string {
+	return s.ObjectMeta.Name
+}

--- a/pkg/api/v1alpha1/snowmachineconfig_types.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_types.go
@@ -33,3 +33,13 @@ type SnowMachineConfig struct {
 	Spec   SnowMachineConfigSpec   `json:"spec,omitempty"`
 	Status SnowMachineConfigStatus `json:"status,omitempty"`
 }
+
+// +kubebuilder:object:generate=false
+
+// Same as SnowMachineConfig except stripped down for generation of yaml file during generate clusterconfig
+type SnowMachineConfigGenerate struct {
+	metav1.TypeMeta `json:",inline"`
+	ObjectMeta      `json:"metadata,omitempty"`
+
+	Spec SnowMachineConfigSpec `json:"spec,omitempty"`
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -27,6 +27,7 @@ const (
 	VSphereProviderName    = "vsphere"
 	DockerProviderName     = "docker"
 	AWSProviderName        = "aws"
+	SnowProviderName       = "snow"
 	TinkerbellProviderName = "tinkerbell"
 	CloudStackProviderName = "cloudstack"
 


### PR DESCRIPTION
*Issue #, if available:*

#1105 

*Description of changes:*

Add Snow provider to `generate clusterconfig` command.
- skipped unstacked etcd when generating default template (will add back after testing out)
- add recommended `instanceType` and `sshKeyName`

*Testing (if applicable):*

Ran `eksctl-anywhere generate clusterconfig test-snow -p snow`

```yaml
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: Cluster
metadata:
  name: test-snow
spec:
  clusterNetwork:
    cni: cilium
    pods:
      cidrBlocks:
      - 192.168.0.0/16
    services:
      cidrBlocks:
      - 10.96.0.0/12
  controlPlaneConfiguration:
    count: 3
    endpoint:
      host: ""
    machineGroupRef:
      kind: SnowMachineConfig
      name: test-snow-cp
  datacenterRef:
    kind: SnowDatacenterConfig
    name: test-snow
  kubernetesVersion: "1.21"
  managementCluster:
    name: test-snow
  workerNodeGroupConfigurations:
  - count: 3
    machineGroupRef:
      kind: SnowMachineConfig
      name: test-snow
    name: md-0

---
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: SnowDatacenterConfig
metadata:
  name: test-snow
spec: {}

---
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: SnowMachineConfig
metadata:
  name: test-snow-cp
spec:
  amiID: ""
  instanceType: sbe-c.xlarge
  sshKeyName: default

---
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: SnowMachineConfig
metadata:
  name: test-snow
spec:
  amiID: ""
  instanceType: sbe-c.large
  sshKeyName: default

---
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

