### PR TITLE
Change default to 1.22

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -217,7 +217,7 @@ func GetAndValidateClusterConfig(fileName string) (*Cluster, error) {
 
 // GetClusterDefaultKubernetesVersion returns the default kubernetes version for a Cluster
 func GetClusterDefaultKubernetesVersion() KubernetesVersion {
-	return Kube121
+	return Kube122
 }
 
 // ValidateClusterConfigContent validates a Cluster object without modifying it


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make the default 1.22 now

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

