### PR TITLE
[release-0.7] Modify bundle-release.yaml to use downloaded artifacts

### DIFF
--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -482,15 +482,6 @@ func (vb *VersionsBundle) Ovas() []v1alpha1.Archive {
 	return vb.VersionsBundle.Ovas()
 }
 
-func (vb *VersionsBundle) Manifests() map[string][]v1alpha1.Manifest {
-	manifests := vb.VersionsBundle.Manifests()
-
-	// EKS Distro release manifest
-	manifests["eks-distro"] = []v1alpha1.Manifest{{URI: vb.EksD.EksDReleaseUrl}}
-
-	return manifests
-}
-
 func (s *Spec) GetReleaseManifestUrl() string {
 	return s.releasesManifestURL
 }

--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -1,50 +1,61 @@
 package v1alpha1
 
-func (vb *VersionsBundle) Manifests() map[string][]Manifest {
-	return map[string][]Manifest{
+func (vb *VersionsBundle) Manifests() map[string][]*string {
+	return map[string][]*string{
 		"cluster-api-provider-aws": {
-			vb.Aws.Components,
-			vb.Aws.ClusterTemplate,
-			vb.Aws.Metadata,
+			&vb.Aws.Components.URI,
+			&vb.Aws.ClusterTemplate.URI,
+			&vb.Aws.Metadata.URI,
 		},
 		"core-cluster-api": {
-			vb.ClusterAPI.Components,
-			vb.ClusterAPI.Metadata,
+			&vb.ClusterAPI.Components.URI,
+			&vb.ClusterAPI.Metadata.URI,
 		},
 		"capi-kubeadm-bootstrap": {
-			vb.Bootstrap.Components,
-			vb.Bootstrap.Metadata,
+			&vb.Bootstrap.Components.URI,
+			&vb.Bootstrap.Metadata.URI,
 		},
 		"capi-kubeadm-control-plane": {
-			vb.ControlPlane.Components,
-			vb.ControlPlane.Metadata,
+			&vb.ControlPlane.Components.URI,
+			&vb.ControlPlane.Metadata.URI,
+		},
+		"cert-manager": {
+			&vb.CertManager.Manifest.URI,
 		},
 		"cluster-api-provider-docker": {
-			vb.Docker.Components,
-			vb.Docker.ClusterTemplate,
-			vb.Docker.Metadata,
+			&vb.Docker.Components.URI,
+			&vb.Docker.ClusterTemplate.URI,
+			&vb.Docker.Metadata.URI,
 		},
 		"cluster-api-provider-vsphere": {
-			vb.VSphere.Components,
-			vb.VSphere.ClusterTemplate,
-			vb.VSphere.Metadata,
+			&vb.VSphere.Components.URI,
+			&vb.VSphere.ClusterTemplate.URI,
+			&vb.VSphere.Metadata.URI,
+		},
+		"cluster-api-provider-tinkerbell": {
+			&vb.Tinkerbell.Components.URI,
+			&vb.Tinkerbell.ClusterTemplate.URI,
+			&vb.Tinkerbell.Metadata.URI,
 		},
 		"cilium": {
-			vb.Cilium.Manifest,
+			&vb.Cilium.Manifest.URI,
 		},
 		"kindnetd": {
-			vb.Kindnetd.Manifest,
+			&vb.Kindnetd.Manifest.URI,
 		},
 		"eks-anywhere-cluster-controller": {
-			vb.Eksa.Components,
+			&vb.Eksa.Components.URI,
 		},
 		"etcdadm-bootstrap-provider": {
-			vb.ExternalEtcdBootstrap.Components,
-			vb.ExternalEtcdBootstrap.Metadata,
+			&vb.ExternalEtcdBootstrap.Components.URI,
+			&vb.ExternalEtcdBootstrap.Metadata.URI,
 		},
 		"etcdadm-controller": {
-			vb.ExternalEtcdController.Components,
-			vb.ExternalEtcdController.Metadata,
+			&vb.ExternalEtcdController.Components.URI,
+			&vb.ExternalEtcdController.Metadata.URI,
+		},
+		"eks-distro": {
+			&vb.EksD.EksDReleaseUrl,
 		},
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Backport of https://github.com/aws/eks-anywhere/pull/1280
Had to remove [cloudstack](https://github.com/aws/eks-anywhere/pull/1280/files#diff-00d7b0c26d532f9a18cd3bdde12c9e6449353a24533ebbce194b69dcd98e0ebbR35) and [eksD.Components](https://github.com/aws/eks-anywhere/pull/1280/files#diff-00d7b0c26d532f9a18cd3bdde12c9e6449353a24533ebbce194b69dcd98e0ebbR62)  from the list of artifacts to download as opposed to the main branch, since these are not part of the release-0.7 manifest.

*Testing (if applicable):*
```
make eks-a
./bin/eksctl-anywhere download artifacts -f cluster.yaml
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

