### PR TITLE
Generate network policy based on cluster spec and provider

### DIFF
--- a/pkg/networking/cilium/network_policy.yaml
+++ b/pkg/networking/cilium/network_policy.yaml
@@ -1,0 +1,242 @@
+{{- if .managementCluster }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-kube-system
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: eksa-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-eksa-system
+  namespace: eksa-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+{{- if .gitopsEnabled }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .fluxNamespace }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-flux-system
+  namespace: {{ .fluxNamespace }}
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+{{- end }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-bootstrap-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-control-plane-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcdadm-bootstrap-provider-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcdadm-controller-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-system
+  namespace: capi-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-cert-manager
+  namespace: cert-manager
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-kubeadm-bootstrap-system
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-kubeadm-control-plane-system
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-etcdadm-bootstrap-provider-system
+  namespace: etcdadm-bootstrap-provider-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-etcdadm-controller-system
+  namespace: etcdadm-controller-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+{{- range $providerNamespace := .providerNamespaces }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $providerNamespace }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-{{ $providerNamespace }}
+  namespace: {{ $providerNamespace }}
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+{{- end }}
+{{- else}}
+{{- if .kubeSystemNSHasLabel }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-kube-system
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+  policyTypes:
+  - Ingress
+  - Egress
+---
+{{- else }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-kube-system
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+{{- end }}
+{{- end }}

--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -2,12 +2,17 @@ package cilium
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"strings"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/semver"
+	"github.com/aws/eks-anywhere/pkg/templater"
 )
+
+//go:embed network_policy.yaml
+var networkPolicyAllowAll string
 
 type Helm interface {
 	Template(ctx context.Context, ociURI, version, namespace string, values interface{}) ([]byte, error)
@@ -71,6 +76,36 @@ func (c *Templater) GenerateManifest(ctx context.Context, spec *cluster.Spec) ([
 	}
 
 	return manifest, nil
+}
+
+func (c *Templater) GenerateNetworkPolicyManifest(spec *cluster.Spec, namespaces []string) ([]byte, error) {
+	values := map[string]interface{}{
+		"managementCluster":  spec.Cluster.IsSelfManaged(),
+		"providerNamespaces": namespaces,
+	}
+
+	if spec.Cluster.Spec.GitOpsRef != nil {
+		values["gitopsEnabled"] = true
+		if spec.GitOpsConfig != nil {
+			values["fluxNamespace"] = spec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace
+		}
+	}
+
+	/* k8s versions 1.21 and higher label each namespace with key `kubernetes.io/metadata.name:` and value is the namespace's name.
+	This can be used to create a networkPolicy that allows traffic only between pods within kube-system ns, which is ideal for workload clusters. (not needed
+	for mgmt clusters).
+	So we will create networkPolicy using this default label as namespaceSelector for all versions 1.21 and higher
+	For 1.20 we will create a networkPolicy that allows allow traffic to/from kube-system pods, and document this. Users can still modify it and add new policies
+	as needed*/
+	k8sVersion, err := semver.New(spec.VersionsBundle.KubeDistro.Kubernetes.Tag)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing kubernetes version %v: %v", spec.Cluster.Spec.KubernetesVersion, err)
+	}
+	if k8sVersion.Major == 1 && k8sVersion.Minor >= 21 {
+		values["kubeSystemNSHasLabel"] = true
+	}
+
+	return templater.Execute(networkPolicyAllowAll, values)
 }
 
 type values map[string]interface{}

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/networking/cilium"
 	"github.com/aws/eks-anywhere/pkg/networking/cilium/mocks"
@@ -226,4 +227,74 @@ func TestTemplaterGenerateUpgradeManifestError(t *testing.T) {
 	_, err := tt.t.GenerateUpgradeManifest(tt.ctx, tt.currentSpec, tt.spec)
 	tt.Expect(err).To(HaveOccurred(), "templater.GenerateUpgradeManifest() should fail")
 	tt.Expect(err).To(MatchError(ContainSubstring("error from helm")))
+}
+
+func TestTemplaterGenerateNetworkPolicy(t *testing.T) {
+	tests := []struct {
+		name                    string
+		k8sVersion              string
+		selfManaged             bool
+		gitopsEnabled           bool
+		infraProviderNamespaces []string
+		wantNetworkPolicyFile   string
+	}{
+		{
+			name:                    "CAPV mgmt cluster",
+			k8sVersion:              "v1.21.9-eks-1-21-10",
+			selfManaged:             true,
+			gitopsEnabled:           false,
+			infraProviderNamespaces: []string{"capv-system"},
+			wantNetworkPolicyFile:   "testdata/network_policy_mgmt_capv.yaml",
+		},
+		{
+			name:                    "CAPT mgmt cluster with flux",
+			k8sVersion:              "v1.21.9-eks-1-21-10",
+			selfManaged:             true,
+			gitopsEnabled:           true,
+			infraProviderNamespaces: []string{"capt-system"},
+			wantNetworkPolicyFile:   "testdata/network_policy_mgmt_capt_flux.yaml",
+		},
+		{
+			name:                    "workload cluster 1.21",
+			k8sVersion:              "v1.21.9-eks-1-21-10",
+			selfManaged:             false,
+			gitopsEnabled:           false,
+			infraProviderNamespaces: []string{},
+			wantNetworkPolicyFile:   "testdata/network_policy_workload_121.yaml",
+		},
+		{
+			name:                    "workload cluster 1.20",
+			k8sVersion:              "v1.20.9-eks-1-20-10",
+			selfManaged:             false,
+			gitopsEnabled:           false,
+			infraProviderNamespaces: []string{},
+			wantNetworkPolicyFile:   "testdata/network_policy_workload_120.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			temp := newtemplaterTest(t)
+			temp.spec.VersionsBundle.KubeDistro.Kubernetes.Tag = tt.k8sVersion
+			if !tt.selfManaged {
+				temp.spec.Cluster.Spec.ManagementCluster.Name = "managed"
+			}
+			if tt.gitopsEnabled {
+				temp.spec.Cluster.Spec.GitOpsRef = &v1alpha1.Ref{
+					Kind: v1alpha1.FluxConfigKind,
+					Name: "eksa-unit-test",
+				}
+				temp.spec.Config.GitOpsConfig = &v1alpha1.GitOpsConfig{
+					Spec: v1alpha1.GitOpsConfigSpec{
+						Flux: v1alpha1.Flux{Github: v1alpha1.Github{FluxSystemNamespace: "flux-system"}},
+					},
+				}
+			}
+			networkPolicy, err := temp.t.GenerateNetworkPolicyManifest(temp.spec, tt.infraProviderNamespaces)
+			if err != nil {
+				t.Fatalf("failed to generate network policy template: %v", err)
+			}
+			test.AssertContentToFile(t, string(networkPolicy), tt.wantNetworkPolicyFile)
+		})
+	}
 }

--- a/pkg/networking/cilium/testdata/network_policy_mgmt_capt_flux.yaml
+++ b/pkg/networking/cilium/testdata/network_policy_mgmt_capt_flux.yaml
@@ -1,0 +1,198 @@
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-kube-system
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: eksa-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-eksa-system
+  namespace: eksa-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flux-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-flux-system
+  namespace: flux-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-bootstrap-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-control-plane-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcdadm-bootstrap-provider-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcdadm-controller-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-system
+  namespace: capi-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-cert-manager
+  namespace: cert-manager
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-kubeadm-bootstrap-system
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-kubeadm-control-plane-system
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-etcdadm-bootstrap-provider-system
+  namespace: etcdadm-bootstrap-provider-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-etcdadm-controller-system
+  namespace: etcdadm-controller-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capt-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capt-system
+  namespace: capt-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---

--- a/pkg/networking/cilium/testdata/network_policy_mgmt_capv.yaml
+++ b/pkg/networking/cilium/testdata/network_policy_mgmt_capv.yaml
@@ -1,0 +1,178 @@
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-kube-system
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: eksa-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-eksa-system
+  namespace: eksa-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-bootstrap-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-control-plane-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcdadm-bootstrap-provider-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcdadm-controller-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-system
+  namespace: capi-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-cert-manager
+  namespace: cert-manager
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-kubeadm-bootstrap-system
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capi-kubeadm-control-plane-system
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-etcdadm-bootstrap-provider-system
+  namespace: etcdadm-bootstrap-provider-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-etcdadm-controller-system
+  namespace: etcdadm-controller-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capv-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-capv-system
+  namespace: capv-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---

--- a/pkg/networking/cilium/testdata/network_policy_workload_120.yaml
+++ b/pkg/networking/cilium/testdata/network_policy_workload_120.yaml
@@ -1,0 +1,15 @@
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-kube-system
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/pkg/networking/cilium/testdata/network_policy_workload_121.yaml
+++ b/pkg/networking/cilium/testdata/network_policy_workload_121.yaml
@@ -1,0 +1,22 @@
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-kube-system
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+  policyTypes:
+  - Ingress
+  - Egress
+---


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If user selects "always" policy enforcement mode for cilium, all communication between pods including core k8s and CAPI pods will be disallowed, blocking cluster creation/upgrades. To avoid this, EKS-A will create NetworkPolicy objects to allow communication between pods crucial to EKS-A. Refer this design doc to see which network policies will be created based on the cluster spec: https://github.com/aws/eks-anywhere/blob/main/designs/cilium-configuration-policy.md
This new templater method will be called while generating manifest for cilium during create and upgrade if the policy enforcement mode is set to "always". The part of calling this during cilium installation/upgrade will follow in a separate PR along with an e2e test

*Testing (if applicable):*
unit tests 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

