### PR TITLE
Fix ip generator rand source

### DIFF
--- a/pkg/networkutils/ipgenerator.go
+++ b/pkg/networkutils/ipgenerator.go
@@ -9,10 +9,14 @@ import (
 
 type IPGenerator struct {
 	netClient NetClient
+	rand      *rand.Rand
 }
 
 func NewIPGenerator(netClient NetClient) IPGenerator {
-	return IPGenerator{netClient: netClient}
+	return IPGenerator{
+		netClient: netClient,
+		rand:      rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
 }
 
 func (ipgen IPGenerator) GenerateUniqueIP(cidrBlock string) (string, error) {
@@ -35,10 +39,9 @@ func (ipgen IPGenerator) GenerateUniqueIP(cidrBlock string) (string, error) {
 
 // generates a random ip within the specified cidr block
 func (ipgen IPGenerator) randIp(cidr *net.IPNet) (net.IP, error) {
-	rand.Seed(time.Now().UnixNano())
 	newIp := *new(net.IP)
 	for i := 0; i < 4; i++ {
-		newIp = append(newIp, byte(rand.Intn(256))&^cidr.Mask[i]|cidr.IP[i])
+		newIp = append(newIp, byte(ipgen.rand.Intn(255))&^cidr.Mask[i]|cidr.IP[i])
 	}
 	if !cidr.Contains(newIp) {
 		return nil, fmt.Errorf("random IP generation failed")

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/artifacts/artifactFetcher.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/artifacts/artifactFetcher.go
@@ -142,10 +142,10 @@ func excludedKey(key string) bool {
 
 func fileWriterRetrier() *retrier.Retrier {
 	return retrier.New(time.Minute, retrier.WithRetryPolicy(func(totalRetries int, err error) (retry bool, wait time.Duration) {
-		rand.Seed(time.Now().UnixNano())
+		generator := rand.New(rand.NewSource(time.Now().UnixNano()))
 		minWait := 1
 		maxWait := 5
-		waitWithJitter := time.Duration(rand.Intn(maxWait-minWait)+minWait) * time.Second
+		waitWithJitter := time.Duration(generator.Intn(maxWait-minWait)+minWait) * time.Second
 		if isTooManyOpenFilesError(err) && totalRetries < 15 {
 			logger.V(2).Info("Too many files open, retrying")
 			return true, waitWithJitter

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/s3/s3.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/s3/s3.go
@@ -101,10 +101,10 @@ func (s *S3) GetObject(bucket string, key string) ([]byte, error) {
 
 func getObjectRetirer() *retrier.Retrier {
 	return retrier.New(time.Minute, retrier.WithRetryPolicy(func(totalRetries int, err error) (retry bool, wait time.Duration) {
-		rand.Seed(time.Now().UnixNano())
+		generator := rand.New(rand.NewSource(time.Now().UnixNano()))
 		minWait := 1
 		maxWait := 5
-		waitWithJitter := time.Duration(rand.Intn(maxWait-minWait)+minWait) * time.Second
+		waitWithJitter := time.Duration(generator.Intn(maxWait-minWait)+minWait) * time.Second
 		if isThrottledError(err) && totalRetries < 15 {
 			logger.V(2).Info("Throttled by S3, retrying")
 			return true, waitWithJitter


### PR DESCRIPTION
Stop seeding the default rand source midway through program execution.

The default rand source should be seeded on program startup as a bootstrapping task, not midway through program execution. This change alters algorithms seeding the default rand by switching to a separate `Rand` instance. In doing so, we remove possible side effects/introducing unintended dependencies in logic executed at later stages.