### PR TITLE
Bring back auth for helm with import-images

### DIFF
--- a/pkg/executables/helm.go
+++ b/pkg/executables/helm.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"sigs.k8s.io/yaml"
-
-	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
 const (
@@ -19,12 +17,12 @@ var helmTemplateEnvVars = map[string]string{
 }
 
 type Helm struct {
-	Executable
+	executable Executable
 }
 
 func NewHelm(executable Executable) *Helm {
 	return &Helm{
-		Executable: executable,
+		executable: executable,
 	}
 }
 
@@ -34,7 +32,7 @@ func (h *Helm) Template(ctx context.Context, ociURI, version, namespace string, 
 		return nil, fmt.Errorf("failed marshalling values for helm template: %v", err)
 	}
 
-	result, err := h.Command(
+	result, err := h.executable.Command(
 		ctx, "template", ociURI, "--version", version, insecureSkipVerifyFlag, "--namespace", namespace, "-f", "-",
 	).WithStdIn(valuesYaml).WithEnvVars(helmTemplateEnvVars).Run()
 	if err != nil {
@@ -45,18 +43,17 @@ func (h *Helm) Template(ctx context.Context, ociURI, version, namespace string, 
 }
 
 func (h *Helm) PullChart(ctx context.Context, ociURI, version string) error {
-	_, err := h.Command(ctx, "pull", ociURI, "--version", version, insecureSkipVerifyFlag).
+	_, err := h.executable.Command(ctx, "pull", ociURI, "--version", version, insecureSkipVerifyFlag).
 		WithEnvVars(helmTemplateEnvVars).Run()
 	return err
 }
 
 func (h *Helm) PushChart(ctx context.Context, chart, registry string) error {
-	logger.Info("Pushing to registry", "chart", chart, "registry", registry)
-	_, err := h.Command(ctx, "push", chart, registry, insecureSkipVerifyFlag).WithEnvVars(helmTemplateEnvVars).Run()
+	_, err := h.executable.Command(ctx, "push", chart, registry, insecureSkipVerifyFlag).WithEnvVars(helmTemplateEnvVars).Run()
 	return err
 }
 
 func (h *Helm) RegistryLogin(ctx context.Context, registry, username, password string) error {
-	_, err := h.Command(ctx, "registry", "login", registry, "--username", username, "--password", password, "--insecure").WithEnvVars(helmTemplateEnvVars).Run()
+	_, err := h.executable.Command(ctx, "registry", "login", registry, "--username", username, "--password", password, "--insecure").WithEnvVars(helmTemplateEnvVars).Run()
 	return err
 }

--- a/pkg/executables/helm.go
+++ b/pkg/executables/helm.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
 const (
@@ -49,11 +51,13 @@ func (h *Helm) PullChart(ctx context.Context, ociURI, version string) error {
 }
 
 func (h *Helm) PushChart(ctx context.Context, chart, registry string) error {
+	logger.Info("Pushing", "chart", chart)
 	_, err := h.executable.Command(ctx, "push", chart, registry, insecureSkipVerifyFlag).WithEnvVars(helmTemplateEnvVars).Run()
 	return err
 }
 
 func (h *Helm) RegistryLogin(ctx context.Context, registry, username, password string) error {
+	logger.Info("Logging in to helm registry", "registry", registry)
 	_, err := h.executable.Command(ctx, "registry", "login", registry, "--username", username, "--password", password, "--insecure").WithEnvVars(helmTemplateEnvVars).Run()
 	return err
 }

--- a/test/framework/registryMirror.go
+++ b/test/framework/registryMirror.go
@@ -36,6 +36,15 @@ func WithRegistryMirrorEndpointAndCert() ClusterE2ETestOpt {
 				api.WithRegistryMirror(endpoint, string(certificate)),
 			)
 		}
+		// Set env vars for helm login/push
+		err = os.Setenv("REGISTRY_USERNAME", username)
+		if err != nil {
+			e.T.Fatalf("unable to set REGISTRY_USERNAME: %v", err)
+		}
+		err = os.Setenv("REGISTRY_PASSWORD", password)
+		if err != nil {
+			e.T.Fatalf("unable to set REGISTRY_PASSWORD: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We reverted the commit in #1609 after doing some testing that didn't require us to be logged in to the registry, but when testing in our ci environment it seemed like it didn't work as expected. The creds might have been cached or the set up for dev is different. Now, we will be asking users to specify the username and password when running import images so helm that is running inside our docker container will be allowed to push. We could have used the `--registry-config` if we had access to the `~/.docker/config.json` to avoid the user from having to login to the registry mirror for docker and also provide these env vars for helm, but I am not sure if there is a quick way for us to do that apart from mounting the `config.json` file after checking for the existence of it in the default path. Ideally if there was a way to get these credential information from the docker service that was accessible from within the docker container, then we can avoid having to provide these env vars.

This change would need to be cherry-picked to the `release-0.8` branch as well

/cherry-pick release-0.8

*Testing (if applicable):*
Tested e2e against ci env

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

