### PR TITLE
Tinkerbell hardware workflow mapping - pre flight validation

### DIFF
--- a/pkg/executables/tink.go
+++ b/pkg/executables/tink.go
@@ -41,13 +41,13 @@ func (t *Tink) PushHardware(ctx context.Context, hardware []byte) error {
 	return nil
 }
 
-func (t *Tink) GetHardware(ctx context.Context) ([]*hardware.Hardware, error) {
+func (t *Tink) GetHardware(ctx context.Context) (map[string]*hardware.Hardware, error) {
 	params := []string{"hardware", "get", "--format", "json"}
 	data, err := t.Command(ctx, params...).WithEnvVars(t.envMap).Run()
 	if err != nil {
 		return nil, fmt.Errorf("error getting hardware list: %v", err)
 	}
-	var hardwareList []*hardware.Hardware
+	hardwareList := make(map[string]*hardware.Hardware)
 	hardwareString := data.String()
 
 	if len(hardwareString) > 0 {
@@ -57,7 +57,9 @@ func (t *Tink) GetHardware(ctx context.Context) ([]*hardware.Hardware, error) {
 			return nil, fmt.Errorf("error unmarshling hardware json: %v", err)
 		}
 		if len(hardwareListData["data"]) > 0 {
-			hardwareList = append(hardwareList, hardwareListData["data"]...)
+			for _, data := range hardwareListData["data"] {
+				hardwareList[data.GetId()] = data
+			}
 		}
 	}
 

--- a/pkg/executables/tink.go
+++ b/pkg/executables/tink.go
@@ -41,13 +41,13 @@ func (t *Tink) PushHardware(ctx context.Context, hardware []byte) error {
 	return nil
 }
 
-func (t *Tink) GetHardware(ctx context.Context) (map[string]*hardware.Hardware, error) {
+func (t *Tink) GetHardware(ctx context.Context) ([]*hardware.Hardware, error) {
 	params := []string{"hardware", "get", "--format", "json"}
 	data, err := t.Command(ctx, params...).WithEnvVars(t.envMap).Run()
 	if err != nil {
 		return nil, fmt.Errorf("error getting hardware list: %v", err)
 	}
-	hardwareList := make(map[string]*hardware.Hardware)
+	var hardwareList []*hardware.Hardware
 	hardwareString := data.String()
 
 	if len(hardwareString) > 0 {
@@ -57,9 +57,7 @@ func (t *Tink) GetHardware(ctx context.Context) (map[string]*hardware.Hardware, 
 			return nil, fmt.Errorf("error unmarshling hardware json: %v", err)
 		}
 		if len(hardwareListData["data"]) > 0 {
-			for _, data := range hardwareListData["data"] {
-				hardwareList[data.GetId()] = data
-			}
+			hardwareList = append(hardwareList, hardwareListData["data"]...)
 		}
 	}
 

--- a/pkg/executables/tink.go
+++ b/pkg/executables/tink.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/tinkerbell/tink/protos/hardware"
+	"github.com/tinkerbell/tink/protos/workflow"
 )
 
 const (
@@ -62,4 +63,27 @@ func (t *Tink) GetHardware(ctx context.Context) ([]*hardware.Hardware, error) {
 	}
 
 	return hardwareList, nil
+}
+
+func (t *Tink) GetWorkflow(ctx context.Context) ([]*workflow.Workflow, error) {
+	params := []string{"workflow", "get", "--format", "json"}
+	data, err := t.Command(ctx, params...).WithEnvVars(t.envMap).Run()
+	if err != nil {
+		return nil, fmt.Errorf("error getting workflow list: %v", err)
+	}
+	var workflowList []*workflow.Workflow
+	workflowString := data.String()
+
+	if len(workflowString) > 0 {
+		workflowListData := map[string][]*workflow.Workflow{}
+
+		if err = json.Unmarshal([]byte(workflowString), &workflowListData); err != nil {
+			return nil, fmt.Errorf("error unmarshling workflow json: %v", err)
+		}
+		if len(workflowListData["data"]) > 0 {
+			workflowList = append(workflowList, workflowListData["data"]...)
+		}
+	}
+
+	return workflowList, nil
 }

--- a/pkg/executables/tink_test.go
+++ b/pkg/executables/tink_test.go
@@ -53,7 +53,7 @@ func TestTinkGetHardware(t *testing.T) {
 	}
 }
 
-func TestTinkWorkflow(t *testing.T) {
+func TestTinkGetWorkflow(t *testing.T) {
 	tink, ctx, e := newTink(t)
 	expectedParam := []string{"workflow", "get", "--format", "json"}
 	expectCommand(e, ctx, expectedParam...).withEnvVars(envMap).to().Return(bytes.Buffer{}, nil)

--- a/pkg/executables/tink_test.go
+++ b/pkg/executables/tink_test.go
@@ -52,3 +52,12 @@ func TestTinkGetHardware(t *testing.T) {
 		t.Errorf("Tink.GetHardware() error = %v, want nil", err)
 	}
 }
+
+func TestTinkWorkflow(t *testing.T) {
+	tink, ctx, e := newTink(t)
+	expectedParam := []string{"workflow", "get", "--format", "json"}
+	expectCommand(e, ctx, expectedParam...).withEnvVars(envMap).to().Return(bytes.Buffer{}, nil)
+	if _, err := tink.GetWorkflow(ctx); err != nil {
+		t.Errorf("Tink.GetWorkflow() error = %v, want nil", err)
+	}
+}

--- a/pkg/providers/tinkerbell/hardware/config.go
+++ b/pkg/providers/tinkerbell/hardware/config.go
@@ -92,9 +92,11 @@ func (hc *HardwareConfig) ValidateHardware(skipPowerActions bool, tinkHardwareMa
 
 		hardwareInterface := tinkHardwareMap[hw.Spec.ID].GetNetwork().GetInterfaces()
 		if len(hardwareInterface) > 0 {
-			mac := hardwareInterface[0].GetDhcp()
-			if _, ok := tinkWorkflowMap[mac.Mac]; ok {
-				return fmt.Errorf("workflow %s alredy exixts for the hardware id %s", tinkWorkflowMap[mac.Mac].Id, hw.Spec.ID)
+			for _, interfaces := range hardwareInterface {
+				mac := interfaces.GetDhcp()
+				if _, ok := tinkWorkflowMap[mac.Mac]; ok {
+					return fmt.Errorf("workflow %s alredy exixts for the hardware id %s", tinkWorkflowMap[mac.Mac].Id, hw.Spec.ID)
+				}
 			}
 		}
 

--- a/pkg/providers/tinkerbell/hardware/config.go
+++ b/pkg/providers/tinkerbell/hardware/config.go
@@ -91,12 +91,10 @@ func (hc *HardwareConfig) ValidateHardware(skipPowerActions bool, tinkHardwareMa
 		}
 
 		hardwareInterface := tinkHardwareMap[hw.Spec.ID].GetNetwork().GetInterfaces()
-		if len(hardwareInterface) > 0 {
-			for _, interfaces := range hardwareInterface {
-				mac := interfaces.GetDhcp()
-				if _, ok := tinkWorkflowMap[mac.Mac]; ok {
-					return fmt.Errorf("workflow %s alredy exixts for the hardware id %s", tinkWorkflowMap[mac.Mac].Id, hw.Spec.ID)
-				}
+		for _, interfaces := range hardwareInterface {
+			mac := interfaces.GetDhcp()
+			if _, ok := tinkWorkflowMap[mac.Mac]; ok {
+				return fmt.Errorf("workflow %s already exixts for the hardware id %s", tinkWorkflowMap[mac.Mac].Id, hw.Spec.ID)
 			}
 		}
 

--- a/pkg/providers/tinkerbell/hardware/config.go
+++ b/pkg/providers/tinkerbell/hardware/config.go
@@ -8,6 +8,7 @@ import (
 	pbnjv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/pbnj/api/v1alpha1"
 	tinkv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/tink/api/v1alpha1"
 	tinkhardware "github.com/tinkerbell/tink/protos/hardware"
+	tinkworkflow "github.com/tinkerbell/tink/protos/workflow"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
@@ -70,7 +71,7 @@ func (hc *HardwareConfig) setHardwareConfigFromFile(hardwareFileName string) err
 	return nil
 }
 
-func (hc *HardwareConfig) ValidateHardware(skipPowerActions bool, tinkHardwareMap map[string]*tinkhardware.Hardware) error {
+func (hc *HardwareConfig) ValidateHardware(skipPowerActions bool, tinkHardwareMap map[string]*tinkhardware.Hardware, tinkWorkflowMap map[string]*tinkworkflow.Workflow) error {
 	bmcRefMap := map[string]*tinkv1alpha1.Hardware{}
 	if !skipPowerActions {
 		bmcRefMap = hc.initBmcRefMap()
@@ -87,6 +88,14 @@ func (hc *HardwareConfig) ValidateHardware(skipPowerActions bool, tinkHardwareMa
 
 		if _, ok := tinkHardwareMap[hw.Spec.ID]; !ok {
 			return fmt.Errorf("hardware id '%s' is not registered with tinkerbell stack", hw.Spec.ID)
+		}
+
+		hardwareInterface := tinkHardwareMap[hw.Spec.ID].GetNetwork().GetInterfaces()
+		if len(hardwareInterface) > 0 {
+			mac := hardwareInterface[0].GetDhcp()
+			if _, ok := tinkWorkflowMap[mac.Mac]; ok {
+				return fmt.Errorf("workflow %s alredy exixts for the hardware id %s", tinkWorkflowMap[mac.Mac].Id, hw.Spec.ID)
+			}
 		}
 
 		if !skipPowerActions {

--- a/pkg/providers/tinkerbell/mocks/client.go
+++ b/pkg/providers/tinkerbell/mocks/client.go
@@ -124,10 +124,10 @@ func (m *MockProviderTinkClient) EXPECT() *MockProviderTinkClientMockRecorder {
 }
 
 // GetHardware mocks base method.
-func (m *MockProviderTinkClient) GetHardware(arg0 context.Context) ([]*hardware.Hardware, error) {
+func (m *MockProviderTinkClient) GetHardware(arg0 context.Context) (map[string]*hardware.Hardware, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHardware", arg0)
-	ret0, _ := ret[0].([]*hardware.Hardware)
+	ret0, _ := ret[0].(map[string]*hardware.Hardware)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/providers/tinkerbell/mocks/client.go
+++ b/pkg/providers/tinkerbell/mocks/client.go
@@ -12,6 +12,7 @@ import (
 	pbnj "github.com/aws/eks-anywhere/pkg/providers/tinkerbell/pbnj"
 	gomock "github.com/golang/mock/gomock"
 	hardware "github.com/tinkerbell/tink/protos/hardware"
+	workflow "github.com/tinkerbell/tink/protos/workflow"
 	v1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -136,6 +137,21 @@ func (m *MockProviderTinkClient) GetHardware(arg0 context.Context) ([]*hardware.
 func (mr *MockProviderTinkClientMockRecorder) GetHardware(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHardware", reflect.TypeOf((*MockProviderTinkClient)(nil).GetHardware), arg0)
+}
+
+// GetWorkflow mocks base method.
+func (m *MockProviderTinkClient) GetWorkflow(arg0 context.Context) ([]*workflow.Workflow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkflow", arg0)
+	ret0, _ := ret[0].([]*workflow.Workflow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkflow indicates an expected call of GetWorkflow.
+func (mr *MockProviderTinkClientMockRecorder) GetWorkflow(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflow", reflect.TypeOf((*MockProviderTinkClient)(nil).GetWorkflow), arg0)
 }
 
 // MockProviderPbnjClient is a mock of ProviderPbnjClient interface.

--- a/pkg/providers/tinkerbell/mocks/client.go
+++ b/pkg/providers/tinkerbell/mocks/client.go
@@ -124,10 +124,10 @@ func (m *MockProviderTinkClient) EXPECT() *MockProviderTinkClientMockRecorder {
 }
 
 // GetHardware mocks base method.
-func (m *MockProviderTinkClient) GetHardware(arg0 context.Context) (map[string]*hardware.Hardware, error) {
+func (m *MockProviderTinkClient) GetHardware(arg0 context.Context) ([]*hardware.Hardware, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHardware", arg0)
-	ret0, _ := ret[0].(map[string]*hardware.Hardware)
+	ret0, _ := ret[0].([]*hardware.Hardware)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -8,7 +8,8 @@ import (
 	"os"
 	"time"
 
-	tink "github.com/tinkerbell/tink/protos/hardware"
+	tinkhardware "github.com/tinkerbell/tink/protos/hardware"
+	tinkworkflow "github.com/tinkerbell/tink/protos/workflow"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -80,7 +81,8 @@ type ProviderKubectlClient interface {
 }
 
 type ProviderTinkClient interface {
-	GetHardware(ctx context.Context) ([]*tink.Hardware, error)
+	GetHardware(ctx context.Context) ([]*tinkhardware.Hardware, error)
+	GetWorkflow(ctx context.Context) ([]*tinkworkflow.Workflow, error)
 }
 
 type ProviderPbnjClient interface {

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	tinkhardware "github.com/tinkerbell/tink/protos/hardware"
+	tinkworkflow "github.com/tinkerbell/tink/protos/workflow"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -151,6 +152,8 @@ func TestTinkerbellProviderGenerateDeploymentFileWithExternalEtcd(t *testing.T) 
 	ctx := context.Background()
 
 	tink.EXPECT().GetHardware(ctx).Return(hardwares, nil)
+	tink.EXPECT().GetWorkflow(ctx).Return([]*tinkworkflow.Workflow{}, nil)
+
 	pbnjClient.EXPECT().ValidateBMCSecretCreds(ctx, gomock.Any()).Return(nil).Times(4)
 
 	provider := newProviderWithKubectlWithTink(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, kubectl, tinkerbellClients)
@@ -184,6 +187,7 @@ func TestTinkerbellProviderGenerateDeploymentFileWithStackedEtcd(t *testing.T) {
 	ctx := context.Background()
 
 	tink.EXPECT().GetHardware(ctx).Return(hardwares, nil)
+	tink.EXPECT().GetWorkflow(ctx).Return([]*tinkworkflow.Workflow{}, nil)
 	pbnjClient.EXPECT().ValidateBMCSecretCreds(ctx, gomock.Any()).Return(nil).Times(4)
 
 	provider := newProviderWithKubectlWithTink(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, kubectl, tinkerbellClients)
@@ -210,11 +214,15 @@ func TestTinkerbellProviderGenerateDeploymentFileMultipleWorkerNodeGroups(t *tes
 	tinkerbellClients := TinkerbellClients{tink, pbnjClient}
 	cluster := &types.Cluster{Name: "test"}
 	hardwares := setupHardware()
+
 	clusterSpec := givenClusterSpec(t, clusterSpecManifest)
 	datacenterConfig := givenDatacenterConfig(t, clusterSpecManifest)
 	machineConfigs := givenMachineConfigs(t, clusterSpecManifest)
 	ctx := context.Background()
+
 	tink.EXPECT().GetHardware(ctx).Return(hardwares, nil)
+	tink.EXPECT().GetWorkflow(ctx).Return([]*tinkworkflow.Workflow{}, nil)
+
 	pbnjClient.EXPECT().ValidateBMCSecretCreds(ctx, gomock.Any()).Return(nil).Times(4)
 	provider := newProviderWithKubectlWithTink(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, kubectl, tinkerbellClients)
 	if err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec); err != nil {

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -129,13 +129,14 @@ func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFi
 		return fmt.Errorf("failed to get hardware Config: %v", err)
 	}
 
-	tinkHardwareMap := hardwareMap(hardwares)
+	tinkHardwareMap := getHardwareMap(hardwares)
 
 	workflows, err := v.tink.GetWorkflow(ctx)
 	if err != nil {
 		return fmt.Errorf("%v", err)
 	}
-	tinkWorkflowMap, err := workflowMap(workflows)
+	tinkWorkflowMap, err := getWorkflowMap(workflows)
+
 	if err != nil {
 		return fmt.Errorf("error validating if the workflow exist for the given list of hardwares %v", err)
 	}
@@ -285,8 +286,8 @@ func validateAddressWithPort(address string) error {
 	return nil
 }
 
-// hardwareMap returns all the hardwares on the tinkerbell stack in the form of map with hardware uuid as a key
-func hardwareMap(hardwareList []*tinkhardware.Hardware) map[string]*tinkhardware.Hardware {
+// getHardwareMap returns all the hardwares on the tinkerbell stack in the form of map with hardware uuid as a key
+func getHardwareMap(hardwareList []*tinkhardware.Hardware) map[string]*tinkhardware.Hardware {
 	hardwareMap := make(map[string]*tinkhardware.Hardware)
 
 	for _, data := range hardwareList {
@@ -296,8 +297,8 @@ func hardwareMap(hardwareList []*tinkhardware.Hardware) map[string]*tinkhardware
 	return hardwareMap
 }
 
-// workflowMap returns all the workflows on the tinkerbell stack in the form of map with mac address as a key
-func workflowMap(workflowList []*tinkworkflow.Workflow) (map[string]*tinkworkflow.Workflow, error) {
+// getWorkflowMap returns all the workflows on the tinkerbell stack in the form of map with mac address as a key
+func getWorkflowMap(workflowList []*tinkworkflow.Workflow) (map[string]*tinkworkflow.Workflow, error) {
 	workflowMap := make(map[string]*tinkworkflow.Workflow)
 
 	for _, data := range workflowList {
@@ -306,9 +307,8 @@ func workflowMap(workflowList []*tinkworkflow.Workflow) (map[string]*tinkworkflo
 		if err := json.Unmarshal([]byte(data.GetHardware()), &macAddress); err != nil {
 			return nil, fmt.Errorf("error unmarshling workflow data: %v", err)
 		}
-
-		if _, ok := macAddress["device_1"]; ok {
-			workflowMap[macAddress["device_1"]] = data
+		for _, mac := range macAddress {
+			workflowMap[mac] = data
 		}
 	}
 

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -136,7 +136,6 @@ func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFi
 		return fmt.Errorf("%v", err)
 	}
 	tinkWorkflowMap, err := getWorkflowMap(workflows)
-
 	if err != nil {
 		return fmt.Errorf("error validating if the workflow exist for the given list of hardwares %v", err)
 	}

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -2,11 +2,13 @@ package tinkerbell
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 
 	tinkhardware "github.com/tinkerbell/tink/protos/hardware"
+	tinkworkflow "github.com/tinkerbell/tink/protos/workflow"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/logger"
@@ -121,7 +123,6 @@ func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFi
 	if err != nil {
 		return fmt.Errorf("failed validating connection to tinkerbell stack: %v", err)
 	}
-
 	logger.MarkPass("Connected to tinkerbell stack")
 
 	if err := v.hardwareConfig.ParseHardwareConfig(hardwareConfigFile); err != nil {
@@ -129,7 +130,17 @@ func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFi
 	}
 
 	tinkHardwareMap := hardwareMap(hardwares)
-	if err := v.hardwareConfig.ValidateHardware(skipPowerActions, tinkHardwareMap); err != nil {
+
+	workflows, err := v.tink.GetWorkflow(ctx)
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+	tinkWorkflowMap, err := workflowMap(workflows)
+	if err != nil {
+		return fmt.Errorf("error validating if the workflow exist for the given list of hardwares %v", err)
+	}
+
+	if err := v.hardwareConfig.ValidateHardware(skipPowerActions, tinkHardwareMap, tinkWorkflowMap); err != nil {
 		return fmt.Errorf("failed validating Hardware BMC refs in hardware config: %v", err)
 	}
 
@@ -274,6 +285,7 @@ func validateAddressWithPort(address string) error {
 	return nil
 }
 
+// hardwareMap returns all the hardwares on the tinkerbell stack in the form of map with hardware uuid as a key
 func hardwareMap(hardwareList []*tinkhardware.Hardware) map[string]*tinkhardware.Hardware {
 	hardwareMap := make(map[string]*tinkhardware.Hardware)
 
@@ -282,4 +294,23 @@ func hardwareMap(hardwareList []*tinkhardware.Hardware) map[string]*tinkhardware
 	}
 
 	return hardwareMap
+}
+
+// workflowMap returns all the workflows on the tinkerbell stack in the form of map with mac address as a key
+func workflowMap(workflowList []*tinkworkflow.Workflow) (map[string]*tinkworkflow.Workflow, error) {
+	workflowMap := make(map[string]*tinkworkflow.Workflow)
+
+	for _, data := range workflowList {
+		var macAddress map[string]string
+
+		if err := json.Unmarshal([]byte(data.GetHardware()), &macAddress); err != nil {
+			return nil, fmt.Errorf("error unmarshling workflow data: %v", err)
+		}
+
+		if _, ok := macAddress["device_1"]; ok {
+			workflowMap[macAddress["device_1"]] = data
+		}
+	}
+
+	return workflowMap, nil
 }


### PR DESCRIPTION
*Description of changes:*

This PR is a part of pre-flight validation for Tinkerbell provider. Before creating a cluster our CLI will check whether a workflow exists in the Tinkerbell stack or not. It will fail the cluster creation if there is any workflows associated with any of the hardwares provided in the hardware yaml file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

