### PR TITLE
Define kubeconfig env var in kubeconfig package

### DIFF
--- a/cmd/eksctl-anywhere/cmd/constants.go
+++ b/cmd/eksctl-anywhere/cmd/constants.go
@@ -1,3 +1,0 @@
-package cmd
-
-const kubeconfigEnvVariable = "KUBECONFIG"

--- a/cmd/eksctl-anywhere/cmd/get.go
+++ b/cmd/eksctl-anywhere/cmd/get.go
@@ -39,7 +39,7 @@ func preRunPackages(cmd *cobra.Command, args []string) error {
 }
 
 func getResources(ctx context.Context, resourceType string, output string, args []string) error {
-	kubeConfig := kubeconfig.FromEnvironment(kubeconfigEnvVariable)
+	kubeConfig := kubeconfig.FromEnvironment()
 
 	deps, err := createKubectl(ctx)
 	if err != nil {

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -9,6 +9,10 @@ import (
 // FromClusterFormat defines the format of the kubeconfig of the
 const FromClusterFormat = "%s-eks-a-cluster.kubeconfig"
 
+// EnvName is the standard KubeConfig environment variable name.
+// https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#set-the-kubeconfig-environment-variable
+const EnvName = "KUBECONFIG"
+
 // FromClusterName formats an expected Kubeconfig path for EKS-A clusters. This includes a subdirecftory
 // named after the cluster name. For example, if the clusterName is 'sandbox' the generated path would be
 // sandbox/sandbox-eks-a-cluster.kubeconfig
@@ -16,8 +20,9 @@ func FromClusterName(clusterName string) string {
 	return filepath.Join(clusterName, fmt.Sprintf(FromClusterFormat, clusterName))
 }
 
-func FromEnvironment(envVariable string) string {
-	return os.Getenv(envVariable)
+// FromEnvironment reads the KubeConfig path from the standard KUBECONFIG environment variable.
+func FromEnvironment() string {
+	return os.Getenv(EnvName)
 }
 
 type missingFileError struct {


### PR DESCRIPTION
The `KUBECONFIG` environment variable has semantics within the Kubernetes community and isn't really customizable. This change acknowledges that by defining it in the `kubconfig` package as opposed to in the `cmd` package.