### PR TITLE
Pass the required info to tink as flags instead of env

### DIFF
--- a/pkg/executables/tink.go
+++ b/pkg/executables/tink.go
@@ -43,8 +43,8 @@ func (t *Tink) PushHardware(ctx context.Context, hardware []byte) error {
 }
 
 func (t *Tink) GetHardware(ctx context.Context) ([]*hardware.Hardware, error) {
-	params := []string{"hardware", "get", "--format", "json"}
-	data, err := t.Command(ctx, params...).WithEnvVars(t.envMap).Run()
+	params := []string{"hardware", "get", "--tinkerbell-cert-url", t.tinkerbellCertUrl, "--tinkerbell-grpc-authority", t.tinkerbellGrpcAuthority, "--format", "json"}
+	data, err := t.Command(ctx, params...).Run()
 	if err != nil {
 		return nil, fmt.Errorf("error getting hardware list: %v", err)
 	}
@@ -66,8 +66,8 @@ func (t *Tink) GetHardware(ctx context.Context) ([]*hardware.Hardware, error) {
 }
 
 func (t *Tink) GetWorkflow(ctx context.Context) ([]*workflow.Workflow, error) {
-	params := []string{"workflow", "get", "--format", "json"}
-	data, err := t.Command(ctx, params...).WithEnvVars(t.envMap).Run()
+	params := []string{"workflow", "get", "--tinkerbell-cert-url", t.tinkerbellCertUrl, "--tinkerbell-grpc-authority", t.tinkerbellGrpcAuthority, "--format", "json"}
+	data, err := t.Command(ctx, params...).Run()
 	if err != nil {
 		return nil, fmt.Errorf("error getting workflow list: %v", err)
 	}

--- a/pkg/executables/tink_test.go
+++ b/pkg/executables/tink_test.go
@@ -46,8 +46,8 @@ func TestTinkPushHardwareSuccess(t *testing.T) {
 
 func TestTinkGetHardware(t *testing.T) {
 	tink, ctx, e := newTink(t)
-	expectedParam := []string{"hardware", "get", "--format", "json"}
-	expectCommand(e, ctx, expectedParam...).withEnvVars(envMap).to().Return(bytes.Buffer{}, nil)
+	expectedParam := []string{"hardware", "get", "--tinkerbell-cert-url", tinkerbellCertUrl, "--tinkerbell-grpc-authority", tinkerbellGrpcAuthority, "--format", "json"}
+	expectCommand(e, ctx, expectedParam...).to().Return(bytes.Buffer{}, nil)
 	if _, err := tink.GetHardware(ctx); err != nil {
 		t.Errorf("Tink.GetHardware() error = %v, want nil", err)
 	}
@@ -55,8 +55,8 @@ func TestTinkGetHardware(t *testing.T) {
 
 func TestTinkGetWorkflow(t *testing.T) {
 	tink, ctx, e := newTink(t)
-	expectedParam := []string{"workflow", "get", "--format", "json"}
-	expectCommand(e, ctx, expectedParam...).withEnvVars(envMap).to().Return(bytes.Buffer{}, nil)
+	expectedParam := []string{"workflow", "get", "--tinkerbell-cert-url", tinkerbellCertUrl, "--tinkerbell-grpc-authority", tinkerbellGrpcAuthority, "--format", "json"}
+	expectCommand(e, ctx, expectedParam...).to().Return(bytes.Buffer{}, nil)
 	if _, err := tink.GetWorkflow(ctx); err != nil {
 		t.Errorf("Tink.GetWorkflow() error = %v, want nil", err)
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Pass the tinkerbell grpc authority and tinkerbell cert url as flags to tink cli's get calls instead of environment variables.
This is needed because the env var approach is deprecated and tink cli prints out a warning if we don't provide these values as flags.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

