### PR TITLE
Modify policy enforcement changed check to include clusters created from 0.7

### DIFF
--- a/pkg/networking/cilium/upgrader.go
+++ b/pkg/networking/cilium/upgrader.go
@@ -72,6 +72,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentS
 
 	if chartValuesChanged {
 		if newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode == v1alpha1.CiliumPolicyModeAlways {
+			logger.V(3).Info("Installing NetworkPolicy resources for policy enforcement mode 'always'")
 			networkPolicyManifest, err := u.templater.GenerateNetworkPolicyManifest(newSpec, namespaces)
 			if err != nil {
 				return nil, err
@@ -138,11 +139,15 @@ func ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
 }
 
 func ciliumHelmChartValuesChanged(currentSpec, newSpec *cluster.Spec) bool {
-	if currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig != nil {
-		if currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium != nil {
-			if newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode != currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode {
-				return true
-			}
+	if currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig == nil {
+		// this is for clusters created using 0.7 and lower versions, they won't have these fields initialized
+		// in these cases, a non-default PolicyEnforcementMode in the newSpec will be considered a change
+		if newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode != v1alpha1.CiliumPolicyModeDefault {
+			return true
+		}
+	} else {
+		if newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode != currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode {
+			return true
 		}
 	}
 	// we can add comparisons for more values here as we start accepting them from cluster spec


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
design doc for reference: https://github.com/aws/eks-anywhere/blob/main/designs/cilium-configuration-policy.md
This [previous PR](https://github.com/aws/eks-anywhere/pull/1559) added checks to see if policy enforcement mode was modified. But the existing check works only for cases where the existing cluster has the cniConfig case and does not cover clusters that don't have cniconfig set (clusters on versions release-0.7 and lower). This PR checks if the existing spec does not have cniConfig initialized (only possible for clusters created with older version), and if the current policy enforcement mode is the non-default option

*Testing (if applicable):*
- Created cluster using release-0.7, upgraded with cluster.spec containing non-default policy enforcement mode
- `TestVSphereKubernetes121UbuntuUpgradeFromLatestMinorReleaseAlwaysNetworkPolicy`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

