### PR TITLE
Fix fetch artifacts command for extra flux and oidc files

### DIFF
--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/filewriter/writer.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/filewriter/writer.go
@@ -53,27 +53,17 @@ func (t *writer) Dir() string {
 	return t.dir
 }
 
-// This method writes the e2e test artifacts from S3 to files in a directory named after the e2e test name.
-// Since OIDC tests have an additional folder within the S3 directory, we must take an additional step to
-// ensure that the OIDC files for the associated e2e test are placed in the correct directory
+// This method writes the e2e test artifacts from S3 to files in a directory named after the e2e test name
 func (t *writer) WriteTestArtifactsS3ToFile(key string, data []byte) error {
-	i := strings.LastIndex(key, "/")
-	filePath := path.Base(key[:i])
-	if filePath == "oidc" {
-		j := strings.LastIndex(key[:i], "/")
-		filePath = path.Base(key[:j])
-	}
-	d := path.Join(t.dir, filePath)
+	i := strings.LastIndex(key, "/Test")
+	p := path.Join(t.dir, key[i:])
 
-	i = strings.LastIndex(key, filePath)
-	f := path.Join(t.dir, key[i:])
-
-	err := os.MkdirAll(d, os.ModePerm)
+	err := os.MkdirAll(path.Dir(p), os.ModePerm)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(f, data, os.ModePerm)
+	err = ioutil.WriteFile(p, data, os.ModePerm)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Tests with more than one directory for its artifacts, like Flux and OIDC, had some misplaced files when using the `fetch artifacts` command due to recent changes. This PR fixes those issues to place those files in their correct directories.

*Testing (if applicable):*
`fetch artifacts` command

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

