### PR TITLE
Backport taints tests

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -60,6 +61,12 @@ func WithControlPlaneCount(r int) ClusterFiller {
 func WithControlPlaneEndpointIP(value string) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		c.Spec.ControlPlaneConfiguration.Endpoint.Host = value
+	}
+}
+
+func WithControlPlaneTaints(taints []corev1.Taint) ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		c.Spec.ControlPlaneConfiguration.Taints = taints
 	}
 }
 

--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -175,12 +175,14 @@ func WithWorkerNodeGroup(name string, fillers ...WorkerNodeGroupFiller) ClusterF
 		position := -1
 		for i, w := range c.Spec.WorkerNodeGroupConfigurations {
 			if w.Name == name {
+				logger.Info("Updating worker node group", "name", name)
 				nodeGroup = &w
 				position = i
 			}
 		}
 
 		if nodeGroup == nil {
+			logger.Info("Adding worker node group", "name", name)
 			nodeGroup = &anywherev1.WorkerNodeGroupConfiguration{Name: name}
 			c.Spec.WorkerNodeGroupConfigurations = append(c.Spec.WorkerNodeGroupConfigurations, *nodeGroup)
 			position = len(c.Spec.WorkerNodeGroupConfigurations) - 1

--- a/internal/pkg/api/nodegroups.go
+++ b/internal/pkg/api/nodegroups.go
@@ -20,6 +20,12 @@ func WithTaint(taint corev1.Taint) WorkerNodeGroupFiller {
 	}
 }
 
