### PR TITLE
Check if ciliumConfig on older cluster spec is nil before upgrade

### DIFF
--- a/pkg/networking/cilium/upgrader.go
+++ b/pkg/networking/cilium/upgrader.go
@@ -139,7 +139,7 @@ func ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
 }
 
 func ciliumHelmChartValuesChanged(currentSpec, newSpec *cluster.Spec) bool {
-	if currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig == nil {
+	if currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig == nil || currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium == nil {
 		// this is for clusters created using 0.7 and lower versions, they won't have these fields initialized
 		// in these cases, a non-default PolicyEnforcementMode in the newSpec will be considered a change
 		if newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode != v1alpha1.CiliumPolicyModeDefault {

--- a/pkg/networking/cilium/upgrader_test.go
+++ b/pkg/networking/cilium/upgrader_test.go
@@ -122,3 +122,55 @@ func TestUpgraderUpgradeSuccessValuesChanged(t *testing.T) {
 
 	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec, []string{})).To(BeNil(), "upgrader.Upgrade() should succeed and return nil ChangeDiff")
 }
+
+func TestUpgraderUpgradeSuccessValuesChangedUpgradeFromNilCNIConfigSpec(t *testing.T) {
+	tt := newUpgraderTest(t)
+	tt.currentSpec.VersionsBundle.Cilium.Version = "v1.0.0"
+	tt.newSpec.VersionsBundle.Cilium.Version = "v1.0.0"
+
+	// simulate the case where existing cluster's CNIConfig is nil
+	tt.currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig = nil
+	// setting policy enforcement mode to something other than the "default" mode
+	tt.newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = v1alpha1.CiliumPolicyModeNever
+
+	// Templater and client and already tested individually so we only want to test the flow (order of calls)
+	gomock.InOrder(
+		tt.expectTemplatePreFlight(),
+		tt.client.EXPECT().Apply(tt.ctx, tt.cluster, tt.manifestPre),
+		tt.client.EXPECT().WaitForPreflightDaemonSet(tt.ctx, tt.cluster),
+		tt.client.EXPECT().WaitForPreflightDeployment(tt.ctx, tt.cluster),
+		tt.client.EXPECT().Delete(tt.ctx, tt.cluster, tt.manifestPre),
+		tt.expectTemplateManifest(),
+		tt.client.EXPECT().Apply(tt.ctx, tt.cluster, tt.manifest),
+		tt.client.EXPECT().WaitForCiliumDaemonSet(tt.ctx, tt.cluster),
+		tt.client.EXPECT().WaitForCiliumDeployment(tt.ctx, tt.cluster),
+	)
+
+	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec, []string{})).To(BeNil(), "upgrader.Upgrade() should succeed and return nil ChangeDiff")
+}
+
+func TestUpgraderUpgradeSuccessValuesChangedUpgradeFromNilCiliumConfigSpec(t *testing.T) {
+	tt := newUpgraderTest(t)
+	tt.currentSpec.VersionsBundle.Cilium.Version = "v1.0.0"
+	tt.newSpec.VersionsBundle.Cilium.Version = "v1.0.0"
+
+	// simulate the case where existing cluster's CNIConfig is nil
+	tt.currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{Cilium: nil}
+	// setting policy enforcement mode to something other than the "default" mode
+	tt.newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = v1alpha1.CiliumPolicyModeNever
+
+	// Templater and client and already tested individually so we only want to test the flow (order of calls)
+	gomock.InOrder(
+		tt.expectTemplatePreFlight(),
+		tt.client.EXPECT().Apply(tt.ctx, tt.cluster, tt.manifestPre),
+		tt.client.EXPECT().WaitForPreflightDaemonSet(tt.ctx, tt.cluster),
+		tt.client.EXPECT().WaitForPreflightDeployment(tt.ctx, tt.cluster),
+		tt.client.EXPECT().Delete(tt.ctx, tt.cluster, tt.manifestPre),
+		tt.expectTemplateManifest(),
+		tt.client.EXPECT().Apply(tt.ctx, tt.cluster, tt.manifest),
+		tt.client.EXPECT().WaitForCiliumDaemonSet(tt.ctx, tt.cluster),
+		tt.client.EXPECT().WaitForCiliumDeployment(tt.ctx, tt.cluster),
+	)
+
+	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec, []string{})).To(BeNil(), "upgrader.Upgrade() should succeed and return nil ChangeDiff")
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Just adding the check to be on the safe side based on this discussion: https://github.com/aws/eks-anywhere/pull/1564#discussion_r831716980

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

