### PR TITLE
use proper cluster ID for uploading test logs

### DIFF
--- a/internal/test/e2e/artifacts.go
+++ b/internal/test/e2e/artifacts.go
@@ -14,7 +14,7 @@ const e2eHomeFolder = "/home/e2e/"
 func (e *E2ESession) uploadGeneratedFilesFromInstance(testName string) {
 	logger.V(1).Info("Uploading log files to s3 bucket")
 	command := newCopyCommand().from(
-		e2eHomeFolder, e.instanceId,
+		e2eHomeFolder, clusterName(e.branchName, e.instanceId),
 	).to(
 		e.generatedArtifactsBucketPath(), testName,
 	).recursive().String()

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -102,7 +102,7 @@ func RunTestsInParallel(conf ParallelRunConf) error {
 			logger.Info("Ec2 instance tests completed successfully", "jobId", r.conf.jobId, "instanceId", r.conf.instanceId, "commandId", r.testCommandResult.CommandId, "tests", r.conf.regex, "status", passedStatus)
 			logResult(r.testCommandResult)
 		}
-		clusterName := fmt.Sprintf("%s-%s", r.conf.branchName, r.conf.instanceId)
+		clusterName := clusterName(r.conf.branchName, r.conf.instanceId)
 		if conf.CleanupVms {
 			err = CleanUpVsphereTestResources(context.Background(), clusterName)
 			if err != nil {

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -135,13 +135,7 @@ func (e *E2ESession) setup(regex string) error {
 		e.testEnvVars[e2etests.BranchNameEnvVar] = e.branchName
 	}
 
-	clusterNameTemplate := "%s-%s"
-	clusterName := fmt.Sprintf(clusterNameTemplate, e.branchName, instanceId)
-	if len(clusterName) > 80 {
-		logger.Info("Cluster name is longer than 80 characters; truncating to 80 characters.", "original cluster name", clusterName, "truncated cluster name", clusterName[:80])
-		clusterName = clusterName[:80]
-	}
-	e.testEnvVars[e2etests.ClusterNameVar] = clusterName
+	e.testEnvVars[e2etests.ClusterNameVar] = clusterName(e.branchName, e.instanceId)
 	return nil
 }
 
@@ -210,4 +204,14 @@ func (e *E2ESession) createTestNameFile(testName string) error {
 	logger.V(1).Info("Successfully created test name file")
 
 	return nil
+}
+
+func clusterName(branch string, instanceId string) (clusterName string) {
+	clusterNameTemplate := "%s-%s"
+	clusterName = fmt.Sprintf(clusterNameTemplate, branch, instanceId)
+	if len(clusterName) > 80 {
+		logger.Info("Cluster name is longer than 80 characters; truncating to 80 characters.", "original cluster name", clusterName, "truncated cluster name", clusterName[:80])
+		clusterName = clusterName[:80]
+	}
+	return clusterName
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Consolidate cluster name generation into one place
make sure to use proper cluster name for uploading logs to s3

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

