### PR TITLE
Add Tinkerbell to new cluster parsing code

### DIFF
--- a/pkg/cluster/default_manager.go
+++ b/pkg/cluster/default_manager.go
@@ -13,6 +13,7 @@ func init() {
 		vsphereEntry(),
 		dockerEntry(),
 		snowEntry(),
+		tinkerbellEntry(),
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/cluster/tinkerbell.go
+++ b/pkg/cluster/tinkerbell.go
@@ -1,0 +1,21 @@
+package cluster
+
+import anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+
+// tinkerbellEntry is unimplemented. Its boiler plate to mute warnings that could confuse the customer until we
+// get round to implementing it.
+func tinkerbellEntry() *ConfigManagerEntry {
+	return &ConfigManagerEntry{
+		APIObjectMapping: map[string]APIObjectGenerator{
+			anywherev1.TinkerbellDatacenterKind: func() APIObject {
+				return &anywherev1.TinkerbellDatacenterConfig{}
+			},
+			anywherev1.TinkerbellMachineConfigKind: func() APIObject {
+				return &anywherev1.TinkerbellMachineConfig{}
+			},
+			anywherev1.TinkerbellTemplateConfigKind: func() APIObject {
+				return &anywherev1.TinkerbellTemplateConfig{}
+			},
+		},
+	}
+}


### PR DESCRIPTION
The Tinkerbell provider isn't represented in the cluster parsing code
resulting in warnings that could mislead the customer in logging. This
cl adds Tinkerbell type so the parsing logic is at least aware of them
but won't do anything with them.

