### PR TITLE
Print command output before returning error

### DIFF
--- a/release/pkg/images/images.go
+++ b/release/pkg/images/images.go
@@ -76,10 +76,10 @@ func CopyToDestination(sourceAuthConfig, releaseAuthConfig *docker.AuthConfigura
 	releaseRegistryPassword := releaseAuthConfig.Password
 	cmd := exec.Command("skopeo", "copy", "--src-creds", fmt.Sprintf("%s:%s", sourceRegistryUsername, sourceRegistryPassword), "--dest-creds", fmt.Sprintf("%s:%s", releaseRegistryUsername, releaseRegistryPassword), fmt.Sprintf("docker://%s", sourceImageUri), fmt.Sprintf("docker://%s", releaseImageUri), "-f", "oci", "--all")
 	out, err := utils.ExecCommand(cmd)
+	fmt.Println(out)
 	if err != nil {
 		return fmt.Errorf("error executing skopeo copy command: %v", err)
 	}
-	fmt.Println(out)
 
 	return nil
 }

--- a/release/pkg/prepare_release.go
+++ b/release/pkg/prepare_release.go
@@ -44,36 +44,36 @@ func (r *ReleaseConfig) SetRepoHeads() error {
 	fmt.Println("Cloning CLI repository")
 	r.CliRepoSource = filepath.Join(parentSourceDir, "eks-a-cli")
 	out, err := git.CloneRepo(r.CliRepoUrl, r.CliRepoSource)
+	fmt.Println(out)
 	if err != nil {
 		return errors.Cause(err)
 	}
-	fmt.Println(out)
 
 	// Clone the build-tooling repository
 	fmt.Println("Cloning build-tooling repository")
 	r.BuildRepoSource = filepath.Join(parentSourceDir, "eks-a-build")
 	out, err = git.CloneRepo(r.BuildRepoUrl, r.BuildRepoSource)
+	fmt.Println(out)
 	if err != nil {
 		return errors.Cause(err)
 	}
-	fmt.Println(out)
 
 	if r.BuildRepoBranchName != "main" {
 		fmt.Printf("Checking out build-tooling repo at branch %s\n", r.BuildRepoBranchName)
 		out, err = git.CheckoutRepo(r.BuildRepoSource, r.BuildRepoBranchName)
+		fmt.Println(out)
 		if err != nil {
 			return errors.Cause(err)
 		}
-		fmt.Println(out)
 	}
 
 	if r.CliRepoBranchName != "main" {
 		fmt.Printf("Checking out CLI repo at branch %s\n", r.CliRepoBranchName)
 		out, err = git.CheckoutRepo(r.CliRepoSource, r.CliRepoBranchName)
+		fmt.Println(out)
 		if err != nil {
 			return errors.Cause(err)
 		}
-		fmt.Println(out)
 	}
 
 	// Set HEADs of the repos


### PR DESCRIPTION
In case of failures, these print statements could give us useful info.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

