### PR TITLE
Avoid processing duplicated images in image mover

### DIFF
--- a/pkg/docker/mover_test.go
+++ b/pkg/docker/mover_test.go
@@ -28,7 +28,7 @@ func newMoverTest(t *testing.T) *moverTest {
 		ctx:    context.Background(),
 		src:    mocks.NewMockImageSource(ctrl),
 		dst:    mocks.NewMockImageDestination(ctrl),
-		images: []string{"image1:1", "image2:2"},
+		images: []string{"image1:1", "image2:2", "image1:1", "image2:2"},
 	}
 }
 

--- a/pkg/types/lookup.go
+++ b/pkg/types/lookup.go
@@ -7,6 +7,14 @@ func (l Lookup) IsPresent(v string) bool {
 	return present
 }
 
+func (l Lookup) ToSlice() []string {
+	keys := make([]string, 0, len(l))
+	for k := range l {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 func SliceToLookup(slice []string) Lookup {
 	l := make(map[string]struct{}, len(slice))
 	for _, e := range slice {

--- a/pkg/types/lookup_test.go
+++ b/pkg/types/lookup_test.go
@@ -3,6 +3,8 @@ package types_test
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 
@@ -44,6 +46,31 @@ func TestLookupIsPresent(t *testing.T) {
 			if got := l.IsPresent(tt.value); got != tt.wantPresent {
 				t.Errorf("Lookup.IsPresent() = %v, want %v", got, tt.wantPresent)
 			}
+		})
+	}
+}
+
+func TestLookupToSlice(t *testing.T) {
+	tests := []struct {
+		name string
+		l    types.Lookup
+		want []string
+	}{
+		{
+			name: "empty",
+			l:    types.Lookup{},
+			want: []string{},
+		},
+		{
+			name: "not empty",
+			l:    types.SliceToLookup([]string{"a", "a", "a", "a"}),
+			want: []string{"a"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.l.ToSlice()).To(Equal(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
Part of https://github.com/aws/eks-anywhere/issues/1166
Will complement https://github.com/aws/eks-anywhere/pull/1478
Builds on top of #1518 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

