### PR TITLE
Cluster config parsing

### DIFF
--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -1,0 +1,27 @@
+package cluster
+
+import (
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+type Config struct {
+	Cluster               *anywherev1.Cluster
+	VSphereDatacenter     *anywherev1.VSphereDatacenterConfig
+	DockerDatacenter      *anywherev1.DockerDatacenterConfig
+	VSphereMachineConfigs map[string]*anywherev1.VSphereMachineConfig
+	OIDCConfigs           map[string]*anywherev1.OIDCConfig
+	AWSIAMConfigs         map[string]*anywherev1.AWSIamConfig
+	GitOpsConfig          *anywherev1.GitOpsConfig
+}
+
+func (c *Config) VsphereMachineConfig(name string) *anywherev1.VSphereMachineConfig {
+	return c.VSphereMachineConfigs[name]
+}
+
+func (c *Config) OIDCConfig(name string) *anywherev1.OIDCConfig {
+	return c.OIDCConfigs[name]
+}
+
+func (c *Config) AWSIamConfig(name string) *anywherev1.AWSIamConfig {
+	return c.AWSIAMConfigs[name]
+}

--- a/pkg/cluster/parse.go
+++ b/pkg/cluster/parse.go
@@ -1,0 +1,210 @@
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+type parsed struct {
+	objects        objects
+	cluster        *anywherev1.Cluster
+	datacenter     apiObject
+	machineConfigs []runtime.Object
+}
+
+type basicAPIObject struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+func (k *basicAPIObject) empty() bool {
+	return k.APIVersion == "" && k.Kind == ""
+}
+
+type apiObject interface {
+	runtime.Object
+	GetName() string
+}
+
+func keyForObject(o apiObject) string {
+	return key(o.GetObjectKind().GroupVersionKind().GroupVersion().String(), o.GetObjectKind().GroupVersionKind().Kind, o.GetName())
+}
+
+type objects map[string]apiObject
+
+func (o objects) add(obj apiObject) {
+	o[keyForObject(obj)] = obj
+}
+
+func (o objects) getFromRef(apiVersion string, ref anywherev1.Ref) apiObject {
+	return o[keyForRef(apiVersion, ref)]
+}
+
+func key(apiVersion, kind, name string) string {
+	// this assumes we don't allow to have objects in multiple namespaces
+	return fmt.Sprintf("%s%s%s", apiVersion, kind, name)
+}
+
+func keyForRef(apiVersion string, ref anywherev1.Ref) string {
+	return key(apiVersion, ref.Kind, ref.Name)
+}
+
+func ParseConfigFromFile(path string) (*Config, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading cluster config file: %v", err)
+	}
+
+	return ParseConfig(content)
+}
+
+func ParseConfig(yamlManifest []byte) (*Config, error) {
+	parsed := &parsed{
+		objects: objects{},
+	}
+	yamlObjs := strings.Split(string(yamlManifest), "---")
+
+	for _, yamlObj := range yamlObjs {
+		k := &basicAPIObject{}
+		err := yaml.Unmarshal([]byte(yamlObj), k)
+		if err != nil {
+			return nil, err
+		}
+
+		// Ignore empty objects.
+		// Empty objects are generated if there are weird things in manifest files like e.g. two --- in a row without a yaml doc in the middle
+		if k.empty() {
+			continue
+		}
+
+		var obj apiObject
+
+		switch k.Kind {
+		case anywherev1.ClusterKind:
+			if parsed.cluster != nil {
+				return nil, errors.New("only one Cluster per yaml manifest is allowed")
+			}
+			parsed.cluster = &anywherev1.Cluster{}
+			obj = parsed.cluster
+		case anywherev1.VSphereDatacenterKind:
+			obj = &anywherev1.VSphereDatacenterConfig{}
+		case anywherev1.VSphereMachineConfigKind:
+			obj = &anywherev1.VSphereMachineConfig{}
+		case anywherev1.DockerDatacenterKind:
+			obj = &anywherev1.DockerDatacenterConfig{}
+		case anywherev1.AWSIamConfigKind:
+			obj = &anywherev1.AWSIamConfig{}
+		case anywherev1.OIDCConfigKind:
+			obj = &anywherev1.OIDCConfig{}
+		case anywherev1.GitOpsConfigKind:
+			obj = &anywherev1.GitOpsConfig{}
+		default:
+			return nil, fmt.Errorf("invalid object with kind %s found on manifest", k.Kind)
+		}
+
+		if err := yaml.Unmarshal([]byte(yamlObj), obj); err != nil {
+			return nil, err
+		}
+
+		parsed.objects.add(obj)
+	}
+
+	return buildConfigFromParsed(parsed)
+}
+
+func buildConfigFromParsed(p *parsed) (*Config, error) {
+	if p.cluster == nil {
+		return nil, errors.New("no Cluster found in manifest")
+	}
+
+	c := &Config{
+		Cluster:               p.cluster,
+		VSphereMachineConfigs: map[string]*anywherev1.VSphereMachineConfig{},
+		OIDCConfigs:           map[string]*anywherev1.OIDCConfig{},
+		AWSIAMConfigs:         map[string]*anywherev1.AWSIamConfig{},
+	}
+
+	// Process datacenter
+	p.datacenter = p.objects.getFromRef(p.cluster.APIVersion, p.cluster.Spec.DatacenterRef)
+	switch p.cluster.Spec.DatacenterRef.Kind {
+	case anywherev1.VSphereDatacenterKind:
+		c.VSphereDatacenter = p.datacenter.(*anywherev1.VSphereDatacenterConfig)
+	case anywherev1.DockerDatacenterKind:
+		c.DockerDatacenter = p.datacenter.(*anywherev1.DockerDatacenterConfig)
+	}
+
+	// Process machine configs
+	processMachineConfig(p, c, p.cluster.Spec.ControlPlaneConfiguration.MachineGroupRef)
+	if p.cluster.Spec.ExternalEtcdConfiguration != nil {
+		processMachineConfig(p, c, c.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef)
+	}
+
+	for _, w := range p.cluster.Spec.WorkerNodeGroupConfigurations {
+		processMachineConfig(p, c, w.MachineGroupRef)
+	}
+
+	// Process IDP
+	for _, idr := range p.cluster.Spec.IdentityProviderRefs {
+		processIdentityProvider(p, c, idr)
+	}
+
+	// Process GitOps
+	processGitOps(p, c)
+
+	return c, nil
+}
+
+func processMachineConfig(p *parsed, c *Config, machineRef *anywherev1.Ref) {
+	if machineRef == nil {
+		return
+	}
+
+	m := p.objects.getFromRef(c.Cluster.APIVersion, *machineRef)
+	if m == nil {
+		return
+	}
+
+	p.machineConfigs = append(p.machineConfigs, m)
+	switch machineRef.Kind {
+	case anywherev1.VSphereMachineConfigKind:
+		c.VSphereMachineConfigs[m.GetName()] = m.(*anywherev1.VSphereMachineConfig)
+	}
+}
+
+func processIdentityProvider(p *parsed, c *Config, idpRef anywherev1.Ref) {
+	idp := p.objects.getFromRef(c.Cluster.APIVersion, idpRef)
+	if idp == nil {
+		return
+	}
+
+	switch idpRef.Kind {
+	case anywherev1.OIDCConfigKind:
+		c.OIDCConfigs[idp.GetName()] = idp.(*anywherev1.OIDCConfig)
+	case anywherev1.AWSIamConfigKind:
+		c.AWSIAMConfigs[idp.GetName()] = idp.(*anywherev1.AWSIamConfig)
+	}
+}
+
+func processGitOps(p *parsed, c *Config) {
+	if c.Cluster.Spec.GitOpsRef == nil {
+		return
+	}
+
+	gitOps := p.objects.getFromRef(p.cluster.APIVersion, *p.cluster.Spec.GitOpsRef)
+	if gitOps == nil {
+		return
+	}
+
+	switch p.cluster.Spec.GitOpsRef.Kind {
+	case anywherev1.GitOpsConfigKind:
+		c.GitOpsConfig = gitOps.(*anywherev1.GitOpsConfig)
+	}
+}

