### PR TITLE
move terraform how-to into the official docs site

### DIFF
--- a/docs/content/en/docs/tasks/cluster/cluster-overview.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-overview.md
@@ -13,6 +13,7 @@ It will also describe which administrative actions done:
 
 * Directly in Kubernetes itself (such as adding nodes with `kubectl`)
 * Through the EKS Anywhere API (such as deleting a cluster with `eksctl`).
+* Through tools which interface with the Kubernetes API (such as [managing a cluster with `terraform`]({{< relref "../../tasks/cluster/cluster-terraform" >}}))
 
 Note that direct changes to OVAs before nodes are deployed is not yet supported.
 However, we are working on a solution for that issue.

--- a/docs/content/en/docs/tasks/cluster/cluster-terraform.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-terraform.md
@@ -8,7 +8,7 @@ description: >
 ---
 
 ## Using Terraform to manage an EKS Anywhere Cluster (Optional)
-This is guide explains how you can use Terraform to manage and modify an EKS Anywhere cluster. 
+This guide explains how you can use Terraform to manage and modify an EKS Anywhere cluster. 
 The guide is meant for illustrative purposes and is not a definitive approach to building production systems with Terraform and EKS Anywhere.
 
 At its heart, EKS Anywhere is a set of Kubernetes CRDs which define an EKS Anywhere cluster,

--- a/docs/content/en/docs/tasks/cluster/cluster-terraform.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-terraform.md
@@ -1,13 +1,23 @@
-## Using Terraform to manage an EKS Anywhere Cluster
-This is a minimal guide that lays out how you can use Terraform to manage and modify an EKS Anywhere cluster. The guide is meant for illustrative purposes only and is not meant as a definitive approach to building production systems with Terraform and EKS Anywhere.
+---
+title: "Manage cluster with Terraform"
+linkTitle: "Manage cluster with Terraform"
+weight: 30
+date: 2017-01-05
+description: >
+  Use Terraform to manage EKS Anywhere Clusters
+---
 
-At its heart, EKS Anywhere is a set of Kubernetes CRDs which define an EKS Anywhere cluster, 
-and a controller which moves the cluster to match these definitions. 
+## Using Terraform to manage an EKS Anywhere Cluster (Optional)
+This is guide explains how you can use Terraform to manage and modify an EKS Anywhere cluster. 
+The guide is meant for illustrative purposes and is not a definitive approach to building production systems with Terraform and EKS Anywhere.
+
+At its heart, EKS Anywhere is a set of Kubernetes CRDs which define an EKS Anywhere cluster,
+and a controller which moves the cluster state to match these definitions.
 These CRDs, and the EKS-A controller, live on the management cluster or
 on a self-managed cluster.
 We can manage a subset of the fields in the EKS Anywhere CRDs with any tool that can interact with the Kubernetes API, like `kubectl` or, in this case, the Terraform Kubernetes provider.
 
-In this guide, we'll show you how to import your EKS Anywhere cluster into Terraform state and 
+In this guide, we'll show you how to import your EKS Anywhere cluster into Terraform state and
 how to scale your EKS Anywhere worker nodes using the Terraform Kubernetes provider.
 
 ### Prerequisites
@@ -19,7 +29,7 @@ how to scale your EKS Anywhere worker nodes using the Terraform Kubernetes provi
 
 
 ### Guide
-0. Create an EKS-A management cluster, or a self-managed stand-alone cluster. 
+0. Create an EKS-A management cluster, or a self-managed stand-alone cluster.
 - if you already have an existing EKS-A cluster, skip this step.
 - if you don't already have an existing EKS-A cluster, follow [the official instructions to create one](https://anywhere.eks.amazonaws.com/docs/getting-started/install/)
 
