### PR TITLE
Print command execution errors to stdout

### DIFF
--- a/release/pkg/utils/utils.go
+++ b/release/pkg/utils/utils.go
@@ -27,7 +27,7 @@ import (
 func ExecCommand(cmd *exec.Cmd) (string, error) {
 	stdout, err := cmd.Output()
 	if err != nil {
-		return "", errors.Cause(err)
+		return string(stdout), errors.Cause(err)
 	}
 	return string(stdout), nil
 }

--- a/test/kube-bench/jobs/controlplane/kube-bench-default.yaml
+++ b/test/kube-bench/jobs/controlplane/kube-bench-default.yaml
@@ -34,7 +34,6 @@ spec:
             value: "1.21"
           - name: SKIPPED_TESTS
             value: "1.1.7,1.1.8,1.1.11,1.1.12,1.2.6,1.2.16,1.2.32,1.2.33,1.2.34"
-          - n
           volumeMounts:
             - name: var-lib-etcd
               mountPath: /var/lib/etcd


### PR DESCRIPTION
The error lines getting written to stdout were not being returned, and hence not printed to stdout in the job run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

