### PR TITLE
Skip eks-a packages helm chart

### DIFF
--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -145,7 +145,9 @@ func (vb *VersionsBundle) Images() []Image {
 
 func (vb *VersionsBundle) Charts() map[string]*Image {
 	return map[string]*Image{
-		"cilium":                &vb.Cilium.HelmChart,
-		"eks-anywhere-packages": &vb.PackageController.HelmChart,
+		"cilium": &vb.Cilium.HelmChart,
+		// Temporarily disabling this chart until we fix the error
+		// when pushing it to harbor
+		//"eks-anywhere-packages": &vb.PackageController.HelmChart,
 	}
 }


### PR DESCRIPTION
Temporarily disabling this chart until we fix the error when pushing it
to an external registry.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

