### PR TITLE
Validate input for cilium policy enforcement mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
 	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf
-	google.golang.org/grpc v1.41.0
 	gopkg.in/ini.v1 v1.63.2
 	gopkg.in/square/go-jose.v2 v2.6.0
 	k8s.io/api v0.22.2

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -1843,18 +1843,74 @@ func TestValidateCNIConfig(t *testing.T) {
 	}{
 		{
 			name:    "CNI plugin not specified",
-			wantErr: fmt.Errorf("no cni plugin specified"),
+			wantErr: fmt.Errorf("error validating cniConfig: no cni plugin specified"),
 			clusterNetwork: &ClusterNetwork{
 				CNIConfig: &CNIConfig{},
 			},
 		},
 		{
 			name:    "multiple CNI plugins specified",
-			wantErr: fmt.Errorf("cannot specify more than one cni plugins"),
+			wantErr: fmt.Errorf("error validating cniConfig: cannot specify more than one cni plugins"),
 			clusterNetwork: &ClusterNetwork{
 				CNIConfig: &CNIConfig{
 					Cilium:   &CiliumConfig{},
 					Kindnetd: &KindnetdConfig{},
+				},
+			},
+		},
+		{
+			name:    "invalid cilium policy enforcement mode",
+			wantErr: fmt.Errorf("error validating cniConfig: cilium policyEnforcementMode \"invalid\" not supported"),
+			clusterNetwork: &ClusterNetwork{
+				CNIConfig: &CNIConfig{
+					Cilium: &CiliumConfig{
+						PolicyEnforcementMode: "invalid",
+					},
+				},
+			},
+		},
+		{
+			name:    "invalid cilium policy enforcement mode and > 1 plugins",
+			wantErr: fmt.Errorf("error validating cniConfig: [cilium policyEnforcementMode \"invalid\" not supported, cannot specify more than one cni plugins]"),
+			clusterNetwork: &ClusterNetwork{
+				CNIConfig: &CNIConfig{
+					Cilium: &CiliumConfig{
+						PolicyEnforcementMode: "invalid",
+					},
+					Kindnetd: &KindnetdConfig{},
+				},
+			},
+		},
+		{
+			name:    "valid cilium policy enforcement mode",
+			wantErr: nil,
+			clusterNetwork: &ClusterNetwork{
+				CNIConfig: &CNIConfig{
+					Cilium: &CiliumConfig{
+						PolicyEnforcementMode: "default",
+					},
+				},
+			},
+		},
+		{
+			name:    "valid cilium policy enforcement mode",
+			wantErr: nil,
+			clusterNetwork: &ClusterNetwork{
+				CNIConfig: &CNIConfig{
+					Cilium: &CiliumConfig{
+						PolicyEnforcementMode: "always",
+					},
+				},
+			},
+		},
+		{
+			name:    "valid cilium policy enforcement mode",
+			wantErr: nil,
+			clusterNetwork: &ClusterNetwork{
+				CNIConfig: &CNIConfig{
+					Cilium: &CiliumConfig{
+						PolicyEnforcementMode: "never",
+					},
 				},
 			},
 		},

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -524,6 +524,8 @@ const (
 
 type CNI string
 
+type CiliumPolicyEnforcementMode string
+
 type CNIConfig struct {
 	Cilium   *CiliumConfig   `json:"cilium,omitempty"`
 	Kindnetd *KindnetdConfig `json:"kindnetd,omitempty"`
@@ -531,7 +533,7 @@ type CNIConfig struct {
 
 type CiliumConfig struct {
 	// PolicyEnforcementMode determines communication allowed between pods. Accepted values are default, always, never.
-	PolicyEnforcementMode string `json:"policyEnforcementMode,omitempty"`
+	PolicyEnforcementMode CiliumPolicyEnforcementMode `json:"policyEnforcementMode,omitempty"`
 }
 
 type KindnetdConfig struct{}
@@ -545,6 +547,18 @@ const (
 var validCNIs = map[CNI]struct{}{
 	Cilium:   {},
 	Kindnetd: {},
+}
+
+const (
+	CiliumPolicyModeDefault CiliumPolicyEnforcementMode = "default"
+	CiliumPolicyModeAlways  CiliumPolicyEnforcementMode = "always"
+	CiliumPolicyModeNever   CiliumPolicyEnforcementMode = "never"
+)
+
+var validCiliumPolicyEnforcementModes = map[CiliumPolicyEnforcementMode]bool{
+	CiliumPolicyModeAlways:  true,
+	CiliumPolicyModeDefault: true,
+	CiliumPolicyModeNever:   true,
 }
 
 // ClusterStatus defines the observed state of Cluster


### PR DESCRIPTION
*Description of changes:*
This PR validates the input for cilium's policy enforcement mode, allowed values are "default", "always", "never" as per cilium docs https://docs.cilium.io/en/v1.8/policy/intro/

Design doc for reference: https://github.com/aws/eks-anywhere/blob/main/designs/cilium-configuration-policy.md

The PR to set this value in the cilium chart values isn't merged yet, so an e2e test will follow with the PR that sets this value

*Testing (if applicable):*
unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

