### PR TITLE
Adding validation on managementApiEndpoints to be consistent

### DIFF
--- a/pkg/providers/cloudstack/testdata/cluster_main.yaml
+++ b/pkg/providers/cloudstack/testdata/cluster_main.yaml
@@ -46,6 +46,7 @@ spec:
   - name: "zone1"
     network:
       name: "net1"
+  managementApiEndpoint: "http://127.16.0.1:8080/client/api"
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: CloudStackMachineConfig

--- a/pkg/providers/cloudstack/testdata/cluster_mirror_config.yaml
+++ b/pkg/providers/cloudstack/testdata/cluster_mirror_config.yaml
@@ -49,6 +49,7 @@ spec:
     - network:
         name: "net1"
       name: "zone1"
+  managementApiEndpoint: "http://127.16.0.1:8080/client/api"
 
 
 ---

--- a/pkg/providers/cloudstack/testdata/cluster_mirror_with_cert_config.yaml
+++ b/pkg/providers/cloudstack/testdata/cluster_mirror_with_cert_config.yaml
@@ -66,6 +66,7 @@ spec:
     - network:
         name: "net1"
       name: "zone1"
+  managementApiEndpoint: "http://127.16.0.1:8080/client/api"
 
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1

--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -58,6 +58,9 @@ func (v *Validator) ValidateCloudStackDatacenterConfig(ctx context.Context, data
 	if len(datacenterConfig.Spec.Domain) <= 0 {
 		return fmt.Errorf("CloudStackDatacenterConfig domain is not set or is empty")
 	}
+	if datacenterConfig.Spec.ManagementApiEndpoint == "" {
+		return fmt.Errorf("CloudStackDatacenterConfig managementApiEndpoint is not set or is empty")
+	}
 	_, err := getHostnameFromUrl(datacenterConfig.Spec.ManagementApiEndpoint)
 	if err != nil {
 		return fmt.Errorf("error while checking management api endpoint: %v", err)

--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -9,6 +9,7 @@ import (
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 )
 
 type Validator struct {
@@ -60,6 +61,14 @@ func (v *Validator) ValidateCloudStackDatacenterConfig(ctx context.Context, data
 	_, err := getHostnameFromUrl(datacenterConfig.Spec.ManagementApiEndpoint)
 	if err != nil {
 		return fmt.Errorf("error while checking management api endpoint: %v", err)
+	}
+	execConfig, err := decoder.ParseCloudStackSecret()
+	if err != nil {
+		return fmt.Errorf("parsing cloudstack secret: %v", err)
+	}
+	if execConfig.ManagementUrl != datacenterConfig.Spec.ManagementApiEndpoint {
+		return fmt.Errorf("cloudstack secret management url (%s) differs from cluster spec management url (%s)",
+			execConfig.ManagementUrl, datacenterConfig.Spec.ManagementApiEndpoint)
 	}
 
 	domain, errDomain := v.cmk.ValidateDomainPresent(ctx, datacenterConfig.Spec.Domain)

--- a/pkg/providers/cloudstack/validator_test.go
+++ b/pkg/providers/cloudstack/validator_test.go
@@ -39,6 +39,7 @@ func thenErrorExpected(t *testing.T, expected string, err error) {
 
 func TestValidateCloudStackDatacenterConfig(t *testing.T) {
 	ctx := context.Background()
+	setupContext()
 	cmk := mocks.NewMockProviderCmkClient(gomock.NewController(t))
 	validator := NewValidator(cmk)
 
@@ -116,6 +117,7 @@ func TestValidateMachineConfigsMultipleWorkerNodeGroupsUnsupported(t *testing.T)
 
 func TestValidateDatacenterConfigsNoNetwork(t *testing.T) {
 	ctx := context.Background()
+	setupContext()
 	cmk := mocks.NewMockProviderCmkClient(gomock.NewController(t))
 	datacenterConfig, err := v1alpha1.GetCloudStackDatacenterConfig(path.Join(testDataDir, testClusterConfigMainFilename))
 	if err != nil {
@@ -158,6 +160,28 @@ func TestValidateDatacenterBadManagementEndpoint(t *testing.T) {
 	err = validator.ValidateCloudStackDatacenterConfig(ctx, cloudStackClusterSpec.datacenterConfig)
 
 	thenErrorExpected(t, "error while checking management api endpoint: :1234.5234 is not a valid url", err)
+}
+
+func TestValidateDatacenterInconsistentManagementEndpoints(t *testing.T) {
+	ctx := context.Background()
+	setupContext()
+	cmk := mocks.NewMockProviderCmkClient(gomock.NewController(t))
+	datacenterConfig, err := v1alpha1.GetCloudStackDatacenterConfig(path.Join(testDataDir, testClusterConfigMainFilename))
+	if err != nil {
+		t.Fatalf("unable to get datacenter config from file")
+	}
+	clusterSpec := test.NewFullClusterSpec(t, path.Join(testDataDir, testClusterConfigMainFilename))
+	cloudStackClusterSpec := &Spec{
+		Spec:                 clusterSpec,
+		datacenterConfig:     datacenterConfig,
+		machineConfigsLookup: nil,
+	}
+	validator := NewValidator(cmk)
+
+	datacenterConfig.Spec.ManagementApiEndpoint = "abcefg.com"
+	err = validator.ValidateCloudStackDatacenterConfig(ctx, cloudStackClusterSpec.datacenterConfig)
+
+	thenErrorExpected(t, "cloudstack secret management url (http://127.16.0.1:8080/client/api) differs from cluster spec management url (abcefg.com)", err)
 }
 
 func TestSetupAndValidateUsersNil(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The compromise discussed exposes the managementApiEndpoint for the cloudstack provider in two ways: environment variable, and cluster spec. This decision was made to be future-proof. This PR adds validation on cluster creation to ensure that the two values are the same.

*Testing (if applicable):*
Unit tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

