### PR TITLE
Add Tinkerbell hardware generation validation

### DIFF
--- a/pkg/providers/tinkerbell/hardware/validator.go
+++ b/pkg/providers/tinkerbell/hardware/validator.go
@@ -1,0 +1,138 @@
+package hardware
+
+import "fmt"
+
+// MachineAssertion defines a condition that Machine must meet.
+type MachineAssertion func(Machine) error
+
+// DefaultMachineValidator validated Machine instances.
+type DefaultMachineValidator struct {
+	assertions []MachineAssertion
+}
+
+var _ MachineValidator = &DefaultMachineValidator{}
+
+// NewDefaultMachineValidator creates a machineValidator instance with default assertions registered.
+func NewDefaultMachineValidator() *DefaultMachineValidator {
+	validator := &DefaultMachineValidator{}
+	WithDefaultAssertions(validator)
+	return validator
+}
+
+// Validate validates machine by executing its Validate() method and passing it to all registered MachineAssertions.
+func (mv *DefaultMachineValidator) Validate(machine Machine) error {
+	if err := machine.Validate(); err != nil {
+		return err
+	}
+
+	for _, fn := range mv.assertions {
+		if err := fn(machine); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Register registers v MachineAssertions with m.
+func (mv *DefaultMachineValidator) Register(v ...MachineAssertion) {
+	mv.assertions = append(mv.assertions, v...)
+}
+
+// UniqueIds asserts a given Machine instance has a unique Id field relative to previously seen Machine instances.
+// It is not thread safe. It has a 1 time use.
+func UniqueIds() MachineAssertion {
+	ids := make(map[string]struct{})
+	return func(m Machine) error {
+		if _, seen := ids[m.Id]; seen {
+			return fmt.Errorf("duplicate Id: %v", m.Id)
+		}
+
+		ids[m.Id] = struct{}{}
+
+		return nil
+	}
+}
+
+// UniqueIpAddress asserts a given Machine instance has a unique IpAddress field relative to previously seen Machine
+// instances. It is not thread safe. It has a 1 time use.
+func UniqueIpAddress() MachineAssertion {
+	ips := make(map[string]struct{})
+	return func(m Machine) error {
+		if _, seen := ips[m.IpAddress]; seen {
+			return fmt.Errorf("duplicate IpAddress: %v", m.IpAddress)
+		}
+
+		ips[m.IpAddress] = struct{}{}
+
+		return nil
+	}
+}
+
+// UniqueMacAddress asserts a given Machine instance has a unique MacAddress field relative to previously seen Machine
+// instances. It is not thread safe. It has a 1 time use.
+func UniqueMacAddress() MachineAssertion {
+	macs := make(map[string]struct{})
+	return func(m Machine) error {
+		if _, seen := macs[m.MacAddress]; seen {
+			return fmt.Errorf("duplicate MacAddress: %v", m.MacAddress)
+		}
+
+		macs[m.MacAddress] = struct{}{}
+
+		return nil
+	}
+}
+
+// UniqueHostnames asserts a given Machine instance has a unique Hostname field relative to previously seen Machine
+// instances. It is not thread safe. It has a 1 time use.
+func UniqueHostnames() MachineAssertion {
+	hostnames := make(map[string]struct{})
+	return func(m Machine) error {
+		if _, seen := hostnames[m.Hostname]; seen {
+			return fmt.Errorf("duplicate Hostname: %v", m.Hostname)
+		}
+
+		hostnames[m.Hostname] = struct{}{}
+
+		return nil
+	}
+}
+
+// UniqueBmcIpAddress asserts a given Machine instance has a unique BmcIpAddress field relative to previously seen
+// Machine instances. If there is no Bmc configuration as defined by machine.HasBmc() the check is a noop. It is
+// not thread safe. It has a 1 time use.
+func UniqueBmcIpAddress() MachineAssertion {
+	ips := make(map[string]struct{})
+	return func(m Machine) error {
+		if !m.HasBmc() {
+			return nil
+		}
+
+		if m.BmcIpAddress == "" {
+			return fmt.Errorf("missing BmcIpAddress (id=\"%v\")", m.Id)
+		}
+
+		if _, seen := ips[m.BmcIpAddress]; seen {
+			return fmt.Errorf("duplicate IpAddress: %v", m.BmcIpAddress)
+		}
+
+		ips[m.BmcIpAddress] = struct{}{}
+
+		return nil
+	}
+}
+
+var defaultAssertions = []MachineAssertion{
+	UniqueIds(),
+	UniqueIpAddress(),
+	UniqueMacAddress(),
+	UniqueHostnames(),
+	UniqueBmcIpAddress(),
+}
+
+// WithDefaultAssertions applies a set of default assertions to validator. The default assertions include
+// UniqueHostnames and UniqueIds.
+func WithDefaultAssertions(validator *DefaultMachineValidator) {
+	validator.Register(defaultAssertions...)
+}

--- a/pkg/providers/tinkerbell/hardware/validator_test.go
+++ b/pkg/providers/tinkerbell/hardware/validator_test.go
@@ -1,0 +1,167 @@
+package hardware_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
+)
+
+func TestDefaultMachineValidatorValidationsRun(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// check is set by assertion when its called and allows us to validate
+	// registered assertions are infact called by the validation decorator.
+	var check bool
+	assertion := func(m hardware.Machine) error {
+		check = true
+		return nil
+	}
+
+	validator := &hardware.DefaultMachineValidator{}
+	validator.Register(assertion)
+
+	err := validator.Validate(NewValidMachine())
+
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(check).To(gomega.BeTrue())
+}
+
+func TestDefaultMachineValidatorErrorsWhenAssertionErrors(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// check is set by assertion when its called and allows us to validate
+	// registered assertions are infact called by the validation decorator.
+	expect := errors.New("something went wrong")
+	assertion := func(hardware.Machine) error {
+		return expect
+	}
+
+	validator := &hardware.DefaultMachineValidator{}
+	validator.Register(assertion)
+
+	err := validator.Validate(NewValidMachine())
+
+	g.Expect(err).To(gomega.BeEquivalentTo(expect))
+}
+
+func TestUniquenessAssertions(t *testing.T) {
+	cases := map[string]struct {
+		Assertion hardware.MachineAssertion
+		Machines  []hardware.Machine
+	}{
+		"Ids": {
+			Assertion: hardware.UniqueIds(),
+			Machines: []hardware.Machine{
+				{Id: "foo"},
+				{Id: "bar"},
+			},
+		},
+		"IpAddresses": {
+			Assertion: hardware.UniqueIpAddress(),
+			Machines: []hardware.Machine{
+				{IpAddress: "foo"},
+				{IpAddress: "bar"},
+			},
+		},
+		"MacAddresses": {
+			Assertion: hardware.UniqueMacAddress(),
+			Machines: []hardware.Machine{
+				{MacAddress: "foo"},
+				{MacAddress: "bar"},
+			},
+		},
+		"Hostnames": {
+			Assertion: hardware.UniqueHostnames(),
+			Machines: []hardware.Machine{
+				{Hostname: "foo"},
+				{Hostname: "bar"},
+			},
+		},
+		"BmcIpAddresses": {
+			Assertion: hardware.UniqueBmcIpAddress(),
+			Machines: []hardware.Machine{
+				{BmcIpAddress: "foo"},
+				{BmcIpAddress: "bar"},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			g.Expect(tc.Assertion(tc.Machines[0])).ToNot(gomega.HaveOccurred())
+			g.Expect(tc.Assertion(tc.Machines[1])).ToNot(gomega.HaveOccurred())
+		})
+	}
+}
+
+func TestUniquenessAssertionsWithDupes(t *testing.T) {
+	cases := map[string]struct {
+		Assertion hardware.MachineAssertion
+		Machines  []hardware.Machine
+	}{
+		"Ids": {
+			Assertion: hardware.UniqueIds(),
+			Machines: []hardware.Machine{
+				{Id: "foo"},
+				{Id: "foo"},
+			},
+		},
+		"IpAddresses": {
+			Assertion: hardware.UniqueIpAddress(),
+			Machines: []hardware.Machine{
+				{IpAddress: "foo"},
+				{IpAddress: "foo"},
+			},
+		},
+		"MacAddresses": {
+			Assertion: hardware.UniqueMacAddress(),
+			Machines: []hardware.Machine{
+				{MacAddress: "foo"},
+				{MacAddress: "foo"},
+			},
+		},
+		"Hostnames": {
+			Assertion: hardware.UniqueHostnames(),
+			Machines: []hardware.Machine{
+				{Hostname: "foo"},
+				{Hostname: "foo"},
+			},
+		},
+		"BmcIpAddresses": {
+			Assertion: hardware.UniqueBmcIpAddress(),
+			Machines: []hardware.Machine{
+				{BmcIpAddress: "foo"},
+				{BmcIpAddress: "foo"},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			g.Expect(tc.Assertion(tc.Machines[0])).ToNot(gomega.HaveOccurred())
+			g.Expect(tc.Assertion(tc.Machines[1])).To(gomega.HaveOccurred())
+		})
+	}
+}
+
+func NewValidMachine() hardware.Machine {
+	return hardware.Machine{
+		Id:           uuid.NewString(),
+		IpAddress:    "10.10.10.10",
+		Gateway:      "10.10.10.1",
+		Nameservers:  []string{"ns1"},
+		MacAddress:   "00:00:00:00:00:00",
+		Netmask:      "255.255.255.255",
+		Hostname:     "localhost",
+		BmcIpAddress: "10.10.10.11",
+		BmcUsername:  "username",
+		BmcPassword:  "password",
+		BmcVendor:    "dell",
+	}
+}


### PR DESCRIPTION
Depends on: https://github.com/aws/eks-anywhere/pull/1336

As part of the Tinkerbell provider end-user workflow we generate files for registration in the Tinkerbell stack and management clusters.

This PR introduces a Validator implementation to be used with the Translate functions. It performs, by default, basic data validation such as unique hostnames and IP addresses within the machine set.