### PR TITLE
Fix delete workflows in Tinkerbell provider

### DIFF
--- a/pkg/providers/tinkerbell/hardware/config.go
+++ b/pkg/providers/tinkerbell/hardware/config.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
 	"github.com/aws/eks-anywhere/pkg/templater"
 )
@@ -74,7 +75,7 @@ func (hc *HardwareConfig) setHardwareConfigFromFile(hardwareFileName string) err
 	return nil
 }
 
-func (hc *HardwareConfig) ValidateHardware(skipPowerActions bool, tinkHardwareMap map[string]*tinkhardware.Hardware, tinkWorkflowMap map[string]*tinkworkflow.Workflow) error {
+func (hc *HardwareConfig) ValidateHardware(skipPowerActions, force bool, tinkHardwareMap map[string]*tinkhardware.Hardware, tinkWorkflowMap map[string]*tinkworkflow.Workflow) error {
 	bmcRefMap := map[string]*tinkv1alpha1.Hardware{}
 	if !skipPowerActions {
 		bmcRefMap = hc.initBmcRefMap()
@@ -109,7 +110,17 @@ func (hc *HardwareConfig) ValidateHardware(skipPowerActions bool, tinkHardwareMa
 		for _, interfaces := range hardwareInterface {
 			mac := interfaces.GetDhcp()
 			if _, ok := tinkWorkflowMap[mac.Mac]; ok {
-				return fmt.Errorf("workflow %s already exixts for the hardware id %s", tinkWorkflowMap[mac.Mac].Id, hw.Spec.ID)
+				message := fmt.Sprintf("workflow %s already exixts for the hardware id %s", tinkWorkflowMap[mac.Mac].Id, hw.Spec.ID)
+
+				// If the --force-cleanup flag was set we have to warn. This is beacuse we haven't separated static
+				// and interactive validations so there's no opportunity, after performing static yaml validation, to
+				// delete any workflows before we check if workflows alredy exist. To avoid erroring out before getting
+				// the chance to delete workflows this code assumes workflows will be deleted at a later stage,
+				// therefore warns only.
+				if !force {
+					return fmt.Errorf(message)
+				}
+				logger.V(2).Info(fmt.Sprintf("Warn: %v", message))
 			}
 		}
 

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -373,7 +373,7 @@ func (p *tinkerbellProvider) SetupAndValidateCreateCluster(ctx context.Context, 
 	// ValidateHardwareConfig performs a lazy load of hardware configuration. Given subsequent steps need the hardware
 	// read into memory it needs to be done first. It also needs connection to
 	// Tinkerbell steps to verify hardware availability on the stack
-	if err := p.validator.ValidateHardwareConfig(ctx, p.hardwareConfigFile, hardware, p.skipPowerActions); err != nil {
+	if err := p.validator.ValidateHardwareConfig(ctx, p.hardwareConfigFile, hardware, p.skipPowerActions, p.force); err != nil {
 		return err
 	}
 

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -124,7 +124,7 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, tinkerbel
 	return nil
 }
 
-func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFile string, hardwares []*tinkhardware.Hardware, skipPowerActions bool) error {
+func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFile string, hardwares []*tinkhardware.Hardware, skipPowerActions, force bool) error {
 	if err := v.hardwareConfig.ParseHardwareConfig(hardwareConfigFile); err != nil {
 		return fmt.Errorf("failed to get hardware Config: %v", err)
 	}
@@ -140,7 +140,7 @@ func (v *Validator) ValidateHardwareConfig(ctx context.Context, hardwareConfigFi
 		return fmt.Errorf("validating if the workflow exist for the given list of hardwares %v", err)
 	}
 
-	if err := v.hardwareConfig.ValidateHardware(skipPowerActions, tinkHardwareMap, tinkWorkflowMap); err != nil {
+	if err := v.hardwareConfig.ValidateHardware(skipPowerActions, force, tinkHardwareMap, tinkWorkflowMap); err != nil {
 		return fmt.Errorf("failed validating Hardware BMC refs in hardware config: %v", err)
 	}
 


### PR DESCRIPTION
Builds on #1727

We don't separate static and interactive validation in Tinkerbell. Consequently, the static yaml validation and interactive workflow validation happen in the same function. This means we don't have an opportunity post yaml validation to clean up workflows before we validate none exist.
    
This change passes the force flag all the way down to validation logic so it can warn in stead of error when it sees workflows already in the Tinkerbell stack. In doing so, we gain yaml validation but have to assume something will clean up the workflows (the scrub function) later in the call path.