@@ -43,26 +53,26 @@ how to scale your EKS Anywhere worker nodes using the Terraform Kubernetes provi
    ```
 
 2. Get  `tfk8s` and use it to convert your EKS Anywhere cluster Kubernetes manifest into Terraform HCL:
-   - Install [tfk8s](https://github.com/jrhouston/tfk8s#install)
-   - Convert the manifest into Terraform HCL:
+    - Install [tfk8s](https://github.com/jrhouston/tfk8s#install)
+    - Convert the manifest into Terraform HCL:
    ```bash
    kubectl get cluster ${MY_EKSA_CLUSTER} -o yaml | tfk8s --strip -o ${MY_EKSA_CLUSTER}.tf
    ``` 
 
 3. Configure the Terraform cluster resource definition generated in step 2
-   - Set `metadata.generation` as a [computed field](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest#computed-fields). Add the following to your cluster resource configuration
+    - Set `metadata.generation` as a [computed field](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest#computed-fields). Add the following to your cluster resource configuration
    ```bash
    computed_fields = ["metadata.generated"]
    ```
-   - Configure the field manager to [force reconcile managed resources](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest#field_manager). Add the following configuration block to your cluster resource:
+    - Configure the field manager to [force reconcile managed resources](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest#field_manager). Add the following configuration block to your cluster resource:
    ```bash
    field_manager {
      force_conflicts = true
    }
    ```
-   - Add the `namespace` `default` to the `metadata` of the cluster
-   - Remove the `generation` field from the `metadata` of the cluster
-   - Your Terraform cluster resource should look similar to this:
+    - Add the `namespace` `default` to the `metadata` of the cluster
+    - Remove the `generation` field from the `metadata` of the cluster
+    - Your Terraform cluster resource should look similar to this:
     ```bash
     computed_fields = ["metadata.generated"]
     field_manager {
@@ -83,13 +93,13 @@ how to scale your EKS Anywhere worker nodes using the Terraform Kubernetes provi
    terraform import kubernetes_manifest.cluster_${MY_EKSA_CLUSTER} "apiVersion=anywhere.eks.amazonaws.com/v1alpha1,kind=Cluster,namespace=default,name=${MY_EKSA_CLUSTER}"
    ```
 
-   After you `import` your cluster, you will need to run `terraform apply` one time to ensure that the `manifest` field of your cluster resource is in-sync. 
+   After you `import` your cluster, you will need to run `terraform apply` one time to ensure that the `manifest` field of your cluster resource is in-sync.
    This will not change the state of your cluster, but is a required step after the initial import.
    The `manifest` field stores the contents of the associated kubernetes manifest, while the `object` field stores the actual state of the resource.
 
 5. Modify Your Cluster using Terraform
-   - Modify the `count` value of one of your `workerNodeGroupConfigurations`, or another mutable field, in the configuration stored in `${MY_EKSA_CLUSTER}.tf` file.
-   - Check the expected diff between your cluster state and the modified local state via `terraform plan`
+    - Modify the `count` value of one of your `workerNodeGroupConfigurations`, or another mutable field, in the configuration stored in `${MY_EKSA_CLUSTER}.tf` file.
+    - Check the expected diff between your cluster state and the modified local state via `terraform plan`
 
    You should see in the output that the worker node group configuration count field (or whichever field you chose to modify) will be modified by Terraform.
 

--- a/docs/content/en/docs/tasks/cluster/cluster-terraform.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-terraform.md
@@ -11,7 +11,7 @@ description: >
 This guide explains how you can use Terraform to manage and modify an EKS Anywhere cluster. 
 The guide is meant for illustrative purposes and is not a definitive approach to building production systems with Terraform and EKS Anywhere.
 
-At its heart, EKS Anywhere is a set of Kubernetes CRDs which define an EKS Anywhere cluster,
+At its heart, EKS Anywhere is a set of Kubernetes CRDs, which define an EKS Anywhere cluster,
 and a controller which moves the cluster state to match these definitions.
 These CRDs, and the EKS-A controller, live on the management cluster or
 on a self-managed cluster.

--- a/docs/content/en/docs/tasks/cluster/cluster-terraform.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-terraform.md
@@ -12,7 +12,7 @@ This guide explains how you can use Terraform to manage and modify an EKS Anywhe
 The guide is meant for illustrative purposes and is not a definitive approach to building production systems with Terraform and EKS Anywhere.
 
 At its heart, EKS Anywhere is a set of Kubernetes CRDs, which define an EKS Anywhere cluster,
-and a controller which moves the cluster state to match these definitions.
+and a controller, which moves the cluster state to match these definitions.
 These CRDs, and the EKS-A controller, live on the management cluster or
 on a self-managed cluster.
 We can manage a subset of the fields in the EKS Anywhere CRDs with any tool that can interact with the Kubernetes API, like `kubectl` or, in this case, the Terraform Kubernetes provider.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Move the guide to managing a cluster with terraform from `examples` to the `tasks/clusters` section of the docs.

Add a section to the cluster mgmt overview which notes the ability to manage a cluster with terraform, including a link to the docs.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

