### PR TITLE
Update test to make use of cluster Spec tooling

### DIFF
--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -50,6 +50,7 @@ func (s *Spec) DeepCopy() *Spec {
 		Cluster:             s.Cluster.DeepCopy(),
 		OIDCConfig:          s.OIDCConfig.DeepCopy(),
 		GitOpsConfig:        s.GitOpsConfig.DeepCopy(),
+		AWSIamConfig:        s.AWSIamConfig.DeepCopy(),
 		releasesManifestURL: s.releasesManifestURL,
 		bundlesManifestURL:  s.bundlesManifestURL,
 		configFS:            s.configFS,

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -27,7 +27,6 @@ import (
 	mocksprovider "github.com/aws/eks-anywhere/pkg/providers/mocks"
 	"github.com/aws/eks-anywhere/pkg/retrier"
 	"github.com/aws/eks-anywhere/pkg/types"
-	anywherev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 var (
@@ -723,8 +722,8 @@ func TestClusterManagerMoveCAPIErrorGetMachines(t *testing.T) {
 }
 
 func TestClusterManagerCreateEKSAResourcesSuccess(t *testing.T) {
-	clusterSpec := &cluster.Spec{
-		Cluster: &v1alpha1.Cluster{
+	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Cluster = &v1alpha1.Cluster{
 			Spec: v1alpha1.ClusterSpec{
 				KubernetesVersion:             "1.19",
 				ControlPlaneConfiguration:     v1alpha1.ControlPlaneConfiguration{Count: 1},
@@ -733,9 +732,8 @@ func TestClusterManagerCreateEKSAResourcesSuccess(t *testing.T) {
 					Kind: v1alpha1.VSphereDatacenterKind,
 				},
 			},
-		},
-		Bundles: &anywherev1alpha1.Bundles{},
-	}
+		}
+	})
 
 	ctx := context.Background()
 	clusterName := "cluster-name"

--- a/pkg/diagnostics/diagnostic_bundle_test.go
+++ b/pkg/diagnostics/diagnostic_bundle_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
@@ -84,27 +85,26 @@ func TestParseTimeOptions(t *testing.T) {
 }
 
 func TestGenerateBundleConfigWithExternalEtcd(t *testing.T) {
-	spec := &cluster.Spec{
-		Cluster: &eksav1alpha1.Cluster{
+	spec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Cluster = &eksav1alpha1.Cluster{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{},
-			Spec:       eksav1alpha1.ClusterSpec{},
-			Status:     eksav1alpha1.ClusterStatus{},
-		},
-	}
-
-	spec.Cluster.Spec.ExternalEtcdConfiguration = &eksav1alpha1.ExternalEtcdConfiguration{
-		Count: 3,
-		MachineGroupRef: &eksav1alpha1.Ref{
-			Kind: eksav1alpha1.VSphereMachineConfigKind,
-			Name: "testRef",
-		},
-	}
-
-	spec.Cluster.Spec.DatacenterRef = eksav1alpha1.Ref{
-		Kind: eksav1alpha1.VSphereDatacenterKind,
-		Name: "testRef",
-	}
+			Spec: eksav1alpha1.ClusterSpec{
+				DatacenterRef: eksav1alpha1.Ref{
+					Kind: eksav1alpha1.VSphereDatacenterKind,
+					Name: "testRef",
+				},
+				ExternalEtcdConfiguration: &eksav1alpha1.ExternalEtcdConfiguration{
+					Count: 3,
+					MachineGroupRef: &eksav1alpha1.Ref{
+						Kind: eksav1alpha1.VSphereMachineConfigKind,
+						Name: "testRef",
+					},
+				},
+			},
+			Status: eksav1alpha1.ClusterStatus{},
+		}
+	})
 
 	t.Run(t.Name(), func(t *testing.T) {
 		p := givenProvider(t)
@@ -138,26 +138,25 @@ func TestGenerateBundleConfigWithExternalEtcd(t *testing.T) {
 }
 
 func TestGenerateBundleConfigWithOidc(t *testing.T) {
-	spec := &cluster.Spec{
-		Cluster: &eksav1alpha1.Cluster{
+	spec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Cluster = &eksav1alpha1.Cluster{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{},
-			Spec:       eksav1alpha1.ClusterSpec{},
-			Status:     eksav1alpha1.ClusterStatus{},
-		},
-	}
-
-	spec.OIDCConfig = &eksav1alpha1.OIDCConfig{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{},
-		Spec:       eksav1alpha1.OIDCConfigSpec{},
-		Status:     eksav1alpha1.OIDCConfigStatus{},
-	}
-
-	spec.Cluster.Spec.DatacenterRef = eksav1alpha1.Ref{
-		Kind: eksav1alpha1.VSphereDatacenterKind,
-		Name: "testRef",
-	}
+			Spec: eksav1alpha1.ClusterSpec{
+				DatacenterRef: eksav1alpha1.Ref{
+					Kind: eksav1alpha1.VSphereDatacenterKind,
+					Name: "testRef",
+				},
+			},
+			Status: eksav1alpha1.ClusterStatus{},
+		}
+		s.OIDCConfig = &eksav1alpha1.OIDCConfig{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{},
+			Spec:       eksav1alpha1.OIDCConfigSpec{},
+			Status:     eksav1alpha1.OIDCConfigStatus{},
+		}
+	})
 
 	t.Run(t.Name(), func(t *testing.T) {
 		p := givenProvider(t)
@@ -191,26 +190,25 @@ func TestGenerateBundleConfigWithOidc(t *testing.T) {
 }
 
 func TestGenerateBundleConfigWithGitOps(t *testing.T) {
-	spec := &cluster.Spec{
-		Cluster: &eksav1alpha1.Cluster{
+	spec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Cluster = &eksav1alpha1.Cluster{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{},
-			Spec:       eksav1alpha1.ClusterSpec{},
-			Status:     eksav1alpha1.ClusterStatus{},
-		},
-	}
-
-	spec.GitOpsConfig = &eksav1alpha1.GitOpsConfig{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{},
-		Spec:       eksav1alpha1.GitOpsConfigSpec{},
-		Status:     eksav1alpha1.GitOpsConfigStatus{},
-	}
-
-	spec.Cluster.Spec.DatacenterRef = eksav1alpha1.Ref{
-		Kind: eksav1alpha1.VSphereDatacenterKind,
-		Name: "testRef",
-	}
+			Spec: eksav1alpha1.ClusterSpec{
+				DatacenterRef: eksav1alpha1.Ref{
+					Kind: eksav1alpha1.VSphereDatacenterKind,
+					Name: "testRef",
+				},
+			},
+			Status: eksav1alpha1.ClusterStatus{},
+		}
+		s.GitOpsConfig = &eksav1alpha1.GitOpsConfig{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{},
+			Spec:       eksav1alpha1.GitOpsConfigSpec{},
+			Status:     eksav1alpha1.GitOpsConfigStatus{},
+		}
+	})
 
 	t.Run(t.Name(), func(t *testing.T) {
 		p := givenProvider(t)
@@ -267,27 +265,26 @@ func TestGenerateDefaultBundle(t *testing.T) {
 }
 
 func TestBundleFromSpecComplete(t *testing.T) {
-	spec := &cluster.Spec{
-		Cluster: &eksav1alpha1.Cluster{
+	spec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Cluster = &eksav1alpha1.Cluster{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{},
-			Spec:       eksav1alpha1.ClusterSpec{},
-			Status:     eksav1alpha1.ClusterStatus{},
-		},
-	}
-
-	spec.Cluster.Spec.ExternalEtcdConfiguration = &eksav1alpha1.ExternalEtcdConfiguration{
-		Count: 3,
-		MachineGroupRef: &eksav1alpha1.Ref{
-			Kind: eksav1alpha1.VSphereMachineConfigKind,
-			Name: "testRef",
-		},
-	}
-
-	spec.Cluster.Spec.DatacenterRef = eksav1alpha1.Ref{
-		Kind: eksav1alpha1.VSphereDatacenterKind,
-		Name: "testRef",
-	}
+			Spec: eksav1alpha1.ClusterSpec{
+				DatacenterRef: eksav1alpha1.Ref{
+					Kind: eksav1alpha1.VSphereDatacenterKind,
+					Name: "testRef",
+				},
+				ExternalEtcdConfiguration: &eksav1alpha1.ExternalEtcdConfiguration{
+					Count: 3,
+					MachineGroupRef: &eksav1alpha1.Ref{
+						Kind: eksav1alpha1.VSphereMachineConfigKind,
+						Name: "testRef",
+					},
+				},
+			},
+			Status: eksav1alpha1.ClusterStatus{},
+		}
+	})
 
 	t.Run(t.Name(), func(t *testing.T) {
 		ctx := context.Background()

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -679,12 +679,7 @@ func TestPreflightValidations(t *testing.T) {
 			}
 
 			clusterSpec.Spec.KubernetesVersion = v1alpha1.KubernetesVersion(tc.upgradeVersion)
-			existingClusterSpec := &cluster.Spec{
-				Cluster:      clusterSpec.Cluster.DeepCopy(),
-				GitOpsConfig: clusterSpec.GitOpsConfig.DeepCopy(),
-				OIDCConfig:   clusterSpec.OIDCConfig.DeepCopy(),
-				AWSIamConfig: clusterSpec.AWSIamConfig.DeepCopy(),
-			}
+			existingClusterSpec := clusterSpec.DeepCopy()
 			existingProviderSpec := defaultDatacenterSpec.DeepCopy()
 			if tc.modifyFunc != nil {
 				tc.modifyFunc(existingClusterSpec)


### PR DESCRIPTION
*Description of changes:*
While continuing the work from #1343, I found some tests that were building the Spec manually, which makes more difficult to make changes in bulk to its structure.

This just updates the tests to make use of existing tooling, so the necessary future changes to embed Config in Spec become more centralized. The behavior is the same.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

