### PR TITLE
Untar tools

### DIFF
--- a/internal/pkg/files/files.go
+++ b/internal/pkg/files/files.go
@@ -4,13 +4,13 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/aws/eks-anywhere/pkg/logger"
+	untar "github.com/aws/eks-anywhere/pkg/tar"
 )
 
 // GzipFileDownloadExtract downloads and extracts a specific file to destination
@@ -33,34 +33,24 @@ func GzipFileDownloadExtract(uri, fileToExtract, destination string) error {
 	}
 	defer gzf.Close()
 
-	tarReader := tar.NewReader(gzf)
-	for {
-		header, err := tarReader.Next()
-		switch {
-		case err == io.EOF:
-			return fmt.Errorf("%s not found: %v", fileToExtract, err)
-		case err != nil:
-			return fmt.Errorf("reading archive: %v", err)
-		case header == nil:
-			continue
-		}
-		switch header.Typeflag {
-		case tar.TypeReg:
-			name := header.FileInfo().Name()
-			if strings.TrimPrefix(name, "./") == fileToExtract {
-				out, err := os.OpenFile(targetFile, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
-				if err != nil {
-					return fmt.Errorf("opening %s file: %v", fileToExtract, err)
-				}
-				defer out.Close()
-
-				_, err = io.Copy(out, tarReader)
-				if err != nil {
-					return fmt.Errorf("writing %s file: %v", fileToExtract, err)
-				}
-				logger.V(4).Info("Downloaded", "file", fileToExtract, "uri", uri)
-				return nil
-			}
-		}
+	router := singleFileRouter{
+		fileName: fileToExtract,
+		folder:   destination,
 	}
+
+	return untar.Untar(gzf, router)
+}
+
+type singleFileRouter struct {
+	folder   string
+	fileName string
+}
+
+func (s singleFileRouter) ExtractPath(header *tar.Header) string {
+	name := header.FileInfo().Name()
+	if strings.TrimPrefix(name, "./") != s.fileName {
+		return ""
+	}
+
+	return filepath.Join(s.folder, name)
 }

--- a/pkg/tar/packager.go
+++ b/pkg/tar/packager.go
@@ -1,0 +1,15 @@
+package tar
+
+type Packager struct{}
+
+func NewPackager() Packager {
+	return Packager{}
+}
+
+func (Packager) Package(sourceFolder, dstFile string) error {
+	return TarFolder(sourceFolder, dstFile)
+}
+
+func (Packager) UnPackage(orgFile, dstFolder string) error {
+	return UntarFile(orgFile, dstFolder)
+}

--- a/pkg/tar/router.go
+++ b/pkg/tar/router.go
@@ -1,0 +1,25 @@
+package tar
+
+import (
+	"archive/tar"
+	"path/filepath"
+)
+
+// Router instructs where to extract a file
+type Router interface {
+	// ExtractPath instructs the path where a file should be extracted.
+	// Empty strings instructs to omit the file extraction
+	ExtractPath(header *tar.Header) string
+}
+
+type FolderRouter struct {
+	folder string
+}
+
+func NewFolderRouter(folder string) FolderRouter {
+	return FolderRouter{folder: folder}
+}
+
+func (f FolderRouter) ExtractPath(header *tar.Header) string {
+	return filepath.Join(f.folder, header.Name)
+}

--- a/pkg/tar/untar.go
+++ b/pkg/tar/untar.go
@@ -1,0 +1,61 @@
+package tar
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+)
+
+type UnPackager struct{}
+
+func NewUnPackager() UnPackager {
+	return UnPackager{}
+}
+
+func UntarFile(tarFile, dstFolder string) error {
+	reader, err := os.Open(tarFile)
+	if err != nil {
+		return err
+	}
+
+	defer reader.Close()
+	return Untar(reader, NewFolderRouter(dstFolder))
+}
+
+func Untar(source io.Reader, router Router) error {
+	tarReader := tar.NewReader(source)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		path := router.ExtractPath(header)
+		if path == "" {
+			continue
+		}
+
+		info := header.FileInfo()
+		if info.IsDir() {
+			if err = os.MkdirAll(path, info.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		_, err = io.Copy(file, tarReader)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/tar/untar_test.go
+++ b/pkg/tar/untar_test.go
@@ -1,0 +1,32 @@
+package tar_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/tar"
+)
+
+func TestUntarFile(t *testing.T) {
+	g := NewWithT(t)
+	dstFile := "dst.tar"
+	untarFolder := "dst-untar"
+	g.Expect(os.MkdirAll(untarFolder, os.ModePerm))
+	t.Cleanup(func() {
+		os.Remove(dstFile)
+		os.RemoveAll(untarFolder)
+	})
+
+	g.Expect(tar.TarFolder("testdata", dstFile)).To(Succeed())
+	g.Expect(dstFile).To(BeAnExistingFile())
+
+	g.Expect(tar.UntarFile(dstFile, untarFolder)).To(Succeed())
+	g.Expect(untarFolder).To(BeADirectory())
+	g.Expect(filepath.Join(untarFolder, "dummy1")).To(BeARegularFile())
+	g.Expect(filepath.Join(untarFolder, "dummy2")).To(BeARegularFile())
+	g.Expect(filepath.Join(untarFolder, "dummy3")).To(BeADirectory())
+	g.Expect(filepath.Join(untarFolder, "dummy3", "dummy4")).To(BeARegularFile())
+}

--- a/pkg/tar/walker.go
+++ b/pkg/tar/walker.go
@@ -1,17 +1,44 @@
 package tar
 
-import "path/filepath"
+import (
+	"archive/tar"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
 
 func NewFolderWalker(folder string) FolderWalker {
 	return FolderWalker{
-		folder: folder,
+		folder:       folder,
+		folderPrefix: fmt.Sprintf("%s/", folder),
 	}
 }
 
 type FolderWalker struct {
-	folder string
+	folder, folderPrefix string
 }
 
-func (f FolderWalker) Walk(fn filepath.WalkFunc) error {
-	return filepath.Walk(f.folder, fn)
+func (f FolderWalker) Walk(fn TarFunc) error {
+	return filepath.Walk(f.folder, f.trimFolder(fn))
+}
+
+func (f FolderWalker) trimFolder(fn TarFunc) filepath.WalkFunc {
+	return func(file string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if file == f.folder {
+			return nil
+		}
+
+		header, err := tar.FileInfoHeader(info, info.Name())
+		if err != nil {
+			return err
+		}
+
+		header.Name = strings.TrimPrefix(file, f.folderPrefix)
+		return fn(file, info, header)
+	}
 }


### PR DESCRIPTION
*Issue #, if available:*
Will complement https://github.com/aws/eks-anywhere/pull/1478

## Description of changes
This adds tooling to untar files. It supports untaring from an `io.Reader`
which allows two chain this with other readers like gzip. It also
supports to route extracted files to different destinations, including
completely skipping their extraction.

Helpers are provided to extract a tarball into a folder.

Tar logic was updated to support nested folders.

`GzipFileDownloadExtract` was updated to use this new untar util.

## Testing
Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

