### PR TITLE
Remove CAPC asset packaging in prod releases

### DIFF
--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -259,7 +259,6 @@ func (r *ReleaseConfig) GenerateBundleArtifactsTable() (map[string][]Artifact, e
 		"cluster-api-provider-aws":        r.GetCapaAssets,
 		"cluster-api-provider-docker":     r.GetDockerAssets,
 		"cluster-api-provider-vsphere":    r.GetCapvAssets,
-		"cluster-api-provider-cloudstack": r.GetCapcAssets,
 		"vsphere-csi-driver":              r.GetVsphereCsiAssets,
 		"cert-manager":                    r.GetCertManagerAssets,
 		"cilium":                          r.GetCiliumAssets,


### PR DESCRIPTION
The CAPC assets are added to bundle for only dev releases (L281). This is a duplication that causes it go get applied for prod releases too.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

