### PR TITLE
Fix git tag assignment to get absolute latest tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ SHELL := /bin/bash
 
 ARTIFACTS_BUCKET?=my-s3-bucket
 GIT_VERSION?=$(shell git describe --tag)
-GIT_TAG?=$(shell git describe --tag | cut -d'-' -f1)
+GIT_TAG?=$(shell git tag -l --sort -v:refname | head -1)
 GOLANG_VERSION?="1.16"
 GO ?= $(shell source ./scripts/common.sh && build::common::get_go_path $(GOLANG_VERSION))/go
 GO_TEST ?= $(GO) test

--- a/release/pkg/assets_cluster_controller.go
+++ b/release/pkg/assets_cluster_controller.go
@@ -31,16 +31,12 @@ func (r *ReleaseConfig) GetClusterControllerAssets() ([]Artifact, error) {
 	var gitTag string
 	if r.DevRelease {
 		// Get git tag
-		out, err := git.GetRepoTags(r.CliRepoSource)
+		out, err := git.GetRepoTagsDescending(r.CliRepoSource)
 		if err != nil {
 			return nil, errors.Cause(err)
 		}
 
-		gitTags := strings.Split(out, "\n")
-		gitTag = gitTags[len(gitTags)-2]
-		if err != nil {
-			return nil, errors.Cause(err)
-		}
+		gitTag = strings.Split(out, "\n")[0]
 	} else {
 		gitTag = r.ReleaseVersion
 	}

--- a/release/pkg/git/git.go
+++ b/release/pkg/git/git.go
@@ -35,8 +35,8 @@ func DescribeTag(gitRoot string) (string, error) {
 	return utils.ExecCommand(cmd)
 }
 
-func GetRepoTags(gitRoot string) (string, error) {
-	cmd := exec.Command("git", "-C", gitRoot, "tag")
+func GetRepoTagsDescending(gitRoot string) (string, error) {
+	cmd := exec.Command("git", "-C", gitRoot, "tag", "-l", "--sort", "-v:refname")
 	return utils.ExecCommand(cmd)
 }
 


### PR DESCRIPTION
This PR fixes the logic for assigning the git tag to the EKS-A cluster controller image/manifests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

