### PR TITLE
Reenable all tests and decrease concurrency to 20

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   variables:
     INTEGRATION_TEST_MAX_EC2_COUNT: 100
-    INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT: 30
+    INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT: 20
     T_VSPHERE_CIDR: "198.18.128.0/17"
     T_VSPHERE_PRIVATE_NETWORK_CIDR: "197.18.128.0/17"
     SKIPPED_TESTS: "TestTinkerbellKubernetes120SimpleFlow,TestTinkerbellKubernetes121ThreeReplicasTwoWorkersSimpleFlow,TestTinkerbellKubernetes121DellSimpleFlow,TestTinkerbellKubernetes121HPSimpleFlow,TestTinkerbellKubernetes121SuperMicroSimpleFlow,TestTinkerbellKubernetes121ExternalEtcdSimpleFlow,TestTinkerbellKubernetes121ExternalEtcdThreeReplicasTwoWorkersSimpleFlow"
@@ -66,7 +66,7 @@ phases:
         -n ${INTEGRATION_TEST_SUBNET_ID}
         -m ${INTEGRATION_TEST_MAX_EC2_COUNT}
         -c ${INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT}
-        -r '(TestVSphereKubernetes121SimpleFlow|TestVSphereKubernetes121ThreeReplicasFiveWorkersSimpleFlow|TestVSphereKubernetes121DifferentNamespaceSimpleFlow|TestVSphereKubernetes122Flux|TestVSphereKubernetes120UbuntuAutoimport|TestVSphereKubernetes121UbuntuTo122MultipleFieldsUpgrade|TestVSphereUpgradeMulticlusterWorkloadClusterWithFlux|TestVSphereKubernetes121MulticlusterWorkloadClusterDemo|TestVSphereKubernetes121BottlerocketAutoimport|TestVSphereKubernetes121UbuntuTo122DifferentNamespaceWithFluxUpgrade|TestVSphereKubernetes120BottlerocketTo121MultipleFieldsUpgrade|TestVSphereKubernetes120BottlerocketTo121Upgrade|TestVSphereKubernetes121UbuntuTo122WithFluxUpgrade)'
+        -r 'Test'
         -v 4
         --skip ${SKIPPED_TESTS}
         --bundles-override=${BUNDLES_OVERRIDE}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reenable tests after confirming that subset of tests are passing, and decreasing the amount of parallel tests more to see if it will help with vsphere limits. Follow up will be to see if changing cleaning up failed tests to within the subroutine is going to help as well.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

