### PR TITLE
trigger test of only a subset of EKS Anywhere test cases

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -66,7 +66,7 @@ phases:
         -n ${INTEGRATION_TEST_SUBNET_ID}
         -m ${INTEGRATION_TEST_MAX_EC2_COUNT}
         -c ${INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT}
-        -r 'Test'
+        -r '(TestVSphereKubernetes121SimpleFlow|TestVSphereKubernetes121ThreeReplicasFiveWorkersSimpleFlow|TestVSphereKubernetes121DifferentNamespaceSimpleFlow|TestVSphereKubernetes122Flux|TestVSphereKubernetes120UbuntuAutoimport|TestVSphereKubernetes121UbuntuTo122MultipleFieldsUpgrade|TestVSphereUpgradeMulticlusterWorkloadClusterWithFlux|TestVSphereKubernetes121MulticlusterWorkloadClusterDemo|TestVSphereKubernetes121BottlerocketAutoimport|TestVSphereKubernetes121UbuntuTo122DifferentNamespaceWithFluxUpgrade|TestVSphereKubernetes120BottlerocketTo121MultipleFieldsUpgrade|TestVSphereKubernetes120BottlerocketTo121Upgrade|TestVSphereKubernetes121UbuntuTo122WithFluxUpgrade)'
         -v 4
         --skip ${SKIPPED_TESTS}
         --bundles-override=${BUNDLES_OVERRIDE}


### PR DESCRIPTION
Modify the build spec to run a subset of tests against against the latest CLI.

*Issue #, if available:*

*Description of changes:*
due to the structure of our build system (using a pipeline to build the artifacts and pass them to the build phase) this is the easiest and most straight forward way to kick off a test run with a subset of tests. Will revert back to 'Test' after this kicks off, and look into a better way to be able to use codeebuild jobs with advanced overrides and the correct artifacts outside of the pipeline.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

