### PR TITLE
Fix upgrade tests to use WithClusterUpgrade

### DIFF
--- a/test/e2e/upgrade_from_latest_test.go
+++ b/test/e2e/upgrade_from_latest_test.go
@@ -150,7 +150,7 @@ func TestVSphereKubernetes121To122UbuntuUpgradeFromLatestMinorRelease(t *testing
 		provider.WithProviderUpgrade(
 			framework.UpdateUbuntuTemplate122Var(), // Set the template so it doesn't get autoimported
 		),
-		framework.WithClusterFiller(api.WithKubernetesVersion(anywherev1.Kube122)),
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(anywherev1.Kube122)),
 		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
@@ -168,7 +168,7 @@ func TestDockerKubernetes121to122UpgradeFromLatestMinorRelease(t *testing.T) {
 	runUpgradeFromLatestReleaseFlow(
 		test,
 		anywherev1.Kube122,
-		framework.WithClusterFiller(api.WithKubernetesVersion(anywherev1.Kube122)),
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(anywherev1.Kube122)),
 		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The upgrade from latest tests were incorrectly using the `ClusterFiller` function instead of the `ClusterUpgrade` function, which was probably resulting in updating the wrong file. 

*Testing (if applicable):*
Ran the `TestDockerKubernetes121to122UpgradeFromLatestMinorRelease` test locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

