### PR TITLE
Process images concurrently in docker image mover

### DIFF
--- a/internal/test/matchers.go
+++ b/internal/test/matchers.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/golang/mock/gomock"
@@ -18,4 +19,11 @@ func (o *ofType) Matches(x interface{}) bool {
 
 func (o *ofType) String() string {
 	return "is of type " + o.t
+}
+
+// AContext returns a gomock matchers that evaluates if the receive value can
+// fullfills the context.Context interface
+func AContext() gomock.Matcher {
+	ctxInterface := reflect.TypeOf((*context.Context)(nil)).Elem()
+	return gomock.AssignableToTypeOf(ctxInterface)
 }

--- a/pkg/docker/concurrent.go
+++ b/pkg/docker/concurrent.go
@@ -1,0 +1,137 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type ConcurrentImageProcessor struct {
+	maxRoutines int
+}
+
+func NewConcurrentImageProcessor(maxRoutines int) *ConcurrentImageProcessor {
+	return &ConcurrentImageProcessor{maxRoutines: maxRoutines}
+}
+
+type ImageProcessor func(ctx context.Context, image string) error
+
+func (c *ConcurrentImageProcessor) Process(ctx context.Context, images []string, process ImageProcessor) error {
+	contextWithCancel, abortRemainingJobs := context.WithCancel(ctx)
+	workers := min(len(images), c.maxRoutines)
+	workers = max(workers, 1)
+	jobsChan := make(chan job)
+	wg := &sync.WaitGroup{}
+	errors := make(chan error)
+	doneChan := make(chan struct{})
+
+	for i := 0; i < workers; i++ {
+		w := &worker{
+			jobs:        jobsChan,
+			process:     process,
+			waitGroup:   wg,
+			errorReturn: errors,
+		}
+		go w.start()
+	}
+
+	f := &feeder{
+		jobs:            jobsChan,
+		images:          images,
+		workersWaiGroup: wg,
+		done:            doneChan,
+	}
+	go f.feed(contextWithCancel)
+
+	var firstError error
+
+loop:
+	for {
+		select {
+		case <-doneChan:
+			break loop
+		case err := <-errors:
+			if firstError == nil {
+				firstError = err
+				abortRemainingJobs()
+			}
+		}
+	}
+
+	// This is not necessary because if we get here all workers are done, regardless if all the jobs
+	// were run or not, so canceling the context is not necessary since there is nothing else using it
+	// This is just to avoid a lint warning for possible context leeking
+	abortRemainingJobs()
+
+	if firstError != nil {
+		return fmt.Errorf("image processor worker failed, rest of jobs were aborted: %v", firstError)
+	}
+
+	return nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+type job struct {
+	ctx   context.Context
+	image string
+}
+
+type feeder struct {
+	jobs            chan<- job
+	images          []string
+	done            chan<- struct{}
+	workersWaiGroup *sync.WaitGroup
+}
+
+func (f *feeder) feed(ctx context.Context) {
+	defer func() {
+		close(f.jobs)
+		f.workersWaiGroup.Wait()
+		close(f.done)
+	}()
+
+	for _, i := range f.images {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			j := job{
+				ctx:   ctx,
+				image: i,
+			}
+			f.jobs <- j
+		}
+	}
+}
+
+type worker struct {
+	jobs        <-chan job
+	process     ImageProcessor
+	waitGroup   *sync.WaitGroup
+	errorReturn chan<- error
+}
+
+func (w *worker) start() {
+	w.waitGroup.Add(1)
+
+	for j := range w.jobs {
+		if err := w.process(j.ctx, j.image); err != nil {
+			w.errorReturn <- err
+		}
+	}
+
+	w.waitGroup.Done()
+}

--- a/pkg/docker/concurrent_test.go
+++ b/pkg/docker/concurrent_test.go
@@ -1,0 +1,113 @@
+package docker_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/docker"
+)
+
+func TestConcurrentImageProcessorProcessSuccess(t *testing.T) {
+	tests := []struct {
+		name        string
+		images      []string
+		maxRoutines int
+	}{
+		{
+			name:        "more jobs than routines",
+			images:      []string{"image1:1", "image2:2", "images3:3"},
+			maxRoutines: 2,
+		},
+		{
+			name:        "same jobs than routines",
+			images:      []string{"image1:1", "image2:2", "images3:3"},
+			maxRoutines: 3,
+		},
+		{
+			name:        "less jobs than routines",
+			images:      []string{"image1:1", "image2:2", "images3:3"},
+			maxRoutines: 4,
+		},
+		{
+			name:        "zero routines",
+			images:      []string{"image1:1", "image2:2", "images3:3"},
+			maxRoutines: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+
+			processor := docker.NewConcurrentImageProcessor(tt.maxRoutines)
+
+			process := func(_ context.Context, _ string) error {
+				return nil
+			}
+
+			g.Expect(processor.Process(ctx, tt.images, process)).To(Succeed())
+		})
+	}
+}
+
+func TestConcurrentImageProcessorProcessError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	images := []string{"image1:1", "image2:2", "images3:3"}
+
+	processor := docker.NewConcurrentImageProcessor(2)
+
+	process := func(_ context.Context, i string) error {
+		if i == "image2:2" {
+			return errors.New("processing error")
+		}
+		return nil
+	}
+
+	g.Expect(processor.Process(ctx, images, process)).To(
+		MatchError(ContainSubstring("image processor worker failed, rest of jobs were aborted: processing error")),
+	)
+}
+
+func TestConcurrentImageProcessorProcessErrorWithJobsBeingCancelled(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	images := []string{"image1:1", "image2:2", "images3:3"}
+
+	processor := docker.NewConcurrentImageProcessor(2)
+
+	process := func(ctx context.Context, i string) error {
+		if i == "image2:2" {
+			return errors.New("processing error")
+		}
+		// Block until context gets cancelled to trigger the flow
+		// where jobs get cancelled after first error
+		<-ctx.Done()
+		return nil
+	}
+
+	g.Expect(processor.Process(ctx, images, process)).To(
+		MatchError(ContainSubstring("image processor worker failed, rest of jobs were aborted: processing error")),
+	)
+}
+
+func TestConcurrentImageProcessorProcessCancelParentContext(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	images := []string{"image1:1", "image2:2", "images3:3"}
+
+	processor := docker.NewConcurrentImageProcessor(2)
+
+	process := func(ctx context.Context, i string) error {
+		<-ctx.Done()
+		return nil
+	}
+
+	cancel()
+
+	g.Expect(processor.Process(ctx, images, process)).To(Succeed())
+}

