### PR TITLE
Avoid race concition in docker concurrent tests

### DIFF
--- a/pkg/docker/registry_test.go
+++ b/pkg/docker/registry_test.go
@@ -40,6 +40,8 @@ func TestNewRegistryDestinationErrorTag(t *testing.T) {
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
 	client.EXPECT().TagImage(test.AContext(), images[0], registry).Return(errors.New("error tagging"))
+	client.EXPECT().TagImage(test.AContext(), images[1], registry).MaxTimes(1)
+	client.EXPECT().PushImage(test.AContext(), images[1], registry).MaxTimes(1)
 
 	g.Expect(dstLoader.Write(ctx, images...)).To(MatchError(ContainSubstring("error tagging")))
 }
@@ -55,6 +57,8 @@ func TestNewRegistryDestinationErrorPush(t *testing.T) {
 	dstLoader := docker.NewRegistryDestination(client, registry)
 	client.EXPECT().TagImage(test.AContext(), images[0], registry)
 	client.EXPECT().PushImage(test.AContext(), images[0], registry).Return(errors.New("error pushing"))
+	client.EXPECT().TagImage(test.AContext(), images[1], registry).MaxTimes(1)
+	client.EXPECT().PushImage(test.AContext(), images[1], registry).MaxTimes(1)
 
 	g.Expect(dstLoader.Write(ctx, images...)).To(MatchError(ContainSubstring("error pushing")))
 }
@@ -83,6 +87,7 @@ func TestOriginalRegistrySourceError(t *testing.T) {
 	ctx := context.Background()
 	dstLoader := docker.NewOriginalRegistrySource(client)
 	client.EXPECT().PullImage(test.AContext(), images[0]).Return(errors.New("error pulling"))
+	client.EXPECT().PullImage(test.AContext(), images[1]).MaxTimes(1)
 
 	g.Expect(dstLoader.Load(ctx, images...)).To(MatchError(ContainSubstring("error pulling")))
 }


### PR DESCRIPTION
*Description of changes:*
Before this change, the processing of the second image could be
triggered before the error from the second one was returned. This would
trigger a panic (since there was no expectation set for such calls in
the mock). The panic would kill the routine without reducing the counter
in the wait group, effectively creating a deadlock.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

