### PR TITLE
Update SSH keys and user names controller changes

### DIFF
--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
@@ -70,13 +70,6 @@ func validateImmutableFieldsVSphereMachineConfig(new, old *VSphereMachineConfig)
 		)
 	}
 
-	if !reflect.DeepEqual(old.Spec.Users, new.Spec.Users) {
-		allErrs = append(
-			allErrs,
-			field.Invalid(field.NewPath("spec", "users"), new.Spec.Users, "field is immutable"),
-		)
-	}
-
 	if old.Spec.StoragePolicyName != new.Spec.StoragePolicyName {
 		allErrs = append(
 			allErrs,
@@ -95,6 +88,13 @@ func validateImmutableFieldsVSphereMachineConfig(new, old *VSphereMachineConfig)
 	}
 
 	vspheremachineconfiglog.Info("Machine config is associated with management cluster's control plane or etcd", "name", old.Name)
+
+	if !reflect.DeepEqual(old.Spec.Users, new.Spec.Users) {
+		allErrs = append(
+			allErrs,
+			field.Invalid(field.NewPath("spec", "users"), new.Spec.Users, "field is immutable"),
+		)
+	}
 
 	if old.Spec.Template != new.Spec.Template {
 		allErrs = append(

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
@@ -289,7 +289,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateDiskGiBSuccess(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
+func TestManagementControlPlaneSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
@@ -301,7 +301,7 @@ func TestManagementSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testi
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
 }
 
-func TestWorkloadVSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
+func TestWorkloadControlPlaneVSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.SetManagedBy("test-cluster")
@@ -311,10 +311,10 @@ func TestWorkloadVSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testin
 
 	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) {
+func TestManagementControlPlaneVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
@@ -325,7 +325,7 @@ func TestManagementVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
 }
 
-func TestWorkloadVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) {
+func TestWorkloadControlPlaneVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.SetManagedBy("test-cluster")
@@ -334,7 +334,99 @@ func TestWorkloadVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) 
 
 	c.Spec.Users[0].Name = "Andy"
 	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
+}
+
+func TestManagementEtcdSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.SetEtcd()
+	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
+	vOld.Spec.Users[0].SshAuthorizedKeys = []string{"rsa-blahdeblahbalh"}
+	c := vOld.DeepCopy()
+
+	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
+	g := NewWithT(t)
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
+}
+
+func TestWorkloadEtcdVSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.SetEtcd()
+	vOld.SetManagedBy("test-cluster")
+	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
+	vOld.Spec.Users[0].SshAuthorizedKeys = []string{"rsa-blahdeblahbalh"}
+	c := vOld.DeepCopy()
+
+	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
+}
+
+func TestManagementEtcdVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.SetEtcd()
+	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
+	c := vOld.DeepCopy()
+
+	c.Spec.Users[0].Name = "Andy"
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
+}
+
+func TestWorkloadEtcdVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.SetEtcd()
+	vOld.SetManagedBy("test-cluster")
+	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
+	c := vOld.DeepCopy()
+
+	c.Spec.Users[0].Name = "Andy"
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
+}
+
+func TestManagementWorkerNodeSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
+	vOld.Spec.Users[0].SshAuthorizedKeys = []string{"rsa-blahdeblahbalh"}
+	c := vOld.DeepCopy()
+
+	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
+}
+
+func TestWorkloadWorkerNodeVSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.SetManagedBy("test-cluster")
+	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
+	vOld.Spec.Users[0].SshAuthorizedKeys = []string{"rsa-blahdeblahbalh"}
+	c := vOld.DeepCopy()
+
+	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
+}
+
+func TestManagementWorkerNodeVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
+	c := vOld.DeepCopy()
+
+	c.Spec.Users[0].Name = "Andy"
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
+}
+
+func TestWorkloadWorkerNodeVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) {
+	vOld := vsphereMachineConfig()
+	vOld.SetManagedBy("test-cluster")
+	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
+	c := vOld.DeepCopy()
+
+	c.Spec.Users[0].Name = "Andy"
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestVSphereMachineValidateUpdateWithPausedAnnotation(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
#1208 

*Description of changes:*
The changes for the controller to update the spec and create a new kubeadm config template were a part of the PR where we [update the cli changes](https://github.com/aws/eks-anywhere/commit/808c311b7eb1fcc9ef47af9c2dc6783d531f1281#diff-bc34991624b50737e326752c68bf11ea5358a19c6f52c7ae6f328e5003278de5).

*Testing (if applicable):*

1. Created management cluster

  - Updated worker node's user name and ssh keys, tested by logging in using new keys and name

  - Updated control plane and etcd node's user name and ssh keys, got an error saying the update was immutable

2. Created workload cluster
  - Updated worker node's user name and ssh keys, tested by logging in using new keys and name
  - Updated control plane and etcd node's user name and ssh keys,  tested by logging in using new keys and name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

