### PR TITLE
check for machine deployment scaling phase in flux validations

### DIFF
--- a/test/e2e/flux_test.go
+++ b/test/e2e/flux_test.go
@@ -20,6 +20,7 @@ const (
 func runUpgradeFlowWithFlux(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
+	test.ValidateFlux()
 	test.UpgradeCluster(clusterOpts)
 	test.ValidateCluster(updateVersion)
 	test.ValidateFlux()

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"path"
 	"path/filepath"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
 	"strings"
 	"time"
 
@@ -593,11 +594,12 @@ func (e *ClusterE2ETest) waitForWorkerScaling(targetvalue int) error {
 			return err
 		}
 
+
 		for _, d := range md {
 			r := int(d.Status.Replicas)
-			if r != targetvalue {
-				e.T.Logf("Waiting for worker node MachineDeployment %s replicas to scale; target: %d, actual: %d", d.Name, targetvalue, r)
-				return fmt.Errorf(" MachineDeployment %s replicas are not at desired scale; target: %d, actual: %d", d.Name, targetvalue, r)
+			if r != targetvalue || d.Status.Phase == v1beta1.ScalingUpReason || d.Status.Phase == v1beta1.ScalingDownReason {
+				e.T.Logf("Waiting for worker node MachineDeployment %s to scale; phase: %s, desired replicas: %d, actual replicas: %d", d.Status.Phase, d.Name, targetvalue, r)
+				return fmt.Errorf(" MachineDeployment %s has not scaled; phase: %s, desired replicas: %d, actual replicas: %d", d.Status.Phase, d.Name, targetvalue, r)
 			}
 			e.T.Logf("Worker node MachineDeployment %s Ready replicas have reached target scale %d", d.Name, r)
 		}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
add a check for the Phase of the MachineDeployment to the worker node scaling validation check in the flux tests.

Previously, we were only checking for number of replicas; these replicas could be present but still in a ScalingUp or ScalingDown phase. We need to make sure we check the phase and wait until the MD stabalizes and is out of these phases before completing the validation. 

This will allow us to validate the state of the flux install on the cluster prior to an upgrade without the preflight validations of the upgrade catching the cluster in a ScalingUp or ScalingDown phase, which cause the validations to fail. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

