### PR TITLE
Import cilium chart as part of import-images

### DIFF
--- a/cmd/eksctl-anywhere/cmd/downloadartifacts.go
+++ b/cmd/eksctl-anywhere/cmd/downloadartifacts.go
@@ -65,6 +65,11 @@ func downloadArtifacts(context context.Context, opts *downloadArtifactsOptions) 
 		return err
 	}
 
+	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration == nil || clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Endpoint == "" {
+		return fmt.Errorf("endpoint not set. It is necessary to define a valid endpoint in your spec (registryMirrorConfiguration.endpoint)")
+	}
+	endpoint := clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Endpoint
+
 	release, err := clusterSpec.GetRelease(cliVersion)
 	if err != nil {
 		return err
@@ -96,6 +101,10 @@ func downloadArtifacts(context context.Context, opts *downloadArtifactsOptions) 
 				}
 				*manifest = filePath
 			}
+		}
+		for component, chart := range bundle.Charts() {
+			chartRegistry := fmt.Sprintf("%s/%s/%s", endpoint, chart.Name, component)
+			chart.URI = fmt.Sprintf("%s:%s", chartRegistry, chart.Tag())
 		}
 		clusterSpec.Bundles.Spec.VersionsBundles[i] = bundle
 	}

--- a/cmd/eksctl-anywhere/cmd/importimages.go
+++ b/cmd/eksctl-anywhere/cmd/importimages.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -16,6 +17,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
 	"github.com/aws/eks-anywhere/pkg/version"
+	"github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 type importImagesOptions struct {
@@ -23,6 +25,8 @@ type importImagesOptions struct {
 }
 
 var opts = &importImagesOptions{}
+
+const ociPrefix = "oci://"
 
 func init() {
 	rootCmd.AddCommand(importImagesCmd)
@@ -47,15 +51,29 @@ var importImagesCmd = &cobra.Command{
 	},
 }
 
