### PR TITLE
Move wait for queue outside of go routine

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -86,10 +86,8 @@ func RunTestsInParallel(conf ParallelRunConf) error {
 		wg.Add(1)
 	}
 
-	go func() {
-		wg.Wait()
-		close(queue)
-	}()
+	wg.Wait()
+	close(queue)
 
 	failedInstances := 0
 	for _, r := range results {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Moving the wait outside of the go routine so that all executions can run. Currently for presubmits, the test is not executing because it is a single case, and it is only running for n-1 executions.

*Testing (if applicable):*
presubmit should show that the test is actually executing now

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

