### PR TITLE
Install required NetworkPolicy objects during cluster creation

### DIFF
--- a/controllers/controllers/clusters/vsphere.go
+++ b/controllers/controllers/clusters/vsphere.go
@@ -266,13 +266,12 @@ func (v *VSphereClusterReconciler) reconcileCNI(ctx context.Context, cluster *an
 
 		v.Log.Info("About to apply CNI")
 
-		// TODO use NewCilium
+		// TODO use NewCilium, create string slice of namespaces used for capv for calling cilium.GenerateManifest
 		cilium := cilium.Cilium{}
 		if err != nil {
 			return reconciler.Result{}, err
 		}
-
-		ciliumSpec, err := cilium.GenerateManifest(ctx, specWithBundles)
+		ciliumSpec, err := cilium.GenerateManifest(ctx, specWithBundles, []string{})
 		if err != nil {
 			return reconciler.Result{}, err
 		}

--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -47,6 +47,15 @@ func WithKubernetesVersion(v anywherev1.KubernetesVersion) ClusterFiller {
 	}
 }
 
+func WithCiliumPolicyEnforcementMode(mode anywherev1.CiliumPolicyEnforcementMode) ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		if c.Spec.ClusterNetwork.CNIConfig == nil {
+			c.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{Cilium: &anywherev1.CiliumConfig{}}
+		}
+		c.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = mode
+	}
+}
+
 func WithClusterNamespace(ns string) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		c.Namespace = ns

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -590,18 +590,18 @@ func (m *MockNetworking) EXPECT() *MockNetworkingMockRecorder {
 }
 
 // GenerateManifest mocks base method.
-func (m *MockNetworking) GenerateManifest(arg0 context.Context, arg1 *cluster.Spec) ([]byte, error) {
+func (m *MockNetworking) GenerateManifest(arg0 context.Context, arg1 *cluster.Spec, arg2 []string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateManifest", arg0, arg1)
+	ret := m.ctrl.Call(m, "GenerateManifest", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GenerateManifest indicates an expected call of GenerateManifest.
-func (mr *MockNetworkingMockRecorder) GenerateManifest(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNetworkingMockRecorder) GenerateManifest(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateManifest", reflect.TypeOf((*MockNetworking)(nil).GenerateManifest), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateManifest", reflect.TypeOf((*MockNetworking)(nil).GenerateManifest), arg0, arg1, arg2)
 }
 
 // Upgrade mocks base method.

--- a/pkg/networking/cilium/cilium.go
+++ b/pkg/networking/cilium/cilium.go
@@ -3,8 +3,10 @@ package cilium
 import (
 	"context"
 
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/templater"
 )
 
 const namespace = constants.KubeSystemNamespace
@@ -19,6 +21,20 @@ func NewCilium(client Client, helm Helm) *Cilium {
 	}
 }
 
-func (c *Cilium) GenerateManifest(ctx context.Context, clusterSpec *cluster.Spec) ([]byte, error) {
-	return c.templater.GenerateManifest(ctx, clusterSpec)
+func (c *Cilium) GenerateManifest(ctx context.Context, clusterSpec *cluster.Spec, providerNamespaces []string) ([]byte, error) {
+	ciliumManifest, err := c.templater.GenerateManifest(ctx, clusterSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	if clusterSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode != v1alpha1.CiliumPolicyModeAlways {
+		return ciliumManifest, nil
+	}
+
+	networkPolicyManifest, err := c.templater.GenerateNetworkPolicyManifest(clusterSpec, providerNamespaces)
+	if err != nil {
+		return nil, err
+	}
+
+	return templater.AppendYamlResources(ciliumManifest, networkPolicyManifest), nil
 }

--- a/pkg/networking/cilium/cilium_test.go
+++ b/pkg/networking/cilium/cilium_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/aws/eks-anywhere/internal/test"
+	v1alpha12 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/networking/cilium"
 	"github.com/aws/eks-anywhere/pkg/networking/cilium/mocks"
@@ -16,11 +17,12 @@ import (
 
 type ciliumtest struct {
 	*WithT
-	ctx    context.Context
-	client mocks.MockClient
-	h      *mocks.MockHelm
-	spec   *cluster.Spec
-	cilium *cilium.Cilium
+	ctx          context.Context
+	client       mocks.MockClient
+	h            *mocks.MockHelm
+	spec         *cluster.Spec
+	cilium       *cilium.Cilium
+	ciliumValues []byte
 }
 
 func newCiliumTest(t *testing.T) *ciliumtest {
@@ -45,8 +47,11 @@ func newCiliumTest(t *testing.T) *ciliumtest {
 					URI:  "public.ecr.aws/isovalent/cilium:1.9.13-eksa.2",
 				},
 			}
+			s.VersionsBundle.KubeDistro.Kubernetes.Tag = "v1.21.9-eks-1-21-10"
+			s.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha12.CNIConfig{Cilium: &v1alpha12.CiliumConfig{}}
 		}),
-		cilium: cilium.NewCilium(client, h),
+		cilium:       cilium.NewCilium(client, h),
+		ciliumValues: []byte("manifest"),
 	}
 }
 
