### PR TITLE
Use test name for temporary test directories.

### DIFF
--- a/internal/test/files.go
+++ b/internal/test/files.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"regexp"
 	"testing"
 
 	"github.com/aws/eks-anywhere/pkg/filewriter"
@@ -76,7 +77,7 @@ func ReadFile(t *testing.T, file string) string {
 }
 
 func NewWriter(t *testing.T) (dir string, writer filewriter.FileWriter) {
-	dir, err := ioutil.TempDir(".", "folderWriter")
+	dir, err := ioutil.TempDir(".", SanitizePath(t.Name())+"-")
 	if err != nil {
 		t.Fatalf("error setting up folder for test: %v", err)
 	}
@@ -95,4 +96,14 @@ func cleanupDir(t *testing.T, dir string) func() {
 			os.RemoveAll(dir)
 		}
 	}
+}
+
+var sanitizePathChars = regexp.MustCompile(`[^\w-]`)
+
+const sanitizePathReplacementChar = "_"
+
+// SanitizePath sanitizes s so its usable as a path name. For safety, it assumes all characters that are not
+// A-Z, a-z, 0-9, _ or - are illegal and replaces them with _.
+func SanitizePath(s string) string {
+	return sanitizePathChars.ReplaceAllString(s, sanitizePathReplacementChar)
 }


### PR DESCRIPTION
The test.NewWriter() method uses a directory prefix of fileWriter. When
multiple tests fail its difficult to know what directory relates to what
test. This ensures we have a delineation between test artifacts