### PR TITLE
Use e2e test name as junit test suite name

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -150,7 +150,7 @@ func RunTests(conf instanceRunConf) (testInstanceID string, testCommandResult *t
 
 func (e *E2ESession) runTests(regex string) (testCommandResult *testCommandResult, err error) {
 	logger.V(1).Info("Running e2e tests", "regex", regex)
-	command := "GOVERSION=go1.16.6 gotestsum --junitfile=junit-testing.xml --raw-command --format=standard-verbose --hide-summary=all --ignore-non-json-output-lines -- test2json -t -p e2e ./bin/e2e.test -test.v"
+	command := fmt.Sprintf("GOVERSION=go1.16.6 gotestsum --junitfile=junit-testing.xml --junitfile-testsuite-name=%s --raw-command --format=standard-verbose --hide-summary=all --ignore-non-json-output-lines -- test2json -t -p e2e ./bin/e2e.test -test.v", regex)
 
 	if regex != "" {
 		command = fmt.Sprintf("%s -test.run %s", command, regex)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When a junit file is generated for a test, it just uses the package name `e2e` as the test suite name. This PR updates it to set the test suite name to the name of the e2e test (e.g. `TestVSphereKubernetes122UbuntuRegistryMirrorAndCert`). This will allow us to better parse the test results from this junit file.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

