### PR TITLE
Handle replace directives for modules with CRDs

### DIFF
--- a/internal/test/envtest/crd_test.go
+++ b/internal/test/envtest/crd_test.go
@@ -1,0 +1,30 @@
+package envtest
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestModuleWithCRDRegexes(t *testing.T) {
+	requireDirective := `	sigs.k8s.io/cluster-api v1.0.2`
+	replaceDirective := `	sigs.k8s.io/cluster-api => github.com/mrajashree/cluster-api v1.0.3-0.20220301005127-382d70d4a76f`
+	g := NewWithT(t)
+	m, err := buildModuleWithCRD("sigs.k8s.io/cluster-api")
+	g.Expect(err).To(BeNil())
+
+	matchesRequire := m.requireRegex.FindStringSubmatch(requireDirective)
+	g.Expect(len(matchesRequire)).To(Equal(3))
+	g.Expect(matchesRequire[2]).To(Equal("1.0.2"))
+
+	matchesRequire = m.requireRegex.FindStringSubmatch(replaceDirective)
+	g.Expect(matchesRequire).To(BeNil())
+
+	matchesReplace := m.replaceRegex.FindStringSubmatch(replaceDirective)
+	g.Expect(len(matchesReplace)).To(Equal(4))
+	g.Expect(matchesReplace[2]).To(Equal("github.com/mrajashree/cluster-api"))
+	g.Expect(matchesReplace[3]).To(Equal("1.0.3-0.20220301005127-382d70d4a76f"))
+
+	matchesReplace = m.replaceRegex.FindStringSubmatch(requireDirective)
+	g.Expect(matchesReplace).To(BeNil())
+}

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	capiPackage = "sigs.k8s.io/cluster-api"
-	capvPackage = "sigs.k8s.io/cluster-api-vsphere-provider"
+	capvPackage = "sigs.k8s.io/cluster-api-provider-vsphere"
 )
 
 func init() {
@@ -45,7 +45,7 @@ func init() {
 	utilruntime.Must(anywherev1.AddToScheme(scheme.Scheme))
 }
 
-var packages = mustBuildPackagesWithCRDs(capiPackage, capvPackage)
+var packages = mustBuildModulesWithCRDs(capiPackage, capvPackage)
 
 type Environment struct {
 	scheme  *runtime.Scheme
@@ -72,7 +72,7 @@ func RunWithEnvironment(m *testing.M, opts ...EnvironmentOpt) int {
 	ctx := ctrl.SetupSignalHandler()
 	env, err := newEnvironment(ctx)
 	if err != nil {
-		fmt.Printf("Failed setting up envtest: %s", err)
+		fmt.Printf("Failed setting up envtest: %s\n", err)
 		return 1
 	}
 


### PR DESCRIPTION
*Description of changes:*
When adding CRDs to `envtest` we depend on the path the source modules are
on disk. These paths obviously change when go.mod has a replace
directive. With this changes we are able to handle those replaces and we
feed `envtest` with the path of the replacing module instead of the
replaced one.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

