### PR TITLE
Enable only docker e2e tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -66,7 +66,7 @@ phases:
         -n ${INTEGRATION_TEST_SUBNET_ID}
         -m ${INTEGRATION_TEST_MAX_EC2_COUNT}
         -c ${INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT}
-        -r 'Test'
+        -r 'TestDocker'
         -v 4
         --skip ${SKIPPED_TESTS}
         --bundles-override=${BUNDLES_OVERRIDE}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
enable only Docker e2e tests

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

