### PR TITLE
Vsphere rm session cmd

### DIFF
--- a/cmd/eks-a-tool/cmd/vspherelogoutsessions.go
+++ b/cmd/eks-a-tool/cmd/vspherelogoutsessions.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/filewriter"
+)
+
+var sessions []string
+
+var vsphereSessionRmCommand = &cobra.Command{
+	Use:    "sessions",
+	Short:  "vsphere logout sessions command",
+	Long:   "This command logs out all of the provided VSphere user sessions ",
+	PreRun: prerunSessionLogoutCmd,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := vsphereLogoutSessions(cmd.Context(), sessions)
+		if err != nil {
+			log.Fatalf("Error removing sessions: %v", err)
+		}
+		return nil
+	},
+}
+
+func init() {
+	vsphereRmCmd.AddCommand(vsphereSessionRmCommand)
+	vsphereSessionRmCommand.Flags().StringSliceVarP(&sessions, "sessionTokens", "s", []string{}, "sessions to logout")
+	err := vsphereSessionRmCommand.MarkFlagRequired("sessionTokens")
+	if err != nil {
+		log.Fatalf("Error marking flag as required: %v", err)
+	}
+}
+
+func prerunSessionLogoutCmd(cmd *cobra.Command, args []string) {
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		err := viper.BindPFlag(flag.Name, flag)
+		if err != nil {
+			log.Fatalf("Error initializing flags: %v", err)
+		}
+	})
+}
+
+func vsphereLogoutSessions(ctx context.Context, sessions []string) error {
+	tmpWriter, _ := filewriter.NewWriter("sessionlogout")
+	executableBuilder, close, err := executables.NewExecutableBuilder(ctx, executables.DefaultEksaImage(), "./sessionlogout")
+	if err != nil {
+		return fmt.Errorf("unable to initialize executables: %v", err)
+	}
+	defer close.CheckErr(ctx)
+	govc := executableBuilder.BuildGovcExecutable(tmpWriter)
+	defer govc.Close(ctx)
+
+	tmpWriter.CleanUp()
+	return govc.Logout(ctx)
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a basic command to the `eks-a-tool vsphere rm` command which allows the removal of VSphere sessions, given a comma separated list of session cookies.

This will be combined with a query of created sessions to automatically close out vsphere sessions after end-to-end test runs.

usage:
`eks-a-tool vsphere rm sessions --sessionTokens=token1,token2 --tlsInsecure false -e https://myVsphereEndpoint.com`

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

