### PR TITLE
Remove 1-22 feature flag

### DIFF
--- a/docs/content/en/docs/reference/changelog.md
+++ b/docs/content/en/docs/reference/changelog.md
@@ -7,6 +7,11 @@ menu:
     weight: 10
 ---
 
+## Unreleased
+
+### Added
+- Add support for Kubernetes 1.22 [#1549](https://github.com/aws/eks-anywhere/pull/1549)
+
 ## [v0.7.1](https://github.com/aws/eks-anywhere/releases/tag/v0.7.1) - 2022-02-25
 
 ### Added

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -6,7 +6,6 @@ const (
 	SnowProviderEnvVar       = "SNOW_PROVIDER"
 	FullLifecycleAPIEnvVar   = "FULL_LIFECYCLE_API"
 	FullLifecycleGate        = "FullLifecycleAPI"
-	K8s122SupportEnvVar      = "K8S_1_22_SUPPORT"
 	CuratedPackagesEnvVar    = "CURATED_PACKAGES_SUPPORT"
 )
 
@@ -48,13 +47,6 @@ func SnowProvider() Feature {
 	return Feature{
 		Name:     "Snow provider support",
 		IsActive: globalFeatures.isActiveForEnvVar(SnowProviderEnvVar),
-	}
-}
-
-func K8s122Support() Feature {
-	return Feature{
-		Name:     "Kubernetes version 1.22 support",
-		IsActive: globalFeatures.isActiveForEnvVar(K8s122SupportEnvVar),
 	}
 }
 

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -4,18 +4,8 @@ import (
 	"fmt"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 )
-
-func ValidateK8s122Support(clusterSpec *cluster.Spec) error {
-	if !features.IsActive(features.K8s122Support()) {
-		if clusterSpec.Cluster.Spec.KubernetesVersion == "1.22" {
-			return fmt.Errorf("Kubernetes version 1.22 is not enabled. Please set the env variable %v.", features.K8s122SupportEnvVar)
-		}
-	}
-	return nil
-}
 
 func ValidateCertForRegistryMirror(clusterSpec *cluster.Spec, tlsValidator TlsValidator) error {
 	cluster := clusterSpec.Cluster

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
@@ -19,12 +18,6 @@ func (u *CreateValidations) PreflightValidations(ctx context.Context) (err error
 	}
 
 	createValidations := []validations.ValidationResult{
-		{
-			Name:        "validate kubernetes version 1.22 support",
-			Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s122SupportEnvVar),
-			Err:         validations.ValidateK8s122Support(u.Opts.Spec),
-			Silent:      true,
-		},
 		{
 			Name:        "validate certificate for registry mirror",
 			Remediation: fmt.Sprintf("provide a valid certificate for you registry endpoint using %s env var", anywherev1.RegistryMirrorCAKey),

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -7,7 +7,6 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
@@ -20,12 +19,6 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) (err erro
 		KubeconfigFile: u.Opts.ManagementCluster.KubeconfigFile,
 	}
 	upgradeValidations := []validations.ValidationResult{
-		{
-			Name:        "validate kubernetes version 1.22 support",
-			Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s122SupportEnvVar),
-			Err:         validations.ValidateK8s122Support(u.Opts.Spec),
-			Silent:      true,
-		},
 		{
 			Name:        "validate certificate for registry mirror",
 			Remediation: fmt.Sprintf("provide a valid certificate for you registry endpoint using %s env var", anywherev1.RegistryMirrorCAKey),

--- a/test/e2e/awsiam_test.go
+++ b/test/e2e/awsiam_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -53,7 +52,6 @@ func TestDockerKubernetes122AWSIamAuth(t *testing.T) {
 		framework.NewDocker(t),
 		framework.WithAWSIam(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runAWSIamAuthFlow(test)
 }
@@ -84,7 +82,6 @@ func TestVSphereKubernetes122AWSIamAuth(t *testing.T) {
 		framework.NewVSphere(t, framework.WithUbuntu122()),
 		framework.WithAWSIam(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runAWSIamAuthFlow(test)
 }
@@ -115,7 +112,6 @@ func TestVSphereKubernetes122BottleRocketAWSIamAuth(t *testing.T) {
 		framework.NewVSphere(t, framework.WithBottleRocket122()),
 		framework.WithAWSIam(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runAWSIamAuthFlow(test)
 }
@@ -132,7 +128,6 @@ func TestVSphereKubernetes121To122AWSIamAuthUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var()),
 	)
 }

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -45,7 +44,6 @@ func TestDockerKubernetes122ThreeWorkersConformanceFlow(t *testing.T) {
 		framework.NewDocker(t),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runConformanceFlow(test)
 }
@@ -76,7 +74,6 @@ func TestVSphereKubernetes122ThreeWorkersConformanceFlow(t *testing.T) {
 		framework.NewVSphere(t, framework.WithUbuntu122()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runConformanceFlow(test)
 }
@@ -107,7 +104,6 @@ func TestVSphereKubernetes122BottleRocketThreeWorkersConformanceFlow(t *testing.
 		framework.NewVSphere(t, framework.WithBottleRocket122()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runConformanceFlow(test)
 }

--- a/test/e2e/flux_test.go
+++ b/test/e2e/flux_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -58,7 +57,6 @@ func TestDockerKubernetes122Flux(t *testing.T) {
 		framework.NewDocker(t),
 		framework.WithFlux(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runFluxFlow(test)
 }
@@ -95,7 +93,6 @@ func TestVSphereKubernetes122Flux(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runFluxFlow(test)
 }
@@ -131,7 +128,6 @@ func TestVSphereKubernetes122ThreeReplicasThreeWorkersFlux(t *testing.T) {
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
 		framework.WithFlux(),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runFluxFlow(test)
 }
@@ -147,7 +143,6 @@ func TestDockerKubernetes122GitopsOptionsFlux(t *testing.T) {
 			api.WithFluxNamespace(fluxUserProvidedNamespace),
 			api.WithFluxConfigurationPath(fluxUserProvidedPath),
 		),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runFluxFlow(test)
 }
@@ -164,7 +159,6 @@ func TestVSphereKubernetes122GitopsOptionsFlux(t *testing.T) {
 			api.WithFluxNamespace(fluxUserProvidedNamespace),
 			api.WithFluxConfigurationPath(fluxUserProvidedPath),
 		),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runFluxFlow(test)
 }
@@ -178,13 +172,11 @@ func TestVSphereKubernetes121To122FluxUpgrade(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runUpgradeFlowWithFlux(
 		test,
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var()),
 	)
 }

--- a/test/e2e/labels_test.go
+++ b/test/e2e/labels_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -45,7 +44,6 @@ func TestVSphereKubernetes122Labels(t *testing.T) {
 			api.WithControlPlaneCount(1),
 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 		),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 
 	runLabelsUpgradeFlow(
@@ -72,7 +70,6 @@ func TestVSphereKubernetes122LabelsBottlerocket(t *testing.T) {
 			api.WithControlPlaneCount(1),
 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 		),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 
 	runLabelsUpgradeFlow(

--- a/test/e2e/multiple_worker_node_groups_test.go
+++ b/test/e2e/multiple_worker_node_groups_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -32,7 +31,6 @@ func TestVSphereKubernetes122BottlerocketAndAndRemoveWorkerNodeGroups(t *testing
 			api.WithControlPlaneCount(1),
 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 		),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 
 	runSimpleUpgradeFlow(

--- a/test/e2e/oidc_test.go
+++ b/test/e2e/oidc_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -53,7 +52,6 @@ func TestDockerKubernetes122OIDC(t *testing.T) {
 		framework.NewDocker(t),
 		framework.WithOIDC(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runOIDCFlow(test)
 }
@@ -93,7 +91,6 @@ func TestVSphereKubernetes122OIDC(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runOIDCFlow(test)
 }
@@ -108,13 +105,11 @@ func TestVSphereKubernetes121To122OIDCUpgrade(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runUpgradeFlowWithOIDC(
 		test,
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var()),
 	)
 }

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -27,7 +26,6 @@ func TestVSphereKubernetes122UbuntuProxyConfig(t *testing.T) {
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithProxy(),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runProxyConfigFlow(test)
 }
@@ -42,7 +40,6 @@ func TestVSphereKubernetes122BottlerocketProxyConfig(t *testing.T) {
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithProxy(),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runProxyConfigFlow(test)
 }

--- a/test/e2e/registry_mirror_test.go
+++ b/test/e2e/registry_mirror_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -28,7 +27,6 @@ func TestVSphereKubernetes122UbuntuRegistryMirrorAndCert(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithRegistryMirrorEndpointAndCert(),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runRegistryMirrorConfigFlow(test)
 }
@@ -42,7 +40,6 @@ func TestVSphereKubernetes122BottlerocketRegistryMirrorAndCert(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithRegistryMirrorEndpointAndCert(),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runRegistryMirrorConfigFlow(test)
 }

--- a/test/e2e/simpleflow_test.go
+++ b/test/e2e/simpleflow_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/test/framework"
 )
@@ -58,7 +57,6 @@ func TestDockerKubernetes122SimpleFlow(t *testing.T) {
 		t,
 		framework.NewDocker(t),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runSimpleFlow(test)
 }
@@ -86,7 +84,6 @@ func TestVSphereKubernetes122SimpleFlow(t *testing.T) {
 		t,
 		framework.NewVSphere(t, framework.WithUbuntu122()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runSimpleFlow(test)
 }
@@ -98,7 +95,6 @@ func TestVSphereKubernetes122ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runSimpleFlow(test)
 }
@@ -109,7 +105,6 @@ func TestVSphereKubernetes122DifferentNamespaceSimpleFlow(t *testing.T) {
 		framework.NewVSphere(t, framework.WithUbuntu122(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runSimpleFlow(test)
 }
@@ -119,7 +114,6 @@ func TestVSphereKubernetes122BottleRocketSimpleFlow(t *testing.T) {
 		t,
 		framework.NewVSphere(t, framework.WithBottleRocket122()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runSimpleFlow(test)
 }
@@ -131,7 +125,6 @@ func TestVSphereKubernetes122BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *t
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runSimpleFlow(test)
 }
@@ -142,7 +135,6 @@ func TestVSphereKubernetes122BottleRocketDifferentNamespaceSimpleFlow(t *testing
 		framework.NewVSphere(t, framework.WithBottleRocket122(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runSimpleFlow(test)
 }

--- a/test/e2e/stackedetcd_test.go
+++ b/test/e2e/stackedetcd_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -59,8 +58,7 @@ func TestVSphereKubernetes122StackedEtcdUbuntu(t *testing.T) {
 		framework.NewVSphere(t, framework.WithUbuntu122()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"))
+		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
 	runStackedEtcdFlow(test)
 }
 

--- a/test/e2e/taints_test.go
+++ b/test/e2e/taints_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -43,7 +42,6 @@ func TestVSphereKubernetes122Taints(t *testing.T) {
 			api.WithControlPlaneCount(1),
 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 		),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 
 	runTaintsUpgradeFlow(
@@ -70,7 +68,6 @@ func TestVSphereKubernetes122TaintsBottlerocket(t *testing.T) {
 			api.WithControlPlaneCount(1),
 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 		),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 
 	runTaintsUpgradeFlow(

--- a/test/e2e/upgrade_from_latest_test.go
+++ b/test/e2e/upgrade_from_latest_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -151,7 +150,6 @@ func TestVSphereKubernetes121To122UbuntuUpgradeFromLatestMinorRelease(t *testing
 			framework.UpdateUbuntuTemplate122Var(), // Set the template so it doesn't get autoimported
 		),
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(anywherev1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 
@@ -169,6 +167,5 @@ func TestDockerKubernetes121to122UpgradeFromLatestMinorRelease(t *testing.T) {
 		test,
 		anywherev1.Kube122,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(anywherev1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -59,7 +58,6 @@ func TestVSphereKubernetes121UbuntuTo122Upgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var()),
 	)
 }
@@ -88,7 +86,6 @@ func TestVSphereKubernetes121UbuntuTo122MultipleFieldsUpgrade(t *testing.T) {
 			// Uncomment the network field once upgrade starts working with it
 			// api.WithNetwork(vsphereNetwork2UpdateVar),
 		),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 
@@ -107,7 +104,6 @@ func TestVSphereKubernetes121UbuntuTo122WithFluxUpgrade(t *testing.T) {
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var()),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 
@@ -127,7 +123,6 @@ func TestVSphereKubernetes121UbuntuTo122DifferentNamespaceWithFluxUpgrade(t *tes
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var()),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 
@@ -139,13 +134,11 @@ func TestVSphereKubernetes122UbuntuControlPlaneNodeUpgrade(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runSimpleUpgradeFlow(
 		test,
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 
@@ -157,13 +150,11 @@ func TestVSphereKubernetes122UbuntuWorkerNodeUpgrade(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runSimpleUpgradeFlow(
 		test,
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 
@@ -179,7 +170,6 @@ func TestVSphereKubernetes121BottlerocketTo122Upgrade(t *testing.T) {
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		provider.WithProviderUpgrade(framework.UpdateBottlerocketTemplate122()),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 
@@ -207,7 +197,6 @@ func TestVSphereKubernetes121BottlerocketTo122MultipleFieldsUpgrade(t *testing.T
 			// Uncomment the network field once upgrade starts working with it
 			// api.WithNetwork(vsphereNetwork2UpdateVar),
 		),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 
@@ -226,7 +215,6 @@ func TestVSphereKubernetes121BottlerocketTo122WithFluxUpgrade(t *testing.T) {
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		provider.WithProviderUpgrade(framework.UpdateBottlerocketTemplate122()),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 
@@ -246,7 +234,6 @@ func TestVSphereKubernetes121BottlerocketTo122DifferentNamespaceWithFluxUpgrade(
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		provider.WithProviderUpgrade(framework.UpdateBottlerocketTemplate122()),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 
@@ -258,13 +245,11 @@ func TestVSphereKubernetes122BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runSimpleUpgradeFlow(
 		test,
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 
@@ -276,13 +261,11 @@ func TestVSphereKubernetes122BottlerocketWorkerNodeUpgrade(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runSimpleUpgradeFlow(
 		test,
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 
@@ -298,7 +281,6 @@ func TestDockerKubernetes121To122StackedEtcdUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 
@@ -317,7 +299,6 @@ func TestVSphereKubernetes121UbuntuTo122StackedEtcdUpgrade(t *testing.T) {
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var()),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 
@@ -336,6 +317,5 @@ func TestVSphereKubernetes121BottlerocketTo122StackedEtcdUpgrade(t *testing.T) {
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		provider.WithProviderUpgrade(framework.UpdateBottlerocketTemplate122()),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }

--- a/test/e2e/vsphere_autoimport_test.go
+++ b/test/e2e/vsphere_autoimport_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -83,7 +82,6 @@ func TestVSphereKubernetes122UbuntuAutoimport(t *testing.T) {
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runAutoImportFlow(test, provider)
 }
@@ -129,7 +127,6 @@ func TestVSphereKubernetes122BottlerocketAutoimport(t *testing.T) {
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 	runAutoImportFlow(test, provider)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removing the 1-22 feature flag to get ready for support

*Testing (if applicable):*
`make`
`make e2e`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

