### PR TITLE
Cilium policy mode

### DIFF
--- a/controllers/controllers/clusters/vsphere.go
+++ b/controllers/controllers/clusters/vsphere.go
@@ -271,8 +271,8 @@ func (v *VSphereClusterReconciler) reconcileCNI(ctx context.Context, cluster *an
 		if err != nil {
 			return reconciler.Result{}, err
 		}
-
-		ciliumSpec, err := cilium.GenerateManifest(ctx, specWithBundles)
+		// TODO: adding to above TODO of using NewCilium, also provide provider interface so cilium generateManifest can get the deployments based on provider
+		ciliumSpec, err := cilium.GenerateManifest(ctx, specWithBundles, nil)
 		if err != nil {
 			return reconciler.Result{}, err
 		}

--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -47,6 +47,15 @@ func WithKubernetesVersion(v anywherev1.KubernetesVersion) ClusterFiller {
 	}
 }
 
+func WithCiliumPolicyEnforcementMode(mode string) ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		if c.Spec.ClusterNetwork.CNIConfig == nil {
+			c.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{Cilium: &anywherev1.CiliumConfig{}}
+		}
+		c.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = mode
+	}
+}
+
 func WithClusterNamespace(ns string) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		c.Namespace = ns

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -93,7 +93,7 @@ type ClusterClient interface {
 }
 
 type Networking interface {
-	GenerateManifest(ctx context.Context, clusterSpec *cluster.Spec) ([]byte, error)
+	GenerateManifest(ctx context.Context, clusterSpec *cluster.Spec, provider providers.Provider) ([]byte, error)
 	Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error)
 }
 
@@ -548,8 +548,8 @@ func (c *ClusterManager) waitForCAPI(ctx context.Context, cluster *types.Cluster
 	return nil
 }
 
