### PR TITLE
Cluster Config defaults

### DIFF
--- a/pkg/api/v1alpha1/awsiamconfig.go
+++ b/pkg/api/v1alpha1/awsiamconfig.go
@@ -17,6 +17,8 @@ func GetAndValidateAWSIamConfig(fileName string, refName string, clusterConfig *
 	if err != nil {
 		return nil, err
 	}
+	config.SetDefaults()
+
 	if err = validateAWSIamConfig(config); err != nil {
 		return nil, err
 	}
@@ -68,10 +70,7 @@ func validateAWSIamConfig(config *AWSIamConfig) error {
 	if err := validateMapUsers(config.Spec.MapUsers); err != nil {
 		return err
 	}
-	if config.Spec.Partition == "" {
-		config.Spec.Partition = "aws"
-		logger.V(1).Info("AWSIamConfig Partition is empty. Using default partition 'aws'")
-	}
+
 	return nil
 }
 
@@ -122,4 +121,11 @@ func validateAWSIamNamespace(config *AWSIamConfig, clusterConfig *Cluster) error
 	}
 
 	return nil
+}
+
+func setDefaultAWSIamPartition(config *AWSIamConfig) {
+	if config.Spec.Partition == "" {
+		config.Spec.Partition = "aws"
+		logger.V(1).Info("AWSIamConfig Partition is empty. Using default partition 'aws'")
+	}
 }

--- a/pkg/api/v1alpha1/awsiamconfig_types.go
+++ b/pkg/api/v1alpha1/awsiamconfig_types.go
@@ -115,6 +115,10 @@ func (c *AWSIamConfig) Validate() error {
 	return validateAWSIamConfig(c)
 }
 
