### PR TITLE
Fix junit file upload/download

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -169,14 +169,15 @@ func (e *E2ESession) runTests(regex string) (testCommandResult *testCommandResul
 }
 
 func (c instanceRunConf) runPostTestsProcessing(e *E2ESession, testCommandResult *testCommandResult) error {
-	e.uploadJUnitReportFromInstance(c.regex)
+	testName := strings.Trim(c.regex, "\"")
+	e.uploadJUnitReportFromInstance(testName)
 	if c.testReportFolder != "" {
-		e.downloadJUnitReportToLocalDisk(c.regex, c.testReportFolder)
+		e.downloadJUnitReportToLocalDisk(testName, c.testReportFolder)
 	}
 
 	if !testCommandResult.Successful() {
-		e.uploadGeneratedFilesFromInstance(c.regex)
-		e.uploadDiagnosticArchiveFromInstance(c.regex)
+		e.uploadGeneratedFilesFromInstance(testName)
+		e.uploadDiagnosticArchiveFromInstance(testName)
 		return nil
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Latest changes here cause the files to be uploaded/downloaded with the string quotes. https://github.com/aws/eks-anywhere/pull/1400

There will still be an issue running multiple tests in the same instance as the test name would be `test1|test2`, which will result in the junit reports to not upload properly, so will be following up with a fix for that.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