+func WithNoTaints() WorkerNodeGroupFiller {
+	return func(w *anywherev1.WorkerNodeGroupConfiguration) {
+		w.Taints = nil
+	}
+}
+
 func WithLabel(key, value string) WorkerNodeGroupFiller {
 	return func(w *anywherev1.WorkerNodeGroupConfiguration) {
 		w.Labels[key] = value

--- a/pkg/awsiamauth/awsiamauth.go
+++ b/pkg/awsiamauth/awsiamauth.go
@@ -46,13 +46,18 @@ func NewAwsIamAuthTemplateBuilder() *AwsIamAuthTemplateBuilder {
 }
 
 func (a *AwsIamAuthTemplateBuilder) GenerateManifest(clusterSpec *cluster.Spec, clusterId uuid.UUID) ([]byte, error) {
-	data := map[string]string{
+	data := map[string]interface{}{
 		"image":       clusterSpec.VersionsBundle.KubeDistro.AwsIamAuthIamge.VersionedImage(),
 		"awsRegion":   clusterSpec.AWSIamConfig.Spec.AWSRegion,
 		"clusterID":   clusterId.String(),
 		"backendMode": strings.Join(clusterSpec.AWSIamConfig.Spec.BackendMode, ","),
 		"partition":   clusterSpec.AWSIamConfig.Spec.Partition,
 	}
+
+	if clusterSpec.Spec.ControlPlaneConfiguration.Taints != nil {
+		data["controlPlaneTaints"] = clusterSpec.Spec.ControlPlaneConfiguration.Taints
+	}
+
 	mapRoles, err := a.mapRolesToYaml(clusterSpec.AWSIamConfig.Spec.MapRoles)
 	if err != nil {
 		return nil, fmt.Errorf("error generating aws-iam-authenticator manifest: %v", err)

--- a/pkg/awsiamauth/config/aws-iam-authenticator.yaml
+++ b/pkg/awsiamauth/config/aws-iam-authenticator.yaml
@@ -100,6 +100,16 @@ spec:
         key: node-role.kubernetes.io/master
       - key: CriticalAddonsOnly
         operator: Exists
+{{- if .controlPlaneTaints }}
+{{- range .controlPlaneTaints }}
+      - key: {{ .Key }}
+        value: {{ .Value }}
+        effect: {{ .Effect }}
+{{- if .TimeAdded }}
+        timeAdded: {{ .TimeAdded }}
+{{- end }}
+{{- end }}
+{{- end }}
 
       # `aws-iam-authenticator server` has four volumes
       # - config (mounted from the ConfigMap at /etc/aws-iam-authenticator/config.yaml)

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	addons "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -293,6 +294,18 @@ func (k *Kubectl) ListCluster(ctx context.Context) error {
 	return nil
 }
 
+func (k *Kubectl) GetNodes(ctx context.Context, kubeconfig string) ([]corev1.Node, error) {
+	params := []string{"get", "nodes", "-o", "json", "--kubeconfig", kubeconfig}
+	stdOut, err := k.Execute(ctx, params...)
+	if err != nil {
+		return nil, fmt.Errorf("error getting nodes: %v", err)
+	}
+	response := &corev1.NodeList{}
+	err = json.Unmarshal(stdOut.Bytes(), response)
+
+	return response.Items, err
+}
+
 func (k *Kubectl) ValidateNodes(ctx context.Context, kubeconfig string) error {
 	template := "{{range .items}}{{.metadata.name}}\n{{end}}"
 	params := []string{"get", "nodes", "-o", "go-template", "--template", template, "--kubeconfig", kubeconfig}
@@ -478,6 +491,31 @@ func (k *Kubectl) GetMachines(ctx context.Context, cluster *types.Cluster, clust
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing get machines response: %v", err)
+	}
+
+	return response.Items, nil
+}
+
+type machineSetResponse struct {
+	Items []clusterv1.MachineSet `json:"items,omitempty"`
+}
+
+func (k *Kubectl) GetMachineSets(ctx context.Context, machineDeploymentName string, cluster *types.Cluster) ([]clusterv1.MachineSet, error) {
+	params := []string{
+		"get", "machinesets", "-o", "json", "--kubeconfig", cluster.KubeconfigFile,
+		"--selector=cluster.x-k8s.io/deployment-name=" + machineDeploymentName,
+		"--namespace", constants.EksaSystemNamespace,
+	}
+
+	stdOut, err := k.Execute(ctx, params...)
+	if err != nil {
+		return nil, fmt.Errorf("error getting machineset associated with deployment %s: %v", machineDeploymentName, err)
+	}
+
+	response := &machineSetResponse{}
+	err = json.Unmarshal(stdOut.Bytes(), response)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing get machinesets response: %v", err)
 	}
 
 	return response.Items, nil
@@ -738,6 +776,23 @@ func (k *Kubectl) GetMachineDeployments(ctx context.Context, opts ...KubectlOpt)
 	}
 
 	return response.Items, nil
+}
+
+func (k *Kubectl) GetKubeadmConfigTemplate(ctx context.Context, kubeadmConfigTemplateName string, opts ...KubectlOpt) (*kubeadmv1.KubeadmConfigTemplate, error) {
+	params := []string{"get", fmt.Sprintf("kubeadmconfigtemplate.%s", kubeadmv1.GroupVersion.Group), kubeadmConfigTemplateName, "-o", "json"}
+	applyOpts(&params, opts...)
+	stdOut, err := k.Execute(ctx, params...)
+	if err != nil {
+		return nil, fmt.Errorf("error getting kubeadmconfigtemplate: %v", err)
+	}
+
+	response := &kubeadmv1.KubeadmConfigTemplate{}
+	err = json.Unmarshal(stdOut.Bytes(), response)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing get kubeadmconfigtemplate response: %v", err)
+	}
+
+	return response, nil
 }
 
 func (k *Kubectl) UpdateEnvironmentVariables(ctx context.Context, resourceType, resourceName string, envMap map[string]string, opts ...KubectlOpt) error {

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -973,6 +973,16 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+{{- if .controlPlaneTaints }}
+{{- range .controlPlaneTaints}}
+          - key: {{ .Key }}
+            value: {{ .Value }}
+            effect: {{ .Effect }}
+{{- if .TimeAdded }}
+            timeAdded: {{ .TimeAdded }}
+{{- end }}
+{{- end }}
+{{- end }}
           volumes:
           - name: vsphere-config-volume
             secret:

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -912,6 +912,15 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - key: key1
+            value: val1
+            effect: PreferNoSchedule
+          - key: key2
+            value: val2
+            effect: NoSchedule
+          - key: key3
+            value: val3
+            effect: NoExecute
           volumes:
           - name: vsphere-config-volume
             secret:

--- a/test/e2e/taints_test.go
+++ b/test/e2e/taints_test.go
@@ -46,7 +46,6 @@ func TestVSphereKubernetes121Taints(t *testing.T) {
 			api.WithControlPlaneCount(1),
 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 		),
-		framework.WithEnvVar("TAINTS_SUPPORT", "true"),
 	)
 
 	runTaintsUpgradeFlow(
@@ -73,7 +72,6 @@ func TestVSphereKubernetes121TaintsBottlerocket(t *testing.T) {
 			api.WithControlPlaneCount(1),
 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 		),
-		framework.WithEnvVar("TAINTS_SUPPORT", "true"),
 	)
 
 	runTaintsUpgradeFlow(

--- a/test/e2e/taints_test.go
+++ b/test/e2e/taints_test.go
@@ -1,0 +1,69 @@
+// +build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/test/framework"
+)
+
+func runTaintsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
+	test.GenerateClusterConfig()
+	test.CreateCluster()
+	test.VaidateWorkerNodeTaints()
+	test.UpgradeCluster(clusterOpts)
+	test.ValidateCluster(updateVersion)
+	test.VaidateWorkerNodeTaints()
+	test.StopIfFailed()
+	test.DeleteCluster()
+}
+
+// this test covers the following scenarios:
+// create a node with a taint
+// remove a taint from a node
+// add a taint to a node which already has another taint
+// add a taint to a node which had no taints
+func TestVSphereKubernetes121TaintsWorkerNodeGroups(t *testing.T) {
+	worker0 := "worker-0"
+	worker1 := "worker-1"
+	worker2 := "worker-2"
+
+	provider := framework.NewVSphere(t,
+		framework.WithVSphereWorkerNodeGroup(
+			worker0,
+			framework.NoScheduleWorkerNodeGroup(worker0, 2),
+		),
+		framework.WithVSphereWorkerNodeGroup(
+			worker1,
+			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+		),
+		framework.WithVSphereWorkerNodeGroup(
+			worker2,
+			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
+		),
+		framework.WithUbuntu121(),
+	)
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube121),
+			api.WithExternalEtcdTopology(1),
+			api.WithControlPlaneCount(1),
+			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+		),
+	)
+
+	runTaintsUpgradeFlow(
+		test,
+		v1alpha1.Kube121,
+		framework.WithClusterUpgrade(
+			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+		),
+	)
+}

