### PR TITLE
Add CNIConfig type

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -39,9 +39,23 @@ spec:
               clusterNetwork:
                 properties:
                   cni:
-                    description: CNI specifies the CNI plugin to be installed in the
-                      cluster
+                    description: Deprecated. Use CNIConfig
                     type: string
+                  cniConfig:
+                    description: CNIConfig specifies the CNI plugin to be installed
+                      in the cluster
+                    properties:
+                      cilium:
+                        properties:
+                          policyEnforcementMode:
+                            description: PolicyEnforcementMode determines communication
+                              allowed between pods. Accepted values are default, always,
+                              never.
+                            type: string
+                        type: object
+                      kindnetd:
+                        type: object
+                    type: object
                   dns:
                     properties:
                       resolvConf:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -3217,9 +3217,23 @@ spec:
               clusterNetwork:
                 properties:
                   cni:
-                    description: CNI specifies the CNI plugin to be installed in the
-                      cluster
+                    description: Deprecated. Use CNIConfig
                     type: string
+                  cniConfig:
+                    description: CNIConfig specifies the CNI plugin to be installed
+                      in the cluster
+                    properties:
+                      cilium:
+                        properties:
+                          policyEnforcementMode:
+                            description: PolicyEnforcementMode determines communication
+                              allowed between pods. Accepted values are default, always,
+                              never.
+                            type: string
+                        type: object
+                      kindnetd:
+                        type: object
+                    type: object
                   dns:
                     properties:
                       resolvConf:

