### PR TITLE
Use bundlesRef instead of eksdReleaseRef to get eksd bundle

### DIFF
--- a/designs/embed_eksd_manifest.md
+++ b/designs/embed_eksd_manifest.md
@@ -71,10 +71,10 @@ spec:
     apiGroup: anywhere.eks.amazonaws.com/v1alpha1
     kind: Bundles
     name: "bundle-name"
-    namespace: "namespace for resource" 
+    namespace: eksa-system 
 ```
 
-This bundles ref will allow us accurately fetch the bundle from the cluster, access the EKSD bundle, and grab the correct release manifest in the controller.
+This bundles ref will allow us to accurately fetch the bundle from the cluster, access the EKSD bundle, and grab the correct release manifest in the controller.
 
 ### Upgrading EKSD components
 

--- a/designs/embed_eksd_manifest.md
+++ b/designs/embed_eksd_manifest.md
@@ -49,10 +49,16 @@ spec:
 
 From here, we can use `kubectl apply` to apply the content from the EKSD release CRD & manifest to the cluster.
 
-#### Cluster status changes
+#### Cluster spec changes
 
 We will need a way to refer to the EKSD release object on the cluster when calling it from the controller.
-One way to achieve this is by adding a field `eksdReleaseRef` to the cluster status.
+One way to achieve this is by grabbing the EKSD bundle from the bundles object.
+We already apply the bundles to the cluster, and we fetch the bundles object in the controller.
+However, we depend on the cluster name to fetch this bundle.
+A more accurate way to fetch this bundle is by adding a field `bundlesRef` to the cluster spec.
+This will serve as our source of truth for the bundles object on the cluster.
+
+
 ```
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Cluster
@@ -61,15 +67,14 @@ metadata:
 spec:
   controlPlaneConfiguration:
     ...
-status:
-  eksdReleaseRef:
-    apiGroup: distro.eks.amazonaws.com/v1alpha1
-    kind: Release
-    name: "name of resource"
-    namespace: "namespace for resource" (default: eksa-system)
+  bundlesRef:
+    apiGroup: anywhere.eks.amazonaws.com/v1alpha1
+    kind: Bundles
+    name: "bundle-name"
+    namespace: "namespace for resource" 
 ```
 
-From here, we can call `kubectl get release` using the `eksdReleaseRef.Name` to access the EKSD release manifest from the controller.
+This bundles ref will allow us accurately fetch the bundle from the cluster, access the EKSD bundle, and grab the correct release manifest in the controller.
 
 ### Upgrading EKSD components
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Instead of using `eksdReleaseRef` in the cluster status, we will fetch the eks-d object using the eks-d bundle name from the versions bundle. We already have access to this bundle. However, we currently grab it based on the cluster name, which is usually the case, but a more accurate way to get this object is by introducing a `bundlesRef` & directly referring to that object instead of assuming the name based on the cluster

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