@@ -56,7 +61,25 @@ func TestCiliumGenerateManifestSuccess(t *testing.T) {
 	// calls the templater and does not try to load the static manifest like earlier version
 	tt.h.EXPECT().Template(
 		tt.ctx, gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(map[string]interface{}{}),
-	).Return([]byte("manifest"), nil)
-	_, err := tt.cilium.GenerateManifest(tt.ctx, tt.spec)
+	).Return(tt.ciliumValues, nil)
+	_, err := tt.cilium.GenerateManifest(tt.ctx, tt.spec, []string{})
 	tt.Expect(err).To(Not(HaveOccurred()), "GenerateManifest() should succeed")
+}
+
+func TestCiliumGenerateManifestAndGenerateNetworkPolicySuccess(t *testing.T) {
+	tt := newCiliumTest(t)
+	/* templater tests already test whether templater.GenerateManifest returns expected values or not. This test ensures that cilium.GenerateManifest
+	calls the templater and does not try to load the static manifest like earlier version */
+	tt.h.EXPECT().Template(
+		tt.ctx, gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(map[string]interface{}{}),
+	).Return(tt.ciliumValues, nil)
+
+	/* templater tests already test network policy generation based on the infra provider, gitops, mgmt/workload cluster and k8s version.
+	adding only 1 test here to ensure that for "always" mode, GenerateNetworkPolicyManifest is called and
+	the cilium manifest gets appended to manifest returned by GenerateNetworkPolicyManifest */
+	tt.spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = v1alpha12.CiliumPolicyModeAlways
+	tt.spec.Cluster.Spec.ManagementCluster.Name = "managed"
+	content, err := tt.cilium.GenerateManifest(tt.ctx, tt.spec, []string{})
+	tt.Expect(err).To(Not(HaveOccurred()), "GenerateManifest() should succeed")
+	test.AssertContentToFile(t, string(content), "testdata/manifest_network_policy.yaml")
 }

--- a/pkg/networking/cilium/network_policy.yaml
+++ b/pkg/networking/cilium/network_policy.yaml
@@ -222,7 +222,6 @@ spec:
   policyTypes:
   - Ingress
   - Egress
----
 {{- else }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -124,7 +124,7 @@ func (c values) set(value interface{}, path ...string) {
 }
 
 func templateValues(spec *cluster.Spec) values {
-	return values{
+	val := values{
 		"cni": values{
 			"chainingMode": "portmap",
 		},
@@ -153,6 +153,11 @@ func templateValues(spec *cluster.Spec) values {
 			},
 		},
 	}
+
+	if spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode != "" {
+		val["policyEnforcementMode"] = spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode
+	}
+	return val
 }
 
 func getChartUriAndVersion(spec *cluster.Spec) (uri, version string) {

--- a/pkg/networking/cilium/testdata/manifest_network_policy.yaml
+++ b/pkg/networking/cilium/testdata/manifest_network_policy.yaml
@@ -1,3 +1,5 @@
+manifest
+---
 
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -19,3 +21,5 @@ spec:
   policyTypes:
   - Ingress
   - Egress
+
+---

--- a/pkg/networking/cilium/upgrader_test.go
+++ b/pkg/networking/cilium/upgrader_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/networking/cilium/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
@@ -40,9 +41,11 @@ func newUpgraderTest(t *testing.T) *upgraderTest {
 		manifest: []byte("manifestContent"),
 		currentSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 			s.VersionsBundle.Cilium.Version = "v1.9.10-eksa.1"
+			s.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{}}
 		}),
 		newSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 			s.VersionsBundle.Cilium.Version = "v1.9.11-eksa.1"
+			s.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{}}
 		}),
 		cluster: &types.Cluster{
 			KubeconfigFile: "kubeconfig",

--- a/pkg/networking/kindnetd/kindnetd.go
+++ b/pkg/networking/kindnetd/kindnetd.go
@@ -26,7 +26,7 @@ func NewKindnetd(client Client) *Kindnetd {
 	}
 }
 
-func (c *Kindnetd) GenerateManifest(ctx context.Context, clusterSpec *cluster.Spec) ([]byte, error) {
+func (c *Kindnetd) GenerateManifest(ctx context.Context, clusterSpec *cluster.Spec, namespaces []string) ([]byte, error) {
 	return generateManifest(clusterSpec)
 }
 

--- a/pkg/networking/kindnetd/kindnetd_test.go
+++ b/pkg/networking/kindnetd/kindnetd_test.go
@@ -37,7 +37,7 @@ func TestKindnetdGenerateManifestSuccess(t *testing.T) {
 		s.VersionsBundle.Kindnetd = KindnetdBundle
 	})
 
-	gotFileContent, err := tt.k.GenerateManifest(context.Background(), clusterSpec)
+	gotFileContent, err := tt.k.GenerateManifest(context.Background(), clusterSpec, []string{})
 	if err != nil {
 		t.Fatalf("Kindnetd.GenerateManifestFile() error = %v, wantErr nil", err)
 	}
