### PR TITLE
Add support to upgrade Kubernetes version through GitOps for Docker

### DIFF
--- a/controllers/controllers/resource/fetcher.go
+++ b/controllers/controllers/resource/fetcher.go
@@ -19,6 +19,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -42,6 +43,8 @@ type ResourceFetcher interface {
 	ExistingVSphereWorkerMachineConfig(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*anywherev1.VSphereMachineConfig, error)
 	ExistingWorkerNodeGroupConfig(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*anywherev1.WorkerNodeGroupConfiguration, error)
 	ExistingKubeVersion(ctx context.Context, cs *anywherev1.Cluster) (string, error)
+	ExistingControlPlaneKindNodeImage(ctx context.Context, cs *anywherev1.Cluster) (string, error)
+	ExistingWorkerKindNodeImage(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (string, error)
 	ControlPlane(ctx context.Context, cs *anywherev1.Cluster) (*controlplanev1.KubeadmControlPlane, error)
 	Etcd(ctx context.Context, cs *anywherev1.Cluster) (*etcdv1.EtcdadmCluster, error)
 	FetchAppliedSpec(ctx context.Context, cs *anywherev1.Cluster) (*cluster.Spec, error)
@@ -257,6 +260,32 @@ func (r *CapiResourceFetcher) VSphereEtcdMachineTemplate(ctx context.Context, cs
 	return vsphereMachineTemplate, nil
 }
 
+func (r *CapiResourceFetcher) DockerControlPlaneMachineTemplate(ctx context.Context, cs *anywherev1.Cluster) (*dockerv1.DockerMachineTemplate, error) {
+	cp, err := r.ControlPlane(ctx, cs)
+	if err != nil {
+		return nil, err
+	}
+	dockerMachineTemplate := &dockerv1.DockerMachineTemplate{}
+	err = r.FetchObjectByName(ctx, cp.Spec.MachineTemplate.InfrastructureRef.Name, constants.EksaSystemNamespace, dockerMachineTemplate)
+	if err != nil {
+		return nil, err
+	}
+	return dockerMachineTemplate, nil
+}
+
+func (r *CapiResourceFetcher) DockerWorkerMachineTemplate(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*dockerv1.DockerMachineTemplate, error) {
+	md, err := r.MachineDeployment(ctx, cs, wnc)
+	if err != nil {
+		return nil, err
+	}
+	dockerMachineTemplate := &dockerv1.DockerMachineTemplate{}
+	err = r.FetchObjectByName(ctx, md.Spec.Template.Spec.InfrastructureRef.Name, constants.EksaSystemNamespace, dockerMachineTemplate)
+	if err != nil {
+		return nil, err
+	}
+	return dockerMachineTemplate, nil
+}
+
 func (r *CapiResourceFetcher) KubeadmConfigTemplate(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*kubeadmv1.KubeadmConfigTemplate, error) {
 	machineDeployment, err := r.MachineDeployment(ctx, cs, wnc)
 	if err != nil {
@@ -415,6 +444,23 @@ func (r *CapiResourceFetcher) ExistingKubeVersion(ctx context.Context, cs *anywh
 		return "", err
 	}
 	return existingControlPlane.Spec.Version, nil
+}
+
+// Control plane and external etcd are configured to use the same node image, so pulling it from control plane
+func (r *CapiResourceFetcher) ExistingControlPlaneKindNodeImage(ctx context.Context, cs *anywherev1.Cluster) (string, error) {
+	existingDockerMachineTemplate, err := r.DockerControlPlaneMachineTemplate(ctx, cs)
+	if err != nil {
+		return "", err
+	}
+	return existingDockerMachineTemplate.Spec.Template.Spec.CustomImage, nil
+}
+
+func (r *CapiResourceFetcher) ExistingWorkerKindNodeImage(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (string, error) {
+	existingDockerMachineTemplate, err := r.DockerWorkerMachineTemplate(ctx, cs, wnc)
+	if err != nil {
+		return "", err
+	}
+	return existingDockerMachineTemplate.Spec.Template.Spec.CustomImage, nil
 }
 
 func MapMachineTemplateToVSphereDatacenterConfigSpec(vsMachineTemplate *vspherev1.VSphereMachineTemplate) (*anywherev1.VSphereDatacenterConfig, error) {

--- a/controllers/controllers/resource/fetcher.go
+++ b/controllers/controllers/resource/fetcher.go
@@ -41,6 +41,7 @@ type ResourceFetcher interface {
 	ExistingVSphereEtcdMachineConfig(ctx context.Context, cs *anywherev1.Cluster) (*anywherev1.VSphereMachineConfig, error)
 	ExistingVSphereWorkerMachineConfig(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*anywherev1.VSphereMachineConfig, error)
 	ExistingWorkerNodeGroupConfig(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*anywherev1.WorkerNodeGroupConfiguration, error)
+	ExistingKubeVersion(ctx context.Context, cs *anywherev1.Cluster) (string, error)
 	ControlPlane(ctx context.Context, cs *anywherev1.Cluster) (*controlplanev1.KubeadmControlPlane, error)
 	Etcd(ctx context.Context, cs *anywherev1.Cluster) (*etcdv1.EtcdadmCluster, error)
 	FetchAppliedSpec(ctx context.Context, cs *anywherev1.Cluster) (*cluster.Spec, error)
@@ -406,6 +407,14 @@ func (r *CapiResourceFetcher) ExistingWorkerNodeGroupConfig(ctx context.Context,
 		return nil, err
 	}
 	return MapKubeadmConfigTemplateToWorkerNodeGroupConfiguration(*existingKubeadmConfigTemplate), nil
+}
+
+func (r *CapiResourceFetcher) ExistingKubeVersion(ctx context.Context, cs *anywherev1.Cluster) (string, error) {
+	existingControlPlane, err := r.ControlPlane(ctx, cs)
+	if err != nil {
+		return "", err
+	}
+	return existingControlPlane.Spec.Version, nil
 }
 
 func MapMachineTemplateToVSphereDatacenterConfigSpec(vsMachineTemplate *vspherev1.VSphereMachineTemplate) (*anywherev1.VSphereDatacenterConfig, error) {

--- a/controllers/controllers/resource/mocks/resource.go
+++ b/controllers/controllers/resource/mocks/resource.go
@@ -90,6 +90,21 @@ func (mr *MockResourceFetcherMockRecorder) Etcd(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Etcd", reflect.TypeOf((*MockResourceFetcher)(nil).Etcd), arg0, arg1)
 }
 
+// ExistingKubeVersion mocks base method.
+func (m *MockResourceFetcher) ExistingKubeVersion(arg0 context.Context, arg1 *v1alpha1.Cluster) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExistingKubeVersion", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExistingKubeVersion indicates an expected call of ExistingKubeVersion.
+func (mr *MockResourceFetcherMockRecorder) ExistingKubeVersion(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExistingKubeVersion", reflect.TypeOf((*MockResourceFetcher)(nil).ExistingKubeVersion), arg0, arg1)
+}
+
 // ExistingVSphereControlPlaneMachineConfig mocks base method.
 func (m *MockResourceFetcher) ExistingVSphereControlPlaneMachineConfig(arg0 context.Context, arg1 *v1alpha1.Cluster) (*v1alpha1.VSphereMachineConfig, error) {
 	m.ctrl.T.Helper()

--- a/controllers/controllers/resource/mocks/resource.go
+++ b/controllers/controllers/resource/mocks/resource.go
@@ -90,6 +90,21 @@ func (mr *MockResourceFetcherMockRecorder) Etcd(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Etcd", reflect.TypeOf((*MockResourceFetcher)(nil).Etcd), arg0, arg1)
 }
 
+// ExistingControlPlaneKindNodeImage mocks base method.
+func (m *MockResourceFetcher) ExistingControlPlaneKindNodeImage(arg0 context.Context, arg1 *v1alpha1.Cluster) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExistingControlPlaneKindNodeImage", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExistingControlPlaneKindNodeImage indicates an expected call of ExistingControlPlaneKindNodeImage.
+func (mr *MockResourceFetcherMockRecorder) ExistingControlPlaneKindNodeImage(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExistingControlPlaneKindNodeImage", reflect.TypeOf((*MockResourceFetcher)(nil).ExistingControlPlaneKindNodeImage), arg0, arg1)
+}
+
 // ExistingKubeVersion mocks base method.
 func (m *MockResourceFetcher) ExistingKubeVersion(arg0 context.Context, arg1 *v1alpha1.Cluster) (string, error) {
 	m.ctrl.T.Helper()
@@ -163,6 +178,21 @@ func (m *MockResourceFetcher) ExistingVSphereWorkerMachineConfig(arg0 context.Co
 func (mr *MockResourceFetcherMockRecorder) ExistingVSphereWorkerMachineConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExistingVSphereWorkerMachineConfig", reflect.TypeOf((*MockResourceFetcher)(nil).ExistingVSphereWorkerMachineConfig), arg0, arg1, arg2)
+}
+
+// ExistingWorkerKindNodeImage mocks base method.
+func (m *MockResourceFetcher) ExistingWorkerKindNodeImage(arg0 context.Context, arg1 *v1alpha1.Cluster, arg2 v1alpha1.WorkerNodeGroupConfiguration) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExistingWorkerKindNodeImage", arg0, arg1, arg2)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExistingWorkerKindNodeImage indicates an expected call of ExistingWorkerKindNodeImage.
+func (mr *MockResourceFetcherMockRecorder) ExistingWorkerKindNodeImage(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExistingWorkerKindNodeImage", reflect.TypeOf((*MockResourceFetcher)(nil).ExistingWorkerKindNodeImage), arg0, arg1, arg2)
 }
 
 // ExistingWorkerNodeGroupConfig mocks base method.

--- a/controllers/controllers/resource/template.go
+++ b/controllers/controllers/resource/template.go
@@ -226,32 +226,56 @@ func generateTemplateResources(builder providers.TemplateBuilder, clusterSpec *c
 }
 
 func (r *DockerTemplate) TemplateResources(ctx context.Context, eksaCluster *anywherev1.Cluster, clusterSpec *cluster.Spec) ([]*unstructured.Unstructured, error) {
+	clusterName := clusterSpec.Cluster.Name
+	bundle := clusterSpec.VersionsBundle
 	templateBuilder := docker.NewDockerTemplateBuilder(r.now)
-	workloadTemplateNames := make(map[string]string, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
-	for _, workerNodeGroupConfiguration := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
-		mcDeployment, err := r.MachineDeployment(ctx, eksaCluster, workerNodeGroupConfiguration)
+
+	existingVersion, err := r.ExistingKubeVersion(ctx, eksaCluster)
+	// Check to see if there is any change the Kubernetes tag that requires a new template in order to specify the new
+	// node image
+	kubeVersionChanged := existingVersion != bundle.KubeDistro.Kubernetes.Tag
+	if err != nil {
+		return nil, err
+	}
+	var controlPlaneTemplateName string
+	if kubeVersionChanged {
+		controlPlaneTemplateName = common.CPMachineTemplateName(clusterName, r.now)
+	} else {
+		kubeadmControlPlane, err := r.ControlPlane(ctx, eksaCluster)
 		if err != nil {
 			return nil, err
 		}
-		workloadTemplateNames[workerNodeGroupConfiguration.Name] = mcDeployment.Spec.Template.Spec.InfrastructureRef.Name
+		controlPlaneTemplateName = kubeadmControlPlane.Spec.MachineTemplate.InfrastructureRef.Name
 	}
 
-	kubeadmControlPlane, err := r.ControlPlane(ctx, eksaCluster)
-	if err != nil {
-		return nil, err
+	workloadTemplateNames := make(map[string]string, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	for _, workerNodeGroupConfiguration := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
+		if kubeVersionChanged {
+			workloadTemplateNames[workerNodeGroupConfiguration.Name] = common.WorkerMachineTemplateName(clusterName, workerNodeGroupConfiguration.Name, r.now)
+		} else {
+			mcDeployment, err := r.MachineDeployment(ctx, eksaCluster, workerNodeGroupConfiguration)
+			if err != nil {
+				return nil, err
+			}
+			workloadTemplateNames[workerNodeGroupConfiguration.Name] = mcDeployment.Spec.Template.Spec.InfrastructureRef.Name
+		}
 	}
 
 	var etcdTemplateName string
 	if eksaCluster.Spec.ExternalEtcdConfiguration != nil {
-		etcd, err := r.Etcd(ctx, eksaCluster)
-		if err != nil {
-			return nil, err
+		if kubeVersionChanged {
+			etcdTemplateName = common.EtcdMachineTemplateName(clusterName, r.now)
+		} else {
+			etcd, err := r.Etcd(ctx, eksaCluster)
+			if err != nil {
+				return nil, err
+			}
+			etcdTemplateName = etcd.Spec.InfrastructureTemplate.Name
 		}
-		etcdTemplateName = etcd.Spec.InfrastructureTemplate.Name
 	}
 
 	cpOpt := func(values map[string]interface{}) {
-		values["controlPlaneTemplateName"] = kubeadmControlPlane.Spec.MachineTemplate.InfrastructureRef.Name
+		values["controlPlaneTemplateName"] = controlPlaneTemplateName
 		values["etcdTemplateName"] = etcdTemplateName
 	}
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -17,6 +17,7 @@ import (
 	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -46,6 +47,7 @@ func init() {
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
 	utilruntime.Must(controlplanev1.AddToScheme(scheme))
 	utilruntime.Must(vspherev1.AddToScheme(scheme))
+	utilruntime.Must(dockerv1.AddToScheme(scheme))
 	utilruntime.Must(etcdv1.AddToScheme(scheme))
 	utilruntime.Must(kubeadmv1.AddToScheme(scheme))
 	utilruntime.Must(eksdv1alpha1.AddToScheme(scheme))

--- a/go.mod
+++ b/go.mod
@@ -34,12 +34,10 @@ require (
 	k8s.io/client-go v0.22.2
 	sigs.k8s.io/cluster-api v1.0.2
 	sigs.k8s.io/cluster-api-provider-vsphere v1.0.1
+	sigs.k8s.io/cluster-api/test v1.0.0
 	sigs.k8s.io/controller-runtime v0.10.3
 	sigs.k8s.io/yaml v1.3.0
 )
-
-// exclude un-required transitive dependency from cluster-api-provider-vsphere v1.0.1
-exclude sigs.k8s.io/cluster-api/test v1.0.0
 
 // TODO: Once the repo is public, remove this so we use a versioned module
 replace (

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,9 @@ github.com/Microsoft/go-winio v0.4.16-0.20201130162521-d1ffc52c7331/go.mod h1:XB
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.17-0.20210324224401-5516f17a5958/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
-github.com/Microsoft/go-winio v0.4.17 h1:iT12IBVClFevaf8PuVyi3UmZOVh4OqnaLxDTW2O6j3w=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
+github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXGjwU=
+github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.14/go.mod h1:NtVKoYxQuTLx6gEq0L96c9Ju4JbRJ4nY2ow3VK6a9Lg=
 github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+VxGOoXdC600=
@@ -2242,6 +2243,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyz
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/cluster-api-provider-vsphere v1.0.1 h1:qs7zSFkAL9tU8tHob7bmrEWfKsOU5JaskpeSIYrhQCc=
 sigs.k8s.io/cluster-api-provider-vsphere v1.0.1/go.mod h1:Z6MDQcZjX5DUcEFStotBptj2fMR4vgCVPAnw6inIY20=
+sigs.k8s.io/cluster-api/test v1.0.0 h1:PeWOLXtDGYMmzXwGX+NtH7Xxx6BtS83DT7vKzITY5X0=
+sigs.k8s.io/cluster-api/test v1.0.0/go.mod h1:8WQozDv62x2qHkCB1wTUeFjuwawuHKUTh8IMH5hePQs=
 sigs.k8s.io/controller-runtime v0.5.0/go.mod h1:REiJzC7Y00U+2YkMbT8wxgrsX5USpXKGhb2sCtAXiT8=
 sigs.k8s.io/controller-runtime v0.10.2/go.mod h1:CQp8eyUQZ/Q7PJvnIrB6/hgfTC1kBkGylwsLgOQi1WY=
 sigs.k8s.io/controller-runtime v0.10.3 h1:s5Ttmw/B4AuIbwrXD3sfBkXwnPMMWrqpVj4WRt1dano=


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating KubernetesVersion through GitOps for Docker is currently not supported, so this will update the machine templates appropriately with the kind node image. It checks to see if there is a difference in version compared to what is specified on KubeadmControlPlane. For worker nodes because we can roll them out on a self managing cluster as well, we will check if there is a newer kind image in the bundle as well in order to decide whether we need a new template or not.

Followup: Need to enable support for changes to the KubeadmConfigTemplate spec as well.

*Testing (if applicable):*
Local testing with tilt against the TestDockerUpgradeWorkloadClusterWithFlux

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

