### PR TITLE
Add tinkerbell test cases for supported hardware vendors, cp replicas…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ generated/
 eks-anywhere-downloads*
 hardware-manifests/
 *.env
+support-bundle*

--- a/cmd/eksctl-anywhere/cmd/generatehardware.go
+++ b/cmd/eksctl-anywhere/cmd/generatehardware.go
@@ -20,6 +20,7 @@ import (
 
 type hardwareOptions struct {
 	csvPath      string
+	outputPath   string
 	tinkerbellIp string
 	grpcPort     string
 	certPort     string
@@ -50,6 +51,7 @@ var generateHardwareCmd = &cobra.Command{
 func init() {
 	generateCmd.AddCommand(generateHardwareCmd)
 	generateHardwareCmd.Flags().StringVarP(&hOpts.csvPath, "filename", "f", "", "path to csv file")
+	generateHardwareCmd.Flags().StringVarP(&hOpts.outputPath, "output", "o", "", "directory path to output hardware files")
 	generateHardwareCmd.Flags().StringVar(&hOpts.tinkerbellIp, "tinkerbell-ip", "", "Tinkerbell stack IP, required unless --dry-run flag is set")
 	generateHardwareCmd.Flags().StringVar(&hOpts.grpcPort, "grpc-port", defaultGrpcPort, "Tinkerbell GRPC Authority port")
 	generateHardwareCmd.Flags().StringVar(&hOpts.certPort, "cert-port", defaultCertPort, "Tinkerbell Cert URL port")
@@ -81,14 +83,14 @@ func (hOpts *hardwareOptions) generateHardware(ctx context.Context) error {
 
 	defer csv.Close()
 
-	json, err := hardware.NewJsonParser()
+	json, err := hardware.NewJsonParser(hOpts.outputPath)
 	if err != nil {
 		return err
 	}
 
 	defer json.CleanUp()
 
-	yaml, err := hardware.NewYamlParser()
+	yaml, err := hardware.NewYamlParser(hOpts.outputPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -6,7 +6,7 @@ env:
     INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT: 30
     T_VSPHERE_CIDR: "198.18.128.0/17"
     T_VSPHERE_PRIVATE_NETWORK_CIDR: "197.18.128.0/17"
-    SKIPPED_TESTS: "TestTinkerbellKubernetes120SimpleFlow,TestTinkerbellKubernetes121SimpleFlow"
+    SKIPPED_TESTS: "TestTinkerbellKubernetes120SimpleFlow,TestTinkerbellKubernetes121ThreeReplicasTwoWorkersSimpleFlow,TestTinkerbellKubernetes121DellSimpleFlow,TestTinkerbellKubernetes121HPSimpleFlow,TestTinkerbellKubernetes121SuperMicroSimpleFlow,TestTinkerbellKubernetes121ExternalEtcdSimpleFlow,TestTinkerbellKubernetes121ExternalEtcdThreeReplicasTwoWorkersSimpleFlow"
   secrets-manager:
     EKSA_VSPHERE_USERNAME: "vsphere_ci_beta_connection:vsphere_username"
     EKSA_VSPHERE_PASSWORD: "vsphere_ci_beta_connection:vsphere_password"

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.4.0
+	github.com/gocarina/gocsv v0.0.0-20220304222734-caabc5f00d30
 	github.com/golang/mock v1.6.0
 	github.com/google/go-github/v35 v35.3.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -568,6 +568,8 @@ github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJA
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
+github.com/gocarina/gocsv v0.0.0-20220304222734-caabc5f00d30 h1:KU1VjUEEbDjzUAnLUOmi4T8bNpoJY/SYBU9JnWOHuBU=
+github.com/gocarina/gocsv v0.0.0-20220304222734-caabc5f00d30/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -9,6 +9,7 @@ import (
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/providers"
 )
 
 type ClusterFiller func(c *anywherev1.Cluster)
@@ -119,6 +120,21 @@ func WithExternalEtcdTopology(count int) ClusterFiller {
 			c.Spec.ExternalEtcdConfiguration = &anywherev1.ExternalEtcdConfiguration{}
 		}
 		c.Spec.ExternalEtcdConfiguration.Count = count
+	}
+}
+
+func WithExternalEtcdMachineRef(kind string) ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		if c.Spec.ExternalEtcdConfiguration == nil {
+			c.Spec.ExternalEtcdConfiguration = &anywherev1.ExternalEtcdConfiguration{}
+			c.Spec.ExternalEtcdConfiguration.Count = 1
+		}
+
+		if c.Spec.ExternalEtcdConfiguration.MachineGroupRef == nil {
+			c.Spec.ExternalEtcdConfiguration.MachineGroupRef = &anywherev1.Ref{}
+		}
+		c.Spec.ExternalEtcdConfiguration.MachineGroupRef.Kind = kind
+		c.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name = providers.GetEtcdNodeName(c.Name)
 	}
 }
 

--- a/internal/pkg/api/hardware.go
+++ b/internal/pkg/api/hardware.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gocarina/gocsv"
+)
+
+const (
+	Dell       = "dell"
+	HP         = "hp"
+	SuperMicro = "supermicro"
+)
+
+type Hardware struct {
+	Id           string `csv:"guid"`
+	IpAddress    string `csv:"ip_address"`
+	Gateway      string `csv:"gateway"`
+	Nameservers  string `csv:"nameservers"`
+	Netmask      string `csv:"netmask"`
+	MacAddress   string `csv:"mac"`
+	Hostname     string `csv:"hostname"`
+	Vendor       string `csv:"vendor"`
+	BmcIpAddress string `csv:"bmc_ip"`
+	BmcUsername  string `csv:"bmc_username"`
+	BmcPassword  string `csv:"bmc_password"`
+}
+
+func NewHardwareSlice(csvFile string) ([]*Hardware, error) {
+	hardwareFile, err := os.OpenFile(csvFile, os.O_RDWR|os.O_CREATE, os.ModePerm)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create hardware slice from hardware csv file: %v", err)
+	}
+
+	defer hardwareFile.Close()
+
+	hardware := []*Hardware{}
+
+	if err := gocsv.UnmarshalFile(hardwareFile, &hardware); err != nil {
+		return nil, fmt.Errorf("failed to create hardware slice from hardware csv file: %v", err)
+	}
+
+	return hardware, nil
+}

