### PR TITLE
Tinkerbell hardware file read from the memory

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -176,16 +176,6 @@ func (k *Kubectl) LoadSecret(ctx context.Context, secretObject string, secretObj
 	return nil
 }
 
-func (k *Kubectl) ApplyHardware(ctx context.Context, hardwareYaml string, kubeConfFile string) error {
-	params := []string{"apply", "-f", hardwareYaml}
-	params = append(params, "--kubeconfig", kubeConfFile)
-	_, err := k.Execute(ctx, params...)
-	if err != nil {
-		return fmt.Errorf("executing hardware yaml apply: %v", err)
-	}
-	return nil
-}
-
 func (k *Kubectl) ApplyKubeSpec(ctx context.Context, cluster *types.Cluster, spec string) error {
 	params := []string{"apply", "-f", spec}
 	if cluster.KubeconfigFile != "" {

--- a/pkg/providers/tinkerbell/hardware/config.go
+++ b/pkg/providers/tinkerbell/hardware/config.go
@@ -10,6 +10,7 @@ import (
 	tinkhardware "github.com/tinkerbell/tink/protos/hardware"
 	tinkworkflow "github.com/tinkerbell/tink/protos/workflow"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/yaml"
@@ -17,6 +18,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
+	"github.com/aws/eks-anywhere/pkg/templater"
 )
 
 type HardwareConfig struct {
@@ -215,4 +217,73 @@ func (hc *HardwareConfig) initSecretRefMap() map[string]struct{} {
 	}
 
 	return secretRefMap
+}
+
+func (hc *HardwareConfig) HardwareSpecMarshallable() ([]byte, error) {
+	var marshallables []v1alpha1.Marshallable
+
+	for _, hw := range hc.Hardwares {
+		marshallables = append(marshallables, hardwareMarshallable(hw))
+	}
+	for _, bmc := range hc.Bmcs {
+		marshallables = append(marshallables, bmcMarshallable(bmc))
+	}
+	for _, secret := range hc.Secrets {
+		marshallables = append(marshallables, secretsMarshallable(secret))
+	}
+
+	resources := make([][]byte, 0, len(marshallables))
+	for _, marshallable := range marshallables {
+		resource, err := yaml.Marshal(marshallable)
+		if err != nil {
+			return nil, fmt.Errorf("failed marshalling resource for hardware spec: %v", err)
+		}
+		resources = append(resources, resource)
+	}
+	return templater.AppendYamlResources(resources...), nil
+}
+
+func hardwareMarshallable(hw tinkv1alpha1.Hardware) *tinkv1alpha1.Hardware {
+	config := &tinkv1alpha1.Hardware{
+		TypeMeta: hw.TypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        hw.Name,
+			Annotations: hw.Annotations,
+			Namespace:   hw.Namespace,
+			Labels:      hw.Labels,
+		},
+		Spec: hw.Spec,
+	}
+
+	return config
+}
+
+func bmcMarshallable(bmc pbnjv1alpha1.BMC) *pbnjv1alpha1.BMC {
+	config := &pbnjv1alpha1.BMC{
+		TypeMeta: bmc.TypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        bmc.Name,
+			Annotations: bmc.Annotations,
+			Namespace:   bmc.Namespace,
+			Labels:      bmc.Labels,
+		},
+		Spec: bmc.Spec,
+	}
+
+	return config
+}
+
+func secretsMarshallable(secret corev1.Secret) *corev1.Secret {
+	config := &corev1.Secret{
+		TypeMeta: secret.TypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        secret.Name,
+			Annotations: secret.Annotations,
+			Namespace:   secret.Namespace,
+			Labels:      secret.Labels,
+		},
+		Data: secret.Data,
+	}
+
+	return config
 }

--- a/pkg/providers/tinkerbell/mocks/client.go
+++ b/pkg/providers/tinkerbell/mocks/client.go
@@ -11,6 +11,7 @@ import (
 	executables "github.com/aws/eks-anywhere/pkg/executables"
 	filewriter "github.com/aws/eks-anywhere/pkg/filewriter"
 	pbnj "github.com/aws/eks-anywhere/pkg/providers/tinkerbell/pbnj"
+	types "github.com/aws/eks-anywhere/pkg/types"
 	gomock "github.com/golang/mock/gomock"
 	hardware "github.com/tinkerbell/tink/protos/hardware"
 	workflow "github.com/tinkerbell/tink/protos/workflow"
@@ -40,18 +41,18 @@ func (m *MockProviderKubectlClient) EXPECT() *MockProviderKubectlClientMockRecor
 	return m.recorder
 }
 
-// ApplyHardware mocks base method.
-func (m *MockProviderKubectlClient) ApplyHardware(arg0 context.Context, arg1, arg2 string) error {
+// ApplyKubeSpecFromBytesForce mocks base method.
+func (m *MockProviderKubectlClient) ApplyKubeSpecFromBytesForce(arg0 context.Context, arg1 *types.Cluster, arg2 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplyHardware", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ApplyKubeSpecFromBytesForce", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ApplyHardware indicates an expected call of ApplyHardware.
-func (mr *MockProviderKubectlClientMockRecorder) ApplyHardware(arg0, arg1, arg2 interface{}) *gomock.Call {
+// ApplyKubeSpecFromBytesForce indicates an expected call of ApplyKubeSpecFromBytesForce.
+func (mr *MockProviderKubectlClientMockRecorder) ApplyKubeSpecFromBytesForce(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyHardware", reflect.TypeOf((*MockProviderKubectlClient)(nil).ApplyHardware), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyKubeSpecFromBytesForce", reflect.TypeOf((*MockProviderKubectlClient)(nil).ApplyKubeSpecFromBytesForce), arg0, arg1, arg2)
 }
 
 // DeleteEksaDatacenterConfig mocks base method.


### PR DESCRIPTION
*Description of changes:*
Our CLI was throwing an error for create cluster command Tinkerbell provider if the given hardware yaml is not within the same directory. This PR has changes that will read the hardware objects from the memory and not from the file itself.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