--- a/test/e2e/taints_test.go
+++ b/test/e2e/taints_test.go
@@ -5,18 +5,26 @@ package e2e
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
+const worker0 = "worker-0"
+const worker1 = "worker-1"
+const worker2 = "worker-2"
+
 func runTaintsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
-	test.VaidateWorkerNodeTaints()
+	test.ValidateWorkerNodes(framework.ValidateWorkerNodeTaints)
+	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneTaints)
 	test.UpgradeCluster(clusterOpts)
 	test.ValidateCluster(updateVersion)
-	test.VaidateWorkerNodeTaints()
+	test.ValidateWorkerNodes(framework.ValidateWorkerNodeTaints)
+	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneTaints)
 	test.StopIfFailed()
 	test.DeleteCluster()
 }
@@ -26,12 +34,63 @@ func runTaintsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1
 // remove a taint from a node
 // add a taint to a node which already has another taint
 // add a taint to a node which had no taints
-func TestVSphereKubernetes121TaintsWorkerNodeGroups(t *testing.T) {
-	worker0 := "worker-0"
-	worker1 := "worker-1"
-	worker2 := "worker-2"
+func TestVSphereKubernetes121Taints(t *testing.T) {
+	provider := ubuntu121ProviderWithTaints(t)
 
-	provider := framework.NewVSphere(t,
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube121),
+			api.WithExternalEtcdTopology(1),
+			api.WithControlPlaneCount(1),
+			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+		),
+		framework.WithEnvVar("TAINTS_SUPPORT", "true"),
+	)
+
+	runTaintsUpgradeFlow(
+		test,
+		v1alpha1.Kube121,
+		framework.WithClusterUpgrade(
+			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+		),
+	)
+}
+
+func TestVSphereKubernetes121TaintsBottlerocket(t *testing.T) {
+	provider := bottlerocket121ProviderWithTaints(t)
+
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube121),
+			api.WithExternalEtcdTopology(1),
+			api.WithControlPlaneCount(1),
+			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+		),
+		framework.WithEnvVar("TAINTS_SUPPORT", "true"),
+	)
+
+	runTaintsUpgradeFlow(
+		test,
+		v1alpha1.Kube121,
+		framework.WithClusterUpgrade(
+			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+		),
+	)
+}
+
+
+func ubuntu121ProviderWithTaints(t *testing.T) *framework.VSphere {
+	return framework.NewVSphere(t,
 		framework.WithVSphereWorkerNodeGroup(
 			worker0,
 			framework.NoScheduleWorkerNodeGroup(worker0, 2),
@@ -46,24 +105,22 @@ func TestVSphereKubernetes121TaintsWorkerNodeGroups(t *testing.T) {
 		),
 		framework.WithUbuntu121(),
 	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube121),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
+}
 
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube121,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+func bottlerocket121ProviderWithTaints(t *testing.T) *framework.VSphere {
+	return framework.NewVSphere(t,
+		framework.WithVSphereWorkerNodeGroup(
+			worker0,
+			framework.NoScheduleWorkerNodeGroup(worker0, 2),
 		),
+		framework.WithVSphereWorkerNodeGroup(
+			worker1,
+			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+		),
+		framework.WithVSphereWorkerNodeGroup(
+			worker2,
+			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
+		),
+		framework.WithBottleRocket121(),
 	)
 }

--- a/test/framework/controlplaneNodes.go
+++ b/test/framework/controlplaneNodes.go
@@ -1,0 +1,39 @@
+package framework
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+// ControlPlaneNodeValidation should return an error if either an error is encountered during execution or the validation logically fails.
+// This validation function will be executed by ValidateControlPlaneNodes with a Control Plane configuration and a corresponding node
+// which was created as a part of that configuration.
+type ControlPlaneNodeValidation func(configuration v1alpha1.ControlPlaneConfiguration, node corev1.Node) (err error)
+
+// ValidateControlPlaneNodes deduces the control plane configuration to node mapping
+// and for each configuration/node pair executes the provided validation functions.
+func (e *ClusterE2ETest) ValidateControlPlaneNodes(validations ...ControlPlaneNodeValidation) {
+	ctx := context.Background()
+	c, err := v1alpha1.GetClusterConfigFromContent(e.ClusterConfigB)
+	if err != nil {
+		e.T.Fatal(err)
+	}
+
+	cpNodes, err := e.KubectlClient.GetControlPlaneNodes(ctx, e.cluster().KubeconfigFile)
+	if err != nil {
+		e.T.Fatal(err)
+	}
+
+	for _, node := range cpNodes {
+		for _, validation := range validations {
+			err = validation(c.Spec.ControlPlaneConfiguration, node)
+			if err != nil {
+				e.T.Errorf("Control plane node %v is not valid: %v", node.Name, err)
+			}
+		}
+	}
+	e.StopIfFailed()
+}

--- a/test/framework/taints.go
+++ b/test/framework/taints.go
@@ -1,0 +1,92 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/executables"
+)
+
+const ownerAnnotation = "cluster.x-k8s.io/owner-name"
+
+func (e *ClusterE2ETest) VaidateWorkerNodeTaints() {
+	ctx := context.Background()
+	nodes, err := e.KubectlClient.GetNodes(ctx, e.cluster().KubeconfigFile)
+	if err != nil {
+		e.T.Fatal(err)
+	}
+
+	c, err := v1alpha1.GetClusterConfigFromContent(e.ClusterConfigB)
+	if err != nil {
+		e.T.Fatal(err)
+	}
+	wn := c.Spec.WorkerNodeGroupConfigurations
+	// deduce the worker node group configuration to node mapping via the machine deployment and machine set
+	for _, w := range wn {
+		mdName := fmt.Sprintf("%v-%v", e.ClusterName, w.Name)
+		md, err := e.KubectlClient.GetMachineDeployment(ctx, mdName, executables.WithKubeconfig(e.cluster().KubeconfigFile), executables.WithNamespace(constants.EksaSystemNamespace))
+		if err != nil {
+			e.T.Fatal(fmt.Errorf("failed to get machine deployment for worker node %s when validating taints: %v", w.Name, err))
+		}
+		ms, err := e.KubectlClient.GetMachineSets(ctx, md.Name, e.cluster())
+		if err != nil {
+			e.T.Fatal(fmt.Errorf("failed to get machine sets when validating taints: %v", err))
+		}
+		if len(ms) == 0 {
+			e.T.Fatal(fmt.Errorf("invalid number of machine sets associated with worker node configuration %v", w.Name))
+		}
+
+		for _, node := range nodes {
+			ownerName, ok := node.Annotations[ownerAnnotation]
+			if ok {
+				// there will be multiple machineSets present on a cluster following an upgrade.
+				// find the one that is associated with this worker node, and compare the taints.
+				for _, machineSet := range ms {
+					if ownerName == machineSet.Name {
+						if !v1alpha1.TaintsSliceEqual(node.Spec.Taints, w.Taints) {
+							e.T.Fatal(fmt.Errorf("taints on node %v and corresponding worker node group configuration %v do not match", node.Name, w.Name))
+						}
+					}
+				}
+			}
+		}
+	}
+	e.T.Log("Validated that expected taints are present on the workload cluster nodes")
+}
+
+func NoExecuteTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    "key1",
+		Value:  "value1",
+		Effect: corev1.TaintEffectNoExecute,
+	}
+}
+
+func NoScheduleTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    "key1",
+		Value:  "value1",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+}
+
+func PreferNoScheduleTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    "key1",
+		Value:  "value1",
+		Effect: corev1.TaintEffectPreferNoSchedule,
+	}
+}
+
+func NoScheduleWorkerNodeGroup(name string, count int) *WorkerNodeGroup {
+	return WithWorkerNodeGroup(name, api.WithCount(count), api.WithTaint(NoScheduleTaint()))
+}
+
+func PreferNoScheduleWorkerNodeGroup(name string, count int) *WorkerNodeGroup {
+	return WithWorkerNodeGroup(name, api.WithCount(count), api.WithTaint(PreferNoScheduleTaint()))
+}

