### PR TITLE
pin linter execution in github actions to specific go version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,7 +8,9 @@ on:
   pull_request:
 jobs:
   golangci:
-    go-version: 1.16.x
+    strategy:
+      matrix:
+        go-version: 1.16.x
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go-version: 1.16.x
+        go-version: [1.16.x]
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
 jobs:
   golangci:
+    go-version: 1.16.x
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,4 +18,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: latest
+          version: v1.42.1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,14 +8,15 @@ on:
   pull_request:
 jobs:
   golangci:
-    strategy:
-      matrix:
-        go-version: [1.16.x]
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.15
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42.1
+          version: latest
+          skip-go-installation: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Checking if we can set goversion this way for the linter

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

