### PR TITLE
Pull CAPAS image from release bundle

### DIFF
--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -200,7 +200,7 @@ func (c *Clusterctl) InitInfrastructure(ctx context.Context, clusterSpec *cluste
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
 
-	envMap, err := provider.EnvMap()
+	envMap, err := provider.EnvMap(clusterSpec)
 	if err != nil {
 		return err
 	}
@@ -342,7 +342,7 @@ func (c *Clusterctl) Upgrade(ctx context.Context, managementCluster *types.Clust
 		upgradeCommand = append(upgradeCommand, "--bootstrap", newBootstrapProvider)
 	}
 
-	providerEnvMap, err := provider.EnvMap()
+	providerEnvMap, err := provider.EnvMap(newSpec)
 	if err != nil {
 		return fmt.Errorf("failed generating provider env map for clusterctl upgrade: %v", err)
 	}
@@ -386,7 +386,7 @@ func (c *Clusterctl) InstallEtcdadmProviders(ctx context.Context, clusterSpec *c
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
 
-	envMap, err := infraProvider.EnvMap()
+	envMap, err := infraProvider.EnvMap(clusterSpec)
 	if err != nil {
 		return err
 	}

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -61,7 +61,7 @@ func (ct *clusterctlTest) expectBuildOverrideLayer() {
 }
 
 func (ct *clusterctlTest) expectGetProviderEnvMap() {
-	ct.provider.EXPECT().EnvMap().Return(ct.providerEnvMap, nil)
+	ct.provider.EXPECT().EnvMap(clusterSpec).Return(ct.providerEnvMap, nil)
 }
 
 func TestClusterctlInitInfrastructure(t *testing.T) {
@@ -131,7 +131,7 @@ func TestClusterctlInitInfrastructure(t *testing.T) {
 			provider := mockproviders.NewMockProvider(mockCtrl)
 			provider.EXPECT().Name().Return(tt.providerName)
 			provider.EXPECT().Version(clusterSpec).Return(tt.providerVersion)
-			provider.EXPECT().EnvMap().Return(tt.env, nil)
+			provider.EXPECT().EnvMap(clusterSpec).Return(tt.env, nil)
 			provider.EXPECT().GetInfrastructureBundle(clusterSpec).Return(&types.InfrastructureBundle{})
 
 			executable := mockexecutables.NewMockExecutable(mockCtrl)
@@ -186,7 +186,7 @@ func TestClusterctlInitInfrastructureEnvMapError(t *testing.T) {
 	provider := mockproviders.NewMockProvider(mockCtrl)
 	provider.EXPECT().Name()
 	provider.EXPECT().Version(clusterSpec)
-	provider.EXPECT().EnvMap().Return(nil, errors.New("error with env map"))
+	provider.EXPECT().EnvMap(clusterSpec).Return(nil, errors.New("error with env map"))
 	provider.EXPECT().GetInfrastructureBundle(clusterSpec).Return(&types.InfrastructureBundle{})
 
 	executable := mockexecutables.NewMockExecutable(mockCtrl)
@@ -213,7 +213,7 @@ func TestClusterctlInitInfrastructureExecutableError(t *testing.T) {
 	provider := mockproviders.NewMockProvider(mockCtrl)
 	provider.EXPECT().Name()
 	provider.EXPECT().Version(clusterSpec)
-	provider.EXPECT().EnvMap()
+	provider.EXPECT().EnvMap(clusterSpec)
 	provider.EXPECT().GetInfrastructureBundle(clusterSpec).Return(&types.InfrastructureBundle{})
 
 	executable := mockexecutables.NewMockExecutable(mockCtrl)

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -615,7 +615,7 @@ func (p *cloudstackProvider) Version(clusterSpec *cluster.Spec) string {
 	return clusterSpec.VersionsBundle.CloudStack.Version
 }
 
-func (p *cloudstackProvider) EnvMap() (map[string]string, error) {
+func (p *cloudstackProvider) EnvMap(_ *cluster.Spec) (map[string]string, error) {
 	envMap := make(map[string]string)
 	for _, key := range requiredEnvs {
 		if env, ok := os.LookupEnv(key); ok && len(env) > 0 {

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -407,7 +407,7 @@ func (p *provider) Version(clusterSpec *cluster.Spec) string {
 	return clusterSpec.VersionsBundle.Docker.Version
 }
 
-func (p *provider) EnvMap() (map[string]string, error) {
+func (p *provider) EnvMap(_ *cluster.Spec) (map[string]string, error) {
 	envMap := make(map[string]string)
 	if env, ok := os.LookupEnv(githubTokenEnvVar); ok && len(env) > 0 {
 		envMap[githubTokenEnvVar] = env

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -111,18 +111,18 @@ func (mr *MockProviderMockRecorder) DeleteResources(arg0, arg1 interface{}) *gom
 }
 
 // EnvMap mocks base method.
-func (m *MockProvider) EnvMap() (map[string]string, error) {
+func (m *MockProvider) EnvMap(arg0 *cluster.Spec) (map[string]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnvMap")
+	ret := m.ctrl.Call(m, "EnvMap", arg0)
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnvMap indicates an expected call of EnvMap.
-func (mr *MockProviderMockRecorder) EnvMap() *gomock.Call {
+func (mr *MockProviderMockRecorder) EnvMap(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvMap", reflect.TypeOf((*MockProvider)(nil).EnvMap))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvMap", reflect.TypeOf((*MockProvider)(nil).EnvMap), arg0)
 }
 
 // GenerateCAPISpecForCreate mocks base method.

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -22,7 +22,7 @@ type Provider interface {
 	BootstrapClusterOpts() ([]bootstrapper.BootstrapClusterOption, error)
 	UpdateKubeConfig(content *[]byte, clusterName string) error
 	Version(clusterSpec *cluster.Spec) string
-	EnvMap() (map[string]string, error)
+	EnvMap(clusterSpec *cluster.Spec) (map[string]string, error)
 	GetDeployments() map[string][]string
 	GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle
 	DatacenterConfig() DatacenterConfig

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -170,13 +170,12 @@ func (p *snowProvider) Version(clusterSpec *cluster.Spec) string {
 	return clusterSpec.VersionsBundle.Snow.Version
 }
 
-func (p *snowProvider) EnvMap() (map[string]string, error) {
+func (p *snowProvider) EnvMap(clusterSpec *cluster.Spec) (map[string]string, error) {
 	envMap := make(map[string]string)
 	envMap[snowCredentialsKey] = p.bootstrapCreds.snowCredsB64
 	envMap[snowCertsKey] = p.bootstrapCreds.snowCertsB64
 
-	// TODO: tmp solution to pull capas image from arbitrary regi
-	envMap["SNOW_CONTROLLER_IMAGE"] = "public.ecr.aws/xyz/aws/cluster-api-provider-aws-snow:latest"
+	envMap["SNOW_CONTROLLER_IMAGE"] = clusterSpec.VersionsBundle.Snow.Manager.VersionedImage()
 
 	return envMap, nil
 }

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -507,7 +507,7 @@ func (p *tinkerbellProvider) Version(clusterSpec *cluster.Spec) string {
 	return clusterSpec.VersionsBundle.Tinkerbell.Version
 }
 
-func (p *tinkerbellProvider) EnvMap() (map[string]string, error) {
+func (p *tinkerbellProvider) EnvMap(_ *cluster.Spec) (map[string]string, error) {
 	// TODO: determine if any env vars are needed and add them to requiredEnvs
 	envMap := make(map[string]string)
 	for _, key := range requiredEnvs {

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1059,7 +1059,7 @@ func (p *vsphereProvider) Version(clusterSpec *cluster.Spec) string {
 	return clusterSpec.VersionsBundle.VSphere.Version
 }
 
-func (p *vsphereProvider) EnvMap() (map[string]string, error) {
+func (p *vsphereProvider) EnvMap(_ *cluster.Spec) (map[string]string, error) {
 	envMap := make(map[string]string)
 	for _, key := range requiredEnvs {
 		if env, ok := os.LookupEnv(key); ok && len(env) > 0 {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

CAPAS image was hardcoded in the snow provider. Now that the image is built in the release bundle, we can fetch it from there instead.

Notice this is still a tmp solution before we automate the build for snow `infrastructure-components.yaml` with proper image  version.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

