### PR TITLE
Added Kubernetes validation for Tinkerbell hardware name field

### DIFF
--- a/pkg/providers/tinkerbell/hardware/config.go
+++ b/pkg/providers/tinkerbell/hardware/config.go
@@ -11,6 +11,7 @@ import (
 	tinkworkflow "github.com/tinkerbell/tink/protos/workflow"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/yaml"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -83,6 +84,10 @@ func (hc *HardwareConfig) ValidateHardware(skipPowerActions bool, tinkHardwareMa
 	for _, hw := range hc.Hardwares {
 		if hw.Name == "" {
 			return fmt.Errorf("hardware name is required")
+		}
+
+		if errs := apimachineryvalidation.IsDNS1123Subdomain(hw.Name); len(errs) > 0 {
+			return fmt.Errorf("invalid hardware name: %v: %v", hw.Name, errs)
 		}
 
 		if hw.Spec.ID == "" {

--- a/pkg/providers/tinkerbell/hardware/validator.go
+++ b/pkg/providers/tinkerbell/hardware/validator.go
@@ -2,8 +2,6 @@ package hardware
 
 import (
 	"fmt"
-
-	apimachineryvalidation "k8s.io/apimachinery/pkg/util/validation"
 )
 
 // MachineAssertion defines a condition that Machine must meet.
@@ -95,11 +93,6 @@ func UniqueHostnames() MachineAssertion {
 	return func(m Machine) error {
 		if _, seen := hostnames[m.Hostname]; seen {
 			return fmt.Errorf("duplicate Hostname: %v", m.Hostname)
-		}
-
-		err := apimachineryvalidation.IsDNS1123Subdomain(m.Hostname)
-		if err != nil {
-			return fmt.Errorf("invalid Hostname %s : %v", m.Hostname, err)
 		}
 
 		hostnames[m.Hostname] = struct{}{}

--- a/pkg/providers/tinkerbell/hardware/validator.go
+++ b/pkg/providers/tinkerbell/hardware/validator.go
@@ -1,6 +1,9 @@
 package hardware
 
-import "fmt"
+import (
+	"fmt"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/util/validation"
+)
 
 // MachineAssertion defines a condition that Machine must meet.
 type MachineAssertion func(Machine) error
@@ -91,6 +94,11 @@ func UniqueHostnames() MachineAssertion {
 	return func(m Machine) error {
 		if _, seen := hostnames[m.Hostname]; seen {
 			return fmt.Errorf("duplicate Hostname: %v", m.Hostname)
+		}
+
+		err := apimachineryvalidation.IsDNS1123Subdomain(m.Hostname)
+		if err != nil {
+			return fmt.Errorf("invalid Hostname %s : %v", m.Hostname, err)
 		}
 
 		hostnames[m.Hostname] = struct{}{}

--- a/pkg/providers/tinkerbell/hardware/validator.go
+++ b/pkg/providers/tinkerbell/hardware/validator.go
@@ -2,6 +2,7 @@ package hardware
 
 import (
 	"fmt"
+
 	apimachineryvalidation "k8s.io/apimachinery/pkg/util/validation"
 )
 


### PR DESCRIPTION
*Description of changes:*
Added Kubernetes validation for Tinkerbell hardware name field for the generate hardware and create cluster command.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

