### PR TITLE
Create NetworkPolicy if required during cilium upgrade

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -94,7 +94,7 @@ type ClusterClient interface {
 
 type Networking interface {
 	GenerateManifest(ctx context.Context, clusterSpec *cluster.Spec, namespaces []string) ([]byte, error)
-	Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error)
+	Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec, namespaces []string) (*types.ChangeDiff, error)
 }
 
 type AwsIamAuth interface {
@@ -565,8 +565,9 @@ func (c *ClusterManager) InstallNetworking(ctx context.Context, cluster *types.C
 	return nil
 }
 
-func (c *ClusterManager) UpgradeNetworking(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error) {
-	return c.networking.Upgrade(ctx, cluster, currentSpec, newSpec)
+func (c *ClusterManager) UpgradeNetworking(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec, provider providers.Provider) (*types.ChangeDiff, error) {
+	providerNamespaces := getProviderNamespaces(provider.GetDeployments())
+	return c.networking.Upgrade(ctx, cluster, currentSpec, newSpec, providerNamespaces)
 }
 
 func getProviderNamespaces(providerDeployments map[string][]string) []string {

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -605,18 +605,18 @@ func (mr *MockNetworkingMockRecorder) GenerateManifest(arg0, arg1, arg2 interfac
 }
 
 // Upgrade mocks base method.
-func (m *MockNetworking) Upgrade(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 *cluster.Spec) (*types.ChangeDiff, error) {
+func (m *MockNetworking) Upgrade(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 *cluster.Spec, arg4 []string) (*types.ChangeDiff, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.ChangeDiff)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Upgrade indicates an expected call of Upgrade.
-func (mr *MockNetworkingMockRecorder) Upgrade(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockNetworkingMockRecorder) Upgrade(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockNetworking)(nil).Upgrade), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockNetworking)(nil).Upgrade), arg0, arg1, arg2, arg3, arg4)
 }
 
 // MockAwsIamAuth is a mock of AwsIamAuth interface.

--- a/pkg/networking/cilium/upgrader.go
+++ b/pkg/networking/cilium/upgrader.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/templater"
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 
@@ -30,14 +32,17 @@ func NewUpgrader(client Client, helm Helm) *Upgrader {
 	}
 }
 
-func (u *Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error) {
+func (u *Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec, namespaces []string) (*types.ChangeDiff, error) {
 	diff := ciliumChangeDiff(currentSpec, newSpec)
-	if diff == nil {
+	chartValuesChanged := ciliumHelmChartValuesChanged(currentSpec, newSpec)
+	if diff == nil && !chartValuesChanged {
 		logger.V(1).Info("Nothing to upgrade for Cilium, skipping")
 		return nil, nil
 	}
 
-	logger.V(1).Info("Upgrading Cilium", "oldVersion", diff.ComponentReports[0].OldVersion, "newVersion", diff.ComponentReports[0].NewVersion)
+	if diff != nil {
+		logger.V(1).Info("Upgrading Cilium", "oldVersion", diff.ComponentReports[0].OldVersion, "newVersion", diff.ComponentReports[0].NewVersion)
+	}
 	logger.V(4).Info("Generating Cilium upgrade preflight manifest")
 	preflight, err := u.templater.GenerateUpgradePreflightManifest(ctx, newSpec)
 	if err != nil {
@@ -63,6 +68,16 @@ func (u *Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentS
 	upgradeManifest, err := u.templater.GenerateUpgradeManifest(ctx, currentSpec, newSpec)
 	if err != nil {
 		return nil, err
+	}
+
+	if chartValuesChanged {
+		if newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode == v1alpha1.CiliumPolicyModeAlways {
+			networkPolicyManifest, err := u.templater.GenerateNetworkPolicyManifest(newSpec, namespaces)
+			if err != nil {
+				return nil, err
+			}
+			upgradeManifest = templater.AppendYamlResources(upgradeManifest, networkPolicyManifest)
+		}
 	}
 
 	logger.V(2).Info("Installing new Cilium version")
@@ -120,4 +135,16 @@ func ciliumChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
 
 func ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
 	return ciliumChangeDiff(currentSpec, newSpec)
+}
+
+func ciliumHelmChartValuesChanged(currentSpec, newSpec *cluster.Spec) bool {
+	if currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig != nil {
+		if currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium != nil {
+			if newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode != currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode {
+				return true
+			}
+		}
+	}
+	// we can add comparisons for more values here as we start accepting them from cluster spec
+	return false
 }

--- a/pkg/networking/cilium/upgrader_test.go
+++ b/pkg/networking/cilium/upgrader_test.go
@@ -88,7 +88,7 @@ func TestUpgraderUpgradeSuccess(t *testing.T) {
 		tt.client.EXPECT().WaitForCiliumDeployment(tt.ctx, tt.cluster),
 	)
 
-	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(Equal(tt.wantChangeDiff), "upgrader.Upgrade() should succeed and return correct ChangeDiff")
+	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec, []string{})).To(Equal(tt.wantChangeDiff), "upgrader.Upgrade() should succeed and return correct ChangeDiff")
 }
 
 func TestUpgraderUpgradeNotNeeded(t *testing.T) {
@@ -96,5 +96,29 @@ func TestUpgraderUpgradeNotNeeded(t *testing.T) {
 	tt.currentSpec.VersionsBundle.Cilium.Version = "v1.0.0"
 	tt.newSpec.VersionsBundle.Cilium.Version = "v1.0.0"
 
-	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(BeNil(), "upgrader.Upgrade() should succeed and return nil ChangeDiff")
+	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec, []string{})).To(BeNil(), "upgrader.Upgrade() should succeed and return nil ChangeDiff")
+}
+
+func TestUpgraderUpgradeSuccessValuesChanged(t *testing.T) {
+	tt := newUpgraderTest(t)
+	tt.currentSpec.VersionsBundle.Cilium.Version = "v1.0.0"
+	tt.newSpec.VersionsBundle.Cilium.Version = "v1.0.0"
+
+	// setting policy enforcement mode to something other than the "default" mode
+	tt.newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = v1alpha1.CiliumPolicyModeNever
+
+	// Templater and client and already tested individually so we only want to test the flow (order of calls)
+	gomock.InOrder(
+		tt.expectTemplatePreFlight(),
+		tt.client.EXPECT().Apply(tt.ctx, tt.cluster, tt.manifestPre),
+		tt.client.EXPECT().WaitForPreflightDaemonSet(tt.ctx, tt.cluster),
+		tt.client.EXPECT().WaitForPreflightDeployment(tt.ctx, tt.cluster),
+		tt.client.EXPECT().Delete(tt.ctx, tt.cluster, tt.manifestPre),
+		tt.expectTemplateManifest(),
+		tt.client.EXPECT().Apply(tt.ctx, tt.cluster, tt.manifest),
+		tt.client.EXPECT().WaitForCiliumDaemonSet(tt.ctx, tt.cluster),
+		tt.client.EXPECT().WaitForCiliumDeployment(tt.ctx, tt.cluster),
+	)
+
+	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec, []string{})).To(BeNil(), "upgrader.Upgrade() should succeed and return nil ChangeDiff")
 }

