### PR TITLE
Added tinkerbellHegelURL field in the Tinkerbell clusterconfig file

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbelldatacenterconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbelldatacenterconfigs.yaml
@@ -42,6 +42,8 @@ spec:
                 type: string
               tinkerbellGRPCAuth:
                 type: string
+              tinkerbellHegelURL:
+                type: string
               tinkerbellIP:
                 description: 'Important: Run "make generate" to regenerate code after
                   modifying this file'
@@ -51,6 +53,7 @@ spec:
             required:
             - tinkerbellCertURL
             - tinkerbellGRPCAuth
+            - tinkerbellHegelURL
             - tinkerbellIP
             - tinkerbellPBnJGRPCAuth
             type: object

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -3995,6 +3995,8 @@ spec:
                 type: string
               tinkerbellGRPCAuth:
                 type: string
+              tinkerbellHegelURL:
+                type: string
               tinkerbellIP:
                 description: 'Important: Run "make generate" to regenerate code after
                   modifying this file'
@@ -4004,6 +4006,7 @@ spec:
             required:
             - tinkerbellCertURL
             - tinkerbellGRPCAuth
+            - tinkerbellHegelURL
             - tinkerbellIP
             - tinkerbellPBnJGRPCAuth
             type: object

--- a/pkg/api/v1alpha1/testdata/cluster_1_21_valid_multiple_tinkerbell_templates.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_1_21_valid_multiple_tinkerbell_templates.yaml
@@ -44,6 +44,7 @@ metadata:
 spec:
   tinkerbellCertURL: "http://1.2.3.4/cert"
   tinkerbellGRPCAuth: "1.2.3.4:0000"
+  tinkerbellHegelURL: "http://1.2.3.4:50051"
   tinkerbellIP: "1.2.3.4"
   tinkerbellPBnJGRPCAuth: "1.2.3.4:00000"
 

--- a/pkg/api/v1alpha1/testdata/cluster_1_21_valid_tinkerbell.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_1_21_valid_tinkerbell.yaml
@@ -44,6 +44,7 @@ metadata:
 spec:
   tinkerbellCertURL: "http://1.2.3.4/cert"
   tinkerbellGRPCAuth: "1.2.3.4:0000"
+  tinkerbellHegelURL: "http://1.2.3.4:50051"
   tinkerbellIP: "1.2.3.4"
   tinkerbellPBnJGRPCAuth: "1.2.3.4:00000"
 

--- a/pkg/api/v1alpha1/testdata/cluster_invalid_kinds_tinkerbell.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_invalid_kinds_tinkerbell.yaml
@@ -44,6 +44,7 @@ metadata:
 spec:
   tinkerbellCertURL: "http://1.2.3.4/cert"
   tinkerbellGRPCAuth: "1.2.3.4:0000"
+  tinkerbellHegelURL: "http://1.2.3.4:50051"
   tinkerbellIP: "1.2.3.4"
   tinkerbellPBnJGRPCAuth: "1.2.3.4:00000"
 

--- a/pkg/api/v1alpha1/testdata/not_parseable_cluster_tinkerbell.yaml
+++ b/pkg/api/v1alpha1/testdata/not_parseable_cluster_tinkerbell.yaml
@@ -44,6 +44,7 @@ metadata:
 spec:
   tinkerbellCertURL: "http://1.2.3.4/cert"
   tinkerbellGRPCAuth: "1.2.3.4:0000"
+  tinkerbellHegelURL: "http://1.2.3.4:50051"
   tinkerbellIP: "1.2.3.4"
   tinkerbellPBnJGRPCAuth: "1.2.3.4:00000"
   idont: "belonghere"

