### PR TITLE
test cluster name wont start with -

### DIFF
--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -208,13 +208,15 @@ func (e *E2ESession) createTestNameFile(testName string) error {
 }
 
 func clusterName(branch string, instanceId string) (clusterName string) {
+	if branch == "" {
+		return instanceId
+	}
 	clusterNameTemplate := "%s-%s"
 	forbiddenChars := []string{"."}
-	sanitizedBranch := branch
+	sanitizedBranch := strings.ToLower(branch)
 	for _, char := range forbiddenChars {
-		sanitizedBranch = strings.ReplaceAll(branch, char, "-")
+		sanitizedBranch = strings.ReplaceAll(sanitizedBranch, char, "-")
 	}
-	sanitizedBranch = strings.ToLower(sanitizedBranch)
 	clusterName = fmt.Sprintf(clusterNameTemplate, sanitizedBranch, instanceId)
 	if len(clusterName) > 80 {
 		logger.Info("Cluster name is longer than 80 characters; truncating to 80 characters.", "original cluster name", clusterName, "truncated cluster name", clusterName[:80])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We ran into an issue where when the BRANCH_NAME env var was not set in a pipeline the test cluster names generated started with `-`, which cobra interpreted as a flag (e.g. `-i-asdflksj`) and caused test runs to fail. If the BRANCH_NAME passed to the cluster name func is "", we now just go ahead and use the instance id.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

