### PR TITLE
Fix 1-22 tests

### DIFF
--- a/test/e2e/taints_test.go
+++ b/test/e2e/taints_test.go
@@ -38,7 +38,7 @@ func TestVSphereKubernetes122Taints(t *testing.T) {
 		t,
 		provider,
 		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube121),
+			api.WithKubernetesVersion(v1alpha1.Kube122),
 			api.WithExternalEtcdTopology(1),
 			api.WithControlPlaneCount(1),
 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -139,6 +139,7 @@ func TestVSphereKubernetes122UbuntuControlPlaneNodeUpgrade(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runSimpleUpgradeFlow(
 		test,
@@ -156,6 +157,7 @@ func TestVSphereKubernetes122UbuntuWorkerNodeUpgrade(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runSimpleUpgradeFlow(
 		test,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes configuration for `TestVSphereKubernetes122Taints` and `TestVSphereKubernetes122UbuntuWorkerNodeUpgrade` tests

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

