### PR TITLE
Add snowmachineconfig context unaware defaulters

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -708,29 +708,29 @@ func (c *Cluster) EtcdAnnotation() string {
 	return etcdAnnotation
 }
 
-func (s *Cluster) IsSelfManaged() bool {
-	return s.Spec.ManagementCluster.Name == "" || s.Spec.ManagementCluster.Name == s.Name
+func (c *Cluster) IsSelfManaged() bool {
+	return c.Spec.ManagementCluster.Name == "" || c.Spec.ManagementCluster.Name == c.Name
 }
 
-func (s *Cluster) SetManagedBy(managementClusterName string) {
-	if s.Annotations == nil {
-		s.Annotations = map[string]string{}
+func (c *Cluster) SetManagedBy(managementClusterName string) {
+	if c.Annotations == nil {
+		c.Annotations = map[string]string{}
 	}
 
-	s.Annotations[managementAnnotation] = managementClusterName
-	s.Spec.ManagementCluster.Name = managementClusterName
+	c.Annotations[managementAnnotation] = managementClusterName
+	c.Spec.ManagementCluster.Name = managementClusterName
 }
 
-func (s *Cluster) SetSelfManaged() {
-	s.Spec.ManagementCluster.Name = s.Name
+func (c *Cluster) SetSelfManaged() {
+	c.Spec.ManagementCluster.Name = c.Name
 }
 
 func (c *ClusterGenerate) SetSelfManaged() {
 	c.Spec.ManagementCluster.Name = c.Name
 }
 
-func (s *Cluster) ManagementClusterEqual(s2 *Cluster) bool {
-	return s.IsSelfManaged() && s2.IsSelfManaged() || s.Spec.ManagementCluster.Equal(s2.Spec.ManagementCluster)
+func (c *Cluster) ManagementClusterEqual(s2 *Cluster) bool {
+	return c.IsSelfManaged() && s2.IsSelfManaged() || c.Spec.ManagementCluster.Equal(s2.Spec.ManagementCluster)
 }
 
 func (c *Cluster) MachineConfigRefs() []Ref {

--- a/pkg/api/v1alpha1/snowmachineconfig.go
+++ b/pkg/api/v1alpha1/snowmachineconfig.go
@@ -62,11 +62,6 @@ func setSnowMachineConfigDefaults(config *SnowMachineConfig) {
 		logger.V(1).Info("SnowMachineConfig InstanceType is empty. Using default", "default instance type", DefaultSnowInstanceType)
 	}
 
-	if config.Spec.SshKeyName == "" {
-		config.Spec.SshKeyName = DefaultSnowSshKeyName
-		logger.V(1).Info("SnowMachineConfig SshKeyName is empty. Using default", "default SSH key name", DefaultSnowSshKeyName)
-	}
-
 	if config.Spec.PhysicalNetworkConnector == "" {
 		config.Spec.PhysicalNetworkConnector = DefaultSnowPhysicalNetworkConnectorType
 		logger.V(1).Info("SnowMachineConfig PhysicalNetworkConnector is empty. Using default", "default physical network connector", DefaultSnowPhysicalNetworkConnectorType)

--- a/pkg/api/v1alpha1/snowmachineconfig_test.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_test.go
@@ -20,7 +20,6 @@ func TestSnowSetDefaults(t *testing.T) {
 			after: &SnowMachineConfig{
 				Spec: SnowMachineConfigSpec{
 					InstanceType:             DefaultSnowInstanceType,
-					SshKeyName:               DefaultSnowSshKeyName,
 					PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
 				},
 			},
@@ -35,7 +34,6 @@ func TestSnowSetDefaults(t *testing.T) {
 			after: &SnowMachineConfig{
 				Spec: SnowMachineConfigSpec{
 					InstanceType:             "instance-type-1",
-					SshKeyName:               DefaultSnowSshKeyName,
 					PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
 				},
 			},
@@ -66,7 +64,6 @@ func TestSnowSetDefaults(t *testing.T) {
 				Spec: SnowMachineConfigSpec{
 					PhysicalNetworkConnector: "network-1",
 					InstanceType:             DefaultSnowInstanceType,
-					SshKeyName:               DefaultSnowSshKeyName,
 				},
 			},
 		},
@@ -125,4 +122,18 @@ func TestSnowValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetControlPlaneAnnotation(t *testing.T) {
+	g := NewWithT(t)
+	m := &SnowMachineConfig{}
+	m.SetControlPlaneAnnotation()
+	g.Expect(m.Annotations).To(Equal(map[string]string{"anywhere.eks.amazonaws.com/control-plane": "true"}))
+}
+
+func TestSetEtcdAnnotation(t *testing.T) {
+	g := NewWithT(t)
+	m := &SnowMachineConfig{}
+	m.SetEtcdAnnotation()
+	g.Expect(m.Annotations).To(Equal(map[string]string{"anywhere.eks.amazonaws.com/etcd": "true"}))
 }

--- a/pkg/api/v1alpha1/snowmachineconfig_types.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_types.go
@@ -71,6 +71,22 @@ func (s *SnowMachineConfig) Validate() error {
 	return validateSnowMachineConfig(s)
 }
 
+func (s *SnowMachineConfig) SetControlPlaneAnnotation() {
+	if s.Annotations == nil {
+		s.Annotations = map[string]string{}
+	}
+
+	s.Annotations[controlPlaneAnnotation] = "true"
+}
+
+func (s *SnowMachineConfig) SetEtcdAnnotation() {
+	if s.Annotations == nil {
+		s.Annotations = map[string]string{}
+	}
+
+	s.Annotations[etcdAnnotation] = "true"
+}
+
 // +kubebuilder:object:generate=false
 
 // Same as SnowMachineConfig except stripped down for generation of yaml file during generate clusterconfig

--- a/pkg/cluster/snow.go
+++ b/pkg/cluster/snow.go
@@ -23,6 +23,7 @@ func snowEntry() *ConfigManagerEntry {
 				}
 				return nil
 			},
+			SetSnowMachineConfigsAnnotations,
 		},
 		Validations: []Validation{
 			func(c *Config) error {
@@ -79,4 +80,23 @@ func processSnowMachineConfig(c *Config, objects ObjectLookup, machineRef *anywh
 	}
 
 	c.SnowMachineConfigs[m.GetName()] = m.(*anywherev1.SnowMachineConfig)
+}
+
+func SetSnowMachineConfigsAnnotations(c *Config) error {
+	if c.SnowMachineConfigs == nil {
+		return nil
+	}
+
+	c.SnowMachineConfigs[c.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name].SetControlPlaneAnnotation()
+
+	if c.Cluster.Spec.ExternalEtcdConfiguration != nil {
+		c.SnowMachineConfigs[c.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name].SetEtcdAnnotation()
+	}
+
+	if c.Cluster.IsManaged() {
+		for _, mc := range c.SnowMachineConfigs {
+			mc.SetManagedBy(c.Cluster.ManagedBy())
+		}
+	}
+	return nil
 }

--- a/pkg/cluster/snow_test.go
+++ b/pkg/cluster/snow_test.go
@@ -1,0 +1,118 @@
+package cluster
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+func TestSetSnowMachineConfigsAnnotations(t *testing.T) {
+	tests := []struct {
+		name                   string
+		config                 *Config
+		wantSnowMachineConfigs map[string]*v1alpha1.SnowMachineConfig
+	}{
+		{
+			name: "workload cluster with external etcd",
+			config: &Config{
+				Cluster: &v1alpha1.Cluster{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "test-cluster",
+					},
+					Spec: v1alpha1.ClusterSpec{
+						ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
+							MachineGroupRef: &v1alpha1.Ref{
+								Name: "cp-machine",
+							},
+						},
+						ExternalEtcdConfiguration: &v1alpha1.ExternalEtcdConfiguration{
+							MachineGroupRef: &v1alpha1.Ref{
+								Name: "etcd-machine",
+							},
+						},
+						ManagementCluster: v1alpha1.ManagementCluster{
+							Name: "mgmt-cluster",
+						},
+					},
+				},
+				SnowMachineConfigs: map[string]*v1alpha1.SnowMachineConfig{
+					"cp-machine": {
+						ObjectMeta: v1.ObjectMeta{
+							Name: "cp-machine",
+						},
+					},
+					"etcd-machine": {
+						ObjectMeta: v1.ObjectMeta{
+							Name: "etcd-machine",
+						},
+					},
+				},
+			},
+			wantSnowMachineConfigs: map[string]*v1alpha1.SnowMachineConfig{
+				"cp-machine": {
+					ObjectMeta: v1.ObjectMeta{
+						Name: "cp-machine",
+						Annotations: map[string]string{
+							"anywhere.eks.amazonaws.com/control-plane": "true",
+							"anywhere.eks.amazonaws.com/managed-by":    "mgmt-cluster",
+						},
+					},
+				},
+				"etcd-machine": {
+					ObjectMeta: v1.ObjectMeta{
+						Name: "etcd-machine",
+						Annotations: map[string]string{
+							"anywhere.eks.amazonaws.com/etcd":       "true",
+							"anywhere.eks.amazonaws.com/managed-by": "mgmt-cluster",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "management cluster",
+			config: &Config{
+				Cluster: &v1alpha1.Cluster{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "test-cluster",
+					},
+					Spec: v1alpha1.ClusterSpec{
+						ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
+							MachineGroupRef: &v1alpha1.Ref{
+								Name: "cp-machine",
+							},
+						},
+					},
+				},
+				SnowMachineConfigs: map[string]*v1alpha1.SnowMachineConfig{
+					"cp-machine": {
+						ObjectMeta: v1.ObjectMeta{
+							Name: "cp-machine",
+						},
+					},
+				},
+			},
+			wantSnowMachineConfigs: map[string]*v1alpha1.SnowMachineConfig{
+				"cp-machine": {
+					ObjectMeta: v1.ObjectMeta{
+						Name: "cp-machine",
+						Annotations: map[string]string{
+							"anywhere.eks.amazonaws.com/control-plane": "true",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := SetSnowMachineConfigsAnnotations(tt.config)
+			g.Expect(err).To(Succeed())
+			g.Expect(tt.config.SnowMachineConfigs).To(Equal(tt.wantSnowMachineConfigs))
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

#1573 

*Description of changes:*

Add snowmachineconfig defaulters to better separate api setDefaults vs provider context aware defaults.

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

