### PR TITLE
[release-0.8] Check if manifest exists before downloading

### DIFF
--- a/cmd/eksctl-anywhere/cmd/downloadartifacts.go
+++ b/cmd/eksctl-anywhere/cmd/downloadartifacts.go
@@ -90,6 +90,10 @@ func downloadArtifacts(context context.Context, opts *downloadArtifactsOptions) 
 	for i, bundle := range versionBundles {
 		for component, manifestList := range bundle.Manifests() {
 			for _, manifest := range manifestList {
+				if *manifest == "" {
+					// This can happen if the provider is not GA and not added to the bundle-release corresponding to an EKS-A release
+					continue
+				}
 				if opts.dryRun {
 					logger.Info(fmt.Sprintf("Found artifact: %s\n", *manifest))
 					continue


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/eks-anywhere/issues/1753

*Description of changes:* Cherry-pick https://github.com/aws/eks-anywhere/pull/1763

*Testing (if applicable):*
manual testing of the download artifacts command

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