--- a/pkg/cluster/parse_test.go
+++ b/pkg/cluster/parse_test.go
@@ -1,0 +1,320 @@
+package cluster_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+)
+
+func TestParseConfig(t *testing.T) {
+	tests := []struct {
+		name                      string
+		yamlManifest              []byte
+		wantCluster               *anywherev1.Cluster
+		wantVsphereDatacenter     *anywherev1.VSphereDatacenterConfig
+		wantDockerDatacenter      *anywherev1.DockerDatacenterConfig
+		wantVsphereMachineConfigs []*anywherev1.VSphereMachineConfig
+		wantOIDCConfigs           []*anywherev1.OIDCConfig
+		wantAWSIamConfigs         []*anywherev1.AWSIamConfig
+		wantGitOpsConfig          *anywherev1.GitOpsConfig
+	}{
+		{
+			name:         "vsphere cluster",
+			yamlManifest: []byte(test.ReadFile(t, "testdata/cluster_1_19.yaml")),
+			wantCluster: &anywherev1.Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       anywherev1.ClusterKind,
+					APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: anywherev1.ClusterSpec{
+					KubernetesVersion: "1.19",
+					ControlPlaneConfiguration: anywherev1.ControlPlaneConfiguration{
+						Count:    1,
+						Endpoint: &anywherev1.Endpoint{Host: "myHostIp"},
+						MachineGroupRef: &anywherev1.Ref{
+							Kind: "VSphereMachineConfig",
+							Name: "eksa-unit-test-cp",
+						},
+					},
+					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+						{
+							Count: 1,
+							MachineGroupRef: &anywherev1.Ref{
+								Kind: "VSphereMachineConfig",
+								Name: "eksa-unit-test",
+							},
+						},
+					},
+					DatacenterRef: anywherev1.Ref{
+						Kind: "VSphereDatacenterConfig",
+						Name: "eksa-unit-test",
+					},
+					ClusterNetwork: anywherev1.ClusterNetwork{
+						Pods: anywherev1.Pods{
+							CidrBlocks: []string{"192.168.0.0/16"},
+						},
+						Services: anywherev1.Services{
+							CidrBlocks: []string{"10.96.0.0/12"},
+						},
+						CNI: "cilium",
+					},
+				},
+			},
+			wantVsphereDatacenter: &anywherev1.VSphereDatacenterConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       anywherev1.VSphereDatacenterKind,
+					APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: anywherev1.VSphereDatacenterConfigSpec{
+					Datacenter: "myDatacenter",
+					Network:    "myNetwork",
+					Server:     "myServer",
+					Thumbprint: "myTlsThumbprint",
+					Insecure:   false,
+				},
+			},
+			wantVsphereMachineConfigs: []*anywherev1.VSphereMachineConfig{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       anywherev1.VSphereMachineConfigKind,
+						APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "eksa-unit-test-cp",
+					},
+					Spec: anywherev1.VSphereMachineConfigSpec{
+						DiskGiB:   25,
+						MemoryMiB: 8192,
+						NumCPUs:   2,
+						OSFamily:  anywherev1.Ubuntu,
+						Users: []anywherev1.UserConfiguration{{
+							Name:              "mySshUsername",
+							SshAuthorizedKeys: []string{"mySshAuthorizedKey"},
+						}},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       anywherev1.VSphereMachineConfigKind,
+						APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "eksa-unit-test",
+					},
+					Spec: anywherev1.VSphereMachineConfigSpec{
+						DiskGiB:   25,
+						MemoryMiB: 8192,
+						NumCPUs:   2,
+						OSFamily:  anywherev1.Ubuntu,
+						Users: []anywherev1.UserConfiguration{{
+							Name:              "mySshUsername",
+							SshAuthorizedKeys: []string{"mySshAuthorizedKey"},
+						}},
+					},
+				},
+			},
+		},
+		{
+			name:         "docker cluster with oidc, awsaim and flux",
+			yamlManifest: []byte(test.ReadFile(t, "testdata/docker_cluster_oidc_awsiam_flux.yaml")),
+			wantCluster: &anywherev1.Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       anywherev1.ClusterKind,
+					APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "m-docker",
+				},
+				Spec: anywherev1.ClusterSpec{
+					KubernetesVersion: "1.21",
+					ManagementCluster: anywherev1.ManagementCluster{
+						Name: "m-docker",
+					},
+					ControlPlaneConfiguration: anywherev1.ControlPlaneConfiguration{
+						Count: 1,
+					},
+					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+						{
+							Count: 1,
+						},
+					},
+					DatacenterRef: anywherev1.Ref{
+						Kind: anywherev1.DockerDatacenterKind,
+						Name: "m-docker",
+					},
+					ClusterNetwork: anywherev1.ClusterNetwork{
+						Pods: anywherev1.Pods{
+							CidrBlocks: []string{"192.168.0.0/16"},
+						},
+						Services: anywherev1.Services{
+							CidrBlocks: []string{"10.96.0.0/12"},
+						},
+						CNI: "cilium",
+					},
+					IdentityProviderRefs: []anywherev1.Ref{
+						{
+							Kind: anywherev1.OIDCConfigKind,
+							Name: "eksa-unit-test",
+						},
+						{
+							Kind: anywherev1.AWSIamConfigKind,
+							Name: "eksa-unit-test",
+						},
+					},
+					GitOpsRef: &anywherev1.Ref{
+						Kind: anywherev1.GitOpsConfigKind,
+						Name: "eksa-unit-test",
+					},
+				},
+			},
+			wantDockerDatacenter: &anywherev1.DockerDatacenterConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       anywherev1.DockerDatacenterKind,
+					APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "m-docker",
+				},
+			},
+			wantGitOpsConfig: &anywherev1.GitOpsConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "GitOpsConfig",
+					APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: anywherev1.GitOpsConfigSpec{
+					Flux: anywherev1.Flux{
+						Github: anywherev1.Github{
+							Owner:      "janedoe",
+							Repository: "flux-fleet",
+						},
+					},
+				},
+			},
+			wantOIDCConfigs: []*anywherev1.OIDCConfig{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "OIDCConfig",
+						APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "eksa-unit-test",
+					},
+					Spec: anywherev1.OIDCConfigSpec{
+						ClientId:     "id12",
+						GroupsClaim:  "claim1",
+						GroupsPrefix: "prefix-for-groups",
+						IssuerUrl:    "https://mydomain.com/issuer",
+						RequiredClaims: []anywherev1.OIDCConfigRequiredClaim{
+							{
+								Claim: "sub",
+								Value: "test",
+							},
+						},
+						UsernameClaim:  "username-claim",
+						UsernamePrefix: "username-prefix",
+					},
+				},
+			},
+			wantAWSIamConfigs: []*anywherev1.AWSIamConfig{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       anywherev1.AWSIamConfigKind,
+						APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "eksa-unit-test",
+					},
+					Spec: anywherev1.AWSIamConfigSpec{
+						AWSRegion:   "test-region",
+						BackendMode: []string{"mode1", "mode2"},
+						MapRoles: []anywherev1.MapRoles{
+							{
+								RoleARN:  "test-role-arn",
+								Username: "test",
+								Groups:   []string{"group1", "group2"},
+							},
+						},
+						MapUsers: []anywherev1.MapUsers{
+							{
+								UserARN:  "test-user-arn",
+								Username: "test",
+								Groups:   []string{"group1", "group2"},
+							},
+						},
+						Partition: "aws",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got, err := cluster.ParseConfig(tt.yamlManifest)
+
+			g.Expect(err).To(Not(HaveOccurred()))
+
+			g.Expect(got.Cluster).To(Equal(tt.wantCluster))
+			g.Expect(got.VSphereDatacenter).To(Equal(tt.wantVsphereDatacenter))
+			g.Expect(got.DockerDatacenter).To(Equal(tt.wantDockerDatacenter))
+			g.Expect(len(got.VSphereMachineConfigs)).To(Equal(len(tt.wantVsphereMachineConfigs)))
+			for _, m := range tt.wantVsphereMachineConfigs {
+				g.Expect(got.VsphereMachineConfig(m.Name)).To(Equal(m))
+			}
+			g.Expect(len(got.OIDCConfigs)).To(Equal(len(tt.wantOIDCConfigs)))
+			for _, o := range tt.wantOIDCConfigs {
+				g.Expect(got.OIDCConfig(o.Name)).To(Equal(o))
+			}
+			g.Expect(len(got.AWSIAMConfigs)).To(Equal(len(tt.wantAWSIamConfigs)))
+			for _, a := range tt.wantAWSIamConfigs {
+				g.Expect(got.AWSIamConfig(a.Name)).To(Equal(a))
+			}
+			g.Expect(got.GitOpsConfig).To(Equal(tt.wantGitOpsConfig))
+		})
+	}
+}
+
+func TestParseConfigMissingCluster(t *testing.T) {
+	g := NewWithT(t)
+	_, err := cluster.ParseConfig([]byte{})
+	g.Expect(err).To(MatchError(ContainSubstring("no Cluster found in manifest")))
+}
+
+func TestParseConfigTwoClusters(t *testing.T) {
+	g := NewWithT(t)
+	manifest := `apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test-2
+`
+	_, err := cluster.ParseConfig([]byte(manifest))
+	g.Expect(err).To(MatchError(ContainSubstring("only one Cluster per yaml manifest is allowed")))
+}
+
+func TestParseConfigUnknownKind(t *testing.T) {
+	g := NewWithT(t)
+	manifest := `apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: MysteryCRD
+`
+	_, err := cluster.ParseConfig([]byte(manifest))
+	g.Expect(err).To(MatchError(ContainSubstring("invalid object with kind MysteryCRD found on manifest")))
+}

