### PR TITLE
Update IRSA doc to point to the working commit and image tag

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/irsa.md
+++ b/docs/content/en/docs/reference/clusterspec/irsa.md
@@ -96,7 +96,13 @@ Set the remaining fields in [cluster spec](https://anywhere.eks.amazonaws.com/do
 
 1. After hosting the service account public signing key and OIDC discovery documents, the applications running in pods can start accessing the desired AWS resources, as long as the pod is mounted with the right service account tokens. This part of configuring the pods with the right service account tokens and env vars is automated by the [amazon pod identity webhook](https://github.com/aws/amazon-eks-pod-identity-webhook). Once the webhook is deployed, it mutates any pods launched using service accounts annotated with `eks.amazonaws.com/role-arn`
 
-1. Follow the [in-cluster installation steps](https://github.com/aws/amazon-eks-pod-identity-webhook#in-cluster) for amazon-eks-pod-identity-webhook. While running the make target, make sure the $KUBECONFIG env var is set to the path of the EKS Anywhere cluster.
+1. Check out [this commit](https://github.com/aws/amazon-eks-pod-identity-webhook/commit/a65cc3d9c61cf6fc43f0f985818c474e0867d786) of the amazon-eks-pod-identity-webhook.
+
+1. Set the $KUBECONFIG env var to the path of the EKS Anywhere cluster. Run the following command:
+
+    ```bash
+    make cluster-up IMAGE=amazon/amazon-eks-pod-identity-webhook:a65cc3d
+    ```
 
 
 #### Configure the trust relationship for the OIDC provider's IAM Role

--- a/docs/content/en/docs/reference/clusterspec/irsa.md
+++ b/docs/content/en/docs/reference/clusterspec/irsa.md
@@ -98,7 +98,8 @@ Set the remaining fields in [cluster spec](https://anywhere.eks.amazonaws.com/do
 
 1. Check out [this commit](https://github.com/aws/amazon-eks-pod-identity-webhook/commit/a65cc3d9c61cf6fc43f0f985818c474e0867d786) of the amazon-eks-pod-identity-webhook.
 
-1. Set the $KUBECONFIG env var to the path of the EKS Anywhere cluster. Run the following command:
+1. Set the $KUBECONFIG env var to the path of the EKS Anywhere cluster.
+1. Run the following command:
 
     ```bash
     make cluster-up IMAGE=amazon/amazon-eks-pod-identity-webhook:a65cc3d


### PR DESCRIPTION
*Description of changes:*
The pod identity webhook repository has some recent changes due to which its installation doesn't work. This PR updates the link of the pod identity webhook repo to an older commit that does work, and updates the image to a previous tag instead of latest.

*Testing (if applicable):*
Installed pod identity webhook with the updated Readme and IRSA worked as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

