### PR TITLE
Refactor BuildSpecForCluster to take in an interface

### DIFF
--- a/controllers/controllers/clusters/provider.go
+++ b/controllers/controllers/clusters/provider.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/eks-anywhere/controllers/controllers/reconciler"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/providers/vsphere"
 )
 
@@ -28,16 +27,6 @@ func BuildProviderReconciler(datacenterKind string, client client.Client, log lo
 }
 
 type providerClusterReconciler struct {
-	providerClient client.Client
-}
-
-func (p *providerClusterReconciler) eksdRelease(ctx context.Context, name, namespace string) (*eksdv1alpha1.Release, error) {
-	eksd := &eksdv1alpha1.Release{}
-	releaseName := types.NamespacedName{Namespace: namespace, Name: name}
-
-	if err := p.providerClient.Get(ctx, releaseName, eksd); err != nil {
-		return nil, err
-	}
-
-	return eksd, nil
+	providerClient      client.Client
+	eksaResourceFetcher cluster.Fetcher
 }

--- a/controllers/controllers/resource/fetcher.go
+++ b/controllers/controllers/resource/fetcher.go
@@ -278,7 +278,7 @@ func (r *CapiResourceFetcher) VSphereCredentials(ctx context.Context) (*corev1.S
 	return secret, nil
 }
 
-func (r *CapiResourceFetcher) bundles(ctx context.Context, name, namespace string) (*releasev1alpha1.Bundles, error) {
+func (r *CapiResourceFetcher) BundlesFetch(ctx context.Context, name, namespace string) (*releasev1alpha1.Bundles, error) {
 	clusterBundle := &releasev1alpha1.Bundles{}
 	err := r.FetchObjectByName(ctx, name, namespace, clusterBundle)
 	if err != nil {
@@ -287,7 +287,7 @@ func (r *CapiResourceFetcher) bundles(ctx context.Context, name, namespace strin
 	return clusterBundle, nil
 }
 
-func (r *CapiResourceFetcher) eksdRelease(ctx context.Context, name, namespace string) (*eksdv1alpha1.Release, error) {
+func (r *CapiResourceFetcher) EksdReleaseFetch(ctx context.Context, name, namespace string) (*eksdv1alpha1.Release, error) {
 	eksd := &eksdv1alpha1.Release{}
 	err := r.FetchObjectByName(ctx, name, namespace, eksd)
 	if err != nil {
@@ -296,7 +296,11 @@ func (r *CapiResourceFetcher) eksdRelease(ctx context.Context, name, namespace s
 	return eksd, nil
 }
 
-func (r *CapiResourceFetcher) oidcConfig(ctx context.Context, name, namespace string) (*anywherev1.OIDCConfig, error) {
+func (r *CapiResourceFetcher) GitOpsFetch(ctx context.Context, name, namespace string) (*anywherev1.GitOpsConfig, error) {
+	return nil, nil
+}
+
+func (r *CapiResourceFetcher) OIDCFetch(ctx context.Context, name, namespace string) (*anywherev1.OIDCConfig, error) {
 	clusterOIDC := &anywherev1.OIDCConfig{}
 	err := r.FetchObjectByName(ctx, name, namespace, clusterOIDC)
 	if err != nil {
@@ -350,7 +354,7 @@ func (r *CapiResourceFetcher) OIDCConfig(ctx context.Context, ref *anywherev1.Re
 }
 
 func (r *CapiResourceFetcher) FetchAppliedSpec(ctx context.Context, cs *anywherev1.Cluster) (*cluster.Spec, error) {
-	return cluster.BuildSpecForCluster(ctx, cs, r.bundles, r.eksdRelease, nil, r.oidcConfig)
+	return cluster.BuildSpecForCluster(ctx, cs, r)
 }
 
 func (r *CapiResourceFetcher) ExistingVSphereDatacenterConfig(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*anywherev1.VSphereDatacenterConfig, error) {


### PR DESCRIPTION
*Issue #, if available:*
#1430 

*Description of changes:*
Refactor this method to take in an interface instead of adding more parameters as we introduce new fetcher options. This will make it easier to add more fetcher options as we continue to add more features

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

