### PR TITLE
Compare only semver and prerelease information when overwriting releases

### DIFF
--- a/release/pkg/prepare_release.go
+++ b/release/pkg/prepare_release.go
@@ -462,8 +462,10 @@ func (r *ReleaseConfig) GetPreviousReleaseIfExists() (*anywherev1alpha1.Release,
 }
 
 func (releases EksAReleases) AppendOrUpdateRelease(r anywherev1alpha1.EksARelease) EksAReleases {
+	currentReleaseSemver := strings.Split(r.Version, "+")[0]
 	for i, release := range releases {
-		if release.Version == r.Version {
+		existingReleaseSemver := strings.Split(release.Version, "+")[0]
+		if currentReleaseSemver == existingReleaseSemver {
 			releases[i] = r
 			fmt.Println("Updating existing release in releases manifest")
 			return releases


### PR DESCRIPTION
This comparison is done to determine whether to overwrite an existing release or append a new one to the list of current EKS-A releases. It won't be proper to compare the whole release version, for example, `v0.0.0-dev+build.100` since the build metadata keeps monotonically increasing. Instead it would suffice to just compare the part before the `+`, i.e. semver and pre-release information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

