### PR TITLE
Fix existing kubeconfig error when creating cluster

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -80,7 +80,10 @@ func (cc *createClusterOptions) validate(ctx context.Context) error {
 
 	kubeconfigPath := kubeconfig.FromClusterName(clusterConfig.Name)
 	if validations.FileExistsAndIsNotEmpty(kubeconfigPath) {
-		return kubeconfig.NewMissingFileError(clusterConfig.Name, kubeconfigPath)
+		return fmt.Errorf(
+			"old cluster config file exists under %s, please use a different clusterName to proceed",
+			clusterConfig.Name,
+		)
 	}
 
 	return nil


### PR DESCRIPTION
In #1302 an error message indicating an existing clusters kubeconfig already exists was replaced with a more abstract missing kubeconfig error that, under the circumstances, is less meaningful.

This replaces the error with the original.