### PR TITLE
Modify bundle-release.yaml to use downloaded artifacts

### DIFF
--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -482,15 +482,6 @@ func (vb *VersionsBundle) Ovas() []v1alpha1.Archive {
 	return vb.VersionsBundle.Ovas()
 }
 
-func (vb *VersionsBundle) Manifests() map[string][]v1alpha1.Manifest {
-	manifests := vb.VersionsBundle.Manifests()
-
-	// EKS Distro release manifest
-	manifests["eks-distro"] = []v1alpha1.Manifest{{URI: vb.EksD.EksDReleaseUrl}}
-
-	return manifests
-}
-
 func (s *Spec) GetReleaseManifestUrl() string {
 	return s.releasesManifestURL
 }

--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -1,54 +1,66 @@
 package v1alpha1
 
-func (vb *VersionsBundle) Manifests() map[string][]Manifest {
-	return map[string][]Manifest{
+func (vb *VersionsBundle) Manifests() map[string][]*string {
+	return map[string][]*string{
 		"cluster-api-provider-aws": {
-			vb.Aws.Components,
-			vb.Aws.ClusterTemplate,
-			vb.Aws.Metadata,
+			&vb.Aws.Components.URI,
+			&vb.Aws.ClusterTemplate.URI,
+			&vb.Aws.Metadata.URI,
 		},
 		"core-cluster-api": {
-			vb.ClusterAPI.Components,
-			vb.ClusterAPI.Metadata,
+			&vb.ClusterAPI.Components.URI,
+			&vb.ClusterAPI.Metadata.URI,
 		},
 		"capi-kubeadm-bootstrap": {
-			vb.Bootstrap.Components,
-			vb.Bootstrap.Metadata,
+			&vb.Bootstrap.Components.URI,
+			&vb.Bootstrap.Metadata.URI,
 		},
 		"capi-kubeadm-control-plane": {
-			vb.ControlPlane.Components,
-			vb.ControlPlane.Metadata,
+			&vb.ControlPlane.Components.URI,
+			&vb.ControlPlane.Metadata.URI,
+		},
+		"cert-manager": {
+			&vb.CertManager.Manifest.URI,
 		},
 		"cluster-api-provider-docker": {
-			vb.Docker.Components,
-			vb.Docker.ClusterTemplate,
-			vb.Docker.Metadata,
+			&vb.Docker.Components.URI,
+			&vb.Docker.ClusterTemplate.URI,
+			&vb.Docker.Metadata.URI,
 		},
 		"cluster-api-provider-vsphere": {
-			vb.VSphere.Components,
-			vb.VSphere.ClusterTemplate,
-			vb.VSphere.Metadata,
+			&vb.VSphere.Components.URI,
+			&vb.VSphere.ClusterTemplate.URI,
+			&vb.VSphere.Metadata.URI,
 		},
 		"cluster-api-provider-cloudstack": {
-			vb.CloudStack.Components,
-			vb.CloudStack.Metadata,
+			&vb.CloudStack.Components.URI,
+			&vb.CloudStack.Metadata.URI,
+		},
+		"cluster-api-provider-tinkerbell": {
+			&vb.Tinkerbell.Components.URI,
+			&vb.Tinkerbell.ClusterTemplate.URI,
+			&vb.Tinkerbell.Metadata.URI,
 		},
 		"cilium": {
-			vb.Cilium.Manifest,
+			&vb.Cilium.Manifest.URI,
 		},
 		"kindnetd": {
-			vb.Kindnetd.Manifest,
+			&vb.Kindnetd.Manifest.URI,
 		},
 		"eks-anywhere-cluster-controller": {
-			vb.Eksa.Components,
+			&vb.Eksa.Components.URI,
 		},
 		"etcdadm-bootstrap-provider": {
-			vb.ExternalEtcdBootstrap.Components,
-			vb.ExternalEtcdBootstrap.Metadata,
+			&vb.ExternalEtcdBootstrap.Components.URI,
+			&vb.ExternalEtcdBootstrap.Metadata.URI,
 		},
 		"etcdadm-controller": {
-			vb.ExternalEtcdController.Components,
-			vb.ExternalEtcdController.Metadata,
+			&vb.ExternalEtcdController.Components.URI,
+			&vb.ExternalEtcdController.Metadata.URI,
+		},
+		"eks-distro": {
+			&vb.EksD.Components,
+			&vb.EksD.EksDReleaseUrl,
 		},
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `download artifacts` command downloads all manifests linked in the bundle-release.yaml corresponding to the eks-a cluster spec, and saves them at the path specified by --downloads-dir (defaults to eks-anywhere-downloads).
The structure looks like this:
```
➜  ls eks-anywhere-downloads
bundle-release.yaml             cert-manager                    cluster-api-provider-docker     eks-a-release.yaml              etcdadm-controller
capi-kubeadm-bootstrap          cilium                          cluster-api-provider-vsphere    eks-anywhere-cluster-controller kindnetd
capi-kubeadm-control-plane      cluster-api-provider-aws        core-cluster-api                etcdadm-bootstrap-provider
```

The goal behind adding this command was so that the `create cluster` command can be run using the `--bundles-override` flag, passing in the locally download bundle-release.yaml
The way the command works currently, user has to manually modify the bundle-release.yaml file to update the URIs for manifests and change them from URLs to local paths within the eks-anywhere-downloads folder.

This PR modifies the command so that it generates the bundle-release.yaml containing these updated paths.
For example, if this is in the original bundle-release.yaml:
```
 versionsBundles:
  - aws:
      clusterTemplate:
        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.1608/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
      components:
        uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.1608/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
```
Modified file will have this:
```
  versionsBundles:
  - aws:
      clusterTemplate:
        uri: eks-anywhere-downloads/cluster-api-provider-aws/cluster-template.yaml
      components:
        uri: eks-anywhere-downloads/cluster-api-provider-aws/infrastructure-components.yaml
```
This PR also downloads artifacts for all bundles in the bundle-release.yaml, and saves them in a separate sub-directory, changing the downloads-dir structure to:
```
➜ ls eks-anywhere-downloads
1.20                1.21                1.22                bundle-release.yaml eks-a-release.yaml
➜ ls eks-anywhere-downloads/1.20
capi-kubeadm-bootstrap          cilium                          cluster-api-provider-vsphere    eks-distro                      kindnetd
capi-kubeadm-control-plane      cluster-api-provider-aws        core-cluster-api                etcdadm-bootstrap-provider
cert-manager                    cluster-api-provider-docker     eks-anywhere-cluster-controller etcdadm-controller
```

User can then run the following command:
```
eksctl anywhere create cluster -f cluster.yaml --bundles-override=eks-anywhere-downloads/bundle-release.yaml
```

*Testing (if applicable):*
Ran the following commands:
```
./bin/eksctl-anywhere download artifacts -f cluster.yaml
tar -xvzf eks-anywhere-downloads.tar.gz
./bin/eksctl anywhere create cluster -f cluster.yaml --bundles-override=eks-anywhere-downloads/bundle-release.yaml

Cluster got created
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