+func (c *AWSIamConfig) SetDefaults() {
+	setDefaultAWSIamPartition(c)
+}
+
 func init() {
 	SchemeBuilder.Register(&AWSIamConfig{}, &AWSIamConfigList{})
 }

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -6,6 +6,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
 const (
@@ -96,6 +98,14 @@ func (n *Cluster) Equal(o *Cluster) bool {
 
 func (n *Cluster) Validate() error {
 	return ValidateClusterConfigContent(n)
+}
+
+func (n *Cluster) SetDefaults() {
+	// TODO: move any defaults that can return error out of this package
+	// All the defaults here should be context unaware
+	if err := setClusterDefaults(n); err != nil {
+		logger.Error(err, "Failed to validate Cluster")
+	}
 }
 
 type ProxyConfiguration struct {

--- a/pkg/api/v1alpha1/gitopsconfig.go
+++ b/pkg/api/v1alpha1/gitopsconfig.go
@@ -6,7 +6,11 @@ import (
 	"regexp"
 )
 
-const GitOpsConfigKind = "GitOpsConfig"
+const (
+	GitOpsConfigKind     = "GitOpsConfig"
+	FluxDefaultNamespace = "flux-system"
+	FluxDefaultBranch    = "main"
+)
 
 func GetAndValidateGitOpsConfig(fileName string, refName string, clusterConfig *Cluster) (*GitOpsConfig, error) {
 	config, err := getGitOpsConfig(fileName)
@@ -102,4 +106,19 @@ func validateGitOpsNamespace(config *GitOpsConfig, clusterConfig *Cluster) error
 	}
 
 	return nil
+}
+
+func setGitOpsConfigDefaults(gitops *GitOpsConfig) {
+	if gitops == nil {
+		return
+	}
+
+	c := &gitops.Spec.Flux
+	if len(c.Github.FluxSystemNamespace) == 0 {
+		c.Github.FluxSystemNamespace = FluxDefaultNamespace
+	}
+
+	if len(c.Github.Branch) == 0 {
+		c.Github.Branch = FluxDefaultBranch
+	}
 }

--- a/pkg/api/v1alpha1/gitopsconfig_types.go
+++ b/pkg/api/v1alpha1/gitopsconfig_types.go
@@ -108,6 +108,10 @@ func (c *GitOpsConfig) Validate() error {
 	return validateGitOpsConfig(c)
 }
 
+func (c *GitOpsConfig) SetDefaults() {
+	setGitOpsConfigDefaults(c)
+}
+
 func init() {
 	SchemeBuilder.Register(&GitOpsConfig{}, &GitOpsConfigList{})
 }

--- a/pkg/cluster/defaults.go
+++ b/pkg/cluster/defaults.go
@@ -1,0 +1,67 @@
+package cluster
+
+import (
+	"path"
+	"reflect"
+)
+
+type configDefaulter func(*Config)
+
+var configDefaulters = []configDefaulter{
+	SetDefaultFluxGitHubConfigPath,
+}
+
+func SetConfigDefaults(c *Config) {
+	for _, d := range getDefaultables(c) {
+		d.SetDefaults()
+	}
+
+	for _, d := range configDefaulters {
+		d(c)
+	}
+}
+
+type defaultable interface {
+	SetDefaults()
+}
+
+func getDefaultables(c *Config) []defaultable {
+	d := make([]defaultable, 0, 1)
+	d = appendDefaultablesIfNotNil(d, c.Cluster, c.VSphereDatacenter, c.GitOpsConfig)
+
+	for _, e := range c.AWSIAMConfigs {
+		d = appendDefaultablesIfNotNil(d, e)
+	}
+
+	return d
+}
+
+func appendDefaultablesIfNotNil(defaultables []defaultable, elems ...defaultable) []defaultable {
+	for _, e := range elems {
+		// Since we receive interfaces, these will never be nil since they contain
+		// the type of the original implementing struct
+		// I can't find another clean option of doing this
+		if !reflect.ValueOf(e).IsNil() {
+			defaultables = append(defaultables, e)
+		}
+	}
+
+	return defaultables
+}
+
+func SetDefaultFluxGitHubConfigPath(c *Config) {
+	if c.GitOpsConfig == nil {
+		return
+	}
+
+	gitops := c.GitOpsConfig
+	if gitops.Spec.Flux.Github.ClusterConfigPath != "" {
+		return
+	}
+
+	if c.Cluster.IsSelfManaged() {
+		gitops.Spec.Flux.Github.ClusterConfigPath = path.Join("clusters", c.Cluster.Name)
+	} else {
+		gitops.Spec.Flux.Github.ClusterConfigPath = path.Join("clusters", c.Cluster.ManagedBy())
+	}
+}

--- a/pkg/cluster/defaults_test.go
+++ b/pkg/cluster/defaults_test.go
@@ -1,0 +1,94 @@
+package cluster_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+)
+
+func TestSetDefaultFluxGitHubConfigPath(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *cluster.Config
+		wantConfigPath string
+	}{
+		{
+			name: "self-managed cluster",
+			config: &cluster.Config{
+				Cluster: &anywherev1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "c-1",
+					},
+					Spec: anywherev1.ClusterSpec{
+						ManagementCluster: anywherev1.ManagementCluster{
+							Name: "c-1",
+						},
+					},
+				},
+				GitOpsConfig: &anywherev1.GitOpsConfig{},
+			},
+			wantConfigPath: "clusters/c-1",
+		},
+		{
+			name: "managed cluster",
+			config: &cluster.Config{
+				Cluster: &anywherev1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "c-1",
+					},
+					Spec: anywherev1.ClusterSpec{
+						ManagementCluster: anywherev1.ManagementCluster{
+							Name: "c-m",
+						},
+					},
+				},
+				GitOpsConfig: &anywherev1.GitOpsConfig{},
+			},
+			wantConfigPath: "clusters/c-m",
+		},
+		{
+			name: "config path is already set",
+			config: &cluster.Config{
+				Cluster: &anywherev1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "c-1",
+					},
+					Spec: anywherev1.ClusterSpec{
+						ManagementCluster: anywherev1.ManagementCluster{
+							Name: "c-m",
+						},
+					},
+				},
+				GitOpsConfig: &anywherev1.GitOpsConfig{
+					Spec: anywherev1.GitOpsConfigSpec{
+						Flux: anywherev1.Flux{
+							Github: anywherev1.Github{
+								ClusterConfigPath: "my-path",
+							},
+						},
+					},
+				},
+			},
+			wantConfigPath: "my-path",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			cluster.SetDefaultFluxGitHubConfigPath(tt.config)
+			g.Expect(tt.config.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath).To(Equal(tt.wantConfigPath))
+		})
+	}
+}
+
+func TestSetConfigDefaults(t *testing.T) {
+	g := NewWithT(t)
+	c := clusterConfigFromFile(t, "testdata/cluster_1_19.yaml")
+	originalC := clusterConfigFromFile(t, "testdata/cluster_1_19.yaml")
+	cluster.SetConfigDefaults(c)
+	g.Expect(c).NotTo(Equal(originalC))
+}


### PR DESCRIPTION
Continues the work started by #1343

*Description of changes:*
Separates validations from some defaults in the api package.

Implements SetDefaults method in some api structs for context unware
defaults.

Adds some context aware defaults at the cluster Config level. These
defaults should have no other dependencies but the cluster.Config
itself.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

