### PR TITLE
Get branchname from Prow env var instead of hardcoding to main

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -18,6 +18,10 @@ CLI_REPO_URL?=https://github.com/aws/eks-anywhere.git
 BUILD_REPO_URL?=https://github.com/aws/eks-anywhere-build-tooling.git
 BUILD_REPO_BRANCH_NAME?=main
 CLI_REPO_BRANCH_NAME?=main
+ifeq ($(CI),true)
+BUILD_REPO_BRANCH_NAME=$(PULL_BASE_REF)
+CLI_REPO_BRANCH_NAME=$(PULL_BASE_REF)
+endif
 ifeq ($(CODEBUILD_CI),)
 DRY_RUN=true
 SOURCE_BUCKET=projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f


### PR DESCRIPTION
Same as #1310.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

