### PR TITLE
clean up test ec2 instances on post build

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -88,6 +88,12 @@ phases:
         "amd64"
         false
       - >
+        ./bin/test e2e cleanup aws
+        -s ${INTEGRATION_TEST_STORAGE_BUCKET}
+        -t EKSA-E2E
+        -b ${CODEBUILD_BUILD_ID}
+        -v 4
+      - >
         ./bin/test e2e cleanup vsphere
         -n ${BRANCH_NAME}
         -v 4

--- a/cmd/integration_test/cmd/cleanupaws.go
+++ b/cmd/integration_test/cmd/cleanupaws.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	maxAgeFlagName = "max-age"
-	tagFlagName    = "tag"
+	maxAgeFlagName  = "max-age"
+	tagFlagName     = "tag"
+	buildIdFlagName = "buildId"
 )
 
 var cleanUpAwsCmd = &cobra.Command{
@@ -49,6 +50,7 @@ func init() {
 	cleanUpAwsCmd.Flags().StringP(storageBucketFlagName, "s", "", "Name of s3 bucket used for e2e testing")
 	cleanUpAwsCmd.Flags().StringP(maxAgeFlagName, "a", "0", "Instance age in seconds after which it should be deleted")
 	cleanUpAwsCmd.Flags().StringP(tagFlagName, "t", "", "EC2 instance tag")
+	cleanUpAwsCmd.Flags().StringP(buildIdFlagName, "b", "", "Build ID of CodeBuild build; will clean up instances associated with the build")
 
 	for _, flag := range requiredAwsCleanUpFlags {
 		if err := cleanUpAwsCmd.MarkFlagRequired(flag); err != nil {
@@ -61,8 +63,9 @@ func cleanUpAwsTestResources(ctx context.Context) error {
 	maxAge := viper.GetString(maxAgeFlagName)
 	storageBucket := viper.GetString(storageBucketFlagName)
 	tag := viper.GetString(tagFlagName)
+	codebuildId := viper.GetString(buildIdFlagName)
 
-	err := e2e.CleanUpAwsTestResources(storageBucket, maxAge, tag)
+	err := e2e.CleanUpAwsTestResources(storageBucket, maxAge, tag, codebuildId)
 	if err != nil {
 		return fmt.Errorf("error running cleanup for aws test resources: %v", err)
 	}

--- a/internal/pkg/ec2/list.go
+++ b/internal/pkg/ec2/list.go
@@ -11,18 +11,12 @@ import (
 	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
-func ListInstances(session *session.Session, key string, value string, maxAge float64) ([]*string, error) {
+func ListInstances(session *session.Session, tags map[string]string, maxAge float64) ([]*string, error) {
 	service := ec2.New(session)
 	var instanceList []*string
 
 	input := &ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
-			{
-				Name: aws.String("tag:" + key),
-				Values: []*string{
-					aws.String(value),
-				},
-			},
 			{
 				Name: aws.String("instance-state-name"),
 				Values: []*string{
@@ -33,6 +27,16 @@ func ListInstances(session *session.Session, key string, value string, maxAge fl
 				},
 			},
 		},
+	}
+
+	for k, v := range tags {
+		tagFilter := ec2.Filter{
+			Name: aws.String("tag:" + k),
+			Values: []*string{
+				aws.String(v),
+			},
+		}
+		input.Filters = append(input.Filters, &tagFilter)
 	}
 
 	for {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Clean up test instances associated with a given build ID during the post-build stage. This change will tag instances with the parent job ID (the codebuild ID), and then in the post-build phase clean up all the e2e instances tagged with the build ID of the executing codebuild job. This will help us to keep from accumulating stranded instances. 

We are cleaning up the instances before cleaning up the VMs so that any orphaned instances with management clusters left behind are not reconciling and spawning new VMs.

- tag e2e test instances with the codebuild Job ID which spawned the test run
- add a 'buildId' parameter to the AWS cleanup command which takes the build id and cleans up all e2e instances that have that build ID.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