--- a/pkg/networking/kindnetd/upgrader.go
+++ b/pkg/networking/kindnetd/upgrader.go
@@ -23,7 +23,7 @@ func NewUpgrader(client Client) *Upgrader {
 	}
 }
 
-func (u Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error) {
+func (u Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec, namespaces []string) (*types.ChangeDiff, error) {
 	diff := kindnetdChangeDiff(currentSpec, newSpec)
 	if diff == nil {
 		logger.V(1).Info("Nothing to upgrade for Kindnetd")

--- a/pkg/networking/kindnetd/upgrader_test.go
+++ b/pkg/networking/kindnetd/upgrader_test.go
@@ -55,7 +55,7 @@ func TestUpgraderUpgradeSuccess(t *testing.T) {
 	tt := newUpgraderTest(t)
 	tt.client.EXPECT().ApplyKubeSpecFromBytes(tt.ctx, tt.cluster, tt.manifest)
 
-	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(Equal(tt.wantChangeDiff), "upgrader.Upgrade() should succeed and return correct ChangeDiff")
+	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec, []string{})).To(Equal(tt.wantChangeDiff), "upgrader.Upgrade() should succeed and return correct ChangeDiff")
 }
 
 func TestUpgraderUpgradeNotNeeded(t *testing.T) {
@@ -63,5 +63,5 @@ func TestUpgraderUpgradeNotNeeded(t *testing.T) {
 	tt.currentSpec.VersionsBundle.Kindnetd.Version = "v1.0.0"
 	tt.newSpec.VersionsBundle.Kindnetd.Version = "v1.0.0"
 
-	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(BeNil(), "upgrader.Upgrade() should succeed and return nil ChangeDiff")
+	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec, []string{})).To(BeNil(), "upgrader.Upgrade() should succeed and return nil ChangeDiff")
 }

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -22,7 +22,7 @@ type ClusterManager interface {
 	DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster, provider providers.Provider, clusterSpec *cluster.Spec) error
 	InstallCAPI(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
 	InstallNetworking(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
-	UpgradeNetworking(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error)
+	UpgradeNetworking(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec, provider providers.Provider) (*types.ChangeDiff, error)
 	InstallStorageClass(ctx context.Context, cluster *types.Cluster, provider providers.Provider) error
 	SaveLogsManagementCluster(ctx context.Context, cluster *types.Cluster) error
 	SaveLogsWorkloadCluster(ctx context.Context, provider providers.Provider, spec *cluster.Spec, cluster *types.Cluster) error

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -400,18 +400,18 @@ func (mr *MockClusterManagerMockRecorder) UpgradeCluster(arg0, arg1, arg2, arg3,
 }
 
 // UpgradeNetworking mocks base method.
-func (m *MockClusterManager) UpgradeNetworking(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 *cluster.Spec) (*types.ChangeDiff, error) {
+func (m *MockClusterManager) UpgradeNetworking(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 *cluster.Spec, arg4 providers.Provider) (*types.ChangeDiff, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpgradeNetworking", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "UpgradeNetworking", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.ChangeDiff)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpgradeNetworking indicates an expected call of UpgradeNetworking.
-func (mr *MockClusterManagerMockRecorder) UpgradeNetworking(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClusterManagerMockRecorder) UpgradeNetworking(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeNetworking", reflect.TypeOf((*MockClusterManager)(nil).UpgradeNetworking), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeNetworking", reflect.TypeOf((*MockClusterManager)(nil).UpgradeNetworking), arg0, arg1, arg2, arg3, arg4)
 }
 
 // MockAddonManager is a mock of AddonManager interface.

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -182,7 +182,7 @@ func (s *upgradeCoreComponents) Run(ctx context.Context, commandContext *task.Co
 
 	logger.Info("Upgrading core components")
 
-	changeDiff, err := commandContext.ClusterManager.UpgradeNetworking(ctx, target, commandContext.CurrentClusterSpec, commandContext.ClusterSpec)
+	changeDiff, err := commandContext.ClusterManager.UpgradeNetworking(ctx, target, commandContext.CurrentClusterSpec, commandContext.ClusterSpec, commandContext.Provider)
 	if err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -127,7 +127,7 @@ func (c *upgradeTestSetup) expectUpgradeCoreComponents(expectedCluster *types.Cl
 	})
 	gomock.InOrder(
 		c.clusterManager.EXPECT().GetCurrentClusterSpec(c.ctx, expectedCluster, c.newClusterSpec.Cluster.Name).Return(currentSpec, nil),
-		c.clusterManager.EXPECT().UpgradeNetworking(c.ctx, expectedCluster, currentSpec, c.newClusterSpec).Return(networkingChangeDiff, nil),
+		c.clusterManager.EXPECT().UpgradeNetworking(c.ctx, expectedCluster, currentSpec, c.newClusterSpec, c.provider).Return(networkingChangeDiff, nil),
 		c.capiManager.EXPECT().Upgrade(c.ctx, expectedCluster, c.provider, currentSpec, c.newClusterSpec).Return(capiChangeDiff, nil),
 		c.addonManager.EXPECT().UpdateLegacyFileStructure(c.ctx, currentSpec, c.newClusterSpec),
 		c.addonManager.EXPECT().Upgrade(c.ctx, expectedCluster, currentSpec, c.newClusterSpec).Return(fluxChangeDiff, nil),

--- a/test/e2e/upgrade_from_latest_test.go
+++ b/test/e2e/upgrade_from_latest_test.go
@@ -114,6 +114,29 @@ func TestVSphereKubernetes121UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
 	)
 }
 
+func TestVSphereKubernetes121UbuntuUpgradeFromLatestMinorReleaseAlwaysNetworkPolicy(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithVSphereFillers(
+		api.WithTemplateForAllMachines(""), // Use default template from bundle
+		api.WithOsFamilyForAllMachines(anywherev1.Ubuntu),
+	))
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(anywherev1.Kube121)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+	)
+	runUpgradeFromLatestReleaseFlow(
+		test,
+		anywherev1.Kube121,
+		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(anywherev1.CiliumPolicyModeAlways)),
+		provider.WithProviderUpgrade(
+			framework.UpdateUbuntuTemplate121Var(), // Set the template so it doesn't get autoimported
+		),
+	)
+}
+
 func TestDockerKubernetes121UpgradeFromLatestMinorRelease(t *testing.T) {
 	provider := framework.NewDocker(t)
 	test := framework.NewClusterE2ETest(

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -62,6 +62,25 @@ func TestVSphereKubernetes121UbuntuTo122Upgrade(t *testing.T) {
 	)
 }
 
+func TestVSphereKubernetes121UbuntuTo122UpgradeCiliumPolicyEnforcementMode(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithUbuntu121())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+	)
+	runSimpleUpgradeFlow(
+		test,
+		v1alpha1.Kube122,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
+		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
+		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var()),
+	)
+}
+
 func TestVSphereKubernetes121UbuntuTo122MultipleFieldsUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu121())
 	test := framework.NewClusterE2ETest(


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/eks-anywhere/issues/726

*Description of changes:*
Refer design doc: https://github.com/aws/eks-anywhere/blob/main/designs/cilium-configuration-policy.md
[Previously merged PR](https://github.com/aws/eks-anywhere/pull/1552) creates NetworkPolicy objects during cluster creation if policy enforcement mode is set to `always`
This PR does the same during cluster upgrade, if the policy enforcement mode value has changed.
Along with this, it also upgrades cilium if the values passed to cilium chart have changed. Right now we only accept and configure the value for the policy enforcement mode so only that is checked

*Testing (if applicable):*
- `TestVSphereKubernetes121UbuntuTo122UpgradeCiliumPolicyEnforcementMode`
-  Created a cluster with no policy enforcement mode specified. The `cilium-config` cm had `enable-policy: default`. Changed cluster spec to use `never` as the value for policy enforcement mode. Configmap got updated. When value was changed to `always`, required network policies also got created
- `TestVSphereKubernetes121UbuntuUpgradeFromLatestMinorReleaseAlwaysNetworkPolicy`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

