### PR TITLE
Cluster Config validation

### DIFF
--- a/pkg/api/v1alpha1/awsiamconfig.go
+++ b/pkg/api/v1alpha1/awsiamconfig.go
@@ -17,10 +17,16 @@ func GetAndValidateAWSIamConfig(fileName string, refName string, clusterConfig *
 	if err != nil {
 		return nil, err
 	}
-	err = validateAWSIamConfig(config, refName, clusterConfig)
-	if err != nil {
+	if err = validateAWSIamConfig(config); err != nil {
 		return nil, err
 	}
+	if err = validateAWSIamRefName(config, refName); err != nil {
+		return nil, err
+	}
+	if err = validateAWSIamNamespace(config, clusterConfig); err != nil {
+		return nil, err
+	}
+
 	return config, nil
 }
 
@@ -37,17 +43,11 @@ func getAWSIamConfig(fileName string) (*AWSIamConfig, error) {
 	return &config, nil
 }
 
-func validateAWSIamConfig(config *AWSIamConfig, refName string, clusterConfig *Cluster) error {
+func validateAWSIamConfig(config *AWSIamConfig) error {
 	if config == nil {
 		return nil
 	}
-	if config.Name != refName {
-		return fmt.Errorf("AWSIamConfig retrieved with name %v does not match name (%v) specified in "+
-			"identityProviderRefs", config.Name, refName)
-	}
-	if config.Namespace != clusterConfig.Namespace {
-		return fmt.Errorf("AWSIamConfig and Cluster objects must have the same namespace specified")
-	}
+
 	if config.Spec.AWSRegion == "" {
 		return fmt.Errorf("AWSIamConfig AWSRegion is a required field")
 	}
@@ -96,5 +96,30 @@ func validateMapUsers(mapUsers []MapUsers) error {
 			return fmt.Errorf("AWSIamConfig MapUsers Username is required")
 		}
 	}
+	return nil
+}
+
+func validateAWSIamRefName(config *AWSIamConfig, refName string) error {
+	if config == nil {
+		return nil
+	}
+
+	if config.Name != refName {
+		return fmt.Errorf("AWSIamConfig retrieved with name %s does not match name (%s) specified in "+
+			"identityProviderRefs", config.Name, refName)
+	}
+
+	return nil
+}
+
+func validateAWSIamNamespace(config *AWSIamConfig, clusterConfig *Cluster) error {
+	if config == nil {
+		return nil
+	}
+
+	if config.Namespace != clusterConfig.Namespace {
+		return fmt.Errorf("AWSIamConfig and Cluster objects must have the same namespace specified")
+	}
+
 	return nil
 }

--- a/pkg/api/v1alpha1/awsiamconfig_types.go
+++ b/pkg/api/v1alpha1/awsiamconfig_types.go
@@ -111,6 +111,10 @@ func (c *AWSIamConfig) ConvertConfigToConfigGenerateStruct() *AWSIamConfigGenera
 	return config
 }
 
+func (c *AWSIamConfig) Validate() error {
+	return validateAWSIamConfig(c)
+}
+
 func init() {
 	SchemeBuilder.Register(&AWSIamConfig{}, &AWSIamConfigList{})
 }

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -94,6 +94,10 @@ func (n *Cluster) Equal(o *Cluster) bool {
 	return true
 }
 
