### PR TITLE
Check if manifest exists before downloading

### DIFF
--- a/cmd/eksctl-anywhere/cmd/downloadartifacts.go
+++ b/cmd/eksctl-anywhere/cmd/downloadartifacts.go
@@ -84,6 +84,10 @@ func downloadArtifacts(context context.Context, opts *downloadArtifactsOptions) 
 	for i, bundle := range versionBundles {
 		for component, manifestList := range bundle.Manifests() {
 			for _, manifest := range manifestList {
+				if *manifest == "" {
+					// This can happen if the provider is not GA and not added to the bundle-release corresponding to an EKS-A release
+					continue
+				}
 				if opts.dryRun {
 					logger.Info(fmt.Sprintf("Found artifact: %s\n", *manifest))
 					continue


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/eks-anywhere/issues/1753

*Description of changes:*
CAPC/CAPT providers are not GA and not a part of the bundle-release.yaml corresponding to releases 0.7.x and 0.8.x
But all providers are part of the dev bundle-release.yaml when they get added to the manifest list to download for `download artifacts`. This PR adds a check to see if the provider's artifacts exist in the bundle-release.yaml
This will ensure download artifacts runs against any bundle-release.yaml irrespective of which providers are added in a release.

*Testing (if applicable):*
Tested against release-0.8 branch

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

