### PR TITLE
Fixing cloudstack upgrade test

### DIFF
--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -347,6 +347,7 @@ func TestCloudStackKubernetes120RedhatTo121Upgrade(t *testing.T) {
 		provider,
 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 	)
 	runSimpleUpgradeFlow(
 		test,
@@ -368,6 +369,7 @@ func TestCloudStackKubernetes120RedhatTo121MultipleFieldsUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube121,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		provider.WithProviderUpgrade(
 			framework.UpdateRedhatTemplate121Var(),
 			framework.UpdateLargerCloudStackComputeOffering(),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When running the cloudstack Upgrade test as is, it fails immediately with error `Error: the cluster config file provided is invalid: control plane node count cannot be an even number`. This PR sets the control plane node count to an odd number for this test

*Testing (if applicable):*
E2e test passed locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

