### PR TITLE
Fix ability to run multiple tests in one instance

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -215,7 +215,7 @@ func splitTests(testsList []string, conf ParallelRunConf) []instanceRunConf {
 	ipman := newE2EIPManager(os.Getenv(cidrVar), os.Getenv(privateNetworkCidrVar))
 
 	testsInCurrentInstance := make([]string, 0, testPerInstance)
-	for _, testName := range testsList {
+	for i, testName := range testsList {
 		testsInCurrentInstance = append(testsInCurrentInstance, testName)
 		multiClusterTest := multiClusterTestsRe.MatchString(testName)
 		var ips networkutils.IPPool
@@ -233,7 +233,7 @@ func splitTests(testsList []string, conf ParallelRunConf) []instanceRunConf {
 			}
 		}
 
-		if len(testsInCurrentInstance) == testPerInstance {
+		if len(testsInCurrentInstance) == testPerInstance || (len(testsList)-1) == i {
 			runConfs = append(runConfs, instanceRunConf{
 				amiId:               conf.AmiId,
 				instanceProfileName: conf.InstanceProfileName,
@@ -241,7 +241,7 @@ func splitTests(testsList []string, conf ParallelRunConf) []instanceRunConf {
 				jobId:               fmt.Sprintf("%s-%d", conf.JobId, len(runConfs)),
 				parentJobId:         conf.JobId,
 				subnetId:            conf.SubnetId,
-				regex:               strings.Join(testsInCurrentInstance, "|"),
+				regex:               fmt.Sprintf("\"%s\"", strings.Join(testsInCurrentInstance, "|")),
 				bundlesOverride:     conf.BundlesOverride,
 				testReportFolder:    conf.TestReportFolder,
 				branchName:          conf.BranchName,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This should fix the e2e tests in order to properly pass in more than one test as a regex. Currently the tests fail due to the following error, and it is because of how the string is represented in unix without the quotes, with the `|` being interpreted as separating two commands.

Error:
```
TestVSphereKubernetes121ThreeReplicasFiveWorkersSimpleFlow: command not found

failed to run commands: exit status 127
```

*Testing (if applicable):*
make integration-test-binary

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