--- a/pkg/providers/tinkerbell/hardware/jsonparser.go
+++ b/pkg/providers/tinkerbell/hardware/jsonparser.go
@@ -3,6 +3,7 @@ package hardware
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/tinkerbell/tink/protos/hardware"
@@ -24,8 +25,9 @@ const (
 	bmcUsername   = "bmc_username"
 	bmcPassword   = "bmc_password"
 	eksaNamespace = "eksa-system"
-	jsonPath      = "hardware-manifests/json"
 )
+
+var jsonPath = "hardware-manifests/json"
 
 type Hardware struct {
 	Id       string                     `json:"id"`
@@ -37,7 +39,10 @@ type JsonParser struct {
 	jsonWriter filewriter.FileWriter
 }
 
-func NewJsonParser() (*JsonParser, error) {
+func NewJsonParser(outputPath string) (*JsonParser, error) {
+	if outputPath != "" {
+		jsonPath = filepath.Join(outputPath, jsonPath)
+	}
 	filewriter, err := filewriter.NewWriter(jsonPath)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing JsonParser: %v", err)

--- a/pkg/providers/tinkerbell/hardware/jsonparser_test.go
+++ b/pkg/providers/tinkerbell/hardware/jsonparser_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNewJsonParserSuccess(t *testing.T) {
 	expected_hardware_json := "testdata/expected_hardware_json.json"
-	json, err := hardware.NewJsonParser()
+	json, err := hardware.NewJsonParser("")
 	if err != nil {
 		t.Fatalf("hardware.NewJsonParser() error = %v, expected = nil", err)
 	}

--- a/pkg/providers/tinkerbell/hardware/yamlparser.go
+++ b/pkg/providers/tinkerbell/hardware/yamlparser.go
@@ -26,22 +26,26 @@ const (
 	moveLabel            = "clusterctl.cluster.x-k8s.io/move"
 )
 
-var (
-	yamlPath      = filepath.Join(yamlDirectory, yamlFile)
-	yamlSeparator = []byte("---\n")
-)
+var yamlSeparator = []byte("---\n")
 
 type YamlParser struct {
 	file *os.File
 }
 
-func NewYamlParser() (*YamlParser, error) {
-	if _, err := os.Stat(yamlDirectory); errors.Is(err, os.ErrNotExist) {
+func NewYamlParser(outputDir string) (*YamlParser, error) {
+	outputYamlDir := yamlDirectory
+	if outputDir != "" {
+		outputYamlDir = filepath.Join(outputDir, yamlDirectory)
+	}
+
+	if _, err := os.Stat(outputYamlDir); errors.Is(err, os.ErrNotExist) {
 		logger.V(4).Info("Creating directory for YamlParser", "Directory", yamlDirectory)
-		if err := os.Mkdir(yamlDirectory, os.ModePerm); err != nil {
+		if err := os.MkdirAll(outputYamlDir, os.ModePerm); err != nil {
 			return nil, fmt.Errorf("error creating directory for YamlParser: %v", err)
 		}
 	}
+
+	yamlPath := filepath.Join(outputYamlDir, yamlFile)
 
 	err := ioutil.WriteFile(yamlPath, []byte{}, 0o644)
 	if err != nil {

--- a/pkg/providers/tinkerbell/hardware/yamlparser_test.go
+++ b/pkg/providers/tinkerbell/hardware/yamlparser_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNewYamlParserSuccess(t *testing.T) {
-	yaml, err := hardware.NewYamlParser()
+	yaml, err := hardware.NewYamlParser("")
 	if err != nil {
 		t.Fatalf("hardware.NewYamlParser() error = %v, expected = nil", err)
 	}

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -465,6 +465,18 @@ func (p *tinkerbellProvider) MachineConfigs() []providers.MachineConfig {
 			p.machineConfigs[workerMachineName].SetManagedBy(p.clusterConfig.ManagedBy())
 		}
 	}
+
+	if p.clusterConfig.Spec.ExternalEtcdConfiguration != nil {
+		etcdMachineName := p.clusterConfig.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+		p.machineConfigs[etcdMachineName].Annotations = map[string]string{p.clusterConfig.EtcdAnnotation(): "true"}
+		if etcdMachineName != controlPlaneMachineName {
+			configs = append(configs, p.machineConfigs[etcdMachineName])
+			if p.clusterConfig.IsManaged() {
+				p.machineConfigs[etcdMachineName].SetManagedBy(p.clusterConfig.ManagedBy())
+			}
+		}
+	}
+
 	return configs
 }
 

--- a/test/e2e/simpleflow_test.go
+++ b/test/e2e/simpleflow_test.go
@@ -151,10 +151,64 @@ func TestTinkerbellKubernetes120SimpleFlow(t *testing.T) {
 	runTinkerbellSimpleFlow(test)
 }
 
-func TestTinkerbellKubernetes121SimpleFlow(t *testing.T) {
+func TestTinkerbellKubernetes121ExternalEtcdSimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewTinkerbell(t, framework.WithUbuntu121Tinkerbell(), framework.WithTinkerbellExternalEtcdTopology(1)),
+		framework.WithEnvVar("TINKERBELL_PROVIDER", "true"),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+	)
+	runTinkerbellSimpleFlow(test)
+}
+
+func TestTinkerbellKubernetes121ExternalEtcdThreeReplicasTwoWorkersSimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewTinkerbell(t, framework.WithUbuntu121Tinkerbell(), framework.WithTinkerbellExternalEtcdTopology(1)),
+		framework.WithEnvVar("TINKERBELL_PROVIDER", "true"),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(2)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+	)
+	runTinkerbellSimpleFlow(test)
+}
+
+func TestTinkerbellKubernetes121ThreeReplicasTwoWorkersSimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewTinkerbell(t, framework.WithUbuntu121Tinkerbell()),
+		framework.WithEnvVar("TINKERBELL_PROVIDER", "true"),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(2)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+	)
+	runTinkerbellSimpleFlow(test)
+}
+
+func TestTinkerbellKubernetes121SuperMicroSimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewTinkerbell(t, framework.WithUbuntu121Tinkerbell(), framework.WithHardware(api.SuperMicro, 2)),
+		framework.WithEnvVar("TINKERBELL_PROVIDER", "true"),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+	)
+	runTinkerbellSimpleFlow(test)
+}
+
+func TestTinkerbellKubernetes121DellSimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewTinkerbell(t, framework.WithUbuntu121Tinkerbell(), framework.WithHardware(api.Dell, 2)),
+		framework.WithEnvVar("TINKERBELL_PROVIDER", "true"),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+	)
+	runTinkerbellSimpleFlow(test)
+}
+
+func TestTinkerbellKubernetes121HPSimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewTinkerbell(t, framework.WithUbuntu121Tinkerbell(), framework.WithHardware(api.HP, 2)),
 		framework.WithEnvVar("TINKERBELL_PROVIDER", "true"),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 	)

