### PR TITLE
Make verify-ssl optional and Add unit tests for decoder.go

### DIFF
--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -28,10 +28,10 @@ const (
 
 	/* Generated from ini file (like the following) then b64 encoded: `cat fake-cloud-config.ini | base64 | tr -d '\n'`
 	[Global]
-	api-key = test-key
-	secret-key = secret-key
-	api-url = http://1.1.1.1:8080/client/api
-	verify-ssl = false
+	api-key    = test-key
+	secret-key = test-secret
+	api-url    = http://127.16.0.1:8080/client/api
+	verify-ssl = true
 	*/
 	expectedCloudStackCloudConfig = "W0dsb2JhbF0KYXBpLWtleSAgICA9IHRlc3Qta2V5CnNlY3JldC1rZXkgPSB0ZXN0LXNlY3JldAphcGktdXJsICAgID0gaHR0cDovLzEyNy4xNi4wLjE6ODA4MC9jbGllbnQvYXBpCnZlcmlmeS1zc2wgPSB0cnVlCg=="
 )

--- a/pkg/providers/cloudstack/decoder/decoder.go
+++ b/pkg/providers/cloudstack/decoder/decoder.go
@@ -4,6 +4,7 @@ import (
 	b64 "encoding/base64"
 	"fmt"
 	"os"
+	"strconv"
 
 	"gopkg.in/ini.v1"
 )
@@ -44,14 +45,18 @@ func ParseCloudStackSecret() (*CloudStackExecConfig, error) {
 		return nil, fmt.Errorf("failed to extract value of 'api-url' from %s: %v", EksacloudStackCloudConfigB64SecretKey, err)
 	}
 	verifySsl, err := section.GetKey("verify-ssl")
-	if err != nil {
-		return nil, fmt.Errorf("failed to extract value of 'verify-ssl' from %s: %v", EksacloudStackCloudConfigB64SecretKey, err)
+	verifySslValue := "true"
+	if err == nil {
+		verifySslValue = verifySsl.Value()
+		if _, err := strconv.ParseBool(verifySslValue); err != nil {
+			return nil, fmt.Errorf("'verify-ssl' has invalid boolean string %s: %v", verifySslValue, err)
+		}
 	}
 	return &CloudStackExecConfig{
 		ApiKey:        apiKey.Value(),
 		SecretKey:     secretKey.Value(),
 		ManagementUrl: apiUrl.Value(),
-		VerifySsl:     verifySsl.Value(),
+		VerifySsl:     verifySslValue,
 	}, nil
 }
 

--- a/pkg/providers/cloudstack/decoder/decoder_test.go
+++ b/pkg/providers/cloudstack/decoder/decoder_test.go
@@ -27,7 +27,25 @@ const (
 	invalidEncoding            = "=====W0dsb2JhbF0KYXBpLWtleSA7IHRlc3Qta2V5CnNlY3JldC1rZXkgOyB0ZXN0LXNlY3JldAphcGktdXJsIDsgaHR0cDovLzEyNy4xNi4wLjE6ODA4MC9jbGllbnQvYXBpCnZlcmlmeS1zc2wgOyBmYWxzZQo======"
 )
 
+type testContext struct {
+	oldCloudStackCloudConfigSecret   string
+	isCloudStackCloudConfigSecretSet bool
+}
+
+func (tctx *testContext) backupContext() {
+	tctx.oldCloudStackCloudConfigSecret, tctx.isCloudStackCloudConfigSecretSet = os.LookupEnv(decoder.EksacloudStackCloudConfigB64SecretKey)
+}
+
+func (tctx *testContext) restoreContext() {
+	if tctx.isCloudStackCloudConfigSecretSet {
+		os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, tctx.oldCloudStackCloudConfigSecret)
+	}
+}
+
 func TestValidConfigShouldSucceedtoParse(t *testing.T) {
+	var tctx testContext
+	tctx.backupContext()
+
 	g := NewWithT(t)
 	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, validCloudStackCloudConfig)
 	execConfig, err := decoder.ParseCloudStackSecret()