--- a/test/framework/taints.go
+++ b/test/framework/taints.go
@@ -1,62 +1,40 @@
 package framework
 
 import (
-	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
 const ownerAnnotation = "cluster.x-k8s.io/owner-name"
 
-func (e *ClusterE2ETest) VaidateWorkerNodeTaints() {
-	ctx := context.Background()
-	nodes, err := e.KubectlClient.GetNodes(ctx, e.cluster().KubeconfigFile)
-	if err != nil {
-		e.T.Fatal(err)
+func ValidateControlPlaneTaints(controlPlane v1alpha1.ControlPlaneConfiguration, node corev1.Node) (err error) {
+	cpTaints := controlPlane.Taints
+	// if no taints are specified, kubeadm defaults it to a well-known control plane taint.
+	// so, we make sure to check for that well-known taint if no taints are provided in the spec.
+	if cpTaints == nil {
+		cpTaints = []corev1.Taint{ControlPlaneTaint()}
 	}
+	valid := v1alpha1.TaintsSliceEqual(cpTaints, node.Spec.Taints)
+	if !valid {
+		return fmt.Errorf("taints on control plane node %v and corresponding control plane configuration do not match; configured taints: %v; node taints: %v",
+			node.Name, cpTaints, node.Spec.Taints)
+	}
+	logger.V(4).Info("expected taints from cluster spec control plane configuration are present on corresponding node", "node", node.Name, "node taints", node.Spec.Taints, "control plane configuration taints", cpTaints)
+	return nil
+}
 
-	c, err := v1alpha1.GetClusterConfigFromContent(e.ClusterConfigB)
-	if err != nil {
-		e.T.Fatal(err)
+func ValidateWorkerNodeTaints(w v1alpha1.WorkerNodeGroupConfiguration, node corev1.Node) (err error) {
+	valid := v1alpha1.TaintsSliceEqual(node.Spec.Taints, w.Taints)
+	if !valid {
+		return fmt.Errorf("taints on node %v and corresponding worker node group configuration %v do not match", node.Name, w.Name)
 	}
-	wn := c.Spec.WorkerNodeGroupConfigurations
-	// deduce the worker node group configuration to node mapping via the machine deployment and machine set
-	for _, w := range wn {
-		mdName := fmt.Sprintf("%v-%v", e.ClusterName, w.Name)
-		md, err := e.KubectlClient.GetMachineDeployment(ctx, mdName, executables.WithKubeconfig(e.cluster().KubeconfigFile), executables.WithNamespace(constants.EksaSystemNamespace))
-		if err != nil {
-			e.T.Fatal(fmt.Errorf("failed to get machine deployment for worker node %s when validating taints: %v", w.Name, err))
-		}
-		ms, err := e.KubectlClient.GetMachineSets(ctx, md.Name, e.cluster())
-		if err != nil {
-			e.T.Fatal(fmt.Errorf("failed to get machine sets when validating taints: %v", err))
-		}
-		if len(ms) == 0 {
-			e.T.Fatal(fmt.Errorf("invalid number of machine sets associated with worker node configuration %v", w.Name))
-		}
-
-		for _, node := range nodes {
-			ownerName, ok := node.Annotations[ownerAnnotation]
-			if ok {
-				// there will be multiple machineSets present on a cluster following an upgrade.
-				// find the one that is associated with this worker node, and compare the taints.
-				for _, machineSet := range ms {
-					if ownerName == machineSet.Name {
-						if !v1alpha1.TaintsSliceEqual(node.Spec.Taints, w.Taints) {
-							e.T.Fatal(fmt.Errorf("taints on node %v and corresponding worker node group configuration %v do not match", node.Name, w.Name))
-						}
-					}
-				}
-			}
-		}
-	}
-	e.T.Log("Validated that expected taints are present on the workload cluster nodes")
+	logger.V(4).Info("expected taints from cluster spec are present on corresponding node", "worker node group", w.Name, "worker node group taints", w.Taints, "node", node.Name, "node taints", node.Spec.Taints)
+	return nil
 }
 
 func NoExecuteTaint() corev1.Taint {
@@ -80,6 +58,13 @@ func PreferNoScheduleTaint() corev1.Taint {
 		Key:    "key1",
 		Value:  "value1",
 		Effect: corev1.TaintEffectPreferNoSchedule,
+	}
+}
+
+func ControlPlaneTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    "node-role.kubernetes.io/master",
+		Effect: corev1.TaintEffectNoSchedule,
 	}
 }
 

--- a/test/framework/workerNodes.go
+++ b/test/framework/workerNodes.go
@@ -1,0 +1,67 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/executables"
+)
+
+// WorkerNodeValidation should return an error if either an error is encountered during execution or the validation logically fails.
+// This validation function will be executed by ValidateWorkerNodes with a worker node group configuration and a corresponding node
+// which was created as a part of that worker node group configuration.
+type WorkerNodeValidation func(configuration v1alpha1.WorkerNodeGroupConfiguration, node corev1.Node) (err error)
+
+// ValidateWorkerNodes deduces the worker node group configuration to node mapping
+// and for each configuration/node pair executes the provided validation functions.
+func (e *ClusterE2ETest) ValidateWorkerNodes(workerNodeValidations ...WorkerNodeValidation) {
+	ctx := context.Background()
+	nodes, err := e.KubectlClient.GetNodes(ctx, e.cluster().KubeconfigFile)
+	if err != nil {
+		e.T.Fatal(err)
+	}
+
+	c, err := v1alpha1.GetClusterConfigFromContent(e.ClusterConfigB)
+	if err != nil {
+		e.T.Fatal(err)
+	}
+	wn := c.Spec.WorkerNodeGroupConfigurations
+	// deduce the worker node group configuration to node mapping via the machine deployment and machine set
+	for _, w := range wn {
+		mdName := fmt.Sprintf("%v-%v", e.ClusterName, w.Name)
+		md, err := e.KubectlClient.GetMachineDeployment(ctx, mdName, executables.WithKubeconfig(e.cluster().KubeconfigFile), executables.WithNamespace(constants.EksaSystemNamespace))
+		if err != nil {
+			e.T.Fatal(fmt.Errorf("failed to get machine deployment for worker node %s when validating taints: %v", w.Name, err))
+		}
+		ms, err := e.KubectlClient.GetMachineSets(ctx, md.Name, e.cluster())
+		if err != nil {
+			e.T.Fatal(fmt.Errorf("failed to get machine sets when validating taints: %v", err))
+		}
+		if len(ms) == 0 {
+			e.T.Fatal(fmt.Errorf("invalid number of machine sets associated with worker node configuration %v", w.Name))
+		}
+
+		for _, node := range nodes {
+			ownerName, ok := node.Annotations[ownerAnnotation]
+			if ok {
+				// there will be multiple machineSets present on a cluster following an upgrade.
+				// find the one that is associated with this worker node, and execute the validations.
+				for _, machineSet := range ms {
+					if ownerName == machineSet.Name {
+						for _, validation := range workerNodeValidations {
+							err = validation(w, node)
+							if err != nil {
+								e.T.Errorf("Worker node %v, member of Worker Node Group Configuration %v, is not valid: %v", node.Name, w.Name, err)
+							}
+						}
+					}
+				}
+			}
+		}
+		e.StopIfFailed()
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/189

*Description of changes:*
Commit to backport all of the taints end-to-end tests to the release-0.7 branch. Once this is merged, the tests will run in the release-0.7 pipeline and be executed in-context.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