@@ -57,7 +57,7 @@ func TestKindnetdGenerateManifestWriterError(t *testing.T) {
 		s.VersionsBundle.Kindnetd.Manifest.URI = "testdata/missing_manifest.yaml"
 	})
 
-	if _, err := tt.k.GenerateManifest(context.Background(), clusterSpec); err == nil {
+	if _, err := tt.k.GenerateManifest(context.Background(), clusterSpec, []string{}); err == nil {
 		t.Fatalf("Kindnetd.GenerateManifestFile() error = nil, want not nil")
 	}
 }

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -182,7 +182,7 @@ func (s *CreateWorkloadClusterTask) Run(ctx context.Context, commandContext *tas
 	commandContext.WorkloadCluster = workloadCluster
 
 	logger.Info("Installing networking on workload cluster")
-	err = commandContext.ClusterManager.InstallNetworking(ctx, workloadCluster, commandContext.ClusterSpec)
+	err = commandContext.ClusterManager.InstallNetworking(ctx, workloadCluster, commandContext.ClusterSpec, commandContext.Provider)
 	if err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -97,7 +97,7 @@ func (c *createTestSetup) expectCreateWorkload() {
 		).Return(c.workloadCluster, nil),
 
 		c.clusterManager.EXPECT().InstallNetworking(
-			c.ctx, c.workloadCluster, c.clusterSpec,
+			c.ctx, c.workloadCluster, c.clusterSpec, c.provider,
 		),
 		c.clusterManager.EXPECT().InstallStorageClass(
 			c.ctx, c.workloadCluster, c.provider,
@@ -116,7 +116,7 @@ func (c *createTestSetup) expectCreateWorkloadSkipCAPI() {
 		).Return(c.workloadCluster, nil),
 
 		c.clusterManager.EXPECT().InstallNetworking(
-			c.ctx, c.workloadCluster, c.clusterSpec,
+			c.ctx, c.workloadCluster, c.clusterSpec, c.provider,
 		),
 		c.clusterManager.EXPECT().InstallStorageClass(
 			c.ctx, c.workloadCluster, c.provider,

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -21,7 +21,7 @@ type ClusterManager interface {
 	UpgradeCluster(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster, provider providers.Provider, clusterSpec *cluster.Spec) error
 	InstallCAPI(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
-	InstallNetworking(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
+	InstallNetworking(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	UpgradeNetworking(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error)
 	InstallStorageClass(ctx context.Context, cluster *types.Cluster, provider providers.Provider) error
 	SaveLogsManagementCluster(ctx context.Context, cluster *types.Cluster) error

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -268,17 +268,17 @@ func (mr *MockClusterManagerMockRecorder) InstallMachineHealthChecks(arg0, arg1,
 }
 
 // InstallNetworking mocks base method.
-func (m *MockClusterManager) InstallNetworking(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec) error {
+func (m *MockClusterManager) InstallNetworking(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec, arg3 providers.Provider) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallNetworking", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "InstallNetworking", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallNetworking indicates an expected call of InstallNetworking.
-func (mr *MockClusterManagerMockRecorder) InstallNetworking(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClusterManagerMockRecorder) InstallNetworking(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallNetworking", reflect.TypeOf((*MockClusterManager)(nil).InstallNetworking), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallNetworking", reflect.TypeOf((*MockClusterManager)(nil).InstallNetworking), arg0, arg1, arg2, arg3)
 }
 
 // InstallStorageClass mocks base method.

--- a/test/e2e/simpleflow_test.go
+++ b/test/e2e/simpleflow_test.go
@@ -147,6 +147,16 @@ func TestVSphereKubernetes122BottleRocketDifferentNamespaceSimpleFlow(t *testing
 	runSimpleFlow(test)
 }
 
+func TestVSphereKubernetes121CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewVSphere(t, framework.WithUbuntu121()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
+	)
+	runSimpleFlow(test)
+}
+
 func TestTinkerbellKubernetes120SimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/eks-anywhere/issues/726

*Description of changes:*
Design doc for reference: https://github.com/aws/eks-anywhere/blob/main/designs/cilium-configuration-policy.md
This PR sets the value of policyEnforcementMode in the cilium chart's values if provided by the user, and calls GenerateNetworkPolicy (added in [this](https://github.com/aws/eks-anywhere/pull/1539) PR) to install required Network Policy objects if `always` mode is selected during cluster creation.
This same method will be called in cilium upgrader in a follow-up PR

*Testing (if applicable):*
- `TestVSphereKubernetes121CiliumAlwaysPolicyEnforcementModeSimpleFlow` (new e2e test added for creating cluster with `always` policy enforcement mode to ensure cluster gets created successfully)
- The cluster's cilium-config configmap in kube-system ns contains all values configured for the cilium chart. For a cluster created with `always` mode, the configmap contains `enable-policy: always`. The same happens for any mode specified.
- `TestVSphereKubernetes121UbuntuTo122Upgrade`
- Created mgmt+workload cluster with flux enabled from release-0.7 branch. Upgraded cluster k8s versions using this PR. Both cluster specs get updated with the new field


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

