### PR TITLE
Add ability to limit number of concurrent e2e test executions

### DIFF
--- a/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
@@ -3,6 +3,7 @@ version: 0.2
 env:
   variables:
     INTEGRATION_TEST_MAX_EC2_COUNT: 25
+    INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT: 25
     T_VSPHERE_CIDR: "198.18.0.0/16"
     T_VSPHERE_PRIVATE_NETWORK_CIDR: "10.1.0.0/24"
   secrets-manager:
@@ -47,5 +48,6 @@ phases:
         -i ${INTEGRATION_TEST_INSTANCE_PROFILE}
         -n ${INTEGRATION_TEST_SUBNET_ID}
         -m ${INTEGRATION_TEST_MAX_EC2_COUNT}
+        -c ${INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT}
         -r 'Test'
         --cleanup-vms=true

--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -2,7 +2,8 @@ version: 0.2
 
 env:
   variables:
-    INTEGRATION_TEST_MAX_EC2_COUNT: 85
+    INTEGRATION_TEST_MAX_EC2_COUNT: 100
+    INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT: 50
     T_VSPHERE_CIDR: "198.18.128.0/17"
     T_VSPHERE_PRIVATE_NETWORK_CIDR: "197.18.128.0/17"
     SKIPPED_TESTS: "TestTinkerbellKubernetes120SimpleFlow,TestTinkerbellKubernetes121SimpleFlow"
@@ -64,6 +65,7 @@ phases:
         -i ${INTEGRATION_TEST_INSTANCE_PROFILE}
         -n ${INTEGRATION_TEST_SUBNET_ID}
         -m ${INTEGRATION_TEST_MAX_EC2_COUNT}
+        -c ${INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT}
         -r 'Test'
         -v 4
         --skip ${SKIPPED_TESTS}

--- a/cmd/integration_test/cmd/run.go
+++ b/cmd/integration_test/cmd/run.go
@@ -14,18 +14,19 @@ import (
 )
 
 const (
-	amiIdFlagName            = "ami-id"
-	storageBucketFlagName    = "storage-bucket"
-	jobIdFlagName            = "job-id"
-	instanceProfileFlagName  = "instance-profile-name"
-	subnetIdFlagName         = "subnet-id"
-	regexFlagName            = "regex"
-	maxInstancesFlagName     = "max-instances"
-	skipFlagName             = "skip"
-	bundlesOverrideFlagName  = "bundles-override"
-	cleanupVmsFlagName       = "cleanup-vms"
-	testReportFolderFlagName = "test-report-folder"
-	branchNameFlagName       = "branch-name"
+	amiIdFlagName              = "ami-id"
+	storageBucketFlagName      = "storage-bucket"
+	jobIdFlagName              = "job-id"
+	instanceProfileFlagName    = "instance-profile-name"
+	subnetIdFlagName           = "subnet-id"
+	regexFlagName              = "regex"
+	maxInstancesFlagName       = "max-instances"
+	maxConcurrentTestsFlagName = "max-concurrent-tests"
+	skipFlagName               = "skip"
+	bundlesOverrideFlagName    = "bundles-override"
+	cleanupVmsFlagName         = "cleanup-vms"
+	testReportFolderFlagName   = "test-report-folder"
+	branchNameFlagName         = "branch-name"
 )
 
 var runE2ECmd = &cobra.Command{
@@ -62,7 +63,8 @@ func init() {
 	runE2ECmd.Flags().StringP(instanceProfileFlagName, "i", "", "IAM instance profile name to attach to ec2 instances")
 	runE2ECmd.Flags().StringP(subnetIdFlagName, "n", "", "EC2 subnet ID")
 	runE2ECmd.Flags().StringP(regexFlagName, "r", "", "Run only those tests and examples matching the regular expression. Equivalent to go test -run")
-	runE2ECmd.Flags().IntP(maxInstancesFlagName, "m", 1, "Run tests in parallel with multiple EC2 instances")
+	runE2ECmd.Flags().IntP(maxInstancesFlagName, "m", 1, "Run tests in parallel on same instance within the max EC2 instance count")
+	runE2ECmd.Flags().IntP(maxConcurrentTestsFlagName, "c", 1, "Maximum number of parallel tests that can be run at a time")
 	runE2ECmd.Flags().StringSlice(skipFlagName, nil, "List of tests to skip")
 	runE2ECmd.Flags().Bool(bundlesOverrideFlagName, false, "Flag to indicate if the tests should run with a bundles override")
 	runE2ECmd.Flags().Bool(cleanupVmsFlagName, false, "Flag to indicate if VSphere VMs should be cleaned up automatically as tests complete")
@@ -84,6 +86,7 @@ func runE2E(ctx context.Context) error {
 	subnetId := viper.GetString(subnetIdFlagName)
 	testRegex := viper.GetString(regexFlagName)
 	maxInstances := viper.GetInt(maxInstancesFlagName)
+	maxConcurrentTests := viper.GetInt(maxConcurrentTestsFlagName)
 	testsToSkip := viper.GetStringSlice(skipFlagName)
 	bundlesOverride := viper.GetBool(bundlesOverrideFlagName)
 	cleanupVms := viper.GetBool(cleanupVmsFlagName)
@@ -92,6 +95,7 @@ func runE2E(ctx context.Context) error {
 
 	runConf := e2e.ParallelRunConf{
 		MaxInstances:        maxInstances,
+		MaxConcurrentTests:  maxConcurrentTests,
 		AmiId:               amiId,
 		InstanceProfileName: instanceProfileName,
 		StorageBucket:       storageBucket,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This makes use of a blocking channel to queue the test executions we want to run based on the limit defined. This should allow our tests to not run into the vcenter limits we are hitting.

*Testing (if applicable):*
`make integration-test-binary`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

