### PR TITLE
Update embed eksd manifest doc

### DIFF
--- a/designs/embed_eksd_manifest.md
+++ b/designs/embed_eksd_manifest.md
@@ -15,14 +15,21 @@ As an EKS Anywhere user:
 
 ## Overview of Solution
 
-The EKS Distro manifest and the release CRD will be applied directly to the cluster.
-This will allow the controller to grab the EKSD release resources from within the cluster instead of reading in the EKSD manifest from the internet when fetching the applied spec.
-
-### Solution Details
-
 With this feature, the EKSD manifest & its CRD will be applied directly to the cluster.
+This will allow the controller to grab the EKSD release resources from within the cluster instead of reading in the EKSD manifest from the internet when fetching the applied spec.
 We will do this similarly to how we apply the EKSA components to the cluster, introducing a new task to the create workflow called `InstallEksdComponentsTask`.
-We currently don’t pull in the EKSD release CRD in the bundle, so I propose introducing a new field `crdUrl` in the EKSD Bundle to refer to the file in S3 that stores this CRD.
+In the upgrade workflow, we will also add a step to apply the EKSD resources as we update other cluster resources.
+
+#### EKS-D bundle changes
+
+We currently don’t pull in the EKSD release CRD in the bundle, but we need to apply this CRD before applying the release manifest.
+I propose introducing a new field `components` in the EKSD bundle to refer to the file in S3 that stores this CRD.
+
+While most of our bundles have a `version` field, the EKS-D bundle does not have this field.
+Instead, the version is typically decided by the `releaseChannel` and the `releaseNumber`.
+We already have the `channel` field in the EKS-D bundle, so I propose adding the `number` field to this bundle to have an effective way to check the EKS-D version during upgrades.
+
+Example bundles manifest with proposed changes:
 
 ```
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
@@ -36,14 +43,23 @@ spec:
   versionsBundles:
     eksD:
       channel: 1-21
-      crdUrl: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+      components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
       gitCommit: |
         fcddf59a516102e20f75b6c672e3aa74cf2da877
       kindNode:
         arch:
+          ...
+      kubeVersion: v1.21.5
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-8.yaml
+      name: kubernetes-1-21-eks-8
+      number: 8
+      ova:
+         ...
 ```
 
-From here, we can use `kubectl apply` to apply the content from the EKSD release URL and the CRD URL to the cluster.
+From here, we can use `kubectl apply` to apply the content from the EKSD release CRD & manifest to the cluster.
+
+#### Cluster status changes
 
 We will need a way to refer to the EKSD release object on the cluster when calling it from the controller.
 One way to achieve this is by adding a field `EkdsReleaseRef` to the cluster status.
@@ -57,8 +73,8 @@ spec:
     ...
 status:
   eksdReleaseRef:
+    kind: Release
     name: "name of resource" 
-    url: "url we downloaded from"
 ```
 
 From here, we can call `kubectl get release` using the `eksdReleaseRef.Name` to access the EKSD release manifest from the controller.
@@ -67,6 +83,6 @@ From here, we can call `kubectl get release` using the `eksdReleaseRef.Name` to 
 
 Now that the EKSD components are embedded in the cluster, we have to ensure that those components are supported during upgrade.
 We will update the upgrader in cluster manager to not only check for updates to EKSA, but it will also check if updates are needed for the EKSD objects on the cluster.
-We will have a method `EksdChangeDiff` to check both the EKSD version in the bundle and the Kubernetes version in the cluster config to decide if we need to update the EKSD manifest objects that are applied to the cluster.
+We will have a method `EksdChangeDiff` to check the EKSD version in the bundle to decide if we need to update the EKSD manifest objects that are applied to the cluster.
 
 

--- a/designs/embed_eksd_manifest.md
+++ b/designs/embed_eksd_manifest.md
@@ -25,10 +25,6 @@ In the upgrade workflow, we will also add a step to apply the EKSD resources as 
 We currently don’t pull in the EKSD release CRD in the bundle, but we need to apply this CRD before applying the release manifest.
 I propose introducing a new field `components` in the EKSD bundle to refer to the file in S3 that stores this CRD.
 
-While most of our bundles have a `version` field, the EKS-D bundle does not have this field.
-Instead, the version is typically decided by the `releaseChannel` and the `releaseNumber`.
-We already have the `channel` field in the EKS-D bundle, so I propose adding the `number` field to this bundle to have an effective way to check the EKS-D version during upgrades.
-
 Example bundles manifest with proposed changes:
 
 ```
