### PR TITLE
 Allow users to configure cloud provider and CSI Driver with different credentials 

### DIFF
--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
@@ -2,134 +2,91 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: {{.clusterName}}
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+    cluster.x-k8s.io/cluster-name: test
+  name: test
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks: {{.podCidrs}}
+      cidrBlocks: [192.168.0.0/16]
     services:
-      cidrBlocks: {{.serviceCidrs}}
+      cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane
-    name: {{.clusterName}}
+    name: test
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: VSphereCluster
-    name: {{.clusterName}}
-{{- if .externalEtcd }}
+    name: test
   managedExternalEtcdRef:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
-    name: {{.clusterName}}-etcd
-{{- end }}
+    name: test-etcd
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster
 metadata:
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test
+  namespace: eksa-system
 spec:
   controlPlaneEndpoint:
-    host: {{.controlPlaneEndpointIp}}
+    host: 1.2.3.4
     port: 6443
   identityRef:
     kind: Secret
-    name: {{.clusterName}}-vsphere-credentials
-  server: {{.vsphereServer}}
-  thumbprint: '{{.thumbprint}}'
+    name: test-vsphere-credentials
+  server: vsphere_server
+  thumbprint: 'ABCDEFG'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
-  name: {{.controlPlaneTemplateName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test-control-plane-template-1234567890000
+  namespace: eksa-system
 spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{.vsphereDatacenter}}
-      datastore: {{.controlPlaneVsphereDatastore}}
-      diskGiB: {{.controlPlaneDiskGiB}}
-      folder: '{{.controlPlaneVsphereFolder}}'
-      memoryMiB: {{.controlPlaneVMsMemoryMiB}}
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 8192
       network:
         devices:
         - dhcp4: true
-          networkName: {{.vsphereNetwork}}
-      numCPUs: {{.controlPlaneVMsNumCPUs}}
-      resourcePool: '{{.controlPlaneVsphereResourcePool}}'
-      server: {{.vsphereServer}}
-{{- if (ne .controlPlaneVsphereStoragePolicyName "") }}
-      storagePolicyName: "{{.controlPlaneVsphereStoragePolicyName}}"
-{{- end }}
-      template: {{.vsphereTemplate}}
-      thumbprint: '{{.thumbprint}}'
+          networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 2
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
+      thumbprint: 'ABCDEFG'
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test
+  namespace: eksa-system
 spec:
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: VSphereMachineTemplate
-      name: {{.controlPlaneTemplateName}}
+      name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: {{.kubernetesRepository}}
+      imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
-{{- if .externalEtcd }}
         external:
           endpoints: []
-{{- if (eq .format "bottlerocket") }}
-          caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
-          certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
-          keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"
-{{- else }}
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
-{{- end }}
-{{- else }}
-        local:
-          imageRepository: {{.etcdRepository}}
-          imageTag: {{.etcdImageTag}}
-{{- if .etcdExtraArgs }}
-          extraArgs:
-{{ .etcdExtraArgs.ToYaml | indent 12 }}
-{{- end }}
-{{- end }}
       dns:
-        imageRepository: {{.corednsRepository}}
-        imageTag: {{.corednsVersion}}
-{{- if (eq .format "bottlerocket") }}
-      pause:
-        imageRepository: {{.pauseRepository}}
-        imageTag: {{.pauseVersion}}
-      bottlerocketBootstrap:
-        imageRepository: {{.bottlerocketBootstrapRepository}}
-        imageTag: {{.bottlerocketBootstrapVersion}}
-{{- end }}
-{{- if and .proxyConfig (eq .format "bottlerocket") }}
-      proxy:
-        httpsProxy: {{.httpsProxy}}
-        noProxy: {{ range .noProxy }}
-          - {{ . }}
-        {{- end }}
-{{- end }}
-{{- if and .registryMirrorConfiguration (eq .format "bottlerocket") }}
-      registryMirror:
-        endpoint: {{.registryMirrorConfiguration}}
-        {{- if .registryCACert }}
-        caCert: |
-{{ .registryCACert | indent 10 }}
-        {{- end }}
-{{- end }}
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.8.0-eks-1-19-4
       apiServer:
         extraArgs:
           cloud-provider: external
@@ -139,15 +96,9 @@ spec:
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
           profiling: "false"
-{{- if .apiserverExtraArgs }}
-{{ .apiserverExtraArgs.ToYaml | indent 10 }}
-{{- end }}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         extraVolumes:
-{{- if (eq .format "bottlerocket") }}
-        - hostPath: /var/lib/kubeadm/audit-policy.yaml
-{{- else }}
         - hostPath: /etc/kubernetes/audit-policy.yaml
-{{- end }}
           mountPath: /etc/kubernetes/audit-policy.yaml
           name: audit-policy
           pathType: File
@@ -157,46 +108,15 @@ spec:
           name: audit-log-dir
           pathType: DirectoryOrCreate
           readOnly: false
-{{- if .awsIamAuth}}
-        - hostPath: /var/lib/kubeadm/aws-iam-authenticator/
-          mountPath: /etc/kubernetes/aws-iam-authenticator/
-          name: authconfig
-          readOnly: false
-        - hostPath: /var/lib/kubeadm/aws-iam-authenticator/pki/
-          mountPath: /var/aws-iam-authenticator/
-          name: awsiamcert
-          readOnly: false
-{{- end}}
       controllerManager:
         extraArgs:
           cloud-provider: external
           profiling: "false"
-{{- if .controllermanagerExtraArgs }}
-{{ .controllermanagerExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-{{- if (eq .format "bottlerocket") }}
-        extraVolumes:
-        - hostPath: /var/lib/kubeadm/controller-manager.conf
-          mountPath: /etc/kubernetes/controller-manager.conf
-          name: kubeconfig
-          pathType: File
-          readOnly: true
-{{- end }}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
       scheduler:
         extraArgs:
           profiling: "false"
-{{- if .schedulerExtraArgs }}
-{{ .schedulerExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-{{- if (eq .format "bottlerocket") }}
-        extraVolumes:
-        - hostPath: /var/lib/kubeadm/scheduler.conf
-          mountPath: /etc/kubernetes/scheduler.conf
-          name: kubeconfig
-          pathType: File
-          readOnly: true
-      certificatesDir: /var/lib/kubeadm/pki
-{{- end }}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
         apiVersion: v1
@@ -231,8 +151,8 @@ spec:
             - name: vip_retryperiod
               value: "2"
             - name: address
-              value: {{.controlPlaneEndpointIp}}
-            image: {{.kubeVipImage}}
+              value: 1.2.3.4
+            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}
@@ -253,75 +173,163 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-{{ .auditPolicy | indent 8 }}
+        apiVersion: audit.k8s.io/v1beta1
+        kind: Policy
+        rules:
+        # Log aws-auth configmap changes
+        - level: RequestResponse
+          namespaces: ["kube-system"]
+          verbs: ["update", "patch", "delete"]
+          resources:
+          - group: "" # core
+            resources: ["configmaps"]
+            resourceNames: ["aws-auth"]
+          omitStages:
+          - "RequestReceived"
+        # The following requests were manually identified as high-volume and low-risk,
+        # so drop them.
+        - level: None
+          users: ["system:kube-proxy"]
+          verbs: ["watch"]
+          resources:
+          - group: "" # core
+            resources: ["endpoints", "services", "services/status"]
+        - level: None
+          users: ["kubelet"] # legacy kubelet identity
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["nodes", "nodes/status"]
+        - level: None
+          userGroups: ["system:nodes"]
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["nodes", "nodes/status"]
+        - level: None
+          users:
+          - system:kube-controller-manager
+          - system:kube-scheduler
+          - system:serviceaccount:kube-system:endpoint-controller
+          verbs: ["get", "update"]
+          namespaces: ["kube-system"]
+          resources:
+          - group: "" # core
+            resources: ["endpoints"]
+        - level: None
+          users: ["system:apiserver"]
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+        # Don't log HPA fetching metrics.
+        - level: None
+          users:
+          - system:kube-controller-manager
+          verbs: ["get", "list"]
+          resources:
+          - group: "metrics.k8s.io"
+        # Don't log these read-only URLs.
+        - level: None
+          nonResourceURLs:
+          - /healthz*
+          - /version
+          - /swagger*
+        # Don't log events requests.
+        - level: None
+          resources:
+          - group: "" # core
+            resources: ["events"]
+        # node and pod status calls from nodes are high-volume and can be large, don't log responses for expected updates from nodes
+        - level: Request
+          users: ["kubelet", "system:node-problem-detector", "system:serviceaccount:kube-system:node-problem-detector"]
+          verbs: ["update","patch"]
+          resources:
+          - group: "" # core
+            resources: ["nodes/status", "pods/status"]
+          omitStages:
+          - "RequestReceived"
+        - level: Request
+          userGroups: ["system:nodes"]
+          verbs: ["update","patch"]
+          resources:
+          - group: "" # core
+            resources: ["nodes/status", "pods/status"]
+          omitStages:
+          - "RequestReceived"
+        # deletecollection calls can be large, don't log responses for expected namespace deletions
+        - level: Request
+          users: ["system:serviceaccount:kube-system:namespace-controller"]
+          verbs: ["deletecollection"]
+          omitStages:
+          - "RequestReceived"
+        # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
+        # so only log at the Metadata level.
+        - level: Metadata
+          resources:
+          - group: "" # core
+            resources: ["secrets", "configmaps"]
+          - group: authentication.k8s.io
+            resources: ["tokenreviews"]
+          omitStages:
+            - "RequestReceived"
+        - level: Request
+          resources:
+          - group: ""
+            resources: ["serviceaccounts/token"]
+        # Get repsonses can be large; skip them.
+        - level: Request
+          verbs: ["get", "list", "watch"]
+          resources:
+          - group: "" # core
+          - group: "admissionregistration.k8s.io"
+          - group: "apiextensions.k8s.io"
+          - group: "apiregistration.k8s.io"
+          - group: "apps"
+          - group: "authentication.k8s.io"
+          - group: "authorization.k8s.io"
+          - group: "autoscaling"
+          - group: "batch"
+          - group: "certificates.k8s.io"
+          - group: "extensions"
+          - group: "metrics.k8s.io"
+          - group: "networking.k8s.io"
+          - group: "policy"
+          - group: "rbac.authorization.k8s.io"
+          - group: "scheduling.k8s.io"
+          - group: "settings.k8s.io"
+          - group: "storage.k8s.io"
+          omitStages:
+          - "RequestReceived"
+        # Default level for known APIs
+        - level: RequestResponse
+          resources:
+          - group: "" # core
+          - group: "admissionregistration.k8s.io"
+          - group: "apiextensions.k8s.io"
+          - group: "apiregistration.k8s.io"
+          - group: "apps"
+          - group: "authentication.k8s.io"
+          - group: "authorization.k8s.io"
+          - group: "autoscaling"
+          - group: "batch"
+          - group: "certificates.k8s.io"
+          - group: "extensions"
+          - group: "metrics.k8s.io"
+          - group: "networking.k8s.io"
+          - group: "policy"
+          - group: "rbac.authorization.k8s.io"
+          - group: "scheduling.k8s.io"
+          - group: "settings.k8s.io"
+          - group: "storage.k8s.io"
+          omitStages:
+          - "RequestReceived"
+        # Default level for all other requests.
+        - level: Metadata
+          omitStages:
+          - "RequestReceived"
       owner: root:root
       path: /etc/kubernetes/audit-policy.yaml
-{{- if and .proxyConfig (ne .format "bottlerocket")}}
-    - content: |
-        [Service]
-        Environment="HTTP_PROXY={{.httpProxy}}"
-        Environment="HTTPS_PROXY={{.httpsProxy}}"
-        Environment="NO_PROXY={{ stringsJoin .noProxy "," }}"
-      owner: root:root
-      path: /etc/systemd/system/containerd.service.d/http-proxy.conf
-{{- end }}
-{{- if (ne .format "bottlerocket") }}
-{{- if .registryCACert }}
-    - content: |
-{{ .registryCACert | indent 8 }}
-      owner: root:root
-      path: "/etc/containerd/certs.d/{{.registryMirrorConfiguration}}/ca.crt"
-{{- end }}
-{{- if .registryMirrorConfiguration }}
-    - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://{{.registryMirrorConfiguration}}"]
-          {{- if .registryCACert }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{.registryMirrorConfiguration}}".tls]
-            ca_file = "/etc/containerd/certs.d/{{.registryMirrorConfiguration}}/ca.crt"
-          {{- end }}
-      owner: root:root
-      path: "/etc/containerd/config_append.toml"
-{{- end }}
-{{- end }}
-{{- if .awsIamAuth}}
-    - content: |
-        # clusters refers to the remote service.
-        clusters:
-          - name: aws-iam-authenticator
-            cluster:
-              certificate-authority: /var/aws-iam-authenticator/cert.pem
-              server: https://localhost:21362/authenticate
-        # users refers to the API Server's webhook configuration
-        # (we don't need to authenticate the API server).
-        users:
-          - name: apiserver
-        # kubeconfig files require a context. Provide one for the API Server.
-        current-context: webhook
-        contexts:
-        - name: webhook
-          context:
-            cluster: aws-iam-authenticator
-            user: apiserver
-      permissions: "0640"
-      owner: root:root
-      path: /var/lib/kubeadm/aws-iam-authenticator/kubeconfig.yaml
-    - contentFrom:
-        secret:
-          name: aws-iam-authenticator-ca
-          key: cert.pem
-      permissions: "0640"
-      owner: root:root
-      path: /var/lib/kubeadm/aws-iam-authenticator/pki/cert.pem
-    - contentFrom:
-        secret:
-          name: aws-iam-authenticator-ca
-          key: key.pem
-      permissions: "0640"
-      owner: root:root
-      path: /var/lib/kubeadm/aws-iam-authenticator/pki/key.pem
-{{- end}}
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -329,104 +337,46 @@ spec:
           cloud-provider: external
           read-only-port: "0"
           anonymous-auth: "false"
-{{- if .kubeletExtraArgs }}
-{{ .kubeletExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-        name: '{{`{{ ds.meta_data.hostname }}`}}'
-{{- if .controlPlaneTaints }}
-        taints:
-{{- range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-        {{- end }}
-{{- else}}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: '{{ ds.meta_data.hostname }}'
         taints: []
-{{- end }}
     joinConfiguration:
-{{- if (eq .format "bottlerocket") }}
-      pause:
-        imageRepository: {{.pauseRepository}}
-        imageTag: {{.pauseVersion}}
-      bottlerocketBootstrap:
-        imageRepository: {{.bottlerocketBootstrapRepository}}
-        imageTag: {{.bottlerocketBootstrapVersion}}
-{{- end }}
-{{- if and .proxyConfig (eq .format "bottlerocket") }}
-      proxy:
-        httpsProxy: {{.httpsProxy}}
-        noProxy: {{ range .noProxy }}
-        - {{ . }}
-        {{- end }}
-{{- end }}
-{{- if and .registryMirrorConfiguration (eq .format "bottlerocket") }}
-      registryMirror:
-        endpoint: {{.registryMirrorConfiguration}}
-        {{- if .registryCACert }}
-        caCert: |
-{{ .registryCACert | indent 10 }}
-        {{- end }}
-{{- end }}
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
           read-only-port: "0"
           anonymous-auth: "false"
-{{- if .kubeletExtraArgs }}
-{{ .kubeletExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-        name: '{{`{{ ds.meta_data.hostname }}`}}'
-{{- if .controlPlaneTaints }}
-        taints:
-{{- range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-        {{- end }}
-{{- else}}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: '{{ ds.meta_data.hostname }}'
         taints: []
-{{- end }}
     preKubeadmCommands:
-{{- if and .registryMirrorConfiguration (ne .format "bottlerocket") }}
-    - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
-{{- end }}
-{{- if and (or .proxyConfig .registryMirrorConfiguration) (ne .format "bottlerocket") }}
-    - sudo systemctl daemon-reload
-    - sudo systemctl restart containerd
-{{- end }}
-    - hostname "{{`{{ ds.meta_data.hostname }}`}}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
-    - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     useExperimentalRetryJoin: true
     users:
-    - name: {{.controlPlaneSshUsername}}
+    - name: capv
       sshAuthorizedKeys:
-      - '{{.vsphereControlPlaneSshAuthorizedKey}}'
+      - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
       sudo: ALL=(ALL) NOPASSWD:ALL
-    format: {{.format}}
-  replicas: {{.controlPlaneReplicas}}
-  version: {{.kubernetesVersion}}
+    format: cloud-config
+  replicas: 3
+  version: v1.19.8-eks-1-19-4
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: {{.clusterName}}
-  name: {{.resourceSetName}}
-  namespace: {{.eksaSystemNamespace}}
+    cluster.x-k8s.io/cluster-name: test
+  name: test-crs-0
+  namespace: eksa-system
 spec:
   clusterSelector:
     matchLabels:
-      cluster.x-k8s.io/cluster-name: {{.clusterName}}
+      cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
     name: vsphere-csi-controller
@@ -449,106 +399,77 @@ spec:
   - kind: ConfigMap
     name: cpi-manifests
 ---
-{{- if .externalEtcd }}
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
 metadata:
-  name: {{.clusterName}}-etcd
-  namespace: {{.eksaSystemNamespace}}
+  name: test-etcd
+  namespace: eksa-system
 spec:
-  replicas: {{.externalEtcdReplicas}}
+  replicas: 3
   etcdadmConfigSpec:
     etcdadmBuiltin: true
-    format: {{.format}}
-{{- if (eq .format "bottlerocket") }}
-    bottlerocketConfig:
-      etcdImage: {{.etcdImage}}
-      bootstrapImage: {{.bottlerocketBootstrapRepository}}:{{.bottlerocketBootstrapVersion}}
-      pauseImage: {{.pauseRepository}}:{{.pauseVersion}}
-{{- else}}
+    format: cloud-config
     cloudInitConfig:
-      version: {{.externalEtcdVersion}}
+      version: 3.4.14
       installDir: "/usr/bin"
     preEtcdadmCommands:
-      - hostname "{{`{{ ds.meta_data.hostname }}`}}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
-      - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
-{{- end }}
-{{- if .etcdCipherSuites }}
-    cipherSuites: {{.etcdCipherSuites}}
-{{- end }}
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
-      - name: {{.etcdSshUsername}}
+      - name: capv
         sshAuthorizedKeys:
-          - '{{.vsphereEtcdSshAuthorizedKey}}'
+          - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
-{{- if .proxyConfig }}
-    proxy:
-      httpProxy: {{ .httpProxy }}
-      httpsProxy: {{ .httpsProxy }}
-      noProxy: {{ range .noProxy }}
-        - {{ . }}
-      {{- end }}
-{{- end }}
-{{- if .registryMirrorConfiguration }}
-    registryMirror:
-      endpoint: {{.registryMirrorConfiguration}}
-      {{- if .registryCACert }}
-      caCert: |
-{{ .registryCACert | indent 8 }}
-      {{- end }}
-{{- end }}
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: VSphereMachineTemplate
-    name: {{.etcdTemplateName}}
+    name: test-etcd-template-1234567890000
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
-  name: {{.etcdTemplateName}}
-  namespace: '{{.eksaSystemNamespace}}'
+  name: test-etcd-template-1234567890000
+  namespace: 'eksa-system'
 spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{.vsphereDatacenter}}
-      datastore: {{.etcdVsphereDatastore}}
-      diskGiB: {{.etcdDiskGiB}}
-      folder: '{{.etcdVsphereFolder}}'
-      memoryMiB: {{.etcdVMsMemoryMiB}}
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 8192
       network:
         devices:
           - dhcp4: true
-            networkName: {{.vsphereNetwork}}
-      numCPUs: {{.etcdVMsNumCPUs}}
-      resourcePool: '{{.etcdVsphereResourcePool}}'
-      server: {{.vsphereServer}}
-{{- if (ne .etcdVsphereStoragePolicyName "") }}
-      storagePolicyName: "{{.etcdVsphereStoragePolicyName}}"
-{{- end }}
-      template: {{.vsphereTemplate}}
-      thumbprint: '{{.thumbprint}}'
+            networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 3
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
+      thumbprint: 'ABCDEFG'
 ---
-{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{.clusterName}}-vsphere-credentials
-  namespace: {{.eksaSystemNamespace}}
+  name: test-vsphere-credentials
+  namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
 stringData:
-  username: "{{.eksaVsphereUsername}}"
-  password: "{{.eksaVspherePassword}}"
+  username: "vsphere_username"
+  password: "vsphere_password"
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-csi-controller
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -562,7 +483,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: csi-vsphere-config
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -573,17 +494,17 @@ stringData:
     stringData:
       csi-vsphere.conf: |+
         [Global]
-        cluster-id = "default/{{.clusterName}}"
-        thumbprint = "{{.thumbprint}}"
+        cluster-id = "default/test"
+        thumbprint = "ABCDEFG"
 
-        [VirtualCenter "{{.vsphereServer}}"]
-        user = "{{.eksaCSIUsername}}"
-        password = "{{.eksaCSIPassword}}"
-        datacenters = "{{.vsphereDatacenter}}"
-        insecure-flag = "{{.insecure}}"
+        [VirtualCenter "vsphere_server"]
+        user = "EksavSphereCSIUsername"
+        password = "EksavSphereCSIPassword"
+        datacenters = "SDDC-Datacenter"
+        insecure-flag = "false"
 
         [Network]
-        public-network = "{{.vsphereNetwork}}"
+        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
@@ -697,7 +618,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-role
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -717,7 +638,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-binding
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -731,7 +652,7 @@ data:
 kind: ConfigMap
 metadata:
   name: csi.vsphere.vmware.com
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -761,7 +682,7 @@ data:
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-            image: {{.nodeDriverRegistrarImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-19-4
             lifecycle:
               preStop:
                 exec:
@@ -795,7 +716,7 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            image: {{.driverImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-7c2690c880c6521afdd9ffa8d90443a11c6b817b
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -828,7 +749,7 @@ data:
               name: device-dir
           - args:
             - --csi-address=/csi/csi.sock
-            image: {{.livenessProbeImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-19-4
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -864,7 +785,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-node
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -894,7 +815,7 @@ data:
             env:
             - name: ADDRESS
               value: /csi/csi.sock
-            image: {{.externalAttacherImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v3.1.0-eks-1-19-4
             name: csi-attacher
             resources: {}
             volumeMounts:
@@ -911,7 +832,7 @@ data:
               value: PRODUCTION
             - name: X_CSI_LOG_LEVEL
               value: INFO
-            image: {{.driverImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-7c2690c880c6521afdd9ffa8d90443a11c6b817b
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -937,7 +858,7 @@ data:
             env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            image: {{.livenessProbeImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-19-4
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -952,7 +873,7 @@ data:
               value: PRODUCTION
             - name: VSPHERE_CSI_CONFIG
               value: /etc/cloud/csi-vsphere.conf
-            image: {{.syncerImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-7c2690c880c6521afdd9ffa8d90443a11c6b817b
             name: vsphere-syncer
             resources: {}
             volumeMounts:
@@ -968,7 +889,7 @@ data:
             env:
             - name: ADDRESS
               value: /csi/csi.sock
-            image: {{.externalProvisionerImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-19-4
             name: csi-provisioner
             resources: {}
             volumeMounts:
@@ -980,16 +901,6 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
-{{- if .controlPlaneTaints }}
-{{- range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-{{- end }}
-{{- end }}
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -999,7 +910,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -1014,13 +925,13 @@ data:
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: cloud-controller-manager
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -1034,7 +945,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloud-provider-vsphere-credentials
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -1043,8 +954,8 @@ stringData:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
     stringData:
-      {{.vsphereServer}}.password: "{{.eksaCloudProviderPassword}}"
-      {{.vsphereServer}}.username: "{{.eksaCloudProviderUsername}}"
+      vsphere_server.password: "EksavSphereCPPassword"
+      vsphere_server.username: "EksavSphereCPUsername"
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
@@ -1156,16 +1067,16 @@ data:
         global:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
-          thumbprint: "{{.thumbprint}}"
-          insecureFlag: {{.insecure}}
+          thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
-          {{.vsphereServer}}:
+          vsphere_server:
             datacenters:
-            - '{{.vsphereDatacenter}}'
+            - 'SDDC-Datacenter'
             secretName: cloud-provider-vsphere-credentials
             secretNamespace: kube-system
-            server: '{{.vsphereServer}}'
-            thumbprint: '{{.thumbprint}}'
+            server: 'vsphere_server'
+            thumbprint: 'ABCDEFG'
     kind: ConfigMap
     metadata:
       name: vsphere-cloud-config
@@ -1224,7 +1135,7 @@ data:
             - --v=2
             - --cloud-provider=vsphere
             - --cloud-config=/etc/cloud/vsphere.conf
-            image: {{.managerImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             name: vsphere-cloud-controller-manager
             resources:
               requests:
@@ -1243,16 +1154,6 @@ data:
             key: node-role.kubernetes.io/master
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
-{{- if .controlPlaneTaints }}
-{{- range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-{{- end }}
-{{- end }}
           volumes:
           - configMap:
               name: vsphere-cloud-config
@@ -1262,4 +1163,4 @@ data:
 kind: ConfigMap
 metadata:
   name: cpi-manifests
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
@@ -2,134 +2,91 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: {{.clusterName}}
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+    cluster.x-k8s.io/cluster-name: test
+  name: test
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks: {{.podCidrs}}
+      cidrBlocks: [192.168.0.0/16]
     services:
-      cidrBlocks: {{.serviceCidrs}}
+      cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane
-    name: {{.clusterName}}
+    name: test
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: VSphereCluster
-    name: {{.clusterName}}
-{{- if .externalEtcd }}
+    name: test
   managedExternalEtcdRef:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
-    name: {{.clusterName}}-etcd
-{{- end }}
+    name: test-etcd
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster
 metadata:
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test
+  namespace: eksa-system
 spec:
   controlPlaneEndpoint:
-    host: {{.controlPlaneEndpointIp}}
+    host: 1.2.3.4
     port: 6443
   identityRef:
     kind: Secret
-    name: {{.clusterName}}-vsphere-credentials
-  server: {{.vsphereServer}}
-  thumbprint: '{{.thumbprint}}'
+    name: test-vsphere-credentials
+  server: vsphere_server
+  thumbprint: 'ABCDEFG'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
-  name: {{.controlPlaneTemplateName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test-control-plane-template-1234567890000
+  namespace: eksa-system
 spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{.vsphereDatacenter}}
-      datastore: {{.controlPlaneVsphereDatastore}}
-      diskGiB: {{.controlPlaneDiskGiB}}
-      folder: '{{.controlPlaneVsphereFolder}}'
-      memoryMiB: {{.controlPlaneVMsMemoryMiB}}
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 8192
       network:
         devices:
         - dhcp4: true
-          networkName: {{.vsphereNetwork}}
-      numCPUs: {{.controlPlaneVMsNumCPUs}}
-      resourcePool: '{{.controlPlaneVsphereResourcePool}}'
-      server: {{.vsphereServer}}
-{{- if (ne .controlPlaneVsphereStoragePolicyName "") }}
-      storagePolicyName: "{{.controlPlaneVsphereStoragePolicyName}}"
-{{- end }}
-      template: {{.vsphereTemplate}}
-      thumbprint: '{{.thumbprint}}'
+          networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 2
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
+      thumbprint: 'ABCDEFG'
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test
+  namespace: eksa-system
 spec:
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: VSphereMachineTemplate
-      name: {{.controlPlaneTemplateName}}
+      name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: {{.kubernetesRepository}}
+      imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
-{{- if .externalEtcd }}
         external:
           endpoints: []
-{{- if (eq .format "bottlerocket") }}
-          caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
-          certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
-          keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"
-{{- else }}
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
-{{- end }}
-{{- else }}
-        local:
-          imageRepository: {{.etcdRepository}}
-          imageTag: {{.etcdImageTag}}
-{{- if .etcdExtraArgs }}
-          extraArgs:
-{{ .etcdExtraArgs.ToYaml | indent 12 }}
-{{- end }}
-{{- end }}
       dns:
-        imageRepository: {{.corednsRepository}}
-        imageTag: {{.corednsVersion}}
-{{- if (eq .format "bottlerocket") }}
-      pause:
-        imageRepository: {{.pauseRepository}}
-        imageTag: {{.pauseVersion}}
-      bottlerocketBootstrap:
-        imageRepository: {{.bottlerocketBootstrapRepository}}
-        imageTag: {{.bottlerocketBootstrapVersion}}
-{{- end }}
-{{- if and .proxyConfig (eq .format "bottlerocket") }}
-      proxy:
-        httpsProxy: {{.httpsProxy}}
-        noProxy: {{ range .noProxy }}
-          - {{ . }}
-        {{- end }}
-{{- end }}
-{{- if and .registryMirrorConfiguration (eq .format "bottlerocket") }}
-      registryMirror:
-        endpoint: {{.registryMirrorConfiguration}}
-        {{- if .registryCACert }}
-        caCert: |
-{{ .registryCACert | indent 10 }}
-        {{- end }}
-{{- end }}
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.8.0-eks-1-19-4
       apiServer:
         extraArgs:
           cloud-provider: external
@@ -139,15 +96,9 @@ spec:
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
           profiling: "false"
-{{- if .apiserverExtraArgs }}
-{{ .apiserverExtraArgs.ToYaml | indent 10 }}
-{{- end }}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         extraVolumes:
-{{- if (eq .format "bottlerocket") }}
-        - hostPath: /var/lib/kubeadm/audit-policy.yaml
-{{- else }}
         - hostPath: /etc/kubernetes/audit-policy.yaml
-{{- end }}
           mountPath: /etc/kubernetes/audit-policy.yaml
           name: audit-policy
           pathType: File
@@ -157,46 +108,15 @@ spec:
           name: audit-log-dir
           pathType: DirectoryOrCreate
           readOnly: false
-{{- if .awsIamAuth}}
-        - hostPath: /var/lib/kubeadm/aws-iam-authenticator/
-          mountPath: /etc/kubernetes/aws-iam-authenticator/
-          name: authconfig
-          readOnly: false
-        - hostPath: /var/lib/kubeadm/aws-iam-authenticator/pki/
-          mountPath: /var/aws-iam-authenticator/
-          name: awsiamcert
-          readOnly: false
-{{- end}}
       controllerManager:
         extraArgs:
           cloud-provider: external
           profiling: "false"
-{{- if .controllermanagerExtraArgs }}
-{{ .controllermanagerExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-{{- if (eq .format "bottlerocket") }}
-        extraVolumes:
-        - hostPath: /var/lib/kubeadm/controller-manager.conf
-          mountPath: /etc/kubernetes/controller-manager.conf
-          name: kubeconfig
-          pathType: File
-          readOnly: true
-{{- end }}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
       scheduler:
         extraArgs:
           profiling: "false"
-{{- if .schedulerExtraArgs }}
-{{ .schedulerExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-{{- if (eq .format "bottlerocket") }}
-        extraVolumes:
-        - hostPath: /var/lib/kubeadm/scheduler.conf
-          mountPath: /etc/kubernetes/scheduler.conf
-          name: kubeconfig
-          pathType: File
-          readOnly: true
-      certificatesDir: /var/lib/kubeadm/pki
-{{- end }}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
         apiVersion: v1
@@ -231,8 +151,8 @@ spec:
             - name: vip_retryperiod
               value: "2"
             - name: address
-              value: {{.controlPlaneEndpointIp}}
-            image: {{.kubeVipImage}}
+              value: 1.2.3.4
+            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}
@@ -253,75 +173,163 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-{{ .auditPolicy | indent 8 }}
+        apiVersion: audit.k8s.io/v1beta1
+        kind: Policy
+        rules:
+        # Log aws-auth configmap changes
+        - level: RequestResponse
+          namespaces: ["kube-system"]
+          verbs: ["update", "patch", "delete"]
+          resources:
+          - group: "" # core
+            resources: ["configmaps"]
+            resourceNames: ["aws-auth"]
+          omitStages:
+          - "RequestReceived"
+        # The following requests were manually identified as high-volume and low-risk,
+        # so drop them.
+        - level: None
+          users: ["system:kube-proxy"]
+          verbs: ["watch"]
+          resources:
+          - group: "" # core
+            resources: ["endpoints", "services", "services/status"]
+        - level: None
+          users: ["kubelet"] # legacy kubelet identity
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["nodes", "nodes/status"]
+        - level: None
+          userGroups: ["system:nodes"]
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["nodes", "nodes/status"]
+        - level: None
+          users:
+          - system:kube-controller-manager
+          - system:kube-scheduler
+          - system:serviceaccount:kube-system:endpoint-controller
+          verbs: ["get", "update"]
+          namespaces: ["kube-system"]
+          resources:
+          - group: "" # core
+            resources: ["endpoints"]
+        - level: None
+          users: ["system:apiserver"]
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+        # Don't log HPA fetching metrics.
+        - level: None
+          users:
+          - system:kube-controller-manager
+          verbs: ["get", "list"]
+          resources:
+          - group: "metrics.k8s.io"
+        # Don't log these read-only URLs.
+        - level: None
+          nonResourceURLs:
+          - /healthz*
+          - /version
+          - /swagger*
+        # Don't log events requests.
+        - level: None
+          resources:
+          - group: "" # core
+            resources: ["events"]
+        # node and pod status calls from nodes are high-volume and can be large, don't log responses for expected updates from nodes
+        - level: Request
+          users: ["kubelet", "system:node-problem-detector", "system:serviceaccount:kube-system:node-problem-detector"]
+          verbs: ["update","patch"]
+          resources:
+          - group: "" # core
+            resources: ["nodes/status", "pods/status"]
+          omitStages:
+          - "RequestReceived"
+        - level: Request
+          userGroups: ["system:nodes"]
+          verbs: ["update","patch"]
+          resources:
+          - group: "" # core
+            resources: ["nodes/status", "pods/status"]
+          omitStages:
+          - "RequestReceived"
+        # deletecollection calls can be large, don't log responses for expected namespace deletions
+        - level: Request
+          users: ["system:serviceaccount:kube-system:namespace-controller"]
+          verbs: ["deletecollection"]
+          omitStages:
+          - "RequestReceived"
+        # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
+        # so only log at the Metadata level.
+        - level: Metadata
+          resources:
+          - group: "" # core
+            resources: ["secrets", "configmaps"]
+          - group: authentication.k8s.io
+            resources: ["tokenreviews"]
+          omitStages:
+            - "RequestReceived"
+        - level: Request
+          resources:
+          - group: ""
+            resources: ["serviceaccounts/token"]
+        # Get repsonses can be large; skip them.
+        - level: Request
+          verbs: ["get", "list", "watch"]
+          resources:
+          - group: "" # core
+          - group: "admissionregistration.k8s.io"
+          - group: "apiextensions.k8s.io"
+          - group: "apiregistration.k8s.io"
+          - group: "apps"
+          - group: "authentication.k8s.io"
+          - group: "authorization.k8s.io"
+          - group: "autoscaling"
+          - group: "batch"
+          - group: "certificates.k8s.io"
+          - group: "extensions"
+          - group: "metrics.k8s.io"
+          - group: "networking.k8s.io"
+          - group: "policy"
+          - group: "rbac.authorization.k8s.io"
+          - group: "scheduling.k8s.io"
+          - group: "settings.k8s.io"
+          - group: "storage.k8s.io"
+          omitStages:
+          - "RequestReceived"
+        # Default level for known APIs
+        - level: RequestResponse
+          resources:
+          - group: "" # core
+          - group: "admissionregistration.k8s.io"
+          - group: "apiextensions.k8s.io"
+          - group: "apiregistration.k8s.io"
+          - group: "apps"
+          - group: "authentication.k8s.io"
+          - group: "authorization.k8s.io"
+          - group: "autoscaling"
+          - group: "batch"
+          - group: "certificates.k8s.io"
+          - group: "extensions"
+          - group: "metrics.k8s.io"
+          - group: "networking.k8s.io"
+          - group: "policy"
+          - group: "rbac.authorization.k8s.io"
+          - group: "scheduling.k8s.io"
+          - group: "settings.k8s.io"
+          - group: "storage.k8s.io"
+          omitStages:
+          - "RequestReceived"
+        # Default level for all other requests.
+        - level: Metadata
+          omitStages:
+          - "RequestReceived"
       owner: root:root
       path: /etc/kubernetes/audit-policy.yaml
-{{- if and .proxyConfig (ne .format "bottlerocket")}}
-    - content: |
-        [Service]
-        Environment="HTTP_PROXY={{.httpProxy}}"
-        Environment="HTTPS_PROXY={{.httpsProxy}}"
-        Environment="NO_PROXY={{ stringsJoin .noProxy "," }}"
-      owner: root:root
-      path: /etc/systemd/system/containerd.service.d/http-proxy.conf
-{{- end }}
-{{- if (ne .format "bottlerocket") }}
-{{- if .registryCACert }}
-    - content: |
-{{ .registryCACert | indent 8 }}
-      owner: root:root
-      path: "/etc/containerd/certs.d/{{.registryMirrorConfiguration}}/ca.crt"
-{{- end }}
-{{- if .registryMirrorConfiguration }}
-    - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://{{.registryMirrorConfiguration}}"]
-          {{- if .registryCACert }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{.registryMirrorConfiguration}}".tls]
-            ca_file = "/etc/containerd/certs.d/{{.registryMirrorConfiguration}}/ca.crt"
-          {{- end }}
-      owner: root:root
-      path: "/etc/containerd/config_append.toml"
-{{- end }}
-{{- end }}
-{{- if .awsIamAuth}}
-    - content: |
-        # clusters refers to the remote service.
-        clusters:
-          - name: aws-iam-authenticator
-            cluster:
-              certificate-authority: /var/aws-iam-authenticator/cert.pem
-              server: https://localhost:21362/authenticate
-        # users refers to the API Server's webhook configuration
-        # (we don't need to authenticate the API server).
-        users:
-          - name: apiserver
-        # kubeconfig files require a context. Provide one for the API Server.
-        current-context: webhook
-        contexts:
-        - name: webhook
-          context:
-            cluster: aws-iam-authenticator
-            user: apiserver
-      permissions: "0640"
-      owner: root:root
-      path: /var/lib/kubeadm/aws-iam-authenticator/kubeconfig.yaml
-    - contentFrom:
-        secret:
-          name: aws-iam-authenticator-ca
-          key: cert.pem
-      permissions: "0640"
-      owner: root:root
-      path: /var/lib/kubeadm/aws-iam-authenticator/pki/cert.pem
-    - contentFrom:
-        secret:
-          name: aws-iam-authenticator-ca
-          key: key.pem
-      permissions: "0640"
-      owner: root:root
-      path: /var/lib/kubeadm/aws-iam-authenticator/pki/key.pem
-{{- end}}
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -329,104 +337,46 @@ spec:
           cloud-provider: external
           read-only-port: "0"
           anonymous-auth: "false"
-{{- if .kubeletExtraArgs }}
-{{ .kubeletExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-        name: '{{`{{ ds.meta_data.hostname }}`}}'
-{{- if .controlPlaneTaints }}
-        taints:
-{{- range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-        {{- end }}
-{{- else}}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: '{{ ds.meta_data.hostname }}'
         taints: []
-{{- end }}
     joinConfiguration:
-{{- if (eq .format "bottlerocket") }}
-      pause:
-        imageRepository: {{.pauseRepository}}
-        imageTag: {{.pauseVersion}}
-      bottlerocketBootstrap:
-        imageRepository: {{.bottlerocketBootstrapRepository}}
-        imageTag: {{.bottlerocketBootstrapVersion}}
-{{- end }}
-{{- if and .proxyConfig (eq .format "bottlerocket") }}
-      proxy:
-        httpsProxy: {{.httpsProxy}}
-        noProxy: {{ range .noProxy }}
-        - {{ . }}
-        {{- end }}
-{{- end }}
-{{- if and .registryMirrorConfiguration (eq .format "bottlerocket") }}
-      registryMirror:
-        endpoint: {{.registryMirrorConfiguration}}
-        {{- if .registryCACert }}
-        caCert: |
-{{ .registryCACert | indent 10 }}
-        {{- end }}
-{{- end }}
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
           read-only-port: "0"
           anonymous-auth: "false"
-{{- if .kubeletExtraArgs }}
-{{ .kubeletExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-        name: '{{`{{ ds.meta_data.hostname }}`}}'
-{{- if .controlPlaneTaints }}
-        taints:
-{{- range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-        {{- end }}
-{{- else}}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: '{{ ds.meta_data.hostname }}'
         taints: []
-{{- end }}
     preKubeadmCommands:
-{{- if and .registryMirrorConfiguration (ne .format "bottlerocket") }}
-    - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
-{{- end }}
-{{- if and (or .proxyConfig .registryMirrorConfiguration) (ne .format "bottlerocket") }}
-    - sudo systemctl daemon-reload
-    - sudo systemctl restart containerd
-{{- end }}
-    - hostname "{{`{{ ds.meta_data.hostname }}`}}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
-    - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     useExperimentalRetryJoin: true
     users:
-    - name: {{.controlPlaneSshUsername}}
+    - name: capv
       sshAuthorizedKeys:
-      - '{{.vsphereControlPlaneSshAuthorizedKey}}'
+      - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
       sudo: ALL=(ALL) NOPASSWD:ALL
-    format: {{.format}}
-  replicas: {{.controlPlaneReplicas}}
-  version: {{.kubernetesVersion}}
+    format: cloud-config
+  replicas: 3
+  version: v1.19.8-eks-1-19-4
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: {{.clusterName}}
-  name: {{.resourceSetName}}
-  namespace: {{.eksaSystemNamespace}}
+    cluster.x-k8s.io/cluster-name: test
+  name: test-crs-0
+  namespace: eksa-system
 spec:
   clusterSelector:
     matchLabels:
-      cluster.x-k8s.io/cluster-name: {{.clusterName}}
+      cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
     name: vsphere-csi-controller
@@ -449,106 +399,77 @@ spec:
   - kind: ConfigMap
     name: cpi-manifests
 ---
-{{- if .externalEtcd }}
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
 metadata:
-  name: {{.clusterName}}-etcd
-  namespace: {{.eksaSystemNamespace}}
+  name: test-etcd
+  namespace: eksa-system
 spec:
-  replicas: {{.externalEtcdReplicas}}
+  replicas: 3
   etcdadmConfigSpec:
     etcdadmBuiltin: true
-    format: {{.format}}
-{{- if (eq .format "bottlerocket") }}
-    bottlerocketConfig:
-      etcdImage: {{.etcdImage}}
-      bootstrapImage: {{.bottlerocketBootstrapRepository}}:{{.bottlerocketBootstrapVersion}}
-      pauseImage: {{.pauseRepository}}:{{.pauseVersion}}
-{{- else}}
+    format: cloud-config
     cloudInitConfig:
-      version: {{.externalEtcdVersion}}
+      version: 3.4.14
       installDir: "/usr/bin"
     preEtcdadmCommands:
-      - hostname "{{`{{ ds.meta_data.hostname }}`}}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
-      - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
-{{- end }}
-{{- if .etcdCipherSuites }}
-    cipherSuites: {{.etcdCipherSuites}}
-{{- end }}
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
-      - name: {{.etcdSshUsername}}
+      - name: capv
         sshAuthorizedKeys:
-          - '{{.vsphereEtcdSshAuthorizedKey}}'
+          - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
-{{- if .proxyConfig }}
-    proxy:
-      httpProxy: {{ .httpProxy }}
-      httpsProxy: {{ .httpsProxy }}
-      noProxy: {{ range .noProxy }}
-        - {{ . }}
-      {{- end }}
-{{- end }}
-{{- if .registryMirrorConfiguration }}
-    registryMirror:
-      endpoint: {{.registryMirrorConfiguration}}
-      {{- if .registryCACert }}
-      caCert: |
-{{ .registryCACert | indent 8 }}
-      {{- end }}
-{{- end }}
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: VSphereMachineTemplate
-    name: {{.etcdTemplateName}}
+    name: test-etcd-template-1234567890000
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
-  name: {{.etcdTemplateName}}
-  namespace: '{{.eksaSystemNamespace}}'
+  name: test-etcd-template-1234567890000
+  namespace: 'eksa-system'
 spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{.vsphereDatacenter}}
-      datastore: {{.etcdVsphereDatastore}}
-      diskGiB: {{.etcdDiskGiB}}
-      folder: '{{.etcdVsphereFolder}}'
-      memoryMiB: {{.etcdVMsMemoryMiB}}
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 8192
       network:
         devices:
           - dhcp4: true
-            networkName: {{.vsphereNetwork}}
-      numCPUs: {{.etcdVMsNumCPUs}}
-      resourcePool: '{{.etcdVsphereResourcePool}}'
-      server: {{.vsphereServer}}
-{{- if (ne .etcdVsphereStoragePolicyName "") }}
-      storagePolicyName: "{{.etcdVsphereStoragePolicyName}}"
-{{- end }}
-      template: {{.vsphereTemplate}}
-      thumbprint: '{{.thumbprint}}'
+            networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 3
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
+      thumbprint: 'ABCDEFG'
 ---
-{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{.clusterName}}-vsphere-credentials
-  namespace: {{.eksaSystemNamespace}}
+  name: test-vsphere-credentials
+  namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
 stringData:
-  username: "{{.eksaVsphereUsername}}"
-  password: "{{.eksaVspherePassword}}"
+  username: "vsphere_username"
+  password: "vsphere_password"
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-csi-controller
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -562,7 +483,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: csi-vsphere-config
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -573,17 +494,17 @@ stringData:
     stringData:
       csi-vsphere.conf: |+
         [Global]
-        cluster-id = "default/{{.clusterName}}"
-        thumbprint = "{{.thumbprint}}"
+        cluster-id = "default/test"
+        thumbprint = "ABCDEFG"
 
-        [VirtualCenter "{{.vsphereServer}}"]
-        user = "{{.eksaCSIUsername}}"
-        password = "{{.eksaCSIPassword}}"
-        datacenters = "{{.vsphereDatacenter}}"
-        insecure-flag = "{{.insecure}}"
+        [VirtualCenter "vsphere_server"]
+        user = "vsphere_username"
+        password = "vsphere_password"
+        datacenters = "SDDC-Datacenter"
+        insecure-flag = "false"
 
         [Network]
-        public-network = "{{.vsphereNetwork}}"
+        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
@@ -697,7 +618,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-role
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -717,7 +638,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-binding
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -731,7 +652,7 @@ data:
 kind: ConfigMap
 metadata:
   name: csi.vsphere.vmware.com
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -761,7 +682,7 @@ data:
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-            image: {{.nodeDriverRegistrarImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-19-4
             lifecycle:
               preStop:
                 exec:
@@ -795,7 +716,7 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            image: {{.driverImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-7c2690c880c6521afdd9ffa8d90443a11c6b817b
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -828,7 +749,7 @@ data:
               name: device-dir
           - args:
             - --csi-address=/csi/csi.sock
-            image: {{.livenessProbeImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-19-4
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -864,7 +785,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-node
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -894,7 +815,7 @@ data:
             env:
             - name: ADDRESS
               value: /csi/csi.sock
-            image: {{.externalAttacherImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v3.1.0-eks-1-19-4
             name: csi-attacher
             resources: {}
             volumeMounts:
@@ -911,7 +832,7 @@ data:
               value: PRODUCTION
             - name: X_CSI_LOG_LEVEL
               value: INFO
-            image: {{.driverImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-7c2690c880c6521afdd9ffa8d90443a11c6b817b
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -937,7 +858,7 @@ data:
             env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            image: {{.livenessProbeImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-19-4
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -952,7 +873,7 @@ data:
               value: PRODUCTION
             - name: VSPHERE_CSI_CONFIG
               value: /etc/cloud/csi-vsphere.conf
-            image: {{.syncerImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-7c2690c880c6521afdd9ffa8d90443a11c6b817b
             name: vsphere-syncer
             resources: {}
             volumeMounts:
@@ -968,7 +889,7 @@ data:
             env:
             - name: ADDRESS
               value: /csi/csi.sock
-            image: {{.externalProvisionerImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-19-4
             name: csi-provisioner
             resources: {}
             volumeMounts:
@@ -980,16 +901,6 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
-{{- if .controlPlaneTaints }}
-{{- range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-{{- end }}
-{{- end }}
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -999,7 +910,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -1014,13 +925,13 @@ data:
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: cloud-controller-manager
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -1034,7 +945,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloud-provider-vsphere-credentials
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -1043,8 +954,8 @@ stringData:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
     stringData:
-      {{.vsphereServer}}.password: "{{.eksaCloudProviderPassword}}"
-      {{.vsphereServer}}.username: "{{.eksaCloudProviderUsername}}"
+      vsphere_server.password: "EksavSphereCPPassword"
+      vsphere_server.username: "EksavSphereCPUsername"
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
@@ -1156,16 +1067,16 @@ data:
         global:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
-          thumbprint: "{{.thumbprint}}"
-          insecureFlag: {{.insecure}}
+          thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
-          {{.vsphereServer}}:
+          vsphere_server:
             datacenters:
-            - '{{.vsphereDatacenter}}'
+            - 'SDDC-Datacenter'
             secretName: cloud-provider-vsphere-credentials
             secretNamespace: kube-system
-            server: '{{.vsphereServer}}'
-            thumbprint: '{{.thumbprint}}'
+            server: 'vsphere_server'
+            thumbprint: 'ABCDEFG'
     kind: ConfigMap
     metadata:
       name: vsphere-cloud-config
@@ -1224,7 +1135,7 @@ data:
             - --v=2
             - --cloud-provider=vsphere
             - --cloud-config=/etc/cloud/vsphere.conf
-            image: {{.managerImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             name: vsphere-cloud-controller-manager
             resources:
               requests:
@@ -1243,16 +1154,6 @@ data:
             key: node-role.kubernetes.io/master
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
-{{- if .controlPlaneTaints }}
-{{- range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-{{- end }}
-{{- end }}
           volumes:
           - configMap:
               name: vsphere-cloud-config
@@ -1262,4 +1163,4 @@ data:
 kind: ConfigMap
 metadata:
   name: cpi-manifests
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
@@ -2,134 +2,91 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: {{.clusterName}}
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+    cluster.x-k8s.io/cluster-name: test
+  name: test
+  namespace: eksa-system
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks: {{.podCidrs}}
+      cidrBlocks: [192.168.0.0/16]
     services:
-      cidrBlocks: {{.serviceCidrs}}
+      cidrBlocks: [10.96.0.0/12]
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane
-    name: {{.clusterName}}
+    name: test
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: VSphereCluster
-    name: {{.clusterName}}
-{{- if .externalEtcd }}
+    name: test
   managedExternalEtcdRef:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
-    name: {{.clusterName}}-etcd
-{{- end }}
+    name: test-etcd
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster
 metadata:
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test
+  namespace: eksa-system
 spec:
   controlPlaneEndpoint:
-    host: {{.controlPlaneEndpointIp}}
+    host: 1.2.3.4
     port: 6443
   identityRef:
     kind: Secret
-    name: {{.clusterName}}-vsphere-credentials
-  server: {{.vsphereServer}}
-  thumbprint: '{{.thumbprint}}'
+    name: test-vsphere-credentials
+  server: vsphere_server
+  thumbprint: 'ABCDEFG'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
-  name: {{.controlPlaneTemplateName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test-control-plane-template-1234567890000
+  namespace: eksa-system
 spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{.vsphereDatacenter}}
-      datastore: {{.controlPlaneVsphereDatastore}}
-      diskGiB: {{.controlPlaneDiskGiB}}
-      folder: '{{.controlPlaneVsphereFolder}}'
-      memoryMiB: {{.controlPlaneVMsMemoryMiB}}
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 8192
       network:
         devices:
         - dhcp4: true
-          networkName: {{.vsphereNetwork}}
-      numCPUs: {{.controlPlaneVMsNumCPUs}}
-      resourcePool: '{{.controlPlaneVsphereResourcePool}}'
-      server: {{.vsphereServer}}
-{{- if (ne .controlPlaneVsphereStoragePolicyName "") }}
-      storagePolicyName: "{{.controlPlaneVsphereStoragePolicyName}}"
-{{- end }}
-      template: {{.vsphereTemplate}}
-      thumbprint: '{{.thumbprint}}'
+          networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 2
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
+      thumbprint: 'ABCDEFG'
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
-  name: {{.clusterName}}
-  namespace: {{.eksaSystemNamespace}}
+  name: test
+  namespace: eksa-system
 spec:
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: VSphereMachineTemplate
-      name: {{.controlPlaneTemplateName}}
+      name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: {{.kubernetesRepository}}
+      imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
-{{- if .externalEtcd }}
         external:
           endpoints: []
-{{- if (eq .format "bottlerocket") }}
-          caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
-          certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
-          keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"
-{{- else }}
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
-{{- end }}
-{{- else }}
-        local:
-          imageRepository: {{.etcdRepository}}
-          imageTag: {{.etcdImageTag}}
-{{- if .etcdExtraArgs }}
-          extraArgs:
-{{ .etcdExtraArgs.ToYaml | indent 12 }}
-{{- end }}
-{{- end }}
       dns:
-        imageRepository: {{.corednsRepository}}
-        imageTag: {{.corednsVersion}}
-{{- if (eq .format "bottlerocket") }}
-      pause:
-        imageRepository: {{.pauseRepository}}
-        imageTag: {{.pauseVersion}}
-      bottlerocketBootstrap:
-        imageRepository: {{.bottlerocketBootstrapRepository}}
-        imageTag: {{.bottlerocketBootstrapVersion}}
-{{- end }}
-{{- if and .proxyConfig (eq .format "bottlerocket") }}
-      proxy:
-        httpsProxy: {{.httpsProxy}}
-        noProxy: {{ range .noProxy }}
-          - {{ . }}
-        {{- end }}
-{{- end }}
-{{- if and .registryMirrorConfiguration (eq .format "bottlerocket") }}
-      registryMirror:
-        endpoint: {{.registryMirrorConfiguration}}
-        {{- if .registryCACert }}
-        caCert: |
-{{ .registryCACert | indent 10 }}
-        {{- end }}
-{{- end }}
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.8.0-eks-1-19-4
       apiServer:
         extraArgs:
           cloud-provider: external
@@ -139,15 +96,9 @@ spec:
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
           profiling: "false"
-{{- if .apiserverExtraArgs }}
-{{ .apiserverExtraArgs.ToYaml | indent 10 }}
-{{- end }}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         extraVolumes:
-{{- if (eq .format "bottlerocket") }}
-        - hostPath: /var/lib/kubeadm/audit-policy.yaml
-{{- else }}
         - hostPath: /etc/kubernetes/audit-policy.yaml
-{{- end }}
           mountPath: /etc/kubernetes/audit-policy.yaml
           name: audit-policy
           pathType: File
@@ -157,46 +108,15 @@ spec:
           name: audit-log-dir
           pathType: DirectoryOrCreate
           readOnly: false
-{{- if .awsIamAuth}}
-        - hostPath: /var/lib/kubeadm/aws-iam-authenticator/
-          mountPath: /etc/kubernetes/aws-iam-authenticator/
-          name: authconfig
-          readOnly: false
-        - hostPath: /var/lib/kubeadm/aws-iam-authenticator/pki/
-          mountPath: /var/aws-iam-authenticator/
-          name: awsiamcert
-          readOnly: false
-{{- end}}
       controllerManager:
         extraArgs:
           cloud-provider: external
           profiling: "false"
-{{- if .controllermanagerExtraArgs }}
-{{ .controllermanagerExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-{{- if (eq .format "bottlerocket") }}
-        extraVolumes:
-        - hostPath: /var/lib/kubeadm/controller-manager.conf
-          mountPath: /etc/kubernetes/controller-manager.conf
-          name: kubeconfig
-          pathType: File
-          readOnly: true
-{{- end }}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
       scheduler:
         extraArgs:
           profiling: "false"
-{{- if .schedulerExtraArgs }}
-{{ .schedulerExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-{{- if (eq .format "bottlerocket") }}
-        extraVolumes:
-        - hostPath: /var/lib/kubeadm/scheduler.conf
-          mountPath: /etc/kubernetes/scheduler.conf
-          name: kubeconfig
-          pathType: File
-          readOnly: true
-      certificatesDir: /var/lib/kubeadm/pki
-{{- end }}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
         apiVersion: v1
@@ -231,8 +151,8 @@ spec:
             - name: vip_retryperiod
               value: "2"
             - name: address
-              value: {{.controlPlaneEndpointIp}}
-            image: {{.kubeVipImage}}
+              value: 1.2.3.4
+            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}
@@ -253,75 +173,163 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-{{ .auditPolicy | indent 8 }}
+        apiVersion: audit.k8s.io/v1beta1
+        kind: Policy
+        rules:
+        # Log aws-auth configmap changes
+        - level: RequestResponse
+          namespaces: ["kube-system"]
+          verbs: ["update", "patch", "delete"]
+          resources:
+          - group: "" # core
+            resources: ["configmaps"]
+            resourceNames: ["aws-auth"]
+          omitStages:
+          - "RequestReceived"
+        # The following requests were manually identified as high-volume and low-risk,
+        # so drop them.
+        - level: None
+          users: ["system:kube-proxy"]
+          verbs: ["watch"]
+          resources:
+          - group: "" # core
+            resources: ["endpoints", "services", "services/status"]
+        - level: None
+          users: ["kubelet"] # legacy kubelet identity
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["nodes", "nodes/status"]
+        - level: None
+          userGroups: ["system:nodes"]
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["nodes", "nodes/status"]
+        - level: None
+          users:
+          - system:kube-controller-manager
+          - system:kube-scheduler
+          - system:serviceaccount:kube-system:endpoint-controller
+          verbs: ["get", "update"]
+          namespaces: ["kube-system"]
+          resources:
+          - group: "" # core
+            resources: ["endpoints"]
+        - level: None
+          users: ["system:apiserver"]
+          verbs: ["get"]
+          resources:
+          - group: "" # core
+            resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+        # Don't log HPA fetching metrics.
+        - level: None
+          users:
+          - system:kube-controller-manager
+          verbs: ["get", "list"]
+          resources:
+          - group: "metrics.k8s.io"
+        # Don't log these read-only URLs.
+        - level: None
+          nonResourceURLs:
+          - /healthz*
+          - /version
+          - /swagger*
+        # Don't log events requests.
+        - level: None
+          resources:
+          - group: "" # core
+            resources: ["events"]
+        # node and pod status calls from nodes are high-volume and can be large, don't log responses for expected updates from nodes
+        - level: Request
+          users: ["kubelet", "system:node-problem-detector", "system:serviceaccount:kube-system:node-problem-detector"]
+          verbs: ["update","patch"]
+          resources:
+          - group: "" # core
+            resources: ["nodes/status", "pods/status"]
+          omitStages:
+          - "RequestReceived"
+        - level: Request
+          userGroups: ["system:nodes"]
+          verbs: ["update","patch"]
+          resources:
+          - group: "" # core
+            resources: ["nodes/status", "pods/status"]
+          omitStages:
+          - "RequestReceived"
+        # deletecollection calls can be large, don't log responses for expected namespace deletions
+        - level: Request
+          users: ["system:serviceaccount:kube-system:namespace-controller"]
+          verbs: ["deletecollection"]
+          omitStages:
+          - "RequestReceived"
+        # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
+        # so only log at the Metadata level.
+        - level: Metadata
+          resources:
+          - group: "" # core
+            resources: ["secrets", "configmaps"]
+          - group: authentication.k8s.io
+            resources: ["tokenreviews"]
+          omitStages:
+            - "RequestReceived"
+        - level: Request
+          resources:
+          - group: ""
+            resources: ["serviceaccounts/token"]
+        # Get repsonses can be large; skip them.
+        - level: Request
+          verbs: ["get", "list", "watch"]
+          resources:
+          - group: "" # core
+          - group: "admissionregistration.k8s.io"
+          - group: "apiextensions.k8s.io"
+          - group: "apiregistration.k8s.io"
+          - group: "apps"
+          - group: "authentication.k8s.io"
+          - group: "authorization.k8s.io"
+          - group: "autoscaling"
+          - group: "batch"
+          - group: "certificates.k8s.io"
+          - group: "extensions"
+          - group: "metrics.k8s.io"
+          - group: "networking.k8s.io"
+          - group: "policy"
+          - group: "rbac.authorization.k8s.io"
+          - group: "scheduling.k8s.io"
+          - group: "settings.k8s.io"
+          - group: "storage.k8s.io"
+          omitStages:
+          - "RequestReceived"
+        # Default level for known APIs
+        - level: RequestResponse
+          resources:
+          - group: "" # core
+          - group: "admissionregistration.k8s.io"
+          - group: "apiextensions.k8s.io"
+          - group: "apiregistration.k8s.io"
+          - group: "apps"
+          - group: "authentication.k8s.io"
+          - group: "authorization.k8s.io"
+          - group: "autoscaling"
+          - group: "batch"
+          - group: "certificates.k8s.io"
+          - group: "extensions"
+          - group: "metrics.k8s.io"
+          - group: "networking.k8s.io"
+          - group: "policy"
+          - group: "rbac.authorization.k8s.io"
+          - group: "scheduling.k8s.io"
+          - group: "settings.k8s.io"
+          - group: "storage.k8s.io"
+          omitStages:
+          - "RequestReceived"
+        # Default level for all other requests.
+        - level: Metadata
+          omitStages:
+          - "RequestReceived"
       owner: root:root
       path: /etc/kubernetes/audit-policy.yaml
-{{- if and .proxyConfig (ne .format "bottlerocket")}}
-    - content: |
-        [Service]
-        Environment="HTTP_PROXY={{.httpProxy}}"
-        Environment="HTTPS_PROXY={{.httpsProxy}}"
-        Environment="NO_PROXY={{ stringsJoin .noProxy "," }}"
-      owner: root:root
-      path: /etc/systemd/system/containerd.service.d/http-proxy.conf
-{{- end }}
-{{- if (ne .format "bottlerocket") }}
-{{- if .registryCACert }}
-    - content: |
-{{ .registryCACert | indent 8 }}
-      owner: root:root
-      path: "/etc/containerd/certs.d/{{.registryMirrorConfiguration}}/ca.crt"
-{{- end }}
-{{- if .registryMirrorConfiguration }}
-    - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://{{.registryMirrorConfiguration}}"]
-          {{- if .registryCACert }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{.registryMirrorConfiguration}}".tls]
-            ca_file = "/etc/containerd/certs.d/{{.registryMirrorConfiguration}}/ca.crt"
-          {{- end }}
-      owner: root:root
-      path: "/etc/containerd/config_append.toml"
-{{- end }}
-{{- end }}
-{{- if .awsIamAuth}}
-    - content: |
-        # clusters refers to the remote service.
-        clusters:
-          - name: aws-iam-authenticator
-            cluster:
-              certificate-authority: /var/aws-iam-authenticator/cert.pem
-              server: https://localhost:21362/authenticate
-        # users refers to the API Server's webhook configuration
-        # (we don't need to authenticate the API server).
-        users:
-          - name: apiserver
-        # kubeconfig files require a context. Provide one for the API Server.
-        current-context: webhook
-        contexts:
-        - name: webhook
-          context:
-            cluster: aws-iam-authenticator
-            user: apiserver
-      permissions: "0640"
-      owner: root:root
-      path: /var/lib/kubeadm/aws-iam-authenticator/kubeconfig.yaml
-    - contentFrom:
-        secret:
-          name: aws-iam-authenticator-ca
-          key: cert.pem
-      permissions: "0640"
-      owner: root:root
-      path: /var/lib/kubeadm/aws-iam-authenticator/pki/cert.pem
-    - contentFrom:
-        secret:
-          name: aws-iam-authenticator-ca
-          key: key.pem
-      permissions: "0640"
-      owner: root:root
-      path: /var/lib/kubeadm/aws-iam-authenticator/pki/key.pem
-{{- end}}
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -329,104 +337,46 @@ spec:
           cloud-provider: external
           read-only-port: "0"
           anonymous-auth: "false"
-{{- if .kubeletExtraArgs }}
-{{ .kubeletExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-        name: '{{`{{ ds.meta_data.hostname }}`}}'
-{{- if .controlPlaneTaints }}
-        taints:
-{{- range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-        {{- end }}
-{{- else}}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: '{{ ds.meta_data.hostname }}'
         taints: []
-{{- end }}
     joinConfiguration:
-{{- if (eq .format "bottlerocket") }}
-      pause:
-        imageRepository: {{.pauseRepository}}
-        imageTag: {{.pauseVersion}}
-      bottlerocketBootstrap:
-        imageRepository: {{.bottlerocketBootstrapRepository}}
-        imageTag: {{.bottlerocketBootstrapVersion}}
-{{- end }}
-{{- if and .proxyConfig (eq .format "bottlerocket") }}
-      proxy:
-        httpsProxy: {{.httpsProxy}}
-        noProxy: {{ range .noProxy }}
-        - {{ . }}
-        {{- end }}
-{{- end }}
-{{- if and .registryMirrorConfiguration (eq .format "bottlerocket") }}
-      registryMirror:
-        endpoint: {{.registryMirrorConfiguration}}
-        {{- if .registryCACert }}
-        caCert: |
-{{ .registryCACert | indent 10 }}
-        {{- end }}
-{{- end }}
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
           read-only-port: "0"
           anonymous-auth: "false"
-{{- if .kubeletExtraArgs }}
-{{ .kubeletExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-        name: '{{`{{ ds.meta_data.hostname }}`}}'
-{{- if .controlPlaneTaints }}
-        taints:
-{{- range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-        {{- end }}
-{{- else}}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: '{{ ds.meta_data.hostname }}'
         taints: []
-{{- end }}
     preKubeadmCommands:
-{{- if and .registryMirrorConfiguration (ne .format "bottlerocket") }}
-    - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
-{{- end }}
-{{- if and (or .proxyConfig .registryMirrorConfiguration) (ne .format "bottlerocket") }}
-    - sudo systemctl daemon-reload
-    - sudo systemctl restart containerd
-{{- end }}
-    - hostname "{{`{{ ds.meta_data.hostname }}`}}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
-    - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     useExperimentalRetryJoin: true
     users:
-    - name: {{.controlPlaneSshUsername}}
+    - name: capv
       sshAuthorizedKeys:
-      - '{{.vsphereControlPlaneSshAuthorizedKey}}'
+      - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
       sudo: ALL=(ALL) NOPASSWD:ALL
-    format: {{.format}}
-  replicas: {{.controlPlaneReplicas}}
-  version: {{.kubernetesVersion}}
+    format: cloud-config
+  replicas: 3
+  version: v1.19.8-eks-1-19-4
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: {{.clusterName}}
-  name: {{.resourceSetName}}
-  namespace: {{.eksaSystemNamespace}}
+    cluster.x-k8s.io/cluster-name: test
+  name: test-crs-0
+  namespace: eksa-system
 spec:
   clusterSelector:
     matchLabels:
-      cluster.x-k8s.io/cluster-name: {{.clusterName}}
+      cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
     name: vsphere-csi-controller
@@ -449,106 +399,77 @@ spec:
   - kind: ConfigMap
     name: cpi-manifests
 ---
-{{- if .externalEtcd }}
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
 metadata:
-  name: {{.clusterName}}-etcd
-  namespace: {{.eksaSystemNamespace}}
+  name: test-etcd
+  namespace: eksa-system
 spec:
-  replicas: {{.externalEtcdReplicas}}
+  replicas: 3
   etcdadmConfigSpec:
     etcdadmBuiltin: true
-    format: {{.format}}
-{{- if (eq .format "bottlerocket") }}
-    bottlerocketConfig:
-      etcdImage: {{.etcdImage}}
-      bootstrapImage: {{.bottlerocketBootstrapRepository}}:{{.bottlerocketBootstrapVersion}}
-      pauseImage: {{.pauseRepository}}:{{.pauseVersion}}
-{{- else}}
+    format: cloud-config
     cloudInitConfig:
-      version: {{.externalEtcdVersion}}
+      version: 3.4.14
       installDir: "/usr/bin"
     preEtcdadmCommands:
-      - hostname "{{`{{ ds.meta_data.hostname }}`}}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
-      - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
-{{- end }}
-{{- if .etcdCipherSuites }}
-    cipherSuites: {{.etcdCipherSuites}}
-{{- end }}
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
-      - name: {{.etcdSshUsername}}
+      - name: capv
         sshAuthorizedKeys:
-          - '{{.vsphereEtcdSshAuthorizedKey}}'
+          - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
-{{- if .proxyConfig }}
-    proxy:
-      httpProxy: {{ .httpProxy }}
-      httpsProxy: {{ .httpsProxy }}
-      noProxy: {{ range .noProxy }}
-        - {{ . }}
-      {{- end }}
-{{- end }}
-{{- if .registryMirrorConfiguration }}
-    registryMirror:
-      endpoint: {{.registryMirrorConfiguration}}
-      {{- if .registryCACert }}
-      caCert: |
-{{ .registryCACert | indent 8 }}
-      {{- end }}
-{{- end }}
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: VSphereMachineTemplate
-    name: {{.etcdTemplateName}}
+    name: test-etcd-template-1234567890000
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
-  name: {{.etcdTemplateName}}
-  namespace: '{{.eksaSystemNamespace}}'
+  name: test-etcd-template-1234567890000
+  namespace: 'eksa-system'
 spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{.vsphereDatacenter}}
-      datastore: {{.etcdVsphereDatastore}}
-      diskGiB: {{.etcdDiskGiB}}
-      folder: '{{.etcdVsphereFolder}}'
-      memoryMiB: {{.etcdVMsMemoryMiB}}
+      datacenter: SDDC-Datacenter
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 8192
       network:
         devices:
           - dhcp4: true
-            networkName: {{.vsphereNetwork}}
-      numCPUs: {{.etcdVMsNumCPUs}}
-      resourcePool: '{{.etcdVsphereResourcePool}}'
-      server: {{.vsphereServer}}
-{{- if (ne .etcdVsphereStoragePolicyName "") }}
-      storagePolicyName: "{{.etcdVsphereStoragePolicyName}}"
-{{- end }}
-      template: {{.vsphereTemplate}}
-      thumbprint: '{{.thumbprint}}'
+            networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 3
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
+      thumbprint: 'ABCDEFG'
 ---
-{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{.clusterName}}-vsphere-credentials
-  namespace: {{.eksaSystemNamespace}}
+  name: test-vsphere-credentials
+  namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
 stringData:
-  username: "{{.eksaVsphereUsername}}"
-  password: "{{.eksaVspherePassword}}"
+  username: "vsphere_username"
+  password: "vsphere_password"
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-csi-controller
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -562,7 +483,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: csi-vsphere-config
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -573,17 +494,17 @@ stringData:
     stringData:
       csi-vsphere.conf: |+
         [Global]
-        cluster-id = "default/{{.clusterName}}"
-        thumbprint = "{{.thumbprint}}"
+        cluster-id = "default/test"
+        thumbprint = "ABCDEFG"
 
-        [VirtualCenter "{{.vsphereServer}}"]
-        user = "{{.eksaCSIUsername}}"
-        password = "{{.eksaCSIPassword}}"
-        datacenters = "{{.vsphereDatacenter}}"
-        insecure-flag = "{{.insecure}}"
+        [VirtualCenter "vsphere_server"]
+        user = "EksavSphereCSIUsername"
+        password = "EksavSphereCSIPassword"
+        datacenters = "SDDC-Datacenter"
+        insecure-flag = "false"
 
         [Network]
-        public-network = "{{.vsphereNetwork}}"
+        public-network = "/SDDC-Datacenter/network/sddc-cgw-network-1"
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
@@ -697,7 +618,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-role
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -717,7 +638,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller-binding
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -731,7 +652,7 @@ data:
 kind: ConfigMap
 metadata:
   name: csi.vsphere.vmware.com
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -761,7 +682,7 @@ data:
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-            image: {{.nodeDriverRegistrarImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-19-4
             lifecycle:
               preStop:
                 exec:
@@ -795,7 +716,7 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            image: {{.driverImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-7c2690c880c6521afdd9ffa8d90443a11c6b817b
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -828,7 +749,7 @@ data:
               name: device-dir
           - args:
             - --csi-address=/csi/csi.sock
-            image: {{.livenessProbeImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-19-4
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -864,7 +785,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-node
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -894,7 +815,7 @@ data:
             env:
             - name: ADDRESS
               value: /csi/csi.sock
-            image: {{.externalAttacherImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v3.1.0-eks-1-19-4
             name: csi-attacher
             resources: {}
             volumeMounts:
@@ -911,7 +832,7 @@ data:
               value: PRODUCTION
             - name: X_CSI_LOG_LEVEL
               value: INFO
-            image: {{.driverImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-7c2690c880c6521afdd9ffa8d90443a11c6b817b
             livenessProbe:
               failureThreshold: 3
               httpGet:
@@ -937,7 +858,7 @@ data:
             env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            image: {{.livenessProbeImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-19-4
             name: liveness-probe
             resources: {}
             volumeMounts:
@@ -952,7 +873,7 @@ data:
               value: PRODUCTION
             - name: VSPHERE_CSI_CONFIG
               value: /etc/cloud/csi-vsphere.conf
-            image: {{.syncerImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-7c2690c880c6521afdd9ffa8d90443a11c6b817b
             name: vsphere-syncer
             resources: {}
             volumeMounts:
@@ -968,7 +889,7 @@ data:
             env:
             - name: ADDRESS
               value: /csi/csi.sock
-            image: {{.externalProvisionerImage}}
+            image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-19-4
             name: csi-provisioner
             resources: {}
             volumeMounts:
@@ -980,16 +901,6 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
-{{- if .controlPlaneTaints }}
-{{- range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-{{- end }}
-{{- end }}
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -999,7 +910,7 @@ data:
 kind: ConfigMap
 metadata:
   name: vsphere-csi-controller
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 data:
@@ -1014,13 +925,13 @@ data:
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: cloud-controller-manager
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -1034,7 +945,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloud-provider-vsphere-credentials
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system
 stringData:
   data: |
     apiVersion: v1
@@ -1043,8 +954,8 @@ stringData:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
     stringData:
-      {{.vsphereServer}}.password: "{{.eksaCloudProviderPassword}}"
-      {{.vsphereServer}}.username: "{{.eksaCloudProviderUsername}}"
+      vsphere_server.password: "vsphere_password"
+      vsphere_server.username: "vsphere_username"
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---
@@ -1156,16 +1067,16 @@ data:
         global:
           secretName: cloud-provider-vsphere-credentials
           secretNamespace: kube-system
-          thumbprint: "{{.thumbprint}}"
-          insecureFlag: {{.insecure}}
+          thumbprint: "ABCDEFG"
+          insecureFlag: false
         vcenter:
-          {{.vsphereServer}}:
+          vsphere_server:
             datacenters:
-            - '{{.vsphereDatacenter}}'
+            - 'SDDC-Datacenter'
             secretName: cloud-provider-vsphere-credentials
             secretNamespace: kube-system
-            server: '{{.vsphereServer}}'
-            thumbprint: '{{.thumbprint}}'
+            server: 'vsphere_server'
+            thumbprint: 'ABCDEFG'
     kind: ConfigMap
     metadata:
       name: vsphere-cloud-config
@@ -1224,7 +1135,7 @@ data:
             - --v=2
             - --cloud-provider=vsphere
             - --cloud-config=/etc/cloud/vsphere.conf
-            image: {{.managerImage}}
+            image: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             name: vsphere-cloud-controller-manager
             resources:
               requests:
@@ -1243,16 +1154,6 @@ data:
             key: node-role.kubernetes.io/master
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
-{{- if .controlPlaneTaints }}
-{{- range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-{{- end }}
-{{- end }}
           volumes:
           - configMap:
               name: vsphere-cloud-config
@@ -1262,4 +1163,4 @@ data:
 kind: ConfigMap
 metadata:
   name: cpi-manifests
-  namespace: {{.eksaSystemNamespace}}
+  namespace: eksa-system

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -36,21 +36,27 @@ import (
 )
 
 const (
-	CredentialsObjectName    = "vsphere-credentials"
-	EksavSphereUsernameKey   = "EKSA_VSPHERE_USERNAME"
-	EksavSpherePasswordKey   = "EKSA_VSPHERE_PASSWORD"
-	eksaLicense              = "EKSA_LICENSE"
-	vSphereUsernameKey       = "VSPHERE_USERNAME"
-	vSpherePasswordKey       = "VSPHERE_PASSWORD"
-	vSphereServerKey         = "VSPHERE_SERVER"
-	govcInsecure             = "GOVC_INSECURE"
-	expClusterResourceSetKey = "EXP_CLUSTER_RESOURCE_SET"
-	defaultTemplateLibrary   = "eks-a-templates"
-	defaultTemplatesFolder   = "vm/Templates"
-	bottlerocketDefaultUser  = "ec2-user"
-	ubuntuDefaultUser        = "capv"
-	maxRetries               = 30
-	backOffPeriod            = 5 * time.Second
+	CredentialsObjectName  = "vsphere-credentials"
+	EksavSphereUsernameKey = "EKSA_VSPHERE_USERNAME"
+	EksavSpherePasswordKey = "EKSA_VSPHERE_PASSWORD"
+	// Username and password for cloud provider
+	EksavSphereCPUsernameKey = "EKSA_VSPHERE_CP_USERNAME"
+	EksavSphereCPPasswordKey = "EKSA_VSPHERE_CP_PASSWORD"
+	// Username and password for the CSI driver
+	EksavSphereCSIUsernameKey = "EKSA_VSPHERE_CSI_USERNAME"
+	EksavSphereCSIPasswordKey = "EKSA_VSPHERE_CSI_PASSWORD"
+	eksaLicense               = "EKSA_LICENSE"
+	vSphereUsernameKey        = "VSPHERE_USERNAME"
+	vSpherePasswordKey        = "VSPHERE_PASSWORD"
+	vSphereServerKey          = "VSPHERE_SERVER"
+	govcInsecure              = "GOVC_INSECURE"
+	expClusterResourceSetKey  = "EXP_CLUSTER_RESOURCE_SET"
+	defaultTemplateLibrary    = "eks-a-templates"
+	defaultTemplatesFolder    = "vm/Templates"
+	bottlerocketDefaultUser   = "ec2-user"
+	ubuntuDefaultUser         = "capv"
+	maxRetries                = 30
+	backOffPeriod             = 5 * time.Second
 )
 
 //go:embed config/template-cp.yaml
@@ -688,6 +694,25 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		Append(clusterapi.PodIAMAuthExtraArgs(clusterSpec.Cluster.Spec.PodIAMConfig)).
 		Append(sharedExtraArgs)
 
+	eksaVsphereUsername := os.Getenv(EksavSphereUsernameKey)
+	eksaVspherePassword := os.Getenv(EksavSpherePasswordKey)
+
+	// Cloud provider credentials
+	eksaCPUsername := os.Getenv(EksavSphereCPUsernameKey)
+	eksaCPassword := os.Getenv(EksavSphereCPPasswordKey)
+
+	if eksaCPUsername == "" {
+		eksaCPUsername = eksaVsphereUsername
+		eksaCPassword = eksaVspherePassword
+	}
+	// CSI driver credentials
+	eksaCSIUsername := os.Getenv(EksavSphereCSIUsernameKey)
+	eksaCSIPassword := os.Getenv(EksavSphereCSIPasswordKey)
+	if eksaCSIUsername == "" {
+		eksaCSIUsername = eksaVsphereUsername
+		eksaCSIPassword = eksaVspherePassword
+	}
+
 	values := map[string]interface{}{
 		"clusterName":                          clusterSpec.Cluster.Name,
 		"controlPlaneEndpointIp":               clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host,
@@ -734,8 +759,12 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		"eksaSystemNamespace":                  constants.EksaSystemNamespace,
 		"auditPolicy":                          common.GetAuditPolicy(),
 		"resourceSetName":                      resourceSetName(clusterSpec),
-		"eksaVsphereUsername":                  os.Getenv(EksavSphereUsernameKey),
-		"eksaVspherePassword":                  os.Getenv(EksavSpherePasswordKey),
+		"eksaVsphereUsername":                  eksaVsphereUsername,
+		"eksaVspherePassword":                  eksaVspherePassword,
+		"eksaCloudProviderUsername":            eksaCPUsername,
+		"eksaCloudProviderPassword":            eksaCPassword,
+		"eksaCSIUsername":                      eksaCSIUsername,
+		"eksaCSIPassword":                      eksaCSIPassword,
 	}
 
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This will allow users to configure cloud provider and CSI Driver with different credentials using new environment variables.
The new environment variables are optional, and if not set, the required variables (EKSA_VSPHERE_USERNAME and EKSA_VSPHERE_PASSWORD) will be used.

Currently the same credentials are used when configuring CAPV, cloud provider and CSI driver. This change will allow users to set new environment variables to be used when configuring cloud provider and CSI credentials:

```
        // cloud provider credentials
	"EKSA_VSPHERE_CP_USERNAME"
	"EKSA_VSPHERE_CP_PASSWORD"
	// CSI driver credentials 
	"EKSA_VSPHERE_CSI_USERNAME"
	"EKSA_VSPHERE_CSI_PASSWORD"
```

The new credentials are optional, if not set then the following credentials will be used
```
     "EKSA_VSPHERE_USERNAME"
     "EKSA_VSPHERE_PASSWORD"
```

*Testing (if applicable):*
Added unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

