### PR TITLE
Implement tinkerbell manifest writer for hardware generation

### DIFF
--- a/pkg/providers/tinkerbell/hardware/yaml.go
+++ b/pkg/providers/tinkerbell/hardware/yaml.go
@@ -1,0 +1,167 @@
+package hardware
+
+import (
+	"fmt"
+	"io"
+
+	pbnjv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/pbnj/api/v1alpha1"
+	tinkv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/tink/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterctlv1alpha3 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
+)
+
+// File writing constants for default output path construction.
+const (
+	yamlDirectory = "hardware-manifests"
+	yamlFile      = "hardware.yaml"
+)
+
+// Kubernetes related constants for describing kinds and api versions.
+const (
+	tinkerbellApiVersion = "tinkerbell.org/v1alpha1"
+	hardwareKind         = "Hardware"
+	bmcKind              = "BMC"
+
+	secretApiVersion = "v1"
+	secretKind       = "Secret"
+)
+
+// TinkerbellManifestYaml is a MachineWriter that writes Tinkerbell manifests to a destination.
+type TinkerbellManifestYaml struct {
+	writer io.Writer
+}
+
+// NewTinkerbellManifestYaml creates a TinkerbellManifestYaml instance that writes its manifests to w.
+func NewTinkerbellManifestYaml(w io.Writer) *TinkerbellManifestYaml {
+	return &TinkerbellManifestYaml{writer: w}
+}
+
+// Write m as a set of Kubernetes manifests for use with Cluster API Tinkerbell Provider. This includes writing a
+// Hardware, BMC and Secret (for the BMC).
+func (yw *TinkerbellManifestYaml) Write(m Machine) error {
+	hardware, err := marshalTinkerbellHardwareYaml(m)
+	if err != nil {
+		return fmt.Errorf("marshalling tinkerbell hardware yaml (id=%v): %v", m.Id, err)
+	}
+	if err := yw.writeWithPrependedSeparator(hardware); err != nil {
+		return fmt.Errorf("writing tinkerbell hardware yaml (id=%v): %v", m.Id, err)
+	}
+
+	bmc, err := marshalTinkerbellBmcYaml(m)
+	if err != nil {
+		return fmt.Errorf("marshalling tinkerbell bmc yaml (id=%v): %v", m.Id, err)
+	}
+	if err := yw.writeWithPrependedSeparator(bmc); err != nil {
+		return fmt.Errorf("writing tinkerbell bmc yaml (id=%v): %v", m.Id, err)
+	}
+
+	secret, err := marshalSecretYaml(m)
+	if err != nil {
+		return fmt.Errorf("marshalling bmc secret yaml (id=%v): %v", m.Id, err)
+	}
+	if err := yw.writeWithPrependedSeparator(secret); err != nil {
+		return fmt.Errorf("writing bmc secret yaml (id=%v): %v", m.Id, err)
+	}
+
+	return nil
+}
+
+var yamlSeparatorWithNewline = []byte("---\n")
+
+func (yw *TinkerbellManifestYaml) writeWithPrependedSeparator(data []byte) error {
+	if err := yw.write(append(data, yamlSeparatorWithNewline...)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (yw *TinkerbellManifestYaml) write(data []byte) error {
+	if _, err := yw.writer.Write(data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func marshalTinkerbellHardwareYaml(m Machine) ([]byte, error) {
+	return yaml.Marshal(
+		tinkv1alpha1.Hardware{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       hardwareKind,
+				APIVersion: tinkerbellApiVersion,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      m.Hostname,
+				Namespace: constants.EksaSystemNamespace,
+				Labels: map[string]string{
+					clusterctlv1alpha3.ClusterctlMoveLabelName: "true",
+				},
+			},
+			Spec: tinkv1alpha1.HardwareSpec{
+				ID:     m.Id,
+				BmcRef: formatBmcRef(m),
+			},
+		},
+	)
+}
+
+func marshalTinkerbellBmcYaml(m Machine) ([]byte, error) {
+	return yaml.Marshal(
+		pbnjv1alpha1.BMC{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       bmcKind,
+				APIVersion: tinkerbellApiVersion,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      formatBmcRef(m),
+				Namespace: constants.EksaSystemNamespace,
+				Labels: map[string]string{
+					clusterctlv1alpha3.ClusterctlMoveLabelName: "true",
+				},
+			},
+			Spec: pbnjv1alpha1.BMCSpec{
+				Host:   m.BmcIpAddress,
+				Vendor: m.BmcVendor,
+				AuthSecretRef: corev1.SecretReference{
+					Name:      formatBmcSecretRef(m),
+					Namespace: constants.EksaSystemNamespace,
+				},
+			},
+		},
+	)
+}
+
+func marshalSecretYaml(m Machine) ([]byte, error) {
+	return yaml.Marshal(
+		corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       secretKind,
+				APIVersion: secretApiVersion,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      formatBmcSecretRef(m),
+				Namespace: constants.EksaSystemNamespace,
+				Labels: map[string]string{
+					clusterctlv1alpha3.ClusterctlMoveLabelName: "true",
+				},
+			},
+			Type: "kubernetes.io/basic-auth",
+			Data: map[string][]byte{
+				"username": []byte(m.BmcUsername),
+				"password": []byte(m.BmcPassword),
+			},
+		},
+	)
+}
+
+func formatBmcRef(m Machine) string {
+	return fmt.Sprintf("bmc-%s", m.Hostname)
+}
+
+func formatBmcSecretRef(m Machine) string {
+	return fmt.Sprintf("%s-auth", formatBmcRef(m))
+}

