### PR TITLE
Manager rbac for taints

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -238,6 +238,9 @@ spec:
                         name:
                           type: string
                       type: object
+                    name:
+                      description: Name refers to the name of the worker node group
+                      type: string
                     taints:
                       description: Taints define the set of taints to be applied on
                         worker nodes
@@ -268,9 +271,6 @@ spec:
                         - key
                         type: object
                       type: array
-                    name:
-                      description: Name refers to the name of the worker node group
-                      type: string
                   type: object
                 type: array
             type: object

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -2339,6 +2339,9 @@ spec:
                         name:
                           type: string
                       type: object
+                    name:
+                      description: Name refers to the name of the worker node group
+                      type: string
                     taints:
                       description: Taints define the set of taints to be applied on
                         worker nodes
@@ -2369,9 +2372,6 @@ spec:
                         - key
                         type: object
                       type: array
-                    name:
-                      description: Name refers to the name of the worker node group
-                      type: string
                   type: object
                 type: array
             type: object
@@ -3086,6 +3086,7 @@ rules:
   - kubeadmconfigtemplates
   - kubeadmconfigtemplates/status
   verbs:
+  - create
   - get
   - list
   - patch

--- a/config/rbac/manager_extraroles_patch.yaml
+++ b/config/rbac/manager_extraroles_patch.yaml
@@ -48,6 +48,7 @@
       - kubeadmconfigtemplates
       - kubeadmconfigtemplates/status
     verbs:
+      - create
       - get
       - list
       - patch


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
allow the manager clusterrole to create kubeadmconfigtemplates, required for reconciling taints.

*Testing (if applicable):*
directly modified the controller clusterrole to allow create and everything worked as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

