### PR TITLE
Use default ssh key if already exists in snow devices

### DIFF
--- a/pkg/providers/snow/aws.go
+++ b/pkg/providers/snow/aws.go
@@ -7,8 +7,8 @@ import (
 )
 
 type AwsClient interface {
-	EC2KeyNameExists(ctx context.Context, imageID string) (bool, error)
-	EC2ImageExists(ctx context.Context, keyName string) (bool, error)
+	EC2ImageExists(ctx context.Context, imageID string) (bool, error)
+	EC2KeyNameExists(ctx context.Context, keyName string) (bool, error)
 	EC2ImportKeyPair(ctx context.Context, keyName string, keyMaterial []byte) error
 }
 

--- a/pkg/providers/snow/defaults_test.go
+++ b/pkg/providers/snow/defaults_test.go
@@ -26,8 +26,8 @@ func TestSetDefaultSshKeyExistsOnAllDevices(t *testing.T) {
 	g.machineConfig.Spec.SshKeyName = ""
 	g.aws.EXPECT().EC2KeyNameExists(g.ctx, "eksa-default").Return(true, nil).Times(2)
 	err := g.machineConfigDefaulters.SetupDefaultSshKey(g.ctx, g.machineConfig)
-	g.Expect(err).To(Succeed())
 	g.Expect(g.machineConfig.Spec.SshKeyName).To(Equal("eksa-default"))
+	g.Expect(err).To(Succeed())
 }
 
 func TestSetDefaultSshKeyExistsOnPartialDevices(t *testing.T) {

--- a/pkg/providers/snow/defaults_test.go
+++ b/pkg/providers/snow/defaults_test.go
@@ -15,9 +15,28 @@ func TestSetDefaultSshKey(t *testing.T) {
 	g := newConfigManagerTest(t)
 	g.machineConfig.Spec.SshKeyName = ""
 	g.keyGenerator.EXPECT().GenerateSSHAuthKey(g.writer).Return(sshKey, nil)
+	g.aws.EXPECT().EC2KeyNameExists(g.ctx, "eksa-default").Return(false, nil).Times(2)
 	g.aws.EXPECT().EC2ImportKeyPair(g.ctx, "eksa-default", []byte(sshKey)).Return(nil).Times(2)
 	err := g.machineConfigDefaulters.SetupDefaultSshKey(g.ctx, g.machineConfig)
 	g.Expect(err).To(Succeed())
+}
+
+func TestSetDefaultSshKeyExistsOnAllDevices(t *testing.T) {
+	g := newConfigManagerTest(t)
+	g.machineConfig.Spec.SshKeyName = ""
+	g.aws.EXPECT().EC2KeyNameExists(g.ctx, "eksa-default").Return(true, nil).Times(2)
+	err := g.machineConfigDefaulters.SetupDefaultSshKey(g.ctx, g.machineConfig)
+	g.Expect(err).To(Succeed())
+	g.Expect(g.machineConfig.Spec.SshKeyName).To(Equal("eksa-default"))
+}
+
+func TestSetDefaultSshKeyExistsOnPartialDevices(t *testing.T) {
+	g := newConfigManagerTest(t)
+	g.machineConfig.Spec.SshKeyName = ""
+	g.aws.EXPECT().EC2KeyNameExists(g.ctx, "eksa-default").Return(true, nil)
+	g.aws.EXPECT().EC2KeyNameExists(g.ctx, "eksa-default").Return(false, nil)
+	err := g.machineConfigDefaulters.SetupDefaultSshKey(g.ctx, g.machineConfig)
+	g.Expect(err).To((MatchError(ContainSubstring("default key [keyName=eksa-default] only exists on some of the devices"))))
 }
 
 func TestSetDefaultSshKeySkip(t *testing.T) {
@@ -26,10 +45,11 @@ func TestSetDefaultSshKeySkip(t *testing.T) {
 	g.Expect(err).To(Succeed())
 }
 
-func TestSetDefaultSshKeyError(t *testing.T) {
+func TestSetDefaultSshKeyImportKeyError(t *testing.T) {
 	g := newConfigManagerTest(t)
 	g.machineConfig.Spec.SshKeyName = ""
 	g.keyGenerator.EXPECT().GenerateSSHAuthKey(g.writer).Return(sshKey, nil)
+	g.aws.EXPECT().EC2KeyNameExists(g.ctx, "eksa-default").Return(false, nil).Times(2)
 	g.aws.EXPECT().EC2ImportKeyPair(g.ctx, "eksa-default", []byte(sshKey)).Return(errors.New("error"))
 	err := g.machineConfigDefaulters.SetupDefaultSshKey(g.ctx, g.machineConfig)
 	g.Expect(err).NotTo(Succeed())

--- a/pkg/providers/snow/mocks/aws.go
+++ b/pkg/providers/snow/mocks/aws.go
@@ -35,18 +35,18 @@ func (m *MockAwsClient) EXPECT() *MockAwsClientMockRecorder {
 }
 
 // EC2ImageExists mocks base method.
-func (m *MockAwsClient) EC2ImageExists(ctx context.Context, keyName string) (bool, error) {
+func (m *MockAwsClient) EC2ImageExists(ctx context.Context, imageID string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EC2ImageExists", ctx, keyName)
+	ret := m.ctrl.Call(m, "EC2ImageExists", ctx, imageID)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EC2ImageExists indicates an expected call of EC2ImageExists.
-func (mr *MockAwsClientMockRecorder) EC2ImageExists(ctx, keyName interface{}) *gomock.Call {
+func (mr *MockAwsClientMockRecorder) EC2ImageExists(ctx, imageID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EC2ImageExists", reflect.TypeOf((*MockAwsClient)(nil).EC2ImageExists), ctx, keyName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EC2ImageExists", reflect.TypeOf((*MockAwsClient)(nil).EC2ImageExists), ctx, imageID)
 }
 
 // EC2ImportKeyPair mocks base method.
@@ -64,16 +64,16 @@ func (mr *MockAwsClientMockRecorder) EC2ImportKeyPair(ctx, keyName, keyMaterial 
 }
 
 // EC2KeyNameExists mocks base method.
-func (m *MockAwsClient) EC2KeyNameExists(ctx context.Context, imageID string) (bool, error) {
+func (m *MockAwsClient) EC2KeyNameExists(ctx context.Context, keyName string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EC2KeyNameExists", ctx, imageID)
+	ret := m.ctrl.Call(m, "EC2KeyNameExists", ctx, keyName)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EC2KeyNameExists indicates an expected call of EC2KeyNameExists.
-func (mr *MockAwsClientMockRecorder) EC2KeyNameExists(ctx, imageID interface{}) *gomock.Call {
+func (mr *MockAwsClientMockRecorder) EC2KeyNameExists(ctx, keyName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EC2KeyNameExists", reflect.TypeOf((*MockAwsClient)(nil).EC2KeyNameExists), ctx, imageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EC2KeyNameExists", reflect.TypeOf((*MockAwsClient)(nil).EC2KeyNameExists), ctx, keyName)
 }


### PR DESCRIPTION
*Issue #, if available:*

Currently we create a default ssh key with name `eksa-default` and import it to snow devices. 
There is a race. If multiple users create clusters in the same device set at the same time, eks-a creates default key for first cluster. The second cluster validation will fail at ec2 import-key-pair step because the key already exists in devices.

*Description of changes:*

Before creating default ssh key, we check if the key exists on devices first. If the key exists on all devices, we skip the key generation and only assign the key name to machine config.

*Testing (if applicable):*

- unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