@@ -49,12 +45,6 @@ spec:
       kindNode:
         arch:
           ...
-      kubeVersion: v1.21.5
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-8.yaml
-      name: kubernetes-1-21-eks-8
-      number: 8
-      ova:
-         ...
 ```
 
 From here, we can use `kubectl apply` to apply the content from the EKSD release CRD & manifest to the cluster.
@@ -73,8 +63,10 @@ spec:
     ...
 status:
   eksdReleaseRef:
+    apiGroup: distro.eks.amazonaws.com/v1alpha1
     kind: Release
-    name: "name of resource" 
+    name: "name of resource"
+    namespace: "namespace for resource" (default: eksa-system)
 ```
 
 From here, we can call `kubectl get release` using the `eksdReleaseRef.Name` to access the EKSD release manifest from the controller.

--- a/designs/embed_eksd_manifest.md
+++ b/designs/embed_eksd_manifest.md
@@ -45,15 +45,28 @@ spec:
 
 From here, we can use `kubectl apply` to apply the content from the EKSD release URL and the CRD URL to the cluster.
 
-We will need a way to refer to the EKSD release object on the cluster.
-One way to achieve this is by adding a field to the cluster status.
-We will introduce a field named `EksdRelease` of type `*v1alpha1.Release`.
-This is how we will attain that direct access to the release object when calling it from the controller.
+We will need a way to refer to the EKSD release object on the cluster when calling it from the controller.
+One way to achieve this is by adding a field `EkdsReleaseRef` to the cluster status.
+```
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: test_cluster
+spec:
+  controlPlaneConfiguration:
+    ...
+status:
+  eksdReleaseRef:
+    name: "name of resource" 
+    url: "url we downloaded from"
+```
 
+From here, we can call `kubectl get release` using the `eksdReleaseRef.Name` to access the EKSD release manifest from the controller.
 
 ### Upgrading EKSD components
 
 Now that the EKSD components are embedded in the cluster, we have to ensure that those components are supported during upgrade.
-We will update the upgrader in cluster manager to not only check for updates to EKSA, but it will also check for updates to EKSD.
-If there is a newer version, we will upgrade those components.
+We will update the upgrader in cluster manager to not only check for updates to EKSA, but it will also check if updates are needed for the EKSD objects on the cluster.
+We will have a method `EksdChangeDiff` to check both the EKSD version in the bundle and the Kubernetes version in the cluster config to decide if we need to update the EKSD manifest objects that are applied to the cluster.
+
 

--- a/designs/embed_eksd_manifest.md
+++ b/designs/embed_eksd_manifest.md
@@ -49,10 +49,16 @@ spec:
 
 From here, we can use `kubectl apply` to apply the content from the EKSD release CRD & manifest to the cluster.
 
-#### Cluster status changes
+#### Cluster spec changes
 
 We will need a way to refer to the EKSD release object on the cluster when calling it from the controller.
-One way to achieve this is by adding a field `EkdsReleaseRef` to the cluster status.
+One way to achieve this is by grabbing the EKSD bundle from the bundles object.
+We already apply the bundles to the cluster, and we fetch the bundles object in the controller.
+However, we depend on the cluster name to fetch this bundle.
+A more accurate way to fetch this bundle is by adding a field `bundlesRef` to the cluster spec.
+This will serve as our source of truth for the bundles object on the cluster.
+
+
 ```
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Cluster
@@ -61,15 +67,14 @@ metadata:
 spec:
   controlPlaneConfiguration:
     ...
-status:
-  eksdReleaseRef:
-    apiGroup: distro.eks.amazonaws.com/v1alpha1
-    kind: Release
-    name: "name of resource"
-    namespace: "namespace for resource" (default: eksa-system)
+  bundlesRef:
+    apiGroup: anywhere.eks.amazonaws.com/v1alpha1
+    kind: Bundles
+    name: "bundle-name"
+    namespace: "namespace for resource" 
 ```
 
-From here, we can call `kubectl get release` using the `eksdReleaseRef.Name` to access the EKSD release manifest from the controller.
+This bundles ref will allow us accurately fetch the bundle from the cluster, access the EKSD bundle, and grab the correct release manifest in the controller.
 
 ### Upgrading EKSD components
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Instead of using `eksdRelaseRef` in the cluster status, we will introduce `bundlesRef` to the cluster spec to access the bundles & grab to the correct EKS-D release object from the cluster.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

