### PR TITLE
Set 1-22 feature flag for e2e test that upgrades to 1.22

### DIFF
--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -80,6 +80,7 @@ func TestVSphereKubernetes121UbuntuTo122UpgradeCiliumPolicyEnforcementMode(t *te
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
 		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var()),
+		framework.WithEnvVar(features.K8s122SupportEnvVar, "true"),
 	)
 }
 


### PR DESCRIPTION
*Description of changes:*
e2e test `TestVSphereKubernetes121UbuntuTo122UpgradeCiliumPolicyEnforcementMode` is failing because of the missing feature flag, this PR sets it

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