--- a/pkg/providers/tinkerbell/hardware/yaml_test.go
+++ b/pkg/providers/tinkerbell/hardware/yaml_test.go
@@ -1,0 +1,85 @@
+package hardware_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/onsi/gomega"
+	pbnjv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/pbnj/api/v1alpha1"
+	tinkv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/tink/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apimachineryyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
+)
+
+func TestTinkerbellManifestYamlWrites(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	var buf bytes.Buffer
+	writer := hardware.NewTinkerbellManifestYaml(&buf)
+
+	expect := NewValidMachine()
+
+	err := writer.Write(expect)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	reader := apimachineryyaml.NewYAMLReader(bufio.NewReader(&buf))
+
+	var hardware tinkv1alpha1.Hardware
+	raw, err := reader.Read()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	err = yaml.Unmarshal(raw, &hardware)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	var bmc pbnjv1alpha1.BMC
+	raw, err = reader.Read()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	err = yaml.Unmarshal(raw, &bmc)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	var secret corev1.Secret
+	raw, err = reader.Read()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	err = yaml.Unmarshal(raw, &secret)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	AssertTinkerbellHardwareRepresentsMachine(g, hardware, expect)
+	AssertTinkerbellBMCRepresentsMachine(g, bmc, expect)
+	AsserBMCSecretRepresentsMachine(g, secret, expect)
+}
+
+func TestTinkerbellManifestYamlWriteErrors(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	writer := hardware.NewTinkerbellManifestYaml(ErrWriter{})
+
+	expect := NewValidMachine()
+
+	err := writer.Write(expect)
+	g.Expect(err).To(gomega.HaveOccurred())
+}
+
+func AssertTinkerbellHardwareRepresentsMachine(g *gomega.WithT, h tinkv1alpha1.Hardware, m hardware.Machine) {
+	g.Expect(h.ObjectMeta.Name).To(gomega.Equal(m.Hostname))
+	g.Expect(h.Spec.ID).To(gomega.Equal(m.Id))
+}
+
+func AssertTinkerbellBMCRepresentsMachine(g *gomega.WithT, b pbnjv1alpha1.BMC, m hardware.Machine) {
+	g.Expect(b.Spec.Host).To(gomega.Equal(m.BmcIpAddress))
+	g.Expect(b.Spec.Vendor).To(gomega.Equal(m.BmcVendor))
+}
+
+func AsserBMCSecretRepresentsMachine(g *gomega.WithT, s corev1.Secret, m hardware.Machine) {
+	g.Expect(s.Data).To(gomega.HaveKeyWithValue("username", []byte(m.BmcUsername)))
+	g.Expect(s.Data).To(gomega.HaveKeyWithValue("password", []byte(m.BmcPassword)))
+}
+
+type ErrWriter struct{}
+
+func (ErrWriter) Write([]byte) (int, error) {
+	return 0, errors.New("ErrWriter: always return an error")
+}

--- a/pkg/providers/tinkerbell/hardware/yamlparser.go
+++ b/pkg/providers/tinkerbell/hardware/yamlparser.go
@@ -16,15 +16,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
-const (
-	yamlDirectory        = "hardware-manifests"
-	yamlFile             = "hardware.yaml"
-	hardwareKind         = "Hardware"
-	bmcKind              = "BMC"
-	secretKind           = "Secret"
-	tinkerbellApiVersion = "tinkerbell.org/v1alpha1"
-	moveLabel            = "clusterctl.cluster.x-k8s.io/move"
-)
+const moveLabel = "clusterctl.cluster.x-k8s.io/move"
 
 var yamlSeparator = []byte("---\n")
 


### PR DESCRIPTION
We are introducing validation and distinct parsing and hardware registration steps to the anywhere generate hardware command.

This PR introduces the Tinkerbell manifest writer that compliments the `MachineWriter` interface allowing us to pass the writer to the `Translate*` family of functions.

A separate PR will address writing JSON files as it requires a mechanism for recording what files were written so we can later register them with Tinkerbell. A final PR will be written to start leveraging the new constructs.