--- a/test/e2e/stackedetcd_test.go
+++ b/test/e2e/stackedetcd_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package e2e

--- a/test/framework/tinkerbell.go
+++ b/test/framework/tinkerbell.go
@@ -46,6 +46,7 @@ type Tinkerbell struct {
 	clusterFillers       []api.ClusterFiller
 	cidr                 string
 	inventoryCsvFilePath string
+	hardware             []*api.Hardware
 }
 
 func NewTinkerbell(t *testing.T, opts ...TinkerbellOpt) *Tinkerbell {
@@ -62,12 +63,19 @@ func NewTinkerbell(t *testing.T, opts ...TinkerbellOpt) *Tinkerbell {
 		},
 	}
 
+	tink.cidr = os.Getenv(tinkerbellNetworkCidrEnvVar)
+	tink.inventoryCsvFilePath = os.Getenv(tinkerbellInventoryCsvFilePathEnvVar)
+
+	var err error
+	tink.hardware, err = api.NewHardwareSlice(tink.inventoryCsvFilePath)
+
+	if err != nil {
+		t.Fatalf("failed to create tinkerbell test provider: %v", err)
+	}
+
 	for _, opt := range opts {
 		opt(tink)
 	}
-
-	tink.cidr = os.Getenv(tinkerbellNetworkCidrEnvVar)
-	tink.inventoryCsvFilePath = os.Getenv(tinkerbellInventoryCsvFilePathEnvVar)
 
 	return tink
 }
