### PR TITLE
Update CNI design doc to include kindnetd config for CAPD

### DIFF
--- a/designs/cilium-configuration-policy.md
+++ b/designs/cilium-configuration-policy.md
@@ -28,12 +28,15 @@ A new type will be added to accept the cni plugin name and additional options fr
 
 ```go
 type CNIConfig struct {
-  Cilium *CiliumConfig `json:"cilium,omitempty"`
+  Cilium   *CiliumConfig   `json:"cilium,omitempty"`
+  Kindnetd *KindnetdConfig `json:"kindnetd,omitempty"`
 }
 
 type CiliumConfig struct {
   PolicyEnforcementMode string `json:"policyEnforcementMode,omitempty"`
 }
+
+type KindnetdConfig struct{}
 ```
 
 The user can then configure cilium, starting with the policy enforcement mode as follows:
@@ -53,7 +56,7 @@ We can further expand the new CNIConfig type to support more CNI plugins. We can
 
 ##### Unsupported CNI plugins
 
-Currently we consider Kindnetd and Cilium Enterprise to be valid CNI plugins for EKS Anywhere, however we don't support them for the workload cluster as of now. So the CNIConfig type won't accept Kindnetd or Cilium Enterprise plugins to begin with, we can add configuration options for plugins as we start supporting them.
+Currently we consider Cilium Enterprise to be a valid CNI plugin for EKS Anywhere, however we don't support it for the workload cluster as of now. So the CNIConfig type won't accept Cilium Enterprise plugin to begin with. We can add configuration options for plugins as we start supporting them.
 
 ##### Validation
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We support Kindnetd as the CNI plugin for CAPD clusters. This PR updates the design doc for CNIConfig to include a field for KindnetdConfig

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

