### PR TITLE
fix diagnostic bundle collection during delete

### DIFF
--- a/pkg/workflows/delete.go
+++ b/pkg/workflows/delete.go
@@ -65,7 +65,7 @@ type deleteWorkloadCluster struct{}
 
 type cleanupGitRepo struct{}
 
-type deleteManagementCluster struct {}
+type deleteManagementCluster struct{}
 
 func (s *setupAndValidate) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Performing provider setup and validations")

--- a/pkg/workflows/delete.go
+++ b/pkg/workflows/delete.go
@@ -65,9 +65,7 @@ type deleteWorkloadCluster struct{}
 
 type cleanupGitRepo struct{}
 
-type deleteManagementCluster struct {
-	*CollectDiagnosticsTask
-}
+type deleteManagementCluster struct {}
 
 func (s *setupAndValidate) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Performing provider setup and validations")
@@ -169,7 +167,8 @@ func (s *cleanupGitRepo) Name() string {
 
 func (s *deleteManagementCluster) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	if commandContext.OriginalError != nil {
-		_ = s.CollectDiagnosticsTask.Run(ctx, commandContext)
+		collector := &CollectMgmtClusterDiagnosticsTask{}
+		collector.Run(ctx, commandContext)
 	}
 	if commandContext.BootstrapCluster != nil && !commandContext.BootstrapCluster.ExistingManagement {
 		if err := commandContext.Bootstrapper.DeleteBootstrapCluster(ctx, commandContext.BootstrapCluster, false); err != nil {

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -450,7 +450,8 @@ func (s *writeClusterConfigTask) Name() string {
 
 func (s *deleteBootstrapClusterTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	if commandContext.OriginalError != nil {
-		_ = s.CollectDiagnosticsTask.Run(ctx, commandContext)
+		c := CollectDiagnosticsTask{}
+		c.Run(ctx, commandContext)
 	}
 	if commandContext.BootstrapCluster != nil && !commandContext.BootstrapCluster.ExistingManagement {
 		if err := commandContext.Bootstrapper.DeleteBootstrapCluster(ctx, commandContext.BootstrapCluster, true); err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Diagnostic bundle collection on delete was broken.
We were referencing uninitialized nested unnamed fields, resulting in a nil pointer. 
This will eliminate the nil pointer exception when collecting diagnostic bundles from mgmt clusters during `delete`.

*Testing (if applicable):*
created and deleted a cluster, forcing an error during delete and observing the behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

