### PR TITLE
Make Cluster a declared member in cluster.Spec

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -160,8 +160,8 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 	var cluster *types.Cluster
 	if clusterSpec.ManagementCluster == nil {
 		cluster = &types.Cluster{
-			Name:           clusterSpec.Name,
-			KubeconfigFile: kubeconfig.FromClusterName(clusterSpec.Name),
+			Name:           clusterSpec.Cluster.Name,
+			KubeconfigFile: kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
 		}
 	} else {
 		cluster = &types.Cluster{
@@ -174,8 +174,8 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		Kubectl: deps.Kubectl,
 		Spec:    clusterSpec,
 		WorkloadCluster: &types.Cluster{
-			Name:           clusterSpec.Name,
-			KubeconfigFile: kubeconfig.FromClusterName(clusterSpec.Name),
+			Name:           clusterSpec.Cluster.Name,
+			KubeconfigFile: kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
 		},
 		ManagementCluster: cluster,
 		Provider:          deps.Provider,

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -123,12 +123,12 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 	var cluster *types.Cluster
 	if clusterSpec.ManagementCluster == nil {
 		cluster = &types.Cluster{
-			Name:           clusterSpec.Name,
-			KubeconfigFile: kubeconfig.FromClusterName(clusterSpec.Name),
+			Name:           clusterSpec.Cluster.Name,
+			KubeconfigFile: kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
 		}
 	} else {
 		cluster = &types.Cluster{
-			Name:           clusterSpec.Name,
+			Name:           clusterSpec.Cluster.Name,
 			KubeconfigFile: clusterSpec.ManagementCluster.KubeconfigFile,
 		}
 	}

--- a/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
@@ -101,5 +101,5 @@ func (gsbo *generateSupportBundleOptions) generateBundleConfig(ctx context.Conte
 	}
 	defer close(ctx, deps)
 
-	return deps.DignosticCollectorFactory.DiagnosticBundleFromSpec(clusterSpec, deps.Provider, kubeconfig.FromClusterName(clusterSpec.Name))
+	return deps.DignosticCollectorFactory.DiagnosticBundleFromSpec(clusterSpec, deps.Provider, kubeconfig.FromClusterName(clusterSpec.Cluster.Name))
 }

--- a/cmd/eksctl-anywhere/cmd/importimages.go
+++ b/cmd/eksctl-anywhere/cmd/importimages.go
@@ -54,17 +54,17 @@ func importImages(context context.Context, spec string) error {
 	}
 	de := executables.BuildDockerExecutable()
 
-	if clusterSpec.Spec.RegistryMirrorConfiguration == nil || clusterSpec.Spec.RegistryMirrorConfiguration.Endpoint == "" {
+	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration == nil || clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Endpoint == "" {
 		return fmt.Errorf("it is necessary to define a valid endpoint in your spec (registryMirrorConfiguration.endpoint)")
 	}
-	host := clusterSpec.Spec.RegistryMirrorConfiguration.Endpoint
-	port := clusterSpec.Spec.RegistryMirrorConfiguration.Port
+	host := clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Endpoint
+	port := clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Port
 	if port == "" {
 		logger.V(1).Info("RegistryMirrorConfiguration.Port is not specified, default port will be used", "Default Port", constants.DefaultHttpsPort)
 		port = constants.DefaultHttpsPort
 	}
-	if !networkutils.IsPortValid(clusterSpec.Spec.RegistryMirrorConfiguration.Port) {
-		return fmt.Errorf("registry mirror port %s is invalid, please provide a valid port", clusterSpec.Spec.RegistryMirrorConfiguration.Port)
+	if !networkutils.IsPortValid(clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Port) {
+		return fmt.Errorf("registry mirror port %s is invalid, please provide a valid port", clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Port)
 	}
 
 	images, err := getImages(spec)

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -98,7 +98,7 @@ func (csbo *createSupportBundleOptions) createBundle(ctx context.Context, since,
 	}
 	defer close(ctx, deps)
 
-	supportBundle, err := deps.DignosticCollectorFactory.DiagnosticBundle(clusterSpec, deps.Provider, getKubeconfigPath(clusterSpec.Name, csbo.wConfig), bundleConfig)
+	supportBundle, err := deps.DignosticCollectorFactory.DiagnosticBundle(clusterSpec, deps.Provider, getKubeconfigPath(clusterSpec.Cluster.Name, csbo.wConfig), bundleConfig)
 	if err != nil {
 		return fmt.Errorf("failed to parse collector: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -101,15 +101,15 @@ func (uc *upgradeClusterOptions) upgradeCluster(ctx context.Context) error {
 	)
 
 	workloadCluster := &types.Cluster{
-		Name:           clusterSpec.Name,
-		KubeconfigFile: getKubeconfigPath(clusterSpec.Name, uc.wConfig),
+		Name:           clusterSpec.Cluster.Name,
+		KubeconfigFile: getKubeconfigPath(clusterSpec.Cluster.Name, uc.wConfig),
 	}
 
 	var cluster *types.Cluster
 	if clusterSpec.ManagementCluster == nil {
 		cluster = &types.Cluster{
-			Name:           clusterSpec.Name,
-			KubeconfigFile: getKubeconfigPath(clusterSpec.Name, uc.wConfig),
+			Name:           clusterSpec.Cluster.Name,
+			KubeconfigFile: getKubeconfigPath(clusterSpec.Cluster.Name, uc.wConfig),
 		}
 	} else {
 		cluster = &types.Cluster{

--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -85,12 +85,12 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 	}
 
 	workloadCluster := &types.Cluster{
-		Name:           newClusterSpec.Name,
-		KubeconfigFile: getKubeconfigPath(newClusterSpec.Name, uc.wConfig),
+		Name:           newClusterSpec.Cluster.Name,
+		KubeconfigFile: getKubeconfigPath(newClusterSpec.Cluster.Name, uc.wConfig),
 	}
 
 	logger.V(0).Info("Checking new release availability...")
-	currentSpec, err := deps.ClusterManager.GetCurrentClusterSpec(ctx, workloadCluster, newClusterSpec.Name)
+	currentSpec, err := deps.ClusterManager.GetCurrentClusterSpec(ctx, workloadCluster, newClusterSpec.Cluster.Name)
 	if err != nil {
 		return err
 	}

--- a/controllers/controllers/clusters/vsphere.go
+++ b/controllers/controllers/clusters/vsphere.go
@@ -178,10 +178,10 @@ func (v *VSphereClusterReconciler) Reconcile(ctx context.Context, cluster *anywh
 		workerNodeGroupMachineSpecs[wnConfig.MachineGroupRef.Name] = machineConfigMap[wnConfig.MachineGroupRef.Name].Spec
 	}
 
-	cp := machineConfigMap[specWithBundles.Spec.ControlPlaneConfiguration.MachineGroupRef.Name]
+	cp := machineConfigMap[specWithBundles.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name]
 	var etcdSpec *anywherev1.VSphereMachineConfigSpec
-	if specWithBundles.Spec.ExternalEtcdConfiguration != nil {
-		etcd := machineConfigMap[specWithBundles.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name]
+	if specWithBundles.Cluster.Spec.ExternalEtcdConfiguration != nil {
+		etcd := machineConfigMap[specWithBundles.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name]
 		etcdSpec = &etcd.Spec
 	}
 

--- a/controllers/controllers/resource/reconciler.go
+++ b/controllers/controllers/resource/reconciler.go
@@ -145,7 +145,7 @@ func (cor *clusterReconciler) applyTemplates(ctx context.Context, resources []*u
 }
 
 func (cor *clusterReconciler) fetchIdentityProviderRefs(ctx context.Context, cs *cluster.Spec, namespace string) error {
-	for _, identityProvider := range cs.Spec.IdentityProviderRefs {
+	for _, identityProvider := range cs.Cluster.Spec.IdentityProviderRefs {
 		switch identityProvider.Kind {
 		case anywherev1.AWSIamConfigKind:
 			awsIamConfig, err := cor.AWSIamConfig(ctx, &identityProvider, namespace)

--- a/controllers/controllers/resource/reconciler_test.go
+++ b/controllers/controllers/resource/reconciler_test.go
@@ -89,7 +89,7 @@ func TestClusterReconcilerReconcile(t *testing.T) {
 				fetcher.EXPECT().FetchCluster(gomock.Any(), gomock.Any()).Return(cluster, nil)
 
 				spec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
-				cluster.Spec = spec.Spec
+				cluster.Spec = spec.Cluster.Spec
 
 				fetcher.EXPECT().FetchAppliedSpec(ctx, gomock.Any()).Return(spec, nil)
 
@@ -215,7 +215,7 @@ func TestClusterReconcilerReconcile(t *testing.T) {
 				fetcher.EXPECT().FetchCluster(gomock.Any(), gomock.Any()).Return(cluster, nil)
 
 				spec := test.NewFullClusterSpec(t, "testdata/eksa-cluster_no_changes.yaml")
-				cluster.Spec = spec.Spec
+				cluster.Spec = spec.Cluster.Spec
 				fetcher.EXPECT().FetchAppliedSpec(ctx, gomock.Any()).Return(spec, nil)
 
 				datacenterSpec := &anywherev1.VSphereDatacenterConfig{}
@@ -326,7 +326,7 @@ func TestClusterReconcilerReconcile(t *testing.T) {
 				fetcher.EXPECT().FetchCluster(gomock.Any(), gomock.Any()).Return(cluster, nil)
 
 				spec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
-				cluster.Spec = spec.Spec
+				cluster.Spec = spec.Cluster.Spec
 
 				fetcher.EXPECT().FetchAppliedSpec(ctx, gomock.Any()).Return(spec, nil)
 
@@ -448,7 +448,7 @@ func TestClusterReconcilerReconcile(t *testing.T) {
 				fetcher.EXPECT().FetchCluster(gomock.Any(), gomock.Any()).Return(cluster, nil)
 
 				spec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
-				cluster.Spec = spec.Spec
+				cluster.Spec = spec.Cluster.Spec
 
 				fetcher.EXPECT().FetchAppliedSpec(ctx, gomock.Any()).Return(spec, nil)
 

--- a/pkg/addonmanager/addonclients/files_test.go
+++ b/pkg/addonmanager/addonclients/files_test.go
@@ -122,9 +122,9 @@ func TestUpdateLegacyFileStructureSuccess(t *testing.T) {
 
 	tt.Expect(f.UpdateLegacyFileStructure(tt.ctx, tt.currentSpec, tt.newSpec)).To(BeNil())
 
-	expectedEksaClusterConfigPath := path.Join(g.Writer.Dir(), tt.fluxConfig.Github.ClusterConfigPath, tt.newSpec.GetClusterName(), "eksa-system", defaultEksaClusterConfigFileName)
+	expectedEksaClusterConfigPath := path.Join(g.Writer.Dir(), tt.fluxConfig.Github.ClusterConfigPath, tt.newSpec.Cluster.GetClusterName(), "eksa-system", defaultEksaClusterConfigFileName)
 	test.AssertFilesEquals(t, expectedEksaClusterConfigPath, "./testdata/cluster-config-default-path-management.yaml")
 
-	expectedEksaKustomizationPath := path.Join(g.Writer.Dir(), tt.fluxConfig.Github.ClusterConfigPath, tt.newSpec.GetClusterName(), "eksa-system", defaultKustomizationManifestFileName)
+	expectedEksaKustomizationPath := path.Join(g.Writer.Dir(), tt.fluxConfig.Github.ClusterConfigPath, tt.newSpec.Cluster.GetClusterName(), "eksa-system", defaultKustomizationManifestFileName)
 	test.AssertFilesEquals(t, expectedEksaKustomizationPath, "./testdata/kustomization.yaml")
 }

--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -313,7 +313,7 @@ func (f *FluxAddonClient) CleanupGitRepo(ctx context.Context, clusterSpec *clust
 	}
 
 	var p string
-	if clusterSpec.IsManaged() {
+	if clusterSpec.Cluster.IsManaged() {
 		p = fc.eksaSystemDir()
 	} else {
 		p = fc.path()
@@ -384,7 +384,7 @@ func (fc *fluxForCluster) commitFluxAndClusterConfigToGit(ctx context.Context) e
 		return &ConfigVersionControlFailedError{Err: err}
 	}
 
-	if fc.clusterSpec.IsSelfManaged() {
+	if fc.clusterSpec.Cluster.IsSelfManaged() {
 		logger.V(3).Info("Generating flux custom manifest files...")
 		err = fc.writeFluxSystemFiles()
 		if err != nil {
@@ -647,7 +647,7 @@ func (fc *fluxForCluster) initializeLocalRepository() error {
 // validateLocalConfigPathDoesNotExist returns an exception if the cluster configuration file exists.
 // This is done so that we avoid clobbering existing cluster configurations in the user-provided git repository.
 func (fc *fluxForCluster) validateLocalConfigPathDoesNotExist() error {
-	if fc.clusterSpec.IsSelfManaged() {
+	if fc.clusterSpec.Cluster.IsSelfManaged() {
 		p := path.Join(fc.gitOpts.Writer.Dir(), fc.path())
 		if validations.FileExists(p) {
 			return fmt.Errorf("a cluster configuration file already exists at path %s", p)
@@ -657,7 +657,7 @@ func (fc *fluxForCluster) validateLocalConfigPathDoesNotExist() error {
 }
 
 func (fc *fluxForCluster) validateRemoteConfigPathDoesNotExist(ctx context.Context) error {
-	if fc.clusterSpec.IsSelfManaged() {
+	if fc.clusterSpec.Cluster.IsSelfManaged() {
 		if exists, err := fc.gitOpts.Git.PathExists(ctx, fc.owner(), fc.repository(), fc.branch(), fc.path()); err != nil {
 			return fmt.Errorf("failed validating remote flux config path: %v", err)
 		} else if exists {
@@ -700,7 +700,7 @@ func (e *ConfigVersionControlFailedError) Error() string {
 }
 
 func (fc *fluxForCluster) eksaSystemDir() string {
-	return path.Join(fc.path(), fc.clusterSpec.GetName(), eksaSystemDirName)
+	return path.Join(fc.path(), fc.clusterSpec.Cluster.GetName(), eksaSystemDirName)
 }
 
 func (fc *fluxForCluster) fluxSystemDir() string {

--- a/pkg/awsiamauth/awsiamauth.go
+++ b/pkg/awsiamauth/awsiamauth.go
@@ -54,8 +54,8 @@ func (a *AwsIamAuthTemplateBuilder) GenerateManifest(clusterSpec *cluster.Spec, 
 		"partition":   clusterSpec.AWSIamConfig.Spec.Partition,
 	}
 
-	if clusterSpec.Spec.ControlPlaneConfiguration.Taints != nil {
-		data["controlPlaneTaints"] = clusterSpec.Spec.ControlPlaneConfiguration.Taints
+	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints != nil {
+		data["controlPlaneTaints"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints
 	}
 
 	mapRoles, err := a.mapRolesToYaml(clusterSpec.AWSIamConfig.Spec.MapRoles)

--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -48,7 +48,7 @@ func (b *Bootstrapper) CreateBootstrapCluster(ctx context.Context, clusterSpec *
 	}
 
 	c := &types.Cluster{
-		Name:           clusterSpec.Name,
+		Name:           clusterSpec.Cluster.Name,
 		KubeconfigFile: kubeconfigFile,
 	}
 

--- a/pkg/bootstrapper/bootstrapper_test.go
+++ b/pkg/bootstrapper/bootstrapper_test.go
@@ -306,7 +306,7 @@ func newBootstrapper(t *testing.T) (*bootstrapper.Bootstrapper, *mocks.MockClust
 
 func given(t *testing.T, clusterName, kubeconfig string) (clusterSpec *cluster.Spec, wantCluster *types.Cluster) {
 	return test.NewClusterSpec(func(s *cluster.Spec) {
-			s.Name = clusterName
+			s.Cluster.Name = clusterName
 			s.VersionsBundle.KubeVersion = "1.19"
 			s.VersionsBundle.KubeDistro.CoreDNS.Tag = "v1.8.3-eks-1-20-1"
 		}), &types.Cluster{

--- a/pkg/cluster/apply.go
+++ b/pkg/cluster/apply.go
@@ -21,7 +21,7 @@ func ApplyExtraObjects(ctx context.Context, clusterClient ClusterClient, cluster
 
 	resourcesSpec := templater.AppendYamlResources(extraObjects.Values()...)
 
-	logger.V(4).Info("Applying extra objects", "cluster", clusterSpec.Name, "resources", extraObjects.Names())
+	logger.V(4).Info("Applying extra objects", "cluster", clusterSpec.Cluster.Name, "resources", extraObjects.Names())
 	err := clusterClient.ApplyKubeSpecFromBytes(ctx, cluster, resourcesSpec)
 	if err != nil {
 		return fmt.Errorf("error applying spec for extra resources to cluster %s: %v", cluster.Name, err)

--- a/pkg/cluster/node_groups.go
+++ b/pkg/cluster/node_groups.go
@@ -11,9 +11,9 @@ func BuildMapForWorkerNodeGroupsByName(workerNodeGroups []eksav1alpha1.WorkerNod
 }
 
 func NodeGroupsToDelete(currentSpec, newSpec *Spec) []eksav1alpha1.WorkerNodeGroupConfiguration {
-	workerConfigs := BuildMapForWorkerNodeGroupsByName(newSpec.Spec.WorkerNodeGroupConfigurations)
-	nodeGroupsToDelete := make([]eksav1alpha1.WorkerNodeGroupConfiguration, 0, len(currentSpec.Spec.WorkerNodeGroupConfigurations))
-	for _, prevWorkerNodeGroupConfig := range currentSpec.Spec.WorkerNodeGroupConfigurations {
+	workerConfigs := BuildMapForWorkerNodeGroupsByName(newSpec.Cluster.Spec.WorkerNodeGroupConfigurations)
+	nodeGroupsToDelete := make([]eksav1alpha1.WorkerNodeGroupConfiguration, 0, len(currentSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	for _, prevWorkerNodeGroupConfig := range currentSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
 		// Current spec doesn't have the default name since we never set the defaults at the api server level
 		if prevWorkerNodeGroupConfig.Name == "" {
 			prevWorkerNodeGroupConfig.Name = "md-0"

--- a/pkg/cluster/node_groups_test.go
+++ b/pkg/cluster/node_groups_test.go
@@ -18,7 +18,7 @@ func TestNodeGroupsToDelete(t *testing.T) {
 		{
 			name: "one worker node group, missing name, no changes",
 			current: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
 					{
 						MachineGroupRef: &anywherev1.Ref{
 							Kind: anywherev1.VSphereMachineConfigKind,
@@ -28,7 +28,7 @@ func TestNodeGroupsToDelete(t *testing.T) {
 				}
 			}),
 			new: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
 					{
 						Name: "md-0",
 						MachineGroupRef: &anywherev1.Ref{
@@ -43,7 +43,7 @@ func TestNodeGroupsToDelete(t *testing.T) {
 		{
 			name: "one worker node group, missing name, new name is not default",
 			current: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
 					{
 						MachineGroupRef: &anywherev1.Ref{
 							Kind: anywherev1.VSphereMachineConfigKind,
@@ -53,7 +53,7 @@ func TestNodeGroupsToDelete(t *testing.T) {
 				}
 			}),
 			new: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
 					{
 						Name: "worker-node-group-0",
 						MachineGroupRef: &anywherev1.Ref{
@@ -76,7 +76,7 @@ func TestNodeGroupsToDelete(t *testing.T) {
 		{
 			name: "new added, some removed, some stay",
 			current: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
 					{
 						Name: "worker-node-group-0",
 						MachineGroupRef: &anywherev1.Ref{
@@ -94,7 +94,7 @@ func TestNodeGroupsToDelete(t *testing.T) {
 				}
 			}),
 			new: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
 					{
 						Name: "worker-node-group-0",
 						MachineGroupRef: &anywherev1.Ref{

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -28,7 +28,7 @@ const (
 var releasesManifestURL string
 
 type Spec struct {
-	*eksav1alpha1.Cluster
+	Cluster                   *eksav1alpha1.Cluster
 	OIDCConfig                *eksav1alpha1.OIDCConfig
 	AWSIamConfig              *eksav1alpha1.AWSIamConfig
 	GitOpsConfig              *eksav1alpha1.GitOpsConfig
@@ -71,7 +71,7 @@ func (cs *Spec) SetDefaultGitOps() {
 		c := &cs.GitOpsConfig.Spec.Flux
 		if len(c.Github.ClusterConfigPath) == 0 {
 			if cs.Cluster.IsSelfManaged() {
-				c.Github.ClusterConfigPath = path.Join("clusters", cs.Name)
+				c.Github.ClusterConfigPath = path.Join("clusters", cs.Cluster.Name)
 			} else {
 				c.Github.ClusterConfigPath = path.Join("clusters", cs.Cluster.ManagedBy())
 			}
@@ -276,9 +276,9 @@ func NewSpecFromClusterConfig(clusterConfigPath string, cliVersion version.Info,
 	}
 
 	if s.ManagementCluster != nil {
-		s.SetManagedBy(s.ManagementCluster.Name)
+		s.Cluster.SetManagedBy(s.ManagementCluster.Name)
 	} else {
-		s.SetSelfManaged()
+		s.Cluster.SetSelfManaged()
 	}
 
 	return s, nil

--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -44,7 +44,7 @@ func clusterLabels(clusterName string) map[string]string {
 }
 
 func Cluster(clusterSpec *cluster.Spec, infrastructureObject, controlPlaneObject APIObject) *clusterv1.Cluster {
-	clusterName := clusterSpec.GetName()
+	clusterName := clusterSpec.Cluster.GetName()
 	cluster := &clusterv1.Cluster{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: clusterAPIVersion,
@@ -58,10 +58,10 @@ func Cluster(clusterSpec *cluster.Spec, infrastructureObject, controlPlaneObject
 		Spec: clusterv1.ClusterSpec{
 			ClusterNetwork: &clusterv1.ClusterNetwork{
 				Pods: &clusterv1.NetworkRanges{
-					CIDRBlocks: clusterSpec.Spec.ClusterNetwork.Pods.CidrBlocks,
+					CIDRBlocks: clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks,
 				},
 				Services: &clusterv1.NetworkRanges{
-					CIDRBlocks: clusterSpec.Spec.ClusterNetwork.Services.CidrBlocks,
+					CIDRBlocks: clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks,
 				},
 			},
 			ControlPlaneRef: &v1.ObjectReference{
@@ -77,7 +77,7 @@ func Cluster(clusterSpec *cluster.Spec, infrastructureObject, controlPlaneObject
 		},
 	}
 
-	if clusterSpec.Spec.ExternalEtcdConfiguration != nil {
+	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		cluster.Spec.ManagedExternalEtcdRef = &v1.ObjectReference{
 			APIVersion: etcdClusterAPIVersion,
 			Kind:       etcdadmClusterKind,
@@ -89,10 +89,10 @@ func Cluster(clusterSpec *cluster.Spec, infrastructureObject, controlPlaneObject
 }
 
 func KubeadmControlPlane(clusterSpec *cluster.Spec, infrastructureObject APIObject) *controlplanev1.KubeadmControlPlane {
-	replicas := int32(clusterSpec.Spec.ControlPlaneConfiguration.Count)
+	replicas := int32(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Count)
 
 	etcd := bootstrapv1.Etcd{}
-	if clusterSpec.Spec.ExternalEtcdConfiguration != nil {
+	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		etcd.External = &bootstrapv1.ExternalEtcd{
 			Endpoints: []string{},
 		}
@@ -112,7 +112,7 @@ func KubeadmControlPlane(clusterSpec *cluster.Spec, infrastructureObject APIObje
 			Kind:       kubeadmControlPlaneKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterSpec.GetName(),
+			Name:      clusterSpec.Cluster.GetName(),
 			Namespace: constants.EksaSystemNamespace,
 		},
 		Spec: controlplanev1.KubeadmControlPlaneSpec{
@@ -198,7 +198,7 @@ func KubeadmConfigTemplate(clusterSpec *cluster.Spec, workerNodeGroupConfig v1al
 }
 
 func MachineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration, bootstrapObject, infrastructureObject APIObject) clusterv1.MachineDeployment {
-	clusterName := clusterSpec.GetName()
+	clusterName := clusterSpec.Cluster.GetName()
 	replicas := int32(workerNodeGroupConfig.Count)
 	version := clusterSpec.VersionsBundle.KubeDistro.Kubernetes.Tag
 

--- a/pkg/clusterapi/upgrader_test.go
+++ b/pkg/clusterapi/upgrader_test.go
@@ -175,7 +175,7 @@ func TestUpgraderUpgradeEverythingChangesStackedEtcd(t *testing.T) {
 
 func TestUpgraderUpgradeEverythingChangesExternalEtcd(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.newSpec.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{}
+	tt.newSpec.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{}
 	tt.newSpec.VersionsBundle.CertManager.Version = "v0.2.0"
 	tt.newSpec.VersionsBundle.ClusterAPI.Version = "v0.2.0"
 	tt.newSpec.VersionsBundle.ControlPlane.Version = "v0.2.0"

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -154,7 +154,7 @@ func TestClusterManagerCAPIWaitForDeploymentExternalEtcd(t *testing.T) {
 	clusterObj := &types.Cluster{}
 	c, m := newClusterManager(t)
 	clusterSpecExternalEtcd := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 1}
+		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 1}
 	})
 	m.client.EXPECT().InitInfrastructure(ctx, clusterSpecExternalEtcd, clusterObj, m.provider)
 	for namespace, deployments := range internal.CAPIDeployments {
@@ -183,9 +183,9 @@ func TestClusterManagerSaveLogsSuccess(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "cluster-name"
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = clusterName
-		s.Spec.ControlPlaneConfiguration.Count = 3
-		s.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Name = clusterName
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
 	})
 
 	bootstrapCluster := &types.Cluster{
@@ -220,9 +220,9 @@ func TestClusterManagerCreateWorkloadClusterSuccess(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "cluster-name"
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = clusterName
-		s.Spec.ControlPlaneConfiguration.Count = 3
-		s.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Name = clusterName
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
 	})
 
 	cluster := &types.Cluster{
@@ -251,10 +251,10 @@ func TestClusterManagerCreateWorkloadClusterWithExternalEtcdSuccess(t *testing.T
 	ctx := context.Background()
 	clusterName := "cluster-name"
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = clusterName
-		s.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-		s.Spec.ControlPlaneConfiguration.Count = 2
-		s.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Name = clusterName
+		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 2
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
 	})
 
 	cluster := &types.Cluster{
@@ -284,9 +284,9 @@ func TestClusterManagerCreateWorkloadClusterSuccessWithExtraObjects(t *testing.T
 	ctx := context.Background()
 	clusterName := "cluster-name"
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = clusterName
-		s.Spec.ControlPlaneConfiguration.Count = 3
-		s.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Name = clusterName
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
 		s.VersionsBundle.KubeVersion = "1.20"
 		s.VersionsBundle.KubeDistro.CoreDNS.Tag = "v1.8.3-eks-1-20-1"
 	})
@@ -329,9 +329,9 @@ func TestClusterManagerCreateWorkloadClusterErrorApplyingExtraObjects(t *testing
 	ctx := context.Background()
 	clusterName := "cluster-name"
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = clusterName
-		s.Spec.ControlPlaneConfiguration.Count = 3
-		s.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Name = clusterName
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
 		s.VersionsBundle.KubeVersion = "1.20"
 		s.VersionsBundle.KubeDistro.CoreDNS.Tag = "v1.8.3-eks-1-20-1"
 	})
@@ -369,9 +369,9 @@ func TestClusterManagerCreateWorkloadClusterWaitForMachinesTimeout(t *testing.T)
 	ctx := context.Background()
 	clusterName := "cluster-name"
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = clusterName
-		s.Spec.ControlPlaneConfiguration.Count = 3
-		s.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Name = clusterName
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
 	})
 
 	cluster := &types.Cluster{
@@ -406,9 +406,9 @@ func TestClusterManagerCreateWorkloadClusterWaitForMachinesSuccessAfterRetries(t
 	ctx := context.Background()
 	clusterName := "cluster-name"
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = clusterName
-		s.Spec.ControlPlaneConfiguration.Count = 3
-		s.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Name = clusterName
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
 	})
 
 	cluster := &types.Cluster{
@@ -469,7 +469,7 @@ func TestClusterManagerUpgradeWorkloadClusterSuccess(t *testing.T) {
 	}
 
 	tt := newSpecChangedTest(t)
-	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Cluster.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
 	tt.mocks.provider.EXPECT().GenerateCAPISpecForUpgrade(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy())
@@ -483,7 +483,7 @@ func TestClusterManagerUpgradeWorkloadClusterSuccess(t *testing.T) {
 	tt.mocks.client.EXPECT().ValidateWorkerNodes(tt.ctx, wCluster.Name, mCluster.KubeconfigFile).Return(nil)
 	tt.mocks.provider.EXPECT().GetDeployments()
 	tt.mocks.writer.EXPECT().Write(clusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
-	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Namespace).Return(nil, nil)
+	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
 
 	if err := tt.clusterManager.UpgradeCluster(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.mocks.provider); err != nil {
 		t.Errorf("ClusterManager.UpgradeCluster() error = %v, wantErr nil", err)
@@ -502,8 +502,8 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForMachinesTimeout(t *testing.T
 	}
 
 	tt := newSpecChangedTest(t, clustermanager.WithWaitForMachines(1*time.Nanosecond, 50*time.Microsecond, 100*time.Microsecond))
-	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Namespace).Return(nil, nil)
-	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
+	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Cluster.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
 	tt.mocks.provider.EXPECT().GenerateCAPISpecForUpgrade(ctx, mCluster, wCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy())
@@ -546,7 +546,7 @@ func TestClusterManagerCreateWorkloadClusterWaitForMachinesFailedWithUnhealthyNo
 	}
 
 	tt := newSpecChangedTest(t, clustermanager.WithWaitForMachines(1*time.Nanosecond, 50*time.Microsecond, 100*time.Microsecond))
-	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Cluster.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
 	tt.mocks.provider.EXPECT().GenerateCAPISpecForUpgrade(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy())
@@ -557,7 +557,7 @@ func TestClusterManagerCreateWorkloadClusterWaitForMachinesFailedWithUnhealthyNo
 	tt.mocks.writer.EXPECT().Write(clusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
 	// Return a machine with no nodeRef the rest of the retries
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).MinTimes(1).Return(machines, nil)
-	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Namespace).Return(nil, nil)
+	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
 
 	if err := tt.clusterManager.UpgradeCluster(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.mocks.provider); err == nil {
 		t.Error("ClusterManager.UpgradeCluster() error = nil, wantErr not nil")
@@ -574,7 +574,7 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForCAPITimeout(t *testing.T) {
 	}
 
 	tt := newSpecChangedTest(t)
-	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Cluster.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
 	tt.mocks.provider.EXPECT().GenerateCAPISpecForUpgrade(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy())
@@ -587,7 +587,7 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForCAPITimeout(t *testing.T) {
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, wCluster.Name).Return(nil)
 	tt.mocks.client.EXPECT().ValidateWorkerNodes(tt.ctx, wCluster.Name, mCluster.KubeconfigFile).Return(nil)
 	tt.mocks.writer.EXPECT().Write(clusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
-	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Namespace).Return(nil, nil)
+	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
 
 	if err := tt.clusterManager.UpgradeCluster(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.mocks.provider); err == nil {
 		t.Error("ClusterManager.UpgradeCluster() error = nil, wantErr not nil")
@@ -602,9 +602,9 @@ func TestClusterManagerMoveCAPISuccess(t *testing.T) {
 		Name: "to-cluster",
 	}
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = to.Name
-		s.Spec.ControlPlaneConfiguration.Count = 3
-		s.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-wn"}}}
+		s.Cluster.Name = to.Name
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-wn"}}}
 	})
 	ctx := context.Background()
 
@@ -632,9 +632,9 @@ func TestClusterManagerMoveCAPIErrorMove(t *testing.T) {
 		Name: "to-cluster",
 	}
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = to.Name
-		s.Spec.ControlPlaneConfiguration.Count = 3
-		s.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Name = to.Name
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
 	})
 	ctx := context.Background()
 
@@ -655,9 +655,9 @@ func TestClusterManagerMoveCAPIErrorGetClusters(t *testing.T) {
 		Name: "to-cluster",
 	}
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = to.Name
-		s.Spec.ControlPlaneConfiguration.Count = 3
-		s.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Name = to.Name
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
 	})
 	ctx := context.Background()
 
@@ -679,9 +679,9 @@ func TestClusterManagerMoveCAPIErrorWaitForControlPlane(t *testing.T) {
 		Name: "to-cluster",
 	}
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = to.Name
-		s.Spec.ControlPlaneConfiguration.Count = 3
-		s.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Name = to.Name
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
 	})
 	ctx := context.Background()
 
@@ -706,9 +706,9 @@ func TestClusterManagerMoveCAPIErrorGetMachines(t *testing.T) {
 		Name: "to-cluster",
 	}
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = to.Name
-		s.Spec.ControlPlaneConfiguration.Count = 3
-		s.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-wn"}}}
+		s.Cluster.Name = to.Name
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-wn"}}}
 	})
 	ctx := context.Background()
 
@@ -771,8 +771,8 @@ func TestClusterManagerPauseEKSAControllerReconcileSuccessWithoutMachineConfig(t
 	cm, m := newClusterManager(t)
 	m.provider.EXPECT().DatacenterResourceType().Return(eksaVSphereDatacenterResourceType)
 	m.provider.EXPECT().MachineResourceType().Return("")
-	m.client.EXPECT().UpdateAnnotationInNamespace(ctx, eksaVSphereDatacenterResourceType, clusterSpec.Spec.DatacenterRef.Name, expectedPauseAnnotation, clusterObj, "").Return(nil)
-	m.client.EXPECT().UpdateAnnotationInNamespace(ctx, eksaClusterResourceType, clusterSpec.Name, expectedPauseAnnotation, clusterObj, "").Return(nil)
+	m.client.EXPECT().UpdateAnnotationInNamespace(ctx, eksaVSphereDatacenterResourceType, clusterSpec.Cluster.Spec.DatacenterRef.Name, expectedPauseAnnotation, clusterObj, "").Return(nil)
+	m.client.EXPECT().UpdateAnnotationInNamespace(ctx, eksaClusterResourceType, clusterSpec.Cluster.Name, expectedPauseAnnotation, clusterObj, "").Return(nil)
 
 	if err := cm.PauseEKSAControllerReconcile(ctx, clusterObj, clusterSpec, m.provider); err != nil {
 		t.Errorf("ClusterManager.PauseEKSAControllerReconcile() error = %v, wantErr nil", err)
@@ -813,10 +813,10 @@ func TestClusterManagerPauseEKSAControllerReconcileSuccessWithMachineConfig(t *t
 	cm, m := newClusterManager(t)
 	m.provider.EXPECT().DatacenterResourceType().Return(eksaVSphereDatacenterResourceType)
 	m.provider.EXPECT().MachineResourceType().Return(eksaVSphereMachineResourceType).Times(3)
-	m.client.EXPECT().UpdateAnnotationInNamespace(ctx, eksaVSphereDatacenterResourceType, clusterSpec.Spec.DatacenterRef.Name, expectedPauseAnnotation, clusterObj, "").Return(nil)
-	m.client.EXPECT().UpdateAnnotationInNamespace(ctx, eksaVSphereMachineResourceType, clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, expectedPauseAnnotation, clusterObj, "").Return(nil)
-	m.client.EXPECT().UpdateAnnotationInNamespace(ctx, eksaVSphereMachineResourceType, clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, expectedPauseAnnotation, clusterObj, "").Return(nil)
-	m.client.EXPECT().UpdateAnnotationInNamespace(ctx, eksaClusterResourceType, clusterSpec.Name, expectedPauseAnnotation, clusterObj, "").Return(nil)
+	m.client.EXPECT().UpdateAnnotationInNamespace(ctx, eksaVSphereDatacenterResourceType, clusterSpec.Cluster.Spec.DatacenterRef.Name, expectedPauseAnnotation, clusterObj, "").Return(nil)
+	m.client.EXPECT().UpdateAnnotationInNamespace(ctx, eksaVSphereMachineResourceType, clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, expectedPauseAnnotation, clusterObj, "").Return(nil)
+	m.client.EXPECT().UpdateAnnotationInNamespace(ctx, eksaVSphereMachineResourceType, clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, expectedPauseAnnotation, clusterObj, "").Return(nil)
+	m.client.EXPECT().UpdateAnnotationInNamespace(ctx, eksaClusterResourceType, clusterSpec.Cluster.Name, expectedPauseAnnotation, clusterObj, "").Return(nil)
 
 	if err := cm.PauseEKSAControllerReconcile(ctx, clusterObj, clusterSpec, m.provider); err != nil {
 		t.Errorf("ClusterManager.PauseEKSAControllerReconcile() error = %v, wantErr nil", err)
@@ -841,7 +841,7 @@ func TestClusterManagerResumeEKSAControllerReconcileSuccessWithoutMachineConfig(
 			},
 		},
 	}
-	clusterSpec.PauseReconcile()
+	clusterSpec.Cluster.PauseReconcile()
 
 	datacenterConfig := &v1alpha1.VSphereDatacenterConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -857,13 +857,13 @@ func TestClusterManagerResumeEKSAControllerReconcileSuccessWithoutMachineConfig(
 	m.provider.EXPECT().DatacenterResourceType().Return(eksaVSphereDatacenterResourceType)
 	m.provider.EXPECT().MachineResourceType().Return("")
 	m.provider.EXPECT().DatacenterConfig().Return(datacenterConfig)
-	m.client.EXPECT().RemoveAnnotationInNamespace(ctx, eksaVSphereDatacenterResourceType, clusterSpec.Spec.DatacenterRef.Name, pauseAnnotation, clusterObj, "").Return(nil)
-	m.client.EXPECT().RemoveAnnotationInNamespace(ctx, eksaClusterResourceType, clusterSpec.Name, pauseAnnotation, clusterObj, "").Return(nil)
+	m.client.EXPECT().RemoveAnnotationInNamespace(ctx, eksaVSphereDatacenterResourceType, clusterSpec.Cluster.Spec.DatacenterRef.Name, pauseAnnotation, clusterObj, "").Return(nil)
+	m.client.EXPECT().RemoveAnnotationInNamespace(ctx, eksaClusterResourceType, clusterSpec.Cluster.Name, pauseAnnotation, clusterObj, "").Return(nil)
 
 	if err := cm.ResumeEKSAControllerReconcile(ctx, clusterObj, clusterSpec, m.provider); err != nil {
 		t.Errorf("ClusterManager.ResumeEKSAControllerReconcile() error = %v, wantErr nil", err)
 	}
-	annotations := clusterSpec.GetAnnotations()
+	annotations := clusterSpec.Cluster.GetAnnotations()
 	if _, ok := annotations[pauseAnnotation]; ok {
 		t.Errorf("%s annotation exists, should be removed", pauseAnnotation)
 	}
@@ -1009,13 +1009,13 @@ func TestClusterManagerClusterSpecChangedNoChanges(t *testing.T) {
 	tt.clusterSpec.Cluster.Spec.IdentityProviderRefs = []v1alpha1.Ref{{Kind: v1alpha1.OIDCConfigKind, Name: tt.clusterName}}
 	tt.clusterSpec.OIDCConfig = tt.oldOIDCConfig.DeepCopy()
 
-	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Cluster.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
 	tt.mocks.client.EXPECT().GetEksaVSphereDatacenterConfig(tt.ctx, tt.oldClusterConfig.Spec.DatacenterRef.Name, gomock.Any(), gomock.Any()).Return(tt.oldDatacenterConfig, nil)
 	tt.mocks.client.EXPECT().GetEksaVSphereMachineConfig(tt.ctx, tt.oldClusterConfig.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, gomock.Any(), gomock.Any()).Return(tt.oldControlPlaneMachineConfig, nil)
 	tt.mocks.client.EXPECT().GetEksaVSphereMachineConfig(tt.ctx, tt.oldClusterConfig.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, gomock.Any(), gomock.Any()).Return(tt.oldWorkerMachineConfig, nil)
-	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.oldClusterConfig.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Namespace).Return(tt.oldOIDCConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.oldClusterConfig.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(tt.oldOIDCConfig, nil)
 	diff, err := tt.clusterManager.EKSAClusterSpecChanged(tt.ctx, tt.cluster, tt.clusterSpec, tt.newDatacenterConfig, []providers.MachineConfig{tt.newControlPlaneMachineConfig, tt.newWorkerMachineConfig})
 	assert.Nil(t, err, "Error should be nil")
 	assert.False(t, diff, "No changes should have been detected")
@@ -1025,7 +1025,7 @@ func TestClusterManagerClusterSpecChangedClusterChanged(t *testing.T) {
 	tt := newSpecChangedTest(t)
 	tt.newClusterConfig.Spec.KubernetesVersion = "1.20"
 
-	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Cluster.Name).Return(tt.oldClusterConfig, nil)
 	diff, err := tt.clusterManager.EKSAClusterSpecChanged(tt.ctx, tt.cluster, tt.clusterSpec, tt.newDatacenterConfig, []providers.MachineConfig{tt.newControlPlaneMachineConfig, tt.newWorkerMachineConfig})
 	assert.Nil(t, err, "Error should be nil")
 	assert.True(t, diff, "Changes should have been detected")
@@ -1035,10 +1035,10 @@ func TestClusterManagerClusterSpecChangedEksDReleaseChanged(t *testing.T) {
 	tt := newSpecChangedTest(t)
 	tt.clusterSpec.VersionsBundle.EksD.Name = "kubernetes-1-19-eks-5"
 
-	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Cluster.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
-	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Namespace).Return(tt.oldOIDCConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(tt.oldOIDCConfig, nil)
 	diff, err := tt.clusterManager.EKSAClusterSpecChanged(tt.ctx, tt.cluster, tt.clusterSpec, tt.newDatacenterConfig, []providers.MachineConfig{tt.newControlPlaneMachineConfig, tt.newWorkerMachineConfig})
 	assert.Nil(t, err, "Error should be nil")
 	assert.True(t, diff, "Changes should have been detected")
@@ -1049,10 +1049,10 @@ func TestClusterManagerClusterSpecChangedNoChangesDatacenterSpecChanged(t *testi
 	tt.newDatacenterConfig.Spec.Insecure = false
 	tt.clusterSpec.OIDCConfig = tt.oldOIDCConfig.DeepCopy()
 
-	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Cluster.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
-	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Namespace).Return(tt.oldOIDCConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(tt.oldOIDCConfig, nil)
 	tt.mocks.client.EXPECT().GetEksaVSphereDatacenterConfig(tt.ctx, tt.oldClusterConfig.Spec.DatacenterRef.Name, gomock.Any(), gomock.Any()).Return(tt.oldDatacenterConfig, nil)
 	diff, err := tt.clusterManager.EKSAClusterSpecChanged(tt.ctx, tt.cluster, tt.clusterSpec, tt.newDatacenterConfig, []providers.MachineConfig{tt.newControlPlaneMachineConfig, tt.newWorkerMachineConfig})
 	assert.Nil(t, err, "Error should be nil")
@@ -1064,12 +1064,12 @@ func TestClusterManagerClusterSpecChangedNoChangesControlPlaneMachineConfigSpecC
 	tt.newControlPlaneMachineConfig.Spec.NumCPUs = 4
 	tt.clusterSpec.OIDCConfig = tt.oldOIDCConfig.DeepCopy()
 
-	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Cluster.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
 	tt.mocks.client.EXPECT().GetEksaVSphereDatacenterConfig(tt.ctx, tt.oldClusterConfig.Spec.DatacenterRef.Name, gomock.Any(), gomock.Any()).Return(tt.oldDatacenterConfig, nil)
 	tt.mocks.client.EXPECT().GetEksaVSphereMachineConfig(tt.ctx, tt.oldClusterConfig.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, gomock.Any(), gomock.Any()).Return(tt.oldControlPlaneMachineConfig, nil)
-	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Namespace).Return(tt.oldOIDCConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(tt.oldOIDCConfig, nil)
 	diff, err := tt.clusterManager.EKSAClusterSpecChanged(tt.ctx, tt.cluster, tt.clusterSpec, tt.newDatacenterConfig, []providers.MachineConfig{tt.newControlPlaneMachineConfig, tt.newWorkerMachineConfig})
 
 	assert.Nil(t, err, "Error should be nil")
@@ -1081,13 +1081,13 @@ func TestClusterManagerClusterSpecChangedNoChangesWorkerNodeMachineConfigSpecCha
 	tt.newWorkerMachineConfig.Spec.NumCPUs = 4
 	tt.clusterSpec.OIDCConfig = tt.oldOIDCConfig.DeepCopy()
 
-	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Cluster.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
 	tt.mocks.client.EXPECT().GetEksaVSphereDatacenterConfig(tt.ctx, tt.oldClusterConfig.Spec.DatacenterRef.Name, gomock.Any(), gomock.Any()).Return(tt.oldDatacenterConfig, nil)
 	tt.mocks.client.EXPECT().GetEksaVSphereMachineConfig(tt.ctx, tt.oldClusterConfig.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, gomock.Any(), gomock.Any()).Return(tt.oldControlPlaneMachineConfig, nil)
 	tt.mocks.client.EXPECT().GetEksaVSphereMachineConfig(tt.ctx, tt.oldClusterConfig.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, gomock.Any(), gomock.Any()).Return(tt.oldWorkerMachineConfig, nil)
-	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Namespace).Return(tt.oldOIDCConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(tt.oldOIDCConfig, nil)
 	diff, err := tt.clusterManager.EKSAClusterSpecChanged(tt.ctx, tt.cluster, tt.clusterSpec, tt.newDatacenterConfig, []providers.MachineConfig{tt.newControlPlaneMachineConfig, tt.newWorkerMachineConfig})
 
 	assert.Nil(t, err, "Error should be nil")
@@ -1103,14 +1103,14 @@ func TestClusterManagerClusterSpecChangedGitOpsDefault(t *testing.T) {
 	tt.clusterSpec.Cluster.Spec.IdentityProviderRefs = []v1alpha1.Ref{{Kind: v1alpha1.OIDCConfigKind, Name: tt.clusterName}}
 	tt.clusterSpec.OIDCConfig = tt.oldOIDCConfig.DeepCopy()
 
-	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Name).Return(tt.oldClusterConfig, nil)
-	tt.mocks.client.EXPECT().GetEksaGitOpsConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.GitOpsRef.Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Namespace).Return(oldGitOpsConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Cluster.Name).Return(tt.oldClusterConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaGitOpsConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.GitOpsRef.Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(oldGitOpsConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
 	tt.mocks.client.EXPECT().GetEksaVSphereDatacenterConfig(tt.ctx, tt.oldClusterConfig.Spec.DatacenterRef.Name, gomock.Any(), gomock.Any()).Return(tt.oldDatacenterConfig, nil)
 	tt.mocks.client.EXPECT().GetEksaVSphereMachineConfig(tt.ctx, tt.oldClusterConfig.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, gomock.Any(), gomock.Any()).Return(tt.oldControlPlaneMachineConfig, nil)
 	tt.mocks.client.EXPECT().GetEksaVSphereMachineConfig(tt.ctx, tt.oldClusterConfig.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, gomock.Any(), gomock.Any()).Return(tt.oldWorkerMachineConfig, nil)
-	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Namespace).Return(tt.oldOIDCConfig, nil)
+	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(tt.oldOIDCConfig, nil)
 	diff, err := tt.clusterManager.EKSAClusterSpecChanged(tt.ctx, tt.cluster, tt.clusterSpec, tt.newDatacenterConfig, []providers.MachineConfig{tt.newControlPlaneMachineConfig, tt.newWorkerMachineConfig})
 
 	assert.Nil(t, err, "Error should be nil")

--- a/pkg/clustermanager/retrier_client.go
+++ b/pkg/clustermanager/retrier_client.go
@@ -65,12 +65,12 @@ func (c *retrierClient) installCustomComponents(ctx context.Context, clusterSpec
 	}
 
 	// inject proxy env vars the eksa-controller-manager deployment if proxy is configured
-	if clusterSpec.Spec.ProxyConfiguration != nil {
-		noProxyList := append(clusterSpec.Spec.ProxyConfiguration.NoProxy, clusterSpec.Spec.ClusterNetwork.Pods.CidrBlocks...)
-		noProxyList = append(noProxyList, clusterSpec.Spec.ClusterNetwork.Services.CidrBlocks...)
+	if clusterSpec.Cluster.Spec.ProxyConfiguration != nil {
+		noProxyList := append(clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy, clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks...)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks...)
 		envMap := map[string]string{
-			"HTTP_PROXY":  clusterSpec.Spec.ProxyConfiguration.HttpProxy,
-			"HTTPS_PROXY": clusterSpec.Spec.ProxyConfiguration.HttpsProxy,
+			"HTTP_PROXY":  clusterSpec.Cluster.Spec.ProxyConfiguration.HttpProxy,
+			"HTTPS_PROXY": clusterSpec.Cluster.Spec.ProxyConfiguration.HttpsProxy,
 			"NO_PROXY":    strings.Join(noProxyList[:], ","),
 		}
 		err = c.Retrier.Retry(

--- a/pkg/clustermarshaller/clustermarshaller.go
+++ b/pkg/clustermarshaller/clustermarshaller.go
@@ -46,7 +46,7 @@ func MarshalClusterSpec(clusterSpec *cluster.Spec, datacenterConfig providers.Da
 		if err != nil {
 			return nil, fmt.Errorf("failed marshalling resource for cluster spec: %v", err)
 		}
-		if clusterSpec.Spec.ClusterNetwork.DNS.ResolvConf == nil {
+		if clusterSpec.Cluster.Spec.ClusterNetwork.DNS.ResolvConf == nil {
 			removeFromDefaultConfig := []string{"spec.clusterNetwork.dns"}
 			resource, err = api.CleanupPathsFromYaml(resource, removeFromDefaultConfig)
 			if err != nil {

--- a/pkg/clustermarshaller/clustermarshaller_test.go
+++ b/pkg/clustermarshaller/clustermarshaller_test.go
@@ -65,7 +65,7 @@ func TestWriteClusterConfigWithOIDCAndGitOps(t *testing.T) {
 				},
 			},
 		}
-		s.SetSelfManaged()
+		s.Cluster.SetSelfManaged()
 	})
 
 	datacenterConfig := &v1alpha1.VSphereDatacenterConfig{

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -71,8 +71,8 @@ func (d *Dependencies) Close(ctx context.Context) error {
 func ForSpec(ctx context.Context, clusterSpec *cluster.Spec) *Factory {
 	eksaToolsImage := clusterSpec.VersionsBundle.Eksa.CliTools
 	return NewFactory().
-		WithExecutableImage(clusterSpec.UseImageMirror(eksaToolsImage.VersionedImage())).
-		WithWriterFolder(clusterSpec.Name).
+		WithExecutableImage(clusterSpec.Cluster.UseImageMirror(eksaToolsImage.VersionedImage())).
+		WithWriterFolder(clusterSpec.Cluster.Name).
 		WithDiagnosticCollectorImage(clusterSpec.VersionsBundle.Eksa.DiagnosticCollector.VersionedImage())
 }
 

--- a/pkg/diagnostics/diagnostic_bundle.go
+++ b/pkg/diagnostics/diagnostic_bundle.go
@@ -87,7 +87,7 @@ func newDiagnosticBundleFromSpec(af AnalyzerFactory, cf CollectorFactory, spec *
 				APIVersion: troubleshootApiVersion,
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: spec.Name,
+				Name: spec.Cluster.Name,
 			},
 			Spec: supportBundleSpec{},
 		},
@@ -104,10 +104,10 @@ func newDiagnosticBundleFromSpec(af AnalyzerFactory, cf CollectorFactory, spec *
 	b = b.
 		WithGitOpsConfig(spec.GitOpsConfig).
 		WithOidcConfig(spec.OIDCConfig).
-		WithExternalEtcd(spec.Spec.ExternalEtcdConfiguration).
-		WithDatacenterConfig(spec.Spec.DatacenterRef).
+		WithExternalEtcd(spec.Cluster.Spec.ExternalEtcdConfiguration).
+		WithDatacenterConfig(spec.Cluster.Spec.DatacenterRef).
 		WithMachineConfigs(provider.MachineConfigs()).
-		WithManagementCluster(spec.IsSelfManaged()).
+		WithManagementCluster(spec.Cluster.IsSelfManaged()).
 		WithDefaultAnalyzers().
 		WithDefaultCollectors().
 		WithLogTextAnalyzers()

--- a/pkg/executables/kind_test.go
+++ b/pkg/executables/kind_test.go
@@ -28,7 +28,7 @@ func TestKindCreateBootstrapClusterSuccess(t *testing.T) {
 
 	clusterName := "test_cluster"
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = clusterName
+		s.Cluster.Name = clusterName
 		s.VersionsBundle = versionBundle
 	})
 	eksClusterName := "test_cluster-eks-a-cluster"
@@ -38,9 +38,9 @@ func TestKindCreateBootstrapClusterSuccess(t *testing.T) {
 	registryMirrorWithPort := net.JoinHostPort(registryMirror, constants.DefaultHttpsPort)
 	kindImageMirror := fmt.Sprintf("%s/l0g8r8j6/kubernetes-sigs/kind/node:v1.20.2", registryMirrorWithPort)
 	clusterSpecWithMirror := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = clusterName
+		s.Cluster.Name = clusterName
 		s.VersionsBundle = versionBundle
-		s.Spec.RegistryMirrorConfiguration = &v1alpha1.RegistryMirrorConfiguration{
+		s.Cluster.Spec.RegistryMirrorConfiguration = &v1alpha1.RegistryMirrorConfiguration{
 			Endpoint: registryMirror,
 			Port:     constants.DefaultHttpsPort,
 		}
@@ -207,7 +207,7 @@ func TestKindCreateBootstrapClusterSuccess(t *testing.T) {
 
 func TestKindCreateBootstrapClusterExecutableError(t *testing.T) {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = "clusterName"
+		s.Cluster.Name = "clusterName"
 		s.VersionsBundle = versionBundle
 	})
 

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -47,7 +47,7 @@ func givenEmptyClusterSpec() *cluster.Spec {
 	return test.NewClusterSpec(func(s *cluster.Spec) {
 		s.VersionsBundle.KubeVersion = "1.19"
 		s.VersionsBundle.EksD.Name = eksd119Release
-		s.Namespace = "test-namespace"
+		s.Cluster.Namespace = "test-namespace"
 	})
 }
 
@@ -309,7 +309,7 @@ func TestSetupAndValidateCreateWorkloadClusterSuccess(t *testing.T) {
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	provider.providerKubectlClient = kubectl
 
-	clusterSpec.SetManagedBy("management-cluster")
+	clusterSpec.Cluster.SetManagedBy("management-cluster")
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
@@ -318,7 +318,7 @@ func TestSetupAndValidateCreateWorkloadClusterSuccess(t *testing.T) {
 	for _, config := range newMachineConfigs {
 		kubectl.EXPECT().SearchCloudStackMachineConfig(context.TODO(), config.Name, clusterSpec.ManagementCluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.CloudStackMachineConfig{}, nil)
 	}
-	kubectl.EXPECT().SearchCloudStackDatacenterConfig(context.TODO(), datacenterConfig.Name, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Namespace).Return([]*v1alpha1.CloudStackDatacenterConfig{}, nil)
+	kubectl.EXPECT().SearchCloudStackDatacenterConfig(context.TODO(), datacenterConfig.Name, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return([]*v1alpha1.CloudStackDatacenterConfig{}, nil)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -341,7 +341,7 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfMachineExists(t *testing.T)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	provider.providerKubectlClient = kubectl
 
-	clusterSpec.SetManagedBy("management-cluster")
+	clusterSpec.Cluster.SetManagedBy("management-cluster")
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
@@ -407,7 +407,7 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfDatacenterExists(t *testing
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	provider.providerKubectlClient = kubectl
 
-	clusterSpec.SetManagedBy("management-cluster")
+	clusterSpec.Cluster.SetManagedBy("management-cluster")
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
@@ -417,7 +417,7 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfDatacenterExists(t *testing
 	for _, config := range newMachineConfigs {
 		kubectl.EXPECT().SearchCloudStackMachineConfig(context.TODO(), config.Name, clusterSpec.ManagementCluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.CloudStackMachineConfig{}, nil)
 	}
-	kubectl.EXPECT().SearchCloudStackDatacenterConfig(context.TODO(), datacenterConfig.Name, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Namespace).Return([]*v1alpha1.CloudStackDatacenterConfig{datacenterConfig}, nil)
+	kubectl.EXPECT().SearchCloudStackDatacenterConfig(context.TODO(), datacenterConfig.Name, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return([]*v1alpha1.CloudStackDatacenterConfig{datacenterConfig}, nil)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 
@@ -495,14 +495,14 @@ func TestSetupAndValidateCreateClusterEndpointPortNotSpecified(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host = "host1"
+	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host = "host1"
 	var tctx testContext
 	tctx.SaveContext()
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "host1:6443", clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host)
+	assert.Equal(t, "host1:6443", clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host)
 }
 
 func TestSetupAndValidateCreateClusterEndpointPortSpecified(t *testing.T) {
@@ -510,14 +510,14 @@ func TestSetupAndValidateCreateClusterEndpointPortSpecified(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host = "host1:443"
+	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host = "host1:443"
 	var tctx testContext
 	tctx.SaveContext()
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "host1:443", clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host)
+	assert.Equal(t, "host1:443", clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host)
 }
 
 func TestSetupAndValidateForCreateSSHAuthorizedKeyInvalidCP(t *testing.T) {
@@ -525,7 +525,7 @@ func TestSetupAndValidateForCreateSSHAuthorizedKeyInvalidCP(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
 	var tctx testContext
@@ -540,7 +540,7 @@ func TestSetupAndValidateForCreateSSHAuthorizedKeyInvalidWorker(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
 	var tctx testContext
@@ -555,7 +555,7 @@ func TestSetupAndValidateForCreateSSHAuthorizedKeyInvalidEtcd(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
 	var tctx testContext
@@ -570,7 +570,7 @@ func TestSetupAndValidateSSHAuthorizedKeyEmptyCP(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -589,7 +589,7 @@ func TestSetupAndValidateSSHAuthorizedKeyEmptyWorker(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -608,7 +608,7 @@ func TestSetupAndValidateSSHAuthorizedKeyEmptyEtcd(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -627,11 +627,11 @@ func TestSetupAndValidateSSHAuthorizedKeyEmptyAllMachineConfigs(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
 
 	var tctx testContext

--- a/pkg/providers/cloudstack/spec.go
+++ b/pkg/providers/cloudstack/spec.go
@@ -13,7 +13,7 @@ type Spec struct {
 
 func NewSpec(clusterSpec *cluster.Spec, machineConfigs map[string]*anywherev1.CloudStackMachineConfig, datacenterConfig *anywherev1.CloudStackDatacenterConfig) *Spec {
 	machineConfigsInCluster := map[string]*anywherev1.CloudStackMachineConfig{}
-	for _, m := range clusterSpec.MachineConfigRefs() {
+	for _, m := range clusterSpec.Cluster.MachineConfigRefs() {
 		machineConfig, ok := machineConfigs[m.Name]
 		if !ok {
 			continue

--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -117,11 +117,11 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, cloudStac
 		}
 	}
 
-	if cloudStackClusterSpec.datacenterConfig.Namespace != cloudStackClusterSpec.Namespace {
+	if cloudStackClusterSpec.datacenterConfig.Namespace != cloudStackClusterSpec.Cluster.Namespace {
 		return fmt.Errorf(
 			"CloudStackDatacenterConfig and Cluster objects must have the same namespace: CloudstackDatacenterConfig namespace=%s; Cluster namespace=%s",
 			cloudStackClusterSpec.datacenterConfig.Namespace,
-			cloudStackClusterSpec.Namespace,
+			cloudStackClusterSpec.Cluster.Namespace,
 		)
 	}
 	if len(cloudStackClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations) > 1 {
@@ -150,12 +150,12 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, cloudStac
 	}
 
 	for _, machineConfig := range cloudStackClusterSpec.machineConfigsLookup {
-		if machineConfig.Namespace != cloudStackClusterSpec.Namespace {
+		if machineConfig.Namespace != cloudStackClusterSpec.Cluster.Namespace {
 			return fmt.Errorf(
 				"CloudStackMachineConfig %s and Cluster objects must have the same namespace: CloudStackMachineConfig namespace=%s; Cluster namespace=%s",
 				machineConfig.Name,
 				machineConfig.Namespace,
-				cloudStackClusterSpec.Namespace,
+				cloudStackClusterSpec.Cluster.Namespace,
 			)
 		}
 		if len(machineConfig.Spec.Users) <= 0 {

--- a/pkg/providers/cloudstack/validator_test.go
+++ b/pkg/providers/cloudstack/validator_test.go
@@ -84,7 +84,7 @@ func TestValidateMachineConfigsNoControlPlaneEndpointIP(t *testing.T) {
 		Spec:             clusterSpec,
 		datacenterConfig: datacenterConfig,
 	}
-	clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host = ""
+	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host = ""
 
 	err = validator.ValidateClusterMachineConfigs(ctx, cloudStackClusterSpec)
 
@@ -158,11 +158,11 @@ func TestSetupAndValidateUsersNil(t *testing.T) {
 		datacenterConfig:     datacenterConfig,
 		machineConfigsLookup: machineConfigs,
 	}
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.Users = nil
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.Users = nil
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.Users = nil
 	cmk.EXPECT().ValidateDomainPresent(gomock.Any(), gomock.Any()).Times(3)
 	cmk.EXPECT().ValidateZonesPresent(gomock.Any(), gomock.Any()).Times(3).Return([]v1alpha1.CloudStackResourceIdentifier{{Name: "zone1", Id: "4e3b338d-87a6-4189-b931-a1747edeea8f"}}, nil)
@@ -194,11 +194,11 @@ func TestSetupAndValidateRestrictedUserDetails(t *testing.T) {
 		datacenterConfig:     datacenterConfig,
 		machineConfigsLookup: machineConfigs,
 	}
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.UserCustomDetails = map[string]string{"keyboard": "test"}
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.UserCustomDetails = map[string]string{"keyboard": "test"}
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.UserCustomDetails = map[string]string{"keyboard": "test"}
 
 	err = validator.ValidateClusterMachineConfigs(ctx, cloudStackClusterSpec)
@@ -225,11 +225,11 @@ func TestSetupAndValidateSshAuthorizedKeysNil(t *testing.T) {
 		datacenterConfig:     datacenterConfig,
 		machineConfigsLookup: machineConfigs,
 	}
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.Users[0].SshAuthorizedKeys = nil
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys = nil
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys = nil
 
 	cmk.EXPECT().ValidateDomainPresent(gomock.Any(), gomock.Any()).Times(3)
@@ -261,7 +261,7 @@ func TestSetupAndValidateCreateClusterCPMachineGroupRefNil(t *testing.T) {
 		datacenterConfig:     datacenterConfig,
 		machineConfigsLookup: machineConfigs,
 	}
-	clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef = nil
+	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef = nil
 
 	err = validator.ValidateClusterMachineConfigs(ctx, cloudStackClusterSpec)
 	thenErrorExpected(t, "must specify machineGroupRef for control plane", err)
@@ -285,7 +285,7 @@ func TestSetupAndValidateCreateClusterWorkerMachineGroupRefNil(t *testing.T) {
 		datacenterConfig:     datacenterConfig,
 		machineConfigsLookup: machineConfigs,
 	}
-	clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef = nil
+	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef = nil
 
 	err = validator.ValidateClusterMachineConfigs(ctx, cloudStackClusterSpec)
 	thenErrorExpected(t, "must specify machineGroupRef for worker nodes", err)
@@ -309,7 +309,7 @@ func TestSetupAndValidateCreateClusterEtcdMachineGroupRefNil(t *testing.T) {
 		datacenterConfig:     datacenterConfig,
 		machineConfigsLookup: machineConfigs,
 	}
-	clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef = nil
+	clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef = nil
 
 	err = validator.ValidateClusterMachineConfigs(ctx, cloudStackClusterSpec)
 	thenErrorExpected(t, "must specify machineGroupRef for etcd machines", err)
@@ -333,7 +333,7 @@ func TestSetupAndValidateCreateClusterCPMachineGroupRefNonexistent(t *testing.T)
 		datacenterConfig:     datacenterConfig,
 		machineConfigsLookup: machineConfigs,
 	}
-	clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "nonexistent"
+	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "nonexistent"
 
 	err = validator.ValidateClusterMachineConfigs(ctx, cloudStackClusterSpec)
 	thenErrorExpected(t, "cannot find CloudStackMachineConfig nonexistent for control plane", err)
@@ -357,7 +357,7 @@ func TestSetupAndValidateCreateClusterWorkerMachineGroupRefNonexistent(t *testin
 		datacenterConfig:     datacenterConfig,
 		machineConfigsLookup: machineConfigs,
 	}
-	clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name = "nonexistent"
+	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name = "nonexistent"
 
 	err = validator.ValidateClusterMachineConfigs(ctx, cloudStackClusterSpec)
 	thenErrorExpected(t, "cannot find CloudStackMachineConfig nonexistent for worker nodes", err)
@@ -381,7 +381,7 @@ func TestSetupAndValidateCreateClusterEtcdMachineGroupRefNonexistent(t *testing.
 		datacenterConfig:     datacenterConfig,
 		machineConfigsLookup: machineConfigs,
 	}
-	clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name = "nonexistent"
+	clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name = "nonexistent"
 
 	err = validator.ValidateClusterMachineConfigs(ctx, cloudStackClusterSpec)
 	thenErrorExpected(t, "cannot find CloudStackMachineConfig nonexistent for etcd machines", err)
@@ -405,7 +405,7 @@ func TestSetupAndValidateCreateClusterTemplateDifferent(t *testing.T) {
 		datacenterConfig:     datacenterConfig,
 		machineConfigsLookup: machineConfigs,
 	}
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.Template = v1alpha1.CloudStackResourceRef{Value: "different", Type: "name"}
 
 	err = validator.ValidateClusterMachineConfigs(ctx, cloudStackClusterSpec)
@@ -438,7 +438,7 @@ func TestValidateMachineConfigsHappyCase(t *testing.T) {
 	cmk.EXPECT().ValidateAffinityGroupsPresent(ctx, gomock.Any(), datacenterConfig.Spec.Account, gomock.Any()).Times(3)
 	err = validator.ValidateClusterMachineConfigs(ctx, cloudStackClusterSpec)
 	assert.Nil(t, err)
-	assert.Equal(t, "1.2.3.4:6443", clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host)
+	assert.Equal(t, "1.2.3.4:6443", clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host)
 }
 
 func TestValidateCloudStackMachineConfig(t *testing.T) {

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -95,7 +95,7 @@ func (p *provider) DeleteResources(_ context.Context, _ *cluster.Spec) error {
 
 func (p *provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpec *cluster.Spec) error {
 	logger.Info("Warning: The docker infrastructure provider is meant for local development and testing only")
-	if clusterSpec.Spec.ControlPlaneConfiguration.Endpoint != nil && clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host != "" {
+	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint != nil && clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host != "" {
 		return fmt.Errorf("specifying endpoint host configuration in Cluster is not supported")
 	}
 	return nil
@@ -159,14 +159,14 @@ func (d *DockerTemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluste
 }
 
 func (d *DockerTemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, workloadTemplateNames, kubeadmconfigTemplateNames map[string]string) (content []byte, err error) {
-	workerSpecs := make([][]byte, 0, len(clusterSpec.Spec.WorkerNodeGroupConfigurations))
-	for _, workerNodeGroupConfiguration := range clusterSpec.Spec.WorkerNodeGroupConfigurations {
+	workerSpecs := make([][]byte, 0, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	for _, workerNodeGroupConfiguration := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
 		values := buildTemplateMapMD(clusterSpec, workerNodeGroupConfiguration)
 		_, ok := workloadTemplateNames[workerNodeGroupConfiguration.Name]
 		if workloadTemplateNames != nil && ok {
 			values["workloadTemplateName"] = workloadTemplateNames[workerNodeGroupConfiguration.Name]
 		} else {
-			values["workloadTemplateName"] = d.WorkerMachineTemplateName(clusterSpec.Name, workerNodeGroupConfiguration.Name)
+			values["workloadTemplateName"] = d.WorkerMachineTemplateName(clusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name)
 		}
 
 		bytes, err := templater.Execute(defaultCAPIConfigMD, values)
@@ -184,16 +184,16 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) map[string]interface{} {
 	etcdExtraArgs := clusterapi.SecureEtcdTlsCipherSuitesExtraArgs()
 	sharedExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs()
 	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
-		Append(clusterapi.ResolvConfExtraArgs(clusterSpec.Spec.ClusterNetwork.DNS.ResolvConf)).
-		Append(clusterapi.ControlPlaneNodeLabelsExtraArgs(clusterSpec.Spec.ControlPlaneConfiguration))
+		Append(clusterapi.ResolvConfExtraArgs(clusterSpec.Cluster.Spec.ClusterNetwork.DNS.ResolvConf)).
+		Append(clusterapi.ControlPlaneNodeLabelsExtraArgs(clusterSpec.Cluster.Spec.ControlPlaneConfiguration))
 	apiServerExtraArgs := clusterapi.OIDCToExtraArgs(clusterSpec.OIDCConfig).
 		Append(clusterapi.AwsIamAuthExtraArgs(clusterSpec.AWSIamConfig)).
-		Append(clusterapi.PodIAMAuthExtraArgs(clusterSpec.Spec.PodIAMConfig)).
+		Append(clusterapi.PodIAMAuthExtraArgs(clusterSpec.Cluster.Spec.PodIAMConfig)).
 		Append(sharedExtraArgs)
 
 	values := map[string]interface{}{
-		"clusterName":                clusterSpec.Name,
-		"control_plane_replicas":     clusterSpec.Spec.ControlPlaneConfiguration.Count,
+		"clusterName":                clusterSpec.Cluster.Name,
+		"control_plane_replicas":     clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Count,
 		"kubernetesRepository":       bundle.KubeDistro.Kubernetes.Repository,
 		"kubernetesVersion":          bundle.KubeDistro.Kubernetes.Tag,
 		"etcdRepository":             bundle.KubeDistro.Etcd.Repository,
@@ -210,21 +210,21 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) map[string]interface{} {
 		"externalEtcdVersion":        bundle.KubeDistro.EtcdVersion,
 		"eksaSystemNamespace":        constants.EksaSystemNamespace,
 		"auditPolicy":                common.GetAuditPolicy(),
-		"podCidrs":                   clusterSpec.Spec.ClusterNetwork.Pods.CidrBlocks,
-		"serviceCidrs":               clusterSpec.Spec.ClusterNetwork.Services.CidrBlocks,
+		"podCidrs":                   clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks,
+		"serviceCidrs":               clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks,
 		"haproxyImageRepository":     getHAProxyImageRepo(bundle.Haproxy.Image),
 		"haproxyImageTag":            bundle.Haproxy.Image.Tag(),
 	}
 
-	if clusterSpec.Spec.ExternalEtcdConfiguration != nil {
+	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		values["externalEtcd"] = true
-		values["externalEtcdReplicas"] = clusterSpec.Spec.ExternalEtcdConfiguration.Count
+		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
 	}
 	if clusterSpec.AWSIamConfig != nil {
 		values["awsIamAuth"] = true
 	}
 
-	values["controlPlaneTaints"] = clusterSpec.Spec.ControlPlaneConfiguration.Taints
+	values["controlPlaneTaints"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints
 
 	return values
 }
@@ -233,16 +233,16 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration 
 	bundle := clusterSpec.VersionsBundle
 	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
 		Append(clusterapi.WorkerNodeLabelsExtraArgs(workerNodeGroupConfiguration)).
-		Append(clusterapi.ResolvConfExtraArgs(clusterSpec.Spec.ClusterNetwork.DNS.ResolvConf))
+		Append(clusterapi.ResolvConfExtraArgs(clusterSpec.Cluster.Spec.ClusterNetwork.DNS.ResolvConf))
 
 	values := map[string]interface{}{
-		"clusterName":           clusterSpec.Name,
+		"clusterName":           clusterSpec.Cluster.Name,
 		"kubernetesVersion":     bundle.KubeDistro.Kubernetes.Tag,
 		"kindNodeImage":         bundle.EksD.KindNode.VersionedImage(),
 		"eksaSystemNamespace":   constants.EksaSystemNamespace,
 		"kubeletExtraArgs":      kubeletExtraArgs.ToPartialYaml(),
 		"workerReplicas":        workerNodeGroupConfiguration.Count,
-		"workerNodeGroupName":   fmt.Sprintf("%s-%s", clusterSpec.Name, workerNodeGroupConfiguration.Name),
+		"workerNodeGroupName":   fmt.Sprintf("%s-%s", clusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name),
 		"workerNodeGroupTaints": workerNodeGroupConfiguration.Taints,
 	}
 
@@ -254,7 +254,7 @@ func NeedsNewControlPlaneTemplate(oldSpec, newSpec *cluster.Spec) bool {
 }
 
 func NeedsNewWorkloadTemplate(oldSpec, newSpec *cluster.Spec) bool {
-	if !v1alpha1.WorkerNodeGroupConfigurationSliceTaintsEqual(oldSpec.Spec.WorkerNodeGroupConfigurations, newSpec.Spec.WorkerNodeGroupConfigurations) {
+	if !v1alpha1.WorkerNodeGroupConfigurationSliceTaintsEqual(oldSpec.Cluster.Spec.WorkerNodeGroupConfigurations, newSpec.Cluster.Spec.WorkerNodeGroupConfigurations) {
 		return true
 	}
 	return (oldSpec.Cluster.Spec.KubernetesVersion != newSpec.Cluster.Spec.KubernetesVersion) || (oldSpec.Bundles.Spec.Number != newSpec.Bundles.Spec.Number)
@@ -265,7 +265,7 @@ func NeedsNewEtcdTemplate(oldSpec, newSpec *cluster.Spec) bool {
 }
 
 func (p *provider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currentSpec, newClusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
-	clusterName := newClusterSpec.ObjectMeta.Name
+	clusterName := newClusterSpec.Cluster.Name
 	var controlPlaneTemplateName, workloadTemplateName, etcdTemplateName string
 	var needsNewEtcdTemplate bool
 
@@ -280,13 +280,13 @@ func (p *provider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapClus
 		controlPlaneTemplateName = p.templateBuilder.CPMachineTemplateName(clusterName)
 	}
 
-	previousWorkerNodeGroupConfigs := cluster.BuildMapForWorkerNodeGroupsByName(currentSpec.Spec.WorkerNodeGroupConfigurations)
+	previousWorkerNodeGroupConfigs := cluster.BuildMapForWorkerNodeGroupsByName(currentSpec.Cluster.Spec.WorkerNodeGroupConfigurations)
 
-	workloadTemplateNames := make(map[string]string, len(newClusterSpec.Spec.WorkerNodeGroupConfigurations))
-	for _, workerNodeGroupConfiguration := range newClusterSpec.Spec.WorkerNodeGroupConfigurations {
+	workloadTemplateNames := make(map[string]string, len(newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	for _, workerNodeGroupConfiguration := range newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
 		needsNewWorkloadTemplate := NeedsNewWorkloadTemplate(currentSpec, newClusterSpec)
 		if _, ok := previousWorkerNodeGroupConfigs[workerNodeGroupConfiguration.Name]; ok && !needsNewWorkloadTemplate {
-			mdName := machineDeploymentName(newClusterSpec.Name, workerNodeGroupConfiguration.Name)
+			mdName := machineDeploymentName(newClusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name)
 			md, err := p.providerKubectlClient.GetMachineDeployment(ctx, mdName, executables.WithCluster(bootstrapCluster), executables.WithNamespace(constants.EksaSystemNamespace))
 			if err != nil {
 				return nil, nil, err
@@ -299,11 +299,11 @@ func (p *provider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapClus
 		}
 	}
 
-	if newClusterSpec.Spec.ExternalEtcdConfiguration != nil {
+	if newClusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		// TODO: replace controlPlaneMachineConfig with etcdMachineConfig once available in final GA spec
 		needsNewEtcdTemplate = NeedsNewEtcdTemplate(currentSpec, newClusterSpec)
 		if !needsNewEtcdTemplate {
-			etcdadmCluster, err := p.providerKubectlClient.GetEtcdadmCluster(ctx, workloadCluster, newClusterSpec.Name, executables.WithCluster(bootstrapCluster), executables.WithNamespace(constants.EksaSystemNamespace))
+			etcdadmCluster, err := p.providerKubectlClient.GetEtcdadmCluster(ctx, workloadCluster, newClusterSpec.Cluster.Name, executables.WithCluster(bootstrapCluster), executables.WithNamespace(constants.EksaSystemNamespace))
 			if err != nil {
 				return nil, nil, err
 			}
@@ -313,7 +313,7 @@ func (p *provider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapClus
 			as etcd endpoints. KCP rollout should not start until then. As a temporary solution in the absence of static etcd endpoints, we annotate the etcd cluster as "upgrading",
 			so that KCP checks this annotation and does not proceed if etcd cluster is upgrading. The etcdadm controller removes this annotation once the etcd upgrade is complete.
 			*/
-			err = p.providerKubectlClient.UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", newClusterSpec.Name),
+			err = p.providerKubectlClient.UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", newClusterSpec.Cluster.Name),
 				map[string]string{etcdv1.UpgradeInProgressAnnotation: "true"},
 				executables.WithCluster(bootstrapCluster),
 				executables.WithNamespace(constants.EksaSystemNamespace))
@@ -341,7 +341,7 @@ func (p *provider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapClus
 }
 
 func (p *provider) generateCAPISpecForCreate(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
-	clusterName := clusterSpec.ObjectMeta.Name
+	clusterName := clusterSpec.Cluster.Name
 
 	cpOpt := func(values map[string]interface{}) {
 		values["controlPlaneTemplateName"] = p.templateBuilder.CPMachineTemplateName(clusterName)

--- a/pkg/providers/docker/docker_test.go
+++ b/pkg/providers/docker/docker_test.go
@@ -127,14 +127,14 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 		{
 			testName: "valid config",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Name = "test-cluster"
-				s.Spec.KubernetesVersion = "1.19"
-				s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
-				s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
-				s.Spec.ControlPlaneConfiguration.Count = 3
+				s.Cluster.Name = "test-cluster"
+				s.Cluster.Spec.KubernetesVersion = "1.19"
+				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
+				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.VersionsBundle = versionsBundle
-				s.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
 			wantCPFile: "testdata/valid_deployment_cp_expected.yaml",
 			wantMDFile: "testdata/valid_deployment_md_expected.yaml",
@@ -142,15 +142,15 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 		{
 			testName: "valid config with cp taints",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Name = "test-cluster"
-				s.Spec.KubernetesVersion = "1.19"
-				s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
-				s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
-				s.Spec.ControlPlaneConfiguration.Count = 3
-				s.Spec.ControlPlaneConfiguration.Taints = cpTaints
+				s.Cluster.Name = "test-cluster"
+				s.Cluster.Spec.KubernetesVersion = "1.19"
+				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
+				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+				s.Cluster.Spec.ControlPlaneConfiguration.Taints = cpTaints
 				s.VersionsBundle = versionsBundle
-				s.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
 			wantCPFile: "testdata/valid_deployment_cp_taints_expected.yaml",
 			wantMDFile: "testdata/valid_deployment_md_expected.yaml",
@@ -158,15 +158,15 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 		{
 			testName: "valid config with md taints",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Name = "test-cluster"
-				s.Spec.KubernetesVersion = "1.19"
-				s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
-				s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
-				s.Spec.ControlPlaneConfiguration.Count = 3
-				s.Spec.ControlPlaneConfiguration.Taints = cpTaints
+				s.Cluster.Name = "test-cluster"
+				s.Cluster.Spec.KubernetesVersion = "1.19"
+				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
+				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+				s.Cluster.Spec.ControlPlaneConfiguration.Taints = cpTaints
 				s.VersionsBundle = versionsBundle
-				s.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, Taints: wnTaints, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, Taints: wnTaints, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
 			wantCPFile: "testdata/valid_deployment_cp_taints_expected.yaml",
 			wantMDFile: "testdata/valid_deployment_md_taints_expected.yaml",
@@ -174,15 +174,15 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 		{
 			testName: "valid config multiple worker node groups with machine deplyoment taints",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Name = "test-cluster"
-				s.Spec.KubernetesVersion = "1.19"
-				s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
-				s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
-				s.Spec.ControlPlaneConfiguration.Count = 3
-				s.Spec.ControlPlaneConfiguration.Taints = cpTaints
-				s.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, Taints: wnTaints, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}, {Count: 3, Taints: wnTaints2, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-1"}}
+				s.Cluster.Name = "test-cluster"
+				s.Cluster.Spec.KubernetesVersion = "1.19"
+				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
+				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+				s.Cluster.Spec.ControlPlaneConfiguration.Taints = cpTaints
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, Taints: wnTaints, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}, {Count: 3, Taints: wnTaints2, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-1"}}
 				s.VersionsBundle = versionsBundle
-				s.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
+				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 			}),
 			wantCPFile: "testdata/valid_deployment_cp_taints_expected.yaml",
 			wantMDFile: "testdata/valid_deployment_multiple_md_taints_expected.yaml",
@@ -190,14 +190,14 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 		{
 			testName: "valid config with node labels",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Name = "test-cluster"
-				s.Spec.KubernetesVersion = "1.19"
-				s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
-				s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
-				s.Spec.ControlPlaneConfiguration.Count = 3
+				s.Cluster.Name = "test-cluster"
+				s.Cluster.Spec.KubernetesVersion = "1.19"
+				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
+				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.VersionsBundle = versionsBundle
-				s.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Labels: nodeLabels, Name: "md-0"}}
+				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Labels: nodeLabels, Name: "md-0"}}
 			}),
 			wantCPFile: "testdata/valid_deployment_cp_expected.yaml",
 			wantMDFile: "testdata/valid_deployment_node_labels_md_expected.yaml",
@@ -205,15 +205,15 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 		{
 			testName: "valid config with cp node labels",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Name = "test-cluster"
-				s.Spec.KubernetesVersion = "1.19"
-				s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
-				s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
-				s.Spec.ControlPlaneConfiguration.Count = 3
-				s.Spec.ControlPlaneConfiguration.Labels = nodeLabels
+				s.Cluster.Name = "test-cluster"
+				s.Cluster.Spec.KubernetesVersion = "1.19"
+				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
+				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+				s.Cluster.Spec.ControlPlaneConfiguration.Labels = nodeLabels
 				s.VersionsBundle = versionsBundle
-				s.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
 			wantCPFile: "testdata/valid_deployment_node_labels_cp_expected.yaml",
 			wantMDFile: "testdata/valid_deployment_md_expected.yaml",
@@ -221,15 +221,15 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 		{
 			testName: "valid config with cidrs and custom resolv.conf",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Name = "test-cluster"
-				s.Spec.KubernetesVersion = "1.19"
-				s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"10.10.0.0/24", "10.128.0.0/12"}
-				s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"192.168.0.0/16", "10.10.0.0/16"}
-				s.Spec.ClusterNetwork.DNS.ResolvConf = &v1alpha1.ResolvConf{Path: "/etc/my-custom-resolv.conf"}
-				s.Spec.ControlPlaneConfiguration.Count = 3
+				s.Cluster.Name = "test-cluster"
+				s.Cluster.Spec.KubernetesVersion = "1.19"
+				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"10.10.0.0/24", "10.128.0.0/12"}
+				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"192.168.0.0/16", "10.10.0.0/16"}
+				s.Cluster.Spec.ClusterNetwork.DNS.ResolvConf = &v1alpha1.ResolvConf{Path: "/etc/my-custom-resolv.conf"}
+				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.VersionsBundle = versionsBundle
-				s.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
 			wantCPFile: "testdata/valid_deployment_custom_cidrs_cp_expected.yaml",
 			wantMDFile: "testdata/valid_deployment_custom_cidrs_md_expected.yaml",
@@ -237,14 +237,14 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 		{
 			testName: "with minimal oidc",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Name = "test-cluster"
-				s.Spec.KubernetesVersion = "1.19"
-				s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
-				s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
-				s.Spec.ControlPlaneConfiguration.Count = 3
+				s.Cluster.Name = "test-cluster"
+				s.Cluster.Spec.KubernetesVersion = "1.19"
+				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
+				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.VersionsBundle = versionsBundle
-				s.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 
 				s.OIDCConfig = &v1alpha1.OIDCConfig{
 					Spec: v1alpha1.OIDCConfigSpec{
@@ -259,14 +259,14 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 		{
 			testName: "with full oidc",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Name = "test-cluster"
-				s.Spec.KubernetesVersion = "1.19"
-				s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
-				s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
-				s.Spec.ControlPlaneConfiguration.Count = 3
+				s.Cluster.Name = "test-cluster"
+				s.Cluster.Spec.KubernetesVersion = "1.19"
+				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
+				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.VersionsBundle = versionsBundle
-				s.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 				s.OIDCConfig = &v1alpha1.OIDCConfig{
 					Spec: v1alpha1.OIDCConfigSpec{
 						ClientId:     "my-client-id",
@@ -303,7 +303,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 			bootstrapCluster := &types.Cluster{
 				Name: "bootstrap-test",
 			}
-			kubectl.EXPECT().UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", tt.clusterSpec.Name),
+			kubectl.EXPECT().UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", tt.clusterSpec.Cluster.Name),
 				map[string]string{etcdv1.UpgradeInProgressAnnotation: "true"}, gomock.Any(), gomock.Any())
 			cpContent, mdContent, err := p.GenerateCAPISpecForUpgrade(ctx, bootstrapCluster, cluster, currentSpec, tt.clusterSpec)
 			if err != nil {
@@ -321,9 +321,9 @@ func TestProviderGenerateDeploymentFileSuccessNotUpdateMachineTemplate(t *testin
 	client := dockerMocks.NewMockProviderClient(mockCtrl)
 	kubectl := dockerMocks.NewMockProviderKubectlClient(mockCtrl)
 	clusterSpec := test.NewClusterSpec()
-	clusterSpec.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
-	clusterSpec.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
-	clusterSpec.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 0, MachineGroupRef: &v1alpha1.Ref{Name: "fluxAddonTestCluster"}, Name: "md-0"}}
+	clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+	clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
+	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 0, MachineGroupRef: &v1alpha1.Ref{Name: "fluxAddonTestCluster"}, Name: "md-0"}}
 	p := docker.NewProvider(&v1alpha1.DockerDatacenterConfig{}, client, kubectl, test.FakeNow)
 	cluster := &types.Cluster{
 		Name: "test",
@@ -353,7 +353,7 @@ func TestProviderGenerateDeploymentFileSuccessNotUpdateMachineTemplate(t *testin
 			},
 		},
 	}
-	machineDeploymentName := fmt.Sprintf("%s-%s", clusterSpec.Name, clusterSpec.Spec.WorkerNodeGroupConfigurations[0].Name)
+	machineDeploymentName := fmt.Sprintf("%s-%s", clusterSpec.Cluster.Name, clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Name)
 
 	kubectl.EXPECT().GetKubeadmControlPlane(ctx, cluster, cluster.Name, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(cp, nil)
 	kubectl.EXPECT().GetMachineDeployment(ctx, machineDeploymentName, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(md, nil)
@@ -369,8 +369,8 @@ func TestProviderGenerateDeploymentFileSuccessNotUpdateMachineTemplate(t *testin
 
 func TestSetupAndValidateClusterWithEndpoint(t *testing.T) {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = "test-cluster"
-		s.Spec.ControlPlaneConfiguration.Endpoint = &v1alpha1.Endpoint{Host: "test-ip"}
+		s.Cluster.Name = "test-cluster"
+		s.Cluster.Spec.ControlPlaneConfiguration.Endpoint = &v1alpha1.Endpoint{Host: "test-ip"}
 	})
 	mockCtrl := gomock.NewController(t)
 	client := dockerMocks.NewMockProviderClient(mockCtrl)
@@ -395,7 +395,7 @@ func TestGetInfrastructureBundleSuccess(t *testing.T) {
 		{
 			testName: "create overrides layer",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Name = "test-cluster"
+				s.Cluster.Name = "test-cluster"
 				s.VersionsBundle = versionsBundle
 			}),
 		},
@@ -508,16 +508,16 @@ func TestProviderGenerateCAPISpecForCreateWithPodIAMConfig(t *testing.T) {
 		Name: "test-cluster",
 	}
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = "test-cluster"
-		s.Spec.KubernetesVersion = "1.19"
-		s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
-		s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
-		s.Spec.ControlPlaneConfiguration.Count = 1
+		s.Cluster.Name = "test-cluster"
+		s.Cluster.Spec.KubernetesVersion = "1.19"
+		s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+		s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 1
 		s.VersionsBundle = versionsBundle
-		s.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-		s.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}}}
+		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
+		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}}}
 	})
-	clusterSpec.Spec.PodIAMConfig = &v1alpha1.PodIAMConfig{ServiceAccountIssuer: "https://test"}
+	clusterSpec.Cluster.Spec.PodIAMConfig = &v1alpha1.PodIAMConfig{ServiceAccountIssuer: "https://test"}
 
 	if provider == nil {
 		t.Fatalf("provider object is nil")
@@ -545,13 +545,13 @@ func TestProviderGenerateCAPISpecForCreateWithStackedEtcd(t *testing.T) {
 		Name: "test-cluster",
 	}
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = "test-cluster"
-		s.Spec.KubernetesVersion = "1.19"
-		s.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
-		s.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
-		s.Spec.ControlPlaneConfiguration.Count = 1
+		s.Cluster.Name = "test-cluster"
+		s.Cluster.Spec.KubernetesVersion = "1.19"
+		s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+		s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 1
 		s.VersionsBundle = versionsBundle
-		s.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}}}
+		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}}}
 	})
 
 	if provider == nil {

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -32,7 +32,7 @@ func newApiBuilerTest(t *testing.T) apiBuilerTest {
 func TestCAPICluster(t *testing.T) {
 	tt := newApiBuilerTest(t)
 	snowCluster := SnowCluster(tt.clusterSpec)
-	controlPlaneMachineTemplate := SnowMachineTemplate(tt.machineConfigs[tt.clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name])
+	controlPlaneMachineTemplate := SnowMachineTemplate(tt.machineConfigs[tt.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name])
 	kubeadmControlPlane := KubeadmControlPlane(tt.clusterSpec, controlPlaneMachineTemplate)
 	got := CAPICluster(tt.clusterSpec, snowCluster, kubeadmControlPlane)
 	want := &clusterv1.Cluster{
@@ -77,7 +77,7 @@ func TestCAPICluster(t *testing.T) {
 
 func TestKubeadmControlPlane(t *testing.T) {
 	tt := newApiBuilerTest(t)
-	controlPlaneMachineTemplate := SnowMachineTemplate(tt.machineConfigs[tt.clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name])
+	controlPlaneMachineTemplate := SnowMachineTemplate(tt.machineConfigs[tt.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name])
 	got := KubeadmControlPlane(tt.clusterSpec, controlPlaneMachineTemplate)
 	wantReplicas := int32(3)
 	want := &controlplanev1.KubeadmControlPlane{

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -106,7 +106,7 @@ func (p *snowProvider) UpdateSecrets(ctx context.Context, cluster *types.Cluster
 
 func ControlPlaneObjects(clusterSpec *cluster.Spec, machineConfigs map[string]*v1alpha1.SnowMachineConfig) []runtime.Object {
 	snowCluster := SnowCluster(clusterSpec)
-	controlPlaneMachineTemplate := SnowMachineTemplate(machineConfigs[clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name])
+	controlPlaneMachineTemplate := SnowMachineTemplate(machineConfigs[clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name])
 	kubeadmControlPlane := KubeadmControlPlane(clusterSpec, controlPlaneMachineTemplate)
 	capiCluster := CAPICluster(clusterSpec, snowCluster, kubeadmControlPlane)
 

--- a/pkg/providers/tinkerbell/spec.go
+++ b/pkg/providers/tinkerbell/spec.go
@@ -13,7 +13,7 @@ type spec struct {
 
 func newSpec(clusterSpec *cluster.Spec, machineConfigs map[string]*anywherev1.TinkerbellMachineConfig, datacenterConfig *anywherev1.TinkerbellDatacenterConfig) *spec {
 	machineConfigsInCluster := map[string]*anywherev1.TinkerbellMachineConfig{}
-	for _, m := range clusterSpec.MachineConfigRefs() {
+	for _, m := range clusterSpec.Cluster.MachineConfigRefs() {
 		machineConfig, ok := machineConfigs[m.Name]
 		if !ok {
 			continue

--- a/pkg/providers/vsphere/spec.go
+++ b/pkg/providers/vsphere/spec.go
@@ -13,7 +13,7 @@ type Spec struct {
 
 func NewSpec(clusterSpec *cluster.Spec, machineConfigs map[string]*anywherev1.VSphereMachineConfig, datacenterConfig *anywherev1.VSphereDatacenterConfig) *Spec {
 	machineConfigsInCluster := map[string]*anywherev1.VSphereMachineConfig{}
-	for _, m := range clusterSpec.MachineConfigRefs() {
+	for _, m := range clusterSpec.Cluster.MachineConfigRefs() {
 		machineConfig, ok := machineConfigs[m.Name]
 		if !ok {
 			continue

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -362,7 +362,7 @@ func (p *vsphereProvider) SetupAndValidateCreateCluster(ctx context.Context, clu
 	}
 
 	// TODO: move this to validator
-	if clusterSpec.IsManaged() {
+	if clusterSpec.Cluster.IsManaged() {
 		for _, mc := range p.MachineConfigs() {
 			em, err := p.providerKubectlClient.SearchVsphereMachineConfig(ctx, mc.GetName(), clusterSpec.ManagementCluster.KubeconfigFile, mc.GetNamespace())
 			if err != nil {
@@ -372,14 +372,14 @@ func (p *vsphereProvider) SetupAndValidateCreateCluster(ctx context.Context, clu
 				return fmt.Errorf("VSphereMachineConfig %s already exists", mc.GetName())
 			}
 		}
-		existingDatacenter, err := p.providerKubectlClient.SearchVsphereDatacenterConfig(ctx, p.datacenterConfig.Name, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Namespace)
+		existingDatacenter, err := p.providerKubectlClient.SearchVsphereDatacenterConfig(ctx, p.datacenterConfig.Name, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Cluster.Namespace)
 		if err != nil {
 			return err
 		}
 		if len(existingDatacenter) > 0 {
 			return fmt.Errorf("VSphereDatacenter %s already exists", p.datacenterConfig.Name)
 		}
-		for _, identityProviderRef := range clusterSpec.Spec.IdentityProviderRefs {
+		for _, identityProviderRef := range clusterSpec.Cluster.Spec.IdentityProviderRefs {
 			if identityProviderRef.Kind == v1alpha1.OIDCConfigKind {
 				clusterSpec.OIDCConfig.SetManagedBy(p.clusterConfig.ManagedBy())
 			}
@@ -436,14 +436,14 @@ func (p *vsphereProvider) SetupAndValidateUpgradeCluster(ctx context.Context, cl
 }
 
 func (p *vsphereProvider) validateMachineConfigsNameUniqueness(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
-	prevSpec, err := p.providerKubectlClient.GetEksaCluster(ctx, cluster, clusterSpec.GetName())
+	prevSpec, err := p.providerKubectlClient.GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName())
 	if err != nil {
 		return err
 	}
 
-	cpMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	cpMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	if prevSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name != cpMachineConfigName {
-		em, err := p.providerKubectlClient.SearchVsphereMachineConfig(ctx, cpMachineConfigName, cluster.KubeconfigFile, clusterSpec.GetNamespace())
+		em, err := p.providerKubectlClient.SearchVsphereMachineConfig(ctx, cpMachineConfigName, cluster.KubeconfigFile, clusterSpec.Cluster.GetNamespace())
 		if err != nil {
 			return err
 		}
@@ -452,10 +452,10 @@ func (p *vsphereProvider) validateMachineConfigsNameUniqueness(ctx context.Conte
 		}
 	}
 
-	if clusterSpec.Spec.ExternalEtcdConfiguration != nil && prevSpec.Spec.ExternalEtcdConfiguration != nil {
-		etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil && prevSpec.Spec.ExternalEtcdConfiguration != nil {
+		etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 		if prevSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name != etcdMachineConfigName {
-			em, err := p.providerKubectlClient.SearchVsphereMachineConfig(ctx, etcdMachineConfigName, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.GetNamespace())
+			em, err := p.providerKubectlClient.SearchVsphereMachineConfig(ctx, etcdMachineConfigName, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Cluster.GetNamespace())
 			if err != nil {
 				return err
 			}
@@ -512,8 +512,8 @@ func NeedsNewWorkloadTemplate(oldSpec, newSpec *cluster.Spec, oldVdc, newVdc *v1
 	if oldSpec.Bundles.Spec.Number != newSpec.Bundles.Spec.Number {
 		return true
 	}
-	if !v1alpha1.WorkerNodeGroupConfigurationSliceTaintsEqual(oldSpec.Spec.WorkerNodeGroupConfigurations, newSpec.Spec.WorkerNodeGroupConfigurations) ||
-		!v1alpha1.WorkerNodeGroupConfigurationsLabelsMapEqual(oldSpec.Spec.WorkerNodeGroupConfigurations, newSpec.Spec.WorkerNodeGroupConfigurations) {
+	if !v1alpha1.WorkerNodeGroupConfigurationSliceTaintsEqual(oldSpec.Cluster.Spec.WorkerNodeGroupConfigurations, newSpec.Cluster.Spec.WorkerNodeGroupConfigurations) ||
+		!v1alpha1.WorkerNodeGroupConfigurationsLabelsMapEqual(oldSpec.Cluster.Spec.WorkerNodeGroupConfigurations, newSpec.Cluster.Spec.WorkerNodeGroupConfigurations) {
 		return true
 	}
 	return AnyImmutableFieldChanged(oldVdc, newVdc, oldVmc, newVmc)
@@ -587,7 +587,7 @@ type VsphereTemplateBuilder struct {
 
 func (vs *VsphereTemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spec, buildOptions ...providers.BuildMapOption) (content []byte, err error) {
 	var etcdMachineSpec v1alpha1.VSphereMachineConfigSpec
-	if clusterSpec.Spec.ExternalEtcdConfiguration != nil {
+	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		etcdMachineSpec = *vs.etcdMachineSpec
 	}
 	values := buildTemplateMapCP(clusterSpec, *vs.datacenterSpec, *vs.controlPlaneMachineSpec, etcdMachineSpec)
@@ -625,8 +625,8 @@ func (vs *VsphereTemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.S
 		return nil, err
 	}
 
-	workerSpecs := make([][]byte, 0, len(clusterSpec.Spec.WorkerNodeGroupConfigurations))
-	for _, workerNodeGroupConfiguration := range clusterSpec.Spec.WorkerNodeGroupConfigurations {
+	workerSpecs := make([][]byte, 0, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	for _, workerNodeGroupConfiguration := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
 		values := buildTemplateMapMD(clusterSpec, *vs.datacenterSpec, vs.WorkerNodeGroupMachineSpecs[workerNodeGroupConfiguration.MachineGroupRef.Name], workerNodeGroupConfiguration)
 		values["workloadTemplateName"] = workloadTemplateNames[workerNodeGroupConfiguration.Name]
 		values["workloadkubeadmconfigTemplateName"] = kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name]
@@ -649,17 +649,17 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 	etcdExtraArgs := clusterapi.SecureEtcdTlsCipherSuitesExtraArgs()
 	sharedExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs()
 	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
-		Append(clusterapi.ResolvConfExtraArgs(clusterSpec.Spec.ClusterNetwork.DNS.ResolvConf)).
-		Append(clusterapi.ControlPlaneNodeLabelsExtraArgs(clusterSpec.Spec.ControlPlaneConfiguration))
+		Append(clusterapi.ResolvConfExtraArgs(clusterSpec.Cluster.Spec.ClusterNetwork.DNS.ResolvConf)).
+		Append(clusterapi.ControlPlaneNodeLabelsExtraArgs(clusterSpec.Cluster.Spec.ControlPlaneConfiguration))
 	apiServerExtraArgs := clusterapi.OIDCToExtraArgs(clusterSpec.OIDCConfig).
 		Append(clusterapi.AwsIamAuthExtraArgs(clusterSpec.AWSIamConfig)).
-		Append(clusterapi.PodIAMAuthExtraArgs(clusterSpec.Spec.PodIAMConfig)).
+		Append(clusterapi.PodIAMAuthExtraArgs(clusterSpec.Cluster.Spec.PodIAMConfig)).
 		Append(sharedExtraArgs)
 
 	values := map[string]interface{}{
-		"clusterName":                          clusterSpec.ObjectMeta.Name,
-		"controlPlaneEndpointIp":               clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host,
-		"controlPlaneReplicas":                 clusterSpec.Spec.ControlPlaneConfiguration.Count,
+		"clusterName":                          clusterSpec.Cluster.Name,
+		"controlPlaneEndpointIp":               clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host,
+		"controlPlaneReplicas":                 clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Count,
 		"kubernetesRepository":                 bundle.KubeDistro.Kubernetes.Repository,
 		"kubernetesVersion":                    bundle.KubeDistro.Kubernetes.Tag,
 		"etcdRepository":                       bundle.KubeDistro.Etcd.Repository,
@@ -688,8 +688,8 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		"controlPlaneVMsNumCPUs":               controlPlaneMachineSpec.NumCPUs,
 		"controlPlaneDiskGiB":                  controlPlaneMachineSpec.DiskGiB,
 		"controlPlaneSshUsername":              controlPlaneMachineSpec.Users[0].Name,
-		"podCidrs":                             clusterSpec.Spec.ClusterNetwork.Pods.CidrBlocks,
-		"serviceCidrs":                         clusterSpec.Spec.ClusterNetwork.Services.CidrBlocks,
+		"podCidrs":                             clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks,
+		"serviceCidrs":                         clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks,
 		"etcdExtraArgs":                        etcdExtraArgs.ToPartialYaml(),
 		"etcdCipherSuites":                     crypto.SecureCipherSuitesString(),
 		"apiserverExtraArgs":                   apiServerExtraArgs.ToPartialYaml(),
@@ -706,38 +706,38 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		"eksaVspherePassword":                  os.Getenv(EksavSpherePasswordKey),
 	}
 
-	if clusterSpec.Spec.RegistryMirrorConfiguration != nil {
-		values["registryMirrorConfiguration"] = net.JoinHostPort(clusterSpec.Spec.RegistryMirrorConfiguration.Endpoint, clusterSpec.Spec.RegistryMirrorConfiguration.Port)
-		if len(clusterSpec.Spec.RegistryMirrorConfiguration.CACertContent) > 0 {
-			values["registryCACert"] = clusterSpec.Spec.RegistryMirrorConfiguration.CACertContent
+	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {
+		values["registryMirrorConfiguration"] = net.JoinHostPort(clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Endpoint, clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Port)
+		if len(clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.CACertContent) > 0 {
+			values["registryCACert"] = clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.CACertContent
 		}
 	}
 
-	if clusterSpec.Spec.ProxyConfiguration != nil {
+	if clusterSpec.Cluster.Spec.ProxyConfiguration != nil {
 		values["proxyConfig"] = true
-		capacity := len(clusterSpec.Spec.ClusterNetwork.Pods.CidrBlocks) +
-			len(clusterSpec.Spec.ClusterNetwork.Services.CidrBlocks) +
-			len(clusterSpec.Spec.ProxyConfiguration.NoProxy) + 4
+		capacity := len(clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks) +
+			len(clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks) +
+			len(clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy) + 4
 		noProxyList := make([]string, 0, capacity)
-		noProxyList = append(noProxyList, clusterSpec.Spec.ClusterNetwork.Pods.CidrBlocks...)
-		noProxyList = append(noProxyList, clusterSpec.Spec.ClusterNetwork.Services.CidrBlocks...)
-		noProxyList = append(noProxyList, clusterSpec.Spec.ProxyConfiguration.NoProxy...)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks...)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks...)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy...)
 
 		// Add no-proxy defaults
 		noProxyList = append(noProxyList, common.NoProxyDefaults...)
 		noProxyList = append(noProxyList,
 			datacenterSpec.Server,
-			clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host,
+			clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host,
 		)
 
-		values["httpProxy"] = clusterSpec.Spec.ProxyConfiguration.HttpProxy
-		values["httpsProxy"] = clusterSpec.Spec.ProxyConfiguration.HttpsProxy
+		values["httpProxy"] = clusterSpec.Cluster.Spec.ProxyConfiguration.HttpProxy
+		values["httpsProxy"] = clusterSpec.Cluster.Spec.ProxyConfiguration.HttpsProxy
 		values["noProxy"] = noProxyList
 	}
 
-	if clusterSpec.Spec.ExternalEtcdConfiguration != nil {
+	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		values["externalEtcd"] = true
-		values["externalEtcdReplicas"] = clusterSpec.Spec.ExternalEtcdConfiguration.Count
+		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
 		values["etcdVsphereDatastore"] = etcdMachineSpec.Datastore
 		values["etcdVsphereFolder"] = etcdMachineSpec.Folder
 		values["etcdDiskGiB"] = etcdMachineSpec.DiskGiB
@@ -756,8 +756,8 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		values["bottlerocketBootstrapVersion"] = bundle.BottleRocketBootstrap.Bootstrap.Tag()
 	}
 
-	if len(clusterSpec.Spec.ControlPlaneConfiguration.Taints) > 0 {
-		values["controlPlaneTaints"] = clusterSpec.Spec.ControlPlaneConfiguration.Taints
+	if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints) > 0 {
+		values["controlPlaneTaints"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints
 	}
 
 	if clusterSpec.AWSIamConfig != nil {
@@ -772,10 +772,10 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 	format := "cloud-config"
 	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
 		Append(clusterapi.WorkerNodeLabelsExtraArgs(workerNodeGroupConfiguration)).
-		Append(clusterapi.ResolvConfExtraArgs(clusterSpec.Spec.ClusterNetwork.DNS.ResolvConf))
+		Append(clusterapi.ResolvConfExtraArgs(clusterSpec.Cluster.Spec.ClusterNetwork.DNS.ResolvConf))
 
 	values := map[string]interface{}{
-		"clusterName":                    clusterSpec.ObjectMeta.Name,
+		"clusterName":                    clusterSpec.Cluster.Name,
 		"kubernetesVersion":              bundle.KubeDistro.Kubernetes.Tag,
 		"thumbprint":                     datacenterSpec.Thumbprint,
 		"vsphereDatacenter":              datacenterSpec.Datacenter,
@@ -795,36 +795,36 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		"kubeletExtraArgs":               kubeletExtraArgs.ToPartialYaml(),
 		"vsphereWorkerSshAuthorizedKey":  workerNodeGroupMachineSpec.Users[0].SshAuthorizedKeys[0],
 		"workerReplicas":                 workerNodeGroupConfiguration.Count,
-		"workerNodeGroupName":            fmt.Sprintf("%s-%s", clusterSpec.Name, workerNodeGroupConfiguration.Name),
+		"workerNodeGroupName":            fmt.Sprintf("%s-%s", clusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name),
 		"workerNodeGroupTaints":          workerNodeGroupConfiguration.Taints,
 	}
 
-	if clusterSpec.Spec.RegistryMirrorConfiguration != nil {
-		values["registryMirrorConfiguration"] = net.JoinHostPort(clusterSpec.Spec.RegistryMirrorConfiguration.Endpoint, clusterSpec.Spec.RegistryMirrorConfiguration.Port)
-		if len(clusterSpec.Spec.RegistryMirrorConfiguration.CACertContent) > 0 {
-			values["registryCACert"] = clusterSpec.Spec.RegistryMirrorConfiguration.CACertContent
+	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {
+		values["registryMirrorConfiguration"] = net.JoinHostPort(clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Endpoint, clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Port)
+		if len(clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.CACertContent) > 0 {
+			values["registryCACert"] = clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.CACertContent
 		}
 	}
 
-	if clusterSpec.Spec.ProxyConfiguration != nil {
+	if clusterSpec.Cluster.Spec.ProxyConfiguration != nil {
 		values["proxyConfig"] = true
-		capacity := len(clusterSpec.Spec.ClusterNetwork.Pods.CidrBlocks) +
-			len(clusterSpec.Spec.ClusterNetwork.Services.CidrBlocks) +
-			len(clusterSpec.Spec.ProxyConfiguration.NoProxy) + 4
+		capacity := len(clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks) +
+			len(clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks) +
+			len(clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy) + 4
 		noProxyList := make([]string, 0, capacity)
-		noProxyList = append(noProxyList, clusterSpec.Spec.ClusterNetwork.Pods.CidrBlocks...)
-		noProxyList = append(noProxyList, clusterSpec.Spec.ClusterNetwork.Services.CidrBlocks...)
-		noProxyList = append(noProxyList, clusterSpec.Spec.ProxyConfiguration.NoProxy...)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks...)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks...)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy...)
 
 		// Add no-proxy defaults
 		noProxyList = append(noProxyList, common.NoProxyDefaults...)
 		noProxyList = append(noProxyList,
 			datacenterSpec.Server,
-			clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host,
+			clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host,
 		)
 
-		values["httpProxy"] = clusterSpec.Spec.ProxyConfiguration.HttpProxy
-		values["httpsProxy"] = clusterSpec.Spec.ProxyConfiguration.HttpsProxy
+		values["httpProxy"] = clusterSpec.Cluster.Spec.ProxyConfiguration.HttpProxy
+		values["httpsProxy"] = clusterSpec.Cluster.Spec.ProxyConfiguration.HttpsProxy
 		values["noProxy"] = noProxyList
 	}
 
@@ -840,20 +840,20 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 }
 
 func (p *vsphereProvider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currentSpec, newClusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
-	clusterName := newClusterSpec.ObjectMeta.Name
+	clusterName := newClusterSpec.Cluster.Name
 	var controlPlaneTemplateName, workloadTemplateName, kubeadmconfigTemplateName, etcdTemplateName string
 	var needsNewEtcdTemplate bool
 
-	c, err := p.providerKubectlClient.GetEksaCluster(ctx, workloadCluster, newClusterSpec.Name)
+	c, err := p.providerKubectlClient.GetEksaCluster(ctx, workloadCluster, newClusterSpec.Cluster.Name)
 	if err != nil {
 		return nil, nil, err
 	}
-	vdc, err := p.providerKubectlClient.GetEksaVSphereDatacenterConfig(ctx, p.datacenterConfig.Name, workloadCluster.KubeconfigFile, newClusterSpec.Namespace)
+	vdc, err := p.providerKubectlClient.GetEksaVSphereDatacenterConfig(ctx, p.datacenterConfig.Name, workloadCluster.KubeconfigFile, newClusterSpec.Cluster.Namespace)
 	if err != nil {
 		return nil, nil, err
 	}
-	controlPlaneMachineConfig := p.machineConfigs[newClusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name]
-	controlPlaneVmc, err := p.providerKubectlClient.GetEksaVSphereMachineConfig(ctx, c.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, workloadCluster.KubeconfigFile, newClusterSpec.Namespace)
+	controlPlaneMachineConfig := p.machineConfigs[newClusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name]
+	controlPlaneVmc, err := p.providerKubectlClient.GetEksaVSphereMachineConfig(ctx, c.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, workloadCluster.KubeconfigFile, newClusterSpec.Cluster.Namespace)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -868,11 +868,11 @@ func (p *vsphereProvider) generateCAPISpecForUpgrade(ctx context.Context, bootst
 		controlPlaneTemplateName = common.CPMachineTemplateName(clusterName, p.templateBuilder.now)
 	}
 
-	previousWorkerNodeGroupConfigs := cluster.BuildMapForWorkerNodeGroupsByName(currentSpec.Spec.WorkerNodeGroupConfigurations)
+	previousWorkerNodeGroupConfigs := cluster.BuildMapForWorkerNodeGroupsByName(currentSpec.Cluster.Spec.WorkerNodeGroupConfigurations)
 
-	workloadTemplateNames := make(map[string]string, len(newClusterSpec.Spec.WorkerNodeGroupConfigurations))
-	kubeadmconfigTemplateNames := make(map[string]string, len(newClusterSpec.Spec.WorkerNodeGroupConfigurations))
-	for _, workerNodeGroupConfiguration := range newClusterSpec.Spec.WorkerNodeGroupConfigurations {
+	workloadTemplateNames := make(map[string]string, len(newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	kubeadmconfigTemplateNames := make(map[string]string, len(newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	for _, workerNodeGroupConfiguration := range newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
 
 		oldWorkerNodeVmc, newWorkerNodeVmc, err := p.getWorkerNodeMachineConfigs(ctx, workloadCluster, newClusterSpec, workerNodeGroupConfiguration, previousWorkerNodeGroupConfigs)
 		if err != nil {
@@ -891,7 +891,7 @@ func (p *vsphereProvider) generateCAPISpecForUpgrade(ctx context.Context, bootst
 			return nil, nil, err
 		}
 		if !needsNewKubeadmConfigTemplate {
-			mdName := machineDeploymentName(newClusterSpec.Name, workerNodeGroupConfiguration.Name)
+			mdName := machineDeploymentName(newClusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name)
 			md, err := p.providerKubectlClient.GetMachineDeployment(ctx, mdName, executables.WithCluster(bootstrapCluster), executables.WithNamespace(constants.EksaSystemNamespace))
 			if err != nil {
 				return nil, nil, err
@@ -904,7 +904,7 @@ func (p *vsphereProvider) generateCAPISpecForUpgrade(ctx context.Context, bootst
 		}
 
 		if !needsNewWorkloadTemplate {
-			mdName := machineDeploymentName(newClusterSpec.Name, workerNodeGroupConfiguration.Name)
+			mdName := machineDeploymentName(newClusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name)
 			md, err := p.providerKubectlClient.GetMachineDeployment(ctx, mdName, executables.WithCluster(bootstrapCluster), executables.WithNamespace(constants.EksaSystemNamespace))
 			if err != nil {
 				return nil, nil, err
@@ -918,9 +918,9 @@ func (p *vsphereProvider) generateCAPISpecForUpgrade(ctx context.Context, bootst
 		p.templateBuilder.WorkerNodeGroupMachineSpecs[workerNodeGroupConfiguration.MachineGroupRef.Name] = p.machineConfigs[workerNodeGroupConfiguration.MachineGroupRef.Name].Spec
 	}
 
-	if newClusterSpec.Spec.ExternalEtcdConfiguration != nil {
-		etcdMachineConfig := p.machineConfigs[newClusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name]
-		etcdMachineVmc, err := p.providerKubectlClient.GetEksaVSphereMachineConfig(ctx, c.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name, workloadCluster.KubeconfigFile, newClusterSpec.Namespace)
+	if newClusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
+		etcdMachineConfig := p.machineConfigs[newClusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name]
+		etcdMachineVmc, err := p.providerKubectlClient.GetEksaVSphereMachineConfig(ctx, c.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name, workloadCluster.KubeconfigFile, newClusterSpec.Cluster.Namespace)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -966,7 +966,7 @@ func (p *vsphereProvider) generateCAPISpecForUpgrade(ctx context.Context, bootst
 }
 
 func (p *vsphereProvider) generateCAPISpecForCreate(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
-	clusterName := clusterSpec.ObjectMeta.Name
+	clusterName := clusterSpec.Cluster.Name
 
 	cpOpt := func(values map[string]interface{}) {
 		values["controlPlaneTemplateName"] = common.CPMachineTemplateName(clusterName, p.templateBuilder.now)
@@ -979,11 +979,11 @@ func (p *vsphereProvider) generateCAPISpecForCreate(ctx context.Context, cluster
 		return nil, nil, err
 	}
 
-	workloadTemplateNames := make(map[string]string, len(clusterSpec.Spec.WorkerNodeGroupConfigurations))
-	kubeadmconfigTemplateNames := make(map[string]string, len(clusterSpec.Spec.WorkerNodeGroupConfigurations))
-	for _, workerNodeGroupConfiguration := range clusterSpec.Spec.WorkerNodeGroupConfigurations {
-		workloadTemplateNames[workerNodeGroupConfiguration.Name] = common.WorkerMachineTemplateName(clusterSpec.Name, workerNodeGroupConfiguration.Name, p.templateBuilder.now)
-		kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name] = common.KubeadmConfigTemplateName(clusterSpec.Name, workerNodeGroupConfiguration.Name, p.templateBuilder.now)
+	workloadTemplateNames := make(map[string]string, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	kubeadmconfigTemplateNames := make(map[string]string, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	for _, workerNodeGroupConfiguration := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
+		workloadTemplateNames[workerNodeGroupConfiguration.Name] = common.WorkerMachineTemplateName(clusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name, p.templateBuilder.now)
+		kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name] = common.KubeadmConfigTemplateName(clusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name, p.templateBuilder.now)
 		p.templateBuilder.WorkerNodeGroupMachineSpecs[workerNodeGroupConfiguration.MachineGroupRef.Name] = p.machineConfigs[workerNodeGroupConfiguration.MachineGroupRef.Name].Spec
 	}
 	workersSpec, err = p.templateBuilder.GenerateCAPISpecWorkers(clusterSpec, workloadTemplateNames, kubeadmconfigTemplateNames)
@@ -1129,7 +1129,7 @@ func (p *vsphereProvider) MachineConfigs() []providers.MachineConfig {
 }
 
 func (p *vsphereProvider) ValidateNewSpec(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
-	prevSpec, err := p.providerKubectlClient.GetEksaCluster(ctx, cluster, clusterSpec.Name)
+	prevSpec, err := p.providerKubectlClient.GetEksaCluster(ctx, cluster, clusterSpec.Cluster.Name)
 	if err != nil {
 		return err
 	}
@@ -1146,7 +1146,7 @@ func (p *vsphereProvider) ValidateNewSpec(ctx context.Context, cluster *types.Cl
 
 	prevMachineConfigRefs := machineRefSliceToMap(prevSpec.MachineConfigRefs())
 
-	for _, machineConfigRef := range clusterSpec.MachineConfigRefs() {
+	for _, machineConfigRef := range clusterSpec.Cluster.MachineConfigRefs() {
 		machineConfig, ok := p.machineConfigs[machineConfigRef.Name]
 		if !ok {
 			return fmt.Errorf("cannot find machine config %s in vsphere provider machine configs", machineConfigRef.Name)
@@ -1193,7 +1193,7 @@ func (p *vsphereProvider) ValidateNewSpec(ctx context.Context, cluster *types.Cl
 func (p *vsphereProvider) getWorkerNodeMachineConfigs(ctx context.Context, workloadCluster *types.Cluster, newClusterSpec *cluster.Spec, workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration, prevWorkerNodeGroupConfigs map[string]v1alpha1.WorkerNodeGroupConfiguration) (*v1alpha1.VSphereMachineConfig, *v1alpha1.VSphereMachineConfig, error) {
 	if _, ok := prevWorkerNodeGroupConfigs[workerNodeGroupConfiguration.Name]; ok {
 		oldWorkerMachineConfig := p.machineConfigs[workerNodeGroupConfiguration.MachineGroupRef.Name]
-		newWorkerMachineConfig, err := p.providerKubectlClient.GetEksaVSphereMachineConfig(ctx, workerNodeGroupConfiguration.MachineGroupRef.Name, workloadCluster.KubeconfigFile, newClusterSpec.Namespace)
+		newWorkerMachineConfig, err := p.providerKubectlClient.GetEksaVSphereMachineConfig(ctx, workerNodeGroupConfiguration.MachineGroupRef.Name, workloadCluster.KubeconfigFile, newClusterSpec.Cluster.Namespace)
 		if err != nil {
 			return oldWorkerMachineConfig, nil, err
 		}
@@ -1219,7 +1219,7 @@ func (p *vsphereProvider) needsNewKubeadmConfigTemplate(workerNodeGroupConfigura
 }
 
 func (p *vsphereProvider) validateMachineConfigImmutability(ctx context.Context, cluster *types.Cluster, newConfig *v1alpha1.VSphereMachineConfig, clusterSpec *cluster.Spec) error {
-	prevMachineConfig, err := p.providerKubectlClient.GetEksaVSphereMachineConfig(ctx, newConfig.Name, cluster.KubeconfigFile, clusterSpec.Namespace)
+	prevMachineConfig, err := p.providerKubectlClient.GetEksaVSphereMachineConfig(ctx, newConfig.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace)
 	if err != nil {
 		return err
 	}
@@ -1280,7 +1280,7 @@ func (p *vsphereProvider) RunPostControlPlaneUpgrade(ctx context.Context, oldClu
 }
 
 func resourceSetName(clusterSpec *cluster.Spec) string {
-	return fmt.Sprintf("%s-crs-0", clusterSpec.Name)
+	return fmt.Sprintf("%s-crs-0", clusterSpec.Cluster.Name)
 }
 
 func (p *vsphereProvider) UpgradeNeeded(_ context.Context, newSpec, currentSpec *cluster.Spec) (bool, error) {

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -181,7 +181,7 @@ func givenEmptyClusterSpec() *cluster.Spec {
 	return test.NewClusterSpec(func(s *cluster.Spec) {
 		s.VersionsBundle.KubeVersion = "1.19"
 		s.VersionsBundle.EksD.Name = eksd119Release
-		s.Namespace = "test-namespace"
+		s.Cluster.Namespace = "test-namespace"
 	})
 }
 
@@ -486,10 +486,10 @@ func TestProviderGenerateCAPISpecForUpgradeUpdateMachineTemplate(t *testing.T) {
 			}
 
 			kubectl.EXPECT().GetMachineDeployment(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(workerNodeGroup1MachineDeployment(), nil)
-			kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Name).Return(clusterSpec.Cluster, nil)
-			kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereDatacenter, nil)
-			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
-			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
+			kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.Name).Return(clusterSpec.Cluster, nil)
+			kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(vsphereDatacenter, nil)
+			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(vsphereMachineConfig, nil)
+			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(vsphereMachineConfig, nil)
 			datacenterConfig := givenDatacenterConfig(t, tt.clusterconfigFile)
 			machineConfigs := givenMachineConfigs(t, tt.clusterconfigFile)
 			provider := newProviderWithKubectl(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, kubectl)
@@ -561,10 +561,10 @@ func TestProviderGenerateCAPISpecForUpgradeOIDC(t *testing.T) {
 			}
 
 			kubectl.EXPECT().GetMachineDeployment(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(workerNodeGroup1MachineDeployment(), nil)
-			kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Name).Return(clusterSpec.Cluster, nil)
-			kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereDatacenter, nil)
-			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
-			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
+			kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.Name).Return(clusterSpec.Cluster, nil)
+			kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(vsphereDatacenter, nil)
+			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(vsphereMachineConfig, nil)
+			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(vsphereMachineConfig, nil)
 			datacenterConfig := givenDatacenterConfig(t, tt.clusterconfigFile)
 			machineConfigs := givenMachineConfigs(t, tt.clusterconfigFile)
 			provider := newProviderWithKubectl(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, kubectl)
@@ -629,15 +629,15 @@ func TestProviderGenerateCAPISpecForUpgradeMultipleWorkerNodeGroups(t *testing.T
 			}
 			newClusterSpec := givenClusterSpec(t, tt.clusterconfigFile)
 			newConfig := v1alpha1.WorkerNodeGroupConfiguration{Count: 1, MachineGroupRef: &v1alpha1.Ref{Name: "test-wn", Kind: "VSphereMachineConfig"}, Name: "md-2"}
-			newClusterSpec.Spec.WorkerNodeGroupConfigurations = append(newClusterSpec.Spec.WorkerNodeGroupConfigurations, newConfig)
+			newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations = append(newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations, newConfig)
 
 			kubectl.EXPECT().GetMachineDeployment(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(workerNodeGroup1MachineDeployment(), nil)
 			kubectl.EXPECT().GetMachineDeployment(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(workerNodeGroup2MachineDeployment(), nil)
-			kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Name).Return(clusterSpec.Cluster, nil)
-			kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereDatacenter, nil)
-			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
-			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil).AnyTimes()
-			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
+			kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.Name).Return(clusterSpec.Cluster, nil)
+			kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(vsphereDatacenter, nil)
+			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(vsphereMachineConfig, nil)
+			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(vsphereMachineConfig, nil).AnyTimes()
+			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(vsphereMachineConfig, nil)
 			kubectl.EXPECT().UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", cluster.Name), map[string]string{etcdv1.UpgradeInProgressAnnotation: "true"}, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster)))
 
 			datacenterConfig := givenDatacenterConfig(t, tt.clusterconfigFile)
@@ -724,11 +724,11 @@ func TestProviderGenerateCAPISpecForUpgradeUpdateMachineTemplateExternalEtcd(t *
 			}
 
 			kubectl.EXPECT().GetMachineDeployment(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(workerNodeGroup1MachineDeployment(), nil)
-			kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Name).Return(clusterSpec.Cluster, nil)
-			kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereDatacenter, nil)
-			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
-			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
-			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(vsphereMachineConfig, nil)
+			kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.Name).Return(clusterSpec.Cluster, nil)
+			kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(vsphereDatacenter, nil)
+			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(vsphereMachineConfig, nil)
+			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(vsphereMachineConfig, nil)
+			kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(vsphereMachineConfig, nil)
 			kubectl.EXPECT().UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", cluster.Name), map[string]string{etcdv1.UpgradeInProgressAnnotation: "true"}, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster)))
 			datacenterConfig := givenDatacenterConfig(t, tt.clusterconfigFile)
 			machineConfigs := givenMachineConfigs(t, tt.clusterconfigFile)
@@ -813,18 +813,18 @@ func TestProviderGenerateCAPISpecForUpgradeNotUpdateMachineTemplate(t *testing.T
 		t.Fatalf("failed to setup and validate: %v", err)
 	}
 
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
-	machineDeploymentName := fmt.Sprintf("%s-%s", clusterSpec.Name, clusterSpec.Spec.WorkerNodeGroupConfigurations[0].Name)
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
-	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Name).Return(clusterSpec.Cluster, nil)
-	kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Namespace).Return(datacenterConfig, nil)
-	kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, controlPlaneMachineConfigName, cluster.KubeconfigFile, clusterSpec.Namespace).Return(machineConfigs[controlPlaneMachineConfigName], nil)
-	kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, workerNodeMachineConfigName, cluster.KubeconfigFile, clusterSpec.Namespace).Return(machineConfigs[workerNodeMachineConfigName], nil)
-	kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, etcdMachineConfigName, cluster.KubeconfigFile, clusterSpec.Namespace).Return(machineConfigs[etcdMachineConfigName], nil)
-	kubectl.EXPECT().GetKubeadmControlPlane(ctx, cluster, clusterSpec.Name, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(oldCP, nil)
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	machineDeploymentName := fmt.Sprintf("%s-%s", clusterSpec.Cluster.Name, clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Name)
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.Name).Return(clusterSpec.Cluster, nil)
+	kubectl.EXPECT().GetEksaVSphereDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(datacenterConfig, nil)
+	kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, controlPlaneMachineConfigName, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(machineConfigs[controlPlaneMachineConfigName], nil)
+	kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, workerNodeMachineConfigName, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(machineConfigs[workerNodeMachineConfigName], nil)
+	kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, etcdMachineConfigName, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(machineConfigs[etcdMachineConfigName], nil)
+	kubectl.EXPECT().GetKubeadmControlPlane(ctx, cluster, clusterSpec.Cluster.Name, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(oldCP, nil)
 	kubectl.EXPECT().GetMachineDeployment(ctx, machineDeploymentName, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(oldMD, nil).Times(2)
-	kubectl.EXPECT().GetEtcdadmCluster(ctx, cluster, clusterSpec.Name, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(etcdadmCluster, nil)
+	kubectl.EXPECT().GetEtcdadmCluster(ctx, cluster, clusterSpec.Cluster.Name, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(etcdadmCluster, nil)
 	cp, md, err := provider.GenerateCAPISpecForUpgrade(context.Background(), bootstrapCluster, cluster, clusterSpec, clusterSpec.DeepCopy())
 	if err != nil {
 		t.Fatalf("failed to generate cluster api spec contents: %v", err)
@@ -1151,7 +1151,7 @@ func TestSetupAndValidateCreateWorkloadClusterSuccess(t *testing.T) {
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	provider.providerKubectlClient = kubectl
 
-	clusterSpec.SetManagedBy("management-cluster")
+	clusterSpec.Cluster.SetManagedBy("management-cluster")
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
@@ -1160,7 +1160,7 @@ func TestSetupAndValidateCreateWorkloadClusterSuccess(t *testing.T) {
 	for _, config := range newMachineConfigs {
 		kubectl.EXPECT().SearchVsphereMachineConfig(context.TODO(), config.Name, clusterSpec.ManagementCluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.VSphereMachineConfig{}, nil)
 	}
-	kubectl.EXPECT().SearchVsphereDatacenterConfig(context.TODO(), datacenterConfig.Name, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Namespace).Return([]*v1alpha1.VSphereDatacenterConfig{}, nil)
+	kubectl.EXPECT().SearchVsphereDatacenterConfig(context.TODO(), datacenterConfig.Name, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return([]*v1alpha1.VSphereDatacenterConfig{}, nil)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -1184,7 +1184,7 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfMachineExists(t *testing.T)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	provider.providerKubectlClient = kubectl
 
-	clusterSpec.SetManagedBy("management-cluster")
+	clusterSpec.Cluster.SetManagedBy("management-cluster")
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
@@ -1252,7 +1252,7 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfDatacenterExists(t *testing
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	provider.providerKubectlClient = kubectl
 
-	clusterSpec.SetManagedBy("management-cluster")
+	clusterSpec.Cluster.SetManagedBy("management-cluster")
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
@@ -1262,7 +1262,7 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfDatacenterExists(t *testing
 	for _, config := range newMachineConfigs {
 		kubectl.EXPECT().SearchVsphereMachineConfig(context.TODO(), config.Name, clusterSpec.ManagementCluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.VSphereMachineConfig{}, nil)
 	}
-	kubectl.EXPECT().SearchVsphereDatacenterConfig(context.TODO(), datacenterConfig.Name, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Namespace).Return([]*v1alpha1.VSphereDatacenterConfig{datacenterConfig}, nil)
+	kubectl.EXPECT().SearchVsphereDatacenterConfig(context.TODO(), datacenterConfig.Name, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return([]*v1alpha1.VSphereDatacenterConfig{datacenterConfig}, nil)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 
@@ -1337,7 +1337,7 @@ func TestSetupAndValidateUpgradeCluster(t *testing.T) {
 	tctx.SaveContext()
 	defer tctx.RestoreContext()
 
-	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
+	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
 	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
 	if err != nil {
 		t.Fatalf("unexpected failure %v", err)
@@ -1379,7 +1379,7 @@ func TestSetupAndValidateUpgradeClusterCPSshNotExists(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -1389,7 +1389,7 @@ func TestSetupAndValidateUpgradeClusterCPSshNotExists(t *testing.T) {
 	provider.providerKubectlClient = kubectl
 
 	cluster := &types.Cluster{}
-	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
+	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
 	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
 	if err != nil {
 		t.Fatalf("unexpected failure %v", err)
@@ -1401,7 +1401,7 @@ func TestSetupAndValidateUpgradeClusterWorkerSshNotExists(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -1411,7 +1411,7 @@ func TestSetupAndValidateUpgradeClusterWorkerSshNotExists(t *testing.T) {
 	provider.providerKubectlClient = kubectl
 
 	cluster := &types.Cluster{}
-	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
+	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
 
 	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
 	if err != nil {
@@ -1424,7 +1424,7 @@ func TestSetupAndValidateUpgradeClusterEtcdSshNotExists(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -1434,7 +1434,7 @@ func TestSetupAndValidateUpgradeClusterEtcdSshNotExists(t *testing.T) {
 	provider.providerKubectlClient = kubectl
 
 	cluster := &types.Cluster{}
-	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
+	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
 
 	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
 	if err != nil {
@@ -1575,7 +1575,7 @@ func TestSetupAndValidateCreateClusterNoControlPlaneEndpointIP(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host = ""
+	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host = ""
 	var tctx testContext
 	tctx.SaveContext()
 
@@ -1603,7 +1603,7 @@ func TestSetupAndValidateCreateClusterNoDatastoreControlPlane(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Datastore = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -1618,7 +1618,7 @@ func TestSetupAndValidateCreateClusterNoDatastoreWorker(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	workerMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerMachineConfigName].Spec.Datastore = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -1633,7 +1633,7 @@ func TestSetupAndValidateCreateClusterNoDatastoreEtcd(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.Datastore = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -1648,7 +1648,7 @@ func TestSetupAndValidateCreateClusterNoResourcePoolControlPlane(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.ResourcePool = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -1663,7 +1663,7 @@ func TestSetupAndValidateCreateClusterNoResourcePoolWorker(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	workerMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerMachineConfigName].Spec.ResourcePool = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -1678,7 +1678,7 @@ func TestSetupAndValidateCreateClusterNoResourcePoolEtcd(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.ResourcePool = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -1707,7 +1707,7 @@ func TestSetupAndValidateCreateClusterNotControlPlaneVMsMemoryMiB(t *testing.T) 
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.MemoryMiB = 0
 	var tctx testContext
 	tctx.SaveContext()
@@ -1726,7 +1726,7 @@ func TestSetupAndValidateCreateClusterNotControlPlaneVMsNumCPUs(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.NumCPUs = 0
 	var tctx testContext
 	tctx.SaveContext()
@@ -1745,7 +1745,7 @@ func TestSetupAndValidateCreateClusterNotWorkloadVMsMemoryMiB(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.MemoryMiB = 0
 	var tctx testContext
 	tctx.SaveContext()
@@ -1764,7 +1764,7 @@ func TestSetupAndValidateCreateClusterNotWorkloadVMsNumCPUs(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.NumCPUs = 0
 	var tctx testContext
 	tctx.SaveContext()
@@ -1783,7 +1783,7 @@ func TestSetupAndValidateCreateClusterNotEtcdVMsMemoryMiB(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.MemoryMiB = 0
 	var tctx testContext
 	tctx.SaveContext()
@@ -1802,7 +1802,7 @@ func TestSetupAndValidateCreateClusterNotEtcdVMsNumCPUs(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.NumCPUs = 0
 	var tctx testContext
 	tctx.SaveContext()
@@ -1821,7 +1821,7 @@ func TestSetupAndValidateCreateClusterBogusIp(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host = "bogus"
+	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host = "bogus"
 	var tctx testContext
 	tctx.SaveContext()
 
@@ -1835,7 +1835,7 @@ func TestSetupAndValidateCreateClusterUsedIp(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host = "255.255.255.255"
+	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host = "255.255.255.255"
 	var tctx testContext
 	tctx.SaveContext()
 
@@ -1849,7 +1849,7 @@ func TestSetupAndValidateForCreateSSHAuthorizedKeyInvalidCP(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
 	var tctx testContext
@@ -1864,7 +1864,7 @@ func TestSetupAndValidateForCreateSSHAuthorizedKeyInvalidWorker(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
 	var tctx testContext
@@ -1879,7 +1879,7 @@ func TestSetupAndValidateForCreateSSHAuthorizedKeyInvalidEtcd(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
 	var tctx testContext
@@ -1894,7 +1894,7 @@ func TestSetupAndValidateForUpgradeSSHAuthorizedKeyInvalidCP(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
 	var tctx testContext
@@ -1910,7 +1910,7 @@ func TestSetupAndValidateForUpgradeSSHAuthorizedKeyInvalidWorker(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
 	var tctx testContext
@@ -1926,7 +1926,7 @@ func TestSetupAndValidateForUpgradeSSHAuthorizedKeyInvalidEtcd(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
 	var tctx testContext
@@ -1946,7 +1946,7 @@ func TestSetupAndValidateSSHAuthorizedKeyEmptyCP(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -1969,7 +1969,7 @@ func TestSetupAndValidateSSHAuthorizedKeyEmptyWorker(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -1992,7 +1992,7 @@ func TestSetupAndValidateSSHAuthorizedKeyEmptyEtcd(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
 	var tctx testContext
 	tctx.SaveContext()
@@ -2015,11 +2015,11 @@ func TestSetupAndValidateSSHAuthorizedKeyEmptyAllMachineConfigs(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
 
 	var tctx testContext
@@ -2055,11 +2055,11 @@ func TestSetupAndValidateUsersNil(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users = nil
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users = nil
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users = nil
 	var tctx testContext
 	tctx.SaveContext()
@@ -2079,11 +2079,11 @@ func TestSetupAndValidateSshAuthorizedKeysNil(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].SshAuthorizedKeys = nil
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys = nil
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys = nil
 	var tctx testContext
 	tctx.SaveContext()
@@ -2099,7 +2099,7 @@ func TestSetupAndValidateCreateClusterCPMachineGroupRefNil(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef = nil
+	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef = nil
 	var tctx testContext
 	tctx.SaveContext()
 
@@ -2114,7 +2114,7 @@ func TestSetupAndValidateCreateClusterWorkerMachineGroupRefNil(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef = nil
+	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef = nil
 	var tctx testContext
 	tctx.SaveContext()
 
@@ -2129,7 +2129,7 @@ func TestSetupAndValidateCreateClusterEtcdMachineGroupRefNil(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef = nil
+	clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef = nil
 	var tctx testContext
 	tctx.SaveContext()
 
@@ -2144,7 +2144,7 @@ func TestSetupAndValidateCreateClusterCPMachineGroupRefNonexistent(t *testing.T)
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "nonexistent"
+	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "nonexistent"
 	var tctx testContext
 	tctx.SaveContext()
 
@@ -2159,7 +2159,7 @@ func TestSetupAndValidateCreateClusterWorkerMachineGroupRefNonexistent(t *testin
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name = "nonexistent"
+	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name = "nonexistent"
 	var tctx testContext
 	tctx.SaveContext()
 
@@ -2174,7 +2174,7 @@ func TestSetupAndValidateCreateClusterEtcdMachineGroupRefNonexistent(t *testing.
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name = "nonexistent"
+	clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name = "nonexistent"
 	var tctx testContext
 	tctx.SaveContext()
 
@@ -2189,7 +2189,7 @@ func TestSetupAndValidateCreateClusterOsFamilyInvalid(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.OSFamily = "rhel"
 	var tctx testContext
 	tctx.SaveContext()
@@ -2202,7 +2202,7 @@ func TestSetupAndValidateCreateClusterOsFamilyInvalidWorkerNode(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	workerMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerMachineConfigName].Spec.OSFamily = "rhel"
 	var tctx testContext
 	tctx.SaveContext()
@@ -2215,7 +2215,7 @@ func TestSetupAndValidateCreateClusterOsFamilyInvalidEtcdNode(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.OSFamily = "rhel"
 	var tctx testContext
 	tctx.SaveContext()
@@ -2228,7 +2228,7 @@ func TestSetupAndValidateCreateClusterOsFamilyDifferent(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.OSFamily = "bottlerocket"
 	var tctx testContext
 	tctx.SaveContext()
@@ -2244,7 +2244,7 @@ func TestSetupAndValidateCreateClusterOsFamilyDifferentForEtcd(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.OSFamily = "bottlerocket"
 	var tctx testContext
 	tctx.SaveContext()
@@ -2266,13 +2266,13 @@ func TestSetupAndValidateCreateClusterOsFamilyEmpty(t *testing.T) {
 	govc.osTag = bottlerocketOSTag
 	provider := newProviderWithGovc(t, datacenterConfig, machineConfigs, clusterConfig, govc)
 	provider.providerGovcClient = govc
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.OSFamily = ""
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].Name = ""
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.OSFamily = ""
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].Name = ""
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.OSFamily = ""
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].Name = ""
 	var tctx testContext
@@ -2298,7 +2298,7 @@ func TestSetupAndValidateCreateClusterTemplateDifferent(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Template = "test"
 	var tctx testContext
 	tctx.SaveContext()
@@ -2349,7 +2349,7 @@ func TestSetupAndValidateCreateClusterTemplateMissingTags(t *testing.T) {
 	for _, mc := range tt.machineConfigs {
 		tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, mc).Return(mc.Spec.Template, nil)
 	}
-	controlPlaneMachineConfigName := tt.clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := tt.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	controlPlaneMachineConfig := tt.machineConfigs[controlPlaneMachineConfigName]
 
 	tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, controlPlaneMachineConfig).Return(controlPlaneMachineConfig.Spec.Template, nil)
@@ -2364,7 +2364,7 @@ func TestSetupAndValidateCreateClusterErrorGettingTags(t *testing.T) {
 	tt := newProviderTest(t)
 	errorMessage := "failed getting tags"
 
-	controlPlaneMachineConfigName := tt.clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := tt.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	controlPlaneMachineConfig := tt.machineConfigs[controlPlaneMachineConfigName]
 
 	tt.setExpectationForSetup()
@@ -2391,15 +2391,15 @@ func TestSetupAndValidateCreateClusterDefaultTemplate(t *testing.T) {
 		s.VersionsBundle.EksD.Name = eksd119Release
 		s.VersionsBundle.EksD.KubeVersion = "v1.19.8"
 		s.VersionsBundle.KubeVersion = "1.19"
-		s.Namespace = "test-namespace"
+		s.Cluster.Namespace = "test-namespace"
 	})
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Template = ""
-	workerNodeMachineConfigName := clusterSpec.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Template = ""
-	etcdMachineConfigName := clusterSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
+	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.Template = ""
 	wantTemplate := "/SDDC-Datacenter/vm/Templates/ubuntu-v1.19.8-kubernetes-1-19-eks-4-amd64-63a8dce"
 	setupContext(t)
@@ -2506,7 +2506,7 @@ func TestValidateNewSpecSuccess(t *testing.T) {
 		},
 	}
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Namespace = "test-namespace"
+		s.Cluster.Namespace = "test-namespace"
 		s.Cluster = clusterConfig
 	})
 	c := &types.Cluster{}
@@ -2548,7 +2548,7 @@ func TestValidateNewSpecMutableFields(t *testing.T) {
 	}
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Namespace = "test-namespace"
+		s.Cluster.Namespace = "test-namespace"
 		s.Cluster = clusterConfig
 	})
 
@@ -2577,7 +2577,7 @@ func TestValidateNewSpecDatacenterImmutable(t *testing.T) {
 	newMachineConfigs := givenMachineConfigs(t, testClusterConfigMainFilename)
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Namespace = "test-namespace"
+		s.Cluster.Namespace = "test-namespace"
 		s.Cluster = clusterConfig
 	})
 
@@ -2603,7 +2603,7 @@ func TestValidateNewSpecMachineConfigNotFound(t *testing.T) {
 	newProviderConfig.Spec.Datacenter = "new-" + newProviderConfig.Spec.Datacenter
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Namespace = "test-namespace"
+		s.Cluster.Namespace = "test-namespace"
 		s.Cluster = clusterConfig.DeepCopy()
 		s.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "missing-machine-group"
 		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name = "missing-machine-group"
@@ -2631,7 +2631,7 @@ func TestValidateNewSpecServerImmutable(t *testing.T) {
 	newMachineConfigs := givenMachineConfigs(t, testClusterConfigMainFilename)
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Namespace = "test-namespace"
+		s.Cluster.Namespace = "test-namespace"
 		s.Cluster = clusterConfig
 	})
 
@@ -2660,7 +2660,7 @@ func TestValidateNewSpecStoragePolicyNameImmutableControlPlane(t *testing.T) {
 	newMachineConfigs[controlPlaneMachineConfigName].Spec.StoragePolicyName = "new-" + newMachineConfigs[controlPlaneMachineConfigName].Spec.StoragePolicyName
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Namespace = "test-namespace"
+		s.Cluster.Namespace = "test-namespace"
 		s.Cluster = clusterConfig
 	})
 
@@ -2687,7 +2687,7 @@ func TestValidateNewSpecStoragePolicyNameImmutableWorker(t *testing.T) {
 	newMachineConfigs[workerMachineConfigName].Spec.StoragePolicyName = "new-" + newMachineConfigs[workerMachineConfigName].Spec.StoragePolicyName
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Namespace = "test-namespace"
+		s.Cluster.Namespace = "test-namespace"
 		s.Cluster = clusterConfig
 	})
 
@@ -2713,7 +2713,7 @@ func TestValidateNewSpecTLSInsecureImmutable(t *testing.T) {
 	newMachineConfigs := givenMachineConfigs(t, testClusterConfigMainFilename)
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Namespace = "test-namespace"
+		s.Cluster.Namespace = "test-namespace"
 		s.Cluster = clusterConfig
 	})
 
@@ -2740,7 +2740,7 @@ func TestValidateNewSpecTLSThumbprintImmutable(t *testing.T) {
 	newMachineConfigs := givenMachineConfigs(t, testClusterConfigMainFilename)
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Namespace = "test-namespace"
+		s.Cluster.Namespace = "test-namespace"
 		s.Cluster = clusterConfig
 	})
 
@@ -2901,7 +2901,7 @@ func TestProviderGenerateCAPISpecForCreateWithPodIAMConfig(t *testing.T) {
 		Name: "test",
 	}
 	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
-	clusterSpec.Spec.PodIAMConfig = &v1alpha1.PodIAMConfig{ServiceAccountIssuer: "https://test"}
+	clusterSpec.Cluster.Spec.PodIAMConfig = &v1alpha1.PodIAMConfig{ServiceAccountIssuer: "https://test"}
 
 	datacenterConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
 	machineConfigs := givenMachineConfigs(t, testClusterConfigMainFilename)
@@ -2933,7 +2933,7 @@ func TestProviderGenerateCAPISpecForCreateWithCustomResolvConf(t *testing.T) {
 		Name: "test",
 	}
 	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
-	clusterSpec.Spec.ClusterNetwork.DNS.ResolvConf = &v1alpha1.ResolvConf{Path: "/etc/my-custom-resolv.conf"}
+	clusterSpec.Cluster.Spec.ClusterNetwork.DNS.ResolvConf = &v1alpha1.ResolvConf{Path: "/etc/my-custom-resolv.conf"}
 
 	datacenterConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
 	machineConfigs := givenMachineConfigs(t, testClusterConfigMainFilename)
@@ -3038,7 +3038,7 @@ func TestSetupAndValidateCreateManagementDoesNotCheckIfMachineAndDataCenterExist
 	for _, config := range newMachineConfigs {
 		kubectl.EXPECT().SearchVsphereMachineConfig(context.TODO(), config.Name, gomock.Any(), config.Namespace).Return([]*v1alpha1.VSphereMachineConfig{}, nil).Times(0)
 	}
-	kubectl.EXPECT().SearchVsphereDatacenterConfig(context.TODO(), datacenterConfig.Name, gomock.Any(), clusterSpec.Namespace).Return([]*v1alpha1.VSphereDatacenterConfig{}, nil).Times(0)
+	kubectl.EXPECT().SearchVsphereDatacenterConfig(context.TODO(), datacenterConfig.Name, gomock.Any(), clusterSpec.Cluster.Namespace).Return([]*v1alpha1.VSphereDatacenterConfig{}, nil).Times(0)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -30,7 +30,7 @@ func newTlsTest(t *testing.T) *tlsTest {
 		WithT:        NewWithT(t),
 		tlsValidator: mocks.NewMockTlsValidator(ctrl),
 		clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-			s.Spec.RegistryMirrorConfiguration = &anywherev1.RegistryMirrorConfiguration{
+			s.Cluster.Spec.RegistryMirrorConfiguration = &anywherev1.RegistryMirrorConfiguration{
 				Endpoint: host,
 				Port:     port,
 			}
@@ -43,14 +43,14 @@ func newTlsTest(t *testing.T) *tlsTest {
 
 func TestValidateCertForRegistryMirrorNoRegistryMirror(t *testing.T) {
 	tt := newTlsTest(t)
-	tt.clusterSpec.Spec.RegistryMirrorConfiguration = nil
+	tt.clusterSpec.Cluster.Spec.RegistryMirrorConfiguration = nil
 
 	tt.Expect(validations.ValidateCertForRegistryMirror(tt.clusterSpec, tt.tlsValidator)).To(Succeed())
 }
 
 func TestValidateCertForRegistryMirrorCertInvalid(t *testing.T) {
 	tt := newTlsTest(t)
-	tt.clusterSpec.Spec.RegistryMirrorConfiguration.CACertContent = tt.certContent
+	tt.clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.CACertContent = tt.certContent
 	tt.tlsValidator.EXPECT().HasSelfSignedCert(tt.host, tt.port).Return(false, nil)
 	tt.tlsValidator.EXPECT().ValidateCert(tt.host, tt.port, tt.certContent).Return(errors.New("invalid cert"))
 
@@ -61,7 +61,7 @@ func TestValidateCertForRegistryMirrorCertInvalid(t *testing.T) {
 
 func TestValidateCertForRegistryMirrorCertValid(t *testing.T) {
 	tt := newTlsTest(t)
-	tt.clusterSpec.Spec.RegistryMirrorConfiguration.CACertContent = tt.certContent
+	tt.clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.CACertContent = tt.certContent
 	tt.tlsValidator.EXPECT().HasSelfSignedCert(tt.host, tt.port).Return(false, nil)
 	tt.tlsValidator.EXPECT().ValidateCert(tt.host, tt.port, tt.certContent).Return(nil)
 

--- a/pkg/validations/createvalidations/gitops.go
+++ b/pkg/validations/createvalidations/gitops.go
@@ -11,17 +11,17 @@ import (
 )
 
 func ValidateGitOps(ctx context.Context, k validations.KubectlClient, cluster *types.Cluster, spec *cluster.Spec) error {
-	if spec.GitOpsConfig == nil || spec.IsSelfManaged() {
+	if spec.GitOpsConfig == nil || spec.Cluster.IsSelfManaged() {
 		logger.V(5).Info("skipping ValidateGitOps")
 		return nil
 	}
 
-	existingGitOps, err := k.SearchEksaGitOpsConfig(ctx, spec.Spec.GitOpsRef.Name, cluster.KubeconfigFile, spec.Namespace)
+	existingGitOps, err := k.SearchEksaGitOpsConfig(ctx, spec.Cluster.Spec.GitOpsRef.Name, cluster.KubeconfigFile, spec.Cluster.Namespace)
 	if err != nil {
 		return err
 	}
 	if len(existingGitOps) > 0 {
-		return fmt.Errorf("gitOpsConfig %s already exists", spec.Spec.GitOpsRef.Name)
+		return fmt.Errorf("gitOpsConfig %s already exists", spec.Cluster.Spec.GitOpsRef.Name)
 	}
 
 	err = validateWorkloadFields(ctx, k, cluster, spec)

--- a/pkg/validations/createvalidations/gitops_test.go
+++ b/pkg/validations/createvalidations/gitops_test.go
@@ -123,13 +123,13 @@ func TestValidateGitopsForWorkloadClustersPath(t *testing.T) {
 			}
 
 			clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-				s.Name = testclustername
-				s.Spec.GitOpsRef = &v1alpha1.Ref{
+				s.Cluster.Name = testclustername
+				s.Cluster.Spec.GitOpsRef = &v1alpha1.Ref{
 					Kind: v1alpha1.GitOpsConfigKind,
 					Name: "gitopstest",
 				}
 				s.GitOpsConfig = defaultGitOps
-				s.SetManagedBy("management-cluster")
+				s.Cluster.SetManagedBy("management-cluster")
 			})
 			k, ctx, cluster, e := validations.NewKubectl(t)
 			cluster.Name = "management-cluster"
@@ -137,7 +137,7 @@ func TestValidateGitopsForWorkloadClustersPath(t *testing.T) {
 			e.EXPECT().Execute(
 				ctx, []string{
 					"get", eksaGitOpsResourceType, "-o", "json", "--kubeconfig",
-					cluster.KubeconfigFile, "--namespace", clusterSpec.Namespace,
+					cluster.KubeconfigFile, "--namespace", clusterSpec.Cluster.Namespace,
 					"--field-selector=metadata.name=gitopstest",
 				}).Return(*bytes.NewBufferString(gitOpsListContent), nil)
 
@@ -151,7 +151,7 @@ func TestValidateGitopsForWorkloadClustersPath(t *testing.T) {
 			e.EXPECT().Execute(
 				ctx, []string{
 					"get", eksaGitOpsResourceType, "management-gitops", "-o", "json", "--kubeconfig",
-					cluster.KubeconfigFile, "--namespace", clusterSpec.Namespace,
+					cluster.KubeconfigFile, "--namespace", clusterSpec.Cluster.Namespace,
 				}).Return(*bytes.NewBufferString(mgmtGitOpsContent), nil)
 
 			err := createvalidations.ValidateGitOps(ctx, k, cluster, clusterSpec)
@@ -191,13 +191,13 @@ func TestValidateGitopsForWorkloadClustersFailure(t *testing.T) {
 	}
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = testclustername
-		s.Spec.GitOpsRef = &v1alpha1.Ref{
+		s.Cluster.Name = testclustername
+		s.Cluster.Spec.GitOpsRef = &v1alpha1.Ref{
 			Kind: v1alpha1.GitOpsConfigKind,
 			Name: "gitopstest",
 		}
 		s.GitOpsConfig = defaultGitOps
-		s.SetManagedBy("management-cluster")
+		s.Cluster.SetManagedBy("management-cluster")
 		// s.OIDCConfig = defaultOIDC
 	})
 	k, ctx, cluster, e := validations.NewKubectl(t)
@@ -208,7 +208,7 @@ func TestValidateGitopsForWorkloadClustersFailure(t *testing.T) {
 			e.EXPECT().Execute(
 				ctx, []string{
 					"get", eksaGitOpsResourceType, "-o", "json", "--kubeconfig",
-					cluster.KubeconfigFile, "--namespace", clusterSpec.Namespace,
+					cluster.KubeconfigFile, "--namespace", clusterSpec.Cluster.Namespace,
 					"--field-selector=metadata.name=gitopstest",
 				}).Return(*bytes.NewBufferString(fileContent), nil)
 
@@ -234,8 +234,8 @@ func TestSkipValidateGitopsWithNoGitOpts(t *testing.T) {
 	}
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.SetManagedBy("management-cluster")
-		s.Name = testclustername
+		s.Cluster.SetManagedBy("management-cluster")
+		s.Cluster.Name = testclustername
 
 		s.GitOpsConfig = nil
 	})
@@ -247,7 +247,7 @@ func TestSkipValidateGitopsWithNoGitOpts(t *testing.T) {
 			e.EXPECT().Execute(
 				ctx, []string{
 					"get", eksaGitOpsResourceType, "-o", "json", "--kubeconfig",
-					cluster.KubeconfigFile, "--namespace", clusterSpec.Namespace,
+					cluster.KubeconfigFile, "--namespace", clusterSpec.Cluster.Namespace,
 					"--field-selector=metadata.name=gitopstest",
 				}).Times(0)
 
@@ -288,14 +288,14 @@ func TestValidateGitopsForSelfManagedCluster(t *testing.T) {
 	}
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = testclustername
-		s.Spec.GitOpsRef = &v1alpha1.Ref{
+		s.Cluster.Name = testclustername
+		s.Cluster.Spec.GitOpsRef = &v1alpha1.Ref{
 			Kind: v1alpha1.GitOpsConfigKind,
 			Name: "gitopstest",
 		}
 		s.GitOpsConfig = defaultGitOps
 
-		s.SetSelfManaged()
+		s.Cluster.SetSelfManaged()
 	})
 	k, ctx, cluster, e := validations.NewKubectl(t)
 	cluster.Name = testclustername
@@ -304,7 +304,7 @@ func TestValidateGitopsForSelfManagedCluster(t *testing.T) {
 			e.EXPECT().Execute(
 				ctx, []string{
 					"get", eksaGitOpsResourceType, "-o", "json", "--kubeconfig",
-					cluster.KubeconfigFile, "--namespace", clusterSpec.Namespace,
+					cluster.KubeconfigFile, "--namespace", clusterSpec.Cluster.Namespace,
 					"--field-selector=metadata.name=gitopstest",
 				}).Times(0)
 

--- a/pkg/validations/createvalidations/identityproviders.go
+++ b/pkg/validations/createvalidations/identityproviders.go
@@ -11,14 +11,14 @@ import (
 )
 
 func ValidateIdentityProviderNameIsUnique(ctx context.Context, k validations.KubectlClient, cluster *types.Cluster, spec *cluster.Spec) error {
-	if len(spec.Spec.IdentityProviderRefs) == 0 || spec.IsSelfManaged() {
+	if len(spec.Cluster.Spec.IdentityProviderRefs) == 0 || spec.Cluster.IsSelfManaged() {
 		logger.V(5).Info("skipping ValidateIdentityProviderNameIsUnique")
 		return nil
 	}
 
 	var existingIR []string
-	for _, ir := range spec.Spec.IdentityProviderRefs {
-		eIR, err := k.SearchIdentityProviderConfig(ctx, ir.Name, ir.Kind, cluster.KubeconfigFile, spec.Namespace)
+	for _, ir := range spec.Cluster.Spec.IdentityProviderRefs {
+		eIR, err := k.SearchIdentityProviderConfig(ctx, ir.Name, ir.Kind, cluster.KubeconfigFile, spec.Cluster.Namespace)
 		if err != nil {
 			return err
 		}

--- a/pkg/validations/createvalidations/identityproviders_test.go
+++ b/pkg/validations/createvalidations/identityproviders_test.go
@@ -51,14 +51,14 @@ func TestValidateIdendityProviderForWorkloadClusters(t *testing.T) {
 	}
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = testclustername
-		s.Spec.IdentityProviderRefs = []v1alpha1.Ref{
+		s.Cluster.Name = testclustername
+		s.Cluster.Spec.IdentityProviderRefs = []v1alpha1.Ref{
 			{
 				Kind: v1alpha1.OIDCConfigKind,
 				Name: "oidc-config-test",
 			},
 		}
-		s.SetManagedBy("management-cluster")
+		s.Cluster.SetManagedBy("management-cluster")
 		s.OIDCConfig = defaultOIDC
 	})
 	k, ctx, cluster, e := validations.NewKubectl(t)
@@ -69,7 +69,7 @@ func TestValidateIdendityProviderForWorkloadClusters(t *testing.T) {
 			e.EXPECT().Execute(
 				ctx, []string{
 					"get", oidcResourceType, "-o", "json", "--kubeconfig",
-					cluster.KubeconfigFile, "--namespace", clusterSpec.Namespace,
+					cluster.KubeconfigFile, "--namespace", clusterSpec.Cluster.Namespace,
 					"--field-selector=metadata.name=oidc-config-test",
 				}).Return(*bytes.NewBufferString(fileContent), nil)
 
@@ -111,8 +111,8 @@ func TestValidateIdentityProviderForSelfManagedCluster(t *testing.T) {
 	}
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = testclustername
-		s.Spec.IdentityProviderRefs = []v1alpha1.Ref{
+		s.Cluster.Name = testclustername
+		s.Cluster.Spec.IdentityProviderRefs = []v1alpha1.Ref{
 			{
 				Kind: v1alpha1.OIDCConfigKind,
 				Name: "oidc-config-test",
@@ -120,7 +120,7 @@ func TestValidateIdentityProviderForSelfManagedCluster(t *testing.T) {
 		}
 		s.OIDCConfig = defaultOIDC
 
-		s.SetSelfManaged()
+		s.Cluster.SetSelfManaged()
 	})
 	k, ctx, cluster, e := validations.NewKubectl(t)
 	cluster.Name = testclustername
@@ -129,7 +129,7 @@ func TestValidateIdentityProviderForSelfManagedCluster(t *testing.T) {
 			e.EXPECT().Execute(
 				ctx, []string{
 					"get", oidcResourceType, "-o", "json", "--kubeconfig",
-					cluster.KubeconfigFile, "--namespace", clusterSpec.Namespace,
+					cluster.KubeconfigFile, "--namespace", clusterSpec.Cluster.Namespace,
 					"--field-selector=metadata.name=oidc-config-test",
 				}).Times(0)
 

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -32,13 +32,13 @@ func (u *CreateValidations) PreflightValidations(ctx context.Context) (err error
 		},
 	}
 
-	if u.Opts.Spec.IsManaged() {
+	if u.Opts.Spec.Cluster.IsManaged() {
 		createValidations = append(
 			createValidations,
 			validations.ValidationResult{
 				Name:        "validate cluster name",
 				Remediation: "",
-				Err:         ValidateClusterNameIsUnique(ctx, k, targetCluster, u.Opts.Spec.Name),
+				Err:         ValidateClusterNameIsUnique(ctx, k, targetCluster, u.Opts.Spec.Cluster.Name),
 			},
 			validations.ValidationResult{
 				Name:        "validate gitops",

--- a/pkg/validations/upgradevalidations/immutableFields.go
+++ b/pkg/validations/upgradevalidations/immutableFields.go
@@ -12,23 +12,23 @@ import (
 )
 
 func ValidateImmutableFields(ctx context.Context, k validations.KubectlClient, cluster *types.Cluster, spec *cluster.Spec, provider providers.Provider) error {
-	prevSpec, err := k.GetEksaCluster(ctx, cluster, spec.Name)
+	prevSpec, err := k.GetEksaCluster(ctx, cluster, spec.Cluster.Name)
 	if err != nil {
 		return err
 	}
 
-	if prevSpec.Name != spec.Name {
-		return fmt.Errorf("cluster name is immutable. previous name %s, new name %s", prevSpec.Name, spec.Name)
+	if prevSpec.Name != spec.Cluster.Name {
+		return fmt.Errorf("cluster name is immutable. previous name %s, new name %s", prevSpec.Name, spec.Cluster.Name)
 	}
 
-	if prevSpec.Namespace != spec.Namespace {
-		if !(prevSpec.Namespace == "default" && spec.Namespace == "") {
+	if prevSpec.Namespace != spec.Cluster.Namespace {
+		if !(prevSpec.Namespace == "default" && spec.Cluster.Namespace == "") {
 			return fmt.Errorf("cluster namespace is immutable")
 		}
 	}
 
 	oSpec := prevSpec.Spec
-	nSpec := spec.Spec
+	nSpec := spec.Cluster.Spec
 
 	if !nSpec.DatacenterRef.Equal(&oSpec.DatacenterRef) {
 		return fmt.Errorf("spec.dataCenterRef.name is immutable")
@@ -39,7 +39,7 @@ func ValidateImmutableFields(ctx context.Context, k validations.KubectlClient, c
 	}
 
 	if nSpec.GitOpsRef != nil {
-		prevGitOps, err := k.GetEksaGitOpsConfig(ctx, nSpec.GitOpsRef.Name, cluster.KubeconfigFile, spec.Namespace)
+		prevGitOps, err := k.GetEksaGitOpsConfig(ctx, nSpec.GitOpsRef.Name, cluster.KubeconfigFile, spec.Cluster.Namespace)
 		if err != nil {
 			return err
 		}
@@ -100,7 +100,7 @@ func ValidateImmutableFields(ctx context.Context, k validations.KubectlClient, c
 		switch nIdentityProvider.Kind {
 		case v1alpha1.AWSIamConfigKind:
 			newAWSIamConfigRef := &nIdentityProvider
-			prevAwsIam, err := k.GetEksaAWSIamConfig(ctx, nIdentityProvider.Name, cluster.KubeconfigFile, spec.Namespace)
+			prevAwsIam, err := k.GetEksaAWSIamConfig(ctx, nIdentityProvider.Name, cluster.KubeconfigFile, spec.Cluster.Namespace)
 			if err != nil {
 				return err
 			}
@@ -110,7 +110,7 @@ func ValidateImmutableFields(ctx context.Context, k validations.KubectlClient, c
 		}
 	}
 
-	if spec.IsSelfManaged() != prevSpec.IsSelfManaged() {
+	if spec.Cluster.IsSelfManaged() != prevSpec.IsSelfManaged() {
 		return fmt.Errorf("management flag is immutable")
 	}
 

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -39,7 +39,7 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) (err erro
 		{
 			Name:        "worker nodes ready",
 			Remediation: fmt.Sprintf("ensure machine deployments for cluster %s are Ready", u.Opts.WorkloadCluster.Name),
-			Err:         k.ValidateWorkerNodes(ctx, u.Opts.Spec.Name, targetCluster.KubeconfigFile),
+			Err:         k.ValidateWorkerNodes(ctx, u.Opts.Spec.Cluster.Name, targetCluster.KubeconfigFile),
 		},
 		{
 			Name:        "nodes ready",
@@ -59,7 +59,7 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) (err erro
 		{
 			Name:        "upgrade cluster kubernetes version increment",
 			Remediation: "ensure that the cluster kubernetes version is incremented by one minor version exactly (e.g. 1.18 -> 1.19)",
-			Err:         ValidateServerVersionSkew(ctx, u.Opts.Spec.Spec.KubernetesVersion, u.Opts.WorkloadCluster, k),
+			Err:         ValidateServerVersionSkew(ctx, u.Opts.Spec.Cluster.Spec.KubernetesVersion, u.Opts.WorkloadCluster, k),
 		},
 		{
 			Name:        "validate immutable fields",

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -160,7 +160,7 @@ func TestPreflightValidations(t *testing.T) {
 			crdResponse:        nil,
 			wantErr:            composeError("spec.externalEtcdConfiguration is immutable"),
 			modifyFunc: func(s *cluster.Spec) {
-				s.Spec.ExternalEtcdConfiguration.Count++
+				s.Cluster.Spec.ExternalEtcdConfiguration.Count++
 			},
 		},
 		{
@@ -174,7 +174,7 @@ func TestPreflightValidations(t *testing.T) {
 			crdResponse:        nil,
 			wantErr:            composeError("spec.controlPlaneConfiguration.endpoint is immutable"),
 			modifyFunc: func(s *cluster.Spec) {
-				s.Spec.ControlPlaneConfiguration.Endpoint.Host = "2.3.4.5"
+				s.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host = "2.3.4.5"
 			},
 		},
 		{
@@ -230,7 +230,7 @@ func TestPreflightValidations(t *testing.T) {
 			crdResponse:        nil,
 			wantErr:            composeError("aws iam identity provider is immutable"),
 			modifyFunc: func(s *cluster.Spec) {
-				s.Spec.IdentityProviderRefs[1] = v1alpha1.Ref{
+				s.Cluster.Spec.IdentityProviderRefs[1] = v1alpha1.Ref{
 					Kind: v1alpha1.AWSIamConfigKind,
 					Name: "aws-iam2",
 				}
@@ -247,7 +247,7 @@ func TestPreflightValidations(t *testing.T) {
 			crdResponse:        nil,
 			wantErr:            composeError("aws iam identity provider is immutable"),
 			modifyFunc: func(s *cluster.Spec) {
-				s.Spec.IdentityProviderRefs[1] = v1alpha1.Ref{
+				s.Cluster.Spec.IdentityProviderRefs[1] = v1alpha1.Ref{
 					Kind: v1alpha1.OIDCConfigKind,
 					Name: "oidc",
 				}
@@ -264,7 +264,7 @@ func TestPreflightValidations(t *testing.T) {
 			crdResponse:        nil,
 			wantErr:            nil,
 			modifyFunc: func(s *cluster.Spec) {
-				s.Spec.IdentityProviderRefs[1] = v1alpha1.Ref{
+				s.Cluster.Spec.IdentityProviderRefs[1] = v1alpha1.Ref{
 					Kind: v1alpha1.AWSIamConfigKind,
 					Name: "aws-iam",
 				}
@@ -463,7 +463,7 @@ func TestPreflightValidations(t *testing.T) {
 			crdResponse:        nil,
 			wantErr:            composeError("spec.clusterNetwork is immutable"),
 			modifyFunc: func(s *cluster.Spec) {
-				s.Spec.ClusterNetwork = v1alpha1.ClusterNetwork{}
+				s.Cluster.Spec.ClusterNetwork = v1alpha1.ClusterNetwork{}
 			},
 		},
 		{
@@ -477,7 +477,7 @@ func TestPreflightValidations(t *testing.T) {
 			crdResponse:        nil,
 			wantErr:            composeError("spec.proxyConfiguration is immutable"),
 			modifyFunc: func(s *cluster.Spec) {
-				s.Spec.ProxyConfiguration = &v1alpha1.ProxyConfiguration{
+				s.Cluster.Spec.ProxyConfiguration = &v1alpha1.ProxyConfiguration{
 					HttpProxy:  "httpproxy2",
 					HttpsProxy: "httpsproxy2",
 					NoProxy: []string{
@@ -497,8 +497,8 @@ func TestPreflightValidations(t *testing.T) {
 			crdResponse:        nil,
 			wantErr:            composeError("spec.externalEtcdConfiguration is immutable"),
 			modifyFunc: func(s *cluster.Spec) {
-				s.Spec.ExternalEtcdConfiguration.Count += 1
-				s.Spec.DatacenterRef = v1alpha1.Ref{
+				s.Cluster.Spec.ExternalEtcdConfiguration.Count += 1
+				s.Cluster.Spec.DatacenterRef = v1alpha1.Ref{
 					Kind: v1alpha1.VSphereDatacenterKind,
 					Name: "vsphere test",
 				}
@@ -515,8 +515,8 @@ func TestPreflightValidations(t *testing.T) {
 			crdResponse:        nil,
 			wantErr:            composeError("spec.externalEtcdConfiguration is immutable"),
 			modifyFunc: func(s *cluster.Spec) {
-				s.Spec.ExternalEtcdConfiguration = nil
-				s.Spec.DatacenterRef = v1alpha1.Ref{
+				s.Cluster.Spec.ExternalEtcdConfiguration = nil
+				s.Cluster.Spec.DatacenterRef = v1alpha1.Ref{
 					Kind: v1alpha1.VSphereDatacenterKind,
 					Name: "vsphere test",
 				}
@@ -533,7 +533,7 @@ func TestPreflightValidations(t *testing.T) {
 			crdResponse:        nil,
 			wantErr:            composeError("management flag is immutable"),
 			modifyFunc: func(s *cluster.Spec) {
-				s.SetManagedBy(fmt.Sprintf("%s-1", s.ManagedBy()))
+				s.Cluster.SetManagedBy(fmt.Sprintf("%s-1", s.Cluster.ManagedBy()))
 			},
 		},
 	}
@@ -611,14 +611,14 @@ func TestPreflightValidations(t *testing.T) {
 	}
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Name = testclustername
-		s.Spec.ControlPlaneConfiguration = defaultControlPlane
-		s.Spec.ExternalEtcdConfiguration = defaultETCD
-		s.Spec.DatacenterRef = v1alpha1.Ref{
+		s.Cluster.Name = testclustername
+		s.Cluster.Spec.ControlPlaneConfiguration = defaultControlPlane
+		s.Cluster.Spec.ExternalEtcdConfiguration = defaultETCD
+		s.Cluster.Spec.DatacenterRef = v1alpha1.Ref{
 			Kind: v1alpha1.VSphereDatacenterKind,
 			Name: "vsphere test",
 		}
-		s.Spec.IdentityProviderRefs = []v1alpha1.Ref{
+		s.Cluster.Spec.IdentityProviderRefs = []v1alpha1.Ref{
 			{
 				Kind: v1alpha1.OIDCConfigKind,
 				Name: "oidc",
@@ -628,11 +628,11 @@ func TestPreflightValidations(t *testing.T) {
 				Name: "aws-iam",
 			},
 		}
-		s.Spec.GitOpsRef = &v1alpha1.Ref{
+		s.Cluster.Spec.GitOpsRef = &v1alpha1.Ref{
 			Kind: v1alpha1.GitOpsConfigKind,
 			Name: "gitops test",
 		}
-		s.Spec.ClusterNetwork = v1alpha1.ClusterNetwork{
+		s.Cluster.Spec.ClusterNetwork = v1alpha1.ClusterNetwork{
 			Pods: v1alpha1.Pods{
 				CidrBlocks: []string{
 					"1.2.3.4/5",
@@ -644,7 +644,7 @@ func TestPreflightValidations(t *testing.T) {
 				},
 			},
 		}
-		s.Spec.ProxyConfiguration = &v1alpha1.ProxyConfiguration{
+		s.Cluster.Spec.ProxyConfiguration = &v1alpha1.ProxyConfiguration{
 			HttpProxy:  "httpproxy",
 			HttpsProxy: "httpsproxy",
 			NoProxy: []string{
@@ -678,7 +678,7 @@ func TestPreflightValidations(t *testing.T) {
 				TlsValidator:      tlsValidator,
 			}
 
-			clusterSpec.Spec.KubernetesVersion = v1alpha1.KubernetesVersion(tc.upgradeVersion)
+			clusterSpec.Cluster.Spec.KubernetesVersion = v1alpha1.KubernetesVersion(tc.upgradeVersion)
 			existingClusterSpec := clusterSpec.DeepCopy()
 			existingProviderSpec := defaultDatacenterSpec.DeepCopy()
 			if tc.modifyFunc != nil {
@@ -692,16 +692,16 @@ func TestPreflightValidations(t *testing.T) {
 
 			provider.EXPECT().DatacenterConfig().Return(existingProviderSpec).MaxTimes(1)
 			provider.EXPECT().ValidateNewSpec(ctx, workloadCluster, clusterSpec).Return(nil).MaxTimes(1)
-			k.EXPECT().GetEksaVSphereDatacenterConfig(ctx, clusterSpec.Spec.DatacenterRef.Name, gomock.Any(), gomock.Any()).Return(existingProviderSpec, nil).MaxTimes(1)
-			k.EXPECT().ValidateControlPlaneNodes(ctx, workloadCluster, clusterSpec.Name).Return(tc.cpResponse)
+			k.EXPECT().GetEksaVSphereDatacenterConfig(ctx, clusterSpec.Cluster.Spec.DatacenterRef.Name, gomock.Any(), gomock.Any()).Return(existingProviderSpec, nil).MaxTimes(1)
+			k.EXPECT().ValidateControlPlaneNodes(ctx, workloadCluster, clusterSpec.Cluster.Name).Return(tc.cpResponse)
 			k.EXPECT().ValidateWorkerNodes(ctx, workloadCluster.Name, workloadCluster.KubeconfigFile).Return(tc.workerResponse)
 			k.EXPECT().ValidateNodes(ctx, kubeconfigFilePath).Return(tc.nodeResponse)
 			k.EXPECT().ValidateClustersCRD(ctx, workloadCluster).Return(tc.crdResponse)
 			k.EXPECT().GetClusters(ctx, workloadCluster).Return(tc.getClusterResponse, nil)
-			k.EXPECT().GetEksaCluster(ctx, workloadCluster, clusterSpec.Name).Return(existingClusterSpec.Cluster, nil)
-			k.EXPECT().GetEksaGitOpsConfig(ctx, clusterSpec.Spec.GitOpsRef.Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.GitOpsConfig, nil).MaxTimes(1)
-			k.EXPECT().GetEksaOIDCConfig(ctx, clusterSpec.Spec.IdentityProviderRefs[0].Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.OIDCConfig, nil).MaxTimes(1)
-			k.EXPECT().GetEksaAWSIamConfig(ctx, clusterSpec.Spec.IdentityProviderRefs[1].Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.AWSIamConfig, nil).MaxTimes(1)
+			k.EXPECT().GetEksaCluster(ctx, workloadCluster, clusterSpec.Cluster.Name).Return(existingClusterSpec.Cluster, nil)
+			k.EXPECT().GetEksaGitOpsConfig(ctx, clusterSpec.Cluster.Spec.GitOpsRef.Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.GitOpsConfig, nil).MaxTimes(1)
+			k.EXPECT().GetEksaOIDCConfig(ctx, clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.OIDCConfig, nil).MaxTimes(1)
+			k.EXPECT().GetEksaAWSIamConfig(ctx, clusterSpec.Cluster.Spec.IdentityProviderRefs[1].Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.AWSIamConfig, nil).MaxTimes(1)
 			k.EXPECT().Version(ctx, workloadCluster).Return(versionResponse, nil)
 			upgradeValidations := upgradevalidations.New(opts)
 			err := upgradeValidations.PreflightValidations(ctx)

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -37,7 +37,7 @@ func NewCreate(bootstrapper interfaces.Bootstrapper, provider providers.Provider
 func (c *Create) Run(ctx context.Context, clusterSpec *cluster.Spec, validator interfaces.Validator, forceCleanup bool) error {
 	if forceCleanup {
 		if err := c.bootstrapper.DeleteBootstrapCluster(ctx, &types.Cluster{
-			Name: clusterSpec.Name,
+			Name: clusterSpec.Cluster.Name,
 		}, false); err != nil {
 			return err
 		}
@@ -271,7 +271,7 @@ func (s *InstallEksaComponentsTask) Run(ctx context.Context, commandContext *tas
 	machineConfigs := commandContext.Provider.MachineConfigs()
 
 	// this disables create-webhook validation during create
-	commandContext.ClusterSpec.PauseReconcile()
+	commandContext.ClusterSpec.Cluster.PauseReconcile()
 	datacenterConfig.PauseReconcile()
 
 	targetCluster := commandContext.WorkloadCluster

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -60,7 +60,7 @@ func newCreateTest(t *testing.T) *createTestSetup {
 		machineConfigs:   machineConfigs,
 		workflow:         workflow,
 		ctx:              context.Background(),
-		clusterSpec:      test.NewClusterSpec(func(s *cluster.Spec) { s.Name = "cluster-name"; s.Annotations = map[string]string{} }),
+		clusterSpec:      test.NewClusterSpec(func(s *cluster.Spec) { s.Cluster.Name = "cluster-name"; s.Cluster.Annotations = map[string]string{} }),
 		bootstrapCluster: &types.Cluster{Name: "bootstrap"},
 		workloadCluster:  &types.Cluster{Name: "workload"},
 	}

--- a/pkg/workflows/delete_test.go
+++ b/pkg/workflows/delete_test.go
@@ -45,7 +45,7 @@ func newDeleteTest(t *testing.T) *deleteTestSetup {
 		provider:         provider,
 		workflow:         workflow,
 		ctx:              context.Background(),
-		clusterSpec:      test.NewClusterSpec(func(s *cluster.Spec) { s.Name = "cluster-name" }),
+		clusterSpec:      test.NewClusterSpec(func(s *cluster.Spec) { s.Cluster.Name = "cluster-name" }),
 		bootstrapCluster: &types.Cluster{Name: "bootstrap"},
 		workloadCluster:  &types.Cluster{Name: "workload"},
 	}
@@ -156,7 +156,7 @@ func TestDeleteWorkloadRunSuccess(t *testing.T) {
 		KubeconfigFile:     "kc.kubeconfig",
 		ExistingManagement: true,
 	}
-	test.clusterSpec.SetManagedBy(test.clusterSpec.ManagementCluster.Name)
+	test.clusterSpec.Cluster.SetManagedBy(test.clusterSpec.ManagementCluster.Name)
 	test.expectDeleteWorkload(test.clusterSpec.ManagementCluster)
 	test.expectCleanupGitRepo()
 	test.expectNotToMoveManagement()

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -43,7 +43,7 @@ func NewUpgrade(bootstrapper interfaces.Bootstrapper, provider providers.Provide
 func (c *Upgrade) Run(ctx context.Context, clusterSpec *cluster.Spec, workloadCluster *types.Cluster, validator interfaces.Validator, forceCleanup bool) error {
 	if forceCleanup {
 		if err := c.bootstrapper.DeleteBootstrapCluster(ctx, &types.Cluster{
-			Name: clusterSpec.Name,
+			Name: clusterSpec.Cluster.Name,
 		}, true); err != nil {
 			return err
 		}
@@ -160,7 +160,7 @@ func (s *ensureEtcdCAPIComponentsExistTask) Run(ctx context.Context, commandCont
 	target := getManagementCluster(commandContext)
 
 	logger.Info("Ensuring etcd CAPI providers exist on management cluster before upgrade")
-	currentSpec, err := commandContext.ClusterManager.GetCurrentClusterSpec(ctx, target, commandContext.ClusterSpec.Name)
+	currentSpec, err := commandContext.ClusterManager.GetCurrentClusterSpec(ctx, target, commandContext.ClusterSpec.Cluster.Name)
 	if err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -81,7 +81,7 @@ func newUpgradeTest(t *testing.T) *upgradeTestSetup {
 		machineConfigs:   machineConfigs,
 		workflow:         workflow,
 		ctx:              context.Background(),
-		newClusterSpec:   test.NewClusterSpec(func(s *cluster.Spec) { s.Name = "cluster-name" }),
+		newClusterSpec:   test.NewClusterSpec(func(s *cluster.Spec) { s.Cluster.Name = "cluster-name" }),
 		bootstrapCluster: &types.Cluster{Name: "bootstrap"},
 		workloadCluster:  &types.Cluster{Name: "workload"},
 	}
@@ -126,7 +126,7 @@ func (c *upgradeTestSetup) expectUpgradeCoreComponents(expectedCluster *types.Cl
 		NewVersion:    "v0.0.2",
 	})
 	gomock.InOrder(
-		c.clusterManager.EXPECT().GetCurrentClusterSpec(c.ctx, expectedCluster, c.newClusterSpec.Name).Return(currentSpec, nil),
+		c.clusterManager.EXPECT().GetCurrentClusterSpec(c.ctx, expectedCluster, c.newClusterSpec.Cluster.Name).Return(currentSpec, nil),
 		c.clusterManager.EXPECT().UpgradeNetworking(c.ctx, expectedCluster, currentSpec, c.newClusterSpec).Return(networkingChangeDiff, nil),
 		c.capiManager.EXPECT().Upgrade(c.ctx, expectedCluster, c.provider, currentSpec, c.newClusterSpec).Return(capiChangeDiff, nil),
 		c.addonManager.EXPECT().UpdateLegacyFileStructure(c.ctx, currentSpec, c.newClusterSpec),
@@ -444,7 +444,7 @@ func TestUpgradeRunFailedUpgrade(t *testing.T) {
 
 func TestUpgradeWorkloadRunSuccess(t *testing.T) {
 	test := newUpgradeTest(t)
-	test.newClusterSpec.SetSelfManaged()
+	test.newClusterSpec.Cluster.SetSelfManaged()
 
 	test.bootstrapCluster.Name = "management-cluster"
 	test.bootstrapCluster.ExistingManagement = true

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -258,7 +258,7 @@ func (e *ClusterE2ETest) validateWorkerNodeMultiConfigUpdates(ctx context.Contex
 		if err != nil {
 			return err
 		}
-		clusterSpec.Spec.WorkerNodeGroupConfigurations[0].Count += 1
+		clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count += 1
 
 		providerConfig := providerConfig{
 			datacenterConfig: vsphereClusterConfig,
@@ -442,7 +442,7 @@ func (e *ClusterE2ETest) updateWorkerNodeCountValue(newValue int) (string, error
 	if err != nil {
 		return "", err
 	}
-	clusterSpec.Spec.WorkerNodeGroupConfigurations[0].Count = newValue
+	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = newValue
 
 	p, err := e.updateEKSASpecInGit(clusterSpec, *providerConfig)
 	if err != nil {


### PR DESCRIPTION
Continues work started in #1343 

*Description of changes:*
This is an intermediate step to be able to embed `cluster.Config` in
`cluster.Spec`. It only contains the change for the new field and updates
every single instance that was relying on Cluster being embed. No change
in functionality or behavior.

Lots of lines changes but it's only adding `.Cluster` to the `cluster.Spec` references.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

