### PR TITLE
Picking Tinkerbell action image URI from bundle

### DIFF
--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig.go
@@ -45,7 +45,7 @@ func NewDefaultTinkerbellTemplateConfigGenerate(name string, versionBundle v1alp
 		},
 	}
 
-	defaultActions := WithDefaultActionsFromBundle(versionBundle)
+	defaultActions := GetDefaultActionsFromBundle(versionBundle)
 	for _, action := range defaultActions {
 		action(&config.Spec.Template.Tasks[0].Actions)
 	}

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
@@ -29,7 +29,7 @@ warnings:
 `
 )
 
-func WithDefaultActionsFromBundle(b v1alpha1.VersionsBundle) []ActionOpt {
+func GetDefaultActionsFromBundle(b v1alpha1.VersionsBundle) []ActionOpt {
 	return []ActionOpt{
 		withStreamImageAction(b),
 		withInstallOpensslAction(b),
@@ -44,7 +44,7 @@ func withStreamImageAction(b v1alpha1.VersionsBundle) ActionOpt {
 	return func(a *[]tinkerbell.Action) {
 		*a = append(*a, tinkerbell.Action{
 			Name:    "stream-image",
-			Image:   "image2disk:v1.0.0",
+			Image:   b.Tinkerbell.Actions.ImageToDisk.URI,
 			Timeout: 360,
 			Environment: map[string]string{
 				"IMG_URL":    b.EksD.Raw.Ubuntu.URI,
@@ -55,13 +55,11 @@ func withStreamImageAction(b v1alpha1.VersionsBundle) ActionOpt {
 	}
 }
 
-// TODO(pokearu): The below functions currently dont use the bundle. Update functions to pull action images from bundle.
-
 func withInstallOpensslAction(b v1alpha1.VersionsBundle) ActionOpt {
 	return func(a *[]tinkerbell.Action) {
 		*a = append(*a, tinkerbell.Action{
 			Name:    "install-openssl",
-			Image:   "cexec:v1.0.0",
+			Image:   b.Tinkerbell.Actions.Cexec.URI,
 			Timeout: 90,
 			Environment: map[string]string{
 				"BLOCK_DEVICE":        "/dev/sda1",
@@ -78,7 +76,7 @@ func withNetplanAction(b v1alpha1.VersionsBundle) ActionOpt {
 	return func(a *[]tinkerbell.Action) {
 		*a = append(*a, tinkerbell.Action{
 			Name:    "write-netplan",
-			Image:   "writefile:v1.0.0",
+			Image:   b.Tinkerbell.Actions.WriteFile.URI,
 			Timeout: 90,
 			Environment: map[string]string{
 				"DEST_DISK": "/dev/sda1",
@@ -98,7 +96,7 @@ func withTinkCloudInitAction(b v1alpha1.VersionsBundle) ActionOpt {
 	return func(a *[]tinkerbell.Action) {
 		*a = append(*a, tinkerbell.Action{
 			Name:    "add-tink-cloud-init-config",
-			Image:   "writefile:v1.0.0",
+			Image:   b.Tinkerbell.Actions.WriteFile.URI,
 			Timeout: 90,
 			Environment: map[string]string{
 				"DEST_DISK": "/dev/sda1",
@@ -118,7 +116,7 @@ func withDsCloudInitAction(b v1alpha1.VersionsBundle) ActionOpt {
 	return func(a *[]tinkerbell.Action) {
 		*a = append(*a, tinkerbell.Action{
 			Name:    "add-tink-cloud-init-ds-config",
-			Image:   "writefile:v1.0.0",
+			Image:   b.Tinkerbell.Actions.WriteFile.URI,
 			Timeout: 90,
 			Environment: map[string]string{
 				"DEST_DISK": "/dev/sda1",
@@ -138,7 +136,7 @@ func withKexecAction(b v1alpha1.VersionsBundle) ActionOpt {
 	return func(a *[]tinkerbell.Action) {
 		*a = append(*a, tinkerbell.Action{
 			Name:    "kexec-image",
-			Image:   "kexec:v1.0.0",
+			Image:   b.Tinkerbell.Actions.Kexec.URI,
 			Timeout: 90,
 			Pid:     "host",
 			Environment: map[string]string{

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
@@ -127,5 +127,6 @@ func givenVersionBundle() v1alpha1.VersionsBundle {
 					URI: "writefile:v1.0.0",
 				},
 			},
-		}}
+		},
+	}
 }

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
@@ -91,7 +91,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 		},
 	}
 
-	opts := WithDefaultActionsFromBundle(vBundle)
+	opts := GetDefaultActionsFromBundle(vBundle)
 	for _, opt := range opts {
 		opt(&givenActions)
 	}
@@ -102,13 +102,30 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 }
 
 func givenVersionBundle() v1alpha1.VersionsBundle {
-	return v1alpha1.VersionsBundle{EksD: v1alpha1.EksDRelease{
-		Raw: v1alpha1.OSImageBundle{
-			Ubuntu: v1alpha1.OSImage{
-				Archive: v1alpha1.Archive{
-					URI: "http://tinkerbell-example:8080/ubuntu-2004-kube-v1.21.5.gz",
+	return v1alpha1.VersionsBundle{
+		EksD: v1alpha1.EksDRelease{
+			Raw: v1alpha1.OSImageBundle{
+				Ubuntu: v1alpha1.OSImage{
+					Archive: v1alpha1.Archive{
+						URI: "http://tinkerbell-example:8080/ubuntu-2004-kube-v1.21.5.gz",
+					},
 				},
 			},
 		},
-	}}
+		Tinkerbell: v1alpha1.TinkerbellBundle{
+			Actions: v1alpha1.Actions{
+				Cexec: v1alpha1.Image{
+					URI: "cexec:v1.0.0",
+				},
+				Kexec: v1alpha1.Image{
+					URI: "kexec:v1.0.0",
+				},
+				ImageToDisk: v1alpha1.Image{
+					URI: "image2disk:v1.0.0",
+				},
+				WriteFile: v1alpha1.Image{
+					URI: "writefile:v1.0.0",
+				},
+			},
+		}}
 }


### PR DESCRIPTION
*Description of changes:*
The patches for eliminating local registry in Tinkerbell stack merged. Hence reading tink-worker action image URIs from bundle release.
 
*Testing:*
`eksctl-anywhere generate clusterconfig`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