@@ -36,30 +54,50 @@ func TestValidConfigShouldSucceedtoParse(t *testing.T) {
 	g.Expect(execConfig.SecretKey).To(Equal(secretKey))
 	g.Expect(execConfig.ManagementUrl).To(Equal(apiUrl))
 	g.Expect(execConfig.VerifySsl).To(Equal(verifySsl))
+
+	tctx.restoreContext()
 }
 
 func TestMissingApiKeyShouldFailToParse(t *testing.T) {
+	var tctx testContext
+	tctx.backupContext()
+
 	g := NewWithT(t)
 	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, missingApiKey)
 	_, err := decoder.ParseCloudStackSecret()
 	g.Expect(err).ToNot(BeNil())
+
+	tctx.restoreContext()
 }
 
 func TestMissingSecretKeyShouldFailToParse(t *testing.T) {
+	var tctx testContext
+	tctx.backupContext()
+
 	g := NewWithT(t)
 	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, missingSecretKey)
 	_, err := decoder.ParseCloudStackSecret()
 	g.Expect(err).ToNot(BeNil())
+
+	tctx.restoreContext()
 }
 
 func TestMissingApiUrlShouldFailToParse(t *testing.T) {
+	var tctx testContext
+	tctx.backupContext()
+
 	g := NewWithT(t)
 	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, missingApiUrl)
 	_, err := decoder.ParseCloudStackSecret()
 	g.Expect(err).ToNot(BeNil())
+
+	tctx.restoreContext()
 }
 
 func TestMissingVerifySslShouldSetDefaultValue(t *testing.T) {
+	var tctx testContext
+	tctx.backupContext()
+
 	g := NewWithT(t)
 	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, missingVerifySsl)
 	execConfig, err := decoder.ParseCloudStackSecret()
@@ -68,39 +106,66 @@ func TestMissingVerifySslShouldSetDefaultValue(t *testing.T) {
 	g.Expect(execConfig.SecretKey).To(Equal(secretKey))
 	g.Expect(execConfig.ManagementUrl).To(Equal(apiUrl))
 	g.Expect(execConfig.VerifySsl).To(Equal(defaultVerifySsl))
+
+	tctx.restoreContext()
 }
 
 func TestInvalidVerifySslShouldFailToParse(t *testing.T) {
+	var tctx testContext
+	tctx.backupContext()
+
 	g := NewWithT(t)
 	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, invalidVerifySslValue)
 	_, err := decoder.ParseCloudStackSecret()
 	g.Expect(err).ToNot(BeNil())
+
+	tctx.restoreContext()
 }
 
 func TestMissingGlobalSectionShouldFailToParse(t *testing.T) {
+	var tctx testContext
+	tctx.backupContext()
+
 	g := NewWithT(t)
 	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, missingGlobalSection)
 	_, err := decoder.ParseCloudStackSecret()
 	g.Expect(err).ToNot(BeNil())
+
+	tctx.restoreContext()
 }
 
 func TestInvalidINIShouldFailToParse(t *testing.T) {
+	var tctx testContext
+	tctx.backupContext()
+
 	g := NewWithT(t)
 	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, invalidINI)
 	_, err := decoder.ParseCloudStackSecret()
 	g.Expect(err).ToNot(BeNil())
+
+	tctx.restoreContext()
 }
 
 func TestMissingEnvVariableShouldFailToParse(t *testing.T) {
+	var tctx testContext
+	tctx.backupContext()
+
 	g := NewWithT(t)
-	os.Clearenv()
+	os.Unsetenv(decoder.EksacloudStackCloudConfigB64SecretKey)
 	_, err := decoder.ParseCloudStackSecret()
 	g.Expect(err).ToNot(BeNil())
+
+	tctx.restoreContext()
 }
 
 func TestInvalidEncodingShouldFailToParse(t *testing.T) {
+	var tctx testContext
+	tctx.backupContext()
+
 	g := NewWithT(t)
 	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, invalidEncoding)
 	_, err := decoder.ParseCloudStackSecret()
 	g.Expect(err).ToNot(BeNil())
