### PR TITLE
skip machine power validation when skipping power actions

### DIFF
--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -394,8 +394,12 @@ func (p *tinkerbellProvider) SetupAndValidateCreateCluster(ctx context.Context, 
 		if err := p.scrubWorkflowsFromTinkerbell(ctx, p.validator.hardwareConfig.Hardwares, hardware); err != nil {
 			return err
 		}
-	} else if err := p.validator.ValidateMachinesPoweredOff(ctx); err != nil {
-		return fmt.Errorf("validating machines are powered off: %w", err)
+	} else {
+		if !p.skipPowerActions {
+			if err := p.validator.ValidateMachinesPoweredOff(ctx); err != nil {
+				return fmt.Errorf("validating machines are powered off: %w", err)
+			}
+		}
 	}
 
 	if err := p.validator.ValidateTinkerbellConfig(ctx, tinkerbellClusterSpec.datacenterConfig); err != nil {

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -394,11 +394,9 @@ func (p *tinkerbellProvider) SetupAndValidateCreateCluster(ctx context.Context, 
 		if err := p.scrubWorkflowsFromTinkerbell(ctx, p.validator.hardwareConfig.Hardwares, hardware); err != nil {
 			return err
 		}
-	} else {
-		if !p.skipPowerActions {
-			if err := p.validator.ValidateMachinesPoweredOff(ctx); err != nil {
-				return fmt.Errorf("validating machines are powered off: %w", err)
-			}
+	} else if !p.skipPowerActions {
+		if err := p.validator.ValidateMachinesPoweredOff(ctx); err != nil {
+			return fmt.Errorf("validating machines are powered off: %w", err)
 		}
 	}
 


### PR DESCRIPTION
skip machine power validation when skipping power actions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