--- a/pkg/docker/file.go
+++ b/pkg/docker/file.go
@@ -1,6 +1,10 @@
 package docker
 
-import "context"
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
+)
 
 // ImageDiskSource implements the ImageSource interface, loading images and tags from
 // a tarbal into the local docker cache
@@ -18,6 +22,7 @@ func NewDiskSource(client ImageDiskLoader, file string) *ImageDiskSource {
 
 // Load reads images and tags from a tarbal into the local docker cache
 func (s *ImageDiskSource) Load(ctx context.Context, images ...string) error {
+	logger.Info("Loading images from disk")
 	return s.client.LoadFromFile(ctx, s.file)
 }
 
@@ -37,5 +42,6 @@ func NewDiskDestination(client ImageDiskWriter, file string) *ImageDiskDestinati
 
 // Write creates a tarball including images and tags from the the local docker cache
 func (s *ImageDiskDestination) Write(ctx context.Context, images ...string) error {
+	logger.Info("Writing images to disk")
 	return s.client.SaveToFile(ctx, s.file, images...)
 }

--- a/pkg/docker/registry.go
+++ b/pkg/docker/registry.go
@@ -2,32 +2,44 @@ package docker
 
 import (
 	"context"
+	"runtime"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
 // ImageRegistryDestination implements the ImageDestination interface, writing images and tags from
 // from the local docker cache to an external registry
 type ImageRegistryDestination struct {
-	client   ImageTaggerPusher
-	endpoint string
+	client    ImageTaggerPusher
+	endpoint  string
+	processor *ConcurrentImageProcessor
 }
 
 func NewRegistryDestination(client ImageTaggerPusher, registryEndpoint string) *ImageRegistryDestination {
 	return &ImageRegistryDestination{
-		client:   client,
-		endpoint: registryEndpoint,
+		client:    client,
+		endpoint:  registryEndpoint,
+		processor: NewConcurrentImageProcessor(runtime.GOMAXPROCS(0) / 2),
 	}
 }
 
 // Write pushes images and tags from from the local docker cache to an external registry
 func (d *ImageRegistryDestination) Write(ctx context.Context, images ...string) error {
-	for _, i := range images {
-		if err := d.client.TagImage(ctx, i, d.endpoint); err != nil {
+	logger.Info("Writing images to registry")
+	logger.V(3).Info("Starting registry write", "numberOfImages", len(images))
+	err := d.processor.Process(ctx, images, func(ctx context.Context, image string) error {
+		if err := d.client.TagImage(ctx, image, d.endpoint); err != nil {
 			return err
 		}
 
-		if err := d.client.PushImage(ctx, i, d.endpoint); err != nil {
+		if err := d.client.PushImage(ctx, image, d.endpoint); err != nil {
 			return err
 		}
+
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -36,21 +48,31 @@ func (d *ImageRegistryDestination) Write(ctx context.Context, images ...string) 
 // ImageOriginalRegistrySource implements the ImageSource interface, pulling images and tags from
 // their original registry into the local docker cache
 type ImageOriginalRegistrySource struct {
-	client ImagePuller
+	client    ImagePuller
+	processor *ConcurrentImageProcessor
 }
 
 func NewOriginalRegistrySource(client ImagePuller) *ImageOriginalRegistrySource {
 	return &ImageOriginalRegistrySource{
-		client: client,
+		client:    client,
+		processor: NewConcurrentImageProcessor(runtime.GOMAXPROCS(0) / 2),
 	}
 }
 
 // Load pulls images and tags from their original registry into the local docker cache
 func (s *ImageOriginalRegistrySource) Load(ctx context.Context, images ...string) error {
-	for _, i := range images {
-		if err := s.client.PullImage(ctx, i); err != nil {
+	logger.Info("Pulling images from origin, this might take a while")
+	logger.V(3).Info("Starting pull", "numberOfImages", len(images))
+
+	err := s.processor.Process(ctx, images, func(ctx context.Context, image string) error {
+		if err := s.client.PullImage(ctx, image); err != nil {
 			return err
 		}
+
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/docker/registry_test.go
+++ b/pkg/docker/registry_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/docker"
 	"github.com/aws/eks-anywhere/pkg/docker/mocks"
 )
@@ -22,8 +23,8 @@ func TestNewRegistryDestination(t *testing.T) {
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
 	for _, i := range images {
-		client.EXPECT().TagImage(ctx, i, registry)
-		client.EXPECT().PushImage(ctx, i, registry)
+		client.EXPECT().TagImage(test.AContext(), i, registry)
+		client.EXPECT().PushImage(test.AContext(), i, registry)
 	}
 
 	g.Expect(dstLoader.Write(ctx, images...)).To(Succeed())
@@ -38,7 +39,7 @@ func TestNewRegistryDestinationErrorTag(t *testing.T) {
 	images := []string{"image1:1", "image2:2"}
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
-	client.EXPECT().TagImage(ctx, images[0], registry).Return(errors.New("error tagging"))
+	client.EXPECT().TagImage(test.AContext(), images[0], registry).Return(errors.New("error tagging"))
 
 	g.Expect(dstLoader.Write(ctx, images...)).To(MatchError(ContainSubstring("error tagging")))
 }
@@ -52,8 +53,8 @@ func TestNewRegistryDestinationErrorPush(t *testing.T) {
 	images := []string{"image1:1", "image2:2"}
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
-	client.EXPECT().TagImage(ctx, images[0], registry)
-	client.EXPECT().PushImage(ctx, images[0], registry).Return(errors.New("error pushing"))
+	client.EXPECT().TagImage(test.AContext(), images[0], registry)
+	client.EXPECT().PushImage(test.AContext(), images[0], registry).Return(errors.New("error pushing"))
 
 	g.Expect(dstLoader.Write(ctx, images...)).To(MatchError(ContainSubstring("error pushing")))
 }
@@ -67,7 +68,7 @@ func TestNewOriginalRegistrySource(t *testing.T) {
 	ctx := context.Background()
 	dstLoader := docker.NewOriginalRegistrySource(client)
 	for _, i := range images {
-		client.EXPECT().PullImage(ctx, i)
+		client.EXPECT().PullImage(test.AContext(), i)
 	}
 
 	g.Expect(dstLoader.Load(ctx, images...)).To(Succeed())
@@ -81,7 +82,7 @@ func TestOriginalRegistrySourceError(t *testing.T) {
 	images := []string{"image1:1", "image2:2"}
 	ctx := context.Background()
 	dstLoader := docker.NewOriginalRegistrySource(client)
-	client.EXPECT().PullImage(ctx, images[0]).Return(errors.New("error pulling"))
+	client.EXPECT().PullImage(test.AContext(), images[0]).Return(errors.New("error pulling"))
 
 	g.Expect(dstLoader.Load(ctx, images...)).To(MatchError(ContainSubstring("error pulling")))
 }


### PR DESCRIPTION
Part of https://github.com/aws/eks-anywhere/issues/1166
Will complement https://github.com/aws/eks-anywhere/pull/1478
Builds on top of https://github.com/aws/eks-anywhere/pull/1518

*Description of changes:*
Little performance improvement for the docker image mover.

Now it runs image push and pulls concurrently. Before this is was doing it sequentially, one after the other. It will use GOMAXPROCS/2 routines, which should be equivalent to half the number of processor cores (in most platforms).

Introduced a new matcher for contexts. It only checks that the argument can be assigned to a `context.Context` variable.

*Testing (if applicable):*
Added unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

