### PR TITLE
Update eksdReleaseFetcher to support previous versions

### DIFF
--- a/pkg/cluster/fetch.go
+++ b/pkg/cluster/fetch.go
@@ -65,10 +65,7 @@ func GetEksdReleaseForCluster(ctx context.Context, cluster *v1alpha1.Cluster, bu
 	if err != nil {
 		return nil, fmt.Errorf("failed fetching versions bundle: %v", err)
 	}
-	eksd, err := fetch(ctx, versionsBundle.EksD.Name, constants.EksaSystemNamespace)
-	if err != nil {
-		return nil, fmt.Errorf("failed fetching EKS-D release for cluster: %v", err)
-	}
+	eksd, _ := fetch(ctx, versionsBundle.EksD.Name, constants.EksaSystemNamespace)
 
 	return eksd, nil
 }

--- a/pkg/cluster/fetch.go
+++ b/pkg/cluster/fetch.go
@@ -3,13 +3,17 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/logger"
 	v1alpha1release "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
+
+const eksdReleaseObjDoesNotExist = "the server doesn't have a resource type \"releases\""
 
 type BundlesFetch func(ctx context.Context, name, namespace string) (*v1alpha1release.Bundles, error)
 
@@ -65,7 +69,15 @@ func GetEksdReleaseForCluster(ctx context.Context, cluster *v1alpha1.Cluster, bu
 	if err != nil {
 		return nil, fmt.Errorf("failed fetching versions bundle: %v", err)
 	}
-	eksd, _ := fetch(ctx, versionsBundle.EksD.Name, constants.EksaSystemNamespace)
+	eksd, err := fetch(ctx, versionsBundle.EksD.Name, constants.EksaSystemNamespace)
+	if err != nil {
+		if strings.Contains(err.Error(), eksdReleaseObjDoesNotExist) {
+			logger.V(4).Info("EKS-D release objects are not present on the cluster. EKS-D release manifest will be retrieved from the URL in the bundle")
+			return nil, nil
+		} else {
+			return nil, fmt.Errorf("failed fetching EKS-D release for cluster: %v", err)
+		}
+	}
 
 	return eksd, nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
E2E tests for prev release versions failed during upgrade because we now embed the eksd release objects to the cluster, so they were failing with this error: 
`Error: failed to upgrade cluster: failed fetching EKS-D release for cluster: error getting releases.distro.eks.amazonaws.com with kubectl: error: the server doesn't have a resource type "releases"`

We already have the logic in place to get the eksd release object if it isn't on the cluster, so this PR updates the eksdReleaseFetcher method to only return the `nil` eksd release object if it isn't on the cluster (instead of returning an error). From here, if it sees the eksd object as nil, it will install it & continue with the upgrade.

*Testing (if applicable):*
Created cluster with 7.0, upgraded with main

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

