### PR TITLE
Increase e2e instance count to 85

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    INTEGRATION_TEST_MAX_EC2_COUNT: 40
+    INTEGRATION_TEST_MAX_EC2_COUNT: 85
     T_VSPHERE_CIDR: "198.18.128.0/17"
     T_VSPHERE_PRIVATE_NETWORK_CIDR: "197.18.128.0/17"
     SKIPPED_TESTS: "TestTinkerbellKubernetes120SimpleFlow,TestTinkerbellKubernetes121SimpleFlow"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Our sequential e2e logic doesn't work as expected right now and fails to upload the JUnit reports due to how the test name is constructed. It could also be that some of the flux tests are failing due to resources not being cleaned up. Changing it back to a higher number to get a test run in and see if we are going to run into the resource limits again.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

