### PR TITLE
Strip superfluous 'error' prepended to error message context

### DIFF
--- a/cmd/eks-a-tool/cmd/vsphereautofill.go
+++ b/cmd/eks-a-tool/cmd/vsphereautofill.go
@@ -115,19 +115,19 @@ func autofill(ctx context.Context) error {
 
 	clusterOutput, err := yaml.Marshal(clusterConfig)
 	if err != nil {
-		return fmt.Errorf("error outputting yaml: %v", err)
+		return fmt.Errorf("outputting yaml: %v", err)
 	}
 	datacenterOutput, err := yaml.Marshal(datacenterConfig)
 	if err != nil {
-		return fmt.Errorf("error outputting yaml: %v", err)
+		return fmt.Errorf("outputting yaml: %v", err)
 	}
 	controlPlaneMachineOutput, err := yaml.Marshal(controlPlaneMachineConfig)
 	if err != nil {
-		return fmt.Errorf("error outputting yaml: %v", err)
+		return fmt.Errorf("outputting yaml: %v", err)
 	}
 	workerMachineOutput, err := yaml.Marshal(workerMachineConfig)
 	if err != nil {
-		return fmt.Errorf("error outputting yaml: %v", err)
+		return fmt.Errorf("outputting yaml: %v", err)
 	}
 	result := strings.ReplaceAll(string(datacenterOutput), "  aws: {}\n", "")
 	result = strings.ReplaceAll(result, "  vsphere: {}\n", "")
@@ -139,7 +139,7 @@ func autofill(ctx context.Context) error {
 	}
 	_, err = writer.Write(filepath.Base(clusterConfig.Name), []byte(result))
 	if err != nil {
-		return fmt.Errorf("error writing to file %s: %v", clusterConfig.Name, err)
+		return fmt.Errorf("writing to file %s: %v", clusterConfig.Name, err)
 	}
 	fmt.Printf("The following fields were updated: %v\n", updatedFields)
 	return nil

--- a/cmd/eksctl-anywhere/cmd/downloadartifacts.go
+++ b/cmd/eksctl-anywhere/cmd/downloadartifacts.go
@@ -82,7 +82,7 @@ func downloadArtifacts(context context.Context, opts *downloadArtifactsOptions) 
 	if !opts.dryRun {
 		releaseManifestURL := clusterSpec.GetReleaseManifestUrl()
 		if err := downloadArtifact(filepath.Join(opts.downloadDir, filepath.Base(releaseManifestURL)), releaseManifestURL, reader); err != nil {
-			return fmt.Errorf("error downloading release manifest: %v", err)
+			return fmt.Errorf("downloading release manifest: %v", err)
 		}
 	}
 
@@ -97,7 +97,7 @@ func downloadArtifacts(context context.Context, opts *downloadArtifactsOptions) 
 
 				filePath := filepath.Join(opts.downloadDir, bundle.KubeVersion, component, filepath.Base(*manifest))
 				if err = downloadArtifact(filePath, *manifest, reader); err != nil {
-					return fmt.Errorf("error downloading artifact for component %s: %v", component, err)
+					return fmt.Errorf("downloading artifact for component %s: %v", component, err)
 				}
 				*manifest = filePath
 			}
