### PR TITLE
Update cluster spec reference doc to include taints fields

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/vsphere.md
+++ b/docs/content/en/docs/reference/clusterspec/vsphere.md
@@ -29,6 +29,10 @@ spec:
       machineGroupRef:
         kind: VSphereMachineConfig
         name: my-cluster-machines
+      taints:
+      - key: ""
+        value: ""
+        effect: ""
    datacenterRef:
       kind: VSphereDatacenterConfig
       name: my-cluster-datacenter
@@ -44,7 +48,11 @@ spec:
        kind: VSphereMachineConfig
        name: my-cluster-machines
      name: md-0
-
+     taints:
+     - key: ""
+       value: ""
+       effect: ""
+       
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: VSphereDatacenterConfig
@@ -124,6 +132,17 @@ range that does not conflict with other VMs.
 the control plane nodes for kube-apiserver loadbalancing. Suggestions on how to ensure this IP does not cause issues during cluster 
 creation process are [here]({{< relref "../vsphere/vsphere-prereq/#:~:text=Below%20are%20some,existent%20mac%20address." >}})
 
+### controlPlaneConfiguration.taints
+A list of taints to apply to the control plane nodes of the cluster.
+
+Replaces the default control plane taint, `node-role.kubernetes.io/master`. The default control plane components will tolerate the provided taints.
+
+Modifying the taints associated with the control plane configuration will cause new nodes to be rolled-out, replacing the existing nodes.
+
+>**_NOTE:_** The taints provided will be used instead of the default control plane taint `node-role.kubernetes.io/master`.
+Any pods that you run on the control plane nodes must tolerate the taints you provide in the control plane configuration.
+> 
+
 ### workerNodeGroupConfigurations (required)
 This takes in a list of node groups that you can define for your workers.
 You may define one or more worker node groups.
@@ -136,6 +155,13 @@ Refers to the Kubernetes object with vsphere specific configuration for your nod
 
 ### workerNodeGroupConfigurations.name (required)
 Name of the worker node group (default: md-0)
+
+### workerNodeGroupConfigurations.taints
+A list of taints to apply to the nodes in the worker node group.
+
+Modifying the taints associated with a worker node group configuration will cause new nodes to be rolled-out, replacing the existing nodes associated with the configuration.
+
+At least one node group must not have `NoSchedule` or `NoExecute` taints applied to it.
 
 ### externalEtcdConfiguration.count
 Number of etcd members


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/189

*Description of changes:*
Include the taints in the reference cluster spec, along with descriptions of the fields and a note about the Control Plane taints behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