-func importImages(context context.Context, spec string) error {
+func importImages(ctx context.Context, spec string) error {
+	registryUsername := os.Getenv("REGISTRY_USERNAME")
+	registryPassword := os.Getenv("REGISTRY_PASSWORD")
+	if registryUsername == "" || registryPassword == "" {
+		return fmt.Errorf("username or password not set. Provide REGISTRY_USERNAME and REGISTRY_PASSWORD for importing helm charts (e.g. cilium)")
+	}
 	clusterSpec, err := cluster.NewSpecFromClusterConfig(spec, version.Get())
 	if err != nil {
 		return err
 	}
+
 	de := executables.BuildDockerExecutable()
 
+	bundle := clusterSpec.VersionsBundle
+	executableBuilder, closer, err := executables.NewExecutableBuilder(ctx, bundle.Eksa.CliTools.VersionedImage())
+	if err != nil {
+		return fmt.Errorf("unable to initialize executables: %v", err)
+	}
+	defer closer.CheckErr(ctx)
+	helmExecutable := executableBuilder.BuildHelmExecutable()
+
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration == nil || clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Endpoint == "" {
-		return fmt.Errorf("it is necessary to define a valid endpoint in your spec (registryMirrorConfiguration.endpoint)")
+		return fmt.Errorf("endpoint not set. It is necessary to define a valid endpoint in your spec (registryMirrorConfiguration.endpoint)")
 	}
 	host := clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Endpoint
 	port := clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Port
@@ -72,11 +90,13 @@ func importImages(context context.Context, spec string) error {
 		return err
 	}
 	for _, image := range images {
-		if err := importImage(context, de, image.URI, net.JoinHostPort(host, port)); err != nil {
+		if err := importImage(ctx, de, image.URI, net.JoinHostPort(host, port)); err != nil {
 			return fmt.Errorf("error importing image %s: %v", image.URI, err)
 		}
 	}
-	return nil
+
+	endpoint := clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Endpoint
+	return importCharts(ctx, helmExecutable, bundle.Charts(), endpoint, registryUsername, registryPassword)
 }
 
 func importImage(ctx context.Context, docker *executables.Docker, image string, endpoint string) error {
@@ -91,6 +111,26 @@ func importImage(ctx context.Context, docker *executables.Docker, image string, 
 	return docker.PushImage(ctx, image, endpoint)
 }
 
+func importCharts(ctx context.Context, helm *executables.Helm, charts map[string]*v1alpha1.Image, endpoint, username, password string) error {
+	if err := helm.RegistryLogin(ctx, endpoint, username, password); err != nil {
+		return err
+	}
+	for _, chart := range charts {
+		if err := importChart(ctx, helm, *chart, endpoint); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func importChart(ctx context.Context, helm *executables.Helm, chart v1alpha1.Image, endpoint string) error {
+	uri, chartVersion := getChartUriAndVersion(chart)
+	if err := helm.PullChart(ctx, uri, chartVersion); err != nil {
+		return err
+	}
+	return helm.PushChart(ctx, chart.ChartName(), fmt.Sprintf("%s%s/%s", ociPrefix, endpoint, chart.Name))
+}
+
 func preRunImportImagesCmd(cmd *cobra.Command, args []string) error {
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 		err := viper.BindPFlag(flag.Name, flag)
@@ -99,4 +139,10 @@ func preRunImportImagesCmd(cmd *cobra.Command, args []string) error {
 		}
 	})
 	return nil
+}
+
+func getChartUriAndVersion(chart v1alpha1.Image) (uri, version string) {
+	uri = fmt.Sprintf("%s%s", ociPrefix, chart.Image())
+	version = chart.Tag()
+	return uri, version
 }

--- a/pkg/executables/helm_test.go
+++ b/pkg/executables/helm_test.go
@@ -63,7 +63,7 @@ key2: values2
 func TestHelmTemplateSuccess(t *testing.T) {
 	tt := newHelmTemplateTest(t)
 	expectCommand(
-		tt.e, tt.ctx, "template", tt.ociURI, "--version", tt.version, "--namespace", tt.namespace, "-f", "-",
+		tt.e, tt.ctx, "template", tt.ociURI, "--version", tt.version, "--insecure-skip-tls-verify", "--namespace", tt.namespace, "-f", "-",
 	).withStdIn(tt.valuesYaml).withEnvVars(tt.envVars).to().Return(*bytes.NewBuffer(tt.wantTemplateContent), nil)
 
 	tt.Expect(tt.h.Template(tt.ctx, tt.ociURI, tt.version, tt.namespace, tt.values)).To(Equal(tt.wantTemplateContent), "helm.Template() should succeed return correct template content")

--- a/release/api/v1alpha1/artifact_types.go
+++ b/release/api/v1alpha1/artifact_types.go
@@ -48,6 +48,17 @@ func (i Image) Tag() string {
 	return i.URI[lastInd+1:]
 }
 
+func (i Image) ChartName() string {
+	lastInd := strings.LastIndex(i.Image(), "/")
+	if lastInd == -1 {
+		return i.URI
+	}
+	chart := i.URI[lastInd+1:]
+	chart = strings.Replace(chart, ":", "-", 1)
+	chart += ".tgz"
+	return chart
+}
+
 type Archive struct {
 	// +kubebuilder:validation:Required
 	// The asset name

--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -141,3 +141,9 @@ func (vb *VersionsBundle) Images() []Image {
 
 	return images
 }
+
+func (vb *VersionsBundle) Charts() map[string]*Image {
+	return map[string]*Image{
+		"cilium": &vb.Cilium.HelmChart,
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cilium is now installed as helm chart. This PR adds the following changes required for offline installation:
- `import-images` will pull + push the cilium chart to the registry mirror endpoint
- `download artifacts` will update the downloaded bundle-release.yaml's cilium helmChart to the one from the registry mirror

*Testing (if applicable):*
```
./bin/eksctl-anywhere download artifacts -f bin/mandaor.yaml -v=9
```
The downloaded bundle-release.yaml has following contents for cilium helm chart:
```
    cilium:
      helmChart:
        description: Helm chart for cilium-chart
        imageDigest: sha256:5982a9b5feded74c14a0b410006bba6d748655f8bc01f393b4519c9b10a463d0
        name: cilium-chart
        uri: <registryMirror>/cilium-chart/cilium:1.9.13-eksa.2
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