@@ -111,7 +111,7 @@ func downloadArtifacts(context context.Context, opts *downloadArtifactsOptions) 
 
 	bundleReleaseContent, err := yaml.Marshal(clusterSpec.Bundles)
 	if err != nil {
-		return fmt.Errorf("error marshaling bundle-release.yaml: %v", err)
+		return fmt.Errorf("marshaling bundle-release.yaml: %v", err)
 	}
 	bundleReleaseFilePath := filepath.Join(opts.downloadDir, filepath.Base(bundlesManifestUrl))
 	if err = ioutil.WriteFile(bundleReleaseFilePath, bundleReleaseContent, 0o644); err != nil {

--- a/cmd/eksctl-anywhere/cmd/importimages.go
+++ b/cmd/eksctl-anywhere/cmd/importimages.go
@@ -91,7 +91,7 @@ func importImages(ctx context.Context, spec string) error {
 	}
 	for _, image := range images {
 		if err := importImage(ctx, de, image.URI, net.JoinHostPort(host, port)); err != nil {
-			return fmt.Errorf("error importing image %s: %v", image.URI, err)
+			return fmt.Errorf("importing image %s: %v", image.URI, err)
 		}
 	}
 

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -111,12 +111,12 @@ func (csbo *createSupportBundleOptions) createBundle(ctx context.Context, since,
 
 	err = supportBundle.CollectAndAnalyze(ctx, sinceTimeValue)
 	if err != nil {
-		return fmt.Errorf("error while collecting and analyzing bundle: %v", err)
+		return fmt.Errorf("collecting and analyzing bundle: %v", err)
 	}
 
 	err = supportBundle.PrintAnalysis()
 	if err != nil {
-		return fmt.Errorf("error when printing analysis")
+		return fmt.Errorf("printing analysis")
 	}
 
 	return nil

--- a/cmd/integration_test/cmd/cleanupaws.go
+++ b/cmd/integration_test/cmd/cleanupaws.go
@@ -64,7 +64,7 @@ func cleanUpAwsTestResources(ctx context.Context) error {
 
 	err := e2e.CleanUpAwsTestResources(storageBucket, maxAge, tag)
 	if err != nil {
-		return fmt.Errorf("error running cleanup for aws test resources: %v", err)
+		return fmt.Errorf("running cleanup for aws test resources: %v", err)
 	}
 
 	return nil

--- a/cmd/integration_test/cmd/cleanupvsphere.go
+++ b/cmd/integration_test/cmd/cleanupvsphere.go
@@ -58,7 +58,7 @@ func cleanUpVsphereTestResources(ctx context.Context) error {
 	clusterName := viper.GetString(clusterNameFlagName)
 	err := e2e.CleanUpVsphereTestResources(ctx, clusterName)
 	if err != nil {
-		return fmt.Errorf("error running cleanup for vsphere vcenter vms: %v", err)
+		return fmt.Errorf("running cleanup for vsphere vcenter vms: %v", err)
 	}
 
 	return nil

--- a/cmd/integration_test/cmd/run.go
+++ b/cmd/integration_test/cmd/run.go
@@ -111,7 +111,7 @@ func runE2E(ctx context.Context) error {
 
 	err := e2e.RunTestsInParallel(runConf)
 	if err != nil {
-		return fmt.Errorf("error running e2e tests: %v", err)
+		return fmt.Errorf("running e2e tests: %v", err)
 	}
 
 	return nil

--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -35,7 +35,7 @@ func AutoFillClusterFromYaml(yamlContent []byte, fillers ...ClusterFiller) ([]by
 
 	clusterOutput, err := yaml.Marshal(clusterConfig)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling cluster config: %v", err)
+		return nil, fmt.Errorf("marshalling cluster config: %v", err)
 	}
 
 	return clusterOutput, nil

--- a/internal/pkg/api/tinkerbell.go
+++ b/internal/pkg/api/tinkerbell.go
@@ -72,7 +72,7 @@ func AutoFillTinkerbellProvider(filename string, fillers ...TinkerbellFiller) ([
 	for _, r := range resources {
 		yamlContent, err := yaml.Marshal(r)
 		if err != nil {
-			return nil, fmt.Errorf("error marshalling tinkerbell resource: %v", err)
+			return nil, fmt.Errorf("marshalling tinkerbell resource: %v", err)
 		}
 
 		yamlResources = append(yamlResources, yamlContent)

--- a/internal/pkg/api/vsphere.go
+++ b/internal/pkg/api/vsphere.go
@@ -48,7 +48,7 @@ func AutoFillVSphereProvider(filename string, fillers ...VSphereFiller) ([]byte,
 	for _, r := range resources {
 		yamlContent, err := yaml.Marshal(r)
 		if err != nil {
-			return nil, fmt.Errorf("error marshalling vsphere resource: %v", err)
+			return nil, fmt.Errorf("marshalling vsphere resource: %v", err)
 		}
 
 		yamlResources = append(yamlResources, yamlContent)

--- a/internal/pkg/awsiam/download.go
+++ b/internal/pkg/awsiam/download.go
@@ -14,11 +14,11 @@ const awsIamClientBinary = "aws-iam-authenticator"
 func DownloadAwsIamAuthClient(eksdRelease *eksdv1alpha1.Release) error {
 	uri, err := getAwsIamAuthClientUri(eksdRelease, getKernelName())
 	if err != nil {
-		return fmt.Errorf("error getting %s uri: %v", awsIamClientBinary, err)
+		return fmt.Errorf("getting %s uri: %v", awsIamClientBinary, err)
 	}
 	err = files.GzipFileDownloadExtract(uri, awsIamClientBinary, "bin")
 	if err != nil {
-		return fmt.Errorf("error downloading %s binary: %v", awsIamClientBinary, err)
+		return fmt.Errorf("downloading %s binary: %v", awsIamClientBinary, err)
 	}
 	return nil
 }

--- a/internal/pkg/ec2/create.go
+++ b/internal/pkg/ec2/create.go
@@ -94,7 +94,7 @@ func CreateInstance(session *session.Session, amiId, key, tag, instanceProfileNa
 	}
 	err = service.WaitUntilInstanceRunning(input)
 	if err != nil {
-		return "", fmt.Errorf("error waiting for instance: %v", err)
+		return "", fmt.Errorf("waiting for instance: %v", err)
 	}
 	logger.V(2).Info("Instance is running")
 

--- a/internal/pkg/ec2/list.go
+++ b/internal/pkg/ec2/list.go
@@ -38,7 +38,7 @@ func ListInstances(session *session.Session, key string, value string, maxAge fl
 	for {
 		result, err := service.DescribeInstances(input)
 		if err != nil {
-			return nil, fmt.Errorf("error describing EC2 instances: %v", err)
+			return nil, fmt.Errorf("describing EC2 instances: %v", err)
 		}
 		reservations := result.Reservations
 		for _, reservation := range reservations {

--- a/internal/pkg/ec2/tag.go
+++ b/internal/pkg/ec2/tag.go
@@ -20,7 +20,7 @@ func TagInstance(session *session.Session, instanceId, key, value string) error 
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("error tagging instance: %v", err)
+		return fmt.Errorf("tagging instance: %v", err)
 	}
 
 	return nil

--- a/internal/pkg/ec2/terminate.go
+++ b/internal/pkg/ec2/terminate.go
@@ -15,7 +15,7 @@ func TerminateEc2Instances(session *session.Session, instances []*string) error 
 
 	_, err := service.TerminateInstances(input)
 	if err != nil {
-		return fmt.Errorf("error terminating EC2 instances: %v", err)
+		return fmt.Errorf("terminating EC2 instances: %v", err)
 	}
 
 	return nil

--- a/internal/pkg/files/files.go
+++ b/internal/pkg/files/files.go
@@ -24,12 +24,12 @@ func GzipFileDownloadExtract(uri, fileToExtract, destination string) error {
 	client := &http.Client{}
 	resp, err := client.Get(uri)
 	if err != nil {
-		return fmt.Errorf("error getting download: %v", err)
+		return fmt.Errorf("getting download: %v", err)
 	}
 	defer resp.Body.Close()
 	gzf, err := gzip.NewReader(resp.Body)
 	if err != nil {
-		return fmt.Errorf("error initializing gzip: %v", err)
+		return fmt.Errorf("initializing gzip: %v", err)
 	}
 	defer gzf.Close()
 
@@ -40,7 +40,7 @@ func GzipFileDownloadExtract(uri, fileToExtract, destination string) error {
 		case err == io.EOF:
 			return fmt.Errorf("%s not found: %v", fileToExtract, err)
 		case err != nil:
-			return fmt.Errorf("error reading archive: %v", err)
+			return fmt.Errorf("reading archive: %v", err)
 		case header == nil:
 			continue
 		}
@@ -50,13 +50,13 @@ func GzipFileDownloadExtract(uri, fileToExtract, destination string) error {
 			if strings.TrimPrefix(name, "./") == fileToExtract {
 				out, err := os.OpenFile(targetFile, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 				if err != nil {
-					return fmt.Errorf("error opening %s file: %v", fileToExtract, err)
+					return fmt.Errorf("opening %s file: %v", fileToExtract, err)
 				}
 				defer out.Close()
 
 				_, err = io.Copy(out, tarReader)
 				if err != nil {
-					return fmt.Errorf("error writing %s file: %v", fileToExtract, err)
+					return fmt.Errorf("writing %s file: %v", fileToExtract, err)
 				}
 				logger.V(4).Info("Downloaded", "file", fileToExtract, "uri", uri)
 				return nil

--- a/internal/pkg/oidc/keys.go
+++ b/internal/pkg/oidc/keys.go
@@ -28,7 +28,7 @@ func parseKeys(bytes []byte) (*keyResponse, error) {
 	keys := &keyResponse{}
 	err := json.Unmarshal(bytes, keys)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing keys.json to get kid: %v", err)
+		return nil, fmt.Errorf("parsing keys.json to get kid: %v", err)
 	}
 
 	return keys, nil

--- a/internal/pkg/oidc/server.go
+++ b/internal/pkg/oidc/server.go
@@ -31,7 +31,7 @@ type discoveryResponse struct {
 func GenerateMinimalProvider(issuerURL string) (*MinimalProvider, error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
-		return nil, fmt.Errorf("error generating rsa key for OIDC: %v", err)
+		return nil, fmt.Errorf("generating rsa key for OIDC: %v", err)
 	}
 
 	pubKey := &privateKey.PublicKey
@@ -44,7 +44,7 @@ func GenerateMinimalProvider(issuerURL string) (*MinimalProvider, error) {
 	sha := sha1.New()
 	_, err = sha.Write(pubKeyEncoded)
 	if err != nil {
-		return nil, fmt.Errorf("error generating sha1 checksum for pubkey: %v", err)
+		return nil, fmt.Errorf("generating sha1 checksum for pubkey: %v", err)
 	}
 
 	kid := fmt.Sprintf("%x", sha.Sum(nil))
@@ -59,7 +59,7 @@ func GenerateMinimalProvider(issuerURL string) (*MinimalProvider, error) {
 
 	keysJson, err := json.MarshalIndent(keyResponse{Keys: keys}, "", "    ")
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling keys.json for OIDC: %v", err)
+		return nil, fmt.Errorf("marshalling keys.json for OIDC: %v", err)
 	}
 
 	d := &discoveryResponse{
@@ -74,7 +74,7 @@ func GenerateMinimalProvider(issuerURL string) (*MinimalProvider, error) {
 
 	discoveryJson, err := json.MarshalIndent(d, "", "    ")
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling json discovery for OIDC: %v", err)
+		return nil, fmt.Errorf("marshalling json discovery for OIDC: %v", err)
 	}
 
 	marshalledPrivateKey, err := marshalPrivateKey(privateKey)
@@ -93,7 +93,7 @@ func GenerateMinimalProvider(issuerURL string) (*MinimalProvider, error) {
 func marshalPubKey(pubKey *rsa.PublicKey) ([]byte, error) {
 	pubKeyBytes, err := x509.MarshalPKIXPublicKey(pubKey)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling pub key for oidc provider: %v", err)
+		return nil, fmt.Errorf("marshalling pub key for oidc provider: %v", err)
 	}
 
 	pubKeyBlock := &pem.Block{
@@ -104,7 +104,7 @@ func marshalPubKey(pubKey *rsa.PublicKey) ([]byte, error) {
 	buffer := &bytes.Buffer{}
 	err = pem.Encode(buffer, pubKeyBlock)
 	if err != nil {
-		return nil, fmt.Errorf("error encoding public key for oidc provider: %v", err)
+		return nil, fmt.Errorf("encoding public key for oidc provider: %v", err)
 	}
 
 	return buffer.Bytes(), nil
@@ -121,7 +121,7 @@ func marshalPrivateKey(k *rsa.PrivateKey) ([]byte, error) {
 	buffer := &bytes.Buffer{}
 	err := pem.Encode(buffer, keyBlock)
 	if err != nil {
-		return nil, fmt.Errorf("error encoding private key for oidc provider: %v", err)
+		return nil, fmt.Errorf("encoding private key for oidc provider: %v", err)
 	}
 
 	return buffer.Bytes(), nil

--- a/internal/pkg/oidc/token.go
+++ b/internal/pkg/oidc/token.go
@@ -91,11 +91,11 @@ func (o *oidcTokenClaim) generateToken() (string, error) {
 	}
 	block, _ := pem.Decode(keyContent)
 	if block == nil {
-		return "", fmt.Errorf("error decoding PEM file %s", o.keyFile)
+		return "", fmt.Errorf("decoding PEM file %s", o.keyFile)
 	}
 	privKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
-		return "", fmt.Errorf("error parsing key content of %s: %v", o.keyFile, err)
+		return "", fmt.Errorf("parsing key content of %s: %v", o.keyFile, err)
 	}
 
 	jwkKey := &jose.JSONWebKey{
@@ -118,7 +118,7 @@ func (o *oidcTokenClaim) generateToken() (string, error) {
 
 	token, err := jwt.Signed(signer).Claims(o).CompactSerialize()
 	if err != nil {
-		return "", fmt.Errorf("error signing token: %v", err)
+		return "", fmt.Errorf("signing token: %v", err)
 	}
 
 	return token, nil

--- a/internal/pkg/s3/delete.go
+++ b/internal/pkg/s3/delete.go
@@ -19,7 +19,7 @@ func CleanUpS3Bucket(session *session.Session, bucket string, maxAge float64) er
 	}
 	result, err := service.ListObjectsV2(input)
 	if err != nil {
-		return fmt.Errorf("error listing s3 bucket objects: %v", err)
+		return fmt.Errorf("listing s3 bucket objects: %v", err)
 	}
 
 	var objectList []*string
@@ -45,7 +45,7 @@ func CleanUpS3Bucket(session *session.Session, bucket string, maxAge float64) er
 				},
 			)
 			if err != nil {
-				return fmt.Errorf("error deleting object %s: %v", *object, err)
+				return fmt.Errorf("deleting object %s: %v", *object, err)
 			}
 		}
 	} else {

--- a/internal/pkg/s3/download.go
+++ b/internal/pkg/s3/download.go
@@ -27,7 +27,7 @@ func download(session *session.Session, key, bucket string, w io.WriterAt) error
 		Key:    aws.String(key),
 	})
 	if err != nil {
-		return fmt.Errorf("error downloading [%s] from [%s] bucket: %v", key, bucket, err)
+		return fmt.Errorf("downloading [%s] from [%s] bucket: %v", key, bucket, err)
 	}
 
 	return nil

--- a/internal/pkg/s3/object.go
+++ b/internal/pkg/s3/object.go
@@ -19,7 +19,7 @@ func ObjectPresent(session *session.Session, key, bucket string) (bool, error) {
 		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "NotFound" {
 			return false, nil
 		}
-		return false, fmt.Errorf("error getting s3 object head to check if present: %v", err)
+		return false, fmt.Errorf("getting s3 object head to check if present: %v", err)
 	}
 
 	return true, nil

--- a/internal/pkg/s3/upload.go
+++ b/internal/pkg/s3/upload.go
@@ -22,7 +22,7 @@ func WithPublicRead() UploadOpt {
 func UploadFile(session *session.Session, file, key, bucket string, opts ...UploadOpt) error {
 	fileBody, err := os.Open(file)
 	if err != nil {
-		return fmt.Errorf("error opening file for upload: %v", err)
+		return fmt.Errorf("opening file for upload: %v", err)
 	}
 
 	return upload(session, fileBody, key, bucket, opts...)
@@ -46,7 +46,7 @@ func upload(session *session.Session, body io.Reader, key, bucket string, opts .
 
 	_, err := s3Uploader.Upload(i)
 	if err != nil {
-		return fmt.Errorf("error uploading to s3: %v", err)
+		return fmt.Errorf("uploading to s3: %v", err)
 	}
 
 	return nil

--- a/internal/pkg/ssm/command.go
+++ b/internal/pkg/ssm/command.go
@@ -22,7 +22,7 @@ func WaitForSSMReady(session *session.Session, instanceId string) error {
 		return Run(session, instanceId, "ls")
 	})
 	if err != nil {
-		return fmt.Errorf("error waiting for ssm to be ready: %v", err)
+		return fmt.Errorf("waiting for ssm to be ready: %v", err)
 	}
 
 	return nil
@@ -83,13 +83,13 @@ func RunCommand(session *session.Session, instanceId, command string, opts ...Co
 	err = retrier.Retry(10, 5*time.Second, func() error {
 		_, err := service.GetCommandInvocation(commandIn)
 		if err != nil {
-			return fmt.Errorf("error getting ssm command invocation: %v", err)
+			return fmt.Errorf("getting ssm command invocation: %v", err)
 		}
 
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error waiting for ssm command to be registered: %v", err)
+		return nil, fmt.Errorf("waiting for ssm command to be registered: %v", err)
 	}
 
 	logger.V(2).Info("Waiting for ssm command to finish")

--- a/internal/test/e2e/cleanup.go
+++ b/internal/test/e2e/cleanup.go
@@ -16,25 +16,25 @@ import (
 func CleanUpAwsTestResources(storageBucket string, maxAge string, tag string) error {
 	session, err := session.NewSession()
 	if err != nil {
-		return fmt.Errorf("error creating session: %v", err)
+		return fmt.Errorf("creating session: %v", err)
 	}
 	logger.V(1).Info("Fetching list of EC2 instances")
 	key := "Integration-Test"
 	value := tag
 	maxAgeFloat, err := strconv.ParseFloat(maxAge, 64)
 	if err != nil {
-		return fmt.Errorf("error parsing max age: %v", err)
+		return fmt.Errorf("parsing max age: %v", err)
 	}
 	results, err := ec2.ListInstances(session, key, value, maxAgeFloat)
 	if err != nil {
-		return fmt.Errorf("error listing EC2 instances: %v", err)
+		return fmt.Errorf("listing EC2 instances: %v", err)
 	}
 	logger.V(1).Info("Successfully listed EC2 instances for termination")
 	if len(results) != 0 {
 		logger.V(1).Info("Terminating EC2 instances")
 		err = ec2.TerminateEc2Instances(session, results)
 		if err != nil {
-			return fmt.Errorf("error terminating EC2 instacnes: %v", err)
+			return fmt.Errorf("terminating EC2 instacnes: %v", err)
 		}
 		logger.V(1).Info("Successfully terminated EC2 instances")
 	} else {
@@ -44,11 +44,11 @@ func CleanUpAwsTestResources(storageBucket string, maxAge string, tag string) er
 	s3MaxAge := "604800" // one week
 	s3MaxAgeFloat, err := strconv.ParseFloat(s3MaxAge, 64)
 	if err != nil {
-		return fmt.Errorf("error parsing S3 max age: %v", err)
+		return fmt.Errorf("parsing S3 max age: %v", err)
 	}
 	err = s3.CleanUpS3Bucket(session, storageBucket, s3MaxAgeFloat)
 	if err != nil {
-		return fmt.Errorf("error clean up s3 bucket objects: %v", err)
+		return fmt.Errorf("clean up s3 bucket objects: %v", err)
 	}
 	logger.V(1).Info("Successfully cleaned up s3 bucket")
 
@@ -58,11 +58,11 @@ func CleanUpAwsTestResources(storageBucket string, maxAge string, tag string) er
 func CleanUpVsphereTestResources(ctx context.Context, clusterName string) error {
 	clusterName, err := validations.ValidateClusterNameArg([]string{clusterName})
 	if err != nil {
-		return fmt.Errorf("error validating cluster name: %v", err)
+		return fmt.Errorf("validating cluster name: %v", err)
 	}
 	err = vsphereRmVms(ctx, clusterName)
 	if err != nil {
-		return fmt.Errorf("error removing vcenter vms: %v", err)
+		return fmt.Errorf("removing vcenter vms: %v", err)
 	}
 	logger.V(1).Info("Vsphere vcenter vms cleanup complete")
 	return nil

--- a/internal/test/e2e/oidc.go
+++ b/internal/test/e2e/oidc.go
@@ -32,7 +32,7 @@ func (e *E2ESession) setupOIDC(testRegex string) error {
 	logger.V(1).Info("OIDC test found. Checking if OIDC folder present in bucket")
 	oidcPresent, err := s3.ObjectPresent(e.session, filepath.Join(e.jobId, keysPath), e.storageBucket)
 	if err != nil {
-		return fmt.Errorf("error checking if oidc is present in bucket: %v", err)
+		return fmt.Errorf("checking if oidc is present in bucket: %v", err)
 	}
 
 	if !oidcPresent {
@@ -67,28 +67,28 @@ func (e *E2ESession) setupOIDC(testRegex string) error {
 func (e *E2ESession) createOIDCFiles(issuerURL, folder string) error {
 	provider, err := oidc.GenerateMinimalProvider(issuerURL)
 	if err != nil {
-		return fmt.Errorf("error setting up generating oidc provider for s3: %v", err)
+		return fmt.Errorf("setting up generating oidc provider for s3: %v", err)
 	}
 
 	logger.V(2).Info("Uploading OIDC discovery file to S3")
 	discoveryKey := filepath.Join(folder, openIDConfPath)
 	err = s3.Upload(e.session, provider.Discovery, discoveryKey, e.storageBucket, s3.WithPublicRead())
 	if err != nil {
-		return fmt.Errorf("error uploading oidc openid-configuration to s3: %v", err)
+		return fmt.Errorf("uploading oidc openid-configuration to s3: %v", err)
 	}
 
 	logger.V(2).Info("Uploading OIDC keys file to S3")
 	keysKey := filepath.Join(folder, keysPath)
 	err = s3.Upload(e.session, provider.Keys, keysKey, e.storageBucket, s3.WithPublicRead())
 	if err != nil {
-		return fmt.Errorf("error uploading oidc keys.json to s3: %v", err)
+		return fmt.Errorf("uploading oidc keys.json to s3: %v", err)
 	}
 
 	logger.V(2).Info("Uploading OIDC signer key to S3")
 	saSignerKey := filepath.Join(folder, saSignerPath)
 	err = s3.Upload(e.session, provider.PrivateKey, saSignerKey, e.storageBucket)
 	if err != nil {
-		return fmt.Errorf("error uploading oidc sa-signer.key to s3: %v", err)
+		return fmt.Errorf("uploading oidc sa-signer.key to s3: %v", err)
 	}
 
 	return nil
@@ -99,12 +99,12 @@ func (e *E2ESession) getKeyID(folder string) (string, error) {
 	logger.V(2).Info("Downloading keys.json file from s3")
 	keysBytes, err := s3.Download(e.session, keysKey, e.storageBucket)
 	if err != nil {
-		return "", fmt.Errorf("error downloading keys.json to get kid: %v", err)
+		return "", fmt.Errorf("downloading keys.json to get kid: %v", err)
 	}
 
 	keyID, err := oidc.GetKeyID(keysBytes)
 	if err != nil {
-		return "", fmt.Errorf("error getting kid from s3: %v", err)
+		return "", fmt.Errorf("getting kid from s3: %v", err)
 	}
 
 	return keyID, nil
@@ -116,7 +116,7 @@ func (e *E2ESession) downloadSignerKeyInInstance(folder string) (pathInInstance 
 	command := fmt.Sprintf("aws s3 cp s3://%s/%s ./%s", e.storageBucket, saSignerKey, saSignerPath)
 
 	if err = ssm.Run(e.session, e.instanceId, command); err != nil {
-		return "", fmt.Errorf("error downloading signer key in instance: %v", err)
+		return "", fmt.Errorf("downloading signer key in instance: %v", err)
 	}
 	logger.V(1).Info("Successfully downloaded signer key")
 

--- a/internal/test/e2e/registryMirror.go
+++ b/internal/test/e2e/registryMirror.go
@@ -37,7 +37,7 @@ func (e *E2ESession) mountRegistryCert(cert string, endpoint string) error {
 	command := fmt.Sprintf("sudo mkdir -p /etc/docker/certs.d/%s", endpoint)
 
 	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
-		return fmt.Errorf("error creating directory in instance: %v", err)
+		return fmt.Errorf("creating directory in instance: %v", err)
 	}
 	decodedCert, err := base64.StdEncoding.DecodeString(cert)
 	if err != nil {
@@ -46,7 +46,7 @@ func (e *E2ESession) mountRegistryCert(cert string, endpoint string) error {
 	command = fmt.Sprintf("sudo cat <<EOF>> /etc/docker/certs.d/%s/ca.crt\n%s\nEOF", endpoint, string(decodedCert))
 
 	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
-		return fmt.Errorf("error mounting certificate in instance: %v", err)
+		return fmt.Errorf("mounting certificate in instance: %v", err)
 	}
 
 	return err

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -167,7 +167,7 @@ func (e *E2ESession) runTests(regex string) (testCommandResult *testCommandResul
 		opt,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error running e2e tests on instance %s: %v", e.instanceId, err)
+		return nil, fmt.Errorf("running e2e tests on instance %s: %v", e.instanceId, err)
 	}
 
 	return testCommandResult, nil
@@ -190,7 +190,7 @@ func (c instanceRunConf) runPostTestsProcessing(e *E2ESession, testCommandResult
 	value := "TRUE"
 	err := ec2.TagInstance(e.session, e.instanceId, key, value)
 	if err != nil {
-		return fmt.Errorf("error tagging instance for e2e success: %v", err)
+		return fmt.Errorf("tagging instance for e2e success: %v", err)
 	}
 
 	return nil

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -45,7 +45,7 @@ type E2ESession struct {
 func newSessionFromConf(conf instanceRunConf) (*E2ESession, error) {
 	session, err := session.NewSession()
 	if err != nil {
-		return nil, fmt.Errorf("error creating session: %v", err)
+		return nil, fmt.Errorf("creating session: %v", err)
 	}
 
 	e := &E2ESession{
@@ -77,7 +77,7 @@ func (e *E2ESession) setup(regex string) error {
 	logger.V(1).Info("Creating ec2 instance", "name", name)
 	instanceId, err := ec2.CreateInstance(e.session, e.amiId, key, tag, e.instanceProfileName, e.subnetId, name)
 	if err != nil {
-		return fmt.Errorf("error creating instance for e2e tests: %v", err)
+		return fmt.Errorf("creating instance for e2e tests: %v", err)
 	}
 	logger.V(1).Info("Instance created", "instance-id", instanceId)
 	e.instanceId = instanceId
@@ -85,7 +85,7 @@ func (e *E2ESession) setup(regex string) error {
 	logger.V(1).Info("Waiting until SSM is ready")
 	err = ssm.WaitForSSMReady(e.session, instanceId)
 	if err != nil {
-		return fmt.Errorf("error waiting for ssm in new instance: %v", err)
+		return fmt.Errorf("waiting for ssm in new instance: %v", err)
 	}
 
 	err = e.createTestNameFile(regex)
@@ -146,7 +146,7 @@ func (e *E2ESession) uploadRequiredFile(file string) error {
 	logger.V(1).Info("Uploading file to s3 bucket", "file", file, "key", key)
 	err := s3.UploadFile(e.session, uploadFile, key, e.storageBucket)
 	if err != nil {
-		return fmt.Errorf("error uploading file [%s]: %v", file, err)
+		return fmt.Errorf("uploading file [%s]: %v", file, err)
 	}
 
 	return nil
@@ -179,7 +179,7 @@ func (e *E2ESession) downloadRequiredFileInInstance(file string) error {
 
 	command := fmt.Sprintf("aws s3 cp s3://%s/%s/%[3]s ./bin/ && chmod 645 ./bin/%[3]s", e.storageBucket, e.jobId, file)
 	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
-		return fmt.Errorf("error downloading file in instance: %v", err)
+		return fmt.Errorf("downloading file in instance: %v", err)
 	}
 	logger.V(1).Info("Successfully downloaded file")
 
@@ -200,7 +200,7 @@ func (e *E2ESession) createTestNameFile(testName string) error {
 	command := fmt.Sprintf("echo %s > %s", testName, testNameFile)
 
 	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
-		return fmt.Errorf("error creating test name file in instance: %v", err)
+		return fmt.Errorf("creating test name file in instance: %v", err)
 	}
 	logger.V(1).Info("Successfully created test name file")
 

--- a/pkg/addonmanager/addonclients/files.go
+++ b/pkg/addonmanager/addonclients/files.go
@@ -42,7 +42,7 @@ func (f *FluxAddonClient) UpdateLegacyFileStructure(ctx context.Context, current
 	oldClusterConfigPath := ofc.path()
 	updateNeeded, err := nfc.filesUpdateNeeded(oldClusterConfigPath)
 	if err != nil {
-		return fmt.Errorf("error updating git repo: %v", err)
+		return fmt.Errorf("updating git repo: %v", err)
 	}
 	if !updateNeeded {
 		logger.V(1).Info("Git repo file structure is already up-to-date")
@@ -54,7 +54,7 @@ func (f *FluxAddonClient) UpdateLegacyFileStructure(ctx context.Context, current
 	}
 
 	if err := nfc.gitOpts.Git.Add(nfc.path()); err != nil {
-		return &ConfigVersionControlFailedError{Err: fmt.Errorf("error when adding %s to git: %v", nfc.path(), err)}
+		return &ConfigVersionControlFailedError{Err: fmt.Errorf("adding %s to git: %v", nfc.path(), err)}
 	}
 
 	if err := nfc.FluxAddonClient.pushToRemoteRepo(ctx, nfc.path(), upgradeFluxconfigCommitMessage); err != nil {
@@ -99,7 +99,7 @@ func updateEksaSystemFiles(ofc, nfc *fluxForCluster) error {
 	if oldEksaPath != nfc.eksaSystemDir() {
 		err = nfc.gitOpts.Git.Remove(oldEksaPath)
 		if err != nil {
-			return &ConfigVersionControlFailedError{Err: fmt.Errorf("error when removing %s in git: %v", oldEksaPath, err)}
+			return &ConfigVersionControlFailedError{Err: fmt.Errorf("removing %s in git: %v", oldEksaPath, err)}
 		}
 	}
 
@@ -131,7 +131,7 @@ func (fc *fluxForCluster) updateGitOpsConfig(fileName string) ([]byte, error) {
 
 		gitopsYaml, err := yaml.Marshal(gitopsconfig.ConvertConfigToConfigGenerateStruct())
 		if err != nil {
-			return nil, fmt.Errorf("error outputting yaml: %v", err)
+			return nil, fmt.Errorf("outputting yaml: %v", err)
 		}
 		resources = append(resources, gitopsYaml)
 	}

--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -77,7 +77,7 @@ func NewGitOptions(ctx context.Context, cluster *v1alpha1.Cluster, gitOpsConfig 
 	gitProviderFactory := gitFactory.New(gitProviderFactoryOptions)
 	gitProvider, err := gitProviderFactory.BuildProvider(ctx, &gitOpsConfig.Spec)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Git provider: %v", err)
+		return nil, fmt.Errorf("creating Git provider: %v", err)
 	}
 	err = gitProvider.Validate(ctx)
 	if err != nil {
@@ -86,7 +86,7 @@ func NewGitOptions(ctx context.Context, cluster *v1alpha1.Cluster, gitOpsConfig 
 	localGitWriterPath := filepath.Join("git", gitOpsConfig.Spec.Flux.Github.Repository)
 	gitwriter, err := writer.WithDir(localGitWriterPath)
 	if err != nil {
-		return nil, fmt.Errorf("error creating file writer: %v", err)
+		return nil, fmt.Errorf("creating file writer: %v", err)
 	}
 	gitwriter.CleanUpTemp()
 	return &GitOptions{
@@ -260,7 +260,7 @@ func (f *FluxAddonClient) UpdateGitEksaSpec(ctx context.Context, clusterSpec *cl
 	path := fc.eksaSystemDir()
 	err := f.gitOpts.Git.Add(path)
 	if err != nil {
-		return &ConfigVersionControlFailedError{Err: fmt.Errorf("error when adding %s to git: %v", path, err)}
+		return &ConfigVersionControlFailedError{Err: fmt.Errorf("adding %s to git: %v", path, err)}
 	}
 
 	err = f.pushToRemoteRepo(ctx, path, updateClusterconfigCommitMessage)
@@ -322,7 +322,7 @@ func (f *FluxAddonClient) CleanupGitRepo(ctx context.Context, clusterSpec *clust
 
 	err := f.gitOpts.Git.Remove(p)
 	if err != nil {
-		return &ConfigVersionControlFailedError{Err: fmt.Errorf("error when removing %s in git: %v", p, err)}
+		return &ConfigVersionControlFailedError{Err: fmt.Errorf("removing %s in git: %v", p, err)}
 	}
 
 	err = f.pushToRemoteRepo(ctx, p, deleteClusterconfigCommitMessage)
@@ -337,14 +337,14 @@ func (f *FluxAddonClient) CleanupGitRepo(ctx context.Context, clusterSpec *clust
 func (f *FluxAddonClient) pushToRemoteRepo(ctx context.Context, path, msg string) error {
 	err := f.gitOpts.Git.Commit(msg)
 	if err != nil {
-		return &ConfigVersionControlFailedError{Err: fmt.Errorf("error when committing %s to git:  %v", path, err)}
+		return &ConfigVersionControlFailedError{Err: fmt.Errorf("committing %s to git:  %v", path, err)}
 	}
 
 	err = f.retrier.Retry(func() error {
 		return f.gitOpts.Git.Push(ctx)
 	})
 	if err != nil {
-		return &ConfigVersionControlFailedError{Err: fmt.Errorf("error when pushing %s to git: %v", path, err)}
+		return &ConfigVersionControlFailedError{Err: fmt.Errorf("pushing %s to git: %v", path, err)}
 	}
 	return nil
 }
@@ -393,7 +393,7 @@ func (fc *fluxForCluster) commitFluxAndClusterConfigToGit(ctx context.Context) e
 	p := path.Dir(config.Spec.Flux.Github.ClusterConfigPath)
 	err = fc.gitOpts.Git.Add(p)
 	if err != nil {
-		return &ConfigVersionControlFailedError{Err: fmt.Errorf("error when adding %s to git: %v", p, err)}
+		return &ConfigVersionControlFailedError{Err: fmt.Errorf("adding %s to git: %v", p, err)}
 	}
 
 	err = fc.FluxAddonClient.pushToRemoteRepo(ctx, p, initialClusterconfigCommitMessage)
@@ -428,7 +428,7 @@ func (fc *fluxForCluster) initEksaWriter() (filewriter.FileWriter, error) {
 	eksaSystemDir := fc.eksaSystemDir()
 	w, err := fc.gitOpts.Writer.WithDir(eksaSystemDir)
 	if err != nil {
-		err = fmt.Errorf("error creating %s directory: %v", eksaSystemDir, err)
+		err = fmt.Errorf("creating %s directory: %v", eksaSystemDir, err)
 	}
 	w.CleanUpTemp()
 	return w, err
@@ -455,7 +455,7 @@ func (fc *fluxForCluster) generateClusterConfigFile(w filewriter.FileWriter) err
 		return err
 	}
 	if filePath, err := w.Write(clusterConfigFileName, resourcesSpec, filewriter.PersistentFile); err != nil {
-		return fmt.Errorf("error writing eks-a cluster config file into %s: %v", filePath, err)
+		return fmt.Errorf("writing eks-a cluster config file into %s: %v", filePath, err)
 	}
 
 	return nil
@@ -467,7 +467,7 @@ func (fc *fluxForCluster) generateEksaKustomizeFile(w filewriter.FileWriter) err
 	}
 	t := templater.New(w)
 	if filePath, err := t.WriteToFile(eksaKustomizeContent, values, kustomizeFileName, filewriter.PersistentFile); err != nil {
-		return fmt.Errorf("error writing eks-a kustomization manifest file into %s: %v", filePath, err)
+		return fmt.Errorf("writing eks-a kustomization manifest file into %s: %v", filePath, err)
 	}
 	return nil
 }
@@ -475,7 +475,7 @@ func (fc *fluxForCluster) generateEksaKustomizeFile(w filewriter.FileWriter) err
 func (fc *fluxForCluster) initFluxWriter() (filewriter.FileWriter, error) {
 	w, err := fc.gitOpts.Writer.WithDir(fc.fluxSystemDir())
 	if err != nil {
-		err = fmt.Errorf("error creating %s directory: %v", fc.fluxSystemDir(), err)
+		err = fmt.Errorf("creating %s directory: %v", fc.fluxSystemDir(), err)
 	}
 	w.CleanUpTemp()
 	return w, err
@@ -512,14 +512,14 @@ func (fc *fluxForCluster) generateFluxKustomizeFile(t *templater.Templater) erro
 		"Namespace": fc.namespace(),
 	}
 	if filePath, err := t.WriteToFile(fluxKustomizeContent, values, kustomizeFileName, filewriter.PersistentFile); err != nil {
-		return fmt.Errorf("error creating flux-system kustomization manifest file into %s: %v", filePath, err)
+		return fmt.Errorf("creating flux-system kustomization manifest file into %s: %v", filePath, err)
 	}
 	return nil
 }
 
 func (f *FluxAddonClient) generateFluxSyncFile(t *templater.Templater) error {
 	if filePath, err := t.WriteToFile(fluxSyncContent, nil, fluxSyncFileName, filewriter.PersistentFile); err != nil {
-		return fmt.Errorf("error creating flux-system sync manifest file into %s: %v", filePath, err)
+		return fmt.Errorf("creating flux-system sync manifest file into %s: %v", filePath, err)
 	}
 	return nil
 }
@@ -534,7 +534,7 @@ func (fc *fluxForCluster) generateFluxPatchFile(t *templater.Templater) error {
 		"NotificationControllerImage": bundle.Flux.NotificationController.VersionedImage(),
 	}
 	if filePath, err := t.WriteToFile(fluxPatchContent, values, fluxPatchFileName, filewriter.PersistentFile); err != nil {
-		return fmt.Errorf("error creating flux-system patch manifest file into %s: %v", filePath, err)
+		return fmt.Errorf("creating flux-system patch manifest file into %s: %v", filePath, err)
 	}
 	return nil
 }
@@ -631,11 +631,11 @@ func (fc *fluxForCluster) initializeLocalRepository() error {
 
 	// git requires at least one commit in the repo to branch from
 	if err = fc.gitOpts.Git.Commit("initializing repository"); err != nil {
-		return fmt.Errorf("error when initializing repository: %v", err)
+		return fmt.Errorf("initializing repository: %v", err)
 	}
 
 	if err = fc.gitOpts.Git.Branch(fc.branch()); err != nil {
-		return fmt.Errorf("error when creating branch: %v", err)
+		return fmt.Errorf("creating branch: %v", err)
 	}
 	return nil
 }

--- a/pkg/addonmanager/addonclients/upgrader.go
+++ b/pkg/addonmanager/addonclients/upgrader.go
@@ -103,7 +103,7 @@ func (fc *fluxForCluster) commitFluxUpgradeFilesToGit(ctx context.Context) error
 	}
 
 	if err := fc.gitOpts.Git.Add(fc.path()); err != nil {
-		return &ConfigVersionControlFailedError{Err: fmt.Errorf("error when adding %s to git: %v", fc.path(), err)}
+		return &ConfigVersionControlFailedError{Err: fmt.Errorf("adding %s to git: %v", fc.path(), err)}
 	}
 
 	if err := fc.FluxAddonClient.pushToRemoteRepo(ctx, fc.path(), upgradeFluxconfigCommitMessage); err != nil {
@@ -169,7 +169,7 @@ func (fc *fluxForCluster) generateUpdatedEksaConfig(fileName string) ([]byte, er
 		}
 		resourceYaml, err := yaml.Marshal(resource.Object)
 		if err != nil {
-			return nil, fmt.Errorf("error outputting yaml: %v", err)
+			return nil, fmt.Errorf("outputting yaml: %v", err)
 		}
 		resources = append(resources, resourceYaml)
 	}

--- a/pkg/addonmanager/addonclients/upgrader_test.go
+++ b/pkg/addonmanager/addonclients/upgrader_test.go
@@ -94,7 +94,7 @@ func TestFluxUpgradeSuccess(t *testing.T) {
 	f, m, g := newAddonClient(t)
 
 	if err := setupTestFiles(t, g); err != nil {
-		t.Errorf("error setting up files: %v", err)
+		t.Errorf("setting up files: %v", err)
 	}
 
 	wantDiff := &types.ChangeDiff{
@@ -133,7 +133,7 @@ func TestFluxUpgradeError(t *testing.T) {
 	f, m, g := newAddonClient(t)
 
 	if err := setupTestFiles(t, g); err != nil {
-		t.Errorf("error setting up files: %v", err)
+		t.Errorf("setting up files: %v", err)
 	}
 
 	m.git.EXPECT().GetRepo(tt.ctx).Return(&git.Repository{Name: tt.fluxConfig.Github.Repository}, nil)

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -474,7 +474,7 @@ func validateCNIConfig(cniConfig *CNIConfig) error {
 
 	if len(allErrs) > 0 {
 		aggregate := utilerrors.NewAggregate(allErrs)
-		return fmt.Errorf("error validating cniConfig: %v", aggregate)
+		return fmt.Errorf("validating cniConfig: %v", aggregate)
 	}
 
 	return nil

--- a/pkg/api/v1alpha1/cluster_defaults.go
+++ b/pkg/api/v1alpha1/cluster_defaults.go
@@ -36,7 +36,7 @@ func setRegistryMirrorConfigDefaults(clusterConfig *Cluster) error {
 		if caCert, set := os.LookupEnv(RegistryMirrorCAKey); set && len(caCert) > 0 {
 			content, err := ioutil.ReadFile(caCert)
 			if err != nil {
-				return fmt.Errorf("error reading the cert file %s: %v", caCert, err)
+				return fmt.Errorf("reading the cert file %s: %v", caCert, err)
 			}
 			logger.V(4).Info(fmt.Sprintf("%s is set, using %s as ca cert for registry", RegistryMirrorCAKey, caCert))
 			clusterConfig.Spec.RegistryMirrorConfiguration.CACertContent = string(content)

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -1015,7 +1015,7 @@ func TestParseClusterConfig(t *testing.T) {
 				clusterConfig: &Cluster{},
 			},
 			wantErr:    true,
-			matchError: fmt.Errorf("error converting YAML to JSON: yaml: line 12: did not find expected key"),
+			matchError: fmt.Errorf("converting YAML to JSON: yaml: line 12: did not find expected key"),
 		},
 		{
 			name: "Invalid key",
@@ -1024,7 +1024,7 @@ func TestParseClusterConfig(t *testing.T) {
 				clusterConfig: &Cluster{},
 			},
 			wantErr:    true,
-			matchError: fmt.Errorf("error unmarshaling JSON: while decoding JSON: json: unknown field \"registryMirro rConfiguration\""),
+			matchError: fmt.Errorf("unmarshaling JSON: while decoding JSON: json: unknown field \"registryMirro rConfiguration\""),
 		},
 		{
 			name: "Invalid yaml",
@@ -1033,7 +1033,7 @@ func TestParseClusterConfig(t *testing.T) {
 				clusterConfig: &Cluster{},
 			},
 			wantErr:    true,
-			matchError: fmt.Errorf("error converting YAML to JSON: yaml: did not find expected node content"),
+			matchError: fmt.Errorf("converting YAML to JSON: yaml: did not find expected node content"),
 		},
 		{
 			name: "Invalid spec field",
@@ -1042,7 +1042,7 @@ func TestParseClusterConfig(t *testing.T) {
 				clusterConfig: &Cluster{},
 			},
 			wantErr:    true,
-			matchError: fmt.Errorf("error unmarshaling JSON: while decoding JSON: json: unknown field \"invalidField\""),
+			matchError: fmt.Errorf("unmarshaling JSON: while decoding JSON: json: unknown field \"invalidField\""),
 		},
 		{
 			name: "Cluster definition at the end",
@@ -1843,14 +1843,14 @@ func TestValidateCNIConfig(t *testing.T) {
 	}{
 		{
 			name:    "CNI plugin not specified",
-			wantErr: fmt.Errorf("error validating cniConfig: no cni plugin specified"),
+			wantErr: fmt.Errorf("validating cniConfig: no cni plugin specified"),
 			clusterNetwork: &ClusterNetwork{
 				CNIConfig: &CNIConfig{},
 			},
 		},
 		{
 			name:    "multiple CNI plugins specified",
-			wantErr: fmt.Errorf("error validating cniConfig: cannot specify more than one cni plugins"),
+			wantErr: fmt.Errorf("validating cniConfig: cannot specify more than one cni plugins"),
 			clusterNetwork: &ClusterNetwork{
 				CNIConfig: &CNIConfig{
 					Cilium:   &CiliumConfig{},
@@ -1860,7 +1860,7 @@ func TestValidateCNIConfig(t *testing.T) {
 		},
 		{
 			name:    "invalid cilium policy enforcement mode",
-			wantErr: fmt.Errorf("error validating cniConfig: cilium policyEnforcementMode \"invalid\" not supported"),
+			wantErr: fmt.Errorf("validating cniConfig: cilium policyEnforcementMode \"invalid\" not supported"),
 			clusterNetwork: &ClusterNetwork{
 				CNIConfig: &CNIConfig{
 					Cilium: &CiliumConfig{
@@ -1871,7 +1871,7 @@ func TestValidateCNIConfig(t *testing.T) {
 		},
 		{
 			name:    "invalid cilium policy enforcement mode and > 1 plugins",
-			wantErr: fmt.Errorf("error validating cniConfig: [cilium policyEnforcementMode \"invalid\" not supported, cannot specify more than one cni plugins]"),
+			wantErr: fmt.Errorf("validating cniConfig: [cilium policyEnforcementMode \"invalid\" not supported, cannot specify more than one cni plugins]"),
 			clusterNetwork: &ClusterNetwork{
 				CNIConfig: &CNIConfig{
 					Cilium: &CiliumConfig{

--- a/pkg/awsiamauth/awsiamauth.go
+++ b/pkg/awsiamauth/awsiamauth.go
@@ -60,17 +60,17 @@ func (a *AwsIamAuthTemplateBuilder) GenerateManifest(clusterSpec *cluster.Spec, 
 
 	mapRoles, err := a.mapRolesToYaml(clusterSpec.AWSIamConfig.Spec.MapRoles)
 	if err != nil {
-		return nil, fmt.Errorf("error generating aws-iam-authenticator manifest: %v", err)
+		return nil, fmt.Errorf("generating aws-iam-authenticator manifest: %v", err)
 	}
 	data["mapRoles"] = mapRoles
 	mapUsers, err := a.mapUsersToYaml(clusterSpec.AWSIamConfig.Spec.MapUsers)
 	if err != nil {
-		return nil, fmt.Errorf("error generating aws-iam-authenticator manifest: %v", err)
+		return nil, fmt.Errorf("generating aws-iam-authenticator manifest: %v", err)
 	}
 	data["mapUsers"] = mapUsers
 	awsIamAuthManifest, err := templater.Execute(awsIamAuthTemplate, data)
 	if err != nil {
-		return nil, fmt.Errorf("error generating aws-iam-authenticator manifest: %v", err)
+		return nil, fmt.Errorf("generating aws-iam-authenticator manifest: %v", err)
 	}
 	return awsIamAuthManifest, nil
 }
@@ -82,7 +82,7 @@ func (a *AwsIamAuth) GenerateManifest(clusterSpec *cluster.Spec) ([]byte, error)
 func (a *AwsIamAuth) GenerateCertKeyPairSecret() ([]byte, error) {
 	certPemBytes, keyPemBytes, err := a.certgen.GenerateIamAuthSelfSignCertKeyPair()
 	if err != nil {
-		return nil, fmt.Errorf("error generating aws-iam-authenticator cert key pair secret: %v", err)
+		return nil, fmt.Errorf("generating aws-iam-authenticator cert key pair secret: %v", err)
 	}
 	data := map[string]string{
 		"namespace":    constants.EksaSystemNamespace,
@@ -91,7 +91,7 @@ func (a *AwsIamAuth) GenerateCertKeyPairSecret() ([]byte, error) {
 	}
 	awsIamAuthCaSecret, err := templater.Execute(awsIamAuthCaSecretTemplate, data)
 	if err != nil {
-		return nil, fmt.Errorf("error generating aws-iam-authenticator cert key pair secret: %v", err)
+		return nil, fmt.Errorf("generating aws-iam-authenticator cert key pair secret: %v", err)
 	}
 	return awsIamAuthCaSecret, nil
 }
@@ -105,7 +105,7 @@ func (a *AwsIamAuth) GenerateAwsIamAuthKubeconfig(clusterSpec *cluster.Spec, ser
 	}
 	awsIamAuthKubeconfig, err := templater.Execute(awsIamAuthKubeconfigTemplate, data)
 	if err != nil {
-		return nil, fmt.Errorf("error generating aws-iam-authenticator kubeconfig content: %v", err)
+		return nil, fmt.Errorf("generating aws-iam-authenticator kubeconfig content: %v", err)
 	}
 	return awsIamAuthKubeconfig, nil
 }
@@ -116,7 +116,7 @@ func (a *AwsIamAuthTemplateBuilder) mapRolesToYaml(m []v1alpha1.MapRoles) (strin
 	}
 	b, err := yaml.Marshal(m)
 	if err != nil {
-		return "", fmt.Errorf("error marshalling AWSIamConfig MapRoles: %v", err)
+		return "", fmt.Errorf("marshalling AWSIamConfig MapRoles: %v", err)
 	}
 	s := string(b)
 	s = strings.TrimSuffix(s, "\n")
@@ -130,7 +130,7 @@ func (a *AwsIamAuthTemplateBuilder) mapUsersToYaml(m []v1alpha1.MapUsers) (strin
 	}
 	b, err := yaml.Marshal(m)
 	if err != nil {
-		return "", fmt.Errorf("error marshalling AWSIamConfig MapUsers: %v", err)
+		return "", fmt.Errorf("marshalling AWSIamConfig MapUsers: %v", err)
 	}
 	s := string(b)
 	s = strings.TrimSuffix(s, "\n")

--- a/pkg/awsiamauth/awsiamauth_test.go
+++ b/pkg/awsiamauth/awsiamauth_test.go
@@ -48,7 +48,7 @@ func TestGenerateCertKeyPairSecretSuccess(t *testing.T) {
 
 func TestGenerateCertKeyPairSecretFail(t *testing.T) {
 	certGenErr := fmt.Errorf("cert gen error")
-	wantErr := fmt.Errorf("error generating aws-iam-authenticator cert key pair secret: cert gen error")
+	wantErr := fmt.Errorf("generating aws-iam-authenticator cert key pair secret: cert gen error")
 	awsIamAuth, mockCertgen := newAwsIamAuth(t)
 
 	mockCertgen.EXPECT().GenerateIamAuthSelfSignCertKeyPair().Return(nil, nil, certGenErr)

--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -44,7 +44,7 @@ func New(clusterClient ClusterClient) *Bootstrapper {
 func (b *Bootstrapper) CreateBootstrapCluster(ctx context.Context, clusterSpec *cluster.Spec, opts ...BootstrapClusterOption) (*types.Cluster, error) {
 	kubeconfigFile, err := b.clusterClient.CreateBootstrapCluster(ctx, clusterSpec, b.getClientOptions(opts)...)
 	if err != nil {
-		return nil, fmt.Errorf("error creating bootstrap cluster: %v, try rerunning with --force-cleanup to force delete previously created bootstrap cluster", err)
+		return nil, fmt.Errorf("creating bootstrap cluster: %v, try rerunning with --force-cleanup to force delete previously created bootstrap cluster", err)
 	}
 
 	c := &types.Cluster{
@@ -61,7 +61,7 @@ func (b *Bootstrapper) CreateBootstrapCluster(ctx context.Context, clusterSpec *
 
 	err = cluster.ApplyExtraObjects(ctx, b.clusterClient, c, clusterSpec)
 	if err != nil {
-		return nil, fmt.Errorf("error applying extra objects to bootstrap cluster: %v", err)
+		return nil, fmt.Errorf("applying extra objects to bootstrap cluster: %v", err)
 	}
 
 	return c, nil
@@ -70,7 +70,7 @@ func (b *Bootstrapper) CreateBootstrapCluster(ctx context.Context, clusterSpec *
 func (b *Bootstrapper) DeleteBootstrapCluster(ctx context.Context, cluster *types.Cluster, isUpgrade bool) error {
 	clusterExists, err := b.clusterClient.ClusterExists(ctx, cluster.Name)
 	if err != nil {
-		return fmt.Errorf("error deleting bootstrap cluster: %v", err)
+		return fmt.Errorf("deleting bootstrap cluster: %v", err)
 	}
 	if !clusterExists {
 		logger.V(4).Info("Skipping delete bootstrap cluster, cluster doesn't exist")
@@ -78,7 +78,7 @@ func (b *Bootstrapper) DeleteBootstrapCluster(ctx context.Context, cluster *type
 	}
 	mgmtCluster, err := b.managementInCluster(ctx, cluster)
 	if err != nil {
-		return fmt.Errorf("error deleting bootstrap cluster: %v", err)
+		return fmt.Errorf("deleting bootstrap cluster: %v", err)
 	}
 
 	if mgmtCluster != nil {
@@ -94,7 +94,7 @@ func (b *Bootstrapper) managementInCluster(ctx context.Context, cluster *types.C
 	if cluster.KubeconfigFile == "" {
 		kubeconfig, err := b.clusterClient.GetKubeconfig(ctx, cluster.Name)
 		if err != nil {
-			return nil, fmt.Errorf("error fetching bootstrap cluster's kubeconfig: %v", err)
+			return nil, fmt.Errorf("fetching bootstrap cluster's kubeconfig: %v", err)
 		}
 		cluster.KubeconfigFile = kubeconfig
 	}

--- a/pkg/cluster/apply.go
+++ b/pkg/cluster/apply.go
@@ -24,7 +24,7 @@ func ApplyExtraObjects(ctx context.Context, clusterClient ClusterClient, cluster
 	logger.V(4).Info("Applying extra objects", "cluster", clusterSpec.Cluster.Name, "resources", extraObjects.Names())
 	err := clusterClient.ApplyKubeSpecFromBytes(ctx, cluster, resourcesSpec)
 	if err != nil {
-		return fmt.Errorf("error applying spec for extra resources to cluster %s: %v", cluster.Name, err)
+		return fmt.Errorf("applying spec for extra resources to cluster %s: %v", cluster.Name, err)
 	}
 
 	return nil

--- a/pkg/cluster/config_manager.go
+++ b/pkg/cluster/config_manager.go
@@ -75,7 +75,7 @@ func (c *ConfigManager) SetDefaults(config *Config) error {
 
 	if len(allErrs) > 0 {
 		aggregate := utilerrors.NewAggregate(allErrs)
-		return fmt.Errorf("error setting defaults on cluster config: %v", aggregate)
+		return fmt.Errorf("setting defaults on cluster config: %v", aggregate)
 	}
 
 	return nil

--- a/pkg/cluster/load.go
+++ b/pkg/cluster/load.go
@@ -29,7 +29,7 @@ func LoadManagement(kubeconfig string) (*types.Cluster, error) {
 	kc.Clusters = []*kubeConfigCluster{}
 	err = yaml.Unmarshal(kubeConfigBytes, &kc)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing kubeconfig file: %v", err)
+		return nil, fmt.Errorf("parsing kubeconfig file: %v", err)
 	}
 	return &types.Cluster{
 		Name:               kc.Clusters[0].Name,

--- a/pkg/clusterapi/resourceset.go
+++ b/pkg/clusterapi/resourceset.go
@@ -100,7 +100,7 @@ func marshall(objects ...interface{}) ([]byte, error) {
 	for _, o := range objects {
 		b, err := yaml.Marshal(o)
 		if err != nil {
-			return nil, fmt.Errorf("error marshalling object for cluster resource set: %v", err)
+			return nil, fmt.Errorf("marshalling object for cluster resource set: %v", err)
 		}
 
 		bytes = append(bytes, b)

--- a/pkg/clustermanager/client.go
+++ b/pkg/clustermanager/client.go
@@ -20,7 +20,7 @@ func (c *client) waitForDeployments(ctx context.Context, deploymentsByNamespace 
 		for _, deployment := range deployments {
 			err := c.WaitForDeployment(ctx, cluster, deploymentWaitStr, "Available", deployment, namespace)
 			if err != nil {
-				return fmt.Errorf("error waiting for %s in namespace %s: %v", deployment, namespace, err)
+				return fmt.Errorf("waiting for %s in namespace %s: %v", deployment, namespace, err)
 			}
 		}
 	}

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -152,7 +152,7 @@ func (c *ClusterManager) MoveCAPI(ctx context.Context, from, to *types.Cluster, 
 
 	err := c.clusterClient.MoveManagement(ctx, from, to)
 	if err != nil {
-		return fmt.Errorf("error moving CAPI management from source to target: %v", err)
+		return fmt.Errorf("moving CAPI management from source to target: %v", err)
 	}
 
 	logger.V(3).Info("Waiting for control planes to be ready after move")
@@ -164,13 +164,13 @@ func (c *ClusterManager) MoveCAPI(ctx context.Context, from, to *types.Cluster, 
 	logger.V(3).Info("Waiting for workload cluster control plane replicas to be ready after move")
 	err = c.waitForControlPlaneReplicasReady(ctx, to, clusterSpec)
 	if err != nil {
-		return fmt.Errorf("error waiting for workload cluster control plane replicas to be ready: %v", err)
+		return fmt.Errorf("waiting for workload cluster control plane replicas to be ready: %v", err)
 	}
 
 	logger.V(3).Info("Waiting for workload cluster machine deployment replicas to be ready after move")
 	err = c.waitForMachineDeploymentReplicasReady(ctx, to, clusterSpec)
 	if err != nil {
-		return fmt.Errorf("error waiting for workload cluster machinedeployment replicas to be ready: %v", err)
+		return fmt.Errorf("waiting for workload cluster machinedeployment replicas to be ready: %v", err)
 	}
 
 	logger.V(3).Info("Waiting for machines to be ready after move")
@@ -184,7 +184,7 @@ func (c *ClusterManager) MoveCAPI(ctx context.Context, from, to *types.Cluster, 
 func (c *ClusterManager) writeCAPISpecFile(clusterName string, content []byte) error {
 	fileName := fmt.Sprintf("%s-eks-a-cluster.yaml", clusterName)
 	if _, err := c.writer.Write(fileName, content); err != nil {
-		return fmt.Errorf("error writing capi spec file: %v", err)
+		return fmt.Errorf("writing capi spec file: %v", err)
 	}
 	return nil
 }
@@ -201,7 +201,7 @@ func (c *ClusterManager) CreateWorkloadCluster(ctx context.Context, managementCl
 
 	cpContent, mdContent, err := provider.GenerateCAPISpecForCreate(ctx, workloadCluster, clusterSpec)
 	if err != nil {
-		return nil, fmt.Errorf("error generating capi spec: %v", err)
+		return nil, fmt.Errorf("generating capi spec: %v", err)
 	}
 
 	content := templater.AppendYamlResources(cpContent, mdContent)
@@ -216,14 +216,14 @@ func (c *ClusterManager) CreateWorkloadCluster(ctx context.Context, managementCl
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error applying capi spec: %v", err)
+		return nil, fmt.Errorf("applying capi spec: %v", err)
 	}
 
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		logger.V(3).Info("Waiting for external etcd to be ready", "cluster", workloadCluster.Name)
 		err = c.clusterClient.WaitForManagedExternalEtcdReady(ctx, managementCluster, etcdWaitStr, workloadCluster.Name)
 		if err != nil {
-			return nil, fmt.Errorf("error waiting for external etcd for workload cluster to be ready: %v", err)
+			return nil, fmt.Errorf("waiting for external etcd for workload cluster to be ready: %v", err)
 		}
 		logger.V(3).Info("External etcd is ready")
 		// the condition external etcd ready if true indicates that all etcd machines are ready and the etcd cluster is ready to accept requests
@@ -240,25 +240,25 @@ func (c *ClusterManager) CreateWorkloadCluster(ctx context.Context, managementCl
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error checking availability of kubeconfig secret: %v", err)
+		return nil, fmt.Errorf("checking availability of kubeconfig secret: %v", err)
 	}
 
 	logger.V(3).Info("Waiting for workload kubeconfig generation", "cluster", workloadCluster.Name)
 	workloadCluster.KubeconfigFile, err = c.generateWorkloadKubeconfig(ctx, workloadCluster.Name, managementCluster, provider)
 	if err != nil {
-		return nil, fmt.Errorf("error generating workload kubeconfig: %v", err)
+		return nil, fmt.Errorf("generating workload kubeconfig: %v", err)
 	}
 
 	logger.V(3).Info("Run post control plane creation operations")
 	err = provider.RunPostControlPlaneCreation(ctx, clusterSpec, workloadCluster)
 	if err != nil {
-		return nil, fmt.Errorf("error running post control plane creation operations: %v", err)
+		return nil, fmt.Errorf("running post control plane creation operations: %v", err)
 	}
 
 	logger.V(3).Info("Waiting for control plane to be ready")
 	err = c.clusterClient.WaitForControlPlaneReady(ctx, managementCluster, ctrlPlaneWaitStr, workloadCluster.Name)
 	if err != nil {
-		return nil, fmt.Errorf("error waiting for workload cluster control plane to be ready: %v", err)
+		return nil, fmt.Errorf("waiting for workload cluster control plane to be ready: %v", err)
 	}
 
 	logger.V(3).Info("Waiting for controlplane and worker machines to be ready")
@@ -269,7 +269,7 @@ func (c *ClusterManager) CreateWorkloadCluster(ctx context.Context, managementCl
 
 	err = cluster.ApplyExtraObjects(ctx, c.clusterClient, workloadCluster, clusterSpec)
 	if err != nil {
-		return nil, fmt.Errorf("error applying extra resources to workload cluster: %v", err)
+		return nil, fmt.Errorf("applying extra resources to workload cluster: %v", err)
 	}
 
 	return workloadCluster, nil
@@ -279,7 +279,7 @@ func (c *ClusterManager) generateWorkloadKubeconfig(ctx context.Context, cluster
 	fileName := fmt.Sprintf("%s-eks-a-cluster.kubeconfig", clusterName)
 	kubeconfig, err := c.clusterClient.GetWorkloadKubeconfig(ctx, clusterName, cluster)
 	if err != nil {
-		return "", fmt.Errorf("error getting workload kubeconfig: %v", err)
+		return "", fmt.Errorf("getting workload kubeconfig: %v", err)
 	}
 	if err := provider.UpdateKubeConfig(&kubeconfig, clusterName); err != nil {
 		return "", err
@@ -287,7 +287,7 @@ func (c *ClusterManager) generateWorkloadKubeconfig(ctx context.Context, cluster
 
 	writtenFile, err := c.writer.Write(fileName, kubeconfig, filewriter.PersistentFile, filewriter.Permission0600)
 	if err != nil {
-		return "", fmt.Errorf("error writing workload kubeconfig: %v", err)
+		return "", fmt.Errorf("writing workload kubeconfig: %v", err)
 	}
 	return writtenFile, nil
 }
@@ -334,12 +334,12 @@ func (c *ClusterManager) DeleteCluster(ctx context.Context, managementCluster, c
 func (c *ClusterManager) UpgradeCluster(ctx context.Context, managementCluster, workloadCluster *types.Cluster, newClusterSpec *cluster.Spec, provider providers.Provider) error {
 	currentSpec, err := c.GetCurrentClusterSpec(ctx, workloadCluster, newClusterSpec.Cluster.Name)
 	if err != nil {
-		return fmt.Errorf("error getting current cluster spec: %v", err)
+		return fmt.Errorf("getting current cluster spec: %v", err)
 	}
 
 	cpContent, mdContent, err := provider.GenerateCAPISpecForUpgrade(ctx, managementCluster, workloadCluster, currentSpec, newClusterSpec)
 	if err != nil {
-		return fmt.Errorf("error generating capi spec: %v", err)
+		return fmt.Errorf("generating capi spec: %v", err)
 	}
 
 	if err = c.writeCAPISpecFile(newClusterSpec.Cluster.Name, templater.AppendYamlResources(cpContent, mdContent)); err != nil {
@@ -352,14 +352,14 @@ func (c *ClusterManager) UpgradeCluster(ctx context.Context, managementCluster, 
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error applying capi control plane spec: %v", err)
+		return fmt.Errorf("applying capi control plane spec: %v", err)
 	}
 
 	var externalEtcdTopology bool
 	if newClusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		logger.V(3).Info("Waiting for external etcd to be ready after upgrade")
 		if err := c.clusterClient.WaitForManagedExternalEtcdReady(ctx, managementCluster, etcdWaitStr, newClusterSpec.Cluster.Name); err != nil {
-			return fmt.Errorf("error waiting for external etcd for workload cluster to be ready: %v", err)
+			return fmt.Errorf("waiting for external etcd for workload cluster to be ready: %v", err)
 		}
 		externalEtcdTopology = true
 		logger.V(3).Info("External etcd is ready")
@@ -368,13 +368,13 @@ func (c *ClusterManager) UpgradeCluster(ctx context.Context, managementCluster, 
 	logger.V(3).Info("Run post control plane upgrade operations")
 	err = provider.RunPostControlPlaneUpgrade(ctx, currentSpec, newClusterSpec, workloadCluster, managementCluster)
 	if err != nil {
-		return fmt.Errorf("error running post control plane upgrade operations: %v", err)
+		return fmt.Errorf("running post control plane upgrade operations: %v", err)
 	}
 
 	logger.V(3).Info("Waiting for control plane to be ready")
 	err = c.clusterClient.WaitForControlPlaneReady(ctx, managementCluster, ctrlPlaneWaitStr, newClusterSpec.Cluster.Name)
 	if err != nil {
-		return fmt.Errorf("error waiting for workload cluster control plane to be ready: %v", err)
+		return fmt.Errorf("waiting for workload cluster control plane to be ready: %v", err)
 	}
 
 	logger.V(3).Info("Waiting for control plane machines to be ready")
@@ -385,13 +385,13 @@ func (c *ClusterManager) UpgradeCluster(ctx context.Context, managementCluster, 
 	logger.V(3).Info("Waiting for control plane to be ready after upgrade")
 	err = c.clusterClient.WaitForControlPlaneReady(ctx, managementCluster, ctrlPlaneWaitStr, newClusterSpec.Cluster.Name)
 	if err != nil {
-		return fmt.Errorf("error waiting for workload cluster control plane to be ready: %v", err)
+		return fmt.Errorf("waiting for workload cluster control plane to be ready: %v", err)
 	}
 
 	logger.V(3).Info("Waiting for workload cluster control plane replicas to be ready after upgrade")
 	err = c.waitForControlPlaneReplicasReady(ctx, managementCluster, newClusterSpec)
 	if err != nil {
-		return fmt.Errorf("error waiting for workload cluster control plane replicas to be ready: %v", err)
+		return fmt.Errorf("waiting for workload cluster control plane replicas to be ready: %v", err)
 	}
 
 	err = c.Retrier.Retry(
@@ -400,17 +400,17 @@ func (c *ClusterManager) UpgradeCluster(ctx context.Context, managementCluster, 
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error applying capi machine deployment spec: %v", err)
+		return fmt.Errorf("applying capi machine deployment spec: %v", err)
 	}
 
 	if err = c.removeOldWorkerNodeGroups(ctx, managementCluster, provider, currentSpec, newClusterSpec); err != nil {
-		return fmt.Errorf("error removing old worker node groups: %v", err)
+		return fmt.Errorf("removing old worker node groups: %v", err)
 	}
 
 	logger.V(3).Info("Waiting for workload cluster machine deployment replicas to be ready after upgrade")
 	err = c.waitForMachineDeploymentReplicasReady(ctx, managementCluster, newClusterSpec)
 	if err != nil {
-		return fmt.Errorf("error waiting for workload cluster machinedeployment replicas to be ready: %v", err)
+		return fmt.Errorf("waiting for workload cluster machinedeployment replicas to be ready: %v", err)
 	}
 
 	logger.V(3).Info("Waiting for machine deployment machines to be ready")
@@ -421,11 +421,11 @@ func (c *ClusterManager) UpgradeCluster(ctx context.Context, managementCluster, 
 	logger.V(3).Info("Waiting for workload cluster capi components to be ready after upgrade")
 	err = c.waitForCAPI(ctx, workloadCluster, provider, externalEtcdTopology)
 	if err != nil {
-		return fmt.Errorf("error waiting for workload cluster capi components to be ready: %v", err)
+		return fmt.Errorf("waiting for workload cluster capi components to be ready: %v", err)
 	}
 
 	if err = cluster.ApplyExtraObjects(ctx, c.clusterClient, workloadCluster, newClusterSpec); err != nil {
-		return fmt.Errorf("error applying extra resources to workload cluster: %v", err)
+		return fmt.Errorf("applying extra resources to workload cluster: %v", err)
 	}
 
 	return nil
@@ -521,7 +521,7 @@ func (c *ClusterManager) EKSAClusterSpecChanged(ctx context.Context, cluster *ty
 func (c *ClusterManager) InstallCAPI(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error {
 	err := c.clusterClient.InitInfrastructure(ctx, clusterSpec, cluster, provider)
 	if err != nil {
-		return fmt.Errorf("error initializing capi resources in cluster: %v", err)
+		return fmt.Errorf("initializing capi resources in cluster: %v", err)
 	}
 
 	return c.waitForCAPI(ctx, cluster, provider, clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil)
@@ -552,7 +552,7 @@ func (c *ClusterManager) InstallNetworking(ctx context.Context, cluster *types.C
 	providerNamespaces := getProviderNamespaces(provider.GetDeployments())
 	networkingManifestContent, err := c.networking.GenerateManifest(ctx, clusterSpec, providerNamespaces)
 	if err != nil {
-		return fmt.Errorf("error generating networking manifest: %v", err)
+		return fmt.Errorf("generating networking manifest: %v", err)
 	}
 	err = c.Retrier.Retry(
 		func() error {
@@ -560,7 +560,7 @@ func (c *ClusterManager) InstallNetworking(ctx context.Context, cluster *types.C
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error applying networking manifest spec: %v", err)
+		return fmt.Errorf("applying networking manifest spec: %v", err)
 	}
 	return nil
 }
@@ -590,7 +590,7 @@ func (c *ClusterManager) InstallStorageClass(ctx context.Context, cluster *types
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error applying storage class manifest: %v", err)
+		return fmt.Errorf("applying storage class manifest: %v", err)
 	}
 	return nil
 }
@@ -610,7 +610,7 @@ func (c *ClusterManager) InstallMachineHealthChecks(ctx context.Context, workloa
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error applying machine health checks: %v", err)
+		return fmt.Errorf("applying machine health checks: %v", err)
 	}
 	return nil
 }
@@ -620,7 +620,7 @@ func (c *ClusterManager) InstallMachineHealthChecks(ctx context.Context, workloa
 func (c *ClusterManager) InstallAwsIamAuth(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	awsIamAuthManifest, err := c.awsIamAuth.GenerateManifest(clusterSpec)
 	if err != nil {
-		return fmt.Errorf("error generating aws-iam-authenticator manifest: %v", err)
+		return fmt.Errorf("generating aws-iam-authenticator manifest: %v", err)
 	}
 	err = c.Retrier.Retry(
 		func() error {
@@ -628,7 +628,7 @@ func (c *ClusterManager) InstallAwsIamAuth(ctx context.Context, managementCluste
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error applying aws-iam-authenticator manifest: %v", err)
+		return fmt.Errorf("applying aws-iam-authenticator manifest: %v", err)
 	}
 	err = c.generateAwsIamAuthKubeconfig(ctx, managementCluster, workloadCluster, clusterSpec)
 	if err != nil {
@@ -640,7 +640,7 @@ func (c *ClusterManager) InstallAwsIamAuth(ctx context.Context, managementCluste
 func (c *ClusterManager) CreateAwsIamAuthCaSecret(ctx context.Context, cluster *types.Cluster) error {
 	awsIamAuthCaSecret, err := c.awsIamAuth.GenerateCertKeyPairSecret()
 	if err != nil {
-		return fmt.Errorf("error generating aws-iam-authenticator ca secret: %v", err)
+		return fmt.Errorf("generating aws-iam-authenticator ca secret: %v", err)
 	}
 	err = c.Retrier.Retry(
 		func() error {
@@ -648,7 +648,7 @@ func (c *ClusterManager) CreateAwsIamAuthCaSecret(ctx context.Context, cluster *
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error applying aws-iam-authenticator ca secret: %v", err)
+		return fmt.Errorf("applying aws-iam-authenticator ca secret: %v", err)
 	}
 	return nil
 }
@@ -657,19 +657,19 @@ func (c *ClusterManager) generateAwsIamAuthKubeconfig(ctx context.Context, manag
 	fileName := fmt.Sprintf("%s-aws.kubeconfig", workloadCluster.Name)
 	serverUrl, err := c.clusterClient.GetApiServerUrl(ctx, workloadCluster)
 	if err != nil {
-		return fmt.Errorf("error generating aws-iam-authenticator kubeconfig: %v", err)
+		return fmt.Errorf("generating aws-iam-authenticator kubeconfig: %v", err)
 	}
 	tlsCert, err := c.clusterClient.GetClusterCATlsCert(ctx, workloadCluster.Name, managementCluster, constants.EksaSystemNamespace)
 	if err != nil {
-		return fmt.Errorf("error generating aws-iam-authenticator kubeconfig: %v", err)
+		return fmt.Errorf("generating aws-iam-authenticator kubeconfig: %v", err)
 	}
 	awsIamAuthKubeconfigContent, err := c.awsIamAuth.GenerateAwsIamAuthKubeconfig(clusterSpec, serverUrl, string(tlsCert))
 	if err != nil {
-		return fmt.Errorf("error generating aws-iam-authenticator kubeconfig: %v", err)
+		return fmt.Errorf("generating aws-iam-authenticator kubeconfig: %v", err)
 	}
 	writtenFile, err := c.writer.Write(fileName, awsIamAuthKubeconfigContent, filewriter.PersistentFile, filewriter.Permission0600)
 	if err != nil {
-		return fmt.Errorf("error writing aws-iam-authenticator kubeconfig to %s: %v", writtenFile, err)
+		return fmt.Errorf("writing aws-iam-authenticator kubeconfig to %s: %v", writtenFile, err)
 	}
 	logger.V(3).Info("Generated aws-iam-authenticator kubeconfig", "kubeconfig", writtenFile)
 	return nil
@@ -818,7 +818,7 @@ func (c *ClusterManager) waitForNodesReady(ctx context.Context, managementCluste
 func (c *ClusterManager) countNodesReady(ctx context.Context, managementCluster *types.Cluster, clusterName string, labels []string, checkers ...types.NodeReadyChecker) (ready, total int, err error) {
 	machines, err := c.clusterClient.GetMachines(ctx, managementCluster, clusterName)
 	if err != nil {
-		return 0, 0, fmt.Errorf("error getting machines resources from management cluster: %v", err)
+		return 0, 0, fmt.Errorf("getting machines resources from management cluster: %v", err)
 	}
 
 	for _, m := range machines {
@@ -847,13 +847,13 @@ func (c *ClusterManager) countNodesReady(ctx context.Context, managementCluster 
 func (c *ClusterManager) waitForAllControlPlanes(ctx context.Context, cluster *types.Cluster, waitForCluster time.Duration) error {
 	clusters, err := c.clusterClient.GetClusters(ctx, cluster)
 	if err != nil {
-		return fmt.Errorf("error getting clusters: %v", err)
+		return fmt.Errorf("getting clusters: %v", err)
 	}
 
 	for _, clu := range clusters {
 		err = c.clusterClient.WaitForControlPlaneReady(ctx, cluster, waitForCluster.String(), clu.Metadata.Name)
 		if err != nil {
-			return fmt.Errorf("error waiting for workload cluster control plane for cluster %s to be ready: %v", clu.Metadata.Name, err)
+			return fmt.Errorf("waiting for workload cluster control plane for cluster %s to be ready: %v", clu.Metadata.Name, err)
 		}
 	}
 
@@ -865,10 +865,10 @@ func (c *ClusterManager) removeOldWorkerNodeGroups(ctx context.Context, workload
 	for _, machineDeploymentName := range machineDeployments {
 		machineDeployment, err := c.clusterClient.GetMachineDeployment(ctx, machineDeploymentName, executables.WithKubeconfig(workloadCluster.KubeconfigFile), executables.WithNamespace(constants.EksaSystemNamespace))
 		if err != nil {
-			return fmt.Errorf("error getting machine deployment to remove: %v", err)
+			return fmt.Errorf("getting machine deployment to remove: %v", err)
 		}
 		if err := c.clusterClient.DeleteOldWorkerNodeGroup(ctx, machineDeployment, workloadCluster.KubeconfigFile); err != nil {
-			return fmt.Errorf("error removing old worker nodes from cluster: %v", err)
+			return fmt.Errorf("removing old worker nodes from cluster: %v", err)
 		}
 	}
 
@@ -912,7 +912,7 @@ func (c *ClusterManager) ApplyBundles(ctx context.Context, clusterSpec *cluster.
 	clusterSpec.Bundles.Namespace = clusterSpec.Cluster.Namespace
 	bundleObj, err := yaml.Marshal(clusterSpec.Bundles)
 	if err != nil {
-		return fmt.Errorf("error outputting bundle yaml: %v", err)
+		return fmt.Errorf("outputting bundle yaml: %v", err)
 	}
 	logger.V(1).Info("Applying Bundles to cluster")
 	err = c.Retrier.Retry(
@@ -921,7 +921,7 @@ func (c *ClusterManager) ApplyBundles(ctx context.Context, clusterSpec *cluster.
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error applying bundle spec: %v", err)
+		return fmt.Errorf("applying bundle spec: %v", err)
 	}
 	return nil
 }
@@ -934,7 +934,7 @@ func (c *ClusterManager) PauseEKSAControllerReconcile(ctx context.Context, clust
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error updating annotation when pausing datacenterconfig reconciliation: %v", err)
+		return fmt.Errorf("updating annotation when pausing datacenterconfig reconciliation: %v", err)
 	}
 	if provider.MachineResourceType() != "" {
 		for _, machineConfigRef := range clusterSpec.Cluster.MachineConfigRefs() {
@@ -944,7 +944,7 @@ func (c *ClusterManager) PauseEKSAControllerReconcile(ctx context.Context, clust
 				},
 			)
 			if err != nil {
-				return fmt.Errorf("error updating annotation when pausing reconciliation for machine config %s: %v", machineConfigRef.Name, err)
+				return fmt.Errorf("updating annotation when pausing reconciliation for machine config %s: %v", machineConfigRef.Name, err)
 			}
 		}
 	}
@@ -955,7 +955,7 @@ func (c *ClusterManager) PauseEKSAControllerReconcile(ctx context.Context, clust
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error updating annotation when pausing cluster reconciliation: %v", err)
+		return fmt.Errorf("updating annotation when pausing cluster reconciliation: %v", err)
 	}
 	return nil
 }
@@ -968,7 +968,7 @@ func (c *ClusterManager) ResumeEKSAControllerReconcile(ctx context.Context, clus
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error updating annotation when unpausing datacenterconfig reconciliation: %v", err)
+		return fmt.Errorf("updating annotation when unpausing datacenterconfig reconciliation: %v", err)
 	}
 	if provider.MachineResourceType() != "" {
 		for _, machineConfigRef := range clusterSpec.Cluster.MachineConfigRefs() {
@@ -978,7 +978,7 @@ func (c *ClusterManager) ResumeEKSAControllerReconcile(ctx context.Context, clus
 				},
 			)
 			if err != nil {
-				return fmt.Errorf("error updating annotation when resuming reconciliation for machine config %s: %v", machineConfigRef.Name, err)
+				return fmt.Errorf("updating annotation when resuming reconciliation for machine config %s: %v", machineConfigRef.Name, err)
 			}
 		}
 	}
@@ -989,7 +989,7 @@ func (c *ClusterManager) ResumeEKSAControllerReconcile(ctx context.Context, clus
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error updating annotation when unpausing cluster reconciliation: %v", err)
+		return fmt.Errorf("updating annotation when unpausing cluster reconciliation: %v", err)
 	}
 	// clear pause annotation
 	clusterSpec.Cluster.ClearPauseAnnotation()
@@ -1004,7 +1004,7 @@ func (c *ClusterManager) applyResource(ctx context.Context, cluster *types.Clust
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error applying eks-a spec: %v", err)
+		return fmt.Errorf("applying eks-a spec: %v", err)
 	}
 	return nil
 }

--- a/pkg/clustermanager/retrier_client.go
+++ b/pkg/clustermanager/retrier_client.go
@@ -35,7 +35,7 @@ func (c *retrierClient) installEksdComponents(ctx context.Context, clusterSpec *
 			return c.ApplyKubeSpecFromBytesWithNamespace(ctx, cluster, eksdComponents.ReleaseCrdContent, constants.EksaSystemNamespace)
 		},
 	); err != nil {
-		return fmt.Errorf("error applying eksd release crd: %v", err)
+		return fmt.Errorf("applying eksd release crd: %v", err)
 	}
 
 	if err = c.Retry(
@@ -43,7 +43,7 @@ func (c *retrierClient) installEksdComponents(ctx context.Context, clusterSpec *
 			return c.ApplyKubeSpecFromBytesWithNamespace(ctx, cluster, eksdComponents.ReleaseManifestContent, constants.EksaSystemNamespace)
 		},
 	); err != nil {
-		return fmt.Errorf("error applying eksd release manifest: %v", err)
+		return fmt.Errorf("applying eksd release manifest: %v", err)
 	}
 
 	return nil
@@ -61,7 +61,7 @@ func (c *retrierClient) installCustomComponents(ctx context.Context, clusterSpec
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error applying eks-a components spec: %v", err)
+		return fmt.Errorf("applying eks-a components spec: %v", err)
 	}
 
 	// inject proxy env vars the eksa-controller-manager deployment if proxy is configured
@@ -79,7 +79,7 @@ func (c *retrierClient) installCustomComponents(ctx context.Context, clusterSpec
 			},
 		)
 		if err != nil {
-			return fmt.Errorf("error applying eks-a components spec: %v", err)
+			return fmt.Errorf("applying eks-a components spec: %v", err)
 		}
 	}
 	return c.waitForDeployments(ctx, internal.EksaDeployments, cluster)

--- a/pkg/clustermarshaller/clustermarshaller.go
+++ b/pkg/clustermarshaller/clustermarshaller.go
@@ -50,7 +50,7 @@ func MarshalClusterSpec(clusterSpec *cluster.Spec, datacenterConfig providers.Da
 			removeFromDefaultConfig := []string{"spec.clusterNetwork.dns"}
 			resource, err = api.CleanupPathsFromYaml(resource, removeFromDefaultConfig)
 			if err != nil {
-				return nil, fmt.Errorf("error cleaning paths from yaml: %v", err)
+				return nil, fmt.Errorf("cleaning paths from yaml: %v", err)
 			}
 		}
 		resources = append(resources, resource)
@@ -64,7 +64,7 @@ func WriteClusterConfig(clusterSpec *cluster.Spec, datacenterConfig providers.Da
 		return err
 	}
 	if filePath, err := writer.Write(fmt.Sprintf("%s-eks-a-cluster.yaml", clusterSpec.Cluster.ObjectMeta.Name), resourcesSpec, filewriter.PersistentFile); err != nil {
-		err = fmt.Errorf("error writing eks-a cluster config file into %s: %v", filePath, err)
+		err = fmt.Errorf("writing eks-a cluster config file into %s: %v", filePath, err)
 		return err
 	}
 

--- a/pkg/diagnostics/diagnostic_bundle.go
+++ b/pkg/diagnostics/diagnostic_bundle.go
@@ -73,7 +73,7 @@ func newDiagnosticBundleManagementCluster(af AnalyzerFactory, cf CollectorFactor
 
 	err := b.WriteBundleConfig()
 	if err != nil {
-		return nil, fmt.Errorf("error writing bundle config: %v", err)
+		return nil, fmt.Errorf("writing bundle config: %v", err)
 	}
 
 	return b, nil
@@ -116,7 +116,7 @@ func newDiagnosticBundleFromSpec(af AnalyzerFactory, cf CollectorFactory, spec *
 
 	err := b.WriteBundleConfig()
 	if err != nil {
-		return nil, fmt.Errorf("error writing bundle config: %v", err)
+		return nil, fmt.Errorf("writing bundle config: %v", err)
 	}
 
 	return b, nil
@@ -167,7 +167,7 @@ func (e *EksaDiagnosticBundle) CollectAndAnalyze(ctx context.Context, sinceTimeV
 	logger.Info("Analyzing support bundle", "bundle", e.bundlePath, "archive", archivePath)
 	analysis, err := e.client.Analyze(ctx, e.bundlePath, archivePath)
 	if err != nil {
-		return fmt.Errorf("error when analyzing bundle: %v", err)
+		return fmt.Errorf("analyzing bundle: %v", err)
 	}
 	e.analysis = analysis
 
@@ -184,7 +184,7 @@ func (e *EksaDiagnosticBundle) CollectAndAnalyze(ctx context.Context, sinceTimeV
 func (e *EksaDiagnosticBundle) PrintBundleConfig() error {
 	bundleYaml, err := yaml.Marshal(e.bundle)
 	if err != nil {
-		return fmt.Errorf("error outputting yaml: %v", err)
+		return fmt.Errorf("outputting yaml: %v", err)
 	}
 	fmt.Println(string(bundleYaml))
 	return nil
@@ -193,7 +193,7 @@ func (e *EksaDiagnosticBundle) PrintBundleConfig() error {
 func (e *EksaDiagnosticBundle) WriteBundleConfig() error {
 	bundleYaml, err := yaml.Marshal(e.bundle)
 	if err != nil {
-		return fmt.Errorf("error outputing yaml: %v", err)
+		return fmt.Errorf("outputing yaml: %v", err)
 	}
 	timestamp := time.Now().Format(time.RFC3339)
 	filename := fmt.Sprintf(generatedBundleNameFormat, e.clusterName(), timestamp)
@@ -211,7 +211,7 @@ func (e *EksaDiagnosticBundle) PrintAnalysis() error {
 	}
 	analysis, err := yaml.Marshal(e.analysis)
 	if err != nil {
-		return fmt.Errorf("error outputing yaml: %v", err)
+		return fmt.Errorf("outputing yaml: %v", err)
 	}
 	fmt.Println(string(analysis))
 	return nil
@@ -224,7 +224,7 @@ func (e *EksaDiagnosticBundle) WriteAnalysisToFile() (path string, err error) {
 
 	yamlAnalysis, err := yaml.Marshal(e.analysis)
 	if err != nil {
-		return "", fmt.Errorf("error while writing analysis: %v", err)
+		return "", fmt.Errorf("writing analysis: %v", err)
 	}
 
 	timestamp := time.Now().Format(time.RFC3339)

--- a/pkg/executables/awscli.go
+++ b/pkg/executables/awscli.go
@@ -20,7 +20,7 @@ func NewAwsCli(executable Executable) *AwsCli {
 func (ac *AwsCli) CreateAccessKey(ctx context.Context, username string) (string, error) {
 	stdOut, err := ac.Execute(ctx, "iam", "create-access-key", "--user-name", username)
 	if err != nil {
-		return "", fmt.Errorf("error executing iam create-access-key: %v", err)
+		return "", fmt.Errorf("executing iam create-access-key: %v", err)
 	}
 	return stdOut.String(), nil
 }

--- a/pkg/executables/builder.go
+++ b/pkg/executables/builder.go
@@ -101,7 +101,7 @@ func checkMRToolsDisabled() bool {
 func NewExecutableBuilder(ctx context.Context, image string, mountDirs ...string) (*ExecutableBuilder, Closer, error) {
 	currentDir, err := os.Getwd()
 	if err != nil {
-		return nil, nil, fmt.Errorf("error getting current directory: %v", err)
+		return nil, nil, fmt.Errorf("getting current directory: %v", err)
 	}
 
 	mountDirs = append(mountDirs, currentDir)

--- a/pkg/executables/clusterawsadm.go
+++ b/pkg/executables/clusterawsadm.go
@@ -22,7 +22,7 @@ func (c *Clusterawsadm) BootstrapIam(ctx context.Context, envs map[string]string
 	_, err := c.ExecuteWithEnv(ctx, envs, "bootstrap", "iam", "create-cloudformation-stack",
 		"--config", configFile)
 	if err != nil {
-		return fmt.Errorf("error executing bootstrap iam: %v", err)
+		return fmt.Errorf("executing bootstrap iam: %v", err)
 	}
 	return err
 }
@@ -30,7 +30,7 @@ func (c *Clusterawsadm) BootstrapIam(ctx context.Context, envs map[string]string
 func (c *Clusterawsadm) BootstrapCreds(ctx context.Context, envs map[string]string) (string, error) {
 	stdOut, err := c.ExecuteWithEnv(ctx, envs, "bootstrap", "credentials", "encode-as-profile")
 	if err != nil {
-		return "", fmt.Errorf("error executing bootstrap credentials: %v", err)
+		return "", fmt.Errorf("executing bootstrap credentials: %v", err)
 	}
 	return stdOut.String(), nil
 }
@@ -38,7 +38,7 @@ func (c *Clusterawsadm) BootstrapCreds(ctx context.Context, envs map[string]stri
 func (c *Clusterawsadm) ListAccessKeys(ctx context.Context, userName string) (string, error) {
 	stdOut, err := c.Execute(ctx, "aws", "iam", "list-access-keys", "--user-name", userName)
 	if err != nil {
-		return "", fmt.Errorf("error listing user keys: %v", err)
+		return "", fmt.Errorf("listing user keys: %v", err)
 	}
 	return stdOut.String(), nil
 }

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -142,7 +142,7 @@ func writeInfrastructureBundle(clusterSpec *cluster.Spec, rootFolder string, bun
 		}
 
 		if err := ioutil.WriteFile(filepath.Join(infraFolder, m.Filename), m.Content, 0o644); err != nil {
-			return fmt.Errorf("error generating file for infrastructure bundle %s: %v", m.Filename, err)
+			return fmt.Errorf("generating file for infrastructure bundle %s: %v", m.Filename, err)
 		}
 	}
 
@@ -168,7 +168,7 @@ func (c *Clusterctl) GetWorkloadKubeconfig(ctx context.Context, clusterName stri
 		"--namespace", constants.EksaSystemNamespace,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error executing get kubeconfig: %v", err)
+		return nil, fmt.Errorf("executing get kubeconfig: %v", err)
 	}
 	return stdOut.Bytes(), nil
 }
@@ -207,7 +207,7 @@ func (c *Clusterctl) InitInfrastructure(ctx context.Context, clusterSpec *cluste
 
 	_, err = c.ExecuteWithEnv(ctx, envMap, params...)
 	if err != nil {
-		return fmt.Errorf("error executing init: %v", err)
+		return fmt.Errorf("executing init: %v", err)
 	}
 
 	return nil
@@ -286,7 +286,7 @@ func (c *Clusterctl) buildConfig(clusterSpec *cluster.Spec, clusterName string, 
 
 	filePath, err := t.WriteToFile(clusterctlConfigTemplate, data, clusterctlConfigFile)
 	if err != nil {
-		return nil, fmt.Errorf("error generating configuration file for clusterctl: %v", err)
+		return nil, fmt.Errorf("generating configuration file for clusterctl: %v", err)
 	}
 	if err := buildOverridesLayer(clusterSpec, clusterName, provider); err != nil {
 		return nil, err
@@ -393,7 +393,7 @@ func (c *Clusterctl) InstallEtcdadmProviders(ctx context.Context, clusterSpec *c
 
 	_, err = c.ExecuteWithEnv(ctx, envMap, params...)
 	if err != nil {
-		return fmt.Errorf("error executing init: %v", err)
+		return fmt.Errorf("executing init: %v", err)
 	}
 
 	return nil

--- a/pkg/executables/cmk.go
+++ b/pkg/executables/cmk.go
@@ -60,7 +60,7 @@ func (c *Cmk) ValidateTemplatePresent(ctx context.Context, domainId string, zone
 	}
 	result, err := c.exec(ctx, command...)
 	if err != nil {
-		return fmt.Errorf("error getting templates info - %s: %v", result.String(), err)
+		return fmt.Errorf("getting templates info - %s: %v", result.String(), err)
 	}
 	if result.Len() == 0 {
 		return fmt.Errorf("template %s not found", template)
@@ -91,7 +91,7 @@ func (c *Cmk) ValidateServiceOfferingPresent(ctx context.Context, zoneId string,
 	applyCmkArgs(&command, withCloudStackZoneId(zoneId))
 	result, err := c.exec(ctx, command...)
 	if err != nil {
-		return fmt.Errorf("error getting service offerings info - %s: %v", result.String(), err)
+		return fmt.Errorf("getting service offerings info - %s: %v", result.String(), err)
 	}
 	if result.Len() == 0 {
 		return fmt.Errorf("service offering %s not found", serviceOffering)
@@ -128,7 +128,7 @@ func (c *Cmk) ValidateAffinityGroupsPresent(ctx context.Context, domainId string
 
 		result, err := c.exec(ctx, command...)
 		if err != nil {
-			return fmt.Errorf("error getting affinity group info - %s: %v", result.String(), err)
+			return fmt.Errorf("getting affinity group info - %s: %v", result.String(), err)
 		}
 		if result.Len() == 0 {
 			return fmt.Errorf(fmt.Sprintf("affinity group %s not found", affinityGroupId))
@@ -161,7 +161,7 @@ func (c *Cmk) ValidateZonesPresent(ctx context.Context, zones []v1alpha1.CloudSt
 		}
 		result, err := c.exec(ctx, command...)
 		if err != nil {
-			return nil, fmt.Errorf("error getting zones info - %s: %v", result.String(), err)
+			return nil, fmt.Errorf("getting zones info - %s: %v", result.String(), err)
 		}
 		if result.Len() == 0 {
 			return nil, fmt.Errorf("zone %s not found", zone)
@@ -191,7 +191,7 @@ func (c *Cmk) ValidateDomainPresent(ctx context.Context, domain string) (v1alpha
 	applyCmkArgs(&command, withCloudStackName(domain))
 	result, err := c.exec(ctx, command...)
 	if err != nil {
-		return domainIdentifier, fmt.Errorf("error getting domain info - %s: %v", result.String(), err)
+		return domainIdentifier, fmt.Errorf("getting domain info - %s: %v", result.String(), err)
 	}
 	if result.Len() == 0 {
 		return domainIdentifier, fmt.Errorf("domain %s not found", domain)
@@ -239,13 +239,13 @@ func (c *Cmk) ValidateNetworkPresent(ctx context.Context, domainId string, zone 
 	} else {
 		zoneId, err = getZoneIdByName(zones, zone.Name)
 		if err != nil {
-			return fmt.Errorf("error getting zone id by name %s: %v", zone.Name, err)
+			return fmt.Errorf("getting zone id by name %s: %v", zone.Name, err)
 		}
 	}
 	applyCmkArgs(&command, withCloudStackZoneId(zoneId))
 	result, err := c.exec(ctx, command...)
 	if err != nil {
-		return fmt.Errorf("error getting network info - %s: %v", result.String(), err)
+		return fmt.Errorf("getting network info - %s: %v", result.String(), err)
 	}
 	if result.Len() == 0 {
 		if multipleZone {
@@ -302,7 +302,7 @@ func (c *Cmk) ValidateAccountPresent(ctx context.Context, account string, domain
 	applyCmkArgs(&command, withCloudStackName(account), withCloudStackDomainId(domainId))
 	result, err := c.exec(ctx, command...)
 	if err != nil {
-		return fmt.Errorf("error getting accounts info - %s: %v", result.String(), err)
+		return fmt.Errorf("getting accounts info - %s: %v", result.String(), err)
 	}
 	if result.Len() == 0 {
 		return fmt.Errorf("account %s not found", account)
@@ -336,7 +336,7 @@ func (c *Cmk) ValidateCloudStackConnection(ctx context.Context) error {
 	command := newCmkCommand("sync")
 	buffer, err := c.exec(ctx, command...)
 	if err != nil {
-		return fmt.Errorf("error validating cloudstack connection for cmk config %s: %v", buffer.String(), err)
+		return fmt.Errorf("validating cloudstack connection for cmk config %s: %v", buffer.String(), err)
 	}
 	logger.MarkPass("Connected to CloudStack server")
 	return nil
@@ -365,7 +365,7 @@ func (c *Cmk) buildCmkConfigFile() (configFile string, err error) {
 	}
 	writtenFileName, err := t.WriteToFile(cmkConfigTemplate, cmkConfig, cmkConfigFileName)
 	if err != nil {
-		return "", fmt.Errorf("error creating file for cmk config: %v", err)
+		return "", fmt.Errorf("creating file for cmk config: %v", err)
 	}
 	configFile, err = filepath.Abs(writtenFileName)
 	if err != nil {

--- a/pkg/executables/dockercontainer.go
+++ b/pkg/executables/dockercontainer.go
@@ -40,7 +40,7 @@ func (d *dockerContainer) init(ctx context.Context) error {
 		var absWorkingDir string
 		absWorkingDir, err = filepath.Abs(d.workingDir)
 		if err != nil {
-			err = fmt.Errorf("error getting abs path for mount dir: %v", err)
+			err = fmt.Errorf("getting abs path for mount dir: %v", err)
 			return
 		}
 
@@ -50,7 +50,7 @@ func (d *dockerContainer) init(ctx context.Context) error {
 			var absMountDir string
 			absMountDir, err = filepath.Abs(m)
 			if err != nil {
-				err = fmt.Errorf("error getting abs path for mount dir: %v", err)
+				err = fmt.Errorf("getting abs path for mount dir: %v", err)
 				return
 			}
 			params = append(params, "-v", fmt.Sprintf("%[1]s:%[1]s", absMountDir))

--- a/pkg/executables/flux.go
+++ b/pkg/executables/flux.go
@@ -55,7 +55,7 @@ func (f *Flux) BootstrapToolkitsComponents(ctx context.Context, cluster *types.C
 
 	token, err := github.GetGithubAccessTokenFromEnv()
 	if err != nil {
-		return fmt.Errorf("error setting token env: %v", err)
+		return fmt.Errorf("setting token env: %v", err)
 	}
 
 	env := make(map[string]string)
@@ -63,7 +63,7 @@ func (f *Flux) BootstrapToolkitsComponents(ctx context.Context, cluster *types.C
 
 	_, err = f.ExecuteWithEnv(ctx, env, params...)
 	if err != nil {
-		return fmt.Errorf("error executing flux bootstrap: %v", err)
+		return fmt.Errorf("executing flux bootstrap: %v", err)
 	}
 
 	return err
@@ -84,7 +84,7 @@ func (f *Flux) UninstallToolkitsComponents(ctx context.Context, cluster *types.C
 
 	_, err := f.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error uninstalling flux: %v", err)
+		return fmt.Errorf("uninstalling flux: %v", err)
 	}
 	return err
 }
@@ -92,7 +92,7 @@ func (f *Flux) UninstallToolkitsComponents(ctx context.Context, cluster *types.C
 func (f *Flux) PauseKustomization(ctx context.Context, cluster *types.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) error {
 	c := gitOpsConfig.Spec.Flux.Github
 	if c.FluxSystemNamespace == "" {
-		return fmt.Errorf("error executing flux suspend kustomization: namespace empty")
+		return fmt.Errorf("executing flux suspend kustomization: namespace empty")
 	}
 	params := []string{"suspend", "ks", c.FluxSystemNamespace, "--namespace", c.FluxSystemNamespace}
 
@@ -102,7 +102,7 @@ func (f *Flux) PauseKustomization(ctx context.Context, cluster *types.Cluster, g
 
 	_, err := f.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error executing flux suspend kustomization: %v", err)
+		return fmt.Errorf("executing flux suspend kustomization: %v", err)
 	}
 
 	return err
@@ -111,7 +111,7 @@ func (f *Flux) PauseKustomization(ctx context.Context, cluster *types.Cluster, g
 func (f *Flux) ResumeKustomization(ctx context.Context, cluster *types.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) error {
 	c := gitOpsConfig.Spec.Flux.Github
 	if c.FluxSystemNamespace == "" {
-		return fmt.Errorf("error executing flux resume kustomization: namespace empty")
+		return fmt.Errorf("executing flux resume kustomization: namespace empty")
 	}
 	params := []string{"resume", "ks", c.FluxSystemNamespace, "--namespace", c.FluxSystemNamespace}
 
@@ -121,7 +121,7 @@ func (f *Flux) ResumeKustomization(ctx context.Context, cluster *types.Cluster, 
 
 	_, err := f.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error executing flux resume kustomization: %v", err)
+		return fmt.Errorf("executing flux resume kustomization: %v", err)
 	}
 
 	return err
@@ -142,7 +142,7 @@ func (f *Flux) Reconcile(ctx context.Context, cluster *types.Cluster, gitOpsConf
 	}
 
 	if _, err := f.Execute(ctx, params...); err != nil {
-		return fmt.Errorf("error executing flux reconcile: %v", err)
+		return fmt.Errorf("executing flux reconcile: %v", err)
 	}
 
 	return nil

--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -108,7 +108,7 @@ func (g *Govc) SearchTemplate(ctx context.Context, datacenter string, machineCon
 	params := []string{"find", "-json", "/" + datacenter, "-type", "VirtualMachine", "-name", filepath.Base(machineConfig.Spec.Template)}
 	templateResponse, err := g.exec(ctx, params...)
 	if err != nil {
-		return "", fmt.Errorf("error getting template: %v", err)
+		return "", fmt.Errorf("getting template: %v", err)
 	}
 
 	templateJson := templateResponse.String()
@@ -170,7 +170,7 @@ func (g *Govc) GetLibraryElementContentVersion(ctx context.Context, element stri
 	elementInfo := make([]libElement, 0)
 	err = yaml.Unmarshal([]byte(elementInfoJson), &elementInfo)
 	if err != nil {
-		return "", fmt.Errorf("error unmarshalling library element info: %v", err)
+		return "", fmt.Errorf("unmarshalling library element info: %v", err)
 	}
 
 	if len(elementInfo) == 0 {
@@ -199,13 +199,13 @@ func (g *Govc) ResizeDisk(ctx context.Context, datacenter, template, diskName st
 func (g *Govc) DevicesInfo(ctx context.Context, datacenter, template string) (interface{}, error) {
 	response, err := g.exec(ctx, "device.info", "-dc", datacenter, "-vm", template, "-json")
 	if err != nil {
-		return nil, fmt.Errorf("error getting template device information: %v", err)
+		return nil, fmt.Errorf("getting template device information: %v", err)
 	}
 
 	var devicesInfo map[string]interface{}
 	err = yaml.Unmarshal(response.Bytes(), &devicesInfo)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling devices info: %v", err)
+		return nil, fmt.Errorf("unmarshalling devices info: %v", err)
 	}
 	return devicesInfo["Devices"], nil
 }
@@ -240,7 +240,7 @@ func (g *Govc) GetWorkloadAvailableSpace(ctx context.Context, datastore string) 
 	params := []string{"datastore.info", "-json=true", datastore}
 	result, err := g.ExecuteWithEnv(ctx, envMap, params...)
 	if err != nil {
-		return 0, fmt.Errorf("error getting datastore info: %v", err)
+		return 0, fmt.Errorf("getting datastore info: %v", err)
 	}
 
 	response := &datastoreResponse{}
@@ -253,12 +253,12 @@ func (g *Govc) GetWorkloadAvailableSpace(ctx context.Context, datastore string) 
 		spaceGiB := freeSpace / byteToGiB
 		return spaceGiB, nil
 	}
-	return 0, fmt.Errorf("error getting datastore available space response: %v", err)
+	return 0, fmt.Errorf("getting datastore available space response: %v", err)
 }
 
 func (g *Govc) CreateLibrary(ctx context.Context, datastore, library string) error {
 	if _, err := g.exec(ctx, "library.create", "-ds", datastore, library); err != nil {
-		return fmt.Errorf("error creating library %s: %v", library, err)
+		return fmt.Errorf("creating library %s: %v", library, err)
 	}
 	return nil
 }
@@ -310,7 +310,7 @@ func (g *Govc) DeployTemplateFromLibrary(ctx context.Context, templateDir, templ
 
 		err = g.ResizeDisk(ctx, datacenter, templateName, diskName, diskSizeInGB)
 		if err != nil {
-			return fmt.Errorf("error resizing disk %v to 20G: %v", diskName, err)
+			return fmt.Errorf("resizing disk %v to 20G: %v", diskName, err)
 		}
 	}
 
@@ -332,7 +332,7 @@ func (g *Govc) DeployTemplateFromLibrary(ctx context.Context, templateDir, templ
 func (g *Govc) ImportTemplate(ctx context.Context, library, ovaURL, name string) error {
 	logger.V(4).Info("Importing template", "ova", ovaURL, "templateName", name)
 	if _, err := g.exec(ctx, "library.import", "-k", "-pull", "-n", name, library, ovaURL); err != nil {
-		return fmt.Errorf("error importing template: %v", err)
+		return fmt.Errorf("importing template: %v", err)
 	}
 	return nil
 }
@@ -360,7 +360,7 @@ func (g *Govc) deployTemplate(ctx context.Context, library, templateName, deploy
 		errString := strings.ToLower(errBuffer.String())
 		if err != nil {
 			if !strings.Contains(errString, "not found") {
-				return fmt.Errorf("error obtaining folder information: %v", err)
+				return fmt.Errorf("obtaining folder information: %v", err)
 			} else {
 				bFolderNotFound = true
 			}
@@ -373,12 +373,12 @@ func (g *Govc) deployTemplate(ctx context.Context, library, templateName, deploy
 			errBuffer, err := g.ExecuteWithEnv(ctx, envMap, params...)
 			errString := strings.ToLower(errBuffer.String())
 			if err != nil && !strings.Contains(errString, "already exists") {
-				return fmt.Errorf("error creating folder: %v", err)
+				return fmt.Errorf("creating folder: %v", err)
 			}
 			return nil
 		})
 		if err != nil {
-			return fmt.Errorf("error creating folder: %v", err)
+			return fmt.Errorf("creating folder: %v", err)
 		}
 	}
 
@@ -392,7 +392,7 @@ func (g *Govc) deployTemplate(ctx context.Context, library, templateName, deploy
 		templateInLibraryPath, templateName,
 	}
 	if _, err := g.exec(ctx, params...); err != nil {
-		return fmt.Errorf("error deploying template: %v", err)
+		return fmt.Errorf("deploying template: %v", err)
 	}
 
 	return nil
@@ -421,14 +421,14 @@ func (g *Govc) markAsVM(ctx context.Context, resourcePool, path string) error {
 
 func (g *Govc) removeSnapshotsFromVM(ctx context.Context, path string) error {
 	if _, err := g.exec(ctx, "snapshot.remove", "-vm", path, "*"); err != nil {
-		return fmt.Errorf("error removing snapshots from vm: %v", err)
+		return fmt.Errorf("removing snapshots from vm: %v", err)
 	}
 	return nil
 }
 
 func (g *Govc) deleteVM(ctx context.Context, path string) error {
 	if _, err := g.exec(ctx, "vm.destroy", path); err != nil {
-		return fmt.Errorf("error deleting vm: %v", err)
+		return fmt.Errorf("deleting vm: %v", err)
 	}
 	return nil
 }
@@ -442,7 +442,7 @@ func (g *Govc) createVMSnapshot(ctx context.Context, datacenter, name string) er
 
 func (g *Govc) markVMAsTemplate(ctx context.Context, datacenter, vmName string) error {
 	if _, err := g.exec(ctx, "vm.markastemplate", "-dc", datacenter, vmName); err != nil {
-		return fmt.Errorf("error marking VM as template: %v", err)
+		return fmt.Errorf("marking VM as template: %v", err)
 	}
 	return nil
 }
@@ -511,7 +511,7 @@ func (g *Govc) CleanupVms(ctx context.Context, clusterName string, dryRun bool) 
 	params = strings.Fields("find -type VirtualMachine -name " + clusterName + "*")
 	result, err = g.ExecuteWithEnv(ctx, envMap, params...)
 	if err != nil {
-		return fmt.Errorf("error getting vm list: %v", err)
+		return fmt.Errorf("getting vm list: %v", err)
 	}
 	scanner := bufio.NewScanner(strings.NewReader(result.String()))
 	for scanner.Scan() {
@@ -579,7 +579,7 @@ func (g *Govc) GetCertThumbprint(ctx context.Context) (string, error) {
 func (g *Govc) ConfigureCertThumbprint(ctx context.Context, server, thumbprint string) error {
 	path, err := g.writer.Write(filepath.Base(govcTlsHostsFile), []byte(fmt.Sprintf("%s %s", server, thumbprint)))
 	if err != nil {
-		return fmt.Errorf("error writing to file %s: %v", govcTlsHostsFile, err)
+		return fmt.Errorf("writing to file %s: %v", govcTlsHostsFile, err)
 	}
 
 	if err = os.Setenv(govcTlsKnownHostsKey, path); err != nil {
@@ -704,7 +704,7 @@ func (g *Govc) ValidateVCenterSetupMachineConfig(ctx context.Context, datacenter
 		return err
 	})
 	if err != nil {
-		return fmt.Errorf("error getting resource pool: %v", err)
+		return fmt.Errorf("getting resource pool: %v", err)
 	}
 
 	poolInfoJson := poolInfoResponse.String()
@@ -759,7 +759,7 @@ func (g *Govc) createFolder(ctx context.Context, envMap map[string]string, machi
 	err := g.retrier.Retry(func() error {
 		_, err := g.ExecuteWithEnv(ctx, envMap, params...)
 		if err != nil {
-			return fmt.Errorf("error creating folder: %v", err)
+			return fmt.Errorf("creating folder: %v", err)
 		}
 		return nil
 	})

--- a/pkg/executables/kind.go
+++ b/pkg/executables/kind.go
@@ -84,7 +84,7 @@ func (k *Kind) CreateBootstrapCluster(ctx context.Context, clusterSpec *cluster.
 	logger.V(4).Info("Creating kind cluster", "name", getInternalName(clusterSpec.Cluster.Name), "kubeconfig", kubeconfigName)
 	_, err = k.ExecuteWithEnv(ctx, k.execConfig.env, executionArgs...)
 	if err != nil {
-		return "", fmt.Errorf("error executing create cluster: %v", err)
+		return "", fmt.Errorf("executing create cluster: %v", err)
 	}
 
 	return kubeconfigName, nil
@@ -94,7 +94,7 @@ func (k *Kind) ClusterExists(ctx context.Context, clusterName string) (bool, err
 	internalName := getInternalName(clusterName)
 	stdOut, err := k.Execute(ctx, "get", "clusters")
 	if err != nil {
-		return false, fmt.Errorf("error executing get clusters: %v", err)
+		return false, fmt.Errorf("executing get clusters: %v", err)
 	}
 
 	logger.V(5).Info("Executed kind get clusters", "response", stdOut.String())
@@ -117,7 +117,7 @@ func (k *Kind) GetKubeconfig(ctx context.Context, clusterName string) (string, e
 	internalName := getInternalName(clusterName)
 	stdOut, err := k.Execute(ctx, "get", "kubeconfig", "--name", internalName)
 	if err != nil {
-		return "", fmt.Errorf("error executing get kubeconfig: %v", err)
+		return "", fmt.Errorf("executing get kubeconfig: %v", err)
 	}
 	return k.createKubeConfig(clusterName, stdOut.Bytes())
 }
@@ -177,7 +177,7 @@ func (k *Kind) DeleteBootstrapCluster(ctx context.Context, cluster *types.Cluste
 	logger.V(4).Info("Deleting kind cluster", "name", internalName)
 	_, err := k.Execute(ctx, "delete", "cluster", "--name", internalName)
 	if err != nil {
-		return fmt.Errorf("error executing delete cluster: %v", err)
+		return fmt.Errorf("executing delete cluster: %v", err)
 	}
 	return err
 }
@@ -218,7 +218,7 @@ func (k *Kind) buildConfigFile() error {
 	t := templater.New(k.writer)
 	writtenFileName, err := t.WriteToFile(kindConfigTemplate, k.execConfig, configFileName)
 	if err != nil {
-		return fmt.Errorf("error creating file for kind config: %v", err)
+		return fmt.Errorf("creating file for kind config: %v", err)
 	}
 
 	k.execConfig.ConfigFile = writtenFileName
@@ -239,7 +239,7 @@ func (k *Kind) execArguments(clusterName string, kubeconfigName string) []string
 func (k *Kind) createKubeConfig(clusterName string, content []byte) (string, error) {
 	fileName, err := k.writer.Write(fmt.Sprintf("%s.kind.kubeconfig", clusterName), content)
 	if err != nil {
-		return "", fmt.Errorf("error generating temp file for storing kind kubeconfig: %v", err)
+		return "", fmt.Errorf("generating temp file for storing kind kubeconfig: %v", err)
 	}
 	return fileName, nil
 }

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -153,7 +153,7 @@ func (k *Kubectl) CreateNamespace(ctx context.Context, kubeconfig string, namesp
 	params := []string{"create", "namespace", namespace, "--kubeconfig", kubeconfig}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error creating namespace %v: %v", namespace, err)
+		return fmt.Errorf("creating namespace %v: %v", namespace, err)
 	}
 	return nil
 }
@@ -162,7 +162,7 @@ func (k *Kubectl) DeleteNamespace(ctx context.Context, kubeconfig string, namesp
 	params := []string{"delete", "namespace", namespace, "--kubeconfig", kubeconfig}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error creating namespace %v: %v", namespace, err)
+		return fmt.Errorf("creating namespace %v: %v", namespace, err)
 	}
 	return nil
 }
@@ -171,7 +171,7 @@ func (k *Kubectl) LoadSecret(ctx context.Context, secretObject string, secretObj
 	params := []string{"create", "secret", "generic", secretObjectName, "--type", secretObjectType, "--from-literal", secretObject, "--kubeconfig", kubeConfFile, "--namespace", constants.EksaSystemNamespace}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error loading secret: %v", err)
+		return fmt.Errorf("loading secret: %v", err)
 	}
 	return nil
 }
@@ -181,7 +181,7 @@ func (k *Kubectl) ApplyHardware(ctx context.Context, hardwareYaml string, kubeCo
 	params = append(params, "--kubeconfig", kubeConfFile)
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error executing hardware yaml apply: %v", err)
+		return fmt.Errorf("executing hardware yaml apply: %v", err)
 	}
 	return nil
 }
@@ -193,7 +193,7 @@ func (k *Kubectl) ApplyKubeSpec(ctx context.Context, cluster *types.Cluster, spe
 	}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error executing apply: %v", err)
+		return fmt.Errorf("executing apply: %v", err)
 	}
 	return nil
 }
@@ -205,7 +205,7 @@ func (k *Kubectl) ApplyKubeSpecWithNamespace(ctx context.Context, cluster *types
 	}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error executing apply: %v", err)
+		return fmt.Errorf("executing apply: %v", err)
 	}
 	return nil
 }
@@ -217,7 +217,7 @@ func (k *Kubectl) ApplyKubeSpecFromBytes(ctx context.Context, cluster *types.Clu
 	}
 	_, err := k.ExecuteWithStdin(ctx, data, params...)
 	if err != nil {
-		return fmt.Errorf("error executing apply: %v", err)
+		return fmt.Errorf("executing apply: %v", err)
 	}
 	return nil
 }
@@ -229,7 +229,7 @@ func (k *Kubectl) ApplyKubeSpecFromBytesWithNamespace(ctx context.Context, clust
 	}
 	_, err := k.ExecuteWithStdin(ctx, data, params...)
 	if err != nil {
-		return fmt.Errorf("error executing apply: %v", err)
+		return fmt.Errorf("executing apply: %v", err)
 	}
 	return nil
 }
@@ -241,7 +241,7 @@ func (k *Kubectl) ApplyKubeSpecFromBytesForce(ctx context.Context, cluster *type
 	}
 	_, err := k.ExecuteWithStdin(ctx, data, params...)
 	if err != nil {
-		return fmt.Errorf("error executing apply --force: %v", err)
+		return fmt.Errorf("executing apply --force: %v", err)
 	}
 	return nil
 }
@@ -253,7 +253,7 @@ func (k *Kubectl) DeleteKubeSpecFromBytes(ctx context.Context, cluster *types.Cl
 	}
 	_, err := k.ExecuteWithStdin(ctx, data, params...)
 	if err != nil {
-		return fmt.Errorf("error executing apply: %v", err)
+		return fmt.Errorf("executing apply: %v", err)
 	}
 	return nil
 }
@@ -274,7 +274,7 @@ func (k *Kubectl) Wait(ctx context.Context, kubeconfig string, timeout string, f
 	_, err := k.Execute(ctx, "wait", "--timeout", timeout,
 		"--for=condition="+forCondition, property, "--kubeconfig", kubeconfig, "-n", namespace)
 	if err != nil {
-		return fmt.Errorf("error executing wait: %v", err)
+		return fmt.Errorf("executing wait: %v", err)
 	}
 	return nil
 }
@@ -283,7 +283,7 @@ func (k *Kubectl) DeleteEksaDatacenterConfig(ctx context.Context, eksaDatacenter
 	params := []string{"delete", eksaDatacenterResourceType, eksaDatacenterConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace, "--ignore-not-found=true"}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error deleting %s cluster %s apply: %v", eksaDatacenterResourceType, eksaDatacenterConfigName, err)
+		return fmt.Errorf("deleting %s cluster %s apply: %v", eksaDatacenterResourceType, eksaDatacenterConfigName, err)
 	}
 	return nil
 }
@@ -292,7 +292,7 @@ func (k *Kubectl) DeleteEksaMachineConfig(ctx context.Context, eksaMachineConfig
 	params := []string{"delete", eksaMachineConfigResourceType, eksaMachineConfigName, "--kubeconfig", kubeconfigFile, "--namespace", namespace, "--ignore-not-found=true"}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error deleting %s cluster %s apply: %v", eksaMachineConfigResourceType, eksaMachineConfigName, err)
+		return fmt.Errorf("deleting %s cluster %s apply: %v", eksaMachineConfigResourceType, eksaMachineConfigName, err)
 	}
 	return nil
 }
@@ -301,7 +301,7 @@ func (k *Kubectl) DeleteEKSACluster(ctx context.Context, managementCluster *type
 	params := []string{"delete", eksaClusterResourceType, eksaClusterName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", eksaClusterNamespace, "--ignore-not-found=true"}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error deleting eksa cluster %s apply: %v", eksaClusterName, err)
+		return fmt.Errorf("deleting eksa cluster %s apply: %v", eksaClusterName, err)
 	}
 	return nil
 }
@@ -310,7 +310,7 @@ func (k *Kubectl) DeleteGitOpsConfig(ctx context.Context, managementCluster *typ
 	params := []string{"delete", eksaGitOpsResourceType, gitOpsConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", gitOpsConfigNamespace, "--ignore-not-found=true"}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error deleting gitops config %s apply: %v", gitOpsConfigName, err)
+		return fmt.Errorf("deleting gitops config %s apply: %v", gitOpsConfigName, err)
 	}
 	return nil
 }
@@ -319,7 +319,7 @@ func (k *Kubectl) DeleteSecret(ctx context.Context, managementCluster *types.Clu
 	params := []string{"delete", "secret", secretName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", namespace}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error deleting secret %s in namespace %s: %v", secretName, namespace, err)
+		return fmt.Errorf("deleting secret %s in namespace %s: %v", secretName, namespace, err)
 	}
 	return nil
 }
@@ -328,7 +328,7 @@ func (k *Kubectl) DeleteOIDCConfig(ctx context.Context, managementCluster *types
 	params := []string{"delete", eksaOIDCResourceType, oidcConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", oidcConfigNamespace, "--ignore-not-found=true"}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error deleting oidc config %s apply: %v", oidcConfigName, err)
+		return fmt.Errorf("deleting oidc config %s apply: %v", oidcConfigName, err)
 	}
 	return nil
 }
@@ -337,7 +337,7 @@ func (k *Kubectl) DeleteAWSIamConfig(ctx context.Context, managementCluster *typ
 	params := []string{"delete", eksaAwsIamResourceType, awsIamConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", awsIamConfigNamespace, "--ignore-not-found=true"}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error deleting awsIam config %s apply: %v", awsIamConfigName, err)
+		return fmt.Errorf("deleting awsIam config %s apply: %v", awsIamConfigName, err)
 	}
 	return nil
 }
@@ -346,7 +346,7 @@ func (k *Kubectl) DeleteCluster(ctx context.Context, managementCluster, clusterT
 	params := []string{"delete", capiClustersResourceType, clusterToDelete.Name, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", constants.EksaSystemNamespace}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error deleting cluster %s apply: %v", clusterToDelete.Name, err)
+		return fmt.Errorf("deleting cluster %s apply: %v", clusterToDelete.Name, err)
 	}
 	return nil
 }
@@ -355,7 +355,7 @@ func (k *Kubectl) ListCluster(ctx context.Context) error {
 	params := []string{"get", "pods", "-A", "-o", "jsonpath={..image}"}
 	output, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error listing cluster versions: %v", err)
+		return fmt.Errorf("listing cluster versions: %v", err)
 	}
 
 	keys := make(map[string]bool)
@@ -378,7 +378,7 @@ func (k *Kubectl) GetNodes(ctx context.Context, kubeconfig string) ([]corev1.Nod
 	params := []string{"get", "nodes", "-o", "json", "--kubeconfig", kubeconfig}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting nodes: %v", err)
+		return nil, fmt.Errorf("getting nodes: %v", err)
 	}
 	response := &corev1.NodeList{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
@@ -390,7 +390,7 @@ func (k *Kubectl) GetControlPlaneNodes(ctx context.Context, kubeconfig string) (
 	params := []string{"get", "nodes", "-o", "json", "--kubeconfig", kubeconfig, "--selector=node-role.kubernetes.io/control-plane"}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting control plane nodes: %v", err)
+		return nil, fmt.Errorf("getting control plane nodes: %v", err)
 	}
 	response := &corev1.NodeList{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
@@ -572,7 +572,7 @@ func (k *Kubectl) SaveLog(ctx context.Context, cluster *types.Cluster, deploymen
 
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error saving logs: %v", err)
+		return fmt.Errorf("saving logs: %v", err)
 	}
 
 	_, err = writer.Write(fileName, stdOut.Bytes())
@@ -594,13 +594,13 @@ func (k *Kubectl) GetMachines(ctx context.Context, cluster *types.Cluster, clust
 	}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting machines: %v", err)
+		return nil, fmt.Errorf("getting machines: %v", err)
 	}
 
 	response := &machinesResponse{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get machines response: %v", err)
+		return nil, fmt.Errorf("parsing get machines response: %v", err)
 	}
 
 	return response.Items, nil
@@ -619,13 +619,13 @@ func (k *Kubectl) GetMachineSets(ctx context.Context, machineDeploymentName stri
 
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting machineset associated with deployment %s: %v", machineDeploymentName, err)
+		return nil, fmt.Errorf("getting machineset associated with deployment %s: %v", machineDeploymentName, err)
 	}
 
 	response := &machineSetResponse{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get machinesets response: %v", err)
+		return nil, fmt.Errorf("parsing get machinesets response: %v", err)
 	}
 
 	return response.Items, nil
@@ -663,7 +663,7 @@ func (k *Kubectl) ValidateClustersCRD(ctx context.Context, cluster *types.Cluste
 	params := []string{"get", "crd", capiClustersResourceType, "--kubeconfig", cluster.KubeconfigFile}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error getting clusters crd: %v", err)
+		return fmt.Errorf("getting clusters crd: %v", err)
 	}
 	return nil
 }
@@ -672,7 +672,7 @@ func (k *Kubectl) ValidateEKSAClustersCRD(ctx context.Context, cluster *types.Cl
 	params := []string{"get", "crd", eksaClusterResourceType, "--kubeconfig", cluster.KubeconfigFile}
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error getting eksa clusters crd: %v", err)
+		return fmt.Errorf("getting eksa clusters crd: %v", err)
 	}
 	return nil
 }
@@ -681,13 +681,13 @@ func (k *Kubectl) GetClusters(ctx context.Context, cluster *types.Cluster) ([]ty
 	params := []string{"get", capiClustersResourceType, "-o", "json", "--kubeconfig", cluster.KubeconfigFile, "--namespace", constants.EksaSystemNamespace}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting clusters: %v", err)
+		return nil, fmt.Errorf("getting clusters: %v", err)
 	}
 
 	response := &ClustersResponse{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get clusters response: %v", err)
+		return nil, fmt.Errorf("parsing get clusters response: %v", err)
 	}
 
 	return response.Items, nil
@@ -697,7 +697,7 @@ func (k *Kubectl) GetApiServerUrl(ctx context.Context, cluster *types.Cluster) (
 	params := []string{"config", "view", "--kubeconfig", cluster.KubeconfigFile, "--minify", "--raw", "-o", "jsonpath={.clusters[0].cluster.server}"}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return "", fmt.Errorf("error getting api server url: %v", err)
+		return "", fmt.Errorf("getting api server url: %v", err)
 	}
 
 	return stdOut.String(), nil
@@ -708,7 +708,7 @@ func (k *Kubectl) GetClusterCATlsCert(ctx context.Context, clusterName string, c
 	params := []string{"get", "secret", secretName, "--kubeconfig", cluster.KubeconfigFile, "-o", `jsonpath={.data.tls\.crt}`, "--namespace", namespace}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting cluster ca tls cert: %v", err)
+		return nil, fmt.Errorf("getting cluster ca tls cert: %v", err)
 	}
 
 	return stdOut.Bytes(), nil
@@ -718,12 +718,12 @@ func (k *Kubectl) Version(ctx context.Context, cluster *types.Cluster) (*Version
 	params := []string{"version", "-o", "json", "--kubeconfig", cluster.KubeconfigFile}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error executing kubectl version: %v", err)
+		return nil, fmt.Errorf("executing kubectl version: %v", err)
 	}
 	response := &VersionResponse{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling kubectl version response: %v", err)
+		return nil, fmt.Errorf("unmarshalling kubectl version response: %v", err)
 	}
 	return response, nil
 }
@@ -787,13 +787,13 @@ func (k *Kubectl) GetPods(ctx context.Context, opts ...KubectlOpt) ([]corev1.Pod
 	applyOpts(&params, opts...)
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting pods: %v", err)
+		return nil, fmt.Errorf("getting pods: %v", err)
 	}
 
 	response := &corev1.PodList{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get pods response: %v", err)
+		return nil, fmt.Errorf("parsing get pods response: %v", err)
 	}
 
 	return response.Items, nil
@@ -804,13 +804,13 @@ func (k *Kubectl) GetDeployments(ctx context.Context, opts ...KubectlOpt) ([]app
 	applyOpts(&params, opts...)
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting deployments: %v", err)
+		return nil, fmt.Errorf("getting deployments: %v", err)
 	}
 
 	response := &appsv1.DeploymentList{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get deployments response: %v", err)
+		return nil, fmt.Errorf("parsing get deployments response: %v", err)
 	}
 
 	return response.Items, nil
@@ -825,12 +825,12 @@ func (k *Kubectl) GetSecret(ctx context.Context, secretObjectName string, opts .
 	applyOpts(&params, opts...)
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting secret: %v", err)
+		return nil, fmt.Errorf("getting secret: %v", err)
 	}
 	response := &corev1.Secret{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get secret response: %v", err)
+		return nil, fmt.Errorf("parsing get secret response: %v", err)
 	}
 	return response, err
 }
@@ -840,13 +840,13 @@ func (k *Kubectl) GetKubeadmControlPlanes(ctx context.Context, opts ...KubectlOp
 	applyOpts(&params, opts...)
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting kubeadmcontrolplanes: %v", err)
+		return nil, fmt.Errorf("getting kubeadmcontrolplanes: %v", err)
 	}
 
 	response := &controlplanev1.KubeadmControlPlaneList{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get kubeadmcontrolplanes response: %v", err)
+		return nil, fmt.Errorf("parsing get kubeadmcontrolplanes response: %v", err)
 	}
 
 	return response.Items, nil
@@ -858,13 +858,13 @@ func (k *Kubectl) GetKubeadmControlPlane(ctx context.Context, cluster *types.Clu
 	applyOpts(&params, opts...)
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting kubeadmcontrolplane: %v", err)
+		return nil, fmt.Errorf("getting kubeadmcontrolplane: %v", err)
 	}
 
 	response := &controlplanev1.KubeadmControlPlane{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get kubeadmcontrolplane response: %v", err)
+		return nil, fmt.Errorf("parsing get kubeadmcontrolplane response: %v", err)
 	}
 
 	return response, nil
@@ -875,13 +875,13 @@ func (k *Kubectl) GetMachineDeployment(ctx context.Context, workerNodeGroupName 
 	applyOpts(&params, opts...)
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting machine deployment: %v", err)
+		return nil, fmt.Errorf("getting machine deployment: %v", err)
 	}
 
 	response := &clusterv1.MachineDeployment{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get machineDeployment response: %v", err)
+		return nil, fmt.Errorf("parsing get machineDeployment response: %v", err)
 	}
 
 	return response, nil
@@ -892,13 +892,13 @@ func (k *Kubectl) GetMachineDeployments(ctx context.Context, opts ...KubectlOpt)
 	applyOpts(&params, opts...)
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting machine deployments: %v", err)
+		return nil, fmt.Errorf("getting machine deployments: %v", err)
 	}
 
 	response := &clusterv1.MachineDeploymentList{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get machineDeployments response: %v", err)
+		return nil, fmt.Errorf("parsing get machineDeployments response: %v", err)
 	}
 
 	return response.Items, nil
@@ -912,7 +912,7 @@ func (k *Kubectl) UpdateEnvironmentVariables(ctx context.Context, resourceType, 
 	applyOpts(&params, opts...)
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error setting the environment variables in %s %s: %v", resourceType, resourceName, err)
+		return fmt.Errorf("setting the environment variables in %s %s: %v", resourceType, resourceName, err)
 	}
 	return nil
 }
@@ -929,7 +929,7 @@ func (k *Kubectl) UpdateAnnotation(ctx context.Context, resourceType, objectName
 	applyOpts(&params, opts...)
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error updating annotation: %v", err)
+		return fmt.Errorf("updating annotation: %v", err)
 	}
 	return nil
 }
@@ -943,7 +943,7 @@ func (k *Kubectl) RemoveAnnotation(ctx context.Context, resourceType, objectName
 	applyOpts(&params, opts...)
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error removing annotation: %v", err)
+		return fmt.Errorf("removing annotation: %v", err)
 	}
 	return nil
 }
@@ -956,13 +956,13 @@ func (k *Kubectl) GetEksaCluster(ctx context.Context, cluster *types.Cluster, cl
 	params := []string{"get", eksaClusterResourceType, "-A", "-o", "jsonpath={.items[0]}", "--kubeconfig", cluster.KubeconfigFile, "--field-selector=metadata.name=" + clusterName}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting eksa cluster: %v", err)
+		return nil, fmt.Errorf("getting eksa cluster: %v", err)
 	}
 
 	response := &v1alpha1.Cluster{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get eksa cluster response: %v", err)
+		return nil, fmt.Errorf("parsing get eksa cluster response: %v", err)
 	}
 
 	return response, nil
@@ -975,13 +975,13 @@ func (k *Kubectl) SearchVsphereMachineConfig(ctx context.Context, name string, k
 	}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error searching eksa VSphereMachineConfigResponse: %v", err)
+		return nil, fmt.Errorf("searching eksa VSphereMachineConfigResponse: %v", err)
 	}
 
 	response := &VSphereMachineConfigResponse{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing VSphereMachineConfigResponse response: %v", err)
+		return nil, fmt.Errorf("parsing VSphereMachineConfigResponse response: %v", err)
 	}
 
 	return response.Items, nil
@@ -1005,13 +1005,13 @@ func (k *Kubectl) SearchIdentityProviderConfig(ctx context.Context, ipName strin
 	}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error searching eksa IdentityProvider: %v", err)
+		return nil, fmt.Errorf("searching eksa IdentityProvider: %v", err)
 	}
 
 	response := &VSphereDatacenterConfigResponse{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing IdentityProviderConfigResponse response: %v", err)
+		return nil, fmt.Errorf("parsing IdentityProviderConfigResponse response: %v", err)
 	}
 
 	return response.Items, nil
@@ -1024,13 +1024,13 @@ func (k *Kubectl) SearchVsphereDatacenterConfig(ctx context.Context, datacenterN
 	}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error searching eksa VSphereDatacenterConfigResponse: %v", err)
+		return nil, fmt.Errorf("searching eksa VSphereDatacenterConfigResponse: %v", err)
 	}
 
 	response := &VSphereDatacenterConfigResponse{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing VSphereDatacenterConfigResponse response: %v", err)
+		return nil, fmt.Errorf("parsing VSphereDatacenterConfigResponse response: %v", err)
 	}
 
 	return response.Items, nil
@@ -1043,13 +1043,13 @@ func (k *Kubectl) SearchEksaGitOpsConfig(ctx context.Context, gitOpsConfigName s
 	}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error searching eksa GitOpsConfig: %v", err)
+		return nil, fmt.Errorf("searching eksa GitOpsConfig: %v", err)
 	}
 
 	response := &GitOpsConfigResponse{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing GitOpsConfig response: %v", err)
+		return nil, fmt.Errorf("parsing GitOpsConfig response: %v", err)
 	}
 
 	return response.Items, nil
@@ -1059,13 +1059,13 @@ func (k *Kubectl) GetEksaGitOpsConfig(ctx context.Context, gitOpsConfigName stri
 	params := []string{"get", eksaGitOpsResourceType, gitOpsConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting eksa GitOpsConfig: %v", err)
+		return nil, fmt.Errorf("getting eksa GitOpsConfig: %v", err)
 	}
 
 	response := &v1alpha1.GitOpsConfig{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing GitOpsConfig response: %v", err)
+		return nil, fmt.Errorf("parsing GitOpsConfig response: %v", err)
 	}
 
 	return response, nil
@@ -1075,13 +1075,13 @@ func (k *Kubectl) GetEksaOIDCConfig(ctx context.Context, oidcConfigName string, 
 	params := []string{"get", eksaOIDCResourceType, oidcConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting eksa OIDCConfig: %v", err)
+		return nil, fmt.Errorf("getting eksa OIDCConfig: %v", err)
 	}
 
 	response := &v1alpha1.OIDCConfig{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing OIDCConfig response: %v", err)
+		return nil, fmt.Errorf("parsing OIDCConfig response: %v", err)
 	}
 
 	return response, nil
@@ -1091,13 +1091,13 @@ func (k *Kubectl) GetEksaAWSIamConfig(ctx context.Context, awsIamConfigName stri
 	params := []string{"get", eksaAwsIamResourceType, awsIamConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting eksa AWSIamConfig: %v", err)
+		return nil, fmt.Errorf("getting eksa AWSIamConfig: %v", err)
 	}
 
 	response := &v1alpha1.AWSIamConfig{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing AWSIamConfig response: %v", err)
+		return nil, fmt.Errorf("parsing AWSIamConfig response: %v", err)
 	}
 
 	return response, nil
@@ -1107,13 +1107,13 @@ func (k *Kubectl) GetEksaVSphereDatacenterConfig(ctx context.Context, vsphereDat
 	params := []string{"get", eksaVSphereDatacenterResourceType, vsphereDatacenterConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting eksa vsphere cluster %v", err)
+		return nil, fmt.Errorf("getting eksa vsphere cluster %v", err)
 	}
 
 	response := &v1alpha1.VSphereDatacenterConfig{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get eksa vsphere cluster response: %v", err)
+		return nil, fmt.Errorf("parsing get eksa vsphere cluster response: %v", err)
 	}
 
 	return response, nil
@@ -1123,13 +1123,13 @@ func (k *Kubectl) GetEksaVSphereMachineConfig(ctx context.Context, vsphereMachin
 	params := []string{"get", eksaVSphereMachineResourceType, vsphereMachineConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting eksa vsphere cluster %v", err)
+		return nil, fmt.Errorf("getting eksa vsphere cluster %v", err)
 	}
 
 	response := &v1alpha1.VSphereMachineConfig{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get eksa vsphere cluster response: %v", err)
+		return nil, fmt.Errorf("parsing get eksa vsphere cluster response: %v", err)
 	}
 
 	return response, nil
@@ -1139,13 +1139,13 @@ func (k *Kubectl) GetEksaAWSDatacenterConfig(ctx context.Context, awsDatacenterC
 	params := []string{"get", eksaAwsResourceType, awsDatacenterConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting eksa aws cluster %v", err)
+		return nil, fmt.Errorf("getting eksa aws cluster %v", err)
 	}
 
 	response := &v1alpha1.AWSDatacenterConfig{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get eksa aws cluster response: %v", err)
+		return nil, fmt.Errorf("parsing get eksa aws cluster response: %v", err)
 	}
 
 	return response, nil
@@ -1155,7 +1155,7 @@ func (k *Kubectl) GetCurrentClusterContext(ctx context.Context, cluster *types.C
 	params := []string{"config", "view", "--kubeconfig", cluster.KubeconfigFile, "--minify", "--raw", "-o", "jsonpath={.contexts[0].name}"}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return "", fmt.Errorf("error getting current cluster context name: %v", err)
+		return "", fmt.Errorf("getting current cluster context name: %v", err)
 	}
 
 	return stdOut.String(), nil
@@ -1167,13 +1167,13 @@ func (k *Kubectl) GetEtcdadmCluster(ctx context.Context, cluster *types.Cluster,
 	applyOpts(&params, opts...)
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting etcdadmCluster: %v", err)
+		return nil, fmt.Errorf("getting etcdadmCluster: %v", err)
 	}
 
 	response := &etcdv1.EtcdadmCluster{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing get etcdadmCluster response: %v", err)
+		return nil, fmt.Errorf("parsing get etcdadmCluster response: %v", err)
 	}
 
 	return response, nil
@@ -1191,7 +1191,7 @@ func (k *Kubectl) ValidateNodesVersion(ctx context.Context, kubeconfig string, k
 		kubeletVersion := scanner.Text()
 		if len(kubeletVersion) != 0 {
 			if !strings.Contains(kubeletVersion, string(kubeVersion)) {
-				return fmt.Errorf("error validating node version: kubernetes version %s does not match expected version %s", kubeletVersion, kubeVersion)
+				return fmt.Errorf("validating node version: kubernetes version %s does not match expected version %s", kubeletVersion, kubeVersion)
 			}
 		}
 	}
@@ -1202,13 +1202,13 @@ func (k *Kubectl) GetBundles(ctx context.Context, kubeconfigFile, name, namespac
 	params := []string{"get", bundlesResourceType, name, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting Bundles with kubectl: %v", err)
+		return nil, fmt.Errorf("getting Bundles with kubectl: %v", err)
 	}
 
 	response := &releasev1alpha1.Bundles{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing Bundles response: %v", err)
+		return nil, fmt.Errorf("parsing Bundles response: %v", err)
 	}
 
 	return response, nil
@@ -1218,12 +1218,12 @@ func (k *Kubectl) GetClusterResourceSet(ctx context.Context, kubeconfigFile, nam
 	params := []string{"get", clusterResourceSetResourceType, name, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting ClusterResourceSet with kubectl: %v", err)
+		return nil, fmt.Errorf("getting ClusterResourceSet with kubectl: %v", err)
 	}
 
 	response := &addons.ClusterResourceSet{}
 	if err = json.Unmarshal(stdOut.Bytes(), response); err != nil {
-		return nil, fmt.Errorf("error parsing ClusterResourceSet response: %v", err)
+		return nil, fmt.Errorf("parsing ClusterResourceSet response: %v", err)
 	}
 
 	return response, nil
@@ -1233,12 +1233,12 @@ func (k *Kubectl) GetConfigMap(ctx context.Context, kubeconfigFile, name, namesp
 	params := []string{"get", "configmap", name, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting ConfigMap with kubectl: %v", err)
+		return nil, fmt.Errorf("getting ConfigMap with kubectl: %v", err)
 	}
 
 	response := &corev1.ConfigMap{}
 	if err = json.Unmarshal(stdOut.Bytes(), response); err != nil {
-		return nil, fmt.Errorf("error parsing ConfigMap response: %v", err)
+		return nil, fmt.Errorf("parsing ConfigMap response: %v", err)
 	}
 
 	return response, nil
@@ -1253,7 +1253,7 @@ func (k *Kubectl) setImage(ctx context.Context, kind, name, container, image str
 	applyOpts(&params, opts...)
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
-		return fmt.Errorf("error setting image for %s: %v", kind, err)
+		return fmt.Errorf("setting image for %s: %v", kind, err)
 	}
 
 	return nil
@@ -1263,7 +1263,7 @@ func (k *Kubectl) CheckProviderExists(ctx context.Context, kubeconfigFile, name,
 	params := []string{"get", "namespace", fmt.Sprintf("--field-selector=metadata.name=%s", namespace), "--kubeconfig", kubeconfigFile}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return false, fmt.Errorf("error checking whether provider namespace exists: %v", err)
+		return false, fmt.Errorf("checking whether provider namespace exists: %v", err)
 	}
 	if stdOut.Len() == 0 {
 		return false, nil
@@ -1272,7 +1272,7 @@ func (k *Kubectl) CheckProviderExists(ctx context.Context, kubeconfigFile, name,
 	params = []string{"get", "provider", "--namespace", namespace, fmt.Sprintf("--field-selector=metadata.name=%s", name), "--kubeconfig", kubeconfigFile}
 	stdOut, err = k.Execute(ctx, params...)
 	if err != nil {
-		return false, fmt.Errorf("error checking whether provider exists: %v", err)
+		return false, fmt.Errorf("checking whether provider exists: %v", err)
 	}
 	return stdOut.Len() != 0, nil
 }
@@ -1303,7 +1303,7 @@ func (k *Kubectl) ApplyTolerationsFromTaints(ctx context.Context, oldTaints []co
 	if len(output.String()) > 0 {
 		err = json.Unmarshal(output.Bytes(), &appliedTolerations)
 		if err != nil {
-			return fmt.Errorf("error parsing toleration response: %v", err)
+			return fmt.Errorf("parsing toleration response: %v", err)
 		}
 	}
 
@@ -1359,11 +1359,11 @@ func (k *Kubectl) GetResource(ctx context.Context, resourceType string, name str
 func (k *Kubectl) getObject(ctx context.Context, resourceType, name, namespace, kubeconfig string, obj client.Object) error {
 	stdOut, err := k.Execute(ctx, "get", "--namespace", namespace, resourceType, name, "-o", "json", "--kubeconfig", kubeconfig)
 	if err != nil {
-		return fmt.Errorf("error getting %s with kubectl: %v", resourceType, err)
+		return fmt.Errorf("getting %s with kubectl: %v", resourceType, err)
 	}
 
 	if err = json.Unmarshal(stdOut.Bytes(), obj); err != nil {
-		return fmt.Errorf("error parsing %s response: %v", resourceType, err)
+		return fmt.Errorf("parsing %s response: %v", resourceType, err)
 	}
 
 	return nil

--- a/pkg/executables/sonobuoy.go
+++ b/pkg/executables/sonobuoy.go
@@ -34,7 +34,7 @@ func (k *Sonobuoy) Run(ctx context.Context, contextName string, args ...string) 
 	output, err := k.Execute(ctx, executionArgs...)
 	command := strings.Join(executionArgs, " ") + "\n"
 	if err != nil {
-		return command, fmt.Errorf("error executing sonobuoy: %v", err)
+		return command, fmt.Errorf("executing sonobuoy: %v", err)
 	}
 	return command + output.String(), err
 }
@@ -49,7 +49,7 @@ func (k *Sonobuoy) GetResults(ctx context.Context, contextName string, args ...s
 	var output bytes.Buffer
 	output, err := k.Execute(ctx, executionArgs...)
 	if err != nil {
-		return "", fmt.Errorf("error executing sonobuoy retrieve: %v", err)
+		return "", fmt.Errorf("executing sonobuoy retrieve: %v", err)
 	}
 	outputFile := strings.TrimSpace(output.String())
 	logger.Info("Sonobuoy results file: " + outputFile)
@@ -61,7 +61,7 @@ func (k *Sonobuoy) GetResults(ctx context.Context, contextName string, args ...s
 	output, err = k.Execute(ctx, executionArgs...)
 	command := strings.Join(executionArgs, " ") + "\n"
 	if err != nil {
-		return command, fmt.Errorf("error executing sonobuoy results command: %v", err)
+		return command, fmt.Errorf("executing sonobuoy results command: %v", err)
 	}
 	return command + output.String(), err
 }

--- a/pkg/executables/tink.go
+++ b/pkg/executables/tink.go
@@ -37,7 +37,7 @@ func NewTink(executable Executable, tinkerbellCertUrl, tinkerbellGrpcAuthority s
 func (t *Tink) PushHardware(ctx context.Context, hardware []byte) error {
 	params := []string{"hardware", "push"}
 	if _, err := t.Command(ctx, params...).WithStdIn(hardware).WithEnvVars(t.envMap).Run(); err != nil {
-		return fmt.Errorf("error pushing hardware: %v", err)
+		return fmt.Errorf("pushing hardware: %v", err)
 	}
 	return nil
 }
@@ -46,7 +46,7 @@ func (t *Tink) GetHardware(ctx context.Context) ([]*hardware.Hardware, error) {
 	params := []string{"hardware", "get", "--tinkerbell-cert-url", t.tinkerbellCertUrl, "--tinkerbell-grpc-authority", t.tinkerbellGrpcAuthority, "--format", "json"}
 	data, err := t.Command(ctx, params...).Run()
 	if err != nil {
-		return nil, fmt.Errorf("error getting hardware list: %v", err)
+		return nil, fmt.Errorf("getting hardware list: %v", err)
 	}
 	var hardwareList []*hardware.Hardware
 	hardwareString := data.String()
@@ -55,7 +55,7 @@ func (t *Tink) GetHardware(ctx context.Context) ([]*hardware.Hardware, error) {
 		hardwareListData := map[string][]*hardware.Hardware{}
 
 		if err = json.Unmarshal([]byte(hardwareString), &hardwareListData); err != nil {
-			return nil, fmt.Errorf("error unmarshling hardware json: %v", err)
+			return nil, fmt.Errorf("unmarshling hardware json: %v", err)
 		}
 		if len(hardwareListData["data"]) > 0 {
 			hardwareList = append(hardwareList, hardwareListData["data"]...)
@@ -69,7 +69,7 @@ func (t *Tink) GetWorkflow(ctx context.Context) ([]*workflow.Workflow, error) {
 	params := []string{"workflow", "get", "--tinkerbell-cert-url", t.tinkerbellCertUrl, "--tinkerbell-grpc-authority", t.tinkerbellGrpcAuthority, "--format", "json"}
 	data, err := t.Command(ctx, params...).Run()
 	if err != nil {
-		return nil, fmt.Errorf("error getting workflow list: %v", err)
+		return nil, fmt.Errorf("getting workflow list: %v", err)
 	}
 	var workflowList []*workflow.Workflow
 	workflowString := data.String()
@@ -78,7 +78,7 @@ func (t *Tink) GetWorkflow(ctx context.Context) ([]*workflow.Workflow, error) {
 		workflowListData := map[string][]*workflow.Workflow{}
 
 		if err = json.Unmarshal([]byte(workflowString), &workflowListData); err != nil {
-			return nil, fmt.Errorf("error unmarshling workflow json: %v", err)
+			return nil, fmt.Errorf("unmarshling workflow json: %v", err)
 		}
 		if len(workflowListData["data"]) > 0 {
 			workflowList = append(workflowList, workflowListData["data"]...)

--- a/pkg/executables/troubleshoot.go
+++ b/pkg/executables/troubleshoot.go
@@ -32,11 +32,11 @@ func (t *Troubleshoot) Collect(ctx context.Context, bundlePath string, sinceTime
 
 	output, err := t.Execute(ctx, params...)
 	if err != nil {
-		return "", fmt.Errorf("error when executing support-bundle: %v", err)
+		return "", fmt.Errorf("executing support-bundle: %v", err)
 	}
 	archivePath, err = parseArchivePathFromCollectOutput(output.String())
 	if err != nil {
-		return "", fmt.Errorf("error when parsing support-bundle output: %v", err)
+		return "", fmt.Errorf("parsing support-bundle output: %v", err)
 	}
 	return archivePath, nil
 }
@@ -45,12 +45,12 @@ func (t *Troubleshoot) Analyze(ctx context.Context, bundleSpecPath string, archi
 	params := []string{"analyze", bundleSpecPath, "--bundle", archivePath, "--output", "json"}
 	output, err := t.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("error when analyzing support bundle %s with analyzers %s: %v", archivePath, bundleSpecPath, err)
+		return nil, fmt.Errorf("analyzing support bundle %s with analyzers %s: %v", archivePath, bundleSpecPath, err)
 	}
 	var analysisOutput []*SupportBundleAnalysis
 	err = json.Unmarshal(output.Bytes(), &analysisOutput)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling support-bundle analyze output: %v", err)
+		return nil, fmt.Errorf("unmarshalling support-bundle analyze output: %v", err)
 	}
 	return analysisOutput, err
 }
@@ -58,11 +58,11 @@ func (t *Troubleshoot) Analyze(ctx context.Context, bundleSpecPath string, archi
 func parseArchivePathFromCollectOutput(tsLogs string) (archivePath string, err error) {
 	r, err := regexp.Compile(supportBundleArchiveRegex)
 	if err != nil {
-		return "", fmt.Errorf("error parsing support-bundle output: %v", err)
+		return "", fmt.Errorf("parsing support-bundle output: %v", err)
 	}
 	archivePath = r.FindString(tsLogs)
 	if archivePath == "" {
-		return "", fmt.Errorf("error parsing support-bundle output: could not find archive path in output")
+		return "", fmt.Errorf("parsing support-bundle output: could not find archive path in output")
 	}
 	return archivePath, nil
 }

--- a/pkg/filewriter/writer.go
+++ b/pkg/filewriter/writer.go
@@ -17,7 +17,7 @@ func NewWriter(dir string) (FileWriter, error) {
 	if _, err := os.Stat(newFolder); errors.Is(err, os.ErrNotExist) {
 		err := os.MkdirAll(newFolder, os.ModePerm)
 		if err != nil {
-			return nil, fmt.Errorf("error creating directory [%s]: %v", dir, err)
+			return nil, fmt.Errorf("creating directory [%s]: %v", dir, err)
 		}
 	}
 	return &writer{dir: dir}, nil
@@ -37,7 +37,7 @@ func (t *writer) Write(fileName string, content []byte, f ...FileOptionsFunc) (s
 	filePath := filepath.Join(currentDir, fileName)
 	err := ioutil.WriteFile(filePath, content, op.Permissions)
 	if err != nil {
-		return "", fmt.Errorf("error writing to file [%s]: %v", filePath, err)
+		return "", fmt.Errorf("writing to file [%s]: %v", filePath, err)
 	}
 
 	return filePath, nil

--- a/pkg/git/gogit/gogit.go
+++ b/pkg/git/gogit/gogit.go
@@ -250,7 +250,7 @@ func (g *GoGit) Push(ctx context.Context) error {
 
 	err = g.Client.PushWithContext(ctx, r, g.Opts.Auth)
 	if err != nil {
-		return fmt.Errorf("error pushing: %v", err)
+		return fmt.Errorf("pushing: %v", err)
 	}
 	return err
 }
@@ -259,12 +259,12 @@ func (g *GoGit) Pull(ctx context.Context, branch string) error {
 	logger.V(3).Info("Pulling from remote", "repo", g.Opts.RepositoryDirectory, "remote", gogit.DefaultRemoteName)
 	r, err := g.Client.OpenDir(g.Opts.RepositoryDirectory)
 	if err != nil {
-		return fmt.Errorf("error pulling from remote: %v", err)
+		return fmt.Errorf("pulling from remote: %v", err)
 	}
 
 	w, err := g.Client.OpenWorktree(r)
 	if err != nil {
-		return fmt.Errorf("error pulling from remote: %v", err)
+		return fmt.Errorf("pulling from remote: %v", err)
 	}
 
 	branchRef := plumbing.NewBranchReferenceName(branch)
@@ -277,17 +277,17 @@ func (g *GoGit) Pull(ctx context.Context, branch string) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error pulling from remote: %v", err)
+		return fmt.Errorf("pulling from remote: %v", err)
 	}
 
 	ref, err := g.Client.Head(r)
 	if err != nil {
-		return fmt.Errorf("error pulling from remote: %v", err)
+		return fmt.Errorf("pulling from remote: %v", err)
 	}
 
 	commit, err := g.Client.CommitObject(r, ref.Hash())
 	if err != nil {
-		return fmt.Errorf("error accessing latest commit after pulling from remote: %v", err)
+		return fmt.Errorf("accessing latest commit after pulling from remote: %v", err)
 	}
 	logger.V(3).Info("Successfully pulled from remote", "repo", g.Opts.RepositoryDirectory, "remote", gogit.DefaultRemoteName, "latest commit", commit.Hash)
 	return nil
@@ -300,7 +300,7 @@ func (g *GoGit) Init(url string) error {
 	}
 
 	if _, err = g.Client.Create(r, url); err != nil {
-		return fmt.Errorf("error initializing repository: %v", err)
+		return fmt.Errorf("initializing repository: %v", err)
 	}
 	return nil
 }
@@ -308,7 +308,7 @@ func (g *GoGit) Init(url string) error {
 func (g *GoGit) Branch(name string) error {
 	r, err := g.Client.OpenDir(g.Opts.RepositoryDirectory)
 	if err != nil {
-		return fmt.Errorf("error creating branch %s: %v", name, err)
+		return fmt.Errorf("creating branch %s: %v", name, err)
 	}
 
 	localBranchRef := plumbing.NewBranchReferenceName(name)
@@ -323,7 +323,7 @@ func (g *GoGit) Branch(name string) error {
 	branchExistsLocally := errors.As(err, &gogit.ErrBranchExists)
 
 	if err != nil && !branchExistsLocally {
-		return fmt.Errorf("error creating branch %s: %v", name, err)
+		return fmt.Errorf("creating branch %s: %v", name, err)
 	}
 
 	if branchExistsLocally {
@@ -334,18 +334,18 @@ func (g *GoGit) Branch(name string) error {
 		logger.V(3).Info("Branch does not exist locally", "branch", name)
 		headref, err := g.Client.Head(r)
 		if err != nil {
-			return fmt.Errorf("error creating branch %s: %v", name, err)
+			return fmt.Errorf("creating branch %s: %v", name, err)
 		}
 		h := headref.Hash()
 		err = g.Client.SetRepositoryReference(r, plumbing.NewHashReference(localBranchRef, h))
 		if err != nil {
-			return fmt.Errorf("error creating branch %s: %v", name, err)
+			return fmt.Errorf("creating branch %s: %v", name, err)
 		}
 	}
 
 	w, err := g.Client.OpenWorktree(r)
 	if err != nil {
-		return fmt.Errorf("error creating branch %s: %v", name, err)
+		return fmt.Errorf("creating branch %s: %v", name, err)
 	}
 
 	err = g.Client.Checkout(w, &gogit.CheckoutOptions{
@@ -353,12 +353,12 @@ func (g *GoGit) Branch(name string) error {
 		Force:  true,
 	})
 	if err != nil {
-		return fmt.Errorf("error creating branch %s: %v", name, err)
+		return fmt.Errorf("creating branch %s: %v", name, err)
 	}
 
 	err = g.pullIfRemoteExists(r, w, name, localBranchRef)
 	if err != nil {
-		return fmt.Errorf("error when creating branch %s: %v", name, err)
+		return fmt.Errorf("creating branch %s: %v", name, err)
 	}
 
 	return nil
@@ -372,13 +372,13 @@ func (g *GoGit) pullIfRemoteExists(r *gogit.Repository, w *gogit.Worktree, branc
 	err := g.Retrier.Retry(func() error {
 		remoteExists, err := g.remoteBranchExists(r, localBranchRef)
 		if err != nil {
-			return fmt.Errorf("error checking if remote branch exists %s: %v", branchName, err)
+			return fmt.Errorf("checking if remote branch exists %s: %v", branchName, err)
 		}
 
 		if remoteExists {
 			err = g.Client.PullWithContext(context.Background(), w, g.Opts.Auth, localBranchRef)
 			if err != nil && !errors.Is(err, gogit.NoErrAlreadyUpToDate) && !errors.Is(err, gogit.ErrRemoteNotFound) {
-				return fmt.Errorf("error pulling from remote when checking out existing branch %s: %v", branchName, err)
+				return fmt.Errorf("pulling from remote when checking out existing branch %s: %v", branchName, err)
 			}
 		}
 		return nil
@@ -392,7 +392,7 @@ func (g *GoGit) remoteBranchExists(r *gogit.Repository, localBranchRef plumbing.
 		if strings.Contains(err.Error(), emptyRepoError) {
 			return false, nil
 		}
-		return false, fmt.Errorf("error when listing remotes: %v", err)
+		return false, fmt.Errorf("listing remotes: %v", err)
 	}
 	lb := localBranchRef.String()
 	for _, ref := range reflist {

--- a/pkg/git/gogit/gogit_test.go
+++ b/pkg/git/gogit/gogit_test.go
@@ -158,7 +158,7 @@ func TestGoGitPull(t *testing.T) {
 			name:       "repo already up-to-date",
 			wantErr:    true,
 			throwError: fmt.Errorf("already up-to-date"),
-			matchError: fmt.Errorf("error pulling from remote: %v", goGit.NoErrAlreadyUpToDate),
+			matchError: fmt.Errorf("pulling from remote: %v", goGit.NoErrAlreadyUpToDate),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/git/gogithub/gogithub.go
+++ b/pkg/git/gogithub/gogithub.go
@@ -118,7 +118,7 @@ func (g *GoGithub) GetAccessTokenPermissions(accessToken string) (string, error)
 	err = r.Retry(func() error {
 		resp, err = HttpClient.Do(req)
 		if err != nil {
-			return fmt.Errorf("error getting Github Personal Access Token permissions %v", err)
+			return fmt.Errorf("getting Github Personal Access Token permissions %v", err)
 		}
 		return nil
 	})
@@ -207,7 +207,7 @@ func (g *GoGithub) DeleteRepo(ctx context.Context, opts git.DeleteRepoOpts) erro
 	logger.V(3).Info("Deleting Github repository", "name", r, "owner", o)
 	_, err := g.Client.DeleteRepo(ctx, o, r)
 	if err != nil {
-		return fmt.Errorf("error when deleting repository %s: %v", r, err)
+		return fmt.Errorf("deleting repository %s: %v", r, err)
 	}
 	return nil
 }

--- a/pkg/git/gogithub/gogithub_test.go
+++ b/pkg/git/gogithub/gogithub_test.go
@@ -288,7 +288,7 @@ func TestGoGithubDeleteRepoFail(t *testing.T) {
 				Owner:      "owner1",
 				Repository: "repo1",
 			},
-			wantErr:  fmt.Errorf("error when deleting repository repo1: github client threw error"),
+			wantErr:  fmt.Errorf("deleting repository repo1: github client threw error"),
 			throwErr: fmt.Errorf("github client threw error"),
 		},
 	}

--- a/pkg/git/providers/github/github_test.go
+++ b/pkg/git/providers/github/github_test.go
@@ -86,7 +86,7 @@ func TestValidate(t *testing.T) {
 			}
 			githubProvider, err := github.New(gitproviderclient, githubproviderclient, opts, auth)
 			if err != nil {
-				t.Errorf("error when instantiating github provider: %v, wanted nil", err)
+				t.Errorf("instantiating github provider: %v, wanted nil", err)
 			}
 
 			if !tt.personal {
@@ -191,11 +191,11 @@ func TestGetRepoSucceeds(t *testing.T) {
 			auth := git.TokenAuth{Token: validPATValue, Username: tt.owner}
 			githubProvider, err := github.New(gitproviderclient, githubproviderclient, githubProviderOpts, auth)
 			if err != nil {
-				t.Errorf("error when instantiating github provider: %v, wanted nil", err)
+				t.Errorf("instantiating github provider: %v, wanted nil", err)
 			}
 			repo, err := githubProvider.GetRepo(context.Background())
 			if err != nil {
-				t.Errorf("error when calling Repo %v, wanted nil", err)
+				t.Errorf("calling Repo %v, wanted nil", err)
 			}
 			assert.Equal(t, testRepo, repo)
 		})
@@ -247,11 +247,11 @@ func TestGetNonExistantRepoSucceeds(t *testing.T) {
 			auth := git.TokenAuth{Token: validPATValue, Username: tt.owner}
 			githubProvider, err := github.New(gitproviderclient, githubproviderclient, githubProviderOpts, auth)
 			if err != nil {
-				t.Errorf("error when instantiating github provider: %v, wanted nil", err)
+				t.Errorf("instantiating github provider: %v, wanted nil", err)
 			}
 			repo, err := githubProvider.GetRepo(context.Background())
 			if err != nil {
-				t.Errorf("error when calling Repo %v, wanted nil", err)
+				t.Errorf("calling Repo %v, wanted nil", err)
 			}
 			var nilRepo *git.Repository
 			assert.Equal(t, nilRepo, repo)

--- a/pkg/logger/zap.go
+++ b/pkg/logger/zap.go
@@ -31,7 +31,7 @@ func InitZap(level int, opts ...LoggerOpt) error {
 
 	zapLog, err := cfg.Build()
 	if err != nil {
-		return fmt.Errorf("error creating zap logger: %v", err)
+		return fmt.Errorf("creating zap logger: %v", err)
 	}
 
 	logr := zapr.NewLogger(zapLog)

--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -99,7 +99,7 @@ func (c *Templater) GenerateNetworkPolicyManifest(spec *cluster.Spec, namespaces
 	as needed*/
 	k8sVersion, err := semver.New(spec.VersionsBundle.KubeDistro.Kubernetes.Tag)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing kubernetes version %v: %v", spec.Cluster.Spec.KubernetesVersion, err)
+		return nil, fmt.Errorf("parsing kubernetes version %v: %v", spec.Cluster.Spec.KubernetesVersion, err)
 	}
 	if k8sVersion.Major == 1 && k8sVersion.Minor >= 21 {
 		values["kubeSystemNSHasLabel"] = true

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -606,7 +606,7 @@ func (p *cloudstackProvider) GenerateCAPISpecForUpgrade(ctx context.Context, boo
 func (p *cloudstackProvider) GenerateCAPISpecForCreate(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	controlPlaneSpec, workersSpec, err = p.generateCAPISpecForCreate(ctx, cluster, clusterSpec)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error generating cluster api Spec contents: %v", err)
+		return nil, nil, fmt.Errorf("generating cluster api Spec contents: %v", err)
 	}
 	return controlPlaneSpec, workersSpec, nil
 }

--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -59,24 +59,24 @@ func (v *Validator) ValidateCloudStackDatacenterConfig(ctx context.Context, data
 	}
 	_, err := getHostnameFromUrl(datacenterConfig.Spec.ManagementApiEndpoint)
 	if err != nil {
-		return fmt.Errorf("error while checking management api endpoint: %v", err)
+		return fmt.Errorf("checking management api endpoint: %v", err)
 	}
 
 	domain, errDomain := v.cmk.ValidateDomainPresent(ctx, datacenterConfig.Spec.Domain)
 	if errDomain != nil {
-		return fmt.Errorf("error while checking domain: %v", errDomain)
+		return fmt.Errorf("checking domain: %v", errDomain)
 	}
 
 	if len(datacenterConfig.Spec.Account) > 0 {
 		err := v.cmk.ValidateAccountPresent(ctx, datacenterConfig.Spec.Account, domain.Id)
 		if err != nil {
-			return fmt.Errorf("error while checking account %v", err)
+			return fmt.Errorf("checking account %v", err)
 		}
 	}
 
 	zones, errZone := v.cmk.ValidateZonesPresent(ctx, datacenterConfig.Spec.Zones)
 	if errZone != nil {
-		return fmt.Errorf("error while checking zones %v", errZone)
+		return fmt.Errorf("checking zones %v", errZone)
 	}
 
 	for _, zone := range datacenterConfig.Spec.Zones {
@@ -85,7 +85,7 @@ func (v *Validator) ValidateCloudStackDatacenterConfig(ctx context.Context, data
 		}
 		err := v.cmk.ValidateNetworkPresent(ctx, domain.Id, zone, zones, datacenterConfig.Spec.Account, len(zones) > 1)
 		if err != nil {
-			return fmt.Errorf("error while checking network %v", err)
+			return fmt.Errorf("checking network %v", err)
 		}
 	}
 
@@ -192,12 +192,12 @@ func (v *Validator) validateMachineConfig(ctx context.Context, datacenterConfigS
 	}
 	domain, errDomain := v.cmk.ValidateDomainPresent(ctx, datacenterConfigSpec.Domain)
 	if errDomain != nil {
-		return fmt.Errorf("error while checking domain: %v", errDomain)
+		return fmt.Errorf("checking domain: %v", errDomain)
 	}
 
 	zones, err := v.cmk.ValidateZonesPresent(ctx, datacenterConfigSpec.Zones)
 	if err != nil {
-		return fmt.Errorf("error while checking zones %v", err)
+		return fmt.Errorf("checking zones %v", err)
 	}
 	domainId := domain.Id
 	account := datacenterConfigSpec.Account

--- a/pkg/providers/cloudstack/validator_test.go
+++ b/pkg/providers/cloudstack/validator_test.go
@@ -157,7 +157,7 @@ func TestValidateDatacenterBadManagementEndpoint(t *testing.T) {
 	datacenterConfig.Spec.ManagementApiEndpoint = ":1234.5234"
 	err = validator.ValidateCloudStackDatacenterConfig(ctx, cloudStackClusterSpec.datacenterConfig)
 
-	thenErrorExpected(t, "error while checking management api endpoint: :1234.5234 is not a valid url", err)
+	thenErrorExpected(t, "checking management api endpoint: :1234.5234 is not a valid url", err)
 }
 
 func TestSetupAndValidateUsersNil(t *testing.T) {

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -361,7 +361,7 @@ func (p *provider) generateCAPISpecForCreate(ctx context.Context, cluster *types
 func (p *provider) GenerateCAPISpecForCreate(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	controlPlaneSpec, workersSpec, err = p.generateCAPISpecForCreate(ctx, cluster, clusterSpec)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error generating cluster api spec contents: %v", err)
+		return nil, nil, fmt.Errorf("generating cluster api spec contents: %v", err)
 	}
 	return controlPlaneSpec, workersSpec, nil
 }
@@ -369,7 +369,7 @@ func (p *provider) GenerateCAPISpecForCreate(ctx context.Context, cluster *types
 func (p *provider) GenerateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currentSpec, newClusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	controlPlaneSpec, workersSpec, err = p.generateCAPISpecForUpgrade(ctx, bootstrapCluster, workloadCluster, currentSpec, newClusterSpec)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error generating cluster api spec contents: %v", err)
+		return nil, nil, fmt.Errorf("generating cluster api spec contents: %v", err)
 	}
 	return controlPlaneSpec, workersSpec, nil
 }

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -202,7 +202,7 @@ func (p *tinkerbellProvider) PostBootstrapSetup(ctx context.Context, clusterConf
 	// TODO: figure out if we need something else here
 	err := p.providerKubectlClient.ApplyHardware(ctx, p.hardwareConfigFile, cluster.KubeconfigFile)
 	if err != nil {
-		return fmt.Errorf("error applying hardware yaml: %v", err)
+		return fmt.Errorf("applying hardware yaml: %v", err)
 	}
 	return nil
 }
@@ -457,7 +457,7 @@ func (vs *TinkerbellTemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluste
 func (p *tinkerbellProvider) GenerateCAPISpecForCreate(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	controlPlaneSpec, workersSpec, err = p.generateCAPISpecForCreate(ctx, cluster, clusterSpec)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error generating cluster api spec contents: %v", err)
+		return nil, nil, fmt.Errorf("generating cluster api spec contents: %v", err)
 	}
 	return controlPlaneSpec, workersSpec, nil
 }

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -138,7 +138,7 @@ func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFi
 	}
 	tinkWorkflowMap, err := getWorkflowMap(workflows)
 	if err != nil {
-		return fmt.Errorf("error validating if the workflow exist for the given list of hardwares %v", err)
+		return fmt.Errorf("validating if the workflow exist for the given list of hardwares %v", err)
 	}
 
 	if err := v.hardwareConfig.ValidateHardware(skipPowerActions, tinkHardwareMap, tinkWorkflowMap); err != nil {
@@ -322,7 +322,7 @@ func getWorkflowMap(workflowList []*tinkworkflow.Workflow) (map[string]*tinkwork
 		var macAddress map[string]string
 
 		if err := json.Unmarshal([]byte(data.GetHardware()), &macAddress); err != nil {
-			return nil, fmt.Errorf("error unmarshling workflow data: %v", err)
+			return nil, fmt.Errorf("unmarshling workflow data: %v", err)
 		}
 		for _, mac := range macAddress {
 			workflowMap[mac] = data

--- a/pkg/providers/vsphere/defaults.go
+++ b/pkg/providers/vsphere/defaults.go
@@ -143,7 +143,7 @@ func (d *Defaulter) setupDefaultTemplate(ctx context.Context, spec *Spec, machin
 func (d *Defaulter) setDiskDefaults(ctx context.Context, machineConfig *anywherev1.VSphereMachineConfig) error {
 	templateHasSnapshot, err := d.govc.TemplateHasSnapshot(ctx, machineConfig.Spec.Template)
 	if err != nil {
-		return fmt.Errorf("error getting template details: %v", err)
+		return fmt.Errorf("getting template details: %v", err)
 	}
 
 	if !templateHasSnapshot {
@@ -165,7 +165,7 @@ func (d *Defaulter) setTemplateFullPath(ctx context.Context,
 	machine *anywherev1.VSphereMachineConfig) error {
 	templateFullPath, err := d.govc.SearchTemplate(ctx, datacenterConfig.Spec.Datacenter, machine)
 	if err != nil {
-		return fmt.Errorf("error setting template full path: %v", err)
+		return fmt.Errorf("setting template full path: %v", err)
 	}
 
 	if len(templateFullPath) <= 0 {

--- a/pkg/providers/vsphere/internal/templates/factory.go
+++ b/pkg/providers/vsphere/internal/templates/factory.go
@@ -54,7 +54,7 @@ func NewFactory(client GovcClient, datacenter, datastore, resourcePool, template
 func (f *Factory) CreateIfMissing(ctx context.Context, datacenter string, machineConfig *v1alpha1.VSphereMachineConfig, ovaURL string, tagsByCategory map[string][]string) error {
 	templateFullPath, err := f.client.SearchTemplate(ctx, datacenter, machineConfig)
 	if err != nil {
-		return fmt.Errorf("error checking for template: %v", err)
+		return fmt.Errorf("checking for template: %v", err)
 	}
 	if err == nil && len(templateFullPath) > 0 {
 		machineConfig.Spec.Template = templateFullPath // TODO: move this out of the factory into the defaulter, it's a side effect

--- a/pkg/providers/vsphere/validator.go
+++ b/pkg/providers/vsphere/validator.go
@@ -154,7 +154,7 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, vsphereCl
 		var b bool                                                                                            // Temporary until we remove the need to pass a bool pointer
 		err := v.govc.ValidateVCenterSetupMachineConfig(ctx, vsphereClusterSpec.datacenterConfig, config, &b) // TODO: remove side effects from this implementation or directly move it to set defaults (pointer to bool is not needed)
 		if err != nil {
-			return fmt.Errorf("error validating vCenter setup for VSphereMachineConfig %v: %v", config.Name, err)
+			return fmt.Errorf("validating vCenter setup for VSphereMachineConfig %v: %v", config.Name, err)
 		}
 	}
 
@@ -169,16 +169,16 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, vsphereCl
 	if err := v.validateSSHUsername(controlPlaneMachineConfig); err == nil {
 		for _, wnConfig := range workerNodeGroupMachineConfigs {
 			if err = v.validateSSHUsername(wnConfig); err != nil {
-				return fmt.Errorf("error validating SSHUsername for worker node VSphereMachineConfig %v: %v", wnConfig.Name, err)
+				return fmt.Errorf("validating SSHUsername for worker node VSphereMachineConfig %v: %v", wnConfig.Name, err)
 			}
 		}
 		if etcdMachineConfig != nil {
 			if err = v.validateSSHUsername(etcdMachineConfig); err != nil {
-				return fmt.Errorf("error validating SSHUsername for etcd VSphereMachineConfig %v: %v", etcdMachineConfig.Name, err)
+				return fmt.Errorf("validating SSHUsername for etcd VSphereMachineConfig %v: %v", etcdMachineConfig.Name, err)
 			}
 		}
 	} else {
-		return fmt.Errorf("error validating SSHUsername for control plane VSphereMachineConfig %v: %v", controlPlaneMachineConfig.Name, err)
+		return fmt.Errorf("validating SSHUsername for control plane VSphereMachineConfig %v: %v", controlPlaneMachineConfig.Name, err)
 	}
 
 	for _, machineConfig := range vsphereClusterSpec.machineConfigsLookup {
@@ -237,7 +237,7 @@ func (v *Validator) validateTemplate(ctx context.Context, spec *Spec, machineCon
 func (v *Validator) validateTemplatePresence(ctx context.Context, datacenter string, machineConfig *anywherev1.VSphereMachineConfig) error {
 	templateFullPath, err := v.govc.SearchTemplate(ctx, datacenter, machineConfig)
 	if err != nil {
-		return fmt.Errorf("error validating template: %v", err)
+		return fmt.Errorf("validating template: %v", err)
 	}
 
 	if len(templateFullPath) <= 0 {
@@ -250,7 +250,7 @@ func (v *Validator) validateTemplatePresence(ctx context.Context, datacenter str
 func (v *Validator) validateTemplateTags(ctx context.Context, spec *Spec, machineConfig *anywherev1.VSphereMachineConfig) error {
 	tags, err := v.govc.GetTags(ctx, machineConfig.Spec.Template)
 	if err != nil {
-		return fmt.Errorf("error validating template tags: %v", err)
+		return fmt.Errorf("validating template tags: %v", err)
 	}
 
 	tagsLookup := types.SliceToLookup(tags)
@@ -275,7 +275,7 @@ func (v *Validator) validateDatastoreUsage(ctx context.Context, vsphereClusterSp
 	usage := make(map[string]*datastoreUsage)
 	controlPlaneAvailableSpace, err := v.govc.GetWorkloadAvailableSpace(ctx, controlPlaneMachineConfig.Spec.Datastore) // TODO: remove dependency on machineConfig
 	if err != nil {
-		return fmt.Errorf("error getting datastore details: %v", err)
+		return fmt.Errorf("getting datastore details: %v", err)
 	}
 	controlPlaneNeedGiB := controlPlaneMachineConfig.Spec.DiskGiB * vsphereClusterSpec.Cluster.Spec.ControlPlaneConfiguration.Count
 	usage[controlPlaneMachineConfig.Spec.Datastore] = &datastoreUsage{
@@ -287,7 +287,7 @@ func (v *Validator) validateDatastoreUsage(ctx context.Context, vsphereClusterSp
 		workerMachineConfig := vsphereClusterSpec.workerMachineConfig(workerNodeGroupConfiguration)
 		workerAvailableSpace, err := v.govc.GetWorkloadAvailableSpace(ctx, workerMachineConfig.Spec.Datastore)
 		if err != nil {
-			return fmt.Errorf("error getting datastore details: %v", err)
+			return fmt.Errorf("getting datastore details: %v", err)
 		}
 		workerNeedGiB := workerMachineConfig.Spec.DiskGiB * workerNodeGroupConfiguration.Count
 		_, ok := usage[workerMachineConfig.Spec.Datastore]
@@ -304,7 +304,7 @@ func (v *Validator) validateDatastoreUsage(ctx context.Context, vsphereClusterSp
 	if etcdMachineConfig != nil {
 		etcdAvailableSpace, err := v.govc.GetWorkloadAvailableSpace(ctx, etcdMachineConfig.Spec.Datastore)
 		if err != nil {
-			return fmt.Errorf("error getting datastore details: %v", err)
+			return fmt.Errorf("getting datastore details: %v", err)
 		}
 		etcdNeedGiB := etcdMachineConfig.Spec.DiskGiB * vsphereClusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
 		if _, ok := usage[etcdMachineConfig.Spec.Datastore]; ok {

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -477,7 +477,7 @@ func (p *vsphereProvider) UpdateSecrets(ctx context.Context, cluster *types.Clus
 
 	err = p.providerKubectlClient.ApplyKubeSpecFromBytes(ctx, cluster, contents.Bytes())
 	if err != nil {
-		return fmt.Errorf("error loading secrets object: %v", err)
+		return fmt.Errorf("loading secrets object: %v", err)
 	}
 	return nil
 }
@@ -608,7 +608,7 @@ func (vs *VsphereTemplateBuilder) isCgroupDriverSystemd(clusterSpec *cluster.Spe
 	bundle := clusterSpec.VersionsBundle
 	k8sVersion, err := semver.New(bundle.KubeDistro.Kubernetes.Tag)
 	if err != nil {
-		return false, fmt.Errorf("error parsing kubernetes version %v: %v", bundle.KubeDistro.Kubernetes.Tag, err)
+		return false, fmt.Errorf("parsing kubernetes version %v: %v", bundle.KubeDistro.Kubernetes.Tag, err)
 	}
 	if vs.fromController && k8sVersion.Major == 1 && k8sVersion.Minor >= 21 {
 		return true, nil
@@ -996,7 +996,7 @@ func (p *vsphereProvider) generateCAPISpecForCreate(ctx context.Context, cluster
 func (p *vsphereProvider) GenerateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currentSpec, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	controlPlaneSpec, workersSpec, err = p.generateCAPISpecForUpgrade(ctx, bootstrapCluster, workloadCluster, currentSpec, clusterSpec)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error generating cluster api spec contents: %v", err)
+		return nil, nil, fmt.Errorf("generating cluster api spec contents: %v", err)
 	}
 	return controlPlaneSpec, workersSpec, nil
 }
@@ -1004,7 +1004,7 @@ func (p *vsphereProvider) GenerateCAPISpecForUpgrade(ctx context.Context, bootst
 func (p *vsphereProvider) GenerateCAPISpecForCreate(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	controlPlaneSpec, workersSpec, err = p.generateCAPISpecForCreate(ctx, cluster, clusterSpec)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error generating cluster api spec contents: %v", err)
+		return nil, nil, fmt.Errorf("generating cluster api spec contents: %v", err)
 	}
 	return controlPlaneSpec, workersSpec, nil
 }
@@ -1033,7 +1033,7 @@ func (p *vsphereProvider) createSecret(ctx context.Context, cluster *types.Clust
 	}
 	t, err := template.New("tmpl").Parse(defaultSecretObject)
 	if err != nil {
-		return fmt.Errorf("error creating secret object template: %v", err)
+		return fmt.Errorf("creating secret object template: %v", err)
 	}
 
 	values := map[string]string{
@@ -1046,7 +1046,7 @@ func (p *vsphereProvider) createSecret(ctx context.Context, cluster *types.Clust
 	}
 	err = t.Execute(contents, values)
 	if err != nil {
-		return fmt.Errorf("error substituting values for secret object template: %v", err)
+		return fmt.Errorf("substituting values for secret object template: %v", err)
 	}
 	return nil
 }
@@ -1235,7 +1235,7 @@ func (p *vsphereProvider) secretContentsChanged(ctx context.Context, workloadClu
 	nPassword := os.Getenv(vSpherePasswordKey)
 	oSecret, err := p.providerKubectlClient.GetSecret(ctx, CredentialsObjectName, executables.WithCluster(workloadCluster), executables.WithNamespace(constants.EksaSystemNamespace))
 	if err != nil {
-		return false, fmt.Errorf("error when obtaining VSphere secret %s from workload cluster: %v", CredentialsObjectName, err)
+		return false, fmt.Errorf("obtaining VSphere secret %s from workload cluster: %v", CredentialsObjectName, err)
 	}
 
 	if string(oSecret.Data["password"]) != nPassword {

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -2335,7 +2335,7 @@ func TestSetupAndValidateCreateClusterErrorCheckingTemplate(t *testing.T) {
 
 	err := tt.provider.SetupAndValidateCreateCluster(tt.ctx, tt.clusterSpec)
 
-	thenErrorExpected(t, "failed setting default values for vsphere machine configs: error setting template full path: "+errorMessage, err)
+	thenErrorExpected(t, "failed setting default values for vsphere machine configs: setting template full path: "+errorMessage, err)
 }
 
 func TestSetupAndValidateCreateClusterTemplateMissingTags(t *testing.T) {
@@ -2379,7 +2379,7 @@ func TestSetupAndValidateCreateClusterErrorGettingTags(t *testing.T) {
 
 	err := tt.provider.SetupAndValidateCreateCluster(tt.ctx, tt.clusterSpec)
 
-	thenErrorExpected(t, "error validating template tags: failed getting tags", err)
+	thenErrorExpected(t, "validating template tags: failed getting tags", err)
 }
 
 func TestSetupAndValidateCreateClusterDefaultTemplate(t *testing.T) {

--- a/pkg/templater/templater.go
+++ b/pkg/templater/templater.go
@@ -26,7 +26,7 @@ func (t *Templater) WriteToFile(templateContent string, data interface{}, fileNa
 	}
 	writtenFilePath, err := t.writer.Write(fileName, bytes, f...)
 	if err != nil {
-		return "", fmt.Errorf("error writing template file: %v", err)
+		return "", fmt.Errorf("writing template file: %v", err)
 	}
 
 	return writtenFilePath, nil
@@ -35,7 +35,7 @@ func (t *Templater) WriteToFile(templateContent string, data interface{}, fileNa
 func (t *Templater) WriteBytesToFile(content []byte, fileName string, f ...filewriter.FileOptionsFunc) (filePath string, err error) {
 	writtenFilePath, err := t.writer.Write(fileName, content, f...)
 	if err != nil {
-		return "", fmt.Errorf("error writing template file: %v", err)
+		return "", fmt.Errorf("writing template file: %v", err)
 	}
 
 	return writtenFilePath, nil
@@ -54,13 +54,13 @@ func Execute(templateContent string, data interface{}) ([]byte, error) {
 
 	temp, err := temp.Parse(templateContent)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing template: %v", err)
+		return nil, fmt.Errorf("parsing template: %v", err)
 	}
 
 	var buf bytes.Buffer
 	err = temp.Execute(&buf, data)
 	if err != nil {
-		return nil, fmt.Errorf("error substituting values for template: %v", err)
+		return nil, fmt.Errorf("substituting values for template: %v", err)
 	}
 	return buf.Bytes(), nil
 }

--- a/pkg/validations/upgradevalidations/eksasystem.go
+++ b/pkg/validations/upgradevalidations/eksasystem.go
@@ -16,7 +16,7 @@ const (
 func ValidateEksaSystemComponents(ctx context.Context, k *executables.Kubectl, cluster *types.Cluster) error {
 	deployments, err := k.GetDeployments(ctx, executables.WithCluster(cluster), executables.WithNamespace(constants.EksaSystemNamespace))
 	if err != nil {
-		return fmt.Errorf("error getting deployments in namespace %s: %v", constants.EksaSystemNamespace, err)
+		return fmt.Errorf("getting deployments in namespace %s: %v", constants.EksaSystemNamespace, err)
 	}
 	for _, d := range deployments {
 		if d.Name == eksaControllerDeploymentName {

--- a/pkg/validations/upgradevalidations/versions.go
+++ b/pkg/validations/upgradevalidations/versions.go
@@ -18,17 +18,17 @@ const supportedMinorVersionIncrement = 1
 func ValidateServerVersionSkew(ctx context.Context, compareVersion v1alpha1.KubernetesVersion, cluster *types.Cluster, kubectl validations.KubectlClient) error {
 	versions, err := kubectl.Version(ctx, cluster)
 	if err != nil {
-		return fmt.Errorf("error while fetching cluster version: %v", err)
+		return fmt.Errorf("fetching cluster version: %v", err)
 	}
 
 	parsedInputVersion, err := version.ParseGeneric(string(compareVersion))
 	if err != nil {
-		return fmt.Errorf("error while parsing comparison version: %v", err)
+		return fmt.Errorf("parsing comparison version: %v", err)
 	}
 
 	parsedServerVersion, err := version.ParseSemantic(versions.ServerVersion.GitVersion)
 	if err != nil {
-		return fmt.Errorf("error while parsing cluster version: %v", err)
+		return fmt.Errorf("parsing cluster version: %v", err)
 	}
 
 	logger.V(3).Info("calculating version differences", "inputVersion", parsedInputVersion, "clusterVersion", parsedServerVersion)

--- a/release/pkg/images/images.go
+++ b/release/pkg/images/images.go
@@ -78,7 +78,7 @@ func CopyToDestination(sourceAuthConfig, releaseAuthConfig *docker.AuthConfigura
 	out, err := utils.ExecCommand(cmd)
 	fmt.Println(out)
 	if err != nil {
-		return fmt.Errorf("error executing skopeo copy command: %v", err)
+		return fmt.Errorf("executing skopeo copy command: %v", err)
 	}
 
 	return nil

--- a/release/pkg/prepare_release.go
+++ b/release/pkg/prepare_release.go
@@ -404,12 +404,12 @@ func (r *ReleaseConfig) UploadArtifacts(eksArtifacts map[string][]Artifact) erro
 				fmt.Printf("Destination Image - %s\n", releaseImageUri)
 				exists, err := ecrpublic.CheckImageExistence(releaseImageUri, r.ReleaseContainerRegistry, r.ReleaseClients.ECRPublic.Client)
 				if err != nil {
-					return fmt.Errorf("error checking for image existence in ECR Public: %v", err)
+					return fmt.Errorf("checking for image existence in ECR Public: %v", err)
 				}
 				if !exists {
 					err := images.CopyToDestination(sourceEcrAuthConfig, releaseEcrAuthConfig, sourceImageUri, releaseImageUri)
 					if err != nil {
-						return fmt.Errorf("error copying image from source to destination: %v", err)
+						return fmt.Errorf("copying image from source to destination: %v", err)
 					}
 				}
 			}

--- a/test/e2e/tools/eks-anywhere-test-tool/cmd/fetchProviderProxyLogs.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/cmd/fetchProviderProxyLogs.go
@@ -28,17 +28,17 @@ var e2eFetchProxyLogsCommand = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		buildAccountCodebuild, err := codebuild.New(awsprofiles.BuildAccount)
 		if err != nil {
-			return fmt.Errorf("error when creating codebuild client: %v", err)
+			return fmt.Errorf("creating codebuild client: %v", err)
 		}
 
 		buildAccountCw, err := cloudwatch.New(awsprofiles.BuildAccount)
 		if err != nil {
-			return fmt.Errorf("error when creating cloudwatch logs client: %v", err)
+			return fmt.Errorf("creating cloudwatch logs client: %v", err)
 		}
 
 		testAccountCw, err := cloudwatch.New(awsprofiles.TestAccount)
 		if err != nil {
-			return fmt.Errorf("error when instantiating CW profile: %v", err)
+			return fmt.Errorf("instantiating CW profile: %v", err)
 		}
 
 		var fetcherOpts []providerProxy.ProxyFetcherOpt

--- a/test/e2e/tools/eks-anywhere-test-tool/cmd/fetchartifacts.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/cmd/fetchartifacts.go
@@ -35,18 +35,18 @@ var e2eFetchArtifactsCommand = &cobra.Command{
 
 		buildAccountCodebuild, err := codebuild.New(awsprofiles.BuildAccount)
 		if err != nil {
-			return fmt.Errorf("error when creating codebuild client: %v", err)
+			return fmt.Errorf("creating codebuild client: %v", err)
 		}
 
 		testAccountS3, err := s3.New(awsprofiles.TestAccount)
 		if err != nil {
-			return fmt.Errorf("error when creating s3 client: %v", err)
+			return fmt.Errorf("creating s3 client: %v", err)
 		}
 
 		now := time.Now().Format(time.RFC3339 + "-artifacts")
 		writer, err := filewriter.NewWriter(now)
 		if err != nil {
-			return fmt.Errorf("error when setting up writer: %v", err)
+			return fmt.Errorf("setting up writer: %v", err)
 		}
 
 		artifactFetcher := artifacts.New(testAccountS3, buildAccountCodebuild, writer)

--- a/test/e2e/tools/eks-anywhere-test-tool/cmd/fetchlogs.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/cmd/fetchlogs.go
@@ -25,17 +25,17 @@ var e2eFetchLogsCommand = &cobra.Command{
 		fmt.Println("Let's fetch some logs! \U0001FAB5")
 		buildAccountCodebuild, err := codebuild.New(awsprofiles.BuildAccount)
 		if err != nil {
-			return fmt.Errorf("error when creating codebuild client: %v", err)
+			return fmt.Errorf("creating codebuild client: %v", err)
 		}
 
 		buildAccountCw, err := cloudwatch.New(awsprofiles.BuildAccount)
 		if err != nil {
-			return fmt.Errorf("error when creating cloudwatch logs client: %v", err)
+			return fmt.Errorf("creating cloudwatch logs client: %v", err)
 		}
 
 		testAccountCw, err := cloudwatch.New(awsprofiles.TestAccount)
 		if err != nil {
-			return fmt.Errorf("error when instantiating CW profile: %v", err)
+			return fmt.Errorf("instantiating CW profile: %v", err)
 		}
 
 		var fetcherOpts []logfetcher.LogFetcherOpt

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/artifacts/artifactFetcher.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/artifacts/artifactFetcher.go
@@ -84,7 +84,7 @@ func (l *testArtifactFetcher) FetchArtifacts(opts ...FetchArtifactsOpt) error {
 	objects, err := l.testAccountS3Client.ListObjects(config.bucket, config.buildId)
 	logger.V(5).Info("Listed objects", "bucket", config.bucket, "prefix", config.buildId, "objects", len(objects))
 	if err != nil {
-		return fmt.Errorf("error listing objects in bucket %s at key %s: %v", config.bucket, config.buildId, err)
+		return fmt.Errorf("listing objects in bucket %s at key %s: %v", config.bucket, config.buildId, err)
 	}
 
 	errs, _ := errgroup.WithContext(context.Background())
@@ -108,7 +108,7 @@ func (l *testArtifactFetcher) FetchArtifacts(opts ...FetchArtifactsOpt) error {
 			})
 			if err != nil {
 				logger.Info("error occured while writing file", "err", err)
-				return fmt.Errorf("error writing object %s from bucket %s to file: %v", *obj.Key, config.bucket, err)
+				return fmt.Errorf("writing object %s from bucket %s to file: %v", *obj.Key, config.bucket, err)
 			}
 			return nil
 		})

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/filewriter/writer.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/filewriter/writer.go
@@ -19,7 +19,7 @@ func NewWriter(dir string) (FileWriter, error) {
 	if _, err := os.Stat(newFolder); errors.Is(err, os.ErrNotExist) {
 		err := os.MkdirAll(newFolder, os.ModePerm)
 		if err != nil {
-			return nil, fmt.Errorf("error creating directory [%s]: %v", dir, err)
+			return nil, fmt.Errorf("creating directory [%s]: %v", dir, err)
 		}
 	}
 	return &writer{dir: dir}, nil
@@ -39,7 +39,7 @@ func (t *writer) Write(fileName string, content []byte, f ...FileOptionsFunc) (s
 	filePath := filepath.Join(currentDir, fileName)
 	err := ioutil.WriteFile(filePath, content, op.Permissions)
 	if err != nil {
-		return "", fmt.Errorf("error writing to file [%s]: %v", filePath, err)
+		return "", fmt.Errorf("writing to file [%s]: %v", filePath, err)
 	}
 
 	return filePath, nil

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/logfetcher/logfetcher.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/logfetcher/logfetcher.go
@@ -163,7 +163,7 @@ func (l *testLogFetcher) GetBuildProjectLogs(project string, buildId string) ([]
 	logger.Info("Fetching build project logs...")
 	build, err := l.buildAccountCodebuildClient.FetchBuildForProject(buildId)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching build project logs for project %s: %v", project, err)
+		return nil, fmt.Errorf("fetching build project logs for project %s: %v", project, err)
 	}
 
 	g := build.Logs.GroupName
@@ -171,7 +171,7 @@ func (l *testLogFetcher) GetBuildProjectLogs(project string, buildId string) ([]
 
 	logs, err := l.buildAccountCwClient.GetLogs(*g, *s)
 	if err != nil {
-		return nil, fmt.Errorf("error when fetching cloudwatch logs: %v", err)
+		return nil, fmt.Errorf("fetching cloudwatch logs: %v", err)
 	}
 
 	allMsg := allMessages(logs)

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/logfetcher/testswriter.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/logfetcher/testswriter.go
@@ -18,7 +18,7 @@ type testsWriter struct {
 func newTestsWriter(folderPath string) (*testsWriter, error) {
 	writer, err := filewriter.NewWriter(folderPath)
 	if err != nil {
-		return nil, fmt.Errorf("error when setting up tests writer: %v", err)
+		return nil, fmt.Errorf("setting up tests writer: %v", err)
 	}
 
 	return &testsWriter{FileWriter: writer}, nil
@@ -26,7 +26,7 @@ func newTestsWriter(folderPath string) (*testsWriter, error) {
 
 func (w *testsWriter) writeCodeBuild(build *awscodebuild.Build) error {
 	if _, err := w.Write(constants.BuildDescriptionFile, []byte(build.String()), filewriter.PersistentFile); err != nil {
-		return fmt.Errorf("error when writing build description: %v", err)
+		return fmt.Errorf("writing build description: %v", err)
 	}
 
 	return nil

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/providerProxy/logFetcher.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/providerProxy/logFetcher.go
@@ -117,7 +117,7 @@ func (l *proxyLogFetcher) FetchProviderProxyLogsForbuild(project string, buildId
 	logger.Info("Fetching provider proxy logs...")
 	build, err := l.buildAccountCodebuildClient.FetchBuildForProject(buildId)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching build for project %s: %v", project, err)
+		return nil, fmt.Errorf("fetching build for project %s: %v", project, err)
 	}
 
 	buildStart := build.StartTime.UnixNano() / 1e6
@@ -128,7 +128,7 @@ func (l *proxyLogFetcher) FetchProviderProxyLogsForbuild(project string, buildId
 
 	logs, err := l.buildAccountCwClient.GetLogsInTimeframe(constants.CiProxyLogGroup, constants.CiProxyLogStream, buildStart, buildEnd)
 	if err != nil {
-		return nil, fmt.Errorf("error when fetching cloudwatch logs: %v", err)
+		return nil, fmt.Errorf("fetching cloudwatch logs: %v", err)
 	}
 	filteredLogs, err := l.filterRequests(logs)
 	return filteredLogs, err

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/providerProxy/requestWriter.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/providerProxy/requestWriter.go
@@ -16,7 +16,7 @@ type requestWriter struct {
 func newRequestWriter(folderPath string) (*requestWriter, error) {
 	writer, err := filewriter.NewWriter(folderPath)
 	if err != nil {
-		return nil, fmt.Errorf("error when setting up tests writer: %v", err)
+		return nil, fmt.Errorf("setting up tests writer: %v", err)
 	}
 
 	return &requestWriter{FileWriter: writer}, nil

--- a/test/framework/awsiam.go
+++ b/test/framework/awsiam.go
@@ -89,7 +89,7 @@ func (e *ClusterE2ETest) setIamAuthClientPATH() error {
 	envPath := os.Getenv("PATH")
 	workDir, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("error finding current working directory: %v", err)
+		return fmt.Errorf("finding current working directory: %v", err)
 	}
 	iamAuthClientPath := fmt.Sprintf("%s/bin", workDir)
 	if strings.Contains(envPath, iamAuthClientPath) {
@@ -97,7 +97,7 @@ func (e *ClusterE2ETest) setIamAuthClientPATH() error {
 	}
 	err = os.Setenv("PATH", fmt.Sprintf("%s:%s", iamAuthClientPath, envPath))
 	if err != nil {
-		return fmt.Errorf("error setting %s to PATH: %v", iamAuthClientPath, err)
+		return fmt.Errorf("setting %s to PATH: %v", iamAuthClientPath, err)
 	}
 	return nil
 }
@@ -106,7 +106,7 @@ func (e *ClusterE2ETest) getEksdReleaseManifest() (*eksdv1alpha1.Release, error)
 	c := e.clusterConfig()
 	_, eksdRelease, err := cluster.GetEksdRelease(version.Get(), c)
 	if err != nil {
-		return nil, fmt.Errorf("error getting EKS-D release spec from bundle: %v", err)
+		return nil, fmt.Errorf("getting EKS-D release spec from bundle: %v", err)
 	}
 	return eksdRelease, nil
 }

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -346,7 +346,7 @@ func (e *ClusterE2ETest) ValidateCluster(kubeVersion v1alpha1.KubernetesVersion)
 	err := r.Retry(func() error {
 		err := e.KubectlClient.ValidateNodes(ctx, e.cluster().KubeconfigFile)
 		if err != nil {
-			return fmt.Errorf("error validating nodes status: %v", err)
+			return fmt.Errorf("validating nodes status: %v", err)
 		}
 		return nil
 	})
@@ -356,7 +356,7 @@ func (e *ClusterE2ETest) ValidateCluster(kubeVersion v1alpha1.KubernetesVersion)
 	e.T.Log("Validating cluster node version")
 	err = retrier.Retry(180, 1*time.Second, func() error {
 		if err = e.KubectlClient.ValidateNodesVersion(ctx, e.cluster().KubeconfigFile, kubeVersion); err != nil {
-			return fmt.Errorf("error validating nodes version: %v", err)
+			return fmt.Errorf("validating nodes version: %v", err)
 		}
 		return nil
 	})

--- a/test/framework/conformance.go
+++ b/test/framework/conformance.go
@@ -58,16 +58,16 @@ func (e *ClusterE2ETest) RunConformanceTests() {
 func (e *ClusterE2ETest) getEksdReleaseKubeVersion() (string, error) {
 	c, err := v1alpha1.GetClusterConfig(e.ClusterConfigLocation)
 	if err != nil {
-		return "", fmt.Errorf("error fetching cluster config from file: %v", err)
+		return "", fmt.Errorf("fetching cluster config from file: %v", err)
 	}
 	eksdRelease, _, err := cluster.GetEksdRelease(version.Get(), c)
 	if err != nil {
-		return "", fmt.Errorf("error getting EKS-D release spec from bundle: %v", err)
+		return "", fmt.Errorf("getting EKS-D release spec from bundle: %v", err)
 	}
 	if kubeVersion := eksdRelease.KubeVersion; kubeVersion != "" {
 		return kubeVersion, nil
 	}
-	return "", fmt.Errorf("error getting KubeVersion from EKS-D release spec: value empty")
+	return "", fmt.Errorf("getting KubeVersion from EKS-D release spec: value empty")
 }
 
 // Function to parse the conformace test results and look for any failed tests.

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -407,7 +407,7 @@ func (e *ClusterE2ETest) validateDeploymentsInManagementCluster(ctx context.Cont
 			executables.WithNamespace(namespace),
 		)
 		if err != nil {
-			return fmt.Errorf("error getting deployments: %v", err)
+			return fmt.Errorf("getting deployments: %v", err)
 		}
 
 		for _, deployment := range deployments {
@@ -492,7 +492,7 @@ func (e *ClusterE2ETest) waitForWorkerNodeValidation() error {
 		e.T.Log("Attempting to validate worker nodes...")
 		if err := e.KubectlClient.ValidateWorkerNodes(ctx, e.ClusterConfig.Name, e.managementKubeconfigFilePath()); err != nil {
 			e.T.Logf("Worker node validation failed: %v", err)
-			return fmt.Errorf("error while validating worker nodes: %v", err)
+			return fmt.Errorf("validating worker nodes: %v", err)
 		}
 		return nil
 	})

--- a/test/framework/git.go
+++ b/test/framework/git.go
@@ -42,7 +42,7 @@ func (e *ClusterE2ETest) NewGitOptions(ctx context.Context, cluster *v1alpha1.Cl
 	gitProviderFactory := gitFactory.New(gitProviderFactoryOptions)
 	gitProvider, err := gitProviderFactory.BuildProvider(ctx, &gitOpsConfig.Spec)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Git provider: %v", err)
+		return nil, fmt.Errorf("creating Git provider: %v", err)
 	}
 	err = gitProvider.Validate(ctx)
 	if err != nil {
@@ -50,7 +50,7 @@ func (e *ClusterE2ETest) NewGitOptions(ctx context.Context, cluster *v1alpha1.Cl
 	}
 	gitwriter, err := writer.WithDir(localGitWriterPath)
 	if err != nil {
-		return nil, fmt.Errorf("error creating file writer: %v", err)
+		return nil, fmt.Errorf("creating file writer: %v", err)
 	}
 	gitwriter.CleanUpTemp()
 	return &GitOptions{

--- a/test/framework/network.go
+++ b/test/framework/network.go
@@ -9,7 +9,7 @@ import (
 func PopIPFromEnv(ipPoolEnvVar string) (string, error) {
 	ipPool, err := networkutils.NewIPPoolFromEnv(ipPoolEnvVar)
 	if err != nil {
-		return "", fmt.Errorf("error popping IP from environment: %v", err)
+		return "", fmt.Errorf("popping IP from environment: %v", err)
 	}
 
 	ip, popErr := ipPool.PopIP()
@@ -21,7 +21,7 @@ func PopIPFromEnv(ipPoolEnvVar string) (string, error) {
 	// Therefore, we rewrite the envvar to the system so the next caller can pick from remaining ips in the pool
 	err = ipPool.ToEnvVar(ipPoolEnvVar)
 	if err != nil {
-		return "", fmt.Errorf("error popping IP from environment: %v", err)
+		return "", fmt.Errorf("popping IP from environment: %v", err)
 	}
 
 	return ip, nil
@@ -31,7 +31,7 @@ func GenerateUniqueIp(cidr string) (string, error) {
 	ipgen := networkutils.NewIPGenerator(&networkutils.DefaultNetClient{})
 	ip, err := ipgen.GenerateUniqueIP(cidr)
 	if err != nil {
-		return "", fmt.Errorf("error getting unique IP for cidr %s: %v", cidr, err)
+		return "", fmt.Errorf("getting unique IP for cidr %s: %v", cidr, err)
 	}
 	return ip, nil
 }

--- a/test/framework/releaseVersions.go
+++ b/test/framework/releaseVersions.go
@@ -121,7 +121,7 @@ func getBinary(release *releasev1alpha1.EksARelease) (string, error) {
 
 		binaryUri, err := r.binaryUri()
 		if err != nil {
-			return "", fmt.Errorf("error determining URI for EKS-A binary: %v", err)
+			return "", fmt.Errorf("determining URI for EKS-A binary: %v", err)
 		}
 		err = files.GzipFileDownloadExtract(binaryUri, releaseBinaryName, latestReleaseBinaryFolder)
 		if err != nil {


### PR DESCRIPTION
Remove superfluous 'error' prefix from error messages when wrapping with context.

When constructing error messages and passing them up the call stack its superfluous to prepend the context with the word 'error' and unnecessarily elongates the message. In general, only constructs that _present_ the error to the end user should prepend 'error' (for example Cobra when we return from the `RunE` funcs). 