--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig_types.go
@@ -13,6 +13,7 @@ type TinkerbellDatacenterConfigSpec struct {
 	TinkerbellCertURL      string `json:"tinkerbellCertURL"`
 	TinkerbellGRPCAuth     string `json:"tinkerbellGRPCAuth"`
 	TinkerbellPBnJGRPCAuth string `json:"tinkerbellPBnJGRPCAuth"`
+	TinkerbellHegelURL     string `json:"tinkerbellHegelURL"`
 }
 
 // TinkerbellDatacenterConfigStatus defines the observed state of TinkerbellDatacenterConfig

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
@@ -15,7 +15,7 @@ const (
 `
 	cloudInit = `datasource:
   Ec2:
-    metadata_urls: ["http://<REPLACE WITH TINKERBELL IP>:50061"]
+    metadata_urls: []
     strict_id: false
 system_info:
   default_user:

--- a/pkg/providers/tinkerbell/envars.go
+++ b/pkg/providers/tinkerbell/envars.go
@@ -23,5 +23,9 @@ func setupEnvVars(datacenterConfig *anywherev1.TinkerbellDatacenterConfig) error
 	if err := os.Setenv(tinkerbellPBnJGRPCAuthorityKey, datacenterConfig.Spec.TinkerbellPBnJGRPCAuth); err != nil {
 		return fmt.Errorf("unable to set %s: %v", tinkerbellPBnJGRPCAuthorityKey, err)
 	}
+
+	if err := os.Setenv(tinkerbellHegelURLKey, datacenterConfig.Spec.TinkerbellHegelURL); err != nil {
+		return fmt.Errorf("unable to set %s: %v", tinkerbellHegelURLKey, err)
+	}
 	return nil
 }

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_external_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_external_etcd.yaml
@@ -42,7 +42,7 @@ kind: TinkerbellDatacenterConfig
 metadata:
   name: test
 spec:
-  tinkerbellCertURL: "http://1.2.3.4/cert"
+  tinkerbellCertURL: "http://1.2.3.4:42114/cert"
   tinkerbellGRPCAuth: "1.2.3.4:99"
   tinkerbellHegelURL: "http://1.2.3.4:50051"
   tinkerbellIP: "1.2.3.4"

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_external_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_external_etcd.yaml
@@ -44,6 +44,7 @@ metadata:
 spec:
   tinkerbellCertURL: "http://1.2.3.4/cert"
   tinkerbellGRPCAuth: "1.2.3.4:99"
+  tinkerbellHegelURL: "http://1.2.3.4:50051"
   tinkerbellIP: "1.2.3.4"
   tinkerbellPBnJGRPCAuth: "1.2.3.4:99"
 
@@ -147,18 +148,18 @@ spec:
       - environment:
           CONTENTS: |
             datasource:
-            Ec2:
-              metadata_urls: ["http://1.2.3.4:50061"]
-              strict_id: false
+              Ec2:
+                metadata_urls: []
+                strict_id: false
             system_info:
-            default_user:
-              name: tink
-              groups: [wheel, adm]
-              sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-              shell: /bin/bash
+              default_user:
+                name: tink
+                groups: [wheel, adm]
+                sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+                shell: /bin/bash
             manage_etc_hosts: localhost
             warnings:
-            dsid_missing_source: off
+              dsid_missing_source: off
           DEST_DISK: /dev/sda1
           DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
           DIRMODE: "0700"

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_missing_ssh_keys.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_missing_ssh_keys.yaml
@@ -39,6 +39,7 @@ metadata:
 spec:
   tinkerbellCertURL: "http://1.2.3.4/cert"
   tinkerbellGRPCAuth: "1.2.3.4:99"
+  tinkerbellHegelURL: "http://1.2.3.4:50051"
   tinkerbellIP: "1.2.3.4"
   tinkerbellPBnJGRPCAuth: "1.2.3.4:99"
 
@@ -125,18 +126,18 @@ spec:
       - environment:
           CONTENTS: |
             datasource:
-            Ec2:
-              metadata_urls: ["http://1.2.3.4:50061"]
-              strict_id: false
+              Ec2:
+                metadata_urls: []
+                strict_id: false
             system_info:
-            default_user:
-              name: tink
-              groups: [wheel, adm]
-              sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-              shell: /bin/bash
+              default_user:
+                name: tink
+                groups: [wheel, adm]
+                sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+                shell: /bin/bash
             manage_etc_hosts: localhost
             warnings:
-            dsid_missing_source: off
+              dsid_missing_source: off
           DEST_DISK: /dev/sda1
           DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
           DIRMODE: "0700"

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_missing_ssh_keys.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_missing_ssh_keys.yaml
@@ -37,7 +37,7 @@ kind: TinkerbellDatacenterConfig
 metadata:
   name: test
 spec:
-  tinkerbellCertURL: "http://1.2.3.4/cert"
+  tinkerbellCertURL: "http://1.2.3.4:42114/cert"
   tinkerbellGRPCAuth: "1.2.3.4:99"
   tinkerbellHegelURL: "http://1.2.3.4:50051"
   tinkerbellIP: "1.2.3.4"

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_multiple_node_groups.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_multiple_node_groups.yaml
@@ -50,6 +50,7 @@ metadata:
 spec:
   tinkerbellCertURL: "http://1.2.3.4/cert"
   tinkerbellGRPCAuth: "1.2.3.4:99"
