### PR TITLE
Revert "Use `latest` version of golangci-lint in GitHub actions"

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,4 +15,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: latest
+          version: v1.42.1

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -901,8 +901,7 @@ func (c *ClusterManager) InstallEksdComponents(ctx context.Context, clusterSpec 
 }
 
 func (c *ClusterManager) CreateEKSAResources(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec,
-	datacenterConfig providers.DatacenterConfig, machineConfigs []providers.MachineConfig,
-) error {
+	datacenterConfig providers.DatacenterConfig, machineConfigs []providers.MachineConfig) error {
 	if clusterSpec.Cluster.Namespace != "" {
 		if err := c.clusterClient.GetNamespace(ctx, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace); err != nil {
 			if err := c.clusterClient.CreateNamespace(ctx, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace); err != nil {

--- a/pkg/providers/vsphere/defaults.go
+++ b/pkg/providers/vsphere/defaults.go
@@ -162,8 +162,7 @@ func (d *Defaulter) setDiskDefaults(ctx context.Context, machineConfig *anywhere
 
 func (d *Defaulter) setTemplateFullPath(ctx context.Context,
 	datacenterConfig *anywherev1.VSphereDatacenterConfig,
-	machine *anywherev1.VSphereMachineConfig,
-) error {
+	machine *anywherev1.VSphereMachineConfig) error {
 	templateFullPath, err := d.govc.SearchTemplate(ctx, datacenterConfig.Spec.Datacenter, machine)
 	if err != nil {
 		return fmt.Errorf("setting template full path: %v", err)

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -24,8 +24,7 @@ type Create struct {
 }
 
 func NewCreate(bootstrapper interfaces.Bootstrapper, provider providers.Provider,
-	clusterManager interfaces.ClusterManager, addonManager interfaces.AddonManager, writer filewriter.FileWriter,
-) *Create {
+	clusterManager interfaces.ClusterManager, addonManager interfaces.AddonManager, writer filewriter.FileWriter) *Create {
 	return &Create{
 		bootstrapper:   bootstrapper,
 		provider:       provider,

--- a/pkg/workflows/delete.go
+++ b/pkg/workflows/delete.go
@@ -19,8 +19,7 @@ type Delete struct {
 }
 
 func NewDelete(bootstrapper interfaces.Bootstrapper, provider providers.Provider,
-	clusterManager interfaces.ClusterManager, addonManager interfaces.AddonManager,
-) *Delete {
+	clusterManager interfaces.ClusterManager, addonManager interfaces.AddonManager) *Delete {
 	return &Delete{
 		bootstrapper:   bootstrapper,
 		provider:       provider,

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -27,8 +27,7 @@ type Upgrade struct {
 
 func NewUpgrade(bootstrapper interfaces.Bootstrapper, provider providers.Provider,
 	capiManager interfaces.CAPIManager,
-	clusterManager interfaces.ClusterManager, addonManager interfaces.AddonManager, writer filewriter.FileWriter,
-) *Upgrade {
+	clusterManager interfaces.ClusterManager, addonManager interfaces.AddonManager, writer filewriter.FileWriter) *Upgrade {
 	upgradeChangeDiff := types.NewChangeDiff()
 	return &Upgrade{
 		bootstrapper:      bootstrapper,


### PR DESCRIPTION
Reverts aws/eks-anywhere#1634

Using the latest version is problematic since it makes the lint runs non deterministic. If they update the linter and they add new rules that our code doesn't comply with, the linter will fail in PRs that are possibly unrelated with the offending code.

If we want to keep the linter updated we should have a recurring task to update it manually