### PR TITLE
Always validate on tinkerbell hardware generate

### DIFF
--- a/cmd/eksctl-anywhere/cmd/generatehardware.go
+++ b/cmd/eksctl-anywhere/cmd/generatehardware.go
@@ -100,11 +100,11 @@ func (hOpts *hardwareOptions) generateHardware(ctx context.Context) error {
 	}
 
 	if !hOpts.dryRun {
-		tink, close, err := tinkExecutableFromOpts(ctx, hOpts)
+		tink, closer, err := tinkExecutableFromOpts(ctx, hOpts)
 		if err != nil {
 			return err
 		}
-		defer close.Close(ctx)
+		defer closer.Close(ctx)
 
 		if err := hardware.RegisterTinkerbellHardware(ctx, tink, journal); err != nil {
 			return err
@@ -115,18 +115,16 @@ func (hOpts *hardwareOptions) generateHardware(ctx context.Context) error {
 }
 
 func validateOptions(opts *hardwareOptions) error {
-	if !opts.dryRun {
-		if err := networkutils.ValidateIP(opts.tinkerbellIp); err != nil {
-			return fmt.Errorf("invalid tinkerbell-ip: %v", err)
-		}
+	if err := networkutils.ValidateIP(opts.tinkerbellIp); err != nil {
+		return fmt.Errorf("invalid tinkerbell-ip: %v", err)
+	}
 
-		if !networkutils.IsPortValid(opts.grpcPort) {
-			return fmt.Errorf("invalid grpc-port: %v", opts.certPort)
-		}
+	if !networkutils.IsPortValid(opts.grpcPort) {
+		return fmt.Errorf("invalid grpc-port: %v", opts.certPort)
+	}
 
-		if !networkutils.IsPortValid(opts.certPort) {
-			return fmt.Errorf("invalid cert-port: %v", opts.certPort)
-		}
+	if !networkutils.IsPortValid(opts.certPort) {
+		return fmt.Errorf("invalid cert-port: %v", opts.certPort)
 	}
 
 	return nil

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -251,7 +251,13 @@ func (e *ClusterE2ETest) generateHardwareConfig(opts ...CommandOpt) {
 		e.T.Fatalf("failed to create hardware csv for the test run: %v", err)
 	}
 
-	generateHardwareConfigArgs := []string{"generate", "hardware", "--dry-run", "-f", e.HardwareCsvLocation, "-o", e.ClusterConfigFolder}
+	generateHardwareConfigArgs := []string{
+		"generate", "hardware",
+		"--skip-registration",
+		"-f", e.HardwareCsvLocation,
+		"-o", e.ClusterConfigFolder,
+	}
+
 	e.RunEKSA(generateHardwareConfigArgs, opts...)
 }
 


### PR DESCRIPTION
When generating Tinkerbell manifests the `--dry-run` option should follow as closely as possible the normal path of operation. This includes performing the validation we would expect if the tool were to run normally. The change ensures validation does run even with `--dry-run`.

Additionally, change the `--dry-run` flag to `--skip-registration` so its clear what behavior to expect. Typical dry run behavior would still perform validations, for example, where as we don't want validation on the Tinkerbell stack config if we don't want to register the hardware.