### PR TITLE
Add e2e tests for labels upgrade

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -70,6 +70,15 @@ func WithControlPlaneTaints(taints []corev1.Taint) ClusterFiller {
 	}
 }
 
+func WithControlPlaneLabel(key string, val string) ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		if c.Spec.ControlPlaneConfiguration.Labels == nil {
+			c.Spec.ControlPlaneConfiguration.Labels = map[string]string{}
+		}
+		c.Spec.ControlPlaneConfiguration.Labels[key] = val
+	}
+}
+
 func WithPodCidr(podCidr string) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		c.Spec.ClusterNetwork.Pods.CidrBlocks = []string{podCidr}

--- a/internal/pkg/api/nodegroups.go
+++ b/internal/pkg/api/nodegroups.go
@@ -28,6 +28,9 @@ func WithNoTaints() WorkerNodeGroupFiller {
 
 func WithLabel(key, value string) WorkerNodeGroupFiller {
 	return func(w *anywherev1.WorkerNodeGroupConfiguration) {
+		if w.Labels == nil {
+			w.Labels = map[string]string{}
+		}
 		w.Labels[key] = value
 	}
 }

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/yaml"
 
 	"github.com/aws/eks-anywhere/pkg/crypto"
@@ -172,6 +174,7 @@ var clusterConfigValidations = []func(*Cluster) error{
 	validateProxyConfig,
 	validateMirrorConfig,
 	validatePodIAMConfig,
+	validateControlPlaneLabels,
 }
 
 // GetClusterConfig parses a Cluster object from a multiobject yaml file in disk
@@ -336,6 +339,13 @@ func validateControlPlaneReplicas(clusterConfig *Cluster) error {
 	return nil
 }
 
+func validateControlPlaneLabels(clusterConfig *Cluster) error {
+	if err := validateNodeLabels(clusterConfig.Spec.ControlPlaneConfiguration.Labels, field.NewPath("spec", "controlPlaneConfiguration", "labels")); err != nil {
+		return fmt.Errorf("labels for control plane not valid: %v", err)
+	}
+	return nil
+}
+
 func validateWorkerNodeGroups(clusterConfig *Cluster) error {
 	workerNodeGroupConfigs := clusterConfig.Spec.WorkerNodeGroupConfigurations
 	if len(workerNodeGroupConfigs) <= 0 {
@@ -343,7 +353,7 @@ func validateWorkerNodeGroups(clusterConfig *Cluster) error {
 	}
 	workerNodeGroupNames := make(map[string]bool, len(workerNodeGroupConfigs))
 	noExecuteNoScheduleTaintedNodeGroups := make(map[string]struct{})
-	for _, workerNodeGroupConfig := range workerNodeGroupConfigs {
+	for i, workerNodeGroupConfig := range workerNodeGroupConfigs {
 		if workerNodeGroupConfig.Name == "" {
 			return errors.New("must specify name for worker nodes")
 		}
@@ -357,10 +367,22 @@ func validateWorkerNodeGroups(clusterConfig *Cluster) error {
 				}
 			}
 		}
+		workerNodeGroupField := fmt.Sprintf("workerNodeGroupConfigurations[%d]", i)
+		if err := validateNodeLabels(workerNodeGroupConfig.Labels, field.NewPath("spec", workerNodeGroupField, "labels")); err != nil {
+			return fmt.Errorf("labels for worker node group %v not valid: %v", workerNodeGroupConfig.Name, err)
+		}
 		workerNodeGroupNames[workerNodeGroupConfig.Name] = true
 	}
 	if len(noExecuteNoScheduleTaintedNodeGroups) == len(workerNodeGroupConfigs) {
 		return errors.New("at least one WorkerNodeGroupConfiguration must not have NoExecute and/or NoSchedule taints")
+	}
+	return nil
+}
+
+func validateNodeLabels(labels map[string]string, fldPath *field.Path) error {
+	errList := validation.ValidateLabels(labels, fldPath)
+	if len(errList) != 0 {
+		return fmt.Errorf("found following errors with labels: %v", errList.ToAggregate().Error())
 	}
 	return nil
 }

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -69,11 +69,27 @@ func (r *Cluster) ValidateUpdate(old runtime.Object) error {
 
 	allErrs = append(allErrs, validateImmutableFieldsCluster(r, oldCluster)...)
 
-	if len(allErrs) == 0 {
-		return nil
+	if len(allErrs) != 0 {
+		return apierrors.NewInvalid(GroupVersion.WithKind(ClusterKind).GroupKind(), r.Name, allErrs)
 	}
 
-	return apierrors.NewInvalid(GroupVersion.WithKind(ClusterKind).GroupKind(), r.Name, allErrs)
+	// Test for both taints and labels
+	if err := validateWorkerNodeGroups(r); err != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "workerNodeGroupConfigurations"), r.Spec.WorkerNodeGroupConfigurations, err.Error()))
+	}
+
+	// Control plane configuration is mutable if workload cluster
+	if !r.IsSelfManaged() {
+		if err := validateControlPlaneLabels(r); err != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "controlPlaneConfiguration", "labels"), r.Spec, err.Error()))
+		}
+	}
+
+	if len(allErrs) != 0 {
+		return apierrors.NewInvalid(GroupVersion.WithKind(ClusterKind).GroupKind(), r.Name, allErrs)
+	}
+
+	return nil
 }
 
 func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -23,7 +23,13 @@ func TestClusterValidateUpdateManagementValueImmutable(t *testing.T) {
 }
 
 func TestClusterValidateUpdateManagementOldNilNewTrueSuccess(t *testing.T) {
-	cOld := &v1alpha1.Cluster{}
+	cOld := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
+		},
+	}
 	c := cOld.DeepCopy()
 	c.SetSelfManaged()
 
