### PR TITLE
Fix nodes to delete calculation for empty name

### DIFF
--- a/pkg/cluster/node_groups.go
+++ b/pkg/cluster/node_groups.go
@@ -14,6 +14,10 @@ func NodeGroupsToDelete(currentSpec, newSpec *Spec) []eksav1alpha1.WorkerNodeGro
 	workerConfigs := BuildMapForWorkerNodeGroupsByName(newSpec.Spec.WorkerNodeGroupConfigurations)
 	nodeGroupsToDelete := make([]eksav1alpha1.WorkerNodeGroupConfiguration, 0, len(currentSpec.Spec.WorkerNodeGroupConfigurations))
 	for _, prevWorkerNodeGroupConfig := range currentSpec.Spec.WorkerNodeGroupConfigurations {
+		// Current spec doesn't have the default name since we never set the defaults at the api server level
+		if prevWorkerNodeGroupConfig.Name == "" {
+			prevWorkerNodeGroupConfig.Name = "md-0"
+		}
 		if _, ok := workerConfigs[prevWorkerNodeGroupConfig.Name]; !ok {
 			nodeGroupsToDelete = append(nodeGroupsToDelete, prevWorkerNodeGroupConfig)
 		}

--- a/pkg/cluster/node_groups_test.go
+++ b/pkg/cluster/node_groups_test.go
@@ -1,0 +1,132 @@
+package cluster_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+)
+
+func TestNodeGroupsToDelete(t *testing.T) {
+	tests := []struct {
+		name         string
+		new, current *cluster.Spec
+		want         []anywherev1.WorkerNodeGroupConfiguration
+	}{
+		{
+			name: "one worker node group, missing name, no changes",
+			current: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						MachineGroupRef: &anywherev1.Ref{
+							Kind: anywherev1.VSphereMachineConfigKind,
+							Name: "machine-config-1",
+						},
+					},
+				}
+			}),
+			new: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						Name: "md-0",
+						MachineGroupRef: &anywherev1.Ref{
+							Kind: anywherev1.VSphereMachineConfigKind,
+							Name: "machine-config-1",
+						},
+					},
+				}
+			}),
+			want: []anywherev1.WorkerNodeGroupConfiguration{},
+		},
+		{
+			name: "one worker node group, missing name, new name is not default",
+			current: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						MachineGroupRef: &anywherev1.Ref{
+							Kind: anywherev1.VSphereMachineConfigKind,
+							Name: "machine-config-1",
+						},
+					},
+				}
+			}),
+			new: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						Name: "worker-node-group-0",
+						MachineGroupRef: &anywherev1.Ref{
+							Kind: anywherev1.VSphereMachineConfigKind,
+							Name: "machine-config-1",
+						},
+					},
+				}
+			}),
+			want: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Name: "md-0",
+					MachineGroupRef: &anywherev1.Ref{
+						Kind: anywherev1.VSphereMachineConfigKind,
+						Name: "machine-config-1",
+					},
+				},
+			},
+		},
+		{
+			name: "new added, some removed, some stay",
+			current: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						Name: "worker-node-group-0",
+						MachineGroupRef: &anywherev1.Ref{
+							Kind: anywherev1.VSphereMachineConfigKind,
+							Name: "machine-config-1",
+						},
+					},
+					{
+						Name: "worker-node-group-1",
+						MachineGroupRef: &anywherev1.Ref{
+							Kind: anywherev1.VSphereMachineConfigKind,
+							Name: "machine-config-1",
+						},
+					},
+				}
+			}),
+			new: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						Name: "worker-node-group-0",
+						MachineGroupRef: &anywherev1.Ref{
+							Kind: anywherev1.VSphereMachineConfigKind,
+							Name: "machine-config-1",
+						},
+					},
+					{
+						Name: "worker-node-group-2",
+						MachineGroupRef: &anywherev1.Ref{
+							Kind: anywherev1.VSphereMachineConfigKind,
+							Name: "machine-config-1",
+						},
+					},
+				}
+			}),
+			want: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Name: "worker-node-group-1",
+					MachineGroupRef: &anywherev1.Ref{
+						Kind: anywherev1.VSphereMachineConfigKind,
+						Name: "machine-config-1",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cluster.NodeGroupsToDelete(tt.current, tt.new); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NodeGroupsToDelete() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Description of changes:*
The old cluster spec (coming from v0.6.1 or prior) doesn't have a
default name for the first worker node group, since the default is
only set at the cli level and not at the api server level. So when
retrieving the cluster object from the kube api server, the name
is empty.

This is just a quick fix for this specific bug. We should find a more
robust way of implementing these defaults (probably with a mutation
webhook) so we don't need to implement the same logic again and again.

We should create tickets for this follow up work.

*Testing (if applicable):*
Added unit tests and run E2E test `TestVSphereKubernetes120BottlerocketUpgradeFromLatestMinorRelease`

/cherrypick release-0.7

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

