### PR TITLE
Re-add VM cleanup command in postbuild stage

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -87,6 +87,10 @@ phases:
         "linux,darwin"
         "amd64"
         false
+      - >
+        ./bin/test e2e cleanup vsphere
+        -n i-
+        -v 4
 reports:
   e2e-reports:
     files:


### PR DESCRIPTION
This PR forces the VM cleanup to happen in the postbuild stage, that always runs irrespective of the success or failure of the build stage. This will ensure test VMs get properly deleted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