@@ -42,7 +48,11 @@ func TestClusterValidateUpdateManagementOldNilNewFalseImmutable(t *testing.T) {
 
 func TestClusterValidateUpdateManagementBothNilImmutable(t *testing.T) {
 	cOld := &v1alpha1.Cluster{
-		Spec: v1alpha1.ClusterSpec{},
+		Spec: v1alpha1.ClusterSpec{
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
+		},
 	}
 	c := cOld.DeepCopy()
 
@@ -93,6 +103,9 @@ func TestWorkloadClusterValidateUpdateKubernetesVersionSuccess(t *testing.T) {
 			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
 				Count: 3, Endpoint: &v1alpha1.Endpoint{Host: "1.1.1.1/1"},
 			},
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
 		},
 	}
 	cOld.SetManagedBy("management-cluster")
@@ -112,6 +125,9 @@ func TestManagementClusterValidateUpdateControlPlaneConfigurationEqual(t *testin
 				Endpoint:        &v1alpha1.Endpoint{Host: "1.1.1.1/1"},
 				MachineGroupRef: &v1alpha1.Ref{Name: "test", Kind: "MachineConfig"},
 			},
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
 		},
 	}
 	cOld.SetSelfManaged()
@@ -135,6 +151,9 @@ func TestWorkloadClusterValidateUpdateControlPlaneConfigurationEqual(t *testing.
 				Endpoint:        &v1alpha1.Endpoint{Host: "1.1.1.1/1"},
 				MachineGroupRef: &v1alpha1.Ref{Name: "test", Kind: "MachineConfig"},
 			},
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
 		},
 	}
 	cOld.SetManagedBy("management-cluster")
@@ -299,6 +318,9 @@ func TestWorkloadClusterValidateUpdateControlPlaneConfigurationMachineGroupRef(t
 			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
 				MachineGroupRef: &v1alpha1.Ref{Name: "test1", Kind: "MachineConfig"},
 			},
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
 		},
 	}
 	cOld.SetManagedBy("management-cluster")
@@ -337,6 +359,9 @@ func TestWorkloadClusterValidateUpdateControlPlaneConfigurationOldMachineGroupRe
 			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
 				MachineGroupRef: nil,
 			},
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
 		},
 	}
 	cOld.SetManagedBy("management-cluster")
@@ -375,6 +400,9 @@ func TestWorkloadClusterValidateUpdateControlPlaneConfigurationNewMachineGroupRe
 			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
 				MachineGroupRef: &v1alpha1.Ref{Name: "test", Kind: "MachineConfig"},
 			},
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
 		},
 	}
 	cOld.SetManagedBy("management-cluster")
