### PR TITLE
Adding account/domain to the capc template

### DIFF
--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -40,6 +40,8 @@ spec:
         {{ $zone.Network.Type}}: {{ $zone.Network.Value}}
       {{ $zone.Zone.Type }}: {{ $zone.Zone.Value }}
   {{- end }}
+  {{ if .cloudstackDomain }}domain: {{.cloudstackDomain}}{{- end}}
+  {{ if .cloudstackAccount }}account: {{.cloudstackAccount}}{{- end}}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: CloudStackMachineTemplate

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
@@ -37,6 +37,8 @@ spec:
     - network:
         Name: net1
       Name: zone1
+  domain: domain1
+  account: admin
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: CloudStackMachineTemplate

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
@@ -37,6 +37,8 @@ spec:
     - network:
         name: net1
       name: zone1
+  domain: domain1
+  account: admin
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: CloudStackMachineTemplate

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -37,6 +37,8 @@ spec:
     - network:
         name: net1
       name: zone1
+  domain: domain1
+  account: admin
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: CloudStackMachineTemplate


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR enables us to pass the specified account/domain down to CAPC. We were already consuming it in the EKSA cluster spec and doing preflight checks on it, but never passing it to CAPC

*Testing (if applicable):*
Successfully created cluster with all machines in specified account/domain, unlike the prior behavior where they defaulted to admin and root. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

