### PR TITLE
Impl tinkerbell workflow removal on force.

### DIFF
--- a/pkg/executables/tink.go
+++ b/pkg/executables/tink.go
@@ -87,3 +87,18 @@ func (t *Tink) GetWorkflow(ctx context.Context) ([]*workflow.Workflow, error) {
 
 	return workflowList, nil
 }
+
+func (t *Tink) DeleteWorkflow(ctx context.Context, workflowIDs ...string) error {
+	params := []string{
+		"workflow", "delete",
+		"--tinkerbell-cert-url", t.tinkerbellCertUrl,
+		"--tinkerbell-grpc-authority", t.tinkerbellGrpcAuthority,
+	}
+	params = append(params, workflowIDs...)
+
+	if _, err := t.Command(ctx, params...).Run(); err != nil {
+		return fmt.Errorf("deleting workflow(s): %v", err)
+	}
+
+	return nil
+}

--- a/pkg/providers/tinkerbell/mocks/client.go
+++ b/pkg/providers/tinkerbell/mocks/client.go
@@ -158,6 +158,25 @@ func (m *MockProviderTinkClient) EXPECT() *MockProviderTinkClientMockRecorder {
 	return m.recorder
 }
 
+// DeleteWorkflow mocks base method.
+func (m *MockProviderTinkClient) DeleteWorkflow(arg0 context.Context, arg1 ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteWorkflow", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteWorkflow indicates an expected call of DeleteWorkflow.
+func (mr *MockProviderTinkClientMockRecorder) DeleteWorkflow(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflow", reflect.TypeOf((*MockProviderTinkClient)(nil).DeleteWorkflow), varargs...)
+}
+
 // GetHardware mocks base method.
 func (m *MockProviderTinkClient) GetHardware(arg0 context.Context) ([]*hardware.Hardware, error) {
 	m.ctrl.T.Helper()

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -124,13 +124,7 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, tinkerbel
 	return nil
 }
 
-func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFile string, skipPowerActions bool) error {
-	hardwares, err := v.tink.GetHardware(ctx)
-	if err != nil {
-		return fmt.Errorf("failed validating connection to tinkerbell stack: %v", err)
-	}
-	logger.MarkPass("Connected to tinkerbell stack")
-
+func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFile string, hardwares []*tinkhardware.Hardware, skipPowerActions bool) error {
 	if err := v.hardwareConfig.ParseHardwareConfig(hardwareConfigFile); err != nil {
 		return fmt.Errorf("failed to get hardware Config: %v", err)
 	}


### PR DESCRIPTION
When force creating a cluster the program should remove all workflows associated with the hardware that's been submitted. This is to ensure we pass validation and can correctly provision the hardware with a new workflow.

#### Todo
- Make MAC address checks case insensitive.
- Whatever unit tests we can write.
- Manual e2e test.