### PR TITLE
Changed DEST_DISK to /dev/sda2

### DIFF
--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
@@ -61,7 +61,7 @@ func withNetplanAction(b v1alpha1.VersionsBundle) ActionOpt {
 			Image:   b.Tinkerbell.Actions.WriteFile.URI,
 			Timeout: 90,
 			Environment: map[string]string{
-				"DEST_DISK": "/dev/sda1",
+				"DEST_DISK": "/dev/sda2",
 				"FS_TYPE":   "ext4",
 				"DEST_PATH": "/etc/netplan/config.yaml",
 				"CONTENTS":  netplan,
@@ -81,7 +81,7 @@ func withTinkCloudInitAction(b v1alpha1.VersionsBundle) ActionOpt {
 			Image:   b.Tinkerbell.Actions.WriteFile.URI,
 			Timeout: 90,
 			Environment: map[string]string{
-				"DEST_DISK": "/dev/sda1",
+				"DEST_DISK": "/dev/sda2",
 				"FS_TYPE":   "ext4",
 				"DEST_PATH": "/etc/cloud/cloud.cfg.d/10_tinkerbell.cfg",
 				"CONTENTS":  cloudInit,
@@ -101,7 +101,7 @@ func withDsCloudInitAction(b v1alpha1.VersionsBundle) ActionOpt {
 			Image:   b.Tinkerbell.Actions.WriteFile.URI,
 			Timeout: 90,
 			Environment: map[string]string{
-				"DEST_DISK": "/dev/sda1",
+				"DEST_DISK": "/dev/sda2",
 				"FS_TYPE":   "ext4",
 				"DEST_PATH": "/etc/cloud/ds-identify.cfg",
 				"CONTENTS":  "datasource: Ec2\n",
@@ -122,7 +122,7 @@ func withKexecAction(b v1alpha1.VersionsBundle) ActionOpt {
 			Timeout: 90,
 			Pid:     "host",
 			Environment: map[string]string{
-				"BLOCK_DEVICE": "/dev/sda1",
+				"BLOCK_DEVICE": "/dev/sda2",
 				"FS_TYPE":      "ext4",
 			},
 		})

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
@@ -27,7 +27,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 			Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
 			Timeout: 90,
 			Environment: map[string]string{
-				"DEST_DISK": "/dev/sda1",
+				"DEST_DISK": "/dev/sda2",
 				"FS_TYPE":   "ext4",
 				"DEST_PATH": "/etc/netplan/config.yaml",
 				"CONTENTS":  netplan,
@@ -42,7 +42,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 			Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
 			Timeout: 90,
 			Environment: map[string]string{
-				"DEST_DISK": "/dev/sda1",
+				"DEST_DISK": "/dev/sda2",
 				"FS_TYPE":   "ext4",
 				"DEST_PATH": "/etc/cloud/cloud.cfg.d/10_tinkerbell.cfg",
 				"CONTENTS":  cloudInit,
@@ -57,7 +57,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 			Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
 			Timeout: 90,
 			Environment: map[string]string{
-				"DEST_DISK": "/dev/sda1",
+				"DEST_DISK": "/dev/sda2",
 				"FS_TYPE":   "ext4",
 				"DEST_PATH": "/etc/cloud/ds-identify.cfg",
 				"CONTENTS":  "datasource: Ec2\n",
@@ -73,7 +73,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 			Timeout: 90,
 			Pid:     "host",
 			Environment: map[string]string{
-				"BLOCK_DEVICE": "/dev/sda1",
+				"BLOCK_DEVICE": "/dev/sda2",
 				"FS_TYPE":      "ext4",
 			},
 		},

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_external_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_external_etcd.yaml
@@ -113,7 +113,7 @@ spec:
         name: stream-image
         timeout: 360
       - environment:
-          BLOCK_DEVICE: /dev/sda1
+          BLOCK_DEVICE: /dev/sda2
           CHROOT: "y"
           CMD_LINE: apt -y update && apt -y install openssl
           DEFAULT_INTERPRETER: /bin/sh -c
@@ -135,7 +135,7 @@ spec:
                       dhcp4: true
                   eno4:
                       dhcp4: true
-          DEST_DISK: /dev/sda1
+          DEST_DISK: /dev/sda2
           DEST_PATH: /etc/netplan/config.yaml
           DIRMODE: "0755"
           FS_TYPE: ext4
@@ -160,7 +160,7 @@ spec:
             manage_etc_hosts: localhost
             warnings:
               dsid_missing_source: off
-          DEST_DISK: /dev/sda1
+          DEST_DISK: /dev/sda2
           DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
           DIRMODE: "0700"
           FS_TYPE: ext4
@@ -172,7 +172,7 @@ spec:
       - environment:
           CONTENTS: |
             datasource: Ec2
-          DEST_DISK: /dev/sda1
+          DEST_DISK: /dev/sda2
           DEST_PATH: /etc/cloud/ds-identify.cfg
           DIRMODE: "0700"
           FS_TYPE: ext4
@@ -183,7 +183,7 @@ spec:
         name: add-tink-cloud-init-ds-config
         timeout: 90
       - environment:
-          BLOCK_DEVICE: /dev/sda1
+          BLOCK_DEVICE: /dev/sda2
           FS_TYPE: ext4
         image: kexec:v1.0.0
         name: kexec-image

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_missing_ssh_keys.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_missing_ssh_keys.yaml
@@ -91,7 +91,7 @@ spec:
         name: stream-image
         timeout: 360
       - environment:
-          BLOCK_DEVICE: /dev/sda1
+          BLOCK_DEVICE: /dev/sda2
           CHROOT: "y"
           CMD_LINE: apt -y update && apt -y install openssl
           DEFAULT_INTERPRETER: /bin/sh -c
@@ -113,7 +113,7 @@ spec:
                       dhcp4: true
                   eno4:
                       dhcp4: true
-          DEST_DISK: /dev/sda1
+          DEST_DISK: /dev/sda2
           DEST_PATH: /etc/netplan/config.yaml
           DIRMODE: "0755"
           FS_TYPE: ext4
@@ -138,7 +138,7 @@ spec:
             manage_etc_hosts: localhost
             warnings:
               dsid_missing_source: off
-          DEST_DISK: /dev/sda1
+          DEST_DISK: /dev/sda2
           DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
           DIRMODE: "0700"
           FS_TYPE: ext4
@@ -150,7 +150,7 @@ spec:
       - environment:
           CONTENTS: |
             datasource: Ec2
-          DEST_DISK: /dev/sda1
+          DEST_DISK: /dev/sda2
           DEST_PATH: /etc/cloud/ds-identify.cfg
           DIRMODE: "0700"
           FS_TYPE: ext4
@@ -161,7 +161,7 @@ spec:
         name: add-tink-cloud-init-ds-config
         timeout: 90
       - environment:
-          BLOCK_DEVICE: /dev/sda1
+          BLOCK_DEVICE: /dev/sda2
           FS_TYPE: ext4
         image: kexec:v1.0.0
         name: kexec-image

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_multiple_node_groups.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_multiple_node_groups.yaml
@@ -119,7 +119,7 @@ spec:
         name: stream-image
         timeout: 360
       - environment:
-          BLOCK_DEVICE: /dev/sda1
+          BLOCK_DEVICE: /dev/sda2
           CHROOT: "y"
           CMD_LINE: apt -y update && apt -y install openssl
           DEFAULT_INTERPRETER: /bin/sh -c
@@ -141,7 +141,7 @@ spec:
                       dhcp4: true
                   eno4:
                       dhcp4: true
-          DEST_DISK: /dev/sda1
+          DEST_DISK: /dev/sda2
           DEST_PATH: /etc/netplan/config.yaml
           DIRMODE: "0755"
           FS_TYPE: ext4
@@ -166,7 +166,7 @@ spec:
             manage_etc_hosts: localhost
             warnings:
               dsid_missing_source: off
-          DEST_DISK: /dev/sda1
+          DEST_DISK: /dev/sda2
           DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
           DIRMODE: "0700"
           FS_TYPE: ext4
@@ -178,7 +178,7 @@ spec:
       - environment:
           CONTENTS: |
             datasource: Ec2
-          DEST_DISK: /dev/sda1
+          DEST_DISK: /dev/sda2
           DEST_PATH: /etc/cloud/ds-identify.cfg
           DIRMODE: "0700"
           FS_TYPE: ext4
@@ -189,7 +189,7 @@ spec:
         name: add-tink-cloud-init-ds-config
         timeout: 90
       - environment:
-          BLOCK_DEVICE: /dev/sda1
+          BLOCK_DEVICE: /dev/sda2
           FS_TYPE: ext4
         image: kexec:v1.0.0
         name: kexec-image

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_stacked_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_stacked_etcd.yaml
@@ -93,7 +93,7 @@ spec:
         name: stream-image
         timeout: 360
       - environment:
-          BLOCK_DEVICE: /dev/sda1
+          BLOCK_DEVICE: /dev/sda2
           CHROOT: "y"
           CMD_LINE: apt -y update && apt -y install openssl
           DEFAULT_INTERPRETER: /bin/sh -c
@@ -115,7 +115,7 @@ spec:
                       dhcp4: true
                   eno4:
                       dhcp4: true
-          DEST_DISK: /dev/sda1
+          DEST_DISK: /dev/sda2
           DEST_PATH: /etc/netplan/config.yaml
           DIRMODE: "0755"
           FS_TYPE: ext4
@@ -140,7 +140,7 @@ spec:
             manage_etc_hosts: localhost
             warnings:
               dsid_missing_source: off
-          DEST_DISK: /dev/sda1
+          DEST_DISK: /dev/sda2
           DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
           DIRMODE: "0700"
           FS_TYPE: ext4
@@ -152,7 +152,7 @@ spec:
       - environment:
           CONTENTS: |
             datasource: Ec2
-          DEST_DISK: /dev/sda1
+          DEST_DISK: /dev/sda2
           DEST_PATH: /etc/cloud/ds-identify.cfg
           DIRMODE: "0700"
           FS_TYPE: ext4
@@ -163,7 +163,7 @@ spec:
         name: add-tink-cloud-init-ds-config
         timeout: 90
       - environment:
-          BLOCK_DEVICE: /dev/sda1
+          BLOCK_DEVICE: /dev/sda2
           FS_TYPE: ext4
         image: kexec:v1.0.0
         name: kexec-image

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
@@ -180,7 +180,7 @@ spec:
             name: stream-image
             timeout: 360
           - environment:
-              BLOCK_DEVICE: /dev/sda1
+              BLOCK_DEVICE: /dev/sda2
               CHROOT: "y"
               CMD_LINE: apt -y update && apt -y install openssl
               DEFAULT_INTERPRETER: /bin/sh -c
@@ -202,7 +202,7 @@ spec:
                           dhcp4: true
                       eno4:
                           dhcp4: true
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/netplan/config.yaml
               DIRMODE: "0755"
               FS_TYPE: ext4
@@ -231,7 +231,7 @@ spec:
                     - ALL=(ALL) NOPASSWD:ALL
                 warnings:
                   dsid_missing_source: false
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
               DIRMODE: "0700"
               FS_TYPE: ext4
@@ -243,7 +243,7 @@ spec:
           - environment:
               CONTENTS: |
                 datasource: Ec2
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/cloud/ds-identify.cfg
               DIRMODE: "0700"
               FS_TYPE: ext4
@@ -254,7 +254,7 @@ spec:
             name: add-tink-cloud-init-ds-config
             timeout: 90
           - environment:
-              BLOCK_DEVICE: /dev/sda1
+              BLOCK_DEVICE: /dev/sda2
               FS_TYPE: ext4
             image: kexec:v1.0.0
             name: kexec-image
@@ -291,7 +291,7 @@ spec:
             name: stream-image
             timeout: 360
           - environment:
-              BLOCK_DEVICE: /dev/sda1
+              BLOCK_DEVICE: /dev/sda2
               CHROOT: "y"
               CMD_LINE: apt -y update && apt -y install openssl
               DEFAULT_INTERPRETER: /bin/sh -c
@@ -313,7 +313,7 @@ spec:
                           dhcp4: true
                       eno4:
                           dhcp4: true
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/netplan/config.yaml
               DIRMODE: "0755"
               FS_TYPE: ext4
@@ -342,7 +342,7 @@ spec:
                     - ALL=(ALL) NOPASSWD:ALL
                 warnings:
                   dsid_missing_source: false
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
               DIRMODE: "0700"
               FS_TYPE: ext4
@@ -354,7 +354,7 @@ spec:
           - environment:
               CONTENTS: |
                 datasource: Ec2
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/cloud/ds-identify.cfg
               DIRMODE: "0700"
               FS_TYPE: ext4
@@ -365,7 +365,7 @@ spec:
             name: add-tink-cloud-init-ds-config
             timeout: 90
           - environment:
-              BLOCK_DEVICE: /dev/sda1
+              BLOCK_DEVICE: /dev/sda2
               FS_TYPE: ext4
             image: kexec:v1.0.0
             name: kexec-image

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
@@ -144,7 +144,7 @@ spec:
             name: stream-image
             timeout: 360
           - environment:
-              BLOCK_DEVICE: /dev/sda1
+              BLOCK_DEVICE: /dev/sda2
               CHROOT: "y"
               CMD_LINE: apt -y update && apt -y install openssl
               DEFAULT_INTERPRETER: /bin/sh -c
@@ -166,7 +166,7 @@ spec:
                           dhcp4: true
                       eno4:
                           dhcp4: true
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/netplan/config.yaml
               DIRMODE: "0755"
               FS_TYPE: ext4
@@ -195,7 +195,7 @@ spec:
                     - ALL=(ALL) NOPASSWD:ALL
                 warnings:
                   dsid_missing_source: false
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
               DIRMODE: "0700"
               FS_TYPE: ext4
@@ -207,7 +207,7 @@ spec:
           - environment:
               CONTENTS: |
                 datasource: Ec2
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/cloud/ds-identify.cfg
               DIRMODE: "0700"
               FS_TYPE: ext4
@@ -218,7 +218,7 @@ spec:
             name: add-tink-cloud-init-ds-config
             timeout: 90
           - environment:
-              BLOCK_DEVICE: /dev/sda1
+              BLOCK_DEVICE: /dev/sda2
               FS_TYPE: ext4
             image: kexec:v1.0.0
             name: kexec-image

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md.yaml
@@ -51,7 +51,7 @@ spec:
             name: stream-image
             timeout: 360
           - environment:
-              BLOCK_DEVICE: /dev/sda1
+              BLOCK_DEVICE: /dev/sda2
               CHROOT: "y"
               CMD_LINE: apt -y update && apt -y install openssl
               DEFAULT_INTERPRETER: /bin/sh -c
@@ -73,7 +73,7 @@ spec:
                           dhcp4: true
                       eno4:
                           dhcp4: true
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/netplan/config.yaml
               DIRMODE: "0755"
               FS_TYPE: ext4
@@ -102,7 +102,7 @@ spec:
                     - ALL=(ALL) NOPASSWD:ALL
                 warnings:
                   dsid_missing_source: false
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
               DIRMODE: "0700"
               FS_TYPE: ext4
@@ -114,7 +114,7 @@ spec:
           - environment:
               CONTENTS: |
                 datasource: Ec2
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/cloud/ds-identify.cfg
               DIRMODE: "0700"
               FS_TYPE: ext4
@@ -125,7 +125,7 @@ spec:
             name: add-tink-cloud-init-ds-config
             timeout: 90
           - environment:
-              BLOCK_DEVICE: /dev/sda1
+              BLOCK_DEVICE: /dev/sda2
               FS_TYPE: ext4
             image: kexec:v1.0.0
             name: kexec-image

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
@@ -144,7 +144,7 @@ spec:
             name: stream-image
             timeout: 360
           - environment:
-              BLOCK_DEVICE: /dev/sda1
+              BLOCK_DEVICE: /dev/sda2
               CHROOT: "y"
               CMD_LINE: apt -y update && apt -y install openssl
               DEFAULT_INTERPRETER: /bin/sh -c
@@ -166,7 +166,7 @@ spec:
                           dhcp4: true
                       eno4:
                           dhcp4: true
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/netplan/config.yaml
               DIRMODE: "0755"
               FS_TYPE: ext4
@@ -195,7 +195,7 @@ spec:
                     - ALL=(ALL) NOPASSWD:ALL
                 warnings:
                   dsid_missing_source: false
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
               DIRMODE: "0700"
               FS_TYPE: ext4
@@ -207,7 +207,7 @@ spec:
           - environment:
               CONTENTS: |
                 datasource: Ec2
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/cloud/ds-identify.cfg
               DIRMODE: "0700"
               FS_TYPE: ext4
@@ -218,7 +218,7 @@ spec:
             name: add-tink-cloud-init-ds-config
             timeout: 90
           - environment:
-              BLOCK_DEVICE: /dev/sda1
+              BLOCK_DEVICE: /dev/sda2
               FS_TYPE: ext4
             image: kexec:v1.0.0
             name: kexec-image

--- a/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_md_multiple_node_groups.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_md_multiple_node_groups.yaml
@@ -51,7 +51,7 @@ spec:
             name: stream-image
             timeout: 360
           - environment:
-              BLOCK_DEVICE: /dev/sda1
+              BLOCK_DEVICE: /dev/sda2
               CHROOT: "y"
               CMD_LINE: apt -y update && apt -y install openssl
               DEFAULT_INTERPRETER: /bin/sh -c
@@ -73,7 +73,7 @@ spec:
                           dhcp4: true
                       eno4:
                           dhcp4: true
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/netplan/config.yaml
               DIRMODE: "0755"
               FS_TYPE: ext4
@@ -102,7 +102,7 @@ spec:
                     - ALL=(ALL) NOPASSWD:ALL
                 warnings:
                   dsid_missing_source: false
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
               DIRMODE: "0700"
               FS_TYPE: ext4
@@ -114,7 +114,7 @@ spec:
           - environment:
               CONTENTS: |
                 datasource: Ec2
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/cloud/ds-identify.cfg
               DIRMODE: "0700"
               FS_TYPE: ext4
@@ -125,7 +125,7 @@ spec:
             name: add-tink-cloud-init-ds-config
             timeout: 90
           - environment:
-              BLOCK_DEVICE: /dev/sda1
+              BLOCK_DEVICE: /dev/sda2
               FS_TYPE: ext4
             image: kexec:v1.0.0
             name: kexec-image
@@ -215,7 +215,7 @@ spec:
             name: stream-image
             timeout: 360
           - environment:
-              BLOCK_DEVICE: /dev/sda1
+              BLOCK_DEVICE: /dev/sda2
               CHROOT: "y"
               CMD_LINE: apt -y update && apt -y install openssl
               DEFAULT_INTERPRETER: /bin/sh -c
@@ -237,7 +237,7 @@ spec:
                           dhcp4: true
                       eno4:
                           dhcp4: true
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/netplan/config.yaml
               DIRMODE: "0755"
               FS_TYPE: ext4
@@ -266,7 +266,7 @@ spec:
                     - ALL=(ALL) NOPASSWD:ALL
                 warnings:
                   dsid_missing_source: false
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
               DIRMODE: "0700"
               FS_TYPE: ext4
@@ -278,7 +278,7 @@ spec:
           - environment:
               CONTENTS: |
                 datasource: Ec2
-              DEST_DISK: /dev/sda1
+              DEST_DISK: /dev/sda2
               DEST_PATH: /etc/cloud/ds-identify.cfg
               DIRMODE: "0700"
               FS_TYPE: ext4
@@ -289,7 +289,7 @@ spec:
             name: add-tink-cloud-init-ds-config
             timeout: 90
           - environment:
-              BLOCK_DEVICE: /dev/sda1
+              BLOCK_DEVICE: /dev/sda2
               FS_TYPE: ext4
             image: kexec:v1.0.0
             name: kexec-image


### PR DESCRIPTION
*Description of changes:*
In the new ubuntu image we have enabled uefi which requires dev/sda1 partition. So for all other actions we have changed DEST_DISK to sda2.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

