### PR TITLE
Gracefully handle non-existent CW log streams

### DIFF
--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/cloudwatch/cloudwatch.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/cloudwatch/cloudwatch.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 
@@ -53,8 +54,12 @@ func (c *Cloudwatch) getLogs(logGroupName string, logStreamName string, startTim
 	for {
 		l, err := c.getLogSegment(logGroupName, logStreamName, startTime, endTime, nextToken)
 		if err != nil {
-			logger.Info("error fetching cloudwatch logs", "group", logGroupName, "stream", logStreamName, "err", err)
-			return nil, err
+			if isInvalidParameterError(err) {
+				logger.Info("log stream does not exist. Proceeding to fetch next log events", "logStream", logStreamName)
+			} else {
+				logger.Info("error fetching cloudwatch logs", "group", logGroupName, "stream", logStreamName, "err", err)
+				return nil, err
+			}
 		}
 		if l.NextForwardToken == nil || nextToken != nil && *nextToken == *l.NextForwardToken {
 			logger.Info("finished fetching logs", "logGroup", logGroupName, "logStream", logStreamName)
@@ -84,4 +89,11 @@ func (c Cloudwatch) getLogSegment(logGroupName string, logStreamName string, sta
 		input.EndTime = endTime
 	}
 	return c.svc.GetLogEvents(input)
+}
+
+func isInvalidParameterError(err error) bool {
+	if awsErr, ok := err.(awserr.Error); ok {
+		return awsErr.Code() == constants.InvalidParameterError
+	}
+	return false
 }

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/cloudwatch/cloudwatch.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/cloudwatch/cloudwatch.go
@@ -93,7 +93,7 @@ func (c Cloudwatch) getLogSegment(logGroupName string, logStreamName string, sta
 
 func isInvalidParameterError(err error) bool {
 	if awsErr, ok := err.(awserr.Error); ok {
-		return awsErr.Code() == constants.InvalidParameterError
+		return awsErr.Code() == cloudwatchlogs.ErrCodeInvalidParameterException
 	}
 	return false
 }

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/constants/constants.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/constants/constants.go
@@ -12,5 +12,4 @@ const (
 	LogOutputFile             = "codebuild-log.txt"
 	CiProxyLogGroup           = "nginx-vcenter-proxy.log"
 	CiProxyLogStream          = "nginx-vcenter-proxy.log"
-	InvalidParameterError     = "InvalidParameterException"
 )

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/constants/constants.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/constants/constants.go
@@ -12,4 +12,5 @@ const (
 	LogOutputFile             = "codebuild-log.txt"
 	CiProxyLogGroup           = "nginx-vcenter-proxy.log"
 	CiProxyLogStream          = "nginx-vcenter-proxy.log"
+	InvalidParameterError     = "InvalidParameterException"
 )


### PR DESCRIPTION
*Issue #, if available:*
#1679 

*Description of changes:*
The `eks-a-test-tool e2e fetch logs` command would error out if the log stream for a test did not exist. This PR changes that behavior to send a warning that the log stream does not exist & continue fetching the logs for the rest of the tests.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