+  tinkerbellHegelURL: "http://1.2.3.4:50051"
   tinkerbellIP: "1.2.3.4"
   tinkerbellPBnJGRPCAuth: "1.2.3.4:99"
 
@@ -153,18 +154,18 @@ spec:
       - environment:
           CONTENTS: |
             datasource:
-            Ec2:
-              metadata_urls: ["http://1.2.3.4:50061"]
-              strict_id: false
+              Ec2:
+                metadata_urls: []
+                strict_id: false
             system_info:
-            default_user:
-              name: tink
-              groups: [wheel, adm]
-              sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-              shell: /bin/bash
+              default_user:
+                name: tink
+                groups: [wheel, adm]
+                sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+                shell: /bin/bash
             manage_etc_hosts: localhost
             warnings:
-            dsid_missing_source: off
+              dsid_missing_source: off
           DEST_DISK: /dev/sda1
           DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
           DIRMODE: "0700"

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_multiple_node_groups.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_multiple_node_groups.yaml
@@ -48,7 +48,7 @@ kind: TinkerbellDatacenterConfig
 metadata:
   name: test
 spec:
-  tinkerbellCertURL: "http://1.2.3.4/cert"
+  tinkerbellCertURL: "http://1.2.3.4:42114/cert"
   tinkerbellGRPCAuth: "1.2.3.4:99"
   tinkerbellHegelURL: "http://1.2.3.4:50051"
   tinkerbellIP: "1.2.3.4"

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_stacked_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_stacked_etcd.yaml
@@ -39,6 +39,7 @@ metadata:
 spec:
   tinkerbellCertURL: "http://1.2.3.4/cert"
   tinkerbellGRPCAuth: "1.2.3.4:99"
+  tinkerbellHegelURL: "http://1.2.3.4:50051"
   tinkerbellIP: "1.2.3.4"
   tinkerbellPBnJGRPCAuth: "1.2.3.4:99"
 
@@ -127,18 +128,18 @@ spec:
       - environment:
           CONTENTS: |
             datasource:
-            Ec2:
-              metadata_urls: ["http://1.2.3.4:50061"]
-              strict_id: false
+              Ec2:
+                metadata_urls: []
+                strict_id: false
             system_info:
-            default_user:
-              name: tink
-              groups: [wheel, adm]
-              sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-              shell: /bin/bash
+              default_user:
+                name: tink
+                groups: [wheel, adm]
+                sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+                shell: /bin/bash
             manage_etc_hosts: localhost
             warnings:
-            dsid_missing_source: off
+              dsid_missing_source: off
           DEST_DISK: /dev/sda1
           DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
           DIRMODE: "0700"

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_stacked_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_stacked_etcd.yaml
@@ -37,7 +37,7 @@ kind: TinkerbellDatacenterConfig
 metadata:
   name: test
 spec:
-  tinkerbellCertURL: "http://1.2.3.4/cert"
+  tinkerbellCertURL: "http://1.2.3.4:42114/cert"
   tinkerbellGRPCAuth: "1.2.3.4:99"
   tinkerbellHegelURL: "http://1.2.3.4:50051"
   tinkerbellIP: "1.2.3.4"

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
@@ -215,18 +215,22 @@ spec:
           - environment:
               CONTENTS: |
                 datasource:
-                Ec2:
-                  metadata_urls: ["http://1.2.3.4:50061"]
-                  strict_id: false
-                system_info:
-                default_user:
-                  name: tink
-                  groups: [wheel, adm]
-                  sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-                  shell: /bin/bash
+                  Ec2:
+                    metadata_urls:
+                    - http://1.2.3.4:50051
+                    strict_id: false
                 manage_etc_hosts: localhost
+                system_info:
+                  default_user:
+                    groups:
+                    - wheel
+                    - adm
+                    name: tink
+                    shell: /bin/bash
+                    sudo:
+                    - ALL=(ALL) NOPASSWD:ALL
                 warnings:
-                dsid_missing_source: off
+                  dsid_missing_source: false
               DEST_DISK: /dev/sda1
               DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
               DIRMODE: "0700"
@@ -322,18 +326,22 @@ spec:
           - environment:
               CONTENTS: |
                 datasource:
-                Ec2:
-                  metadata_urls: ["http://1.2.3.4:50061"]
-                  strict_id: false
-                system_info:
-                default_user:
-                  name: tink
-                  groups: [wheel, adm]
-                  sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-                  shell: /bin/bash
+                  Ec2:
+                    metadata_urls:
+                    - http://1.2.3.4:50051
+                    strict_id: false
                 manage_etc_hosts: localhost