+func (n *Cluster) Validate() error {
+	return ValidateClusterConfigContent(n)
+}
+
 type ProxyConfiguration struct {
 	HttpProxy  string   `json:"httpProxy,omitempty"`
 	HttpsProxy string   `json:"httpsProxy,omitempty"`

--- a/pkg/api/v1alpha1/dockerdatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/dockerdatacenterconfig_types.go
@@ -71,6 +71,10 @@ func (d *DockerDatacenterConfig) Marshallable() Marshallable {
 	return d.ConvertConfigToConfigGenerateStruct()
 }
 
+func (d *DockerDatacenterConfig) Validate() error {
+	return nil
+}
+
 // +kubebuilder:object:generate=false
 
 // Same as DockerDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig

--- a/pkg/api/v1alpha1/gitopsconfig.go
+++ b/pkg/api/v1alpha1/gitopsconfig.go
@@ -13,10 +13,16 @@ func GetAndValidateGitOpsConfig(fileName string, refName string, clusterConfig *
 	if err != nil {
 		return nil, err
 	}
-	err = validateGitOpsConfig(config, refName, clusterConfig)
-	if err != nil {
+	if err = validateGitOpsConfig(config); err != nil {
 		return nil, err
 	}
+	if err = validateGitOpsRefName(config, refName); err != nil {
+		return nil, err
+	}
+	if err = validateGitOpsNamespace(config, clusterConfig); err != nil {
+		return nil, err
+	}
+
 	return config, nil
 }
 
@@ -29,16 +35,9 @@ func getGitOpsConfig(fileName string) (*GitOpsConfig, error) {
 	return &config, nil
 }
 
-func validateGitOpsConfig(config *GitOpsConfig, refName string, clusterConfig *Cluster) error {
+func validateGitOpsConfig(config *GitOpsConfig) error {
 	if config == nil {
 		return errors.New("gitOpsRef is specified but GitOpsConfig is not specified")
-	}
-	if config.Name != refName {
-		return fmt.Errorf("GitOpsConfig retrieved with name %s does not match name (%s) specified in "+
-			"gitOpsRef", config.Name, refName)
-	}
-	if config.Namespace != clusterConfig.Namespace {
-		return errors.New("GitOpsConfig and Cluster objects must have the same namespace specified")
 	}
 
 	flux := config.Spec.Flux
@@ -77,5 +76,30 @@ func validateGitRepoName(repoName string) error {
 	if !allowedGitRepoName.MatchString(repoName) {
 		return fmt.Errorf("%s is not a valid git repository name, name can contain only letters, digits, '_', '-' and '.'", repoName)
 	}
+	return nil
+}
+
+func validateGitOpsRefName(config *GitOpsConfig, refName string) error {
+	if config == nil {
+		return nil
+	}
+
+	if config.Name != refName {
+		return fmt.Errorf("GitOpsConfig retrieved with name %s does not match name (%s) specified in "+
+			"identityProviderRefs", config.Name, refName)
+	}
+
+	return nil
+}
+
+func validateGitOpsNamespace(config *GitOpsConfig, clusterConfig *Cluster) error {
+	if config == nil {
+		return nil
+	}
+
+	if config.Namespace != clusterConfig.Namespace {
+		return fmt.Errorf("GitOpsConfig and Cluster objects must have the same namespace specified")
+	}
+
 	return nil
 }

--- a/pkg/api/v1alpha1/gitopsconfig_types.go
+++ b/pkg/api/v1alpha1/gitopsconfig_types.go
@@ -104,6 +104,10 @@ func (c *GitOpsConfig) ConvertConfigToConfigGenerateStruct() *GitOpsConfigGenera
 	return config
 }
 
+func (c *GitOpsConfig) Validate() error {
+	return validateGitOpsConfig(c)
+}
+
 func init() {
 	SchemeBuilder.Register(&GitOpsConfig{}, &GitOpsConfigList{})
 }

--- a/pkg/api/v1alpha1/oidcconfig.go
+++ b/pkg/api/v1alpha1/oidcconfig.go
@@ -12,10 +12,16 @@ func GetAndValidateOIDCConfig(fileName string, refName string, clusterConfig *Cl
 	if err != nil {
 		return nil, err
 	}
-	err = validateOIDCConfig(config, refName, clusterConfig)
-	if err != nil {
+	if err = validateOIDCConfig(config); err != nil {
 		return nil, err
 	}
+	if err = validateOIDCRefName(config, refName); err != nil {
+		return nil, err
+	}
+	if err = validateOIDCNamespace(config, clusterConfig); err != nil {
+		return nil, err
+	}
+
 	return config, nil
 }
 
@@ -32,17 +38,11 @@ func getOIDCConfig(fileName string) (*OIDCConfig, error) {
 	return &config, nil
 }
 
-func validateOIDCConfig(config *OIDCConfig, refName string, clusterConfig *Cluster) error {
+func validateOIDCConfig(config *OIDCConfig) error {
 	if config == nil {
 		return nil
 	}
-	if config.Name != refName {
-		return fmt.Errorf("OIDCConfig retrieved with name %v does not match name (%v) specified in "+
-			"identityProviderRefs", config.Name, refName)
-	}
-	if config.Namespace != clusterConfig.Namespace {
-		return fmt.Errorf("OIDCConfig and Cluster objects must have the same namespace specified")
-	}
+
 	if config.Spec.ClientId == "" {
 		return fmt.Errorf("OIDCConfig clientId is required")
 	}
@@ -62,5 +62,30 @@ func validateOIDCConfig(config *OIDCConfig, refName string, clusterConfig *Clust
 	if len(config.Spec.RequiredClaims) > 1 {
 		return fmt.Errorf("only one OIDConfig RequiredClaim is supported at this time")
 	}
+	return nil
+}
+
+func validateOIDCRefName(config *OIDCConfig, refName string) error {
+	if config == nil {
+		return nil
+	}
+
+	if config.Name != refName {
+		return fmt.Errorf("OIDCConfig retrieved with name %v does not match name (%s) specified in "+
+			"identityProviderRefs", config.Name, refName)
+	}
+
+	return nil
+}
+
+func validateOIDCNamespace(config *OIDCConfig, clusterConfig *Cluster) error {
+	if config == nil {
+		return nil
+	}
+
+	if config.Namespace != clusterConfig.Namespace {
+		return fmt.Errorf("OIDCConfig and Cluster objects must have the same namespace specified")
+	}
+
 	return nil
 }

--- a/pkg/api/v1alpha1/oidcconfig_types.go
+++ b/pkg/api/v1alpha1/oidcconfig_types.go
@@ -125,6 +125,10 @@ func (c *OIDCConfig) ExpectedKind() string {
 	return OIDCConfigKind
 }
 
+func (c *OIDCConfig) Validate() error {
+	return validateOIDCConfig(c)
+}
+
 func (c *OIDCConfig) ConvertConfigToConfigGenerateStruct() *OIDCConfigGenerate {
 	namespace := defaultEksaNamespace
 	if c.Namespace != "" {

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_types.go
@@ -125,6 +125,10 @@ func (v *VSphereDatacenterConfig) Marshallable() Marshallable {
 	return v.ConvertConfigToConfigGenerateStruct()
 }
 
+func (v *VSphereDatacenterConfig) Validate() error {
+	return nil
+}
+
 // +kubebuilder:object:generate=false
 
 // Same as VSphereDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig

--- a/pkg/api/v1alpha1/vspheremachineconfig_types.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_types.go
@@ -117,6 +117,10 @@ func (c *VSphereMachineConfig) Marshallable() Marshallable {
 	return c.ConvertConfigToConfigGenerateStruct()
 }
 
+func (c *VSphereMachineConfig) Validate() error {
+	return nil
+}
+
 // +kubebuilder:object:generate=false
 
 // Same as VSphereMachineConfig except stripped down for generation of yaml file during generate clusterconfig

--- a/pkg/cluster/parse_test.go
+++ b/pkg/cluster/parse_test.go
@@ -46,6 +46,7 @@ func TestParseConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
 						{
+							Name:  "workers-1",
 							Count: 1,
 							MachineGroupRef: &anywherev1.Ref{
 								Kind: "VSphereMachineConfig",
@@ -146,6 +147,7 @@ func TestParseConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
 						{
+							Name:  "workers-1",
 							Count: 1,
 						},
 					},

--- a/pkg/cluster/testdata/cluster_1_19.yaml
+++ b/pkg/cluster/testdata/cluster_1_19.yaml
@@ -23,7 +23,8 @@ spec:
     name: eksa-unit-test
   kubernetesVersion: "1.19"
   workerNodeGroupConfigurations:
-    - count: 1
+    - name: workers-1
+      count: 1
       machineGroupRef:
         kind: VSphereMachineConfig
         name: eksa-unit-test

--- a/pkg/cluster/testdata/docker_cluster_oidc_awsiam_flux.yaml
+++ b/pkg/cluster/testdata/docker_cluster_oidc_awsiam_flux.yaml
@@ -20,7 +20,8 @@ spec:
   managementCluster:
     name: m-docker
   workerNodeGroupConfigurations:
-  - count: 1
+  - name: workers-1
+    count: 1
   identityProviderRefs:
   - kind: OIDCConfig
     name: eksa-unit-test

--- a/pkg/cluster/validate.go
+++ b/pkg/cluster/validate.go
@@ -1,0 +1,85 @@
+package cluster
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+type validableValidation func(*Config, validable) error
+
+var validableValidations = []validableValidation{
+	validateSameNamespace,
+}
+
+func ValidateConfig(c *Config) error {
+	var allErrs []error
+	validables := getValidables(c)
+
+	for _, v := range validables {
+		if err := v.Validate(); err != nil {
+			allErrs = append(allErrs, err)
+		}
+
+		for _, validation := range validableValidations {
+			if err := validation(c, v); err != nil {
+				allErrs = append(allErrs, err)
+			}
+		}
+	}
+
+	if len(allErrs) > 0 {
+		aggregate := utilerrors.NewAggregate(allErrs)
+		return fmt.Errorf("invalid cluster config: %v", aggregate)
+	}
+
+	return nil
+}
+
+type validable interface {
+	Validate() error
+	GetNamespace() string
+	GetObjectKind() schema.ObjectKind
+}
+
+func getValidables(c *Config) []validable {
+	v := make([]validable, 0, 3)
+	v = appendIfNotNil(v, c.Cluster, c.VSphereDatacenter, c.DockerDatacenter, c.GitOpsConfig)
+
+	for _, e := range c.VSphereMachineConfigs {
+		v = appendIfNotNil(v, e)
+	}
+
+	for _, e := range c.OIDCConfigs {
+		v = appendIfNotNil(v, e)
+	}
+
+	for _, e := range c.AWSIAMConfigs {
+		v = appendIfNotNil(v, e)
+	}
+
+	return v
+}
+
+func appendIfNotNil(validables []validable, elems ...validable) []validable {
+	for _, e := range elems {
+		// Since we receive interfaces, these will never be nil since they contain
+		// the type of the original implementing struct
+		// I can't find another clean option of doing this
+		if !reflect.ValueOf(e).IsNil() {
+			validables = append(validables, e)
+		}
+	}
+
+	return validables
+}
+
+func validateSameNamespace(c *Config, v validable) error {
+	if c.Cluster.Namespace != v.GetNamespace() {
+		return fmt.Errorf("%s and Cluster objects must have the same namespace specified", v.GetObjectKind().GroupVersionKind().Kind)
+	}
+
+	return nil
+}

--- a/pkg/cluster/validate_test.go
+++ b/pkg/cluster/validate_test.go
@@ -1,0 +1,77 @@
+package cluster_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+)
+
+func TestValidateConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		// Using testdata file here to avoid specifying structs in code that
+		// we already have. If you need to test specific logic, create the structs
+		// in this package to avoid testadat file explosion
+		config *cluster.Config
+	}{
+		{
+			name:   "vsphere cluster",
+			config: clusterConfigFromFile(t, "testdata/cluster_1_19.yaml"),
+		},
+		{
+			name:   "docker cluster",
+			config: clusterConfigFromFile(t, "testdata/docker_cluster_oidc_awsiam_flux.yaml"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(cluster.ValidateConfig(tt.config)).To(Succeed())
+		})
+	}
+}
+
+func clusterConfigFromFile(t *testing.T, path string) *cluster.Config {
+	t.Helper()
+	c, err := cluster.ParseConfigFromFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return c
+}
+
+func TestValidateConfigDifferentNamespace(t *testing.T) {
+	g := NewWithT(t)
+	c := &cluster.Config{
+		Cluster: &anywherev1.Cluster{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       anywherev1.ClusterKind,
+				APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "eksa-unit-test",
+				Namespace: "ns-1",
+			},
+		},
+		VSphereDatacenter: &anywherev1.VSphereDatacenterConfig{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       anywherev1.VSphereDatacenterKind,
+				APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "eksa-unit-test",
+				Namespace: "ns-2",
+			},
+		},
+	}
+
+	g.Expect(cluster.ValidateConfig(c)).To(
+		MatchError(ContainSubstring("VSphereDatacenterConfig and Cluster objects must have the same namespace specified")),
+	)
+}


### PR DESCRIPTION
This continues the work started on #1343

*Description of changes:*
Context unaware validations rely on having a Validate method in the api
structs.

This adds the option to run context aware validations at the cluster
Config level. These should have no external dependencies and depend
solely on the data in cluster Config.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

