### PR TITLE
Update OIDC settings after cluster creation

### DIFF
--- a/controllers/controllers/cluster_controller_legacy.go
+++ b/controllers/controllers/cluster_controller_legacy.go
@@ -119,5 +119,6 @@ func (r *ClusterReconcilerLegacy) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &anywherev1.VSphereMachineConfig{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &anywherev1.DockerDatacenterConfig{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &anywherev1.AWSIamConfig{}}, &handler.EnqueueRequestForObject{}).
+		Watches(&source.Kind{Type: &anywherev1.OIDCConfig{}}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }

--- a/controllers/controllers/clusters/vsphere.go
+++ b/controllers/controllers/clusters/vsphere.go
@@ -111,7 +111,7 @@ func (v *VSphereClusterReconciler) bundles(ctx context.Context, name, namespace 
 }
 
 func (v *VSphereClusterReconciler) FetchAppliedSpec(ctx context.Context, cs *anywherev1.Cluster) (*c.Spec, error) {
-	return c.BuildSpecForCluster(ctx, cs, v.bundles, nil)
+	return c.BuildSpecForCluster(ctx, cs, v.bundles, nil, nil)
 }
 
 func (v *VSphereClusterReconciler) Reconcile(ctx context.Context, cluster *anywherev1.Cluster) (reconciler.Result, error) {

--- a/controllers/controllers/resource/fetcher.go
+++ b/controllers/controllers/resource/fetcher.go
@@ -76,7 +76,7 @@ func (r *CapiResourceFetcher) FetchObject(ctx context.Context, objectKey types.N
 }
 
 func (r *CapiResourceFetcher) fetchClusterKind(ctx context.Context, objectKey types.NamespacedName) (string, error) {
-	supportedKinds := []string{anywherev1.ClusterKind, anywherev1.VSphereDatacenterKind, anywherev1.DockerDatacenterKind, anywherev1.VSphereMachineConfigKind, anywherev1.AWSIamConfigKind}
+	supportedKinds := []string{anywherev1.ClusterKind, anywherev1.VSphereDatacenterKind, anywherev1.DockerDatacenterKind, anywherev1.VSphereMachineConfigKind, anywherev1.AWSIamConfigKind, anywherev1.OIDCConfigKind}
 	for _, kind := range supportedKinds {
 		obj := &unstructured.Unstructured{}
 		obj.SetKind(kind)
@@ -156,9 +156,9 @@ func (r *CapiResourceFetcher) fetchClusterForRef(ctx context.Context, refId type
 				}
 			}
 		}
-		if kind == anywherev1.AWSIamConfigKind {
-			for _, indentityProviderRef := range c.Spec.IdentityProviderRefs {
-				if indentityProviderRef.Name == refId.Name {
+		if kind == anywherev1.OIDCConfigKind || kind == anywherev1.AWSIamConfigKind {
+			for _, identityProviderRef := range c.Spec.IdentityProviderRefs {
+				if identityProviderRef.Name == refId.Name {
 					if _, err := r.clusterByName(ctx, constants.EksaSystemNamespace, c.Name); err == nil { // further validates a capi cluster exists
 						return &c, nil
 					}
@@ -286,6 +286,15 @@ func (r *CapiResourceFetcher) bundles(ctx context.Context, name, namespace strin
 	return clusterBundle, nil
 }
 
+func (r *CapiResourceFetcher) oidcConfig(ctx context.Context, name, namespace string) (*anywherev1.OIDCConfig, error) {
+	clusterOIDC := &anywherev1.OIDCConfig{}
+	err := r.FetchObjectByName(ctx, name, namespace, clusterOIDC)
+	if err != nil {
+		return nil, err
+	}
+	return clusterOIDC, nil
+}
+
 func (r *CapiResourceFetcher) ControlPlane(ctx context.Context, cs *anywherev1.Cluster) (*controlplanev1.KubeadmControlPlane, error) {
 	// Fetch capi cluster
 	capiCluster := &clusterv1.Cluster{}
@@ -331,7 +340,7 @@ func (r *CapiResourceFetcher) OIDCConfig(ctx context.Context, ref *anywherev1.Re
 }
 
 func (r *CapiResourceFetcher) FetchAppliedSpec(ctx context.Context, cs *anywherev1.Cluster) (*cluster.Spec, error) {
-	return cluster.BuildSpecForCluster(ctx, cs, r.bundles, nil)
+	return cluster.BuildSpecForCluster(ctx, cs, r.bundles, nil, r.oidcConfig)
 }
 
 func (r *CapiResourceFetcher) ExistingVSphereDatacenterConfig(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*anywherev1.VSphereDatacenterConfig, error) {

--- a/pkg/api/v1alpha1/oidcconfig_types.go
+++ b/pkg/api/v1alpha1/oidcconfig_types.go
@@ -79,6 +79,21 @@ func RequiredClaimsSliceEqual(a, b []OIDCConfigRequiredClaim) bool {
 	return len(m) == 0
 }
 
+// IsManaged returns true if the oidcconfig is associated with a workload cluster
+func (c *OIDCConfig) IsManaged() bool {
+	if s, ok := c.Annotations[managementAnnotation]; ok {
+		return s != ""
+	}
+	return false
+}
+
+func (c *OIDCConfig) SetManagedBy(clusterName string) {
+	if c.Annotations == nil {
+		c.Annotations = map[string]string{}
+	}
+	c.Annotations[managementAnnotation] = clusterName
+}
+
 type OIDCConfigRequiredClaim struct {
 	Claim string `json:"claim,omitempty"`
 	Value string `json:"value,omitempty"`

--- a/pkg/api/v1alpha1/oidcconfig_webhook.go
+++ b/pkg/api/v1alpha1/oidcconfig_webhook.go
@@ -41,6 +41,13 @@ func (r *OIDCConfig) ValidateUpdate(old runtime.Object) error {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a OIDCConfig but got a %T", old))
 	}
 
+	if oldOIDCConfig.IsManaged() {
+		clusterlog.Info("OIDC config is associated with workload cluster", "name", oldOIDCConfig.Name)
+		return nil
+	}
+
+	clusterlog.Info("OIDC config is associated with management cluster", "name", oldOIDCConfig.Name)
+
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, validateImmutableOIDCFields(r, oldOIDCConfig)...)

--- a/pkg/api/v1alpha1/oidcconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/oidcconfig_webhook_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
-func TestValidateUpdateOIDCClientId(t *testing.T) {
+func TestValidateUpdateOIDCClientIdMgmtCluster(t *testing.T) {
 	ocOld := oidcConfig()
 	ocOld.Spec.ClientId = "test"
 	c := ocOld.DeepCopy()
@@ -19,7 +19,7 @@ func TestValidateUpdateOIDCClientId(t *testing.T) {
 	o.Expect(c.ValidateUpdate(&ocOld)).NotTo(Succeed())
 }
 
-func TestValidateUpdateOIDCGroupsClaim(t *testing.T) {
+func TestValidateUpdateOIDCGroupsClaimMgmtCluster(t *testing.T) {
 	ocOld := oidcConfig()
 	ocOld.Spec.GroupsClaim = "test"
 	c := ocOld.DeepCopy()
@@ -29,7 +29,7 @@ func TestValidateUpdateOIDCGroupsClaim(t *testing.T) {
 	o.Expect(c.ValidateUpdate(&ocOld)).NotTo(Succeed())
 }
 
-func TestValidateUpdateOIDCGroupsPrefix(t *testing.T) {
+func TestValidateUpdateOIDCGroupsPrefixMgmtCluster(t *testing.T) {
 	ocOld := oidcConfig()
 	ocOld.Spec.GroupsPrefix = "test"
 	c := ocOld.DeepCopy()
@@ -39,7 +39,7 @@ func TestValidateUpdateOIDCGroupsPrefix(t *testing.T) {
 	o.Expect(c.ValidateUpdate(&ocOld)).NotTo(Succeed())
 }
 
-func TestValidateUpdateOIDCIssuerUrl(t *testing.T) {
+func TestValidateUpdateOIDCIssuerUrlMgmtCluster(t *testing.T) {
 	ocOld := oidcConfig()
 	ocOld.Spec.IssuerUrl = "test"
 	c := ocOld.DeepCopy()
@@ -49,7 +49,7 @@ func TestValidateUpdateOIDCIssuerUrl(t *testing.T) {
 	o.Expect(c.ValidateUpdate(&ocOld)).NotTo(Succeed())
 }
 
-func TestValidateUpdateOIDCUsernameClaim(t *testing.T) {
+func TestValidateUpdateOIDCUsernameClaimMgmtCluster(t *testing.T) {
 	ocOld := oidcConfig()
 	ocOld.Spec.UsernameClaim = "test"
 	c := ocOld.DeepCopy()
@@ -59,7 +59,7 @@ func TestValidateUpdateOIDCUsernameClaim(t *testing.T) {
 	o.Expect(c.ValidateUpdate(&ocOld)).NotTo(Succeed())
 }
 
-func TestValidateUpdateOIDCUsernamePrefix(t *testing.T) {
+func TestValidateUpdateOIDCUsernamePrefixMgmtCluster(t *testing.T) {
 	ocOld := oidcConfig()
 	ocOld.Spec.UsernamePrefix = "test"
 	c := ocOld.DeepCopy()
@@ -69,7 +69,7 @@ func TestValidateUpdateOIDCUsernamePrefix(t *testing.T) {
 	o.Expect(c.ValidateUpdate(&ocOld)).NotTo(Succeed())
 }
 
-func TestValidateUpdateOIDCRequiredClaims(t *testing.T) {
+func TestValidateUpdateOIDCRequiredClaimsMgmtCluster(t *testing.T) {
 	ocOld := oidcConfig()
 	ocOld.Spec.RequiredClaims = []v1alpha1.OIDCConfigRequiredClaim{{Claim: "test", Value: "value"}}
 	c := ocOld.DeepCopy()
@@ -79,7 +79,7 @@ func TestValidateUpdateOIDCRequiredClaims(t *testing.T) {
 	o.Expect(c.ValidateUpdate(&ocOld)).NotTo(Succeed())
 }
 
-func TestValidateUpdateOIDCRequiredClaimsMultiple(t *testing.T) {
+func TestValidateUpdateOIDCRequiredClaimsMultipleMgmtCluster(t *testing.T) {
 	ocOld := oidcConfig()
 	ocOld.Spec.RequiredClaims = []v1alpha1.OIDCConfigRequiredClaim{{Claim: "test", Value: "value"}}
 	c := ocOld.DeepCopy()
@@ -90,6 +90,116 @@ func TestValidateUpdateOIDCRequiredClaimsMultiple(t *testing.T) {
 	})
 	o := NewWithT(t)
 	o.Expect(c.ValidateUpdate(&ocOld)).NotTo(Succeed())
+}
+
+func TestClusterValidateUpdateOIDCclientIdMutableUpdateNameWorkloadCluster(t *testing.T) {
+	ocOld := oidcConfig()
+	ocOld.Spec.ClientId = "test"
+	ocOld.SetManagedBy("test")
+	c := ocOld.DeepCopy()
+
+	c.Spec.ClientId = "test2"
+	o := NewWithT(t)
+	o.Expect(c.ValidateUpdate(&ocOld)).To(Succeed())
+}
+
+func TestValidateUpdateOIDCClientIdWorkloadCluster(t *testing.T) {
+	ocOld := oidcConfig()
+	ocOld.Spec.ClientId = "test"
+	ocOld.SetManagedBy("test")
+
+	c := ocOld.DeepCopy()
+
+	c.Spec.ClientId = "test2"
+	o := NewWithT(t)
+	o.Expect(c.ValidateUpdate(&ocOld)).To(Succeed())
+}
+
+func TestValidateUpdateOIDCGroupsClaimWorkloadCluster(t *testing.T) {
+	ocOld := oidcConfig()
+	ocOld.Spec.GroupsClaim = "test"
+	ocOld.SetManagedBy("test")
+
+	c := ocOld.DeepCopy()
+
+	c.Spec.GroupsClaim = "test2"
+	o := NewWithT(t)
+	o.Expect(c.ValidateUpdate(&ocOld)).To(Succeed())
+}
+
+func TestValidateUpdateOIDCGroupsPrefixWorkloadCluster(t *testing.T) {
+	ocOld := oidcConfig()
+	ocOld.Spec.GroupsPrefix = "test"
+	ocOld.SetManagedBy("test")
+
+	c := ocOld.DeepCopy()
+
+	c.Spec.GroupsPrefix = "test2"
+	o := NewWithT(t)
+	o.Expect(c.ValidateUpdate(&ocOld)).To(Succeed())
+}
+
+func TestValidateUpdateOIDCIssuerUrlWorkloadCluster(t *testing.T) {
+	ocOld := oidcConfig()
+	ocOld.Spec.IssuerUrl = "test"
+	ocOld.SetManagedBy("test")
+
+	c := ocOld.DeepCopy()
+
+	c.Spec.IssuerUrl = "test2"
+	o := NewWithT(t)
+	o.Expect(c.ValidateUpdate(&ocOld)).To(Succeed())
+}
+
+func TestValidateUpdateOIDCUsernameClaimWorkloadCluster(t *testing.T) {
+	ocOld := oidcConfig()
+	ocOld.Spec.UsernameClaim = "test"
+	ocOld.SetManagedBy("test")
+
+	c := ocOld.DeepCopy()
+
+	c.Spec.UsernameClaim = "test2"
+	o := NewWithT(t)
+	o.Expect(c.ValidateUpdate(&ocOld)).To(Succeed())
+}
+
+func TestValidateUpdateOIDCUsernamePrefixWorkloadCluster(t *testing.T) {
+	ocOld := oidcConfig()
+	ocOld.Spec.UsernamePrefix = "test"
+	ocOld.SetManagedBy("test")
+
+	c := ocOld.DeepCopy()
+
+	c.Spec.UsernamePrefix = "test2"
+	o := NewWithT(t)
+	o.Expect(c.ValidateUpdate(&ocOld)).To(Succeed())
+}
+
+func TestValidateUpdateOIDCRequiredClaimsWorkloadCluster(t *testing.T) {
+	ocOld := oidcConfig()
+	ocOld.Spec.RequiredClaims = []v1alpha1.OIDCConfigRequiredClaim{{Claim: "test", Value: "value"}}
+	ocOld.SetManagedBy("test")
+
+	c := ocOld.DeepCopy()
+
+	c.Spec.RequiredClaims = []v1alpha1.OIDCConfigRequiredClaim{{Claim: "test", Value: "value2"}}
+	o := NewWithT(t)
+	o.Expect(c.ValidateUpdate(&ocOld)).To(Succeed())
+}
+
+func TestValidateUpdateOIDCRequiredClaimsMultipleWorkloadCluster(t *testing.T) {
+	ocOld := oidcConfig()
+	ocOld.Spec.RequiredClaims = []v1alpha1.OIDCConfigRequiredClaim{{Claim: "test", Value: "value"}}
+	ocOld.SetManagedBy("test")
+
+	c := ocOld.DeepCopy()
+
+	c.Spec.RequiredClaims = append(c.Spec.RequiredClaims, v1alpha1.OIDCConfigRequiredClaim{
+		Claim: "test2",
+		Value: "value2",
+	})
+	o := NewWithT(t)
+	o.Expect(c.ValidateUpdate(&ocOld)).To(Succeed())
 }
 
 func oidcConfig() v1alpha1.OIDCConfig {

--- a/pkg/cluster/fetch.go
+++ b/pkg/cluster/fetch.go
@@ -12,7 +12,9 @@ type BundlesFetch func(ctx context.Context, name, namespace string) (*v1alpha1re
 
 type GitOpsFetch func(ctx context.Context, name, namespace string) (*v1alpha1.GitOpsConfig, error)
 
-func BuildSpecForCluster(ctx context.Context, cluster *v1alpha1.Cluster, bundlesFetch BundlesFetch, gitOpsFetch GitOpsFetch) (*Spec, error) {
+type OIDCFetch func(ctx context.Context, name, namespace string) (*v1alpha1.OIDCConfig, error)
+
+func BuildSpecForCluster(ctx context.Context, cluster *v1alpha1.Cluster, bundlesFetch BundlesFetch, gitOpsFetch GitOpsFetch, oidcFetch OIDCFetch) (*Spec, error) {
 	bundles, err := GetBundlesForCluster(ctx, cluster, bundlesFetch)
 	if err != nil {
 		return nil, err
@@ -21,7 +23,11 @@ func BuildSpecForCluster(ctx context.Context, cluster *v1alpha1.Cluster, bundles
 	if err != nil {
 		return nil, err
 	}
-	return BuildSpecFromBundles(cluster, bundles, WithGitOpsConfig(gitOpsConfig))
+	oidcConfig, err := GetOIDCForCluster(ctx, cluster, oidcFetch)
+	if err != nil {
+		return nil, err
+	}
+	return BuildSpecFromBundles(cluster, bundles, WithGitOpsConfig(gitOpsConfig), WithOIDCConfig(oidcConfig))
 }
 
 func GetBundlesForCluster(ctx context.Context, cluster *v1alpha1.Cluster, fetch BundlesFetch) (*v1alpha1release.Bundles, error) {
@@ -43,4 +49,21 @@ func GetGitOpsForCluster(ctx context.Context, cluster *v1alpha1.Cluster, fetch G
 	}
 
 	return gitops, nil
+}
+
+func GetOIDCForCluster(ctx context.Context, cluster *v1alpha1.Cluster, fetch OIDCFetch) (*v1alpha1.OIDCConfig, error) {
+	if fetch == nil || cluster.Spec.IdentityProviderRefs == nil {
+		return nil, nil
+	}
+
+	for _, identityProvider := range cluster.Spec.IdentityProviderRefs {
+		if identityProvider.Kind == v1alpha1.OIDCConfigKind {
+			oidc, err := fetch(ctx, identityProvider.Name, cluster.Namespace)
+			if err != nil {
+				return nil, fmt.Errorf("failed fetching OIDCConfig for cluster: %v", err)
+			}
+			return oidc, nil
+		}
+	}
+	return nil, nil
 }

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -151,6 +151,12 @@ func WithGitOpsConfig(gitOpsConfig *eksav1alpha1.GitOpsConfig) SpecOpt {
 	}
 }
 
+func WithOIDCConfig(oidcConfig *eksav1alpha1.OIDCConfig) SpecOpt {
+	return func(s *Spec) {
+		s.OIDCConfig = oidcConfig
+	}
+}
+
 func NewSpec(opts ...SpecOpt) *Spec {
 	s := &Spec{
 		releasesManifestURL: releasesManifestURL,

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -272,6 +272,21 @@ func (mr *MockClusterClientMockRecorder) GetEksaGitOpsConfig(arg0, arg1, arg2, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEksaGitOpsConfig", reflect.TypeOf((*MockClusterClient)(nil).GetEksaGitOpsConfig), arg0, arg1, arg2, arg3)
 }
 
+// GetEksaOIDCConfig mocks base method.
+func (m *MockClusterClient) GetEksaOIDCConfig(arg0 context.Context, arg1, arg2, arg3 string) (*v1alpha1.OIDCConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEksaOIDCConfig", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*v1alpha1.OIDCConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEksaOIDCConfig indicates an expected call of GetEksaOIDCConfig.
+func (mr *MockClusterClientMockRecorder) GetEksaOIDCConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEksaOIDCConfig", reflect.TypeOf((*MockClusterClient)(nil).GetEksaOIDCConfig), arg0, arg1, arg2, arg3)
+}
+
 // GetEksaVSphereDatacenterConfig mocks base method.
 func (m *MockClusterClient) GetEksaVSphereDatacenterConfig(arg0 context.Context, arg1, arg2, arg3 string) (*v1alpha1.VSphereDatacenterConfig, error) {
 	m.ctrl.T.Helper()

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -418,6 +418,11 @@ func (p *vsphereProvider) SetupAndValidateCreateCluster(ctx context.Context, clu
 		if len(existingDatacenter) > 0 {
 			return fmt.Errorf("VSphereDatacenter %s already exists", p.datacenterConfig.Name)
 		}
+		for _, identityProviderRef := range clusterSpec.Spec.IdentityProviderRefs {
+			if identityProviderRef.Kind == v1alpha1.OIDCConfigKind {
+				clusterSpec.OIDCConfig.SetManagedBy(p.clusterConfig.ManagedBy())
+			}
+		}
 	}
 
 	if !p.skipIpCheck {

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -45,11 +45,10 @@ func TestPreflightValidations(t *testing.T) {
 			upgradeVersion:     "1.19",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
-
-			workerResponse: nil,
-			nodeResponse:   nil,
-			crdResponse:    nil,
-			wantErr:        nil,
+			workerResponse:     nil,
+			nodeResponse:       nil,
+			crdResponse:        nil,
+			wantErr:            nil,
 		},
 		{
 			name:               "ValidationFailsMajorVersionPlus2",
@@ -179,7 +178,7 @@ func TestPreflightValidations(t *testing.T) {
 			},
 		},
 		{
-			name:               "ValidationIdentityProviderRefsImmutable",
+			name:               "ValidationAwsIamRegionImmutable",
 			clusterVersion:     "v1.19.16-eks-1-19-4",
 			upgradeVersion:     "1.19",
 			getClusterResponse: goodClusterResponse,
@@ -187,13 +186,87 @@ func TestPreflightValidations(t *testing.T) {
 			workerResponse:     nil,
 			nodeResponse:       nil,
 			crdResponse:        nil,
-			wantErr:            composeError("spec.identityProviderRefs is immutable"),
+			wantErr:            composeError("aws iam identity provider is immutable"),
 			modifyFunc: func(s *cluster.Spec) {
-				s.Spec.IdentityProviderRefs = []v1alpha1.Ref{
-					{
-						Kind: v1alpha1.OIDCConfigKind,
-						Name: "oidc-2",
-					},
+				s.AWSIamConfig.Spec.AWSRegion = "us-east-2"
+			},
+		},
+		{
+			name:               "ValidationAwsIamBackEndModeImmutable",
+			clusterVersion:     "v1.19.16-eks-1-19-4",
+			upgradeVersion:     "1.19",
+			getClusterResponse: goodClusterResponse,
+			cpResponse:         nil,
+			workerResponse:     nil,
+			nodeResponse:       nil,
+			crdResponse:        nil,
+			wantErr:            composeError("aws iam identity provider is immutable"),
+			modifyFunc: func(s *cluster.Spec) {
+				s.AWSIamConfig.Spec.BackendMode = append(s.AWSIamConfig.Spec.BackendMode, "us-east-2")
+			},
+		},
+		{
+			name:               "ValidationAwsIamPartitionImmutable",
+			clusterVersion:     "v1.19.16-eks-1-19-4",
+			upgradeVersion:     "1.19",
+			getClusterResponse: goodClusterResponse,
+			cpResponse:         nil,
+			workerResponse:     nil,
+			nodeResponse:       nil,
+			crdResponse:        nil,
+			wantErr:            composeError("aws iam identity provider is immutable"),
+			modifyFunc: func(s *cluster.Spec) {
+				s.AWSIamConfig.Spec.Partition = "partition2"
+			},
+		},
+		{
+			name:               "ValidationAwsIamNameImmutable",
+			clusterVersion:     "v1.19.16-eks-1-19-4",
+			upgradeVersion:     "1.19",
+			getClusterResponse: goodClusterResponse,
+			cpResponse:         nil,
+			workerResponse:     nil,
+			nodeResponse:       nil,
+			crdResponse:        nil,
+			wantErr:            composeError("aws iam identity provider is immutable"),
+			modifyFunc: func(s *cluster.Spec) {
+				s.Spec.IdentityProviderRefs[1] = v1alpha1.Ref{
+					Kind: v1alpha1.AWSIamConfigKind,
+					Name: "aws-iam2",
+				}
+			},
+		},
+		{
+			name:               "ValidationAwsIamKindImmutable",
+			clusterVersion:     "v1.19.16-eks-1-19-4",
+			upgradeVersion:     "1.19",
+			getClusterResponse: goodClusterResponse,
+			cpResponse:         nil,
+			workerResponse:     nil,
+			nodeResponse:       nil,
+			crdResponse:        nil,
+			wantErr:            composeError("aws iam identity provider is immutable"),
+			modifyFunc: func(s *cluster.Spec) {
+				s.Spec.IdentityProviderRefs[1] = v1alpha1.Ref{
+					Kind: v1alpha1.OIDCConfigKind,
+					Name: "oidc",
+				}
+			},
+		},
+		{
+			name:               "ValidationAwsIamKindImmutable",
+			clusterVersion:     "v1.19.16-eks-1-19-4",
+			upgradeVersion:     "1.19",
+			getClusterResponse: goodClusterResponse,
+			cpResponse:         nil,
+			workerResponse:     nil,
+			nodeResponse:       nil,
+			crdResponse:        nil,
+			wantErr:            nil,
+			modifyFunc: func(s *cluster.Spec) {
+				s.Spec.IdentityProviderRefs[1] = v1alpha1.Ref{
+					Kind: v1alpha1.AWSIamConfigKind,
+					Name: "aws-iam",
 				}
 			},
 		},
@@ -282,7 +355,7 @@ func TestPreflightValidations(t *testing.T) {
 			},
 		},
 		{
-			name:               "ValidationOIDCClientIdImmutable",
+			name:               "ValidationOIDCClientIdMutable",
 			clusterVersion:     "v1.19.16-eks-1-19-4",
 			upgradeVersion:     "1.19",
 			getClusterResponse: goodClusterResponse,
@@ -290,13 +363,13 @@ func TestPreflightValidations(t *testing.T) {
 			workerResponse:     nil,
 			nodeResponse:       nil,
 			crdResponse:        nil,
-			wantErr:            composeError("oidc identity provider is immutable"),
+			wantErr:            nil,
 			modifyFunc: func(s *cluster.Spec) {
 				s.OIDCConfig.Spec.ClientId = "new-client-id"
 			},
 		},
 		{
-			name:               "ValidationOIDCGroupsClaimImmutable",
+			name:               "ValidationOIDCGroupsClaimMutable",
 			clusterVersion:     "v1.19.16-eks-1-19-4",
 			upgradeVersion:     "1.19",
 			getClusterResponse: goodClusterResponse,
@@ -304,13 +377,13 @@ func TestPreflightValidations(t *testing.T) {
 			workerResponse:     nil,
 			nodeResponse:       nil,
 			crdResponse:        nil,
-			wantErr:            composeError("oidc identity provider is immutable"),
+			wantErr:            nil,
 			modifyFunc: func(s *cluster.Spec) {
 				s.OIDCConfig.Spec.GroupsClaim = "new-groups-claim"
 			},
 		},
 		{
-			name:               "ValidationOIDCGroupsPrefixImmutable",
+			name:               "ValidationOIDCGroupsPrefixMutable",
 			clusterVersion:     "v1.19.16-eks-1-19-4",
 			upgradeVersion:     "1.19",
 			getClusterResponse: goodClusterResponse,
@@ -318,13 +391,13 @@ func TestPreflightValidations(t *testing.T) {
 			workerResponse:     nil,
 			nodeResponse:       nil,
 			crdResponse:        nil,
-			wantErr:            composeError("oidc identity provider is immutable"),
+			wantErr:            nil,
 			modifyFunc: func(s *cluster.Spec) {
 				s.OIDCConfig.Spec.GroupsPrefix = "new-groups-prefix"
 			},
 		},
 		{
-			name:               "ValidationOIDCIssuerUrlImmutable",
+			name:               "ValidationOIDCIssuerUrlMutable",
 			clusterVersion:     "v1.19.16-eks-1-19-4",
 			upgradeVersion:     "1.19",
 			getClusterResponse: goodClusterResponse,
@@ -332,13 +405,13 @@ func TestPreflightValidations(t *testing.T) {
 			workerResponse:     nil,
 			nodeResponse:       nil,
 			crdResponse:        nil,
-			wantErr:            composeError("oidc identity provider is immutable"),
+			wantErr:            nil,
 			modifyFunc: func(s *cluster.Spec) {
 				s.OIDCConfig.Spec.IssuerUrl = "new-issuer-url"
 			},
 		},
 		{
-			name:               "ValidationOIDCUsernameClaimImmutable",
+			name:               "ValidationOIDCUsernameClaimMutable",
 			clusterVersion:     "v1.19.16-eks-1-19-4",
 			upgradeVersion:     "1.19",
 			getClusterResponse: goodClusterResponse,
@@ -346,13 +419,13 @@ func TestPreflightValidations(t *testing.T) {
 			workerResponse:     nil,
 			nodeResponse:       nil,
 			crdResponse:        nil,
-			wantErr:            composeError("oidc identity provider is immutable"),
+			wantErr:            nil,
 			modifyFunc: func(s *cluster.Spec) {
 				s.OIDCConfig.Spec.UsernameClaim = "new-username-claim"
 			},
 		},
 		{
-			name:               "ValidationOIDCUsernamePrefixImmutable",
+			name:               "ValidationOIDCUsernamePrefixMutable",
 			clusterVersion:     "v1.19.16-eks-1-19-4",
 			upgradeVersion:     "1.19",
 			getClusterResponse: goodClusterResponse,
@@ -360,13 +433,13 @@ func TestPreflightValidations(t *testing.T) {
 			workerResponse:     nil,
 			nodeResponse:       nil,
 			crdResponse:        nil,
-			wantErr:            composeError("oidc identity provider is immutable"),
+			wantErr:            nil,
 			modifyFunc: func(s *cluster.Spec) {
 				s.OIDCConfig.Spec.UsernamePrefix = "new-username-prefix"
 			},
 		},
 		{
-			name:               "ValidationOIDCRequiredClaimsImmutable",
+			name:               "ValidationOIDCRequiredClaimsMutable",
 			clusterVersion:     "v1.19.16-eks-1-19-4",
 			upgradeVersion:     "1.19",
 			getClusterResponse: goodClusterResponse,
@@ -374,7 +447,7 @@ func TestPreflightValidations(t *testing.T) {
 			workerResponse:     nil,
 			nodeResponse:       nil,
 			crdResponse:        nil,
-			wantErr:            composeError("oidc identity provider is immutable"),
+			wantErr:            nil,
 			modifyFunc: func(s *cluster.Spec) {
 				s.OIDCConfig.Spec.RequiredClaims[0].Claim = "new-groups-claim"
 			},
@@ -520,6 +593,23 @@ func TestPreflightValidations(t *testing.T) {
 		},
 	}
 
+	defaultAWSIAM := &v1alpha1.AWSIamConfig{
+		Spec: v1alpha1.AWSIamConfigSpec{
+			AWSRegion: "us-east-1",
+			MapRoles: []v1alpha1.MapRoles{{
+				RoleARN:  "roleARN",
+				Username: "username",
+				Groups:   []string{"group1", "group2"},
+			}},
+			MapUsers: []v1alpha1.MapUsers{{
+				UserARN:  "userARN",
+				Username: "username",
+				Groups:   []string{"group1", "group2"},
+			}},
+			Partition: "partition",
+		},
+	}
+
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Name = testclustername
 		s.Spec.ControlPlaneConfiguration = defaultControlPlane
@@ -532,6 +622,10 @@ func TestPreflightValidations(t *testing.T) {
 			{
 				Kind: v1alpha1.OIDCConfigKind,
 				Name: "oidc",
+			},
+			{
+				Kind: v1alpha1.AWSIamConfigKind,
+				Name: "aws-iam",
 			},
 		}
 		s.Spec.GitOpsRef = &v1alpha1.Ref{
@@ -561,6 +655,7 @@ func TestPreflightValidations(t *testing.T) {
 
 		s.GitOpsConfig = defaultGitOps
 		s.OIDCConfig = defaultOIDC
+		s.AWSIamConfig = defaultAWSIAM
 	})
 
 	for _, tc := range tests {
@@ -588,6 +683,7 @@ func TestPreflightValidations(t *testing.T) {
 				Cluster:      clusterSpec.Cluster.DeepCopy(),
 				GitOpsConfig: clusterSpec.GitOpsConfig.DeepCopy(),
 				OIDCConfig:   clusterSpec.OIDCConfig.DeepCopy(),
+				AWSIamConfig: clusterSpec.AWSIamConfig.DeepCopy(),
 			}
 			existingProviderSpec := defaultDatacenterSpec.DeepCopy()
 			if tc.modifyFunc != nil {
@@ -610,6 +706,7 @@ func TestPreflightValidations(t *testing.T) {
 			k.EXPECT().GetEksaCluster(ctx, workloadCluster, clusterSpec.Name).Return(existingClusterSpec.Cluster, nil)
 			k.EXPECT().GetEksaGitOpsConfig(ctx, clusterSpec.Spec.GitOpsRef.Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.GitOpsConfig, nil).MaxTimes(1)
 			k.EXPECT().GetEksaOIDCConfig(ctx, clusterSpec.Spec.IdentityProviderRefs[0].Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.OIDCConfig, nil).MaxTimes(1)
+			k.EXPECT().GetEksaAWSIamConfig(ctx, clusterSpec.Spec.IdentityProviderRefs[1].Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.AWSIamConfig, nil).MaxTimes(1)
 			k.EXPECT().Version(ctx, workloadCluster).Return(versionResponse, nil)
 			upgradeValidations := upgradevalidations.New(opts)
 			err := upgradeValidations.PreflightValidations(ctx)

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -2,6 +2,8 @@
 
 package e2e
 
-const worker0 = "worker-0"
-const worker1 = "worker-1"
-const worker2 = "worker-2"
+const (
+	worker0 = "worker-0"
+	worker1 = "worker-1"
+	worker2 = "worker-2"
+)


### PR DESCRIPTION
*Issue #, if available:*
#676

*Description of changes:*
In these code changes, we let users update (add/remove/change) their OIDC config settings for the EKSA clusters.
These changes include CLI and controller changes.
**- CLI** : Users can update their OIDC config settings for their management as well as workload clusters by making changes to the existing cluster specs for their clusters.
**- Flux** : If users have flux enabled, they can update the eks-a-cluster spec from their Github repository, however this can only be done for workload clusters. Management clusters can not update OIDC config via flux.

*Testing (if applicable):*
 - Unit tests
 - Manual cluster creation and upgrading the same with OIDC settings using the cli
 - Manual cluster creation and upgrading the same with OIDC settings using the git ops controller (tested with tilt as well)
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