--- a/pkg/cluster/testdata/docker_cluster_oidc_awsiam_flux.yaml
+++ b/pkg/cluster/testdata/docker_cluster_oidc_awsiam_flux.yaml
@@ -1,0 +1,85 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: m-docker
+spec:
+  clusterNetwork:
+    cni: cilium
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+  datacenterRef:
+    kind: DockerDatacenterConfig
+    name: m-docker
+  kubernetesVersion: "1.21"
+  managementCluster:
+    name: m-docker
+  workerNodeGroupConfigurations:
+  - count: 1
+  identityProviderRefs:
+  - kind: OIDCConfig
+    name: eksa-unit-test
+  - kind: AWSIamConfig
+    name: eksa-unit-test
+  gitOpsRef:
+    kind: GitOpsConfig
+    name: eksa-unit-test
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: DockerDatacenterConfig
+metadata:
+  name: m-docker
+spec: {}
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: OIDCConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  clientId: id12
+  groupsClaim: claim1
+  groupsPrefix: prefix-for-groups
+  issuerUrl: https://mydomain.com/issuer
+  requiredClaims:
+    - claim: sub
+      value: test
+  usernameClaim: username-claim
+  usernamePrefix: username-prefix
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: AWSIamConfig
+metadata:
+   name: eksa-unit-test
+spec:
+  awsRegion: test-region
+  partition: aws
+  backendMode:
+    - mode1
+    - mode2
+  mapRoles:
+    - groups:
+      - group1
+      - group2
+      roleARN: test-role-arn
+      username: test
+  mapUsers:
+    - groups:
+      - group1
+      - group2
+      userARN: test-user-arn
+      username: test
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: GitOpsConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  flux:
+    github:
+      owner: "janedoe"
+      repository: "flux-fleet"


