### PR TITLE
clean up ec2 instances after each build job

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -91,6 +91,11 @@ phases:
         ./bin/test e2e cleanup vsphere
         -n i-
         -v 4
+      - >
+        ./cmd/test e2e cleanup aws
+        -s ${INTEGRATION_TEST_STORAGE_BUCKET}
+        -t EKSA-E2E
+        -v 4
 reports:
   e2e-reports:
     files:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Clean up the e2e test instances after each test run. Follow up to this is going to be tagging instances based on the build ID and using that tag for the cleanup.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

