### PR TITLE
Improve missing hardwarefile flag error speed

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -1,16 +1,18 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"log"
+	"runtime"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/dependencies"
+	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/types"
@@ -35,15 +37,7 @@ var createClusterCmd = &cobra.Command{
 	Long:         "This command is used to create workload clusters",
 	PreRunE:      preRunCreateCluster,
 	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := cc.validate(cmd.Context()); err != nil {
-			return err
-		}
-		if err := cc.createCluster(cmd); err != nil {
-			return fmt.Errorf("failed to create cluster: %v", err)
-		}
-		return nil
-	},
+	RunE:         cc.createCluster,
 }
 
 func init() {
@@ -57,8 +51,8 @@ func init() {
 	createClusterCmd.Flags().BoolVar(&cc.skipIpCheck, "skip-ip-check", false, "Skip check for whether cluster control plane ip is in use")
 	createClusterCmd.Flags().StringVar(&cc.bundlesOverride, "bundles-override", "", "Override default Bundles manifest (not recommended)")
 	createClusterCmd.Flags().StringVar(&cc.managementKubeconfig, "kubeconfig", "", "Management cluster kubeconfig file")
-	err := createClusterCmd.MarkFlagRequired("filename")
-	if err != nil {
+
+	if err := createClusterCmd.MarkFlagRequired("filename"); err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
 	}
 }
@@ -73,11 +67,50 @@ func preRunCreateCluster(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (cc *createClusterOptions) validate(ctx context.Context) error {
-	clusterConfig, err := commonValidation(ctx, cc.fileName)
-	if err != nil {
-		return err
+func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	clusterConfigFileExist := validations.FileExists(cc.fileName)
+	if !clusterConfigFileExist {
+		return fmt.Errorf("the cluster config file %s does not exist", cc.fileName)
 	}
+
+	clusterConfig, err := v1alpha1.GetAndValidateClusterConfig(cc.fileName)
+	if err != nil {
+		return fmt.Errorf("the cluster config file provided is invalid: %v", err)
+	}
+
+	if clusterConfig.Spec.DatacenterRef.Kind == v1alpha1.TinkerbellDatacenterKind {
+		flag := cmd.Flags().Lookup("hardwarefile")
+
+		// If no flag was returned there is a developer error as the flag has been removed
+		// from the program rendering it invalid.
+		if flag == nil {
+			panic("'hardwarefile' flag not configured")
+		}
+
+		if !viper.IsSet("hardwarefile") || viper.GetString("hardwarefile") == "" {
+			return fmt.Errorf("required flag \"hardwarefile\" not set")
+		}
+
+		if !validations.FileExists(cc.hardwareFileName) {
+			return fmt.Errorf("hardware config file %s does not exist", cc.hardwareFileName)
+		}
+	}
+
+	docker := executables.BuildDockerExecutable()
+
+	if err := validations.CheckMinimumDockerVersion(ctx, docker); err != nil {
+		return fmt.Errorf("failed to validate docker: %v", err)
+	}
+
+	if runtime.GOOS == "darwin" {
+		if err = validations.CheckDockerDesktopVersion(ctx, docker); err != nil {
+			return fmt.Errorf("failed to validate docker desktop: %v", err)
+		}
+	}
+
+	validations.CheckDockerAllocatedMemory(ctx, docker)
 
 	kubeconfigPath := kubeconfig.FromClusterName(clusterConfig.Name)
 	if validations.FileExistsAndIsNotEmpty(kubeconfigPath) {
@@ -86,12 +119,6 @@ func (cc *createClusterOptions) validate(ctx context.Context) error {
 			clusterConfig.Name,
 		)
 	}
-
-	return nil
-}
-
-func (cc *createClusterOptions) createCluster(cmd *cobra.Command) error {
-	ctx := cmd.Context()
 
 	clusterSpec, err := newClusterSpec(cc.clusterOptions)
 	if err != nil {
@@ -112,20 +139,6 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command) error {
 
 	if !features.IsActive(features.TinkerbellProvider()) && deps.Provider.Name() == constants.TinkerbellProviderName {
 		return fmt.Errorf("provider tinkerbell is not supported in this release")
-	}
-
-	if deps.Provider.Name() == constants.TinkerbellProviderName {
-		flag := cmd.Flags().Lookup("hardwarefile")
-		if flag == nil {
-			return fmt.Errorf("something wrong. Flag hardwarefile not set up for provider tinkerbell")
-		}
-		if !viper.IsSet("hardwarefile") || viper.GetString("hardwarefile") == "" {
-			return fmt.Errorf("required flag \"hardwarefile\" not set")
-		}
-		hardwareConfigFileExist := validations.FileExists(cc.hardwareFileName)
-		if !hardwareConfigFileExist {
-			return fmt.Errorf("hardware config file %s does not exist", cc.hardwareFileName)
-		}
 	}
 
 	if !features.IsActive(features.CloudStackProvider()) && deps.Provider.Name() == constants.CloudStackProviderName {


### PR DESCRIPTION
The `hardwarefile` flag is required when creating a cluster with a tinkerbell provider. We noticed the 'missing flag' error was taking unnecessarily long to appear.

The flag can't be modeled as required using Cobra because its only required if the cluster configuration uses a `TinkerbellDatacenterConfig`. Consequently, we need to establish what provider is in use with the `create cluster` command via the yaml before we can make the flag required. The cause for the delay (approximately 2s) stems from the app performing disk io, network io, sub process management and validation activities.

The launching of child processes and performing network io (the majority of the wait) was performed by a bulk `commonValidations` function that's shared between sub commands. This function makes it difficult to model a succinct bootstrapping process for sub command implementations so I took the liberty to break away from it to model the steps in a more atomic fashion. In doing so I could rejig the order of events the command executes and got the error down to milliseconds.

The change here isn't the most idiomatic. We need a follow up to define bootstrapping for CLI commands. As it stands there doesn't seem to be anything detailing a clear bootstrapping order anywhere.