### PR TITLE
Tinkerbell implement force create cluster

### DIFF
--- a/pkg/providers/tinkerbell/mocks/client.go
+++ b/pkg/providers/tinkerbell/mocks/client.go
@@ -13,6 +13,7 @@ import (
 	pbnj "github.com/aws/eks-anywhere/pkg/providers/tinkerbell/pbnj"
 	types "github.com/aws/eks-anywhere/pkg/types"
 	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/tinkerbell/pbnj/api/v1"
 	hardware "github.com/tinkerbell/tink/protos/hardware"
 	workflow "github.com/tinkerbell/tink/protos/workflow"
 	v1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -192,6 +193,48 @@ func (m *MockProviderPbnjClient) GetPowerState(arg0 context.Context, arg1 pbnj.B
 func (mr *MockProviderPbnjClientMockRecorder) GetPowerState(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPowerState", reflect.TypeOf((*MockProviderPbnjClient)(nil).GetPowerState), arg0, arg1)
+}
+
+// PowerOff mocks base method.
+func (m *MockProviderPbnjClient) PowerOff(arg0 context.Context, arg1 pbnj.BmcSecretConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PowerOff", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PowerOff indicates an expected call of PowerOff.
+func (mr *MockProviderPbnjClientMockRecorder) PowerOff(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PowerOff", reflect.TypeOf((*MockProviderPbnjClient)(nil).PowerOff), arg0, arg1)
+}
+
+// PowerOn mocks base method.
+func (m *MockProviderPbnjClient) PowerOn(arg0 context.Context, arg1 pbnj.BmcSecretConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PowerOn", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PowerOn indicates an expected call of PowerOn.
+func (mr *MockProviderPbnjClientMockRecorder) PowerOn(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PowerOn", reflect.TypeOf((*MockProviderPbnjClient)(nil).PowerOn), arg0, arg1)
+}
+
+// SetBootDevice mocks base method.
+func (m *MockProviderPbnjClient) SetBootDevice(arg0 context.Context, arg1 pbnj.BmcSecretConfig, arg2 v1.BootDevice) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetBootDevice", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetBootDevice indicates an expected call of SetBootDevice.
+func (mr *MockProviderPbnjClientMockRecorder) SetBootDevice(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBootDevice", reflect.TypeOf((*MockProviderPbnjClient)(nil).SetBootDevice), arg0, arg1, arg2)
 }
 
 // MockSSHAuthKeyGenerator is a mock of SSHAuthKeyGenerator interface.

--- a/pkg/providers/tinkerbell/pbnj/client.go
+++ b/pkg/providers/tinkerbell/pbnj/client.go
@@ -12,9 +12,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
-const (
-	PbnjGrpcAuth = "PBNJ_GRPC_AUTHORITY"
-)
+const PbnjGrpcAuth = client.PbnjGrpcAuthorityEnv
 
 type PowerState string
 
@@ -22,6 +20,18 @@ const (
 	PowerStateOn      PowerState = "on"
 	PowerStateOff     PowerState = "off"
 	PowerStateUnknown PowerState = "unknown"
+)
+
+// Boot devices patched from upstream PBNJ so consumers don't need to depend on the upstream package.
+type BootDevice = v1.BootDevice
+
+const (
+	BootDeviceUnspecified BootDevice = v1.BootDevice_BOOT_DEVICE_UNSPECIFIED
+	BootDeviceNone                   = v1.BootDevice_BOOT_DEVICE_NONE
+	BootDeviceBIOS                   = v1.BootDevice_BOOT_DEVICE_BIOS
+	BootDeviceCDROM                  = v1.BootDevice_BOOT_DEVICE_CDROM
+	BootDeviceDisk                   = v1.BootDevice_BOOT_DEVICE_DISK
+	BootDevicePXE                    = v1.BootDevice_BOOT_DEVICE_PXE
 )
 
 const (
@@ -93,6 +103,42 @@ func (p *Pbnj) PowerOn(ctx context.Context, bmcInfo BmcSecretConfig) error {
 	}
 
 	return nil
+}
+
+func (p *Pbnj) SetBootDevice(ctx context.Context, info BmcSecretConfig, mode BootDevice) error {
+	logger := logger.V(4).WithValues("component", "pbnj-client")
+
+	request := newBootDeviceRequest(info, mode)
+	logger.Info("Set boot device request", "request", request)
+
+	response, err := p.pbnj.MachineBootDev(ctx, request)
+	if err != nil {
+		return err
+	}
+	logger.Info("Set boot device response", "response", response)
+
+	return nil
+}
+
+func newBootDeviceRequest(bmc BmcSecretConfig, device v1.BootDevice) *v1.DeviceRequest {
+	return &v1.DeviceRequest{
+		Authn: &v1.Authn{
+			Authn: &v1.Authn_DirectAuthn{
+				DirectAuthn: &v1.DirectAuthn{
+					Host: &v1.Host{
+						Host: bmc.Host,
+					},
+					Username: bmc.Username,
+					Password: bmc.Password,
+				},
+			},
+		},
+		Vendor: &v1.Vendor{
+			Name: bmc.Vendor,
+		},
+		BootDevice: device,
+		EfiBoot:    true, // hardcoded for our use-case.
+	}
 }
 
 func NewPowerRequest(bmcInfo BmcSecretConfig, powerAction v1.PowerAction) *v1.PowerRequest {


### PR DESCRIPTION
Builds on #1661

Implement the force node reset to PXE behavior desired when the --force-cleanup flag is specified. Node should power off, be set to PXE boot and power on again where they'll sit waiting for the Tinkerbell stack to respond.

Manually tested by powering machines on and observed the logging to power off during create cluster cmd.