### PR TITLE
Make artifacts download tests more robust

### DIFF
--- a/cmd/eksctl-anywhere/cmd/internal/commands/artifacts/download.go
+++ b/cmd/eksctl-anywhere/cmd/internal/commands/artifacts/download.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aws/eks-anywhere/pkg/bundles"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/version"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -14,6 +13,7 @@ import (
 type Reader interface {
 	ReadBundlesForVersion(eksaVersion string) (*releasev1.Bundles, error)
 	ReadImagesFromBundles(bundles *releasev1.Bundles) ([]releasev1.Image, error)
+	ReadChartsFromBundles(bundles *releasev1.Bundles) []releasev1.Image
 }
 
 type ImageMover interface {
@@ -62,7 +62,7 @@ func (d Download) Run(ctx context.Context) error {
 		return err
 	}
 
-	charts := bundles.Charts(b)
+	charts := d.Reader.ReadChartsFromBundles(b)
 
 	if err := d.ChartDownloader.Download(ctx, artifactNames(charts)...); err != nil {
 		return err

--- a/cmd/eksctl-anywhere/cmd/internal/commands/artifacts/mocks/download.go
+++ b/cmd/eksctl-anywhere/cmd/internal/commands/artifacts/mocks/download.go
@@ -50,6 +50,20 @@ func (mr *MockReaderMockRecorder) ReadBundlesForVersion(eksaVersion interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadBundlesForVersion", reflect.TypeOf((*MockReader)(nil).ReadBundlesForVersion), eksaVersion)
 }
 
+// ReadChartsFromBundles mocks base method.
+func (m *MockReader) ReadChartsFromBundles(bundles *v1alpha1.Bundles) []v1alpha1.Image {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadChartsFromBundles", bundles)
+	ret0, _ := ret[0].([]v1alpha1.Image)
+	return ret0
+}
+
+// ReadChartsFromBundles indicates an expected call of ReadChartsFromBundles.
+func (mr *MockReaderMockRecorder) ReadChartsFromBundles(bundles interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadChartsFromBundles", reflect.TypeOf((*MockReader)(nil).ReadChartsFromBundles), bundles)
+}
+
 // ReadImagesFromBundles mocks base method.
 func (m *MockReader) ReadImagesFromBundles(bundles *v1alpha1.Bundles) ([]v1alpha1.Image, error) {
 	m.ctrl.T.Helper()

--- a/pkg/manifests/reader.go
+++ b/pkg/manifests/reader.go
@@ -91,3 +91,7 @@ func (r *Reader) ReadCharts(eksaVersion string) ([]releasev1.Image, error) {
 
 	return bundles.Charts(bundle), nil
 }
+
+func (r *Reader) ReadChartsFromBundles(b *releasev1.Bundles) []releasev1.Image {
+	return bundles.Charts(b)
+}


### PR DESCRIPTION
## Description of changes
Before this change, the code was depending on bundles.Charts, which calls
Bundles.Charts, which return a map. This is made the order non
predictable, hence making any tests depending on it, flaky.

This change has the added benefit that it makes the tests independent
from the number of charts stored in the bundles manifest. Hence we can
keep adding more info in the VersionsBundle without having to update
unrelated unit tests every time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

