### PR TITLE
Added validation for metadata_url of the template config  field

### DIFF
--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
@@ -15,7 +15,7 @@ const (
 `
 	cloudInit = `datasource:
   Ec2:
-    metadata_urls: ["http://TINKERBELL_IP:50061"]
+    metadata_urls: ["http://<REPLACE WITH TINKERBELL IP>:50061"]
     strict_id: false
 system_info:
   default_user:

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -318,6 +318,14 @@ func (p *tinkerbellProvider) SetupAndValidateCreateCluster(ctx context.Context, 
 		return err
 	}
 
+	if err := p.validator.ValidateTinkerbellTemplate(ctx, tinkerbellClusterSpec.datacenterConfig.Spec.TinkerbellIP, tinkerbellClusterSpec.Spec.TinkerbellTemplateConfigs[tinkerbellClusterSpec.controlPlaneMachineConfig().Spec.TemplateRef.Name]); err != nil {
+		return fmt.Errorf("failed validating control plane template config: %v", err)
+	}
+
+	if err := p.validator.ValidateTinkerbellTemplate(ctx, tinkerbellClusterSpec.datacenterConfig.Spec.TinkerbellIP, tinkerbellClusterSpec.Spec.TinkerbellTemplateConfigs[tinkerbellClusterSpec.firstWorkerMachineConfig().Spec.TemplateRef.Name]); err != nil {
+		return fmt.Errorf("failed validating worker node template config: %v", err)
+	}
+
 	if err := p.validator.ValidateMinimumRequiredTinkerbellHardwareAvailable(tinkerbellClusterSpec.Spec.Cluster.Spec); err != nil {
 		return fmt.Errorf("minimum hardware not available: %v", err)
 	}

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 
 	tinkhardware "github.com/tinkerbell/tink/protos/hardware"
 	tinkworkflow "github.com/tinkerbell/tink/protos/workflow"
@@ -174,6 +175,23 @@ func (v *Validator) ValidateBMCSecretCreds(ctx context.Context, hc hardware.Hard
 		}
 		if err := v.pbnj.ValidateBMCSecretCreds(ctx, bmcInfo); err != nil {
 			return fmt.Errorf("failed validating Hardware BMC credentials for the node %s, host %s : %v", hc.Hardwares[index].Name, bmcInfo.Host, err)
+		}
+	}
+
+	return nil
+}
+
+func (v *Validator) ValidateTinkerbellTemplate(ctx context.Context, tinkerbellIp string, templateConfig *v1alpha1.TinkerbellTemplateConfig) error {
+	for _, task := range templateConfig.Spec.Template.Tasks {
+		for _, action := range task.Actions {
+			// check if the metadata_url provided by the user is valid or not
+			// TODO(pjshah):: add more validations around metadata_url field and parse
+			if action.Name == "add-tink-cloud-init-config" {
+				metadataUrl := fmt.Sprintf("http://%s:50061", tinkerbellIp)
+				if !strings.Contains(action.Environment["CONTENTS"], metadataUrl) {
+					return fmt.Errorf("failed validating metadata_url, template metadata_url should be in http://<TINKERBELL_IP>:50061 format")
+				}
+			}
 		}
 	}
 

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -189,7 +189,7 @@ func (v *Validator) ValidateTinkerbellTemplate(ctx context.Context, tinkerbellIp
 			if action.Name == "add-tink-cloud-init-config" {
 				metadataUrl := fmt.Sprintf("http://%s:50061", tinkerbellIp)
 				if !strings.Contains(action.Environment["CONTENTS"], metadataUrl) {
-					return fmt.Errorf("failed validating metadata_url, template metadata_url should be in http://<TINKERBELL_IP>:50061 format")
+					return fmt.Errorf("failed validating metadata_url, template metadata_url should be set to %s", metadataUrl)
 				}
 			}
 		}


### PR DESCRIPTION
*Description of changes:*
Added initial validation for the metadata_url field for the the template config crd. I will be adding unit tests for this in my next PR. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