+                system_info:
+                  default_user:
+                    groups:
+                    - wheel
+                    - adm
+                    name: tink
+                    shell: /bin/bash
+                    sudo:
+                    - ALL=(ALL) NOPASSWD:ALL
                 warnings:
-                dsid_missing_source: off
+                  dsid_missing_source: false
               DEST_DISK: /dev/sda1
               DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
               DIRMODE: "0700"

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
@@ -179,18 +179,22 @@ spec:
           - environment:
               CONTENTS: |
                 datasource:
-                Ec2:
-                  metadata_urls: ["http://1.2.3.4:50061"]
-                  strict_id: false
-                system_info:
-                default_user:
-                  name: tink
-                  groups: [wheel, adm]
-                  sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-                  shell: /bin/bash
+                  Ec2:
+                    metadata_urls:
+                    - http://1.2.3.4:50051
+                    strict_id: false
                 manage_etc_hosts: localhost
+                system_info:
+                  default_user:
+                    groups:
+                    - wheel
+                    - adm
+                    name: tink
+                    shell: /bin/bash
+                    sudo:
+                    - ALL=(ALL) NOPASSWD:ALL
                 warnings:
-                dsid_missing_source: off
+                  dsid_missing_source: false
               DEST_DISK: /dev/sda1
               DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
               DIRMODE: "0700"

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md.yaml
@@ -86,18 +86,22 @@ spec:
           - environment:
               CONTENTS: |
                 datasource:
-                Ec2:
-                  metadata_urls: ["http://1.2.3.4:50061"]
-                  strict_id: false
-                system_info:
-                default_user:
-                  name: tink
-                  groups: [wheel, adm]
-                  sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-                  shell: /bin/bash
+                  Ec2:
+                    metadata_urls:
+                    - http://1.2.3.4:50051
+                    strict_id: false
                 manage_etc_hosts: localhost
+                system_info:
+                  default_user:
+                    groups:
+                    - wheel
+                    - adm
+                    name: tink
+                    shell: /bin/bash
+                    sudo:
+                    - ALL=(ALL) NOPASSWD:ALL
                 warnings:
-                dsid_missing_source: off
+                  dsid_missing_source: false
               DEST_DISK: /dev/sda1
               DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
               DIRMODE: "0700"

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
@@ -179,18 +179,22 @@ spec:
           - environment:
               CONTENTS: |
                 datasource:
-                Ec2:
-                  metadata_urls: ["http://1.2.3.4:50061"]
-                  strict_id: false
-                system_info:
-                default_user:
-                  name: tink
-                  groups: [wheel, adm]
-                  sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-                  shell: /bin/bash
+                  Ec2:
+                    metadata_urls:
+                    - http://1.2.3.4:50051
+                    strict_id: false
                 manage_etc_hosts: localhost
+                system_info:
+                  default_user:
+                    groups:
+                    - wheel
+                    - adm
+                    name: tink
+                    shell: /bin/bash
+                    sudo:
+                    - ALL=(ALL) NOPASSWD:ALL
                 warnings:
-                dsid_missing_source: off
+                  dsid_missing_source: false
               DEST_DISK: /dev/sda1
               DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
               DIRMODE: "0700"

--- a/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_md_multiple_node_groups.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_md_multiple_node_groups.yaml
@@ -86,18 +86,22 @@ spec:
           - environment:
               CONTENTS: |
                 datasource:
-                Ec2:
-                  metadata_urls: ["http://1.2.3.4:50061"]
-                  strict_id: false
-                system_info:
-                default_user:
-                  name: tink
-                  groups: [wheel, adm]
-                  sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-                  shell: /bin/bash
+                  Ec2:
+                    metadata_urls:
+                    - http://1.2.3.4:50051
+                    strict_id: false
                 manage_etc_hosts: localhost
+                system_info:
+                  default_user:
+                    groups:
+                    - wheel
+                    - adm
+                    name: tink
+                    shell: /bin/bash
+                    sudo:
+                    - ALL=(ALL) NOPASSWD:ALL
                 warnings:
-                dsid_missing_source: off
+                  dsid_missing_source: false
               DEST_DISK: /dev/sda1
               DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
               DIRMODE: "0700"
@@ -246,18 +250,22 @@ spec:
           - environment:
               CONTENTS: |
                 datasource:
-                Ec2:
-                  metadata_urls: ["http://1.2.3.4:50061"]
-                  strict_id: false
-                system_info:
-                default_user:
-                  name: tink
-                  groups: [wheel, adm]
-                  sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-                  shell: /bin/bash
+                  Ec2:
+                    metadata_urls:
+                    - http://1.2.3.4:50051
+                    strict_id: false
                 manage_etc_hosts: localhost
+                system_info:
+                  default_user:
+                    groups:
+                    - wheel
+                    - adm
+                    name: tink
+                    shell: /bin/bash
+                    sudo:
+                    - ALL=(ALL) NOPASSWD:ALL
                 warnings:
-                dsid_missing_source: off
+                  dsid_missing_source: false
               DEST_DISK: /dev/sda1
               DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
               DIRMODE: "0700"

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -35,6 +35,7 @@ const (
 	tinkerbellGRPCAuthKey          = "TINKERBELL_GRPC_AUTHORITY"
 	tinkerbellIPKey                = "TINKERBELL_IP"
 	tinkerbellPBnJGRPCAuthorityKey = "PBNJ_GRPC_AUTHORITY"
+	tinkerbellHegelURLKey          = "TINKERBELL_HEGEL_URL"
 )
 
 //go:embed config/template-cp.yaml
@@ -51,7 +52,7 @@ const defaultUsername = "ec2-user"
 var (
 	eksaTinkerbellDatacenterResourceType = fmt.Sprintf("tinkerbelldatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaTinkerbellMachineResourceType    = fmt.Sprintf("tinkerbellmachineconfigs.%s", v1alpha1.GroupVersion.Group)
-	requiredEnvs                         = []string{tinkerbellCertURLKey, tinkerbellGRPCAuthKey, tinkerbellIPKey, tinkerbellPBnJGRPCAuthorityKey}
+	requiredEnvs                         = []string{tinkerbellCertURLKey, tinkerbellGRPCAuthKey, tinkerbellIPKey, tinkerbellPBnJGRPCAuthorityKey, tinkerbellHegelURLKey}
 )
 
 type tinkerbellProvider struct {
@@ -330,11 +331,11 @@ func (p *tinkerbellProvider) SetupAndValidateCreateCluster(ctx context.Context, 
 		return err
 	}
 
-	if err := p.validator.ValidateTinkerbellTemplate(ctx, tinkerbellClusterSpec.datacenterConfig.Spec.TinkerbellIP, tinkerbellClusterSpec.Spec.TinkerbellTemplateConfigs[tinkerbellClusterSpec.controlPlaneMachineConfig().Spec.TemplateRef.Name]); err != nil {
+	if err := p.validator.ValidateAndPopulateTemplate(ctx, tinkerbellClusterSpec.datacenterConfig, tinkerbellClusterSpec.Spec.TinkerbellTemplateConfigs[tinkerbellClusterSpec.controlPlaneMachineConfig().Spec.TemplateRef.Name]); err != nil {
 		return fmt.Errorf("failed validating control plane template config: %v", err)
 	}
 
-	if err := p.validator.ValidateTinkerbellTemplate(ctx, tinkerbellClusterSpec.datacenterConfig.Spec.TinkerbellIP, tinkerbellClusterSpec.Spec.TinkerbellTemplateConfigs[tinkerbellClusterSpec.firstWorkerMachineConfig().Spec.TemplateRef.Name]); err != nil {
+	if err := p.validator.ValidateAndPopulateTemplate(ctx, tinkerbellClusterSpec.datacenterConfig, tinkerbellClusterSpec.Spec.TinkerbellTemplateConfigs[tinkerbellClusterSpec.firstWorkerMachineConfig().Spec.TemplateRef.Name]); err != nil {
 		return fmt.Errorf("failed validating worker node template config: %v", err)
 	}
 

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -25,7 +25,7 @@ const (
 	testDataDir                         = "testdata"
 	expectedTinkerbellIP                = "1.2.3.4"
 	expectedTinkerbellGRPCAuth          = "1.2.3.4:42113"
-	expectedTinkerbellCertURL           = "1.2.3.4:42114/cert"
+	expectedTinkerbellCertURL           = "http://1.2.3.4:42114/cert"
 	expectedTinkerbellPBnJGRPCAuthority = "1.2.3.4:42000"
 	expectedTinkerbellHegelURL          = "http://1.2.3.4:50051"
 )

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -27,6 +27,7 @@ const (
 	expectedTinkerbellGRPCAuth          = "1.2.3.4:42113"
 	expectedTinkerbellCertURL           = "1.2.3.4:42114/cert"
 	expectedTinkerbellPBnJGRPCAuthority = "1.2.3.4:42000"
+	expectedTinkerbellHegelURL          = "http://1.2.3.4:50051"
 )
 
 func givenClusterSpec(t *testing.T, fileName string) *cluster.Spec {
@@ -85,6 +86,8 @@ type testContext struct {
 	isTinkerbellGRPCAuthSet          bool
 	oldTinkerbellPBnJGRPCAuthority   string
 	isTinkerbellPBnJGRPCAuthoritySet bool
+	isTinkerbellHegelURLSet          bool
+	oldTinkerbellHegelURL            string
 }
 
 func (tctx *testContext) SaveContext() {
@@ -92,10 +95,12 @@ func (tctx *testContext) SaveContext() {
 	tctx.oldTinkerbellCertURL, tctx.isTinkerbellCertURLSet = os.LookupEnv(tinkerbellCertURLKey)
 	tctx.oldtinkerbellGRPCAuth, tctx.isTinkerbellGRPCAuthSet = os.LookupEnv(tinkerbellGRPCAuthKey)
 	tctx.oldTinkerbellPBnJGRPCAuthority, tctx.isTinkerbellPBnJGRPCAuthoritySet = os.LookupEnv(tinkerbellPBnJGRPCAuthorityKey)
+	tctx.oldTinkerbellHegelURL, tctx.isTinkerbellHegelURLSet = os.LookupEnv(tinkerbellHegelURLKey)
 	os.Setenv(tinkerbellIPKey, expectedTinkerbellIP)
 	os.Setenv(tinkerbellCertURLKey, expectedTinkerbellCertURL)
 	os.Setenv(tinkerbellGRPCAuthKey, expectedTinkerbellGRPCAuth)
 	os.Setenv(tinkerbellPBnJGRPCAuthorityKey, expectedTinkerbellPBnJGRPCAuthority)
+	os.Setenv(tinkerbellHegelURLKey, expectedTinkerbellHegelURL)
 	os.Setenv(features.TinkerbellProviderEnvVar, "true")
 }
 
@@ -119,6 +124,11 @@ func (tctx *testContext) RestoreContext() {
 		os.Setenv(tinkerbellPBnJGRPCAuthorityKey, tctx.oldTinkerbellPBnJGRPCAuthority)
 	} else {
 		os.Unsetenv(tinkerbellPBnJGRPCAuthorityKey)
+	}
+	if tctx.isTinkerbellHegelURLSet {
+		os.Setenv(tinkerbellHegelURLKey, tctx.oldTinkerbellHegelURL)
+	} else {
+		os.Unsetenv(tinkerbellHegelURLKey)
 	}
 }
 

--- a/pkg/providers/tinkerbell/validator_test.go
+++ b/pkg/providers/tinkerbell/validator_test.go
@@ -157,6 +157,7 @@ func newValidTinkerbellDatacenterConfig() *v1alpha1.TinkerbellDatacenterConfig {
 			TinkerbellCertURL:      "http://domain.com/path",
 			TinkerbellGRPCAuth:     "1.1.1.1:444",
 			TinkerbellPBnJGRPCAuth: "1.1.1.1:444",
+			TinkerbellHegelURL:     "1.1.1.1:444",
 		},
 	}
 }

--- a/pkg/providers/tinkerbell/validator_test.go
+++ b/pkg/providers/tinkerbell/validator_test.go
@@ -154,10 +154,10 @@ func newValidTinkerbellDatacenterConfig() *v1alpha1.TinkerbellDatacenterConfig {
 		Status: v1alpha1.TinkerbellDatacenterConfigStatus{},
 		Spec: v1alpha1.TinkerbellDatacenterConfigSpec{
 			TinkerbellIP:           "1.1.1.1",
-			TinkerbellCertURL:      "http://domain.com/path",
+			TinkerbellCertURL:      "http://1.1.1.1:444/path",
 			TinkerbellGRPCAuth:     "1.1.1.1:444",
 			TinkerbellPBnJGRPCAuth: "1.1.1.1:444",
-			TinkerbellHegelURL:     "1.1.1.1:444",
+			TinkerbellHegelURL:     "http://1.1.1.1:444",
 		},
 	}
 }


### PR DESCRIPTION
*Description of changes:*
Added tinkerbellHegelURL field in the clusterconfig file to replace metadata_url in the template field. I haven't added e2e test changes in this PR. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