-func (c *ClusterManager) InstallNetworking(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
-	networkingManifestContent, err := c.networking.GenerateManifest(ctx, clusterSpec)
+func (c *ClusterManager) InstallNetworking(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error {
+	networkingManifestContent, err := c.networking.GenerateManifest(ctx, clusterSpec, provider)
 	if err != nil {
 		return fmt.Errorf("error generating networking manifest: %v", err)
 	}

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -590,18 +590,18 @@ func (m *MockNetworking) EXPECT() *MockNetworkingMockRecorder {
 }
 
 // GenerateManifest mocks base method.
-func (m *MockNetworking) GenerateManifest(arg0 context.Context, arg1 *cluster.Spec) ([]byte, error) {
+func (m *MockNetworking) GenerateManifest(arg0 context.Context, arg1 *cluster.Spec, arg2 providers.Provider) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateManifest", arg0, arg1)
+	ret := m.ctrl.Call(m, "GenerateManifest", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GenerateManifest indicates an expected call of GenerateManifest.
-func (mr *MockNetworkingMockRecorder) GenerateManifest(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNetworkingMockRecorder) GenerateManifest(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateManifest", reflect.TypeOf((*MockNetworking)(nil).GenerateManifest), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateManifest", reflect.TypeOf((*MockNetworking)(nil).GenerateManifest), arg0, arg1, arg2)
 }
 
 // Upgrade mocks base method.

--- a/pkg/networking/cilium/cilium.go
+++ b/pkg/networking/cilium/cilium.go
@@ -2,12 +2,20 @@ package cilium
 
 import (
 	"context"
+	_ "embed"
+	"fmt"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/providers"
+	"github.com/aws/eks-anywhere/pkg/semver"
+	"github.com/aws/eks-anywhere/pkg/templater"
 )
 
 const namespace = constants.KubeSystemNamespace
+
+//go:embed network_policy.yaml
+var networkPolicyAllowAll string
 
 type Cilium struct {
 	*Upgrader
@@ -19,6 +27,39 @@ func NewCilium(client Client, helm Helm) *Cilium {
 	}
 }
 
-func (c *Cilium) GenerateManifest(ctx context.Context, clusterSpec *cluster.Spec) ([]byte, error) {
-	return c.templater.GenerateManifest(ctx, clusterSpec)
+func (c *Cilium) GenerateManifest(ctx context.Context, clusterSpec *cluster.Spec, provider providers.Provider) ([]byte, error) {
+	ciliumManifest, err := c.templater.GenerateManifest(ctx, clusterSpec)
+	if err != nil {
+		return nil, err
+	}
+	if clusterSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode != "always" {
+		return ciliumManifest, nil
+	}
+
+	// if always mode, create NetworkPolicy objects for kube-system, EKS-A and CAPI components as required
+	values := map[string]interface{}{
+		"managementCluster":  clusterSpec.Cluster.IsSelfManaged(),
+		"providerNamespaces": provider.GetDeployments(),
+		"gitopsEnabled":      clusterSpec.Cluster.Spec.GitOpsRef != nil,
+	}
+
+	/* k8s 1.21 and up labels each namespace with key `kubernetes.io/metadata.name:` and value is the namespace's name.
+	This can be used to create a networkPolicy that allows traffic only between pods within kube-system ns, which is ideal for workload clusters. (not needed
+	for mgmt clusters).
+	So we will create networkPolicy using this default label as namespaceSelector for all versions 1.21 and higher
+	For 1.20 we will create a networkPolicy that allows allow traffic to/from kube-system pods, and document this. Users can still modify it and add new policies
+	as needed*/
+	k8sVersion, err := semver.New(clusterSpec.VersionsBundle.KubeDistro.Kubernetes.Tag)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing kubernetes version %v: %v", clusterSpec.Cluster.Spec.KubernetesVersion, err)
+	}
+	if k8sVersion.Major == 1 && k8sVersion.Minor >= 21 {
+		values["kubeSystemNSHasLabel"] = true
+	}
+
+	content, err := templater.Execute(networkPolicyAllowAll, values)
+	if err != nil {
+		return nil, err
+	}
+	return templater.AppendYamlResources(ciliumManifest, content), nil
 }

--- a/pkg/networking/cilium/cilium_test.go
+++ b/pkg/networking/cilium/cilium_test.go
@@ -8,19 +8,23 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/aws/eks-anywhere/internal/test"
+	v1alpha12 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/networking/cilium"
 	"github.com/aws/eks-anywhere/pkg/networking/cilium/mocks"
+	mocksprovider "github.com/aws/eks-anywhere/pkg/providers/mocks"
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 type ciliumtest struct {
 	*WithT
-	ctx    context.Context
-	client mocks.MockClient
-	h      *mocks.MockHelm
-	spec   *cluster.Spec
-	cilium *cilium.Cilium
+	ctx          context.Context
+	client       mocks.MockClient
+	h            *mocks.MockHelm
+	spec         *cluster.Spec
+	cilium       *cilium.Cilium
+	provider     *mocksprovider.MockProvider
+	ciliumValues []byte
 }
 
 func newCiliumTest(t *testing.T) *ciliumtest {
@@ -45,8 +49,12 @@ func newCiliumTest(t *testing.T) *ciliumtest {
 					URI:  "public.ecr.aws/isovalent/cilium:1.9.13-eksa.2",
 				},
 			}
+			s.VersionsBundle.KubeDistro.Kubernetes.Tag = "v1.21.9-eks-1-21-10"
+			s.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha12.CNIConfig{Cilium: &v1alpha12.CiliumConfig{}}
 		}),
-		cilium: cilium.NewCilium(client, h),
+		cilium:       cilium.NewCilium(client, h),
+		provider:     mocksprovider.NewMockProvider(ctrl),
+		ciliumValues: []byte("manifest"),
 	}
 }
 
