### PR TITLE
Embed `cluster.Config` in `cluster.Spec`

### DIFF
--- a/internal/test/cluster.go
+++ b/internal/test/cluster.go
@@ -43,7 +43,6 @@ func NewClusterSpec(opts ...ClusterSpecOpt) *cluster.Spec {
 		opt(s)
 	}
 
-	s.SetDefaultGitOps()
 	return s
 }
 

--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -277,8 +277,6 @@ func (f *FluxAddonClient) Validations(ctx context.Context, clusterSpec *cluster.
 		return nil
 	}
 
-	clusterSpec.SetDefaultGitOps()
-
 	fc := &fluxForCluster{
 		FluxAddonClient: f,
 		clusterSpec:     clusterSpec,
@@ -300,8 +298,6 @@ func (f *FluxAddonClient) CleanupGitRepo(ctx context.Context, clusterSpec *clust
 		logger.Info("GitOps field not specified, clean up git repo skipped")
 		return nil
 	}
-
-	clusterSpec.SetDefaultGitOps()
 
 	fc := &fluxForCluster{
 		FluxAddonClient: f,

--- a/pkg/addonmanager/addonclients/fluxaddonclient_test.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient_test.go
@@ -86,7 +86,7 @@ func TestFluxAddonClientInstallGitOpsOnManagementClusterWithPrexistingRepo(t *te
 			cluster := &types.Cluster{}
 			clusterConfig := v1alpha1.NewCluster(tt.clusterName)
 			f, m, g := newAddonClient(t)
-			clusterSpec := newClusterSpec(clusterConfig, tt.fluxpath)
+			clusterSpec := newClusterSpec(t, clusterConfig, tt.fluxpath)
 
 			m.flux.EXPECT().BootstrapToolkitsComponents(ctx, cluster, clusterSpec.GitOpsConfig)
 
@@ -127,7 +127,7 @@ func TestFluxAddonClientInstallGitOpsOnWorkloadClusterWithPrexistingRepo(t *test
 	clusterConfig := v1alpha1.NewCluster(clusterName)
 	clusterConfig.SetManagedBy("management-cluster")
 	f, m, g := newAddonClient(t)
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 
 	m.flux.EXPECT().BootstrapToolkitsComponents(ctx, cluster, clusterSpec.GitOpsConfig)
 
@@ -212,7 +212,7 @@ func TestFluxAddonClientInstallGitOpsNoPrexistingRepo(t *testing.T) {
 			cluster := &types.Cluster{}
 			clusterConfig := v1alpha1.NewCluster(tt.clusterName)
 			f, m, g := newAddonClient(t)
-			clusterSpec := newClusterSpec(clusterConfig, tt.fluxpath)
+			clusterSpec := newClusterSpec(t, clusterConfig, tt.fluxpath)
 
 			m.flux.EXPECT().BootstrapToolkitsComponents(ctx, cluster, clusterSpec.GitOpsConfig)
 
@@ -295,7 +295,7 @@ func TestFluxAddonClientInstallGitOpsToolkitsBareRepo(t *testing.T) {
 			cluster := &types.Cluster{}
 			clusterConfig := v1alpha1.NewCluster(tt.clusterName)
 			f, m, g := newAddonClient(t)
-			clusterSpec := newClusterSpec(clusterConfig, tt.fluxpath)
+			clusterSpec := newClusterSpec(t, clusterConfig, tt.fluxpath)
 
 			m.flux.EXPECT().BootstrapToolkitsComponents(ctx, cluster, clusterSpec.GitOpsConfig)
 
@@ -334,7 +334,7 @@ func TestFluxAddonClientPauseKustomization(t *testing.T) {
 	ctx := context.Background()
 	cluster := &types.Cluster{}
 	clusterConfig := v1alpha1.NewCluster("management-cluster")
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
 	m.flux.EXPECT().PauseKustomization(ctx, cluster, clusterSpec.GitOpsConfig)
@@ -350,7 +350,7 @@ func TestFluxAddonClientResumeKustomization(t *testing.T) {
 	cluster := &types.Cluster{}
 	clusterConfig := v1alpha1.NewCluster("management-cluster")
 
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
 	m.flux.EXPECT().ResumeKustomization(ctx, cluster, clusterSpec.GitOpsConfig)
@@ -367,7 +367,7 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecLocalRepoNotExists(t *testing.T) {
 	clusterConfig := v1alpha1.NewCluster(clusterName)
 	eksaSystemDirPath := "clusters/management-cluster/management-cluster/eksa-system"
 	f, m, g := newAddonClient(t)
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 
 	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
 	m.git.EXPECT().Clone(ctx).Return(nil)
@@ -392,7 +392,7 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecLocalRepoExists(t *testing.T) {
 	clusterName := "management-cluster"
 	clusterConfig := v1alpha1.NewCluster(clusterName)
 	eksaSystemDirPath := "clusters/management-cluster/management-cluster/eksa-system"
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	flux := addonClientMocks.NewMockFlux(mockCtrl)
 
 	gitProvider := gitMocks.NewMockProvider(mockCtrl)
@@ -422,7 +422,7 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecErrorGetRepo(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "management-cluster"
 	clusterConfig := v1alpha1.NewCluster(clusterName)
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
 	m.git.EXPECT().GetRepo(ctx).MaxTimes(2).Return(nil, errors.New("fail to get repo"))
@@ -439,7 +439,7 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecErrorCloneRepo(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "management-cluster"
 	clusterConfig := v1alpha1.NewCluster(clusterName)
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
 	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
@@ -457,7 +457,7 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecErrorSwitchBranch(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "management-cluster"
 	clusterConfig := v1alpha1.NewCluster(clusterName)
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
 	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
@@ -476,7 +476,7 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecErrorAddFile(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "management-cluster"
 	clusterConfig := v1alpha1.NewCluster(clusterName)
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
 	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
@@ -496,7 +496,7 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecErrorCommit(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "management-cluster"
 	clusterConfig := v1alpha1.NewCluster(clusterName)
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
 	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
@@ -517,7 +517,7 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecErrorPushAfterRetry(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "management-cluster"
 	clusterConfig := v1alpha1.NewCluster(clusterName)
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
 	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
@@ -539,7 +539,7 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecSkip(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "management-cluster"
 	clusterConfig := v1alpha1.NewCluster(clusterName)
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f := addonclients.NewFluxAddonClient(nil, nil)
 
 	datacenterConfig := datacenterConfig(clusterName)
@@ -554,7 +554,7 @@ func TestFluxAddonClientForceReconcileGitRepo(t *testing.T) {
 	ctx := context.Background()
 	cluster := &types.Cluster{}
 	clusterConfig := v1alpha1.NewCluster("")
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
 	m.flux.EXPECT().ForceReconcileGitRepo(ctx, cluster, "flux-system")
@@ -570,7 +570,7 @@ func TestFluxAddonClientCleanupGitRepo(t *testing.T) {
 	ctx := context.Background()
 	clusterConfig := v1alpha1.NewCluster("management-cluster")
 	expectedClusterPath := "clusters/management-cluster"
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 
 	gitProvider := gitMocks.NewMockProvider(mockCtrl)
 	gitProvider.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
@@ -599,7 +599,7 @@ func TestFluxAddonClientCleanupGitRepoWorkloadCluster(t *testing.T) {
 	clusterConfig := v1alpha1.NewCluster("workload-cluster")
 	clusterConfig.SetManagedBy("management-cluster")
 	expectedClusterPath := "clusters/management-cluster/workload-cluster/" + constants.EksaSystemNamespace
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 
 	gitProvider := gitMocks.NewMockProvider(mockCtrl)
 	gitProvider.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
@@ -625,7 +625,7 @@ func TestFluxAddonClientCleanupGitRepoWorkloadCluster(t *testing.T) {
 func TestFluxAddonClientCleanupGitRepoSkip(t *testing.T) {
 	ctx := context.Background()
 	clusterConfig := v1alpha1.NewCluster("management-cluster")
-	clusterSpec := newClusterSpec(clusterConfig, "")
+	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
 	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
@@ -681,6 +681,7 @@ func runValidations(validations []validations.Validation) error {
 
 type fluxTest struct {
 	*WithT
+	*testing.T
 	f           *addonclients.FluxAddonClient
 	flux        *addonClientMocks.MockFlux
 	provider    *gitMocks.MockProvider
@@ -701,6 +702,7 @@ func newTest(t *testing.T) *fluxTest {
 		s.Cluster = clusterConfig
 	})
 	return &fluxTest{
+		T:           t,
 		f:           f,
 		flux:        flux,
 		provider:    gitProvider,
@@ -712,6 +714,7 @@ func newTest(t *testing.T) *fluxTest {
 }
 
 func (tt *fluxTest) setupFlux() (owner, repo, path string) {
+	tt.Helper()
 	path = "fluxFolder"
 	owner = "aws"
 	repo = "eksa-gitops"
@@ -726,7 +729,9 @@ func (tt *fluxTest) setupFlux() (owner, repo, path string) {
 			},
 		},
 	}
-	tt.clusterSpec.SetDefaultGitOps()
+	if err := c.SetConfigDefaults(tt.clusterSpec.Config); err != nil {
+		tt.Fatal(err)
+	}
 
 	return owner, repo, path
 }
@@ -759,7 +764,8 @@ func machineConfig(clusterName string) *v1alpha1.VSphereMachineConfig {
 	}
 }
 
-func newClusterSpec(clusterConfig *v1alpha1.Cluster, fluxPath string) *c.Spec {
+func newClusterSpec(t *testing.T, clusterConfig *v1alpha1.Cluster, fluxPath string) *c.Spec {
+	t.Helper()
 	fluxConfig := v1alpha1.Flux{
 		Github: v1alpha1.Github{
 			Owner:               "mFowler",
@@ -792,6 +798,9 @@ func newClusterSpec(clusterConfig *v1alpha1.Cluster, fluxPath string) *c.Spec {
 		s.VersionsBundle.Flux = fluxBundle()
 		s.GitOpsConfig = &gitOpsConfig
 	})
+	if err := c.SetConfigDefaults(clusterSpec.Config); err != nil {
+		t.Fatal(err)
+	}
 	return clusterSpec
 }
 

--- a/pkg/addonmanager/addonclients/testdata/cluster-config-default-path-management.yaml
+++ b/pkg/addonmanager/addonclients/testdata/cluster-config-default-path-management.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
 spec:
   clusterNetwork:
+    cniConfig: {}
     pods: {}
     services: {}
   controlPlaneConfiguration: {}

--- a/pkg/addonmanager/addonclients/testdata/cluster-config-default-path-workload.yaml
+++ b/pkg/addonmanager/addonclients/testdata/cluster-config-default-path-workload.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: default
 spec:
   clusterNetwork:
+    cniConfig: {}
     pods: {}
     services: {}
   controlPlaneConfiguration: {}

--- a/pkg/addonmanager/addonclients/testdata/cluster-config-user-provided-path.yaml
+++ b/pkg/addonmanager/addonclients/testdata/cluster-config-user-provided-path.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
 spec:
   clusterNetwork:
+    cniConfig: {}
     pods: {}
     services: {}
   controlPlaneConfiguration: {}

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -32,3 +32,35 @@ func (c *Config) OIDCConfig(name string) *anywherev1.OIDCConfig {
 func (c *Config) AWSIamConfig(name string) *anywherev1.AWSIamConfig {
 	return c.AWSIAMConfigs[name]
 }
+
+func (c *Config) DeepCopy() *Config {
+	c2 := &Config{
+		Cluster:           c.Cluster.DeepCopy(),
+		VSphereDatacenter: c.VSphereDatacenter.DeepCopy(),
+		DockerDatacenter:  c.DockerDatacenter.DeepCopy(),
+		GitOpsConfig:      c.GitOpsConfig.DeepCopy(),
+	}
+
+	if c.VSphereMachineConfigs != nil {
+		c2.VSphereMachineConfigs = make(map[string]*anywherev1.VSphereMachineConfig, len(c.VSphereMachineConfigs))
+	}
+	for k, v := range c.VSphereMachineConfigs {
+		c2.VSphereMachineConfigs[k] = v.DeepCopy()
+	}
+
+	if c.OIDCConfigs != nil {
+		c2.OIDCConfigs = make(map[string]*anywherev1.OIDCConfig, len(c.OIDCConfigs))
+	}
+	for k, v := range c.OIDCConfigs {
+		c2.OIDCConfigs[k] = v.DeepCopy()
+	}
+
+	if c.AWSIAMConfigs != nil {
+		c2.AWSIAMConfigs = make(map[string]*anywherev1.AWSIamConfig, len(c.AWSIAMConfigs))
+	}
+	for k, v := range c.AWSIAMConfigs {
+		c2.AWSIAMConfigs[k] = v.DeepCopy()
+	}
+
+	return c2
+}

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -4,12 +4,10 @@ import (
 	"embed"
 	"fmt"
 	"net/url"
-	"path"
 	"path/filepath"
 	"strings"
 
 	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/features"
@@ -28,11 +26,9 @@ const (
 var releasesManifestURL string
 
 type Spec struct {
-	Cluster                   *eksav1alpha1.Cluster
+	*Config
 	OIDCConfig                *eksav1alpha1.OIDCConfig
 	AWSIamConfig              *eksav1alpha1.AWSIamConfig
-	GitOpsConfig              *eksav1alpha1.GitOpsConfig
-	DatacenterConfig          *metav1.ObjectMeta
 	releasesManifestURL       string
 	bundlesManifestURL        string
 	configFS                  embed.FS
@@ -47,9 +43,8 @@ type Spec struct {
 
 func (s *Spec) DeepCopy() *Spec {
 	return &Spec{
-		Cluster:             s.Cluster.DeepCopy(),
+		Config:              s.Config.DeepCopy(),
 		OIDCConfig:          s.OIDCConfig.DeepCopy(),
-		GitOpsConfig:        s.GitOpsConfig.DeepCopy(),
 		AWSIamConfig:        s.AWSIamConfig.DeepCopy(),
 		releasesManifestURL: s.releasesManifestURL,
 		bundlesManifestURL:  s.bundlesManifestURL,
@@ -63,26 +58,6 @@ func (s *Spec) DeepCopy() *Spec {
 		eksdRelease:               s.eksdRelease.DeepCopy(),
 		Bundles:                   s.Bundles.DeepCopy(),
 		TinkerbellTemplateConfigs: s.TinkerbellTemplateConfigs,
-	}
-}
-
-func (cs *Spec) SetDefaultGitOps() {
-	if cs != nil && cs.GitOpsConfig != nil {
-		c := &cs.GitOpsConfig.Spec.Flux
-		if len(c.Github.ClusterConfigPath) == 0 {
-			if cs.Cluster.IsSelfManaged() {
-				c.Github.ClusterConfigPath = path.Join("clusters", cs.Cluster.Name)
-			} else {
-				c.Github.ClusterConfigPath = path.Join("clusters", cs.Cluster.ManagedBy())
-			}
-		}
-		if len(c.Github.FluxSystemNamespace) == 0 {
-			c.Github.FluxSystemNamespace = FluxDefaultNamespace
-		}
-
-		if len(c.Github.Branch) == 0 {
-			c.Github.Branch = FluxDefaultBranch
-		}
 	}
 }
 
@@ -166,6 +141,7 @@ func WithOIDCConfig(oidcConfig *eksav1alpha1.OIDCConfig) SpecOpt {
 
 func NewSpec(opts ...SpecOpt) *Spec {
 	s := &Spec{
+		Config:              &Config{},
 		releasesManifestURL: releasesManifestURL,
 		configFS:            configFS,
 		userAgent:           userAgent("unknown", "unknown"),
@@ -188,8 +164,11 @@ func newWithCliVersion(cliVersion version.Info, opts ...SpecOpt) *Spec {
 func NewSpecFromClusterConfig(clusterConfigPath string, cliVersion version.Info, opts ...SpecOpt) (*Spec, error) {
 	s := newWithCliVersion(cliVersion, opts...)
 
-	clusterConfig, err := eksav1alpha1.GetClusterConfig(clusterConfigPath)
+	clusterConfig, err := ParseConfigFromFile(clusterConfigPath)
 	if err != nil {
+		return nil, err
+	}
+	if err = SetConfigDefaults(clusterConfig); err != nil {
 		return nil, err
 	}
 
@@ -198,7 +177,7 @@ func NewSpecFromClusterConfig(clusterConfigPath string, cliVersion version.Info,
 		return nil, err
 	}
 
-	versionsBundle, err := s.getVersionsBundle(clusterConfig.Spec.KubernetesVersion, bundles)
+	versionsBundle, err := s.getVersionsBundle(clusterConfig.Cluster.Spec.KubernetesVersion, bundles)
 	if err != nil {
 		return nil, err
 	}
@@ -214,57 +193,30 @@ func NewSpecFromClusterConfig(clusterConfigPath string, cliVersion version.Info,
 	}
 
 	s.Bundles = bundles
-	s.Cluster = clusterConfig
+	s.Config = clusterConfig
 	s.VersionsBundle = &VersionsBundle{
 		VersionsBundle: versionsBundle,
 		KubeDistro:     kubeDistro,
 	}
 	s.eksdRelease = eksd
-	for _, identityProvider := range s.Cluster.Spec.IdentityProviderRefs {
-		switch identityProvider.Kind {
-		case eksav1alpha1.OIDCConfigKind:
-			oidcConfig, err := eksav1alpha1.GetAndValidateOIDCConfig(clusterConfigPath, identityProvider.Name, clusterConfig)
-			if err != nil {
-				return nil, err
-			}
-			s.OIDCConfig = oidcConfig
-		case eksav1alpha1.AWSIamConfigKind:
-			awsIamConfig, err := eksav1alpha1.GetAndValidateAWSIamConfig(clusterConfigPath, identityProvider.Name, clusterConfig)
-			if err != nil {
-				return nil, err
-			}
-			s.AWSIamConfig = awsIamConfig
-		}
+
+	// Get first aws iam config if it exists
+	// Config supports multiple configs because Cluster references a slice
+	// But we validate that only one of each type is referenced
+	for _, ac := range s.Config.AWSIAMConfigs {
+		s.AWSIamConfig = ac
+		break
 	}
 
-	if s.Cluster.Spec.GitOpsRef != nil {
-		gitOpsConfig, err := eksav1alpha1.GetAndValidateGitOpsConfig(clusterConfigPath, s.Cluster.Spec.GitOpsRef.Name, clusterConfig)
-		if err != nil {
-			return nil, err
-		}
-		s.GitOpsConfig = gitOpsConfig
+	// Get first oidc config if it exists
+	for _, oc := range s.Config.OIDCConfigs {
+		s.OIDCConfig = oc
+		break
 	}
 
 	switch s.Cluster.Spec.DatacenterRef.Kind {
-	case eksav1alpha1.VSphereDatacenterKind:
-		datacenterConfig, err := eksav1alpha1.GetVSphereDatacenterConfig(clusterConfigPath)
-		if err != nil {
-			return nil, err
-		}
-		s.DatacenterConfig = &datacenterConfig.ObjectMeta
-	case eksav1alpha1.DockerDatacenterKind:
-		datacenterConfig, err := eksav1alpha1.GetDockerDatacenterConfig(clusterConfigPath)
-		if err != nil {
-			return nil, err
-		}
-		s.DatacenterConfig = &datacenterConfig.ObjectMeta
 	case eksav1alpha1.TinkerbellDatacenterKind:
 		if features.IsActive(features.TinkerbellProvider()) {
-			datacenterConfig, err := eksav1alpha1.GetTinkerbellDatacenterConfig(clusterConfigPath)
-			if err != nil {
-				return nil, err
-			}
-			s.DatacenterConfig = &datacenterConfig.ObjectMeta
 			templateConfigs, err := eksav1alpha1.GetTinkerbellTemplateConfig(clusterConfigPath)
 			if err != nil {
 				return nil, err
@@ -305,7 +257,7 @@ func BuildSpecFromBundles(cluster *eksav1alpha1.Cluster, bundles *v1alpha1.Bundl
 	}
 
 	s.Bundles = bundles
-	s.Cluster = cluster
+	s.Config.Cluster = cluster
 	s.VersionsBundle = &VersionsBundle{
 		VersionsBundle: versionsBundle,
 		KubeDistro:     kubeDistro,

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -752,8 +752,8 @@ func TestClusterManagerPauseEKSAControllerReconcileSuccessWithoutMachineConfig(t
 		Name: clusterName,
 	}
 
-	clusterSpec := &cluster.Spec{
-		Cluster: &v1alpha1.Cluster{
+	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Cluster = &v1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "cluster-test",
 			},
@@ -763,8 +763,8 @@ func TestClusterManagerPauseEKSAControllerReconcileSuccessWithoutMachineConfig(t
 					Name: "data-center-name",
 				},
 			},
-		},
-	}
+		}
+	})
 
 	expectedPauseAnnotation := map[string]string{"anywhere.eks.amazonaws.com/paused": "true"}
 
@@ -787,8 +787,8 @@ func TestClusterManagerPauseEKSAControllerReconcileSuccessWithMachineConfig(t *t
 		Name: clusterName,
 	}
 
-	clusterSpec := &cluster.Spec{
-		Cluster: &v1alpha1.Cluster{
+	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Cluster = &v1alpha1.Cluster{
 			Spec: v1alpha1.ClusterSpec{
 				DatacenterRef: v1alpha1.Ref{
 					Kind: v1alpha1.VSphereDatacenterKind,
@@ -805,8 +805,8 @@ func TestClusterManagerPauseEKSAControllerReconcileSuccessWithMachineConfig(t *t
 					},
 				}},
 			},
-		},
-	}
+		}
+	})
 
 	expectedPauseAnnotation := map[string]string{"anywhere.eks.amazonaws.com/paused": "true"}
 
@@ -831,16 +831,16 @@ func TestClusterManagerResumeEKSAControllerReconcileSuccessWithoutMachineConfig(
 		Name: clusterName,
 	}
 
-	clusterSpec := &cluster.Spec{
-		Cluster: &v1alpha1.Cluster{
+	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Cluster = &v1alpha1.Cluster{
 			Spec: v1alpha1.ClusterSpec{
 				DatacenterRef: v1alpha1.Ref{
 					Kind: v1alpha1.VSphereDatacenterKind,
 					Name: "data-center-name",
 				},
 			},
-		},
-	}
+		}
+	})
 	clusterSpec.Cluster.PauseReconcile()
 
 	datacenterConfig := &v1alpha1.VSphereDatacenterConfig{
@@ -1098,7 +1098,6 @@ func TestClusterManagerClusterSpecChangedGitOpsDefault(t *testing.T) {
 	tt := newSpecChangedTest(t)
 	tt.clusterSpec.Cluster.Spec.GitOpsRef = &v1alpha1.Ref{Kind: v1alpha1.GitOpsConfigKind}
 	tt.oldClusterConfig = tt.clusterSpec.Cluster.DeepCopy()
-	tt.clusterSpec.SetDefaultGitOps()
 	oldGitOpsConfig := tt.clusterSpec.GitOpsConfig.DeepCopy()
 	tt.clusterSpec.Cluster.Spec.IdentityProviderRefs = []v1alpha1.Ref{{Kind: v1alpha1.OIDCConfigKind, Name: tt.clusterName}}
 	tt.clusterSpec.OIDCConfig = tt.oldOIDCConfig.DeepCopy()

--- a/pkg/clustermarshaller/clustermarshaller_test.go
+++ b/pkg/clustermarshaller/clustermarshaller_test.go
@@ -60,7 +60,10 @@ func TestWriteClusterConfigWithOIDCAndGitOps(t *testing.T) {
 			Spec: v1alpha1.GitOpsConfigSpec{
 				Flux: v1alpha1.Flux{
 					Github: v1alpha1.Github{
-						Owner: "me",
+						Owner:               "me",
+						Branch:              "main",
+						ClusterConfigPath:   "clusters/mycluster",
+						FluxSystemNamespace: "flux-system",
 					},
 				},
 			},

--- a/pkg/validations/upgradevalidations/immutableFields.go
+++ b/pkg/validations/upgradevalidations/immutableFields.go
@@ -62,8 +62,6 @@ func ValidateImmutableFields(ctx context.Context, k validations.KubectlClient, c
 		if spec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath != "" && prevGitOps.Spec.Flux.Github.ClusterConfigPath != spec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath {
 			return fmt.Errorf("gitOps spec.flux.github.clusterConfigPath is immutable")
 		}
-
-		spec.SetDefaultGitOps()
 	}
 
 	if !nSpec.ControlPlaneConfiguration.Endpoint.Equal(oSpec.ControlPlaneConfiguration.Endpoint) {


### PR DESCRIPTION
Continues the work started by #1343 

*Description of changes:*
This makes `cluster.Config` available almost everywhere in the CLI, since
we pass cluster.Spec as argument to most calls.

Removed a few parsed api structs from `cluster.Spec` that are not used
anymore.

Removed the GitOps default method from `cluster.Spec` and use the one for
`cluster.Config` when necessary (just in tests).

*Testing (if applicable):*
I ran all unit test and a couple e2e for vsphere and docker, all good.
However, I want to keep this on hold until we release, to avoid extra noise if any of the e2e tests fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

