### PR TITLE
Add support for extraPortMappings in Kind

### DIFF
--- a/pkg/executables/config/kind.yaml
+++ b/pkg/executables/config/kind.yaml
@@ -45,3 +45,12 @@ nodes:
     - hostPath: /var/run/docker.sock
       containerPath: /var/run/docker.sock
 {{- end }}
+{{- if ne (len .ExtraPortMappings) 0 }}
+nodes:
+- role: control-plane
+  extraPortMappings:
+{{- range .ExtraPortMappings }}
+  - containerPort: {{ . }}
+    hostPort: {{ . }}
+{{- end }}
+{{- end }}

--- a/pkg/executables/kind.go
+++ b/pkg/executables/kind.go
@@ -48,6 +48,7 @@ type kindExecConfig struct {
 	KubernetesVersion      string
 	RegistryMirrorEndpoint string
 	RegistryCACertPath     string
+	ExtraPortMappings      []int
 	DockerExtraMounts      bool
 	DisableDefaultCNI      bool
 }
@@ -130,6 +131,22 @@ func (k *Kind) WithExtraDockerMounts() bootstrapper.BootstrapClusterClientOption
 		}
 
 		k.execConfig.DockerExtraMounts = true
+		return nil
+	}
+}
+
+func (k *Kind) WithExtraPortMappings(ports []int) bootstrapper.BootstrapClusterClientOption {
+	return func() error {
+		if k.execConfig == nil {
+			return errors.New("kind exec config is not ready")
+		}
+
+		if len(ports) == 0 {
+			return errors.New("no ports found in the list")
+		}
+
+		k.execConfig.ExtraPortMappings = ports
+
 		return nil
 	}
 }

--- a/pkg/executables/kind_test.go
+++ b/pkg/executables/kind_test.go
@@ -90,6 +90,18 @@ func TestKindCreateBootstrapClusterSuccess(t *testing.T) {
 			registryMirrorTest: false,
 		},
 		{
+			name:           "With extra port mappings option",
+			wantKubeconfig: kubeConfigFile,
+			options: []testKindOption{
+				func(k *executables.Kind) bootstrapper.BootstrapClusterClientOption {
+					return k.WithExtraPortMappings([]int{80, 443})
+				},
+			},
+			env:                map[string]string{},
+			wantKindConfig:     "testdata/kind_config_extra_port_mappings.yaml",
+			registryMirrorTest: false,
+		},
+		{
 			name:           "With docker option and disable CNI option",
 			wantKubeconfig: kubeConfigFile,
 			options: []testKindOption{

--- a/pkg/executables/testdata/kind_config_extra_port_mappings.yaml
+++ b/pkg/executables/testdata/kind_config_extra_port_mappings.yaml
@@ -1,0 +1,23 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: ClusterConfiguration
+    dns:
+      type: CoreDNS
+      imageRepository: public.ecr.aws/eks-distro/coredns
+      imageTag: v1.8.0-eks-1-19-2
+    etcd:
+      local:
+        imageRepository: public.ecr.aws/eks-distro/etcd-io
+        imageTag: v3.4.14-eks-1-19-2
+    imageRepository: public.ecr.aws/eks-distro/kubernetes
+    kubernetesVersion: v1.19.6-eks-1-19-2
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+  - containerPort: 443
+    hostPort: 443


### PR DESCRIPTION
*Description of changes:*
Adding support for extraPortMappings in Kind. This is needed for Tinkerbell provider

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

