### PR TITLE
Revert "Specify namespace when describing deployments"

### DIFF
--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -588,7 +588,6 @@ func (e *ClusterE2ETest) waitForWorkerScaling(targetvalue int) error {
 	return retrier.Retry(120, time.Second*10, func() error {
 		md, err := e.KubectlClient.GetMachineDeployments(ctx,
 			executables.WithKubeconfig(e.managementKubeconfigFilePath()),
-			executables.WithNamespace(constants.EksaSystemNamespace),
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
Reverts aws/eks-anywhere#1519

This may be causing issue with the tests.