### PR TITLE
sanitize branch name used for cluster naming convention

### DIFF
--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 
@@ -208,7 +209,13 @@ func (e *E2ESession) createTestNameFile(testName string) error {
 
 func clusterName(branch string, instanceId string) (clusterName string) {
 	clusterNameTemplate := "%s-%s"
-	clusterName = fmt.Sprintf(clusterNameTemplate, branch, instanceId)
+	forbiddenChars := []string{"."}
+	var sanitizedBranch string
+	for _, char := range forbiddenChars {
+		sanitizedBranch = strings.Replace(branch, char, "-", -1)
+	}
+	sanitizedBranch = strings.ToLower(sanitizedBranch)
+	clusterName = fmt.Sprintf(clusterNameTemplate, sanitizedBranch, instanceId)
 	if len(clusterName) > 80 {
 		logger.Info("Cluster name is longer than 80 characters; truncating to 80 characters.", "original cluster name", clusterName, "truncated cluster name", clusterName[:80])
 		clusterName = clusterName[:80]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We now prefix test cluster names with the branch name.
Release branches have a `.` in them, which is illegal in cluster names.
Add some sanitization to make sure we can run release branch tests.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

