### PR TITLE
Add timeout between performing upgrade on workload cluster, and delet…

### DIFF
--- a/test/e2e/workload_clusters_test.go
+++ b/test/e2e/workload_clusters_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"testing"
+	"time"
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -17,6 +18,7 @@ func runWorkloadClusterFlow(test *framework.MulticlusterE2ETest) {
 		w.CreateCluster()
 		w.DeleteCluster()
 	})
+	time.Sleep(5 * time.Minute)
 	test.DeleteManagementCluster()
 }
 
@@ -26,8 +28,10 @@ func runWorkloadClusterFlowWithGitOps(test *framework.MulticlusterE2ETest, clust
 		w.GenerateClusterConfig()
 		w.CreateCluster()
 		w.UpgradeWithGitOps(clusterOpts...)
+		time.Sleep(5 * time.Minute)
 		w.DeleteCluster()
 	})
+	time.Sleep(5 * time.Minute)
 	test.DeleteManagementCluster()
 }
 


### PR DESCRIPTION
…ing workload cluster and management cluster for e2e test

*Issue #, if available:*

*Description of changes:*
Running into some issues with asynchronous behavior with upgrades and deletes. For now, adding sleeps to the test until we have a long term solution for this, which I plan to create an issue for.

*Testing (if applicable):*
`TestDockerUpgradeWorkloadClusterWithFlux`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