@@ -394,6 +422,9 @@ func TestClusterValidateUpdateDatacenterRefImmutableEqual(t *testing.T) {
 			DatacenterRef: v1alpha1.Ref{
 				Name: "test", Kind: "DatacenterConfig",
 			},
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
 		},
 	}
 	c := cOld.DeepCopy()
@@ -514,6 +545,9 @@ func TestClusterValidateUpdateClusterNetworkEqualOrder(t *testing.T) {
 					CidrBlocks: []string{"1.2.3.4/7", "1.2.3.4/8"},
 				},
 			},
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
 		},
 	}
 	c := cOld.DeepCopy()
@@ -606,6 +640,9 @@ func TestClusterValidateUpdateProxyConfigurationEqualOrder(t *testing.T) {
 					"noproxy2",
 				},
 			},
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
 		},
 	}
 
@@ -619,6 +656,9 @@ func TestClusterValidateUpdateProxyConfigurationEqualOrder(t *testing.T) {
 					"noproxy1",
 				},
 			},
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
 		},
 	}
 
@@ -702,6 +742,9 @@ func TestClusterValidateUpdateGitOpsRefImmutableNilEqual(t *testing.T) {
 	cOld := &v1alpha1.Cluster{
 		Spec: v1alpha1.ClusterSpec{
 			GitOpsRef: nil,
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
 		},
 	}
 	c := cOld.DeepCopy()
@@ -794,6 +837,9 @@ func TestClusterValidateUpdateIdentityProviderRefsImmutableEqualOrder(t *testing
 					Name: "name2",
 				},
 			},
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
 		},
 	}
 	c := &v1alpha1.Cluster{
@@ -808,6 +854,9 @@ func TestClusterValidateUpdateIdentityProviderRefsImmutableEqualOrder(t *testing
 					Name: "name1",
 				},
 			},
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
 		},
 	}
 
@@ -913,6 +962,9 @@ func TestClusterValidateUpdateWithPausedAnnotation(t *testing.T) {
 		},
 		Spec: v1alpha1.ClusterSpec{
 			KubernetesVersion: v1alpha1.Kube119,
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
 		},
 	}
 	cOld.PauseReconcile()
