### PR TITLE
use injected git dev version for tests

### DIFF
--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -669,7 +669,7 @@ func (e *ClusterE2ETest) clusterConfigGitPath() string {
 func (e *ClusterE2ETest) clusterSpecFromGit() (*cluster.Spec, error) {
 	s, err := cluster.NewSpecFromClusterConfig(
 		e.clusterConfigGitPath(),
-		version.Info{GitVersion: "v0.0.0-dev"},
+		version.Get(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to build spec from git: %v", err)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use the injected gitVersion for marshalling cluster configuration during flux tests, rather than hard-coding the dev release.

This will ensure that we have the proper git version for release branch tests (e.g. v0.0.0-dev-release-0.8 vs v0.0.0-dev)

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