@@ -56,7 +64,85 @@ func TestCiliumGenerateManifestSuccess(t *testing.T) {
 	// calls the templater and does not try to load the static manifest like earlier version
 	tt.h.EXPECT().Template(
 		tt.ctx, gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(map[string]interface{}{}),
-	).Return([]byte("manifest"), nil)
-	_, err := tt.cilium.GenerateManifest(tt.ctx, tt.spec)
+	).Return(tt.ciliumValues, nil)
+	_, err := tt.cilium.GenerateManifest(tt.ctx, tt.spec, nil)
+	tt.Expect(err).To(Not(HaveOccurred()), "GenerateManifest() should succeed")
+}
+
+func TestCiliumGenerateManifestNetworkPolicyMgmtVSphereProvider(t *testing.T) {
+	tt := newCiliumTest(t)
+	tt.h.EXPECT().Template(
+		tt.ctx, gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(map[string]interface{}{}),
+	).Return(tt.ciliumValues, nil)
+
+	alwaysModeSpec := tt.spec
+	alwaysModeSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = "always"
+
+	providerDeployments := map[string][]string{
+		"capv-system": {"capv-controller-manager"},
+	}
+	tt.provider.EXPECT().GetDeployments().Return(providerDeployments)
+
+	ciliumManifest, err := tt.cilium.GenerateManifest(tt.ctx, alwaysModeSpec, tt.provider)
+	test.AssertContentToFile(t, string(ciliumManifest), "testdata/network_policy_mgmt_capv.yaml")
+
+	tt.Expect(err).To(Not(HaveOccurred()), "GenerateManifest() should succeed")
+}
+
+func TestCiliumGenerateManifestNetworkPolicyMgmtTinkerBellProviderFluxEnabled(t *testing.T) {
+	tt := newCiliumTest(t)
+	tt.h.EXPECT().Template(
+		tt.ctx, gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(map[string]interface{}{}),
+	).Return(tt.ciliumValues, nil)
+
+	alwaysModeSpec := tt.spec
+	alwaysModeSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = "always"
+	alwaysModeSpec.Cluster.Spec.GitOpsRef = &v1alpha12.Ref{
+		Kind: v1alpha12.FluxConfigKind,
+		Name: "eksa-unit-test",
+	}
+	providerDeployments := map[string][]string{
+		"capt-system": {"capt-controller-manager"},
+	}
+	tt.provider.EXPECT().GetDeployments().Return(providerDeployments)
+
+	ciliumManifest, err := tt.cilium.GenerateManifest(tt.ctx, alwaysModeSpec, tt.provider)
+	test.AssertContentToFile(t, string(ciliumManifest), "testdata/network_policy_mgmt_capt_flux.yaml")
+
+	tt.Expect(err).To(Not(HaveOccurred()), "GenerateManifest() should succeed")
+}
+
+func TestCiliumGenerateManifestNetworkPolicyWorkload121(t *testing.T) {
+	tt := newCiliumTest(t)
+	tt.h.EXPECT().Template(
+		tt.ctx, gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(map[string]interface{}{}),
+	).Return(tt.ciliumValues, nil)
+
+	alwaysModeSpec := tt.spec
+	alwaysModeSpec.Cluster.Spec.ManagementCluster.Name = "mgmt"
+	alwaysModeSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = "always"
+	tt.provider.EXPECT().GetDeployments().Return(nil)
+
+	ciliumManifest, err := tt.cilium.GenerateManifest(tt.ctx, alwaysModeSpec, tt.provider)
+	test.AssertContentToFile(t, string(ciliumManifest), "testdata/network_policy_workload_121.yaml")
+
+	tt.Expect(err).To(Not(HaveOccurred()), "GenerateManifest() should succeed")
+}
+
+func TestCiliumGenerateManifestNetworkPolicyWorkload120(t *testing.T) {
+	tt := newCiliumTest(t)
+	tt.h.EXPECT().Template(
+		tt.ctx, gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(map[string]interface{}{}),
+	).Return(tt.ciliumValues, nil)
+
+	alwaysModeSpec := tt.spec
+	alwaysModeSpec.Cluster.Spec.ManagementCluster.Name = "mgmt"
+	alwaysModeSpec.VersionsBundle.KubeDistro.Kubernetes.Tag = "v1.20.9-eks-1-20-10"
+	alwaysModeSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = "always"
+	tt.provider.EXPECT().GetDeployments().Return(nil)
+
+	ciliumManifest, err := tt.cilium.GenerateManifest(tt.ctx, alwaysModeSpec, tt.provider)
+	test.AssertContentToFile(t, string(ciliumManifest), "testdata/network_policy_workload_120.yaml")
+
 	tt.Expect(err).To(Not(HaveOccurred()), "GenerateManifest() should succeed")
 }

