### PR TITLE
Validate host machines are powered off when provisioning with Tinkerbell

### DIFF
--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -387,6 +387,8 @@ func (p *tinkerbellProvider) SetupAndValidateCreateCluster(ctx context.Context, 
 		if err := p.scrubWorkflowsFromTinkerbell(ctx, p.validator.hardwareConfig.Hardwares, hardware); err != nil {
 			return err
 		}
+	} else if err := p.validator.ValidateMachinesPoweredOff(ctx); err != nil {
+		return fmt.Errorf("validating machines are powered off: %w", err)
 	}
 
 	if err := p.validator.ValidateTinkerbellConfig(ctx, tinkerbellClusterSpec.datacenterConfig); err != nil {

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -170,7 +170,7 @@ func TestTinkerbellProviderGenerateDeploymentFileWithExternalEtcd(t *testing.T) 
 	tink.EXPECT().GetHardware(ctx).Return(hardwares, nil)
 	tink.EXPECT().GetWorkflow(ctx).Return([]*tinkworkflow.Workflow{}, nil)
 
-	pbnjClient.EXPECT().GetPowerState(ctx, gomock.Any()).Return(pbnj.PowerStateOff, nil).Times(4)
+	pbnjClient.EXPECT().GetPowerState(ctx, gomock.Any()).Return(pbnj.PowerStateOff, nil).Times(8)
 
 	provider := newProviderWithKubectlWithTink(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, kubectl, tinkerbellClients)
 	if err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec); err != nil {
@@ -207,7 +207,7 @@ func TestTinkerbellProviderMachineConfigsMissingUserSshKeys(t *testing.T) {
 	tink.EXPECT().GetHardware(ctx).Return(hardwares, nil)
 	tink.EXPECT().GetWorkflow(ctx).Return([]*tinkworkflow.Workflow{}, nil)
 
-	pbnjClient.EXPECT().GetPowerState(ctx, gomock.Any()).Return(pbnj.PowerStateOff, nil).Times(4)
+	pbnjClient.EXPECT().GetPowerState(ctx, gomock.Any()).Return(pbnj.PowerStateOff, nil).Times(8)
 
 	const sshKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=="
 	keyGenerator.EXPECT().GenerateSSHAuthKey(gomock.Any()).Return(sshKey, nil)
@@ -248,7 +248,7 @@ func TestTinkerbellProviderGenerateDeploymentFileWithStackedEtcd(t *testing.T) {
 
 	tink.EXPECT().GetHardware(ctx).Return(hardwares, nil)
 	tink.EXPECT().GetWorkflow(ctx).Return([]*tinkworkflow.Workflow{}, nil)
-	pbnjClient.EXPECT().GetPowerState(ctx, gomock.Any()).Return(pbnj.PowerStateOff, nil).Times(4)
+	pbnjClient.EXPECT().GetPowerState(ctx, gomock.Any()).Return(pbnj.PowerStateOff, nil).Times(8)
 
 	provider := newProviderWithKubectlWithTink(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, kubectl, tinkerbellClients)
 	if err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec); err != nil {
@@ -284,7 +284,7 @@ func TestTinkerbellProviderGenerateDeploymentFileMultipleWorkerNodeGroups(t *tes
 	tink.EXPECT().GetHardware(ctx).Return(hardwares, nil)
 	tink.EXPECT().GetWorkflow(ctx).Return([]*tinkworkflow.Workflow{}, nil)
 
-	pbnjClient.EXPECT().GetPowerState(ctx, gomock.Any()).Return(pbnj.PowerStateOff, nil).Times(4)
+	pbnjClient.EXPECT().GetPowerState(ctx, gomock.Any()).Return(pbnj.PowerStateOff, nil).Times(8)
 	provider := newProviderWithKubectlWithTink(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, kubectl, tinkerbellClients)
 	if err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec); err != nil {
 		t.Fatalf("failed to setup and validate: %v", err)


### PR DESCRIPTION
Add validation to check if machines are powered off.

If machines are powered on we want customers to have the opportunity to check they configured the correct machine. Users can force power off machines with the `--force-cleanup` flag.

This was tested locally by ensuring the machine was powered on and no `--force-cleanup` flag and again with `--force-cleanup`. The first case received the error below and the second proceeded to power off the machine and set PXE boot as expected.

```
❌ Validation failed    {"validation": "tinkerbell Provider setup is valid", "error": "validating machines are powered off: expecting host machines to be powered off; use --force-cleanup flag to power off machine and set pxe boot: hosts = [10.61.250.59]", "remediation": ""}
```