@@ -932,7 +984,7 @@ func TestClusterValidateUpdateInvalidType(t *testing.T) {
 }
 
 func TestClusterValidateUpdateSuccess(t *testing.T) {
-	workerConfiguration := append([]v1alpha1.WorkerNodeGroupConfiguration{}, v1alpha1.WorkerNodeGroupConfiguration{Count: 5})
+	workerConfiguration := append([]v1alpha1.WorkerNodeGroupConfiguration{}, v1alpha1.WorkerNodeGroupConfiguration{Count: 5, Name: "test"})
 	cOld := &v1alpha1.Cluster{
 		Spec: v1alpha1.ClusterSpec{
 			WorkerNodeGroupConfigurations: workerConfiguration,
@@ -987,4 +1039,129 @@ func TestClusterCreateWorkloadCluster(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(cluster.ValidateCreate()).To(Succeed())
 	os.Unsetenv("FULL_LIFECYCLE_API")
+}
+
+func TestClusterUpdateWorkerNodeGroupTaintsAndLabelsSuccess(t *testing.T) {
+	cOld := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+				Taints: []v1.Taint{{
+					Key:    "test",
+					Value:  "test",
+					Effect: "PreferNoSchedule",
+				}},
+				Labels: map[string]string{
+					"test": "val1",
+				},
+			}},
+		},
+	}
+	c := cOld.DeepCopy()
+	c.Spec.WorkerNodeGroupConfigurations[0].Taints[0].Value = "test2"
+	c.Spec.WorkerNodeGroupConfigurations[0].Labels["test"] = "val2"
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(cOld)).To(Succeed())
+}
+
+func TestClusterUpdateWorkerNodeGroupTaintsInvalid(t *testing.T) {
+	cOld := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+				Taints: []v1.Taint{{
+					Key:    "test",
+					Value:  "test",
+					Effect: "PreferNoSchedule",
+				}},
+			}},
+		},
+	}
+	c := cOld.DeepCopy()
+	c.Spec.WorkerNodeGroupConfigurations[0].Taints[0].Effect = "NoSchedule"
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(cOld)).NotTo(Succeed())
+}
+
+func TestClusterUpdateWorkerNodeGroupNameInvalid(t *testing.T) {
+	cOld := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
+		},
+	}
+	c := cOld.DeepCopy()
+	c.Spec.WorkerNodeGroupConfigurations[0].Name = ""
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(cOld)).NotTo(Succeed())
+}
+
+func TestClusterUpdateWorkerNodeGroupLabelsInvalid(t *testing.T) {
+	cOld := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+				Labels: map[string]string{
+					"test": "val1",
+				},
+			}},
+		},
+	}
+	c := cOld.DeepCopy()
+	c.Spec.WorkerNodeGroupConfigurations[0].Labels["test"] = "val1/val2"
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(cOld)).NotTo(Succeed())
+}
+
+func TestClusterUpdateControlPlaneTaintsAndLabelsSuccess(t *testing.T) {
+	cOld := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
+				Taints: []v1.Taint{{
+					Key:    "test",
+					Value:  "test",
+					Effect: "PreferNoSchedule",
+				}},
+				Labels: map[string]string{
+					"test": "val1",
+				},
+			},
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
+		},
+	}
+	cOld.SetManagedBy("management-cluster")
+	c := cOld.DeepCopy()
+	c.Spec.ControlPlaneConfiguration.Taints[0].Value = "test2"
+	c.Spec.ControlPlaneConfiguration.Labels["test"] = "val2"
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(cOld)).To(Succeed())
+}
+
+func TestClusterUpdateControlPlaneLabelsInvalid(t *testing.T) {
+	cOld := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
+				Labels: map[string]string{
+					"test": "val1",
+				},
+			},
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
+				Name: "test",
+			}},
+		},
+	}
+	cOld.SetManagedBy("management-cluster")
+	c := cOld.DeepCopy()
+	c.Spec.ControlPlaneConfiguration.Labels["test"] = "val1/val2"
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(cOld)).NotTo(Succeed())
 }

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -1,0 +1,7 @@
+// +build e2e
+
+package e2e
+
+const worker0 = "worker-0"
+const worker1 = "worker-1"
+const worker2 = "worker-2"

--- a/test/e2e/labels_test.go
+++ b/test/e2e/labels_test.go
@@ -1,0 +1,127 @@
+// +build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/test/framework"
+)
+
+const (
+	key1   = framework.LabelPrefix + "/" + "key1"
+	key2   = framework.LabelPrefix + "/" + "key2"
+	cpKey1 = framework.LabelPrefix + "/" + "cp-key1"
+	val1   = "val1"
+	val2   = "val2"
+	cpVal1 = "cp-val1"
+)
+
+func runLabelsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
+	test.GenerateClusterConfig()
+	test.CreateCluster()
+	test.ValidateWorkerNodes(framework.ValidateWorkerNodeLabels)
+	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneLabels)
+	test.UpgradeCluster(clusterOpts)
+	test.ValidateCluster(updateVersion)
+	test.ValidateWorkerNodes(framework.ValidateWorkerNodeLabels)
+	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneLabels)
+	test.StopIfFailed()
+	test.DeleteCluster()
+}
+
+func TestVSphereKubernetes121Labels(t *testing.T) {
+	provider := ubuntu121ProviderWithLabels(t)
+
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube121),
+			api.WithExternalEtcdTopology(1),
+			api.WithControlPlaneCount(1),
+			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+		),
+		framework.WithEnvVar("NODE_LABELS_SUPPORT", "true"),
+	)
+
+	runLabelsUpgradeFlow(
+		test,
+		v1alpha1.Kube121,
+		framework.WithClusterUpgrade(
+			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+			api.WithWorkerNodeGroup(worker2),
+			api.WithControlPlaneLabel(cpKey1, cpVal1),
+		),
+	)
+}
+
+func TestVSphereKubernetes121LabelsBottlerocket(t *testing.T) {
+	provider := bottlerocket121ProviderWithLabels(t)
+
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube121),
+			api.WithExternalEtcdTopology(1),
+			api.WithControlPlaneCount(1),
+			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+		),
+		framework.WithEnvVar("NODE_LABELS_SUPPORT", "true"),
+	)
+
+	runLabelsUpgradeFlow(
+		test,
+		v1alpha1.Kube121,
+		framework.WithClusterUpgrade(
+			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+			api.WithWorkerNodeGroup(worker2),
+			api.WithControlPlaneLabel(cpKey1, cpVal1),
+		),
+	)
+}
+
+func ubuntu121ProviderWithLabels(t *testing.T) *framework.VSphere {
+	return framework.NewVSphere(t,
+		framework.WithVSphereWorkerNodeGroup(
+			worker0,
+			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
+				api.WithLabel(key1, val2)),
+		),
+		framework.WithVSphereWorkerNodeGroup(
+			worker1,
+			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+		),
+		framework.WithVSphereWorkerNodeGroup(
+			worker2,
+			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
+				api.WithLabel(key2, val2)),
+		),
+		framework.WithUbuntu121(),
+	)
+}
+
+func bottlerocket121ProviderWithLabels(t *testing.T) *framework.VSphere {
+	return framework.NewVSphere(t,
+		framework.WithVSphereWorkerNodeGroup(
+			worker0,
+			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
+				api.WithLabel(key1, val2)),
+		),
+		framework.WithVSphereWorkerNodeGroup(
+			worker1,
+			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+		),
+		framework.WithVSphereWorkerNodeGroup(
+			worker2,
+			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
+				api.WithLabel(key2, val2)),
+		),
+		framework.WithBottleRocket121(),
+	)
+}