--- a/pkg/networking/cilium/network_policy.yaml
+++ b/pkg/networking/cilium/network_policy.yaml
@@ -1,0 +1,242 @@
+{{- if .managementCluster }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-kube-system
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: eksa-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-eksa-system
+  namespace: eksa-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+{{- if .gitopsEnabled }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flux-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-flux-system
+  namespace: flux-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+{{- end }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-bootstrap-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-control-plane-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcdadm-bootstrap-provider-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcdadm-controller-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-system
+  namespace: capi-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-cert-manager
+  namespace: cert-manager
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-kubeadm-bootstrap-system
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-kubeadm-control-plane-system
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-etcdadm-bootstrap-provider-system
+  namespace: etcdadm-bootstrap-provider-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-etcdadm-controller-system
+  namespace: etcdadm-controller-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+{{- range $providerNamespace, $deployment := .providerNamespaces }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $providerNamespace }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-{{ $providerNamespace }}
+  namespace: {{ $providerNamespace }}
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+{{- end }}
+{{- else}}
+{{- if .kubeSystemNSHasLabel }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-kube-system
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+  policyTypes:
+  - Ingress
+  - Egress
+---
+{{- else }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-kube-system
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+{{- end }}
+{{- end }}

--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -117,6 +117,7 @@ func templateValues(spec *cluster.Spec) values {
 				"enabled": true,
 			},
 		},
+		"policyEnforcementMode": spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode,
 	}
 }
 

--- a/pkg/networking/cilium/testdata/network_policy_mgmt_capt_flux.yaml
+++ b/pkg/networking/cilium/testdata/network_policy_mgmt_capt_flux.yaml
@@ -1,0 +1,201 @@
+manifest
+---
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-kube-system
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: eksa-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-eksa-system
+  namespace: eksa-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flux-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-flux-system
+  namespace: flux-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-bootstrap-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-control-plane-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcdadm-bootstrap-provider-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcdadm-controller-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-system
+  namespace: capi-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-cert-manager
+  namespace: cert-manager
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-kubeadm-bootstrap-system
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-kubeadm-control-plane-system
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-etcdadm-bootstrap-provider-system
+  namespace: etcdadm-bootstrap-provider-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-etcdadm-controller-system
+  namespace: etcdadm-controller-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capt-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capt-system
+  namespace: capt-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+---

--- a/pkg/networking/cilium/testdata/network_policy_mgmt_capv.yaml
+++ b/pkg/networking/cilium/testdata/network_policy_mgmt_capv.yaml
@@ -1,0 +1,181 @@
+manifest
+---
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-kube-system
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: eksa-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-eksa-system
+  namespace: eksa-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-bootstrap-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-control-plane-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcdadm-bootstrap-provider-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcdadm-controller-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-system
+  namespace: capi-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-cert-manager
+  namespace: cert-manager
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-kubeadm-bootstrap-system
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-kubeadm-control-plane-system
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-etcdadm-bootstrap-provider-system
+  namespace: etcdadm-bootstrap-provider-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-etcdadm-controller-system
+  namespace: etcdadm-controller-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capv-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capv-system
+  namespace: capv-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+---

--- a/pkg/networking/cilium/testdata/network_policy_workload_120.yaml
+++ b/pkg/networking/cilium/testdata/network_policy_workload_120.yaml
@@ -1,0 +1,18 @@
+manifest
+---
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-kube-system
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---

--- a/pkg/networking/cilium/testdata/network_policy_workload_121.yaml
+++ b/pkg/networking/cilium/testdata/network_policy_workload_121.yaml
@@ -1,0 +1,25 @@
+manifest
+---
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-kube-system
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+  policyTypes:
+  - Ingress
+  - Egress
+---
+---

--- a/pkg/networking/cilium/upgrader_test.go
+++ b/pkg/networking/cilium/upgrader_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/networking/cilium/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
@@ -40,9 +41,11 @@ func newUpgraderTest(t *testing.T) *upgraderTest {
 		manifest: []byte("manifestContent"),
 		currentSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 			s.VersionsBundle.Cilium.Version = "v1.9.10-eksa.1"
+			s.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{}}
 		}),
 		newSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 			s.VersionsBundle.Cilium.Version = "v1.9.11-eksa.1"
+			s.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{}}
 		}),
 		cluster: &types.Cluster{
 			KubeconfigFile: "kubeconfig",

--- a/pkg/networking/kindnetd/kindnetd.go
+++ b/pkg/networking/kindnetd/kindnetd.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	networking "github.com/aws/eks-anywhere/pkg/networking/internal"
+	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/templater"
 )
 
@@ -26,7 +27,7 @@ func NewKindnetd(client Client) *Kindnetd {
 	}
 }
 
-func (c *Kindnetd) GenerateManifest(ctx context.Context, clusterSpec *cluster.Spec) ([]byte, error) {
+func (c *Kindnetd) GenerateManifest(ctx context.Context, clusterSpec *cluster.Spec, provider providers.Provider) ([]byte, error) {
 	return generateManifest(clusterSpec)
 }
 

--- a/pkg/networking/kindnetd/kindnetd_test.go
+++ b/pkg/networking/kindnetd/kindnetd_test.go
@@ -37,7 +37,7 @@ func TestKindnetdGenerateManifestSuccess(t *testing.T) {
 		s.VersionsBundle.Kindnetd = KindnetdBundle
 	})
 
-	gotFileContent, err := tt.k.GenerateManifest(context.Background(), clusterSpec)
+	gotFileContent, err := tt.k.GenerateManifest(context.Background(), clusterSpec, nil)
 	if err != nil {
 		t.Fatalf("Kindnetd.GenerateManifestFile() error = %v, wantErr nil", err)
 	}
@@ -57,7 +57,7 @@ func TestKindnetdGenerateManifestWriterError(t *testing.T) {
 		s.VersionsBundle.Kindnetd.Manifest.URI = "testdata/missing_manifest.yaml"
 	})
 
