### PR TITLE
Unset external cloud-provider config for snow provider

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,6 +22,9 @@ spec:
         image: controller:latest
         imagePullPolicy: Always
         name: manager
+        env:
+        - name: FULL_LIFECYCLE_API
+          value: "false"
         ports:
         - containerPort: 8081
           name: healthz

--- a/controllers/Tiltfile
+++ b/controllers/Tiltfile
@@ -31,6 +31,9 @@ local_resource(
 
 DOCKERFILE = '''FROM golang:alpine
 WORKDIR /
+ENV MR_TOOLS_DISABLE=true
+RUN apk --no-cache add curl
+RUN curl -L -o - "https://github.com/vmware/govmomi/releases/latest/download/govc_$(uname -s)_$(uname -m).tar.gz" | tar -C /usr/local/bin -xvzf - govc
 COPY ./bin/manager /
 CMD ["/manager"]
 '''

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -33,18 +33,10 @@ func KubeadmControlPlane(clusterSpec *cluster.Spec, snowMachineTemplate *snowv1.
 	stackedEtcdExtraArgs["listen-peer-urls"] = "https://0.0.0.0:2380"
 	stackedEtcdExtraArgs["listen-client-urls"] = "https://0.0.0.0:2379"
 
-	apiServerExtraArgs := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ControlPlaneComponent.ExtraArgs
-	apiServerExtraArgs["cloud-provider"] = "external"
-
-	controllerManagerExtraArgs := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager.ExtraArgs
-	controllerManagerExtraArgs["cloud-provider"] = "external"
-
 	initConfigKubeletExtraArg := kcp.Spec.KubeadmConfigSpec.InitConfiguration.NodeRegistration.KubeletExtraArgs
-	initConfigKubeletExtraArg["cloud-provider"] = "external"
 	initConfigKubeletExtraArg["provider-id"] = "aws-snow:////'{{ ds.meta_data.instance_id }}'"
 
 	joinConfigKubeletExtraArg := kcp.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.KubeletExtraArgs
-	joinConfigKubeletExtraArg["cloud-provider"] = "external"
 	joinConfigKubeletExtraArg["provider-id"] = "aws-snow:////'{{ ds.meta_data.instance_id }}'"
 
 	kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands = []string{
@@ -62,7 +54,6 @@ func kubeadmConfigTemplate(clusterSpec *cluster.Spec, workerNodeGroupConfig v1al
 	kct := clusterapi.KubeadmConfigTemplate(clusterSpec, workerNodeGroupConfig)
 
 	joinConfigKubeletExtraArg := kct.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs
-	joinConfigKubeletExtraArg["cloud-provider"] = "external"
 	joinConfigKubeletExtraArg["provider-id"] = "aws-snow:////'{{ ds.meta_data.instance_id }}'"
 
 	kct.Spec.Template.Spec.PreKubeadmCommands = []string{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Snow does not have a cloud provider controller set up. Remove from CAPI config.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