--- a/test/e2e/taints_test.go
+++ b/test/e2e/taints_test.go
@@ -12,10 +12,6 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-const worker0 = "worker-0"
-const worker1 = "worker-1"
-const worker2 = "worker-2"
-
 func runTaintsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
@@ -85,7 +81,6 @@ func TestVSphereKubernetes121TaintsBottlerocket(t *testing.T) {
 		),
 	)
 }
-
 
 func ubuntu121ProviderWithTaints(t *testing.T) *framework.VSphere {
 	return framework.NewVSphere(t,

--- a/test/framework/labels.go
+++ b/test/framework/labels.go
@@ -1,0 +1,46 @@
+package framework
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/logger"
+)
+
+const LabelPrefix = "eksa.e2e"
+
+func ValidateControlPlaneLabels(controlPlane v1alpha1.ControlPlaneConfiguration, node corev1.Node) error {
+	logger.V(4).Info("Validating control plane labels")
+	return validateLabels(controlPlane.Labels, node)
+}
+
+func ValidateWorkerNodeLabels(w v1alpha1.WorkerNodeGroupConfiguration, node corev1.Node) error {
+	logger.V(4).Info("Validating worker node labels", "worker node group", w.Name)
+	return validateLabels(w.Labels, node)
+}
+
+func validateLabels(expectedLabels map[string]string, node corev1.Node) error {
+	actualLabels := retrieveTestNodeLabels(node.Labels)
+	expectedBytes, _ := json.Marshal(expectedLabels)
+	actualBytes, _ := json.Marshal(actualLabels)
+	if !v1alpha1.LabelsMapEqual(expectedLabels, actualLabels) {
+		return fmt.Errorf("labels on node %v and corresponding configuration do not match; configured labels: %v; node labels: %v",
+			node.Name, string(expectedBytes), string(actualBytes))
+	}
+	logger.V(4).Info("expected labels from cluster spec configuration are present on the corresponding node", "node", node.Name, "node labels", string(actualBytes), "configuration labels", string(expectedBytes))
+	return nil
+}
+
+func retrieveTestNodeLabels(nodeLabels map[string]string) map[string]string {
+	labels := map[string]string{}
+	for key, val := range nodeLabels {
+		if strings.HasPrefix(key, LabelPrefix) {
+			labels[key] = val
+		}
+	}
+	return labels
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/1053

*Description of changes:*

Adding end to end tests for labels. With these changes, I am also bringing in some cluster validations we have for `create cluster` for the webhook. 

*Testing (if applicable):*

Ran e2e tests with these changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

