### PR TITLE
Helm registry mirror

### DIFF
--- a/cmd/eksctl-anywhere/cmd/downloadartifacts.go
+++ b/cmd/eksctl-anywhere/cmd/downloadartifacts.go
@@ -69,7 +69,6 @@ func downloadArtifacts(context context.Context, opts *downloadArtifactsOptions) 
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration == nil || clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Endpoint == "" {
 		return fmt.Errorf("endpoint not set. It is necessary to define a valid endpoint in your spec (registryMirrorConfiguration.endpoint)")
 	}
-	endpoint := clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Endpoint
 
 	reader := files.NewReader(files.WithUserAgent(fmt.Sprintf("eks-a-cli-download/%s", version.Get().GitVersion)))
 
@@ -96,10 +95,6 @@ func downloadArtifacts(context context.Context, opts *downloadArtifactsOptions) 
 				}
 				*manifest = filePath
 			}
-		}
-		for component, chart := range bundle.Charts() {
-			chartRegistry := fmt.Sprintf("%s/%s/%s", endpoint, chart.Name, component)
-			chart.URI = fmt.Sprintf("%s:%s", chartRegistry, chart.Tag())
 		}
 		clusterSpec.Bundles.Spec.VersionsBundles[i] = bundle
 	}

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -276,12 +276,12 @@ func (c *Cluster) ClearPauseAnnotation() {
 	}
 }
 
-func (c *Cluster) UseImageMirror(defaultImage string) string {
+func (c *Cluster) RegistryMirror() string {
 	if c.Spec.RegistryMirrorConfiguration == nil {
-		return defaultImage
+		return ""
 	}
-	imageUrl, _ := url.Parse("https://" + defaultImage)
-	return net.JoinHostPort(c.Spec.RegistryMirrorConfiguration.Endpoint, c.Spec.RegistryMirrorConfiguration.Port) + imageUrl.Path
+
+	return net.JoinHostPort(c.Spec.RegistryMirrorConfiguration.Endpoint, c.Spec.RegistryMirrorConfiguration.Port)
 }
 
 func (c *Cluster) IsReconcilePaused() bool {

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -2011,3 +2011,35 @@ func TestValidateMirrorConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterRegistryMirror(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *Cluster
+		want    string
+	}{
+		{
+			name: "with registry mirror",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					RegistryMirrorConfiguration: &RegistryMirrorConfiguration{
+						Endpoint: "1.2.3.4",
+						Port:     "443",
+					},
+				},
+			},
+			want: "1.2.3.4:443",
+		},
+		{
+			name:    "without registry mirror",
+			cluster: &Cluster{},
+			want:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.cluster.RegistryMirror()).To(Equal(tt.want))
+		})
+	}
+}

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -82,3 +82,14 @@ func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
 	tt.Expect(deps.Troubleshoot).NotTo(BeNil())
 	tt.Expect(deps.CAPIManager).NotTo(BeNil())
 }
+
+func TestFactoryBuildWithRegistryMirror(t *testing.T) {
+	tt := newTest(t)
+	deps, err := dependencies.NewFactory().
+		WithRegistryMirror("1.2.3.4:443").
+		WithHelm().
+		Build(context.Background())
+
+	tt.Expect(err).To(BeNil())
+	tt.Expect(deps.Helm).NotTo(BeNil())
+}

--- a/pkg/executables/builder.go
+++ b/pkg/executables/builder.go
@@ -61,8 +61,8 @@ func (b *ExecutableBuilder) BuildTroubleshootExecutable() *Troubleshoot {
 	return NewTroubleshoot(b.buildExecutable(troubleshootPath))
 }
 
