### PR TITLE
Fix docker e2e gitops test by reading datacenter config from repo

### DIFF
--- a/test/e2e/workload_clusters_test.go
+++ b/test/e2e/workload_clusters_test.go
@@ -131,5 +131,8 @@ func TestDockerUpgradeWorkloadClusterWithFlux(t *testing.T) {
 			api.WithControlPlaneCount(2),
 			api.WithWorkerNodeCount(2),
 		),
+		// Needed in order to replace the DockerDatacenterConfig namespace field with the value specified
+		// compared to when it was initially created without it.
+		provider.WithProviderUpgradeGit(),
 	)
 }

--- a/test/framework/docker.go
+++ b/test/framework/docker.go
@@ -39,6 +39,12 @@ func (d *Docker) CustomizeProviderConfig(file string) []byte {
 	return providerOutput
 }
 
+func (d *Docker) WithProviderUpgradeGit() ClusterE2ETestOpt {
+	return func(e *ClusterE2ETest) {
+		e.ProviderConfigB = d.CustomizeProviderConfig(e.clusterConfigGitPath())
+	}
+}
+
 func (d *Docker) ClusterConfigFillers() []api.ClusterFiller {
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Right now the e2e test is rewriting the config file in git without the namespace field for DockerDatacenterConfig, which is resulting in the flux controllers throwing an error because it is required. This will marshal the structs properly when making a configuration update.

*Testing (if applicable):*
Ran `TestDockerUpgradeWorkloadClusterWithFlux`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

