### PR TITLE
Print a better cluster not found error

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -966,7 +966,12 @@ func (k *Kubectl) GetEksaCluster(ctx context.Context, cluster *types.Cluster, cl
 	params := []string{"get", eksaClusterResourceType, "-A", "-o", "jsonpath={.items[0]}", "--kubeconfig", cluster.KubeconfigFile, "--field-selector=metadata.name=" + clusterName}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("getting eksa cluster: %v", err)
+		params := []string{"get", eksaClusterResourceType, "-A", "--kubeconfig", cluster.KubeconfigFile, "--field-selector=metadata.name=" + clusterName}
+		stdOut, err = k.Execute(ctx, params...)
+		if err != nil {
+			return nil, fmt.Errorf("getting eksa cluster: %v", err)
+		}
+		return nil, fmt.Errorf("cluster %s not found of custom resource type %s", clusterName, eksaClusterResourceType)
 	}
 
 	response := &v1alpha1.Cluster{}


### PR DESCRIPTION
This:
```
Error: failed to display upgrade plan: failed getting EKS-A cluster to build current cluster Spec: cluster mgmt7 not found of custom resource type clusters.anywhere.eks.amazonaws.com
```

Instead of:
```
Error: failed to display upgrade plan: failed getting EKS-A cluster to build current cluster Spec: getting eksa cluster: error: error executing jsonpath "{.items[0]}": Error executing template: array index out of bounds: index 0, length 0. Printing more information for debugging the template:
	template was:
		{.items[0]}
	object given to jsonpath engine was:
		map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":"", "selfLink":""}}
```