### PR DESCRIPTION
## What are we solving and why
* We lack an entity that represents a full cluster configuration.
  * We have `cluster.Spec` but it doesn't have provider specific api structs (like machine configs or datacenter). 
  * This has created duplicated logic, pushing providers into implementing the same thing again and again.
  * It complicates providers: since they don't receive their specific api structs as method arguments, they need to store them as members. This introduces complexity for both data management and construction. Moreover, it tides providers to a specific cluster config as a side effect.
* The api package has grown a lot, assuming too many responsibilities. It unmarshals, sets defaults and validates. And all of this tied to an inflexible public api that only takes paths to files in local disk as input.
  * This makes it difficult to construct, validate and set defaults for these structs in alternative ways.
  * This has been a patent problem in our E2E tests, which would benefit significantly from more flexibility on this area.
  * In order to move to a controller based workflow, we need to be able to run some of this logic in the validation and mutation webhooks.

## Proposal
I propose to introduce a new entity:
```go
type Config struct {
	Cluster               *anywherev1.Cluster
	VSphereDatacenter     *anywherev1.VSphereDatacenterConfig
	DockerDatacenter      *anywherev1.DockerDatacenterConfig
	VSphereMachineConfigs map[string]*anywherev1.VSphereMachineConfig
	OIDCConfigs           map[string]*anywherev1.OIDCConfig
	AWSIAMConfigs         map[string]*anywherev1.AWSIamConfig
	GitOpsConfig          *anywherev1.GitOpsConfig
}
```
`cluster.Config` represents the whole cluster API definition, including all necessary objects specified by the user and linked to the `Cluster` object.

