### PR TITLE
ensure release-0.7 e2e tests are using the correct bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GOLANG_VERSION?="1.16"
 GO ?= $(shell source ./scripts/common.sh && build::common::get_go_path $(GOLANG_VERSION))/go
 GO_TEST ?= $(GO) test
 
-## ensure local execution uses the 'main' branch bundle
+## ensure local execution uses the 'release-0.7' branch bundle
 BRANCH_NAME?=release-0.7
 ifeq (,$(findstring $(BRANCH_NAME),main))
 ## use the branch-specific bundle manifest if the branch is not 'main'

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GO ?= $(shell source ./scripts/common.sh && build::common::get_go_path $(GOLANG_
 GO_TEST ?= $(GO) test
 
 ## ensure local execution uses the 'main' branch bundle
-BRANCH_NAME?=main
+BRANCH_NAME?=release-0.7
 ifeq (,$(findstring $(BRANCH_NAME),main))
 ## use the branch-specific bundle manifest if the branch is not 'main'
 BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${BRANCH_NAME}/bundle-release.yaml
@@ -565,3 +565,7 @@ $(BINARY_DEPS_DIR)/linux-%:
 ifneq ($(FETCH_BINARIES_TARGETS),)
 .SECONDARY: $(call FULL_FETCH_BINARIES_TARGETS, $(FETCH_BINARIES_TARGETS))
 endif
+
+.PHONY: get-override-bundle
+get-override-bundle:
+	curl -L $(BUNDLE_MANIFEST_URL) --output bin/local-bundle-release.yaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Ensure the `release-0.7` tests are using the correct bundle override when executed.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