-func (b *ExecutableBuilder) BuildHelmExecutable() *Helm {
-	return NewHelm(b.buildExecutable(helmPath))
+func (b *ExecutableBuilder) BuildHelmExecutable(opts ...HelmOpt) *Helm {
+	return NewHelm(b.buildExecutable(helmPath), opts...)
 }
 
 func (b *ExecutableBuilder) Close(ctx context.Context) *Troubleshoot {

--- a/pkg/executables/helm_test.go
+++ b/pkg/executables/helm_test.go
@@ -69,6 +69,16 @@ func TestHelmTemplateSuccess(t *testing.T) {
 	tt.Expect(tt.h.Template(tt.ctx, tt.ociURI, tt.version, tt.namespace, tt.values)).To(Equal(tt.wantTemplateContent), "helm.Template() should succeed return correct template content")
 }
 
+func TestHelmTemplateSuccessWithRegistryMirror(t *testing.T) {
+	tt := newHelmTemplateTest(t)
+	tt.h = executables.NewHelm(tt.e, executables.WithRegistryMirror("1.2.3.4:443"))
+	expectCommand(
+		tt.e, tt.ctx, "template", "oci://1.2.3.4:443/account/charts", "--version", tt.version, "--insecure-skip-tls-verify", "--namespace", tt.namespace, "-f", "-",
+	).withStdIn(tt.valuesYaml).withEnvVars(tt.envVars).to().Return(*bytes.NewBuffer(tt.wantTemplateContent), nil)
+
+	tt.Expect(tt.h.Template(tt.ctx, tt.ociURI, tt.version, tt.namespace, tt.values)).To(Equal(tt.wantTemplateContent), "helm.Template() should succeed return correct template content")
+}
+
 func TestHelmTemplateErrorYaml(t *testing.T) {
 	tt := newHelmTemplateTest(t)
 	values := func() {}

--- a/pkg/executables/kind.go
+++ b/pkg/executables/kind.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/templater"
 	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/utils/urls"
 )
 
 const kindPath = "kind"
@@ -185,7 +186,7 @@ func (k *Kind) DeleteBootstrapCluster(ctx context.Context, cluster *types.Cluste
 func (k *Kind) setupExecConfig(clusterSpec *cluster.Spec) error {
 	bundle := clusterSpec.VersionsBundle
 	k.execConfig = &kindExecConfig{
-		KindImage:            clusterSpec.Cluster.UseImageMirror(bundle.EksD.KindNode.VersionedImage()),
+		KindImage:            urls.ReplaceHost(bundle.EksD.KindNode.VersionedImage(), clusterSpec.Cluster.RegistryMirror()),
 		KubernetesRepository: bundle.KubeDistro.Kubernetes.Repository,
 		KubernetesVersion:    bundle.KubeDistro.Kubernetes.Tag,
 		EtcdRepository:       bundle.KubeDistro.Etcd.Repository,

--- a/pkg/utils/urls/replace.go
+++ b/pkg/utils/urls/replace.go
@@ -1,0 +1,25 @@
+package urls
+
+import (
+	"net/url"
+	"strings"
+)
+
+// ReplaceHost replaces the host in a url
+// It supports full URLs and container image URLs
+// If the provided original url is malformed, the are no guarantees
+// that the returned value will be valid
+// If host is empty, it will return the original URL
+func ReplaceHost(orgURL, host string) string {
+	if host == "" {
+		return orgURL
+	}
+
+	u, _ := url.Parse(orgURL)
+	if u.Scheme == "" {
+		u, _ = url.Parse("oci://" + orgURL)
+		u.Scheme = ""
+	}
+	u.Host = host
+	return strings.TrimPrefix(u.String(), "//")
+}

--- a/pkg/utils/urls/replace_test.go
+++ b/pkg/utils/urls/replace_test.go
@@ -1,0 +1,48 @@
+package urls_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/utils/urls"
+)
+
+func TestReplaceHost(t *testing.T) {
+	tests := []struct {
+		name   string
+		orgURL string
+		host   string
+		want   string
+	}{
+		{
+			name:   "oci url",
+			orgURL: "oci://public.ecr.aws/product/chart",
+			host:   "1.2.3.4:443",
+			want:   "oci://1.2.3.4:443/product/chart",
+		},
+		{
+			name:   "https url",
+			orgURL: "https://public.ecr.aws/product/site",
+			host:   "1.2.3.4:443",
+			want:   "https://1.2.3.4:443/product/site",
+		},
+		{
+			name:   "container image",
+			orgURL: "public.ecr.aws/product/image:tag",
+			host:   "1.2.3.4:443",
+			want:   "1.2.3.4:443/product/image:tag",
+		},
+		{
+			name:   "empty host",
+			orgURL: "public.ecr.aws/product/image:tag",
+			want:   "public.ecr.aws/product/image:tag",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(urls.ReplaceHost(tt.orgURL, tt.host)).To(Equal(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
Related to https://github.com/aws/eks-anywhere/issues/1166

## Description of changes
Instead of modifying the downloaded bundle manifests to point the helm
charts to the registry mirror, we leave them untouched, and we make helm
patch the requests urls on the fly.

The main advantage is that downloaded artifacts remain agnostic from the
registry. This allows to download them before having access to the
registry or even used the same artifacts for different registries.

## Testing (if applicable):
* Added unit tests
* ~I'll test the whole flow e2e before merging~ Tested e2e manually

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