`cluster.Spec` will wrap around `cluster.Config`, adding other external data objects that complement the cluster config to form the full cluster specification

Why exported fields? This facilitates the mutation of the cluster config: eg. defaults being set by other packages like providers. It also facilitates testing, since any test package can set the data appropriately. This is supposed to be a data container and doesn’t need to enforce anything else. As a drawback, any piece of code receiving `cluster.Spec` can modify the cluster configuration. It is up to us to define when it’s ok and when it’s not to modify it. The only decision this proposal make in that regard is that validations should never modify the cluster config.

The implementation should allow to construct a `cluster.Config` from a:
* Yaml file
  * When parsing from a yaml file, and due to the fact that most flows in the CLI happen without going through the kube api server, we need to “manually” take care of validation and defaults. This should be independent from parsing and the logic should be reusable even when not building `cluster.Config` from a file.
* Kube api server (using a Kubernetes client)
  * When using the api server, defaults and validation should already be taken care of (by the validation and mutation webhooks), so this implementation should assume so.

### Validations

There are two types of validations:
* Context agnostic validations: there are no external dependencies, having the API object is enough to validate it: mutually exclusive fields, string format, empty fields…
  * These should live in the pkg/api/version package
  * These should be the ones called in the validation webhook
* Context aware validations: these are dependent on other entities like clients or even other API objects
  * These could leave in different places, I’m not making a decision right now: providers, validations package… This is probably worth a separate discussion.
  * Try to keep these modular and reusable (eg. Don’t make them part of the providers struct’s api)
  * If they only need other API objects from the same package, they can live in the api package
  * Controller: these shouldn’t be run in a webhook and must be part of the main reconciliation loop

### Defaults
These follow the same categorization and rules as the validations: 
* Context agnostic
    * In api package
    * Run un mutation webhook
* Context aware
    * Keep them modular
    * In controller reconcile loop

## Implementation plan
* **Add new `cluster.Config` struct (this PR)**
* **Add utils to build `Config` from yaml (this PR)**
* Make sure all validations in the `api/v1alpha1` package comply with the proposed definition of context unaware validations
* Make sure all defaults in the `api/v1alpha1` package comply with the proposed definition of context unaware defaults
* Add some validate tooling to `cluster.Config` to be able to run api level validations
* Embed `cluster.Config` in `cluster.Spec`


*Testing (if applicable):*
The PR includes unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