@@ -82,10 +90,10 @@ func (t *Tinkerbell) CustomizeProviderConfig(file string) []byte {
 	return t.customizeProviderConfig(file, t.fillers...)
 }
 
-func (v *Tinkerbell) customizeProviderConfig(file string, fillers ...api.TinkerbellFiller) []byte {
+func (t *Tinkerbell) customizeProviderConfig(file string, fillers ...api.TinkerbellFiller) []byte {
 	providerOutput, err := api.AutoFillTinkerbellProvider(file, fillers...)
 	if err != nil {
-		v.t.Fatalf("Error customizing provider config from file: %v", err)
+		t.t.Fatalf("failed to customize provider config from file: %v", err)
 	}
 	return providerOutput
 }
@@ -96,6 +104,7 @@ func (t *Tinkerbell) ClusterConfigFillers() []api.ClusterFiller {
 		t.t.Fatalf("failed to generate ip for tinkerbell cidr %s: %v", t.cidr, err)
 	}
 	t.clusterFillers = append(t.clusterFillers, api.WithControlPlaneEndpointIP(clusterIP))
+
 	return t.clusterFillers
 }
 
@@ -114,5 +123,26 @@ func WithUbuntu121Tinkerbell() TinkerbellOpt {
 			api.WithStringFromEnvVarTinkerbell(tinkerbellImageUbuntu121EnvVar, api.WithImageUrlForAllTinkerbellMachines),
 			api.WithOsFamilyForAllTinkerbellMachines(anywherev1.Ubuntu),
 		)
+	}
+}
+
+func WithHardware(vendor string, requiredCount int) TinkerbellOpt {
+	return func(t *Tinkerbell) {
+		var count int
+		for _, h := range t.hardware {
+			if h.Vendor == vendor {
+				count++
+			}
+		}
+		if count < requiredCount {
+			t.t.Errorf("this test requires at least %d piece(s) of %s hardware", requiredCount, vendor)
+		}
+	}
+}
+
+func WithTinkerbellExternalEtcdTopology(count int) TinkerbellOpt {
+	return func(t *Tinkerbell) {
+		t.fillers = append([]api.TinkerbellFiller{api.WithTinkerbellEtcdMachineConfig()}, t.fillers...)
+		t.clusterFillers = append(t.clusterFillers, api.WithExternalEtcdTopology(count), api.WithExternalEtcdMachineRef(anywherev1.TinkerbellMachineConfigKind))
 	}
 }


### PR DESCRIPTION
…, and worker replicas, and external etcd

- Add hardware specific tests to check for vendor 
- Add test for multiple control planes and worker nodes
- Add test case for external etcd
- Fix for external etcd found by external etcd e2e test
- Add option to provide output location of hardware-manifests
- Output hardware manifests to cluster config folder per test so tests can be ran in parallel from separate shells if desired in the future

*Testing (if applicable):*

E2E Tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