-	if _, err := tt.k.GenerateManifest(context.Background(), clusterSpec); err == nil {
+	if _, err := tt.k.GenerateManifest(context.Background(), clusterSpec, nil); err == nil {
 		t.Fatalf("Kindnetd.GenerateManifestFile() error = nil, want not nil")
 	}
 }

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -182,7 +182,7 @@ func (s *CreateWorkloadClusterTask) Run(ctx context.Context, commandContext *tas
 	commandContext.WorkloadCluster = workloadCluster
 
 	logger.Info("Installing networking on workload cluster")
-	err = commandContext.ClusterManager.InstallNetworking(ctx, workloadCluster, commandContext.ClusterSpec)
+	err = commandContext.ClusterManager.InstallNetworking(ctx, workloadCluster, commandContext.ClusterSpec, commandContext.Provider)
 	if err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -97,7 +97,7 @@ func (c *createTestSetup) expectCreateWorkload() {
 		).Return(c.workloadCluster, nil),
 
 		c.clusterManager.EXPECT().InstallNetworking(
-			c.ctx, c.workloadCluster, c.clusterSpec,
+			c.ctx, c.workloadCluster, c.clusterSpec, c.provider,
 		),
 		c.clusterManager.EXPECT().InstallStorageClass(
 			c.ctx, c.workloadCluster, c.provider,
@@ -116,7 +116,7 @@ func (c *createTestSetup) expectCreateWorkloadSkipCAPI() {
 		).Return(c.workloadCluster, nil),
 
 		c.clusterManager.EXPECT().InstallNetworking(
-			c.ctx, c.workloadCluster, c.clusterSpec,
+			c.ctx, c.workloadCluster, c.clusterSpec, c.provider,
 		),
 		c.clusterManager.EXPECT().InstallStorageClass(
 			c.ctx, c.workloadCluster, c.provider,

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -21,7 +21,7 @@ type ClusterManager interface {
 	UpgradeCluster(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster, provider providers.Provider, clusterSpec *cluster.Spec) error
 	InstallCAPI(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
-	InstallNetworking(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
+	InstallNetworking(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	UpgradeNetworking(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error)
 	InstallStorageClass(ctx context.Context, cluster *types.Cluster, provider providers.Provider) error
 	SaveLogsManagementCluster(ctx context.Context, cluster *types.Cluster) error

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -268,17 +268,17 @@ func (mr *MockClusterManagerMockRecorder) InstallMachineHealthChecks(arg0, arg1,
 }
 
 // InstallNetworking mocks base method.
-func (m *MockClusterManager) InstallNetworking(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec) error {
+func (m *MockClusterManager) InstallNetworking(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec, arg3 providers.Provider) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallNetworking", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "InstallNetworking", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallNetworking indicates an expected call of InstallNetworking.
-func (mr *MockClusterManagerMockRecorder) InstallNetworking(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClusterManagerMockRecorder) InstallNetworking(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallNetworking", reflect.TypeOf((*MockClusterManager)(nil).InstallNetworking), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallNetworking", reflect.TypeOf((*MockClusterManager)(nil).InstallNetworking), arg0, arg1, arg2, arg3)
 }
 
 // InstallStorageClass mocks base method.

--- a/test/e2e/simpleflow_test.go
+++ b/test/e2e/simpleflow_test.go
@@ -142,6 +142,16 @@ func TestVSphereKubernetes120BottleRocketDifferentNamespaceSimpleFlow(t *testing
 	runSimpleFlow(test)
 }
 
+func TestVSphereKubernetes121CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewVSphere(t, framework.WithUbuntu121()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode("always")),
+	)
+	runSimpleFlow(test)
+}
+
 func TestTinkerbellKubernetes120SimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Design doc for reference: https://github.com/aws/eks-anywhere/blob/main/designs/cilium-configuration-policy.md

This commit configures cilium to use the user supplied value for policy
enforcement mode, by passing setting it as a value for the helm chart.
The accepted values for this field by cilium are "default", "always" and "never"
If no value is passed, cilium uses "default" as the default value.
When "always" mode is used, cilium blocks all communication.
This can prevent block cluster creation. To prevent this, eks anywhere
will create networkPolicy objects to allow communication between pods crucial
to eks-a. For a management cluster, network policies will be created for all
core kubernetes pods, CAPI, eks-a and flux controllers. For workload cluster,
the network policy will only be created for the kube-system pods.

*Testing (if applicable):*
```
TestVSphereKubernetes121CiliumAlwaysPolicyEnforcementModeSimpleFlow
TestVSphereKubernetes120UbuntuTo121Upgrade
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

