### PR TITLE
Update `cluster.Config` validation to config manager

### DIFF
--- a/pkg/cluster/awsiam.go
+++ b/pkg/cluster/awsiam.go
@@ -17,6 +17,24 @@ func awsIamEntry() *ConfigManagerEntry {
 				}
 			},
 		},
+		Validations: []Validation{
+			func(c *Config) error {
+				for _, a := range c.AWSIAMConfigs {
+					if err := a.Validate(); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			func(c *Config) error {
+				for _, a := range c.AWSIAMConfigs {
+					if err := validateSameNamespace(c, a); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		},
 	}
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -7,5 +7,10 @@ func clusterEntry() *ConfigManagerEntry {
 				c.Cluster.SetDefaults()
 			},
 		},
+		Validations: []Validation{
+			func(c *Config) error {
+				return c.Cluster.Validate()
+			},
+		},
 	}
 }

--- a/pkg/cluster/docker.go
+++ b/pkg/cluster/docker.go
@@ -12,6 +12,22 @@ func dockerEntry() *ConfigManagerEntry {
 		Processors: []ParsedProcessor{
 			processDockerDatacenter,
 		},
+		Validations: []Validation{
+			func(c *Config) error {
+				if c.DockerDatacenter != nil {
+					return c.DockerDatacenter.Validate()
+				}
+				return nil
+			},
+			func(c *Config) error {
+				if c.DockerDatacenter != nil {
+					if err := validateSameNamespace(c, c.DockerDatacenter); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		},
 	}
 }
 

--- a/pkg/cluster/gitops.go
+++ b/pkg/cluster/gitops.go
@@ -22,6 +22,22 @@ func gitOpsEntry() *ConfigManagerEntry {
 			},
 			SetDefaultFluxGitHubConfigPath,
 		},
+		Validations: []Validation{
+			func(c *Config) error {
+				if c.GitOpsConfig != nil {
+					return c.GitOpsConfig.Validate()
+				}
+				return nil
+			},
+			func(c *Config) error {
+				if c.GitOpsConfig != nil {
+					if err := validateSameNamespace(c, c.GitOpsConfig); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		},
 	}
 }
 

--- a/pkg/cluster/oidc.go
+++ b/pkg/cluster/oidc.go
@@ -10,6 +10,24 @@ func oidcEntry() *ConfigManagerEntry {
 			},
 		},
 		Processors: []ParsedProcessor{processOIDC},
+		Validations: []Validation{
+			func(c *Config) error {
+				for _, o := range c.OIDCConfigs {
+					if err := o.Validate(); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			func(c *Config) error {
+				for _, o := range c.OIDCConfigs {
+					if err := validateSameNamespace(c, o); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		},
 	}
 }
 

--- a/pkg/cluster/validate.go
+++ b/pkg/cluster/validate.go
@@ -2,83 +2,22 @@ package cluster
 
 import (
 	"fmt"
-	"reflect"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
-type validableValidation func(*Config, validable) error
-
-var validableValidations = []validableValidation{
-	validateSameNamespace,
-}
-
 func ValidateConfig(c *Config) error {
-	var allErrs []error
-	validables := getValidables(c)
-
-	for _, v := range validables {
-		if err := v.Validate(); err != nil {
-			allErrs = append(allErrs, err)
-		}
-
-		for _, validation := range validableValidations {
-			if err := validation(c, v); err != nil {
-				allErrs = append(allErrs, err)
-			}
-		}
-	}
-
-	if len(allErrs) > 0 {
-		aggregate := utilerrors.NewAggregate(allErrs)
-		return fmt.Errorf("invalid cluster config: %v", aggregate)
-	}
-
-	return nil
+	return manager().Validate(c)
 }
 
-type validable interface {
-	Validate() error
+type namespaceObject interface {
+	runtime.Object
 	GetNamespace() string
-	GetObjectKind() schema.ObjectKind
 }
 
-func getValidables(c *Config) []validable {
-	v := make([]validable, 0, 3)
-	v = appendIfNotNil(v, c.Cluster, c.VSphereDatacenter, c.DockerDatacenter, c.GitOpsConfig)
-
-	for _, e := range c.VSphereMachineConfigs {
-		v = appendIfNotNil(v, e)
-	}
-
-	for _, e := range c.OIDCConfigs {
-		v = appendIfNotNil(v, e)
-	}
-
-	for _, e := range c.AWSIAMConfigs {
-		v = appendIfNotNil(v, e)
-	}
-
-	return v
-}
-
-func appendIfNotNil(validables []validable, elems ...validable) []validable {
-	for _, e := range elems {
-		// Since we receive interfaces, these will never be nil since they contain
-		// the type of the original implementing struct
-		// I can't find another clean option of doing this
-		if !reflect.ValueOf(e).IsNil() {
-			validables = append(validables, e)
-		}
-	}
-
-	return validables
-}
-
-func validateSameNamespace(c *Config, v validable) error {
-	if c.Cluster.Namespace != v.GetNamespace() {
-		return fmt.Errorf("%s and Cluster objects must have the same namespace specified", v.GetObjectKind().GroupVersionKind().Kind)
+func validateSameNamespace(c *Config, o namespaceObject) error {
+	if c.Cluster.Namespace != o.GetNamespace() {
+		return fmt.Errorf("%s and Cluster objects must have the same namespace specified", o.GetObjectKind().GroupVersionKind().Kind)
 	}
 
 	return nil

--- a/pkg/cluster/vsphere.go
+++ b/pkg/cluster/vsphere.go
@@ -23,6 +23,38 @@ func vsphereEntry() *ConfigManagerEntry {
 				}
 			},
 		},
+		Validations: []Validation{
+			func(c *Config) error {
+				if c.VSphereDatacenter != nil {
+					return c.VSphereDatacenter.Validate()
+				}
+				return nil
+			},
+			func(c *Config) error {
+				for _, m := range c.VSphereMachineConfigs {
+					if err := m.Validate(); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			func(c *Config) error {
+				if c.VSphereDatacenter != nil {
+					if err := validateSameNamespace(c, c.VSphereDatacenter); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			func(c *Config) error {
+				for _, v := range c.VSphereMachineConfigs {
+					if err := validateSameNamespace(c, v); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Following up on https://github.com/aws/eks-anywhere/pull/1432

No change in behavior, just refactor to use dynamic registerable config

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

