### PR TITLE
Define assertion functioins as helpers.

### DIFF
--- a/internal/test/files.go
+++ b/internal/test/files.go
@@ -16,6 +16,7 @@ import (
 var updateGoldenFiles = flag.Bool("update", false, "update golden files")
 
 func AssertFilesEquals(t *testing.T, gotPath, wantPath string) {
+	t.Helper()
 	gotFile := ReadFile(t, gotPath)
 	processUpdate(t, wantPath, gotFile)
 	wantFile := ReadFile(t, wantPath)
@@ -35,6 +36,7 @@ func AssertFilesEquals(t *testing.T, gotPath, wantPath string) {
 }
 
 func AssertContentToFile(t *testing.T, gotContent, wantFile string) {
+	t.Helper()
 	if wantFile == "" && gotContent == "" {
 		return
 	}


### PR DESCRIPTION
Assertion funcs called by test funcs add to the call stack creating
incorrect assertion reporting. Declaring an assertion function as a
helper ensure the assertion function is skipped when inspecting the call
stack.