### PR TITLE
Remove need for auth with helm

### DIFF
--- a/cmd/eksctl-anywhere/cmd/importimages.go
+++ b/cmd/eksctl-anywhere/cmd/importimages.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -52,11 +51,6 @@ var importImagesCmd = &cobra.Command{
 }
 
 func importImages(ctx context.Context, spec string) error {
-	registryUsername := os.Getenv("REGISTRY_USERNAME")
-	registryPassword := os.Getenv("REGISTRY_PASSWORD")
-	if registryUsername == "" || registryPassword == "" {
-		return fmt.Errorf("username or password not set. Provide REGISTRY_USERNAME and REGISTRY_PASSWORD for importing helm charts (e.g. cilium)")
-	}
 	clusterSpec, err := cluster.NewSpecFromClusterConfig(spec, version.Get())
 	if err != nil {
 		return err
@@ -96,7 +90,7 @@ func importImages(ctx context.Context, spec string) error {
 	}
 
 	endpoint := clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Endpoint
-	return importCharts(ctx, helmExecutable, bundle.Charts(), endpoint, registryUsername, registryPassword)
+	return importCharts(ctx, helmExecutable, bundle.Charts(), endpoint)
 }
 
 func importImage(ctx context.Context, docker *executables.Docker, image string, endpoint string) error {
@@ -111,10 +105,7 @@ func importImage(ctx context.Context, docker *executables.Docker, image string, 
 	return docker.PushImage(ctx, image, endpoint)
 }
 
-func importCharts(ctx context.Context, helm *executables.Helm, charts map[string]*v1alpha1.Image, endpoint, username, password string) error {
-	if err := helm.RegistryLogin(ctx, endpoint, username, password); err != nil {
-		return err
-	}
+func importCharts(ctx context.Context, helm *executables.Helm, charts map[string]*v1alpha1.Image, endpoint string) error {
 	for _, chart := range charts {
 		if err := importChart(ctx, helm, *chart, endpoint); err != nil {
 			return err

--- a/pkg/executables/helm.go
+++ b/pkg/executables/helm.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
 const (
@@ -17,12 +19,12 @@ var helmTemplateEnvVars = map[string]string{
 }
 
 type Helm struct {
-	executable Executable
+	Executable
 }
 
 func NewHelm(executable Executable) *Helm {
 	return &Helm{
-		executable: executable,
+		Executable: executable,
 	}
 }
 
@@ -32,7 +34,7 @@ func (h *Helm) Template(ctx context.Context, ociURI, version, namespace string, 
 		return nil, fmt.Errorf("failed marshalling values for helm template: %v", err)
 	}
 
-	result, err := h.executable.Command(
+	result, err := h.Command(
 		ctx, "template", ociURI, "--version", version, insecureSkipVerifyFlag, "--namespace", namespace, "-f", "-",
 	).WithStdIn(valuesYaml).WithEnvVars(helmTemplateEnvVars).Run()
 	if err != nil {
@@ -43,17 +45,18 @@ func (h *Helm) Template(ctx context.Context, ociURI, version, namespace string, 
 }
 
 func (h *Helm) PullChart(ctx context.Context, ociURI, version string) error {
-	_, err := h.executable.Command(ctx, "pull", ociURI, "--version", version, insecureSkipVerifyFlag).
+	_, err := h.Command(ctx, "pull", ociURI, "--version", version, insecureSkipVerifyFlag).
 		WithEnvVars(helmTemplateEnvVars).Run()
 	return err
 }
 
 func (h *Helm) PushChart(ctx context.Context, chart, registry string) error {
-	_, err := h.executable.Command(ctx, "push", chart, registry, insecureSkipVerifyFlag).WithEnvVars(helmTemplateEnvVars).Run()
+	logger.Info("Pushing to registry", "chart", chart, "registry", registry)
+	_, err := h.Command(ctx, "push", chart, registry, insecureSkipVerifyFlag).WithEnvVars(helmTemplateEnvVars).Run()
 	return err
 }
 
 func (h *Helm) RegistryLogin(ctx context.Context, registry, username, password string) error {
-	_, err := h.executable.Command(ctx, "registry", "login", registry, "--username", username, "--password", password, "--insecure").WithEnvVars(helmTemplateEnvVars).Run()
+	_, err := h.Command(ctx, "registry", "login", registry, "--username", username, "--password", password, "--insecure").WithEnvVars(helmTemplateEnvVars).Run()
 	return err
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As talked about in https://github.com/aws/eks-anywhere/pull/1587, we actually don't need the auth here as initially expected like docker. We thought we needed it because the repo we were testing against was private, so after I made it public, it works now.

*Testing (if applicable):*
Ran both `import-images` and `create cluster`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

