### PR TITLE
Fix source S3 path for imagebuilder assets

### DIFF
--- a/release/pkg/assets_eksd.go
+++ b/release/pkg/assets_eksd.go
@@ -78,7 +78,7 @@ func (r *ReleaseConfig) GetEksDChannelAssets(eksDReleaseChannel, kubeVer, eksDRe
 					arch,
 					imageExtensions[imageFormat],
 				)
-				sourceS3Prefix = fmt.Sprintf("releases/bundles/%d/artifacts/%s/%s", r.BundleNumber, eksDReleaseChannel, imageFormat)
+				sourceS3Prefix = fmt.Sprintf("releases/bundles/%d/artifacts/%s/%s", r.BundleNumber, imageFormat, eksDReleaseChannel)
 			}
 
 			if r.DevRelease {


### PR DESCRIPTION
This fixes the Prod release looking at the wrong place for the S3 artifact.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