--- a/pkg/api/v1alpha1/cluster_defaults.go
+++ b/pkg/api/v1alpha1/cluster_defaults.go
@@ -12,6 +12,7 @@ import (
 var clusterDefaults = []func(*Cluster) error{
 	setRegistryMirrorConfigDefaults,
 	setWorkerNodeGroupDefaults,
+	setCNIConfigDefault,
 }
 
 func setClusterDefaults(cluster *Cluster) error {
@@ -49,5 +50,22 @@ func setWorkerNodeGroupDefaults(cluster *Cluster) error {
 		logger.V(1).Info("First worker node group name not specified. Defaulting name to md-0.")
 		cluster.Spec.WorkerNodeGroupConfigurations[0].Name = "md-0"
 	}
+	return nil
+}
+
+func setCNIConfigDefault(cluster *Cluster) error {
+	if cluster.Spec.ClusterNetwork.CNIConfig != nil {
+		return nil
+	}
+
+	cluster.Spec.ClusterNetwork.CNIConfig = &CNIConfig{}
+	switch cluster.Spec.ClusterNetwork.CNI {
+	case Cilium, CiliumEnterprise:
+		cluster.Spec.ClusterNetwork.CNIConfig.Cilium = &CiliumConfig{}
+	case Kindnetd:
+		cluster.Spec.ClusterNetwork.CNIConfig.Kindnetd = &KindnetdConfig{}
+	}
+
+	cluster.Spec.ClusterNetwork.CNI = ""
 	return nil
 }

--- a/pkg/api/v1alpha1/cluster_defaults_test.go
+++ b/pkg/api/v1alpha1/cluster_defaults_test.go
@@ -47,7 +47,9 @@ func TestSetClusterDefaults(t *testing.T) {
 						Name: "eksa-unit-test",
 					},
 					ClusterNetwork: ClusterNetwork{
-						CNI: Cilium,
+						CNIConfig: &CNIConfig{
+							Cilium: &CiliumConfig{},
+						},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},
@@ -90,7 +92,57 @@ func TestSetClusterDefaults(t *testing.T) {
 						Name: "eksa-unit-test",
 					},
 					ClusterNetwork: ClusterNetwork{
+						CNIConfig: &CNIConfig{
+							Cilium: &CiliumConfig{},
+						},
+						Pods: Pods{
+							CidrBlocks: []string{"192.168.0.0/16"},
+						},
+						Services: Services{
+							CidrBlocks: []string{"10.96.0.0/12"},
+						},
+					},
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "cni plugin - old format in input, set new format",
+			in: &Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       ClusterKind,
+					APIVersion: SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: ClusterSpec{
+					KubernetesVersion: Kube119,
+					ClusterNetwork: ClusterNetwork{
 						CNI: Cilium,
+						Pods: Pods{
+							CidrBlocks: []string{"192.168.0.0/16"},
+						},
+						Services: Services{
+							CidrBlocks: []string{"10.96.0.0/12"},
+						},
+					},
+				},
+			},
+			wantCluster: &Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       ClusterKind,
+					APIVersion: SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: ClusterSpec{
+					KubernetesVersion: Kube119,
+					ClusterNetwork: ClusterNetwork{
+						CNIConfig: &CNIConfig{
+							Cilium: &CiliumConfig{},
+						},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -141,7 +141,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 						},
 					}},
 					ClusterNetwork: ClusterNetwork{
-						CNI: Cilium,
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},
@@ -193,7 +193,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 						Name: "eksa-unit-test",
 					},
 					ClusterNetwork: ClusterNetwork{
-						CNI: Cilium,
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},
@@ -241,7 +241,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 						Name: "eksa-unit-test",
 					},
 					ClusterNetwork: ClusterNetwork{
-						CNI: Cilium,
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},
@@ -289,7 +289,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 						Name: "eksa-unit-test",
 					},
 					ClusterNetwork: ClusterNetwork{
-						CNI: Cilium,
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},
@@ -337,7 +337,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 						Name: "eksa-unit-test",
 					},
 					ClusterNetwork: ClusterNetwork{
-						CNI: Cilium,
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},
@@ -389,7 +389,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 						Name: "test-gitops",
 					},
 					ClusterNetwork: ClusterNetwork{
-						CNI: Cilium,
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},
@@ -441,7 +441,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 						Name: "test-gitops",
 					},
 					ClusterNetwork: ClusterNetwork{
-						CNI: Cilium,
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},
@@ -489,7 +489,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 						Name: "eksa-unit-test",
 					},
 					ClusterNetwork: ClusterNetwork{
-						CNI: Cilium,
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},
@@ -566,7 +566,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 						Name: "eksa-unit-test",
 					},
 					ClusterNetwork: ClusterNetwork{
-						CNI: Cilium,
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},
@@ -767,7 +767,7 @@ func TestGetClusterConfig(t *testing.T) {
 						Name: "eksa-unit-test",
 					},
 					ClusterNetwork: ClusterNetwork{
-						CNI: Cilium,
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},
@@ -815,7 +815,7 @@ func TestGetClusterConfig(t *testing.T) {
 						Name: "eksa-unit-test",
 					},
 					ClusterNetwork: ClusterNetwork{
-						CNI: Cilium,
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},
@@ -863,7 +863,7 @@ func TestGetClusterConfig(t *testing.T) {
 						Name: "eksa-unit-test",
 					},
 					ClusterNetwork: ClusterNetwork{
-						CNI: Cilium,
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},
@@ -907,7 +907,7 @@ func TestGetClusterConfig(t *testing.T) {
 						},
 					}},
 					ClusterNetwork: ClusterNetwork{
-						CNI: Cilium,
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 						Pods: Pods{
 							CidrBlocks: []string{"192.168.0.0/16"},
 						},
@@ -1481,7 +1481,7 @@ func TestClusterNetworkEquals(t *testing.T) {
 			name: "previous == new, all exists",
 			want: true,
 			prev: &ClusterNetwork{
-				CNI: Cilium,
+				CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 				Pods: Pods{
 					CidrBlocks: []string{
 						"1.2.3.4/5",
@@ -1496,7 +1496,7 @@ func TestClusterNetworkEquals(t *testing.T) {
 				},
 			},
 			new: &ClusterNetwork{
-				CNI: Cilium,
+				CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 				Pods: Pods{
 					CidrBlocks: []string{
 						"1.2.3.4/5",
@@ -1528,7 +1528,7 @@ func TestClusterNetworkEquals(t *testing.T) {
 			name: "previous == new, order diff",
 			want: true,
 			prev: &ClusterNetwork{
-				CNI: Cilium,
+				CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 				Pods: Pods{
 					CidrBlocks: []string{
 						"1.2.3.4/5",
@@ -1543,7 +1543,7 @@ func TestClusterNetworkEquals(t *testing.T) {
 				},
 			},
 			new: &ClusterNetwork{
-				CNI: Cilium,
+				CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 				Pods: Pods{
 					CidrBlocks: []string{
 						"1.2.3.4/6",
@@ -1562,7 +1562,7 @@ func TestClusterNetworkEquals(t *testing.T) {
 			name: "previous != new, pods diff",
 			want: false,
 			prev: &ClusterNetwork{
-				CNI: Cilium,
+				CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 				Pods: Pods{
 					CidrBlocks: []string{
 						"1.2.3.4/5",
@@ -1571,7 +1571,7 @@ func TestClusterNetworkEquals(t *testing.T) {
 				},
 			},
 			new: &ClusterNetwork{
-				CNI: Cilium,
+				CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
 				Pods: Pods{
 					CidrBlocks: []string{
 						"1.2.3.4/6",
@@ -1610,19 +1610,89 @@ func TestClusterNetworkEquals(t *testing.T) {
 			},
 		},
 		{
-			name: "previous != new, diff CNI",
-			want: false,
+			name: "previous == new, same cni, older format",
+			want: true,
 			prev: &ClusterNetwork{
-				CNI: CiliumEnterprise,
+				CNI: Cilium,
 			},
 			new: &ClusterNetwork{
 				CNI: Cilium,
 			},
 		},
+		{
+			name: "previous != new, diff CNI, older format",
+			want: false,
+			prev: &ClusterNetwork{
+				CNI: Kindnetd,
+			},
+			new: &ClusterNetwork{
+				CNI: Cilium,
+			},
+		},
+		{
+			name: "previous == new, same cni, diff format",
+			want: true,
+			prev: &ClusterNetwork{
+				CNI: Cilium,
+			},
+			new: &ClusterNetwork{
+				CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
+			},
+		},
+		{
+			name: "previous != new, same cni, diff format, diff cilium policy  mode",
+			want: false,
+			prev: &ClusterNetwork{
+				CNI: Cilium,
+			},
+			new: &ClusterNetwork{
+				CNIConfig: &CNIConfig{Cilium: &CiliumConfig{PolicyEnforcementMode: "always"}},
+			},
+		},
+		{
+			name: "previous != new, different cni, different format",
+			want: false,
+			prev: &ClusterNetwork{
+				CNI: Kindnetd,
+			},
+			new: &ClusterNetwork{
+				CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
+			},
+		},
+		{
+			name: "previous != new, new cniConfig format, diff cni",
+			want: false,
+			prev: &ClusterNetwork{
+				CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
+			},
+			new: &ClusterNetwork{
+				CNIConfig: &CNIConfig{Kindnetd: &KindnetdConfig{}},
+			},
+		},
+		{
+			name: "previous == new, new cniConfig format, same cni",
+			want: true,
+			prev: &ClusterNetwork{
+				CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
+			},
+			new: &ClusterNetwork{
+				CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
+			},
+		},
+		{
+			name: "previous != new, new cniConfig format, same cilium cni, diff configuration",
+			want: false,
+			prev: &ClusterNetwork{
+				CNIConfig: &CNIConfig{Cilium: &CiliumConfig{PolicyEnforcementMode: "always"}},
+			},
+			new: &ClusterNetwork{
+				CNIConfig: &CNIConfig{Cilium: &CiliumConfig{PolicyEnforcementMode: "default"}},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.want != tt.prev.Equal(tt.new) {
+			if tt.want != tt.new.Equal(tt.prev) {
 				t.Errorf("ClusterNetwork %+v should be equals to  %+v", tt.prev, tt.new)
 			}
 		})
@@ -1677,6 +1747,123 @@ func TestRefEquals(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.want != tt.prev.Equal(tt.new) {
 				t.Errorf("Ref %+v should be equals to  %+v", tt.prev, tt.new)
+			}
+		})
+	}
+}
+
+func TestValidateNetworkingCNIPlugin(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr error
+		cluster *Cluster
+	}{
+		{
+			name:    "both formats used",
+			wantErr: fmt.Errorf("invalid format for cni plugin: both old and new formats used, use only the CNIConfig field"),
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					ClusterNetwork: ClusterNetwork{
+						Pods: Pods{
+							CidrBlocks: []string{
+								"1.2.3.4/6",
+							},
+						},
+						Services: Services{
+							CidrBlocks: []string{
+								"1.2.3.4/7",
+							},
+						},
+						CNI:       Cilium,
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
+					},
+				},
+			},
+		},
+		{
+			name:    "deprecated CNI field",
+			wantErr: nil,
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					ClusterNetwork: ClusterNetwork{
+						Pods: Pods{
+							CidrBlocks: []string{
+								"1.2.3.4/6",
+							},
+						},
+						Services: Services{
+							CidrBlocks: []string{
+								"1.2.3.4/7",
+							},
+						},
+						CNI:       Cilium,
+						CNIConfig: nil,
+					},
+				},
+			},
+		},
+		{
+			name:    "no CNI plugin input",
+			wantErr: fmt.Errorf("cni not specified"),
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					ClusterNetwork: ClusterNetwork{
+						Pods: Pods{
+							CidrBlocks: []string{
+								"1.2.3.4/6",
+							},
+						},
+						Services: Services{
+							CidrBlocks: []string{
+								"1.2.3.4/7",
+							},
+						},
+						CNI:       "",
+						CNIConfig: nil,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validateNetworking(tt.cluster)
+			if !reflect.DeepEqual(tt.wantErr, got) {
+				t.Errorf("%v got = %v, want %v", tt.name, got, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateCNIConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		wantErr        error
+		clusterNetwork *ClusterNetwork
+	}{
+		{
+			name:    "CNI plugin not specified",
+			wantErr: fmt.Errorf("no cni plugin specified"),
+			clusterNetwork: &ClusterNetwork{
+				CNIConfig: &CNIConfig{},
+			},
+		},
+		{
+			name:    "multiple CNI plugins specified",
+			wantErr: fmt.Errorf("cannot specify more than one cni plugins"),
+			clusterNetwork: &ClusterNetwork{
+				CNIConfig: &CNIConfig{
+					Cilium:   &CiliumConfig{},
+					Kindnetd: &KindnetdConfig{},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validateCNIConfig(tt.clusterNetwork.CNIConfig)
+			if !reflect.DeepEqual(tt.wantErr, got) {
+				t.Errorf("%v got = %v, want %v", tt.name, got, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -311,9 +311,11 @@ type ClusterNetwork struct {
 	// Defaults to 192.168.0.0/16 for pod subnet.
 	Pods     Pods     `json:"pods,omitempty"`
 	Services Services `json:"services,omitempty"`
-	// CNI specifies the CNI plugin to be installed in the cluster
+	// Deprecated. Use CNIConfig
 	CNI CNI `json:"cni,omitempty"`
-	DNS DNS `json:"dns,omitempty"`
+	// CNIConfig specifies the CNI plugin to be installed in the cluster
+	CNIConfig *CNIConfig `json:"cniConfig,omitempty"`
+	DNS       DNS        `json:"dns,omitempty"`
 }
 
 func (n *ClusterNetwork) Equal(o *ClusterNetwork) bool {
@@ -323,9 +325,121 @@ func (n *ClusterNetwork) Equal(o *ClusterNetwork) bool {
 	if n == nil || o == nil {
 		return false
 	}
-	return SliceEqual(n.Pods.CidrBlocks, o.Pods.CidrBlocks) &&
-		SliceEqual(n.Services.CidrBlocks, o.Services.CidrBlocks) &&
-		n.CNI == o.CNI && n.DNS.ResolvConf.Equal(o.DNS.ResolvConf)
+
+	if !CNIPluginSame(*n, *o) {
+		return false
+	}
+
+	oldCNIConfig := getCNIConfig(o)
+	newCNIConfig := getCNIConfig(n)
+	if !newCNIConfig.Equal(oldCNIConfig) {
+		return false
+	}
+
+	return n.Pods.Equal(&o.Pods) && n.Services.Equal(&o.Services) && n.DNS.Equal(&o.DNS)
+}
+
+func getCNIConfig(cn *ClusterNetwork) *CNIConfig {
+	/* Only needed since we're introducing CNIConfig to replace the deprecated CNI field. This way we can compare the individual fields
+	for the CNI plugin configuration*/
+	var tempCNIConfig *CNIConfig
+	if cn.CNIConfig == nil {
+		// This is for upgrading from release-0.7, to ensure that all oCNIConfig fields, such as policyEnforcementMode have the default values
+		switch cn.CNI {
+		case Cilium, CiliumEnterprise:
+			tempCNIConfig = &CNIConfig{Cilium: &CiliumConfig{}}
+		case Kindnetd:
+			tempCNIConfig = &CNIConfig{Kindnetd: &KindnetdConfig{}}
+		}
+	} else {
+		tempCNIConfig = cn.CNIConfig
+	}
+	return tempCNIConfig
+}
+
+func (n *Pods) Equal(o *Pods) bool {
+	return SliceEqual(n.CidrBlocks, o.CidrBlocks)
+}
+
+func (n *Services) Equal(o *Services) bool {
+	return SliceEqual(n.CidrBlocks, o.CidrBlocks)
+}
+
+func (n *DNS) Equal(o *DNS) bool {
+	return n.ResolvConf.Equal(o.ResolvConf)
+}
+
+func (n *CNIConfig) Equal(o *CNIConfig) bool {
+	if n == o {
+		return true
+	}
+	if n == nil || o == nil {
+		return false
+	}
+	if !n.Cilium.Equal(o.Cilium) {
+		return false
+	}
+	if !n.Kindnetd.Equal(o.Kindnetd) {
+		return false
+	}
+	return true
+}
+
+func (n *CiliumConfig) Equal(o *CiliumConfig) bool {
+	if n == o {
+		return true
+	}
+	if n == nil || o == nil {
+		return false
+	}
+	return n.PolicyEnforcementMode == o.PolicyEnforcementMode
+}
+
+func (n *KindnetdConfig) Equal(o *KindnetdConfig) bool {
+	if n == o {
+		return true
+	}
+	if n == nil || o == nil {
+		return false
+	}
+	return true
+}
+
+func CNIPluginSame(n ClusterNetwork, o ClusterNetwork) bool {
+	if n.CNI != "" {
+		/*This shouldn't be required since we set CNIConfig and unset CNI as part of cluster_defaults. However, while upgrading an existing cluster, the eks-a controller
+		does not set any defaults (no mutating webhook), so it gets stuck in an error loop. Adding these checks to avoid that. We can remove it when removing the CNI field
+		in a later release*/
+		return o.CNI == n.CNI
+	}
+
+	if n.CNIConfig != nil {
+		if o.CNI != "" {
+			switch o.CNI {
+			case Cilium, CiliumEnterprise:
+				if n.CNIConfig.Cilium == nil {
+					return false
+				}
+			case Kindnetd:
+				if n.CNIConfig.Kindnetd == nil {
+					return false
+				}
+			default:
+				return false
+			}
+			return true
+		}
+		if o.CNIConfig != nil {
+			if (n.CNIConfig.Cilium != nil && o.CNIConfig.Cilium == nil) || (n.CNIConfig.Cilium == nil && o.CNIConfig.Cilium != nil) {
+				return false
+			}
+			if (n.CNIConfig.Kindnetd != nil && o.CNIConfig.Kindnetd == nil) || (n.CNIConfig.Kindnetd == nil && o.CNIConfig.Kindnetd != nil) {
+				return false
+			}
+		}
+	}
+
+	return true
 }
 
 func SliceEqual(a, b []string) bool {
@@ -409,6 +523,18 @@ const (
 )
 
 type CNI string
+
+type CNIConfig struct {
+	Cilium   *CiliumConfig   `json:"cilium,omitempty"`
+	Kindnetd *KindnetdConfig `json:"kindnetd,omitempty"`
+}
+
+type CiliumConfig struct {
+	// PolicyEnforcementMode determines communication allowed between pods. Accepted values are default, always, never.
+	PolicyEnforcementMode string `json:"policyEnforcementMode,omitempty"`
+}
+
+type KindnetdConfig struct{}
 
 const (
 	Cilium           CNI = "cilium"

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -802,6 +802,36 @@ func TestClusterEqualClusterNetwork(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			testName: "same cni plugin (cilium), diff format",
+			cluster1ClusterNetwork: v1alpha1.ClusterNetwork{
+				CNIConfig: &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{}},
+			},
+			cluster2ClusterNetwork: v1alpha1.ClusterNetwork{
+				CNI: v1alpha1.Cilium,
+			},
+			want: true,
+		},
+		{
+			testName: "different cni plugin (cilium), diff format",
+			cluster1ClusterNetwork: v1alpha1.ClusterNetwork{
+				CNIConfig: &v1alpha1.CNIConfig{Kindnetd: &v1alpha1.KindnetdConfig{}},
+			},
+			cluster2ClusterNetwork: v1alpha1.ClusterNetwork{
+				CNIConfig: &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{}},
+			},
+			want: false,
+		},
+		{
+			testName: "same cni plugin (cilium), diff cilium configuration",
+			cluster1ClusterNetwork: v1alpha1.ClusterNetwork{
+				CNIConfig: &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{PolicyEnforcementMode: "always"}},
+			},
+			cluster2ClusterNetwork: v1alpha1.ClusterNetwork{
+				CNIConfig: &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{PolicyEnforcementMode: "default"}},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -54,6 +54,11 @@ func (r *Cluster) ValidateCreate() error {
 	if r.IsSelfManaged() {
 		return apierrors.NewBadRequest("Creating new cluster on existing cluster is not supported")
 	}
+
+	if err := validateCNIPlugin(r.Spec.ClusterNetwork); err != nil {
+		return apierrors.NewBadRequest(err.Error())
+	}
+
 	return nil
 }
 

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -630,6 +630,31 @@ func TestClusterValidateUpdateClusterNetworkNewEmptyImmutable(t *testing.T) {
 	g.Expect(c.ValidateUpdate(cOld)).NotTo(Succeed())
 }
 
+func TestClusterValidateUpdateClusterNetworkCiliumConfigImmutable(t *testing.T) {
+	cOld := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			ClusterNetwork: v1alpha1.ClusterNetwork{
+				CNIConfig: &v1alpha1.CNIConfig{
+					Cilium: &v1alpha1.CiliumConfig{
+						PolicyEnforcementMode: "default",
+					},
+				},
+			},
+		},
+	}
+	c := cOld.DeepCopy()
+	c.Spec.ClusterNetwork = v1alpha1.ClusterNetwork{
+		CNIConfig: &v1alpha1.CNIConfig{
+			Cilium: &v1alpha1.CiliumConfig{
+				PolicyEnforcementMode: "always",
+			},
+		},
+	}
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(cOld)).NotTo(Succeed())
+}
+
 func TestClusterValidateUpdateProxyConfigurationEqualOrder(t *testing.T) {
 	cOld := &v1alpha1.Cluster{
 		Spec: v1alpha1.ClusterSpec{
@@ -1225,6 +1250,7 @@ func TestClusterCreateWorkloadCluster(t *testing.T) {
 				Count: 3, Endpoint: &v1alpha1.Endpoint{Host: "1.1.1.1/1"},
 			},
 			ExternalEtcdConfiguration: &v1alpha1.ExternalEtcdConfiguration{Count: 3},
+			ClusterNetwork:            v1alpha1.ClusterNetwork{CNIConfig: &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{}}},
 		},
 	}
 	cluster.Spec.ManagementCluster.Name = "management-cluster"

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -423,7 +423,7 @@ func (f *Factory) WithHelm() *Factory {
 
 func (f *Factory) WithNetworking(clusterConfig *v1alpha1.Cluster) *Factory {
 	var networkingBuilder func() clustermanager.Networking
-	if clusterConfig.Spec.ClusterNetwork.CNI == v1alpha1.Kindnetd {
+	if clusterConfig.Spec.ClusterNetwork.CNIConfig.Kindnetd != nil {
 		f.WithKubectl()
 		networkingBuilder = func() clustermanager.Networking {
 			return kindnetd.NewKindnetd(f.dependencies.Kubectl)

--- a/pkg/validations/upgradevalidations/immutableFields.go
+++ b/pkg/validations/upgradevalidations/immutableFields.go
@@ -70,8 +70,18 @@ func ValidateImmutableFields(ctx context.Context, k validations.KubectlClient, c
 		return fmt.Errorf("spec.controlPlaneConfiguration.endpoint is immutable")
 	}
 
-	if !nSpec.ClusterNetwork.Equal(&oSpec.ClusterNetwork) {
-		return fmt.Errorf("spec.clusterNetwork is immutable")
+	/* compare all clusterNetwork fields individually, since we do allow updating updating fields for configuring plugins such as CiliumConfig through the cli*/
+	if !nSpec.ClusterNetwork.Pods.Equal(&oSpec.ClusterNetwork.Pods) {
+		return fmt.Errorf("spec.clusterNetwork.Pods is immutable")
+	}
+	if !nSpec.ClusterNetwork.Services.Equal(&oSpec.ClusterNetwork.Services) {
+		return fmt.Errorf("spec.clusterNetwork.Services is immutable")
+	}
+	if !nSpec.ClusterNetwork.DNS.Equal(&oSpec.ClusterNetwork.DNS) {
+		return fmt.Errorf("spec.clusterNetwork.DNS is immutable")
+	}
+	if !v1alpha1.CNIPluginSame(nSpec.ClusterNetwork, oSpec.ClusterNetwork) {
+		return fmt.Errorf("spec.clusterNetwork.CNI/CNIConfig is immutable")
 	}
 
 	if !nSpec.ProxyConfiguration.Equal(oSpec.ProxyConfiguration) {

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -453,7 +453,7 @@ func TestPreflightValidations(t *testing.T) {
 			},
 		},
 		{
-			name:               "ValidationClusterNetworkImmutable",
+			name:               "ValidationClusterNetworkPodsImmutable",
 			clusterVersion:     "v1.19.16-eks-1-19-4",
 			upgradeVersion:     "1.19",
 			getClusterResponse: goodClusterResponse,
@@ -461,9 +461,37 @@ func TestPreflightValidations(t *testing.T) {
 			workerResponse:     nil,
 			nodeResponse:       nil,
 			crdResponse:        nil,
-			wantErr:            composeError("spec.clusterNetwork is immutable"),
+			wantErr:            composeError("spec.clusterNetwork.Pods is immutable"),
 			modifyFunc: func(s *cluster.Spec) {
-				s.Cluster.Spec.ClusterNetwork = v1alpha1.ClusterNetwork{}
+				s.Cluster.Spec.ClusterNetwork.Pods = v1alpha1.Pods{}
+			},
+		},
+		{
+			name:               "ValidationClusterNetworkServicesImmutable",
+			clusterVersion:     "v1.19.16-eks-1-19-4",
+			upgradeVersion:     "1.19",
+			getClusterResponse: goodClusterResponse,
+			cpResponse:         nil,
+			workerResponse:     nil,
+			nodeResponse:       nil,
+			crdResponse:        nil,
+			wantErr:            composeError("spec.clusterNetwork.Services is immutable"),
+			modifyFunc: func(s *cluster.Spec) {
+				s.Cluster.Spec.ClusterNetwork.Services = v1alpha1.Services{}
+			},
+		},
+		{
+			name:               "ValidationClusterNetworkDNSImmutable",
+			clusterVersion:     "v1.19.16-eks-1-19-4",
+			upgradeVersion:     "1.19",
+			getClusterResponse: goodClusterResponse,
+			cpResponse:         nil,
+			workerResponse:     nil,
+			nodeResponse:       nil,
+			crdResponse:        nil,
+			wantErr:            composeError("spec.clusterNetwork.DNS is immutable"),
+			modifyFunc: func(s *cluster.Spec) {
+				s.Cluster.Spec.ClusterNetwork.DNS = v1alpha1.DNS{}
 			},
 		},
 		{
@@ -642,6 +670,9 @@ func TestPreflightValidations(t *testing.T) {
 				CidrBlocks: []string{
 					"1.2.3.4/6",
 				},
+			},
+			DNS: v1alpha1.DNS{
+				ResolvConf: &v1alpha1.ResolvConf{Path: "file.conf"},
 			},
 		}
 		s.Cluster.Spec.ProxyConfiguration = &v1alpha1.ProxyConfiguration{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds the new field CNIConfig to specify cni plugin proposed in this design doc: https://github.com/aws/eks-anywhere/blob/main/designs/cilium-configuration-policy.md#api-changes

The exiting CNI field will be deprecated.
The reason behind adding this new type is to allow users to specify more configuration options for the different CNI plugins where possible. For instance, eks anywhere installs cilium through a helm chart, which can accept values from the user. So the new CNIConfig type has separate fields to configure each plugin, like CiliumConfig that can accept values from the user and configure the cilium helm chart with it.

*Testing (if applicable):*
1. Cluster creation & upgrade
2. Upgrade existing cluster from release-0.7
3. Upgrade existing mgmt & workload cluster with flux enabled from release-0.7

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

