### PR TITLE
Use `latest` version of golangci-lint in GitHub actions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,4 +15,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42.1
+          version: latest

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -884,7 +884,8 @@ func (c *ClusterManager) InstallEksdComponents(ctx context.Context, clusterSpec 
 }
 
 func (c *ClusterManager) CreateEKSAResources(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec,
-	datacenterConfig providers.DatacenterConfig, machineConfigs []providers.MachineConfig) error {
+	datacenterConfig providers.DatacenterConfig, machineConfigs []providers.MachineConfig,
+) error {
 	if clusterSpec.Cluster.Namespace != "" {
 		if err := c.clusterClient.GetNamespace(ctx, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace); err != nil {
 			if err := c.clusterClient.CreateNamespace(ctx, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace); err != nil {

--- a/pkg/providers/vsphere/defaults.go
+++ b/pkg/providers/vsphere/defaults.go
@@ -162,7 +162,8 @@ func (d *Defaulter) setDiskDefaults(ctx context.Context, machineConfig *anywhere
 
 func (d *Defaulter) setTemplateFullPath(ctx context.Context,
 	datacenterConfig *anywherev1.VSphereDatacenterConfig,
-	machine *anywherev1.VSphereMachineConfig) error {
+	machine *anywherev1.VSphereMachineConfig,
+) error {
 	templateFullPath, err := d.govc.SearchTemplate(ctx, datacenterConfig.Spec.Datacenter, machine)
 	if err != nil {
 		return fmt.Errorf("setting template full path: %v", err)

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -24,7 +24,8 @@ type Create struct {
 }
 
 func NewCreate(bootstrapper interfaces.Bootstrapper, provider providers.Provider,
-	clusterManager interfaces.ClusterManager, addonManager interfaces.AddonManager, writer filewriter.FileWriter) *Create {
+	clusterManager interfaces.ClusterManager, addonManager interfaces.AddonManager, writer filewriter.FileWriter,
+) *Create {
 	return &Create{
 		bootstrapper:   bootstrapper,
 		provider:       provider,

--- a/pkg/workflows/delete.go
+++ b/pkg/workflows/delete.go
@@ -19,7 +19,8 @@ type Delete struct {
 }
 
 func NewDelete(bootstrapper interfaces.Bootstrapper, provider providers.Provider,
-	clusterManager interfaces.ClusterManager, addonManager interfaces.AddonManager) *Delete {
+	clusterManager interfaces.ClusterManager, addonManager interfaces.AddonManager,
+) *Delete {
 	return &Delete{
 		bootstrapper:   bootstrapper,
 		provider:       provider,

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -27,7 +27,8 @@ type Upgrade struct {
 
 func NewUpgrade(bootstrapper interfaces.Bootstrapper, provider providers.Provider,
 	capiManager interfaces.CAPIManager,
-	clusterManager interfaces.ClusterManager, addonManager interfaces.AddonManager, writer filewriter.FileWriter) *Upgrade {
+	clusterManager interfaces.ClusterManager, addonManager interfaces.AddonManager, writer filewriter.FileWriter,
+) *Upgrade {
 	upgradeChangeDiff := types.NewChangeDiff()
 	return &Upgrade{
 		bootstrapper:      bootstrapper,


### PR DESCRIPTION
*Description of changes:*
The `make` target pulls the latest version of `golangci-lint` but the version is hardcoded to `v1.42.1` in the GitHub action.
This PR changes it to the latest version to be consistent with the `make` target.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

