### PR TITLE
remove incompatible field from 0.7.2

### DIFF
--- a/test/framework/api.go
+++ b/test/framework/api.go
@@ -9,6 +9,9 @@ var incompatiblePathsForVersion = map[string][]string{
 		"spec.clusterNetwork.dns",
 		"spec.workerNodeGroupConfigurations[].name",
 	},
+	"v0.7.2": {
+		"spec.clusterNetwork.cniConfig",
+	},
 }
 
 func cleanUpClusterForVersion(clusterYaml []byte, version string) ([]byte, error) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
clean up cluster config cniConfig in 0.7.2 previosuMinorRelease tests

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

