### PR TITLE
fix bundle usage in release branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,19 +28,20 @@ GO_TEST ?= $(GO) test
 BRANCH_NAME?=release-0.7
 ifeq (,$(findstring $(BRANCH_NAME),main))
 ## use the branch-specific bundle manifest if the branch is not 'main'
+DEV_GIT_VERSION:=v0.0.0-dev-${BRANCH_NAME}
 BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${BRANCH_NAME}/bundle-release.yaml
+RELEASE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/${BRANCH_NAME}/eks-a-release.yaml
 LATEST=$(BRANCH_NAME)
-$(info    Using branch-specific BUNDLE_RELEASE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))
+$(info    Using branch-specific BUNDLE_MANIFEST_URL $(BUNDLE_MANIFEST_URL) and RELEASE_MANIFEST_URL $(RELEASE_MANIFEST_URL))
 else
 ## use the standard bundle manifest if the branch is 'main'
+DEV_GIT_VERSION:=v0.0.0-dev
 BUNDLE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/bundle-release.yaml
-$(info    Using stanard BUNDLE_RELEASE_MANIFEST_URL $(BUNDLE_MANIFEST_URL))
+RELEASE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/eks-a-release.yaml
+$(info    Using stanard BUNDLE_MANIFEST_URL $(BUNDLE_MANIFEST_URL) and RELEASE_MANIFEST_URL $(RELEASE_MANIFEST_URL))
 LATEST=latest
 endif
 
-RELEASE_MANIFEST_URL?=https://dev-release-prod-pdx.s3.us-west-2.amazonaws.com/eks-a-release.yaml
-
-DEV_GIT_VERSION:=v0.0.0-dev
 CUSTOM_GIT_VERSION:=v0.0.0-custom
 
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When building locally from a release branch it was still using the main eks-a-release.yaml and 0.0.0-dev version.  This meant by default the build would end up using the latest main bundle, which is not what we want.  The makefile was setup to handle the embed case, but this is the default for people and has burned us in the past.  

I think this change makes sense and I would "backport" it to main for future release branches.  

The change to spec.go is def up for debate.  Currently every build from a specific branch adds the new build into the eks-a-release.yaml, but they all point to the same bundle.  @abhay-krishna fixed the release tooling to point to the release branch bundle from release branches so the latest build in the 0.7 release points to the correct bundle.  This ends up not being enough because the code when finding the version just finds the first one that passes `cliSemVersion.SamePrerelease(releaseVersion)` so in the case of release-0.7 it picks one of the older releases still pointing at the wrong bundle.

This is my attempt at changing the code to find the "latest" release in the releases yaml to ensure it pulls the correct bundle.  Another option is to say that we know we are always going to point to the same bundle, release to release per a given release branch, and just manually fix the 0.7 file on s3 and remove the code changes.  Open to either approach.

*Testing (if applicable):*

Built from the release-0.7 branch and created a cluster, confirmed it was using the 07 bundle vs the main branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

