### PR TITLE
Fix snow registry mirror prekubeadmcommand overrides

### DIFF
--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -250,9 +250,9 @@ func wantRegistryMirrorFiles() []bootstrapv1.File {
 			Path:  "/etc/containerd/config_append.toml",
 			Owner: "root:root",
 			Content: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
     endpoint = ["https://1.2.3.4:443"]
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:443".tls]
+  [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:443".tls]
     ca_file = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"`,
 		},
 		{

--- a/pkg/clusterapi/config/containerd_config_append.toml
+++ b/pkg/clusterapi/config/containerd_config_append.toml
@@ -1,7 +1,7 @@
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
     endpoint = ["https://{{.registryMirrorAddress}}"]
 {{- if .registryCACert }}
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."{{.registryMirrorAddress}}".tls]
+  [plugins."io.containerd.grpc.v1.cri".registry.configs."{{.registryMirrorAddress}}".tls]
     ca_file = "/etc/containerd/certs.d/{{.registryMirrorAddress}}/ca.crt"
 {{- end }}

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -42,13 +42,13 @@ func KubeadmControlPlane(clusterSpec *cluster.Spec, snowMachineTemplate *snowv1.
 	joinConfigKubeletExtraArg := kcp.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.KubeletExtraArgs
 	joinConfigKubeletExtraArg["provider-id"] = "aws-snow:////'{{ ds.meta_data.instance_id }}'"
 
-	kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands = []string{
+	kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands = append(kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands,
 		fmt.Sprintf("/etc/eks/bootstrap.sh %s %s", clusterSpec.VersionsBundle.Snow.KubeVip.VersionedImage(), clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host),
-	}
+	)
 
-	kcp.Spec.KubeadmConfigSpec.PostKubeadmCommands = []string{
+	kcp.Spec.KubeadmConfigSpec.PostKubeadmCommands = append(kcp.Spec.KubeadmConfigSpec.PostKubeadmCommands,
 		fmt.Sprintf("/etc/eks/bootstrap-after.sh %s %s", clusterSpec.VersionsBundle.Snow.KubeVip.VersionedImage(), clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host),
-	}
+	)
 
 	return kcp, nil
 }
@@ -62,9 +62,9 @@ func kubeadmConfigTemplate(clusterSpec *cluster.Spec, workerNodeGroupConfig v1al
 	joinConfigKubeletExtraArg := kct.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs
 	joinConfigKubeletExtraArg["provider-id"] = "aws-snow:////'{{ ds.meta_data.instance_id }}'"
 
-	kct.Spec.Template.Spec.PreKubeadmCommands = []string{
+	kct.Spec.Template.Spec.PreKubeadmCommands = append(kct.Spec.Template.Spec.PreKubeadmCommands,
 		"/etc/eks/bootstrap.sh",
-	}
+	)
 	return kct, nil
 }
 


### PR DESCRIPTION
*Issue #, if available:*

#1105 

*Description of changes:*

Snow apibuilder should append to existing kcp PreKubeadmCommands. So that the registry mirror command won't be overridden.

*Testing (if applicable):*

- unit tests
- local e2e

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