+
+	tctx.restoreContext()
 }

--- a/pkg/providers/cloudstack/decoder/decoder_test.go
+++ b/pkg/providers/cloudstack/decoder/decoder_test.go
@@ -1,0 +1,106 @@
+package decoder_test
+
+import (
+	_ "embed"
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
+)
+
+const (
+	apiKey                     = "test-key"
+	secretKey                  = "test-secret"
+	apiUrl                     = "http://127.16.0.1:8080/client/api"
+	verifySsl                  = "false"
+	defaultVerifySsl           = "true"
+	validCloudStackCloudConfig = "W0dsb2JhbF0KYXBpLWtleSA9IHRlc3Qta2V5CnNlY3JldC1rZXkgPSB0ZXN0LXNlY3JldAphcGktdXJsID0gaHR0cDovLzEyNy4xNi4wLjE6ODA4MC9jbGllbnQvYXBpCnZlcmlmeS1zc2wgPSBmYWxzZQo="
+	missingApiKey              = "W0dsb2JhbF0Kc2VjcmV0LWtleSA9IHRlc3Qtc2VjcmV0CmFwaS11cmwgPSBodHRwOi8vMTI3LjE2LjAuMTo4MDgwL2NsaWVudC9hcGkKdmVyaWZ5LXNzbCA9IGZhbHNlCg=="
+	missingSecretKey           = "W0dsb2JhbF0KYXBpLWtleSA9IHRlc3Qta2V5CmFwaS11cmwgPSBodHRwOi8vMTI3LjE2LjAuMTo4MDgwL2NsaWVudC9hcGkKdmVyaWZ5LXNzbCA9IGZhbHNlCg=="
+	missingApiUrl              = "W0dsb2JhbF0KYXBpLWtleSA9IHRlc3Qta2V5CnNlY3JldC1rZXkgPSB0ZXN0LXNlY3JldAp2ZXJpZnktc3NsID0gZmFsc2UK"
+	missingVerifySsl           = "W0dsb2JhbF0KYXBpLWtleSA9IHRlc3Qta2V5CnNlY3JldC1rZXkgPSB0ZXN0LXNlY3JldAphcGktdXJsID0gaHR0cDovLzEyNy4xNi4wLjE6ODA4MC9jbGllbnQvYXBpCg=="
+	invalidVerifySslValue      = "W0dsb2JhbF0KYXBpLWtleSA9IHRlc3Qta2V5CnNlY3JldC1rZXkgPSB0ZXN0LXNlY3JldAphcGktdXJsID0gaHR0cDovLzEyNy4xNi4wLjE6ODA4MC9jbGllbnQvYXBpCnZlcmlmeS1zc2wgPSBUVFRUVAo="
+	missingGlobalSection       = "YXBpLWtleSA9IHRlc3Qta2V5CnNlY3JldC1rZXkgPSB0ZXN0LXNlY3JldAphcGktdXJsID0gaHR0cDovLzEyNy4xNi4wLjE6ODA4MC9jbGllbnQvYXBpCnZlcmlmeS1zc2wgPSBmYWxzZQo="
+	invalidINI                 = "W0dsb2JhbF0KYXBpLWtleSA7IHRlc3Qta2V5CnNlY3JldC1rZXkgOyB0ZXN0LXNlY3JldAphcGktdXJsIDsgaHR0cDovLzEyNy4xNi4wLjE6ODA4MC9jbGllbnQvYXBpCnZlcmlmeS1zc2wgOyBmYWxzZQo="
+	invalidEncoding            = "=====W0dsb2JhbF0KYXBpLWtleSA7IHRlc3Qta2V5CnNlY3JldC1rZXkgOyB0ZXN0LXNlY3JldAphcGktdXJsIDsgaHR0cDovLzEyNy4xNi4wLjE6ODA4MC9jbGllbnQvYXBpCnZlcmlmeS1zc2wgOyBmYWxzZQo======"
+)
+
+func TestValidConfigShouldSucceedtoParse(t *testing.T) {
+	g := NewWithT(t)
+	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, validCloudStackCloudConfig)
+	execConfig, err := decoder.ParseCloudStackSecret()
+	g.Expect(err).To(BeNil(), "An error occurred when parsing a valid secret")
+	g.Expect(execConfig.ApiKey).To(Equal(apiKey))
+	g.Expect(execConfig.SecretKey).To(Equal(secretKey))
+	g.Expect(execConfig.ManagementUrl).To(Equal(apiUrl))
+	g.Expect(execConfig.VerifySsl).To(Equal(verifySsl))
+}
+
+func TestMissingApiKeyShouldFailToParse(t *testing.T) {
+	g := NewWithT(t)
+	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, missingApiKey)
+	_, err := decoder.ParseCloudStackSecret()
+	g.Expect(err).ToNot(BeNil())
+}
+
+func TestMissingSecretKeyShouldFailToParse(t *testing.T) {
+	g := NewWithT(t)
+	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, missingSecretKey)
+	_, err := decoder.ParseCloudStackSecret()
+	g.Expect(err).ToNot(BeNil())
+}
+
+func TestMissingApiUrlShouldFailToParse(t *testing.T) {
+	g := NewWithT(t)
+	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, missingApiUrl)
+	_, err := decoder.ParseCloudStackSecret()
+	g.Expect(err).ToNot(BeNil())
+}
+
+func TestMissingVerifySslShouldSetDefaultValue(t *testing.T) {
+	g := NewWithT(t)
+	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, missingVerifySsl)
+	execConfig, err := decoder.ParseCloudStackSecret()
+	g.Expect(err).To(BeNil(), "An error occurred when parsing a valid secret")
+	g.Expect(execConfig.ApiKey).To(Equal(apiKey))
+	g.Expect(execConfig.SecretKey).To(Equal(secretKey))
+	g.Expect(execConfig.ManagementUrl).To(Equal(apiUrl))
+	g.Expect(execConfig.VerifySsl).To(Equal(defaultVerifySsl))
+}
+
+func TestInvalidVerifySslShouldFailToParse(t *testing.T) {
+	g := NewWithT(t)
+	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, invalidVerifySslValue)
+	_, err := decoder.ParseCloudStackSecret()
+	g.Expect(err).ToNot(BeNil())
+}
+
+func TestMissingGlobalSectionShouldFailToParse(t *testing.T) {
+	g := NewWithT(t)
+	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, missingGlobalSection)
+	_, err := decoder.ParseCloudStackSecret()
+	g.Expect(err).ToNot(BeNil())
+}
+
+func TestInvalidINIShouldFailToParse(t *testing.T) {
+	g := NewWithT(t)
+	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, invalidINI)
+	_, err := decoder.ParseCloudStackSecret()
+	g.Expect(err).ToNot(BeNil())
+}
+
+func TestMissingEnvVariableShouldFailToParse(t *testing.T) {
+	g := NewWithT(t)
+	os.Clearenv()
+	_, err := decoder.ParseCloudStackSecret()
+	g.Expect(err).ToNot(BeNil())
+}
+
+func TestInvalidEncodingShouldFailToParse(t *testing.T) {
+	g := NewWithT(t)
+	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, invalidEncoding)
+	_, err := decoder.ParseCloudStackSecret()
+	g.Expect(err).ToNot(BeNil())
+}


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* 
verify-ssl value in the cloudstack cloud config secret should be optional and its default value should be "true". 

*Testing (if applicable):* 
unit testing
`ok      github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder    0.341s   coverage: 100.0% of statements`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

