### PR TITLE
Remove string until we fix running multiple e2e tests on one ec2 inst…

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -247,7 +247,7 @@ func splitTests(testsList []string, conf ParallelRunConf) []instanceRunConf {
 				jobId:               fmt.Sprintf("%s-%d", conf.JobId, len(runConfs)),
 				parentJobId:         conf.JobId,
 				subnetId:            conf.SubnetId,
-				regex:               fmt.Sprintf("\"%s\"", strings.Join(testsInCurrentInstance, "|")),
+				regex:               strings.Join(testsInCurrentInstance, "|"),
 				bundlesOverride:     conf.BundlesOverride,
 				testReportFolder:    conf.TestReportFolder,
 				branchName:          conf.BranchName,


### PR DESCRIPTION
…ance

*Issue #, if available:*

*Description of changes:*
Adding the string quotes before fixed the issue of running multiple tests on an instance initially, but more needs to be done to support that use case. https://github.com/aws/eks-anywhere/issues/1548

*Testing (if applicable):*
make

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

