### PR TITLE
Use `FluxConfig` internally instead of `GitOpsConfig`

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -133,7 +133,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		WithBootstrapper().
 		WithClusterManager(clusterSpec.Cluster).
 		WithProvider(cc.fileName, clusterSpec.Cluster, cc.skipIpCheck, cc.hardwareFileName, cc.skipPowerActions, cc.setupTinkerbell, cc.forceClean).
-		WithFluxAddonClient(ctx, clusterSpec.Cluster, clusterSpec.GitOpsConfig).
+		WithFluxAddonClient(ctx, clusterSpec.Cluster, clusterSpec.FluxConfig).
 		WithWriter().
 		Build(ctx)
 	if err != nil {

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -98,7 +98,7 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 		WithBootstrapper().
 		WithClusterManager(clusterSpec.Cluster).
 		WithProvider(dc.fileName, clusterSpec.Cluster, cc.skipIpCheck, dc.hardwareFileName, cc.skipPowerActions, cc.setupTinkerbell, false).
-		WithFluxAddonClient(ctx, clusterSpec.Cluster, clusterSpec.GitOpsConfig).
+		WithFluxAddonClient(ctx, clusterSpec.Cluster, clusterSpec.FluxConfig).
 		WithWriter().
 		Build(ctx)
 	if err != nil {

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -77,7 +77,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(ctx context.Context) error {
 		WithBootstrapper().
 		WithClusterManager(clusterSpec.Cluster).
 		WithProvider(uc.fileName, clusterSpec.Cluster, cc.skipIpCheck, uc.hardwareFileName, cc.skipPowerActions, cc.setupTinkerbell, uc.forceClean).
-		WithFluxAddonClient(ctx, clusterSpec.Cluster, clusterSpec.GitOpsConfig).
+		WithFluxAddonClient(ctx, clusterSpec.Cluster, clusterSpec.FluxConfig).
 		WithWriter().
 		WithCAPIManager().
 		WithKubectl().

--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -74,10 +74,11 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
 	deps, err := dependencies.ForSpec(ctx, newClusterSpec).
 		WithClusterManager(newClusterSpec.Cluster).
 		WithProvider(uc.fileName, newClusterSpec.Cluster, cc.skipIpCheck, uc.hardwareFileName, cc.skipPowerActions, cc.setupTinkerbell, uc.forceClean).
-		WithFluxAddonClient(ctx, newClusterSpec.Cluster, newClusterSpec.GitOpsConfig).
+		WithFluxAddonClient(ctx, newClusterSpec.Cluster, newClusterSpec.FluxConfig).
 		WithCAPIManager().
 		Build(ctx)
 	if err != nil {

--- a/pkg/addonmanager/addonclients/files.go
+++ b/pkg/addonmanager/addonclients/files.go
@@ -20,7 +20,7 @@ import (
 func (f *FluxAddonClient) UpdateLegacyFileStructure(ctx context.Context, currentSpec *cluster.Spec, newSpec *cluster.Spec) error {
 	logger.V(1).Info("Checking for Flux repo file structure...")
 
-	if newSpec.GitOpsConfig == nil {
+	if newSpec.FluxConfig == nil {
 		logger.V(1).Info("Skipping Flux repo file structure update, GitOps not enabled")
 		return nil
 	}

--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -106,16 +106,16 @@ func NewFluxAddonClient(flux Flux, gitOpts *GitOptions) *FluxAddonClient {
 // Flux is an interface that abstracts the basic commands of flux executable.
 type Flux interface {
 	// BootstrapToolkitsComponents bootstraps toolkit components in a GitHub repository.
-	BootstrapToolkitsComponents(ctx context.Context, cluster *types.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) error
+	BootstrapToolkitsComponents(ctx context.Context, cluster *types.Cluster, fluxConfig *v1alpha1.FluxConfig) error
 
 	// UninstallToolkitsComponents UninstallFluxComponents removes the Flux components and the toolkit.fluxcd.io resources from the cluster.
-	UninstallToolkitsComponents(ctx context.Context, cluster *types.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) error
+	UninstallToolkitsComponents(ctx context.Context, cluster *types.Cluster, fluxConfig *v1alpha1.FluxConfig) error
 
 	// PauseKustomization pauses reconciliation of Kustomization
-	PauseKustomization(ctx context.Context, cluster *types.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) error
+	PauseKustomization(ctx context.Context, cluster *types.Cluster, fluxConfig *v1alpha1.FluxConfig) error
 
 	// ResumeKustomization resumes a paused Kustomization
-	ResumeKustomization(ctx context.Context, cluster *types.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) error
+	ResumeKustomization(ctx context.Context, cluster *types.Cluster, fluxConfig *v1alpha1.FluxConfig) error
 
 	// ForceReconcileGitRepo sync git repo with latest commit
 	ForceReconcileGitRepo(ctx context.Context, cluster *types.Cluster, namespace string) error
@@ -124,7 +124,7 @@ type Flux interface {
 	DeleteFluxSystemSecret(ctx context.Context, cluster *types.Cluster, namespace string) error
 
 	// Reconcile reconciles sources and resources
-	Reconcile(ctx context.Context, cluster *types.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) error
+	Reconcile(ctx context.Context, cluster *types.Cluster, fluxConfig *v1alpha1.FluxConfig) error
 }
 
 func (f *FluxAddonClient) SetRetier(retrier *retrier.Retrier) {
@@ -141,7 +141,7 @@ func (f *FluxAddonClient) ForceReconcileGitRepo(ctx context.Context, cluster *ty
 		clusterSpec:     clusterSpec,
 	}
 
-	return f.flux.ForceReconcileGitRepo(ctx, cluster, fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace)
+	return f.flux.ForceReconcileGitRepo(ctx, cluster, fc.clusterSpec.FluxConfig.Spec.SystemNamespace)
 }
 
 // InstallGitOps validates and sets up the gitops/flux config, creates a repository if one doesn’t exist,
@@ -166,7 +166,7 @@ func (f *FluxAddonClient) InstallGitOps(ctx context.Context, cluster *types.Clus
 
 	if !cluster.ExistingManagement {
 		err := f.retrier.Retry(func() error {
-			return fc.flux.BootstrapToolkitsComponents(ctx, cluster, clusterSpec.GitOpsConfig)
+			return fc.flux.BootstrapToolkitsComponents(ctx, cluster, clusterSpec.FluxConfig)
 		})
 		if err != nil {
 			uninstallErr := f.uninstallGitOpsToolkits(ctx, cluster, clusterSpec)
@@ -197,7 +197,7 @@ func (f *FluxAddonClient) uninstallGitOpsToolkits(ctx context.Context, cluster *
 	}
 
 	return f.retrier.Retry(func() error {
-		return fc.flux.UninstallToolkitsComponents(ctx, cluster, clusterSpec.GitOpsConfig)
+		return fc.flux.UninstallToolkitsComponents(ctx, cluster, clusterSpec.FluxConfig)
 	})
 }
 
@@ -215,7 +215,7 @@ func (f *FluxAddonClient) PauseGitOpsKustomization(ctx context.Context, cluster 
 	logger.V(3).Info("pause reconciliation of all Kustomization", "namespace", fc.namespace())
 
 	return f.retrier.Retry(func() error {
-		return fc.flux.PauseKustomization(ctx, cluster, clusterSpec.GitOpsConfig)
+		return fc.flux.PauseKustomization(ctx, cluster, clusterSpec.FluxConfig)
 	})
 }
 
@@ -232,7 +232,7 @@ func (f *FluxAddonClient) ResumeGitOpsKustomization(ctx context.Context, cluster
 
 	logger.V(3).Info("resume reconciliation of all Kustomization", "namespace", fc.namespace())
 	return f.retrier.Retry(func() error {
-		return fc.flux.ResumeKustomization(ctx, cluster, clusterSpec.GitOpsConfig)
+		return fc.flux.ResumeKustomization(ctx, cluster, clusterSpec.FluxConfig)
 	})
 }
 
@@ -362,8 +362,8 @@ type fluxForCluster struct {
 // These will later be used by Flux and our controllers to reconcile the repository contents and the cluster configuration.
 func (fc *fluxForCluster) commitFluxAndClusterConfigToGit(ctx context.Context) error {
 	logger.Info("Adding cluster configuration files to Git")
-	config := fc.clusterSpec.GitOpsConfig
-	repository := config.Spec.Flux.Github.Repository
+	config := fc.clusterSpec.FluxConfig
+	repository := config.Spec.Github.Repository
 
 	if err := fc.setupRepository(ctx); err != nil {
 		return err
@@ -390,7 +390,7 @@ func (fc *fluxForCluster) commitFluxAndClusterConfigToGit(ctx context.Context) e
 	} else {
 		logger.V(3).Info("Skipping flux custom manifest files")
 	}
-	p := path.Dir(config.Spec.Flux.Github.ClusterConfigPath)
+	p := path.Dir(config.Spec.ClusterConfigPath)
 	err = fc.gitOpts.Git.Add(p)
 	if err != nil {
 		return &ConfigVersionControlFailedError{Err: fmt.Errorf("adding %s to git: %v", p, err)}
@@ -664,27 +664,27 @@ func (fc *fluxForCluster) validateRemoteConfigPathDoesNotExist(ctx context.Conte
 }
 
 func (fc *fluxForCluster) namespace() string {
-	return fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace
+	return fc.clusterSpec.FluxConfig.Spec.SystemNamespace
 }
 
 func (fc *fluxForCluster) repository() string {
-	return fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository
+	return fc.clusterSpec.FluxConfig.Spec.Github.Repository
 }
 
 func (fc *fluxForCluster) owner() string {
-	return fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.Owner
+	return fc.clusterSpec.FluxConfig.Spec.Github.Owner
 }
 
 func (fc *fluxForCluster) branch() string {
-	return fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch
+	return fc.clusterSpec.FluxConfig.Spec.Branch
 }
 
 func (fc *fluxForCluster) personal() bool {
-	return fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.Personal
+	return fc.clusterSpec.FluxConfig.Spec.Github.Personal
 }
 
 func (fc *fluxForCluster) path() string {
-	return fc.clusterSpec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath
+	return fc.clusterSpec.FluxConfig.Spec.ClusterConfigPath
 }
 
 type ConfigVersionControlFailedError struct {

--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -63,11 +63,11 @@ type GitOptions struct {
 	Writer filewriter.FileWriter
 }
 
-func NewGitOptions(ctx context.Context, cluster *v1alpha1.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig, writer filewriter.FileWriter) (*GitOptions, error) {
-	if gitOpsConfig == nil {
+func NewGitOptions(ctx context.Context, cluster *v1alpha1.Cluster, fluxConfig *v1alpha1.FluxConfig, writer filewriter.FileWriter) (*GitOptions, error) {
+	if fluxConfig == nil {
 		return nil, nil
 	}
-	localGitRepoPath := filepath.Join(cluster.Name, "git", gitOpsConfig.Spec.Flux.Github.Repository)
+	localGitRepoPath := filepath.Join(cluster.Name, "git", fluxConfig.Spec.Github.Repository)
 	gogitOptions := gogit.Options{
 		RepositoryDirectory: localGitRepoPath,
 	}
@@ -75,7 +75,7 @@ func NewGitOptions(ctx context.Context, cluster *v1alpha1.Cluster, gitOpsConfig 
 
 	gitProviderFactoryOptions := gitFactory.Options{GithubGitClient: goGit}
 	gitProviderFactory := gitFactory.New(gitProviderFactoryOptions)
-	gitProvider, err := gitProviderFactory.BuildProvider(ctx, &gitOpsConfig.Spec)
+	gitProvider, err := gitProviderFactory.BuildProvider(ctx, &fluxConfig.Spec)
 	if err != nil {
 		return nil, fmt.Errorf("creating Git provider: %v", err)
 	}
@@ -83,7 +83,7 @@ func NewGitOptions(ctx context.Context, cluster *v1alpha1.Cluster, gitOpsConfig 
 	if err != nil {
 		return nil, err
 	}
-	localGitWriterPath := filepath.Join("git", gitOpsConfig.Spec.Flux.Github.Repository)
+	localGitWriterPath := filepath.Join("git", fluxConfig.Spec.Github.Repository)
 	gitwriter, err := writer.WithDir(localGitWriterPath)
 	if err != nil {
 		return nil, fmt.Errorf("creating file writer: %v", err)

--- a/pkg/addonmanager/addonclients/fluxaddonclient_test.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient_test.go
@@ -88,15 +88,15 @@ func TestFluxAddonClientInstallGitOpsOnManagementClusterWithPrexistingRepo(t *te
 			f, m, g := newAddonClient(t)
 			clusterSpec := newClusterSpec(t, clusterConfig, tt.fluxpath)
 
-			m.flux.EXPECT().BootstrapToolkitsComponents(ctx, cluster, clusterSpec.GitOpsConfig)
+			m.flux.EXPECT().BootstrapToolkitsComponents(ctx, cluster, clusterSpec.FluxConfig)
 
-			m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
+			m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.FluxConfig.Spec.Github.Repository}, nil)
 			m.git.EXPECT().Clone(ctx).Return(nil)
-			m.git.EXPECT().Branch(clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
+			m.git.EXPECT().Branch(clusterSpec.FluxConfig.Spec.Branch).Return(nil)
 			m.git.EXPECT().Add(path.Dir(tt.expectedClusterConfigGitPath)).Return(nil)
 			m.git.EXPECT().Commit(test.OfType("string")).Return(nil)
 			m.git.EXPECT().Push(ctx).Return(nil)
-			m.git.EXPECT().Pull(ctx, clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
+			m.git.EXPECT().Pull(ctx, clusterSpec.FluxConfig.Spec.Branch).Return(nil)
 
 			datacenterConfig := datacenterConfig(tt.clusterName)
 			machineConfig := machineConfig(tt.clusterName)
@@ -129,15 +129,15 @@ func TestFluxAddonClientInstallGitOpsOnWorkloadClusterWithPrexistingRepo(t *test
 	f, m, g := newAddonClient(t)
 	clusterSpec := newClusterSpec(t, clusterConfig, "")
 
-	m.flux.EXPECT().BootstrapToolkitsComponents(ctx, cluster, clusterSpec.GitOpsConfig)
+	m.flux.EXPECT().BootstrapToolkitsComponents(ctx, cluster, clusterSpec.FluxConfig)
 
-	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
+	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.FluxConfig.Spec.Github.Repository}, nil)
 	m.git.EXPECT().Clone(ctx).Return(nil)
-	m.git.EXPECT().Branch(clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
+	m.git.EXPECT().Branch(clusterSpec.FluxConfig.Spec.Branch).Return(nil)
 	m.git.EXPECT().Add(path.Dir("clusters/management-cluster")).Return(nil)
 	m.git.EXPECT().Commit(test.OfType("string")).Return(nil)
 	m.git.EXPECT().Push(ctx).Return(nil)
-	m.git.EXPECT().Pull(ctx, clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
+	m.git.EXPECT().Pull(ctx, clusterSpec.FluxConfig.Spec.Branch).Return(nil)
 
 	datacenterConfig := datacenterConfig(clusterName)
 	machineConfig := machineConfig(clusterName)
@@ -214,18 +214,18 @@ func TestFluxAddonClientInstallGitOpsNoPrexistingRepo(t *testing.T) {
 			f, m, g := newAddonClient(t)
 			clusterSpec := newClusterSpec(t, clusterConfig, tt.fluxpath)
 
-			m.flux.EXPECT().BootstrapToolkitsComponents(ctx, cluster, clusterSpec.GitOpsConfig)
+			m.flux.EXPECT().BootstrapToolkitsComponents(ctx, cluster, clusterSpec.FluxConfig)
 
-			n := clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository
-			o := clusterSpec.GitOpsConfig.Spec.Flux.Github.Owner
-			p := clusterSpec.GitOpsConfig.Spec.Flux.Github.Personal
-			b := clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch
+			n := clusterSpec.FluxConfig.Spec.Github.Repository
+			o := clusterSpec.FluxConfig.Spec.Github.Owner
+			p := clusterSpec.FluxConfig.Spec.Github.Personal
+			b := clusterSpec.FluxConfig.Spec.Branch
 			d := "EKS-A cluster configuration repository"
 			createRepoOpts := git.CreateRepoOpts{Name: n, Owner: o, Description: d, Personal: p, Privacy: true}
 
 			returnRepo := git.Repository{
-				Name:         clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository,
-				Owner:        clusterSpec.GitOpsConfig.Spec.Flux.Github.Owner,
+				Name:         clusterSpec.FluxConfig.Spec.Github.Repository,
+				Owner:        clusterSpec.FluxConfig.Spec.Github.Owner,
 				Organization: "",
 				CloneUrl:     fmt.Sprintf("https://github.com/%s/%s.git", o, n),
 			}
@@ -297,17 +297,17 @@ func TestFluxAddonClientInstallGitOpsToolkitsBareRepo(t *testing.T) {
 			f, m, g := newAddonClient(t)
 			clusterSpec := newClusterSpec(t, clusterConfig, tt.fluxpath)
 
-			m.flux.EXPECT().BootstrapToolkitsComponents(ctx, cluster, clusterSpec.GitOpsConfig)
+			m.flux.EXPECT().BootstrapToolkitsComponents(ctx, cluster, clusterSpec.FluxConfig)
 
-			m.git.EXPECT().GetRepo(ctx).MaxTimes(2).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
+			m.git.EXPECT().GetRepo(ctx).MaxTimes(2).Return(&git.Repository{Name: clusterSpec.FluxConfig.Spec.Github.Repository}, nil)
 			m.git.EXPECT().Clone(ctx).MaxTimes(2).Return(&git.RepositoryIsEmptyError{Repository: "testRepo"})
 			m.git.EXPECT().Init().Return(nil)
 			m.git.EXPECT().Commit(gomock.Any()).Return(nil)
-			m.git.EXPECT().Branch(clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
+			m.git.EXPECT().Branch(clusterSpec.FluxConfig.Spec.Branch).Return(nil)
 			m.git.EXPECT().Add(path.Dir(tt.expectedClusterConfigGitPath)).Return(nil)
 			m.git.EXPECT().Commit(test.OfType("string")).Return(nil)
 			m.git.EXPECT().Push(ctx).Return(nil)
-			m.git.EXPECT().Pull(ctx, clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
+			m.git.EXPECT().Pull(ctx, clusterSpec.FluxConfig.Spec.Branch).Return(nil)
 
 			datacenterConfig := datacenterConfig(tt.clusterName)
 			machineConfig := machineConfig(tt.clusterName)
@@ -337,7 +337,7 @@ func TestFluxAddonClientPauseKustomization(t *testing.T) {
 	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
-	m.flux.EXPECT().PauseKustomization(ctx, cluster, clusterSpec.GitOpsConfig)
+	m.flux.EXPECT().PauseKustomization(ctx, cluster, clusterSpec.FluxConfig)
 
 	err := f.PauseGitOpsKustomization(ctx, cluster, clusterSpec)
 	if err != nil {
@@ -353,7 +353,7 @@ func TestFluxAddonClientResumeKustomization(t *testing.T) {
 	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
-	m.flux.EXPECT().ResumeKustomization(ctx, cluster, clusterSpec.GitOpsConfig)
+	m.flux.EXPECT().ResumeKustomization(ctx, cluster, clusterSpec.FluxConfig)
 
 	err := f.ResumeGitOpsKustomization(ctx, cluster, clusterSpec)
 	if err != nil {
@@ -369,9 +369,9 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecLocalRepoNotExists(t *testing.T) {
 	f, m, g := newAddonClient(t)
 	clusterSpec := newClusterSpec(t, clusterConfig, "")
 
-	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
+	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.FluxConfig.Spec.Github.Repository}, nil)
 	m.git.EXPECT().Clone(ctx).Return(nil)
-	m.git.EXPECT().Branch(clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
+	m.git.EXPECT().Branch(clusterSpec.FluxConfig.Spec.Branch).Return(nil)
 	m.git.EXPECT().Add(eksaSystemDirPath).Return(nil)
 	m.git.EXPECT().Commit(test.OfType("string")).Return(nil)
 	m.git.EXPECT().Push(ctx).Return(nil)
@@ -396,7 +396,7 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecLocalRepoExists(t *testing.T) {
 	flux := addonClientMocks.NewMockFlux(mockCtrl)
 
 	gitProvider := gitMocks.NewMockProvider(mockCtrl)
-	gitProvider.EXPECT().Branch(clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
+	gitProvider.EXPECT().Branch(clusterSpec.FluxConfig.Spec.Branch).Return(nil)
 	gitProvider.EXPECT().Add(eksaSystemDirPath).Return(nil)
 	gitProvider.EXPECT().Commit(test.OfType("string")).Return(nil)
 	gitProvider.EXPECT().Push(ctx).Return(nil)
@@ -442,7 +442,7 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecErrorCloneRepo(t *testing.T) {
 	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
-	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
+	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.FluxConfig.Spec.Github.Repository}, nil)
 	m.git.EXPECT().Clone(ctx).MaxTimes(2).Return(errors.New("failed to clone repo"))
 
 	datacenterConfig := datacenterConfig(clusterName)
@@ -460,9 +460,9 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecErrorSwitchBranch(t *testing.T) {
 	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
-	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
+	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.FluxConfig.Spec.Github.Repository}, nil)
 	m.git.EXPECT().Clone(ctx).Return(nil)
-	m.git.EXPECT().Branch(clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(errors.New("failed to switch branch"))
+	m.git.EXPECT().Branch(clusterSpec.FluxConfig.Spec.Branch).Return(errors.New("failed to switch branch"))
 
 	datacenterConfig := datacenterConfig(clusterName)
 	machineConfig := machineConfig(clusterName)
@@ -479,9 +479,9 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecErrorAddFile(t *testing.T) {
 	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
-	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
+	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.FluxConfig.Spec.Github.Repository}, nil)
 	m.git.EXPECT().Clone(ctx).Return(nil)
-	m.git.EXPECT().Branch(clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
+	m.git.EXPECT().Branch(clusterSpec.FluxConfig.Spec.Branch).Return(nil)
 	m.git.EXPECT().Add("clusters/management-cluster/management-cluster/eksa-system").Return(errors.New("failed to add file"))
 
 	datacenterConfig := datacenterConfig(clusterName)
@@ -499,9 +499,9 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecErrorCommit(t *testing.T) {
 	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
-	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
+	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.FluxConfig.Spec.Github.Repository}, nil)
 	m.git.EXPECT().Clone(ctx).Return(nil)
-	m.git.EXPECT().Branch(clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
+	m.git.EXPECT().Branch(clusterSpec.FluxConfig.Spec.Branch).Return(nil)
 	m.git.EXPECT().Add("clusters/management-cluster/management-cluster/eksa-system").Return(nil)
 	m.git.EXPECT().Commit(test.OfType("string")).Return(errors.New("failed to commit"))
 
@@ -520,9 +520,9 @@ func TestFluxAddonClientUpdateGitRepoEksaSpecErrorPushAfterRetry(t *testing.T) {
 	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
-	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
+	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.FluxConfig.Spec.Github.Repository}, nil)
 	m.git.EXPECT().Clone(ctx).Return(nil)
-	m.git.EXPECT().Branch(clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
+	m.git.EXPECT().Branch(clusterSpec.FluxConfig.Spec.Branch).Return(nil)
 	m.git.EXPECT().Add("clusters/management-cluster/management-cluster/eksa-system").Return(nil)
 	m.git.EXPECT().Commit(test.OfType("string")).Return(nil)
 	m.git.EXPECT().Push(ctx).MaxTimes(2).Return(errors.New("failed to push code"))
@@ -573,9 +573,9 @@ func TestFluxAddonClientCleanupGitRepo(t *testing.T) {
 	clusterSpec := newClusterSpec(t, clusterConfig, "")
 
 	gitProvider := gitMocks.NewMockProvider(mockCtrl)
-	gitProvider.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
+	gitProvider.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.FluxConfig.Spec.Github.Repository}, nil)
 	gitProvider.EXPECT().Clone(ctx).Return(nil)
-	gitProvider.EXPECT().Branch(clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
+	gitProvider.EXPECT().Branch(clusterSpec.FluxConfig.Spec.Branch).Return(nil)
 	gitProvider.EXPECT().Remove(expectedClusterPath).Return(nil)
 	gitProvider.EXPECT().Commit(test.OfType("string")).Return(nil)
 	gitProvider.EXPECT().Push(ctx).Return(nil)
@@ -602,9 +602,9 @@ func TestFluxAddonClientCleanupGitRepoWorkloadCluster(t *testing.T) {
 	clusterSpec := newClusterSpec(t, clusterConfig, "")
 
 	gitProvider := gitMocks.NewMockProvider(mockCtrl)
-	gitProvider.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
+	gitProvider.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.FluxConfig.Spec.Github.Repository}, nil)
 	gitProvider.EXPECT().Clone(ctx).Return(nil)
-	gitProvider.EXPECT().Branch(clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
+	gitProvider.EXPECT().Branch(clusterSpec.FluxConfig.Spec.Branch).Return(nil)
 	gitProvider.EXPECT().Remove(expectedClusterPath).Return(nil)
 	gitProvider.EXPECT().Commit(test.OfType("string")).Return(nil)
 	gitProvider.EXPECT().Push(ctx).Return(nil)
@@ -628,9 +628,9 @@ func TestFluxAddonClientCleanupGitRepoSkip(t *testing.T) {
 	clusterSpec := newClusterSpec(t, clusterConfig, "")
 	f, m, _ := newAddonClient(t)
 
-	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository}, nil)
+	m.git.EXPECT().GetRepo(ctx).Return(&git.Repository{Name: clusterSpec.FluxConfig.Spec.Github.Repository}, nil)
 	m.git.EXPECT().Clone(ctx).Return(nil)
-	m.git.EXPECT().Branch(clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch).Return(nil)
+	m.git.EXPECT().Branch(clusterSpec.FluxConfig.Spec.Branch).Return(nil)
 
 	err := f.CleanupGitRepo(ctx, clusterSpec)
 	if err != nil {
@@ -718,17 +718,17 @@ func (tt *fluxTest) setupFlux() (owner, repo, path string) {
 	path = "fluxFolder"
 	owner = "aws"
 	repo = "eksa-gitops"
-	tt.clusterSpec.GitOpsConfig = &v1alpha1.GitOpsConfig{
-		Spec: v1alpha1.GitOpsConfigSpec{
-			Flux: v1alpha1.Flux{
-				Github: v1alpha1.Github{
-					ClusterConfigPath: path,
-					Owner:             owner,
-					Repository:        repo,
-				},
+	tt.clusterSpec.FluxConfig = &v1alpha1.FluxConfig{
+		Spec: v1alpha1.FluxConfigSpec{
+			ClusterConfigPath: path,
+			Branch:            "main",
+			Github: &v1alpha1.GithubProviderConfig{
+				Owner:      owner,
+				Repository: repo,
 			},
 		},
 	}
+
 	if err := c.SetConfigDefaults(tt.clusterSpec.Config); err != nil {
 		tt.Fatal(err)
 	}
@@ -766,37 +766,34 @@ func machineConfig(clusterName string) *v1alpha1.VSphereMachineConfig {
 
 func newClusterSpec(t *testing.T, clusterConfig *v1alpha1.Cluster, fluxPath string) *c.Spec {
 	t.Helper()
-	fluxConfig := v1alpha1.Flux{
-		Github: v1alpha1.Github{
-			Owner:               "mFowler",
-			Repository:          "testRepo",
-			FluxSystemNamespace: "flux-system",
-			Branch:              "testBranch",
-			ClusterConfigPath:   fluxPath,
-			Personal:            true,
-		},
-	}
 
-	gitOpsConfig := v1alpha1.GitOpsConfig{
+	fluxConfig := v1alpha1.FluxConfig{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       v1alpha1.GitOpsConfigKind,
+			Kind:       v1alpha1.FluxConfigKind,
 			APIVersion: v1alpha1.SchemeBuilder.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-gitops",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.GitOpsConfigSpec{
-			Flux: fluxConfig,
+		Spec: v1alpha1.FluxConfigSpec{
+			SystemNamespace:   "flux-system",
+			ClusterConfigPath: fluxPath,
+			Branch:            "testBranch",
+			Github: &v1alpha1.GithubProviderConfig{
+				Owner:      "mFolwer",
+				Repository: "testRepo",
+				Personal:   true,
+			},
 		},
 	}
 
-	clusterConfig.Spec.GitOpsRef = &v1alpha1.Ref{Kind: v1alpha1.GitOpsConfigKind, Name: "test-gitops"}
+	clusterConfig.Spec.GitOpsRef = &v1alpha1.Ref{Kind: v1alpha1.FluxConfigKind, Name: "test-gitops"}
 
 	clusterSpec := test.NewClusterSpec(func(s *c.Spec) {
 		s.Cluster = clusterConfig
 		s.VersionsBundle.Flux = fluxBundle()
-		s.GitOpsConfig = &gitOpsConfig
+		s.FluxConfig = &fluxConfig
 	})
 	if err := c.SetConfigDefaults(clusterSpec.Config); err != nil {
 		t.Fatal(err)

--- a/pkg/addonmanager/addonclients/mocks/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/mocks/fluxaddonclient.go
@@ -37,7 +37,7 @@ func (m *MockFlux) EXPECT() *MockFluxMockRecorder {
 }
 
 // BootstrapToolkitsComponents mocks base method.
-func (m *MockFlux) BootstrapToolkitsComponents(arg0 context.Context, arg1 *types.Cluster, arg2 *v1alpha1.GitOpsConfig) error {
+func (m *MockFlux) BootstrapToolkitsComponents(arg0 context.Context, arg1 *types.Cluster, arg2 *v1alpha1.FluxConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BootstrapToolkitsComponents", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -79,7 +79,7 @@ func (mr *MockFluxMockRecorder) ForceReconcileGitRepo(arg0, arg1, arg2 interface
 }
 
 // PauseKustomization mocks base method.
-func (m *MockFlux) PauseKustomization(arg0 context.Context, arg1 *types.Cluster, arg2 *v1alpha1.GitOpsConfig) error {
+func (m *MockFlux) PauseKustomization(arg0 context.Context, arg1 *types.Cluster, arg2 *v1alpha1.FluxConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PauseKustomization", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -93,7 +93,7 @@ func (mr *MockFluxMockRecorder) PauseKustomization(arg0, arg1, arg2 interface{})
 }
 
 // Reconcile mocks base method.
-func (m *MockFlux) Reconcile(arg0 context.Context, arg1 *types.Cluster, arg2 *v1alpha1.GitOpsConfig) error {
+func (m *MockFlux) Reconcile(arg0 context.Context, arg1 *types.Cluster, arg2 *v1alpha1.FluxConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Reconcile", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -107,7 +107,7 @@ func (mr *MockFluxMockRecorder) Reconcile(arg0, arg1, arg2 interface{}) *gomock.
 }
 
 // ResumeKustomization mocks base method.
-func (m *MockFlux) ResumeKustomization(arg0 context.Context, arg1 *types.Cluster, arg2 *v1alpha1.GitOpsConfig) error {
+func (m *MockFlux) ResumeKustomization(arg0 context.Context, arg1 *types.Cluster, arg2 *v1alpha1.FluxConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResumeKustomization", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -121,7 +121,7 @@ func (mr *MockFluxMockRecorder) ResumeKustomization(arg0, arg1, arg2 interface{}
 }
 
 // UninstallToolkitsComponents mocks base method.
-func (m *MockFlux) UninstallToolkitsComponents(arg0 context.Context, arg1 *types.Cluster, arg2 *v1alpha1.GitOpsConfig) error {
+func (m *MockFlux) UninstallToolkitsComponents(arg0 context.Context, arg1 *types.Cluster, arg2 *v1alpha1.FluxConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UninstallToolkitsComponents", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/pkg/addonmanager/addonclients/testdata/cluster-config-default-path-management.yaml
+++ b/pkg/addonmanager/addonclients/testdata/cluster-config-default-path-management.yaml
@@ -11,7 +11,7 @@ spec:
   controlPlaneConfiguration: {}
   datacenterRef: {}
   gitOpsRef:
-    kind: GitOpsConfig
+    kind: FluxConfig
     name: test-gitops
   kubernetesVersion: "1.19"
   managementCluster:
@@ -45,18 +45,17 @@ spec:
 
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
-kind: GitOpsConfig
+kind: FluxConfig
 metadata:
   name: test-gitops
   namespace: default
 spec:
-  flux:
-    github:
-      branch: testBranch
-      clusterConfigPath: clusters/management-cluster
-      fluxSystemNamespace: flux-system
-      owner: mFowler
-      personal: true
-      repository: testRepo
+  branch: testBranch
+  clusterConfigPath: clusters/management-cluster
+  github:
+    owner: mFolwer
+    personal: true
+    repository: testRepo
+  systemNamespace: flux-system
 
 ---

--- a/pkg/addonmanager/addonclients/testdata/cluster-config-default-path-workload.yaml
+++ b/pkg/addonmanager/addonclients/testdata/cluster-config-default-path-workload.yaml
@@ -13,7 +13,7 @@ spec:
   controlPlaneConfiguration: {}
   datacenterRef: {}
   gitOpsRef:
-    kind: GitOpsConfig
+    kind: FluxConfig
     name: test-gitops
   kubernetesVersion: "1.19"
   managementCluster:
@@ -47,18 +47,17 @@ spec:
 
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
-kind: GitOpsConfig
+kind: FluxConfig
 metadata:
   name: test-gitops
   namespace: default
 spec:
-  flux:
-    github:
-      branch: testBranch
-      clusterConfigPath: clusters/management-cluster
-      fluxSystemNamespace: flux-system
-      owner: mFowler
-      personal: true
-      repository: testRepo
+  branch: testBranch
+  clusterConfigPath: clusters/management-cluster
+  github:
+    owner: mFolwer
+    personal: true
+    repository: testRepo
+  systemNamespace: flux-system
 
 ---

--- a/pkg/addonmanager/addonclients/testdata/cluster-config-user-provided-path.yaml
+++ b/pkg/addonmanager/addonclients/testdata/cluster-config-user-provided-path.yaml
@@ -11,7 +11,7 @@ spec:
   controlPlaneConfiguration: {}
   datacenterRef: {}
   gitOpsRef:
-    kind: GitOpsConfig
+    kind: FluxConfig
     name: test-gitops
   kubernetesVersion: "1.19"
   managementCluster:
@@ -45,18 +45,17 @@ spec:
 
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
-kind: GitOpsConfig
+kind: FluxConfig
 metadata:
   name: test-gitops
   namespace: default
 spec:
-  flux:
-    github:
-      branch: testBranch
-      clusterConfigPath: user/provided/path
-      fluxSystemNamespace: flux-system
-      owner: mFowler
-      personal: true
-      repository: testRepo
+  branch: testBranch
+  clusterConfigPath: user/provided/path
+  github:
+    owner: mFolwer
+    personal: true
+    repository: testRepo
+  systemNamespace: flux-system
 
 ---

--- a/pkg/addonmanager/addonclients/upgrader.go
+++ b/pkg/addonmanager/addonclients/upgrader.go
@@ -33,13 +33,13 @@ func (f *FluxAddonClient) Upgrade(ctx context.Context, managementCluster *types.
 	if err := f.upgradeFilesAndCommit(ctx, newSpec); err != nil {
 		return nil, fmt.Errorf("failed upgrading Flux from bundles %d to bundles %d: %v", currentSpec.Bundles.Spec.Number, newSpec.Bundles.Spec.Number, err)
 	}
-	if err := f.flux.DeleteFluxSystemSecret(ctx, managementCluster, newSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace); err != nil {
+	if err := f.flux.DeleteFluxSystemSecret(ctx, managementCluster, newSpec.FluxConfig.Spec.SystemNamespace); err != nil {
 		return nil, fmt.Errorf("failed upgrading Flux when deleting old flux-system secret: %v", err)
 	}
-	if err := f.flux.BootstrapToolkitsComponents(ctx, managementCluster, newSpec.GitOpsConfig); err != nil {
+	if err := f.flux.BootstrapToolkitsComponents(ctx, managementCluster, newSpec.FluxConfig); err != nil {
 		return nil, fmt.Errorf("failed upgrading Flux components: %v", err)
 	}
-	if err := f.flux.Reconcile(ctx, managementCluster, newSpec.GitOpsConfig); err != nil {
+	if err := f.flux.Reconcile(ctx, managementCluster, newSpec.FluxConfig); err != nil {
 		return nil, fmt.Errorf("failed reconciling Flux components: %v", err)
 	}
 

--- a/pkg/addonmanager/addonclients/upgrader_test.go
+++ b/pkg/addonmanager/addonclients/upgrader_test.go
@@ -25,7 +25,7 @@ type upgraderTest struct {
 	currentSpec *cluster.Spec
 	newSpec     *cluster.Spec
 	cluster     *types.Cluster
-	fluxConfig  v1alpha1.Flux
+	fluxConfig  v1alpha1.FluxConfig
 }
 
 func newUpgraderTest(t *testing.T) *upgraderTest {
@@ -53,14 +53,16 @@ func newUpgraderTest(t *testing.T) *upgraderTest {
 			Name:           "management-cluster",
 			KubeconfigFile: "k.kubeconfig",
 		},
-		fluxConfig: v1alpha1.Flux{
-			Github: v1alpha1.Github{
-				Owner:               "mFowler",
-				Repository:          "testRepo",
-				FluxSystemNamespace: "flux-system",
-				Branch:              "testBranch",
-				ClusterConfigPath:   "clusters/management-cluster",
-				Personal:            true,
+		fluxConfig: v1alpha1.FluxConfig{
+			Spec: v1alpha1.FluxConfigSpec{
+				SystemNamespace:   "flux-system",
+				ClusterConfigPath: "clusters/management-cluster",
+				Branch:            "testBranch",
+				Github: &v1alpha1.GithubProviderConfig{
+					Owner:      "mFowler",
+					Repository: "testRepo",
+					Personal:   true,
+				},
 			},
 		},
 	}
@@ -86,11 +88,8 @@ func TestFluxUpgradeSuccess(t *testing.T) {
 	tt := newUpgraderTest(t)
 	tt.newSpec.VersionsBundle.Flux.Version = "v0.2.0"
 
-	tt.newSpec.GitOpsConfig = &v1alpha1.GitOpsConfig{
-		Spec: v1alpha1.GitOpsConfigSpec{
-			Flux: tt.fluxConfig,
-		},
-	}
+	tt.newSpec.FluxConfig = &tt.fluxConfig
+
 	f, m, g := newAddonClient(t)
 
 	if err := setupTestFiles(t, g); err != nil {
@@ -107,16 +106,16 @@ func TestFluxUpgradeSuccess(t *testing.T) {
 		},
 	}
 
-	m.git.EXPECT().GetRepo(tt.ctx).Return(&git.Repository{Name: tt.fluxConfig.Github.Repository}, nil)
+	m.git.EXPECT().GetRepo(tt.ctx).Return(&git.Repository{Name: tt.fluxConfig.Spec.Github.Repository}, nil)
 	m.git.EXPECT().Clone(tt.ctx).Return(nil)
-	m.git.EXPECT().Branch(tt.fluxConfig.Github.Branch).Return(nil)
-	m.git.EXPECT().Add(tt.fluxConfig.Github.ClusterConfigPath).Return(nil)
+	m.git.EXPECT().Branch(tt.fluxConfig.Spec.Branch).Return(nil)
+	m.git.EXPECT().Add(tt.fluxConfig.Spec.ClusterConfigPath).Return(nil)
 	m.git.EXPECT().Commit(test.OfType("string")).Return(nil)
 	m.git.EXPECT().Push(tt.ctx).Return(nil)
 
-	m.flux.EXPECT().DeleteFluxSystemSecret(tt.ctx, tt.cluster, tt.newSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace)
-	m.flux.EXPECT().BootstrapToolkitsComponents(tt.ctx, tt.cluster, tt.newSpec.GitOpsConfig)
-	m.flux.EXPECT().Reconcile(tt.ctx, tt.cluster, tt.newSpec.GitOpsConfig)
+	m.flux.EXPECT().DeleteFluxSystemSecret(tt.ctx, tt.cluster, tt.newSpec.FluxConfig.Spec.SystemNamespace)
+	m.flux.EXPECT().BootstrapToolkitsComponents(tt.ctx, tt.cluster, tt.newSpec.FluxConfig)
+	m.flux.EXPECT().Reconcile(tt.ctx, tt.cluster, tt.newSpec.FluxConfig)
 
 	tt.Expect(f.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(Equal(wantDiff))
 }
@@ -125,26 +124,22 @@ func TestFluxUpgradeError(t *testing.T) {
 	tt := newUpgraderTest(t)
 	tt.newSpec.VersionsBundle.Flux.Version = "v0.2.0"
 
-	tt.newSpec.GitOpsConfig = &v1alpha1.GitOpsConfig{
-		Spec: v1alpha1.GitOpsConfigSpec{
-			Flux: tt.fluxConfig,
-		},
-	}
+	tt.newSpec.FluxConfig = &tt.fluxConfig
 	f, m, g := newAddonClient(t)
 
 	if err := setupTestFiles(t, g); err != nil {
 		t.Errorf("setting up files: %v", err)
 	}
 
-	m.git.EXPECT().GetRepo(tt.ctx).Return(&git.Repository{Name: tt.fluxConfig.Github.Repository}, nil)
+	m.git.EXPECT().GetRepo(tt.ctx).Return(&git.Repository{Name: tt.fluxConfig.Spec.Github.Repository}, nil)
 	m.git.EXPECT().Clone(tt.ctx).Return(nil)
-	m.git.EXPECT().Branch(tt.fluxConfig.Github.Branch).Return(nil)
-	m.git.EXPECT().Add(tt.fluxConfig.Github.ClusterConfigPath).Return(nil)
+	m.git.EXPECT().Branch(tt.fluxConfig.Spec.Branch).Return(nil)
+	m.git.EXPECT().Add(tt.fluxConfig.Spec.ClusterConfigPath).Return(nil)
 	m.git.EXPECT().Commit(test.OfType("string")).Return(nil)
 	m.git.EXPECT().Push(tt.ctx).Return(nil)
 
-	m.flux.EXPECT().DeleteFluxSystemSecret(tt.ctx, tt.cluster, tt.newSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace)
-	m.flux.EXPECT().BootstrapToolkitsComponents(tt.ctx, tt.cluster, tt.newSpec.GitOpsConfig).Return(errors.New("error from client"))
+	m.flux.EXPECT().DeleteFluxSystemSecret(tt.ctx, tt.cluster, tt.newSpec.FluxConfig.Spec.SystemNamespace)
+	m.flux.EXPECT().BootstrapToolkitsComponents(tt.ctx, tt.cluster, tt.newSpec.FluxConfig).Return(errors.New("error from client"))
 
 	_, err := f.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)
 	tt.Expect(err).NotTo(BeNil())
@@ -153,7 +148,7 @@ func TestFluxUpgradeError(t *testing.T) {
 func TestFluxUpgradeNoGitOpsConfig(t *testing.T) {
 	tt := newUpgraderTest(t)
 	f, _, _ := newAddonClient(t)
-	tt.newSpec.GitOpsConfig = nil
+	tt.newSpec.FluxConfig = nil
 
 	tt.Expect(f.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(BeNil())
 }

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/yaml"
 
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
 )
@@ -572,11 +573,17 @@ func validateGitOps(clusterConfig *Cluster) error {
 	if gitOpsRef == nil {
 		return nil
 	}
-	if gitOpsRef.Kind != GitOpsConfigKind {
+
+	if gitOpsRef.Kind == FluxConfigKind && !features.IsActive(features.GenericGitProviderSupport()) {
+		return fmt.Errorf("FluxConfig and the generic git provider are not currently supported")
+	}
+
+	if gitOpsRef.Kind != GitOpsConfigKind && gitOpsRef.Kind != FluxConfigKind {
 		return errors.New("only GitOpsConfig Kind is supported at this time")
 	}
+
 	if gitOpsRef.Name == "" {
-		return errors.New("GitOpsConfig name can't be empty; specify a valid name for GitOpsConfig")
+		return errors.New("GitOpsRef name can't be empty; specify a valid GitOpsConfig name")
 	}
 	return nil
 }

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -574,12 +574,20 @@ func validateGitOps(clusterConfig *Cluster) error {
 		return nil
 	}
 
-	if gitOpsRef.Kind == FluxConfigKind && !features.IsActive(features.GenericGitProviderSupport()) {
-		return fmt.Errorf("FluxConfig and the generic git provider are not currently supported")
+	gitOpsRefKind := gitOpsRef.Kind
+	fluxConfigActive := features.IsActive(features.GenericGitProviderSupport())
+
+	if gitOpsRefKind == FluxConfigKind && !fluxConfigActive {
+		return fmt.Errorf("FluxConfig and the generic git provider are not currently supported; " +
+			"to use this experimental feature, please set the environment variable GENERIC_GIT_PROVIDER_SUPPORT to true")
 	}
 
-	if gitOpsRef.Kind != GitOpsConfigKind && gitOpsRef.Kind != FluxConfigKind {
+	if gitOpsRefKind != GitOpsConfigKind && !fluxConfigActive {
 		return errors.New("only GitOpsConfig Kind is supported at this time")
+	}
+
+	if gitOpsRefKind != GitOpsConfigKind && gitOpsRefKind != FluxConfigKind {
+		return errors.New("only GitOpsConfig or FluxConfig Kind are supported at this time")
 	}
 
 	if gitOpsRef.Name == "" {

--- a/pkg/api/v1alpha1/gitopsconfig_test.go
+++ b/pkg/api/v1alpha1/gitopsconfig_test.go
@@ -87,3 +87,67 @@ func TestGetAndValidateGitOpsConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertGitOpsConfigToFluxConfig(t *testing.T) {
+	tests := []struct {
+		testName          string
+		givenGitOpsConfig *GitOpsConfig
+		wantFluxConfig    *FluxConfig
+		clusterConfig     *Cluster
+	}{
+		{
+			testName: "Convert GitOps Config to FluxConfig",
+			givenGitOpsConfig: &GitOpsConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "GitOpsConfig",
+					APIVersion: SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gitops",
+					Namespace: "default",
+				},
+				Spec: GitOpsConfigSpec{
+					Flux: Flux{
+						Github: Github{
+							Owner:               "janedoe",
+							Repository:          "flux-fleet",
+							FluxSystemNamespace: "flux-system-test",
+							Branch:              "test-branch",
+							Personal:            false,
+							ClusterConfigPath:   "test-config-path",
+						},
+					},
+				},
+			},
+			wantFluxConfig: &FluxConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       FluxConfigKind,
+					APIVersion: SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gitops",
+					Namespace: "default",
+				},
+				Spec: FluxConfigSpec{
+					SystemNamespace:   "flux-system-test",
+					ClusterConfigPath: "test-config-path",
+					Branch:            "test-branch",
+					Github: &GithubProviderConfig{
+						Owner:      "janedoe",
+						Repository: "flux-fleet",
+						Personal:   false,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			convertedGitOps := tt.givenGitOpsConfig.ConvertToFluxConfig()
+			if !reflect.DeepEqual(convertedGitOps, tt.wantFluxConfig) {
+				t.Fatalf("ConvertToFluxConfig() = %#v, want %#v", convertedGitOps, tt.wantFluxConfig)
+			}
+		})
+	}
+}

--- a/pkg/api/v1alpha1/gitopsconfig_types.go
+++ b/pkg/api/v1alpha1/gitopsconfig_types.go
@@ -110,7 +110,6 @@ func (c *GitOpsConfig) ConvertToFluxConfig() *FluxConfig {
 			},
 		},
 	}
-	config.ObjectMeta.Name = c.Name
 	return config
 }
 

--- a/pkg/api/v1alpha1/gitopsconfig_types.go
+++ b/pkg/api/v1alpha1/gitopsconfig_types.go
@@ -86,6 +86,30 @@ func (c *GitOpsConfig) ExpectedKind() string {
 	return GitOpsConfigKind
 }
 
+func (c *GitOpsConfig) ConvertToFluxConfig() *FluxConfig {
+	if c == nil {
+		return nil
+	}
+	config := &FluxConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       FluxConfigKind,
+			APIVersion: c.APIVersion,
+		},
+		Spec: FluxConfigSpec{
+			SystemNamespace:   c.Spec.Flux.Github.FluxSystemNamespace,
+			Branch:            c.Spec.Flux.Github.Branch,
+			ClusterConfigPath: c.Spec.Flux.Github.ClusterConfigPath,
+			Github: &GithubProviderConfig{
+				Owner:      c.Spec.Flux.Github.Owner,
+				Repository: c.Spec.Flux.Github.Repository,
+				Personal:   c.Spec.Flux.Github.Personal,
+			},
+		},
+	}
+	config.ObjectMeta.Name = c.Name
+	return config
+}
+
 func (c *GitOpsConfig) ConvertConfigToConfigGenerateStruct() *GitOpsConfigGenerate {
 	namespace := defaultEksaNamespace
 	if c.Namespace != "" {

--- a/pkg/api/v1alpha1/gitopsconfig_types.go
+++ b/pkg/api/v1alpha1/gitopsconfig_types.go
@@ -95,6 +95,10 @@ func (c *GitOpsConfig) ConvertToFluxConfig() *FluxConfig {
 			Kind:       FluxConfigKind,
 			APIVersion: c.APIVersion,
 		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.Name,
+			Namespace: c.Namespace,
+		},
 		Spec: FluxConfigSpec{
 			SystemNamespace:   c.Spec.Flux.Github.FluxSystemNamespace,
 			Branch:            c.Spec.Flux.Github.Branch,

--- a/pkg/cluster/defaults_test.go
+++ b/pkg/cluster/defaults_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 )
 
-func TestSetDefaultFluxGitHubConfigPath(t *testing.T) {
+func TestSetDefaultFluxConfigPath(t *testing.T) {
 	tests := []struct {
 		name           string
 		config         *cluster.Config
@@ -29,7 +29,7 @@ func TestSetDefaultFluxGitHubConfigPath(t *testing.T) {
 						},
 					},
 				},
-				GitOpsConfig: &anywherev1.GitOpsConfig{},
+				FluxConfig: &anywherev1.FluxConfig{},
 			},
 			wantConfigPath: "clusters/c-1",
 		},
@@ -46,7 +46,7 @@ func TestSetDefaultFluxGitHubConfigPath(t *testing.T) {
 						},
 					},
 				},
-				GitOpsConfig: &anywherev1.GitOpsConfig{},
+				FluxConfig: &anywherev1.FluxConfig{},
 			},
 			wantConfigPath: "clusters/c-m",
 		},
@@ -63,13 +63,9 @@ func TestSetDefaultFluxGitHubConfigPath(t *testing.T) {
 						},
 					},
 				},
-				GitOpsConfig: &anywherev1.GitOpsConfig{
-					Spec: anywherev1.GitOpsConfigSpec{
-						Flux: anywherev1.Flux{
-							Github: anywherev1.Github{
-								ClusterConfigPath: "my-path",
-							},
-						},
+				FluxConfig: &anywherev1.FluxConfig{
+					Spec: anywherev1.FluxConfigSpec{
+						ClusterConfigPath: "my-path",
 					},
 				},
 			},
@@ -80,8 +76,8 @@ func TestSetDefaultFluxGitHubConfigPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			g.Expect(cluster.SetDefaultFluxGitHubConfigPath(tt.config)).To(Succeed())
-			g.Expect(tt.config.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath).To(Equal(tt.wantConfigPath))
+			g.Expect(cluster.SetDefaultFluxConfigPath(tt.config)).To(Succeed())
+			g.Expect(tt.config.FluxConfig.Spec.ClusterConfigPath).To(Equal(tt.wantConfigPath))
 		})
 	}
 }

--- a/pkg/cluster/flux.go
+++ b/pkg/cluster/flux.go
@@ -15,13 +15,12 @@ func fluxEntry() *ConfigManagerEntry {
 		},
 		Processors: []ParsedProcessor{processFlux},
 		Defaulters: []Defaulter{
-			func(c *Config) error {
-				if c.FluxConfig != nil {
-					c.FluxConfig.SetDefaults()
-				}
-				return nil
-			},
+			setFluxDefaults,
 			SetDefaultFluxConfigPath,
+		},
+		Validations: []Validation{
+			validateFlux,
+			validateFluxNamespace,
 		},
 	}
 }
@@ -39,6 +38,29 @@ func processFlux(c *Config, objects ObjectLookup) {
 
 		c.FluxConfig = flux.(*anywherev1.FluxConfig)
 	}
+}
+
+func validateFlux(c *Config) error {
+	if c.FluxConfig != nil {
+		return c.FluxConfig.Validate()
+	}
+	return nil
+}
+
+func validateFluxNamespace(c *Config) error {
+	if c.FluxConfig != nil {
+		if err := validateSameNamespace(c, c.FluxConfig); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setFluxDefaults(c *Config) error {
+	if c.FluxConfig != nil {
+		c.FluxConfig.SetDefaults()
+	}
+	return nil
 }
 
 func SetDefaultFluxConfigPath(c *Config) error {

--- a/pkg/cluster/gitops.go
+++ b/pkg/cluster/gitops.go
@@ -15,29 +15,16 @@ func gitOpsEntry() *ConfigManagerEntry {
 		},
 		Processors: []ParsedProcessor{processGitOps},
 		Defaulters: []Defaulter{
-			func(c *Config) error {
-				if c.GitOpsConfig != nil {
-					c.GitOpsConfig.SetDefaults()
-				}
-				return nil
-			},
+			setGitOpsDefaults,
 			SetDefaultFluxGitHubConfigPath,
+			setFluxDefaults,
+			SetDefaultFluxConfigPath,
 		},
 		Validations: []Validation{
-			func(c *Config) error {
-				if c.GitOpsConfig != nil {
-					return c.GitOpsConfig.Validate()
-				}
-				return nil
-			},
-			func(c *Config) error {
-				if c.GitOpsConfig != nil {
-					if err := validateSameNamespace(c, c.GitOpsConfig); err != nil {
-						return err
-					}
-				}
-				return nil
-			},
+			validateGitOps,
+			validateGitOpsNamespace,
+			validateFlux,
+			validateFluxNamespace,
 		},
 	}
 }
@@ -53,8 +40,36 @@ func processGitOps(c *Config, objects ObjectLookup) {
 			return
 		}
 
-		c.GitOpsConfig = gitOps.(*anywherev1.GitOpsConfig)
+		// GitOpsConfig will be deprecated.
+		// During the deprecation window, FluxConfig will be used internally
+		// GitOpsConfig will preserved it was in the original spec
+		gitOpsConf := gitOps.(*anywherev1.GitOpsConfig)
+		c.GitOpsConfig = gitOpsConf
+		c.FluxConfig = gitOpsConf.ConvertToFluxConfig()
 	}
+}
+
+func validateGitOps(c *Config) error {
+	if c.GitOpsConfig != nil {
+		return c.GitOpsConfig.Validate()
+	}
+	return nil
+}
+
+func validateGitOpsNamespace(c *Config) error {
+	if c.GitOpsConfig != nil {
+		if err := validateSameNamespace(c, c.GitOpsConfig); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setGitOpsDefaults(c *Config) error {
+	if c.GitOpsConfig != nil {
+		c.GitOpsConfig.SetDefaults()
+	}
+	return nil
 }
 
 func SetDefaultFluxGitHubConfigPath(c *Config) error {

--- a/pkg/cluster/gitops.go
+++ b/pkg/cluster/gitops.go
@@ -17,14 +17,10 @@ func gitOpsEntry() *ConfigManagerEntry {
 		Defaulters: []Defaulter{
 			setGitOpsDefaults,
 			SetDefaultFluxGitHubConfigPath,
-			setFluxDefaults,
-			SetDefaultFluxConfigPath,
 		},
 		Validations: []Validation{
 			validateGitOps,
 			validateGitOpsNamespace,
-			validateFlux,
-			validateFluxNamespace,
 		},
 	}
 }

--- a/pkg/cluster/gitops_test.go
+++ b/pkg/cluster/gitops_test.go
@@ -1,0 +1,1 @@
+package cluster

--- a/pkg/cluster/gitops_test.go
+++ b/pkg/cluster/gitops_test.go
@@ -1,1 +1,52 @@
-package cluster
+package cluster_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+)
+
+const (
+	owner             = "janedoe"
+	repository        = "flux-fleet"
+	fluxNamespace     = "test-ns"
+	branch            = "test-branch"
+	clusterConfigPath = "test-path"
+	personal          = false
+)
+
+func TestGitOpsToFluxConversionProcessing(t *testing.T) {
+	tests := []struct {
+		name           string
+		wantConfigPath string
+		wantFluxSpec   anywherev1.FluxConfigSpec
+	}{
+		{
+			name:           "workload cluster with GitOpsConfig",
+			wantConfigPath: "testdata/cluster_gitops_1_21.yaml",
+			wantFluxSpec: anywherev1.FluxConfigSpec{
+				SystemNamespace:   fluxNamespace,
+				ClusterConfigPath: clusterConfigPath,
+				Branch:            branch,
+				Github: &anywherev1.GithubProviderConfig{
+					Owner:      owner,
+					Repository: repository,
+					Personal:   personal,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			config, err := cluster.ParseConfigFromFile(tt.wantConfigPath)
+			if err != nil {
+				t.Fatal("cluster.ParseConfigFromFile error != nil, want nil", err)
+			}
+			g.Expect(config.FluxConfig.Spec).To(Equal(tt.wantFluxSpec))
+		})
+	}
+}

--- a/pkg/cluster/parse_test.go
+++ b/pkg/cluster/parse_test.go
@@ -296,6 +296,21 @@ func TestParseConfig(t *testing.T) {
 					},
 				},
 			},
+			wantFluxConfig: &anywherev1.FluxConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "FluxConfig",
+					APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: anywherev1.FluxConfigSpec{
+					Github: &anywherev1.GithubProviderConfig{
+						Owner:      "janedoe",
+						Repository: "flux-fleet",
+					},
+				},
+			},
 			wantOIDCConfigs: []*anywherev1.OIDCConfig{
 				{
 					TypeMeta: metav1.TypeMeta{

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -131,6 +131,7 @@ func WithEksdRelease(release *eksdv1alpha1.Release) SpecOpt {
 func WithGitOpsConfig(gitOpsConfig *eksav1alpha1.GitOpsConfig) SpecOpt {
 	return func(s *Spec) {
 		s.GitOpsConfig = gitOpsConfig
+		s.FluxConfig = gitOpsConfig.ConvertToFluxConfig()
 	}
 }
 

--- a/pkg/cluster/testdata/cluster_gitops_1_21.yaml
+++ b/pkg/cluster/testdata/cluster_gitops_1_21.yaml
@@ -1,0 +1,88 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+    endpoint:
+      host: "myHostIp"
+    machineGroupRef:
+      kind: VSphereMachineConfig
+      name: eksa-unit-test-cp
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: eksa-unit-test
+  gitOpsRef:
+    kind: GitOpsConfig
+    name: eksa-unit-test
+  kubernetesVersion: "1.21"
+  workerNodeGroupConfigurations:
+    - name: workers-1
+      count: 1
+      machineGroupRef:
+        kind: VSphereMachineConfig
+        name: eksa-unit-test
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  datacenter: "myDatacenter"
+  network: "myNetwork"
+  server: "myServer"
+  insecure: false
+  thumbprint: "myTlsThumbprint"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test-cp
+spec:
+  diskGiB: 25
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: ubuntu
+  users:
+    - name: mySshUsername
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  diskGiB: 25
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: ubuntu
+  users:
+    - name: mySshUsername
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: GitOpsConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  flux:
+    github:
+      personal: false
+      repository: flux-fleet
+      owner: janedoe
+      branch: test-branch
+      clusterConfigPath: test-path
+      fluxSystemNamespace: test-ns
+
+---

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -618,7 +618,7 @@ func (f *Factory) WithClusterManager(clusterConfig *v1alpha1.Cluster) *Factory {
 	return f
 }
 
-func (f *Factory) WithFluxAddonClient(ctx context.Context, clusterConfig *v1alpha1.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) *Factory {
+func (f *Factory) WithFluxAddonClient(ctx context.Context, clusterConfig *v1alpha1.Cluster, fluxConfig *v1alpha1.FluxConfig) *Factory {
 	f.WithWriter().WithFlux().WithKubectl()
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
@@ -626,7 +626,7 @@ func (f *Factory) WithFluxAddonClient(ctx context.Context, clusterConfig *v1alph
 			return nil
 		}
 
-		gitOpts, err := addonclients.NewGitOptions(ctx, clusterConfig, gitOpsConfig, f.dependencies.Writer)
+		gitOpts, err := addonclients.NewGitOptions(ctx, clusterConfig, fluxConfig, f.dependencies.Writer)
 		if err != nil {
 			return err
 		}

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -65,7 +65,7 @@ func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
 		WithBootstrapper().
 		WithClusterManager(tt.clusterSpec.Cluster).
 		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, false, false).
-		WithFluxAddonClient(tt.ctx, tt.clusterSpec.Cluster, tt.clusterSpec.GitOpsConfig).
+		WithFluxAddonClient(tt.ctx, tt.clusterSpec.Cluster, tt.clusterSpec.FluxConfig).
 		WithWriter().
 		WithDiagnosticCollectorImage("public.ecr.aws/collector").
 		WithAnalyzerFactory().

--- a/pkg/executables/flux.go
+++ b/pkg/executables/flux.go
@@ -29,13 +29,13 @@ func NewFlux(executable Executable) *Flux {
 // BootstrapToolkitsComponents creates the GitHub repository if it doesn’t exist, and commits the toolkit
 // components manifests to the main branch. Then it configures the target cluster to synchronize with the repository.
 // If the toolkit components are present on the cluster, the bootstrap command will perform an upgrade if needed.
-func (f *Flux) BootstrapToolkitsComponents(ctx context.Context, cluster *types.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) error {
-	c := gitOpsConfig.Spec.Flux.Github
+func (f *Flux) BootstrapToolkitsComponents(ctx context.Context, cluster *types.Cluster, fluxConfig *v1alpha1.FluxConfig) error {
+	c := fluxConfig.Spec
 	params := []string{
 		"bootstrap",
 		gitProvider,
-		"--repository", c.Repository,
-		"--owner", c.Owner,
+		"--repository", c.Github.Repository,
+		"--owner", c.Github.Owner,
 		"--path", c.ClusterConfigPath,
 		"--ssh-key-algorithm", privateKeyAlgorithm,
 	}
@@ -43,14 +43,14 @@ func (f *Flux) BootstrapToolkitsComponents(ctx context.Context, cluster *types.C
 	if cluster.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
-	if c.Personal {
+	if c.Github.Personal {
 		params = append(params, "--personal")
 	}
 	if c.Branch != "" {
 		params = append(params, "--branch", c.Branch)
 	}
-	if c.FluxSystemNamespace != "" {
-		params = append(params, "--namespace", c.FluxSystemNamespace)
+	if c.SystemNamespace != "" {
+		params = append(params, "--namespace", c.SystemNamespace)
 	}
 
 	token, err := github.GetGithubAccessTokenFromEnv()
@@ -69,8 +69,8 @@ func (f *Flux) BootstrapToolkitsComponents(ctx context.Context, cluster *types.C
 	return err
 }
 
-func (f *Flux) UninstallToolkitsComponents(ctx context.Context, cluster *types.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) error {
-	c := gitOpsConfig.Spec.Flux.Github
+func (f *Flux) UninstallToolkitsComponents(ctx context.Context, cluster *types.Cluster, fluxConfig *v1alpha1.FluxConfig) error {
+	c := fluxConfig.Spec
 	params := []string{
 		"uninstall",
 		"--silent",
@@ -78,8 +78,8 @@ func (f *Flux) UninstallToolkitsComponents(ctx context.Context, cluster *types.C
 	if cluster.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
-	if c.FluxSystemNamespace != "" {
-		params = append(params, "--namespace", c.FluxSystemNamespace)
+	if c.SystemNamespace != "" {
+		params = append(params, "--namespace", c.SystemNamespace)
 	}
 
 	_, err := f.Execute(ctx, params...)
@@ -89,12 +89,12 @@ func (f *Flux) UninstallToolkitsComponents(ctx context.Context, cluster *types.C
 	return err
 }
 
-func (f *Flux) PauseKustomization(ctx context.Context, cluster *types.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) error {
-	c := gitOpsConfig.Spec.Flux.Github
-	if c.FluxSystemNamespace == "" {
+func (f *Flux) PauseKustomization(ctx context.Context, cluster *types.Cluster, fluxConfig *v1alpha1.FluxConfig) error {
+	c := fluxConfig.Spec
+	if c.SystemNamespace == "" {
 		return fmt.Errorf("executing flux suspend kustomization: namespace empty")
 	}
-	params := []string{"suspend", "ks", c.FluxSystemNamespace, "--namespace", c.FluxSystemNamespace}
+	params := []string{"suspend", "ks", c.SystemNamespace, "--namespace", c.SystemNamespace}
 
 	if cluster.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
@@ -108,12 +108,12 @@ func (f *Flux) PauseKustomization(ctx context.Context, cluster *types.Cluster, g
 	return err
 }
 
-func (f *Flux) ResumeKustomization(ctx context.Context, cluster *types.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) error {
-	c := gitOpsConfig.Spec.Flux.Github
-	if c.FluxSystemNamespace == "" {
+func (f *Flux) ResumeKustomization(ctx context.Context, cluster *types.Cluster, fluxConfig *v1alpha1.FluxConfig) error {
+	c := fluxConfig.Spec
+	if c.SystemNamespace == "" {
 		return fmt.Errorf("executing flux resume kustomization: namespace empty")
 	}
-	params := []string{"resume", "ks", c.FluxSystemNamespace, "--namespace", c.FluxSystemNamespace}
+	params := []string{"resume", "ks", c.SystemNamespace, "--namespace", c.SystemNamespace}
 
 	if cluster.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
@@ -127,12 +127,12 @@ func (f *Flux) ResumeKustomization(ctx context.Context, cluster *types.Cluster, 
 	return err
 }
 
-func (f *Flux) Reconcile(ctx context.Context, cluster *types.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig) error {
-	c := gitOpsConfig.Spec.Flux.Github
+func (f *Flux) Reconcile(ctx context.Context, cluster *types.Cluster, fluxConfig *v1alpha1.FluxConfig) error {
+	c := fluxConfig.Spec
 	params := []string{"reconcile", "source", "git"}
 
-	if c.FluxSystemNamespace != "" {
-		params = append(params, c.FluxSystemNamespace, "--namespace", c.FluxSystemNamespace)
+	if c.SystemNamespace != "" {
+		params = append(params, c.SystemNamespace, "--namespace", c.SystemNamespace)
 	} else {
 		params = append(params, "flux-system")
 	}

--- a/pkg/executables/flux_test.go
+++ b/pkg/executables/flux_test.go
@@ -54,7 +54,7 @@ func TestFluxInstallGitOpsToolkitsSuccess(t *testing.T) {
 	tests := []struct {
 		testName     string
 		cluster      *types.Cluster
-		fluxConfig   v1alpha1.Flux
+		fluxConfig   *v1alpha1.FluxConfig
 		wantExecArgs []interface{}
 	}{
 		{
@@ -62,11 +62,13 @@ func TestFluxInstallGitOpsToolkitsSuccess(t *testing.T) {
 			cluster: &types.Cluster{
 				KubeconfigFile: "f.kubeconfig",
 			},
-			fluxConfig: v1alpha1.Flux{
-				Github: v1alpha1.Github{
-					Owner:             owner,
-					Repository:        repo,
+			fluxConfig: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
 					ClusterConfigPath: path,
+					Github: &v1alpha1.GithubProviderConfig{
+						Owner:      owner,
+						Repository: repo,
+					},
 				},
 			},
 			wantExecArgs: []interface{}{
@@ -76,12 +78,14 @@ func TestFluxInstallGitOpsToolkitsSuccess(t *testing.T) {
 		{
 			testName: "with personal",
 			cluster:  &types.Cluster{},
-			fluxConfig: v1alpha1.Flux{
-				Github: v1alpha1.Github{
-					Owner:             owner,
-					Repository:        repo,
+			fluxConfig: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
 					ClusterConfigPath: path,
-					Personal:          true,
+					Github: &v1alpha1.GithubProviderConfig{
+						Owner:      owner,
+						Repository: repo,
+						Personal:   true,
+					},
 				},
 			},
 			wantExecArgs: []interface{}{
@@ -91,14 +95,17 @@ func TestFluxInstallGitOpsToolkitsSuccess(t *testing.T) {
 		{
 			testName: "with branch",
 			cluster:  &types.Cluster{},
-			fluxConfig: v1alpha1.Flux{
-				Github: v1alpha1.Github{
-					Owner:             owner,
-					Repository:        repo,
+			fluxConfig: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
 					ClusterConfigPath: path,
 					Branch:            "main",
+					Github: &v1alpha1.GithubProviderConfig{
+						Owner:      owner,
+						Repository: repo,
+					},
 				},
 			},
+
 			wantExecArgs: []interface{}{
 				"bootstrap", gitProvider, "--repository", repo, "--owner", owner, "--path", path, "--ssh-key-algorithm", "ecdsa", "--branch", "main",
 			},
@@ -106,12 +113,14 @@ func TestFluxInstallGitOpsToolkitsSuccess(t *testing.T) {
 		{
 			testName: "with namespace",
 			cluster:  &types.Cluster{},
-			fluxConfig: v1alpha1.Flux{
-				Github: v1alpha1.Github{
-					Owner:               owner,
-					Repository:          repo,
-					ClusterConfigPath:   path,
-					FluxSystemNamespace: "flux-system",
+			fluxConfig: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					ClusterConfigPath: path,
+					SystemNamespace:   "flux-system",
+					Github: &v1alpha1.GithubProviderConfig{
+						Owner:      owner,
+						Repository: repo,
+					},
 				},
 			},
 			wantExecArgs: []interface{}{
@@ -121,8 +130,10 @@ func TestFluxInstallGitOpsToolkitsSuccess(t *testing.T) {
 		{
 			testName: "minimum args",
 			cluster:  &types.Cluster{},
-			fluxConfig: v1alpha1.Flux{
-				Github: v1alpha1.Github{},
+			fluxConfig: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					Github: &v1alpha1.GithubProviderConfig{},
+				},
 			},
 			wantExecArgs: []interface{}{
 				"bootstrap", gitProvider, "--repository", "", "--owner", "", "--path", "", "--ssh-key-algorithm", "ecdsa",
@@ -135,12 +146,6 @@ func TestFluxInstallGitOpsToolkitsSuccess(t *testing.T) {
 			ctx := context.Background()
 			executable := mockexecutables.NewMockExecutable(mockCtrl)
 			env := map[string]string{githubToken: validPATValue}
-			gitOpsConfig := v1alpha1.GitOpsConfig{
-				Spec: v1alpha1.GitOpsConfigSpec{
-					Flux: tt.fluxConfig,
-				},
-			}
-
 			executable.EXPECT().ExecuteWithEnv(
 				ctx,
 				env,
@@ -148,7 +153,7 @@ func TestFluxInstallGitOpsToolkitsSuccess(t *testing.T) {
 			).Return(bytes.Buffer{}, nil)
 
 			f := executables.NewFlux(executable)
-			if err := f.BootstrapToolkitsComponents(ctx, tt.cluster, &gitOpsConfig); err != nil {
+			if err := f.BootstrapToolkitsComponents(ctx, tt.cluster, tt.fluxConfig); err != nil {
 				t.Errorf("flux.BootstrapToolkitsComponents() error = %v, want nil", err)
 			}
 		})
@@ -165,12 +170,13 @@ func TestFluxUninstallGitOpsToolkitsComponents(t *testing.T) {
 	tests := []struct {
 		testName     string
 		cluster      *types.Cluster
-		fluxConfig   v1alpha1.Flux
+		fluxConfig   *v1alpha1.FluxConfig
 		wantExecArgs []interface{}
 	}{
 		{
-			testName: "minimum args",
-			cluster:  &types.Cluster{},
+			testName:   "minimum args",
+			cluster:    &types.Cluster{},
+			fluxConfig: &v1alpha1.FluxConfig{},
 			wantExecArgs: []interface{}{
 				"uninstall", "--silent",
 			},
@@ -180,6 +186,7 @@ func TestFluxUninstallGitOpsToolkitsComponents(t *testing.T) {
 			cluster: &types.Cluster{
 				KubeconfigFile: "f.kubeconfig",
 			},
+			fluxConfig: &v1alpha1.FluxConfig{},
 			wantExecArgs: []interface{}{
 				"uninstall", "--silent", "--kubeconfig", "f.kubeconfig",
 			},
@@ -187,9 +194,10 @@ func TestFluxUninstallGitOpsToolkitsComponents(t *testing.T) {
 		{
 			testName: "with namespace",
 			cluster:  &types.Cluster{},
-			fluxConfig: v1alpha1.Flux{
-				Github: v1alpha1.Github{
-					FluxSystemNamespace: "flux-system",
+			fluxConfig: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					SystemNamespace: "flux-system",
+					Github:          &v1alpha1.GithubProviderConfig{},
 				},
 			},
 			wantExecArgs: []interface{}{
@@ -202,18 +210,13 @@ func TestFluxUninstallGitOpsToolkitsComponents(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			ctx := context.Background()
 			executable := mockexecutables.NewMockExecutable(mockCtrl)
-			gitOpsConfig := v1alpha1.GitOpsConfig{
-				Spec: v1alpha1.GitOpsConfigSpec{
-					Flux: tt.fluxConfig,
-				},
-			}
 			executable.EXPECT().Execute(
 				ctx,
 				tt.wantExecArgs...,
 			).Return(bytes.Buffer{}, nil)
 
 			f := executables.NewFlux(executable)
-			if err := f.UninstallToolkitsComponents(ctx, tt.cluster, &gitOpsConfig); err != nil {
+			if err := f.UninstallToolkitsComponents(ctx, tt.cluster, tt.fluxConfig); err != nil {
 				t.Errorf("flux.UninstallToolkitsComponents() error = %v, want nil", err)
 			}
 		})
@@ -230,15 +233,16 @@ func TestFluxPauseKustomization(t *testing.T) {
 	tests := []struct {
 		testName     string
 		cluster      *types.Cluster
-		fluxConfig   v1alpha1.Flux
+		fluxConfig   *v1alpha1.FluxConfig
 		wantExecArgs []interface{}
 	}{
 		{
 			testName: "minimum args",
 			cluster:  &types.Cluster{},
-			fluxConfig: v1alpha1.Flux{
-				Github: v1alpha1.Github{
-					FluxSystemNamespace: "flux-system",
+			fluxConfig: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					SystemNamespace: "flux-system",
+					Github:          &v1alpha1.GithubProviderConfig{},
 				},
 			},
 			wantExecArgs: []interface{}{
@@ -250,9 +254,10 @@ func TestFluxPauseKustomization(t *testing.T) {
 			cluster: &types.Cluster{
 				KubeconfigFile: "f.kubeconfig",
 			},
-			fluxConfig: v1alpha1.Flux{
-				Github: v1alpha1.Github{
-					FluxSystemNamespace: "flux-system",
+			fluxConfig: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					SystemNamespace: "flux-system",
+					Github:          &v1alpha1.GithubProviderConfig{},
 				},
 			},
 			wantExecArgs: []interface{}{
@@ -262,9 +267,10 @@ func TestFluxPauseKustomization(t *testing.T) {
 		{
 			testName: "with namespace",
 			cluster:  &types.Cluster{},
-			fluxConfig: v1alpha1.Flux{
-				Github: v1alpha1.Github{
-					FluxSystemNamespace: "custom-ns",
+			fluxConfig: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					SystemNamespace: "custom-ns",
+					Github:          &v1alpha1.GithubProviderConfig{},
 				},
 			},
 			wantExecArgs: []interface{}{
@@ -277,19 +283,13 @@ func TestFluxPauseKustomization(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			ctx := context.Background()
 			executable := mockexecutables.NewMockExecutable(mockCtrl)
-			gitOpsConfig := v1alpha1.GitOpsConfig{
-				Spec: v1alpha1.GitOpsConfigSpec{
-					Flux: tt.fluxConfig,
-				},
-			}
-
 			executable.EXPECT().Execute(
 				ctx,
 				tt.wantExecArgs...,
 			).Return(bytes.Buffer{}, nil)
 
 			f := executables.NewFlux(executable)
-			if err := f.PauseKustomization(ctx, tt.cluster, &gitOpsConfig); err != nil {
+			if err := f.PauseKustomization(ctx, tt.cluster, tt.fluxConfig); err != nil {
 				t.Errorf("flux.PauseKustomization() error = %v, want nil", err)
 			}
 		})
@@ -306,15 +306,16 @@ func TestFluxResumeKustomization(t *testing.T) {
 	tests := []struct {
 		testName     string
 		cluster      *types.Cluster
-		fluxConfig   v1alpha1.Flux
+		fluxConfig   *v1alpha1.FluxConfig
 		wantExecArgs []interface{}
 	}{
 		{
 			testName: "minimum args",
 			cluster:  &types.Cluster{},
-			fluxConfig: v1alpha1.Flux{
-				Github: v1alpha1.Github{
-					FluxSystemNamespace: "flux-system",
+			fluxConfig: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					SystemNamespace: "flux-system",
+					Github:          &v1alpha1.GithubProviderConfig{},
 				},
 			},
 			wantExecArgs: []interface{}{
@@ -326,9 +327,10 @@ func TestFluxResumeKustomization(t *testing.T) {
 			cluster: &types.Cluster{
 				KubeconfigFile: "f.kubeconfig",
 			},
-			fluxConfig: v1alpha1.Flux{
-				Github: v1alpha1.Github{
-					FluxSystemNamespace: "flux-system",
+			fluxConfig: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					SystemNamespace: "flux-system",
+					Github:          &v1alpha1.GithubProviderConfig{},
 				},
 			},
 			wantExecArgs: []interface{}{
@@ -338,9 +340,10 @@ func TestFluxResumeKustomization(t *testing.T) {
 		{
 			testName: "with namespace",
 			cluster:  &types.Cluster{},
-			fluxConfig: v1alpha1.Flux{
-				Github: v1alpha1.Github{
-					FluxSystemNamespace: "custom-ns",
+			fluxConfig: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					SystemNamespace: "custom-ns",
+					Github:          &v1alpha1.GithubProviderConfig{},
 				},
 			},
 			wantExecArgs: []interface{}{
@@ -353,11 +356,6 @@ func TestFluxResumeKustomization(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			ctx := context.Background()
 			executable := mockexecutables.NewMockExecutable(mockCtrl)
-			gitOpsConfig := v1alpha1.GitOpsConfig{
-				Spec: v1alpha1.GitOpsConfigSpec{
-					Flux: tt.fluxConfig,
-				},
-			}
 
 			executable.EXPECT().Execute(
 				ctx,
@@ -365,7 +363,7 @@ func TestFluxResumeKustomization(t *testing.T) {
 			).Return(bytes.Buffer{}, nil)
 
 			f := executables.NewFlux(executable)
-			if err := f.ResumeKustomization(ctx, tt.cluster, &gitOpsConfig); err != nil {
+			if err := f.ResumeKustomization(ctx, tt.cluster, tt.fluxConfig); err != nil {
 				t.Errorf("flux.ResumeKustomization() error = %v, want nil", err)
 			}
 		})
@@ -382,13 +380,13 @@ func TestFluxReconcile(t *testing.T) {
 	tests := []struct {
 		testName     string
 		cluster      *types.Cluster
-		fluxConfig   v1alpha1.Flux
+		fluxConfig   *v1alpha1.FluxConfig
 		wantExecArgs []interface{}
 	}{
 		{
 			testName:   "minimum args",
 			cluster:    &types.Cluster{},
-			fluxConfig: v1alpha1.Flux{},
+			fluxConfig: &v1alpha1.FluxConfig{},
 			wantExecArgs: []interface{}{
 				"reconcile", "source", "git", "flux-system",
 			},
@@ -398,7 +396,7 @@ func TestFluxReconcile(t *testing.T) {
 			cluster: &types.Cluster{
 				KubeconfigFile: "f.kubeconfig",
 			},
-			fluxConfig: v1alpha1.Flux{},
+			fluxConfig: &v1alpha1.FluxConfig{},
 			wantExecArgs: []interface{}{
 				"reconcile", "source", "git", "flux-system", "--kubeconfig", "f.kubeconfig",
 			},
@@ -406,9 +404,10 @@ func TestFluxReconcile(t *testing.T) {
 		{
 			testName: "with custom namespace",
 			cluster:  &types.Cluster{},
-			fluxConfig: v1alpha1.Flux{
-				Github: v1alpha1.Github{
-					FluxSystemNamespace: "custom-ns",
+			fluxConfig: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					SystemNamespace: "custom-ns",
+					Github:          &v1alpha1.GithubProviderConfig{},
 				},
 			},
 			wantExecArgs: []interface{}{
@@ -421,11 +420,6 @@ func TestFluxReconcile(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			ctx := context.Background()
 			executable := mockexecutables.NewMockExecutable(mockCtrl)
-			gitOpsConfig := v1alpha1.GitOpsConfig{
-				Spec: v1alpha1.GitOpsConfigSpec{
-					Flux: tt.fluxConfig,
-				},
-			}
 
 			executable.EXPECT().Execute(
 				ctx,
@@ -433,7 +427,7 @@ func TestFluxReconcile(t *testing.T) {
 			).Return(bytes.Buffer{}, nil)
 
 			f := executables.NewFlux(executable)
-			if err := f.Reconcile(ctx, tt.cluster, &gitOpsConfig); err != nil {
+			if err := f.Reconcile(ctx, tt.cluster, tt.fluxConfig); err != nil {
 				t.Errorf("flux.Reconcile() error = %v, want nil", err)
 			}
 		})

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -9,6 +9,7 @@ const (
 	FullLifecycleAPIEnvVar          = "FULL_LIFECYCLE_API"
 	FullLifecycleGate               = "FullLifecycleAPI"
 	CuratedPackagesEnvVar           = "CURATED_PACKAGES_SUPPORT"
+	GenericGitProviderEnvVar        = "GENERIC_GIT_PROVIDER_SUPPORT"
 )
 
 func FeedGates(featureGates []string) {
@@ -70,5 +71,12 @@ func CuratedPackagesSupport() Feature {
 	return Feature{
 		Name:     "Curated Packages Support",
 		IsActive: globalFeatures.isActiveForEnvVar(CuratedPackagesEnvVar),
+	}
+}
+
+func GenericGitProviderSupport() Feature {
+	return Feature{
+		Name:     "Generic Git Provider Support",
+		IsActive: globalFeatures.isActiveForEnvVar(GenericGitProviderEnvVar),
 	}
 }

--- a/pkg/git/factory/gitfactory.go
+++ b/pkg/git/factory/gitfactory.go
@@ -10,7 +10,7 @@ import (
 )
 
 type gitProviderFactory struct {
-	GithubGitClient github.GitProviderClient
+	GitClient github.GitProviderClient
 }
 
 type Options struct {
@@ -18,24 +18,24 @@ type Options struct {
 }
 
 func New(opts Options) *gitProviderFactory {
-	return &gitProviderFactory{GithubGitClient: opts.GithubGitClient}
+	return &gitProviderFactory{GitClient: opts.GithubGitClient}
 }
 
 // BuildProvider will configure and return the proper Github based on the given GitOps configuration.
-func (g *gitProviderFactory) BuildProvider(ctx context.Context, gitOpsConfig *v1alpha1.GitOpsConfigSpec) (git.Provider, error) {
+func (g *gitProviderFactory) BuildProvider(ctx context.Context, fluxConfig *v1alpha1.FluxConfigSpec) (git.Provider, error) {
 	token, err := github.GetGithubAccessTokenFromEnv()
 	if err != nil {
 		return nil, err
 	}
-	auth := git.TokenAuth{Token: token, Username: gitOpsConfig.Flux.Github.Owner}
+	auth := git.TokenAuth{Token: token, Username: fluxConfig.Github.Owner}
 	gogithubOpts := gogithub.Options{Auth: auth}
 	githubProviderClient := gogithub.New(ctx, gogithubOpts)
 	githubProviderOpts := github.Options{
-		Repository: gitOpsConfig.Flux.Github.Repository,
-		Owner:      gitOpsConfig.Flux.Github.Owner,
-		Personal:   gitOpsConfig.Flux.Github.Personal,
+		Repository: fluxConfig.Github.Repository,
+		Owner:      fluxConfig.Github.Owner,
+		Personal:   fluxConfig.Github.Personal,
 	}
-	provider, err := github.New(g.GithubGitClient, githubProviderClient, githubProviderOpts, auth)
+	provider, err := github.New(g.GitClient, githubProviderClient, githubProviderOpts, auth)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/git/factory/gitfactory_test.go
+++ b/pkg/git/factory/gitfactory_test.go
@@ -35,16 +35,25 @@ func TestGitFactoryHappyPath(t *testing.T) {
 			defer tctx.RestoreContext()
 
 			mockCtrl := gomock.NewController(t)
-			gitProviderConfig := v1alpha1.Github{Owner: "Jeff"}
-			fluxConfig := v1alpha1.Flux{Github: gitProviderConfig}
-			gitopsConfig := &v1alpha1.GitOpsConfigSpec{Flux: fluxConfig}
+
+			gitProviderConfig := v1alpha1.GithubProviderConfig{
+				Owner:      "Jeff",
+				Repository: "testRepo",
+				Personal:   true,
+			}
+
+			fluxConfig := v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					Github: &gitProviderConfig,
+				},
+			}
 
 			githubProviderClient := githubMocks.NewMockGitProviderClient(mockCtrl)
-			githubProviderClient.EXPECT().SetTokenAuth(gomock.Any(), fluxConfig.Github.Owner)
+			githubProviderClient.EXPECT().SetTokenAuth(gomock.Any(), fluxConfig.Spec.Github.Owner)
 			opts := gitFactory.Options{GithubGitClient: githubProviderClient}
 			factory := gitFactory.New(opts)
 
-			_, err := factory.BuildProvider(context.Background(), gitopsConfig)
+			_, err := factory.BuildProvider(context.Background(), &fluxConfig.Spec)
 			if err != nil {
 				t.Errorf("gitfactory.BuldProvider returned err, wanted nil. err: %v", err)
 			}

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -129,7 +129,7 @@ func (e *ClusterE2ETest) initGit(ctx context.Context) {
 		e.T.Errorf("Error configuring filewriter for e2e test: %v", err)
 	}
 
-	g, err := e.NewGitOptions(ctx, c, e.GitOpsConfig, writer, "")
+	g, err := e.NewGitOptions(ctx, c, e.GitOpsConfig.ConvertToFluxConfig(), writer, "")
 	if err != nil {
 		e.T.Errorf("Error configuring git client for e2e test: %v", err)
 	}
@@ -153,7 +153,7 @@ func (e *ClusterE2ETest) ValidateFlux() {
 		e.T.Errorf("Error configuring filewriter for e2e test: %v", err)
 	}
 	ctx := context.Background()
-	g, err := e.NewGitOptions(ctx, c, e.GitOpsConfig, writer, "")
+	g, err := e.NewGitOptions(ctx, c, e.GitOpsConfig.ConvertToFluxConfig(), writer, "")
 	if err != nil {
 		e.T.Errorf("Error configuring git client for e2e test: %v", err)
 	}
@@ -176,7 +176,7 @@ func (e *ClusterE2ETest) ValidateFlux() {
 		e.T.Errorf("Error configuring filewriter for e2e test: %v", err)
 	}
 	repoName := e.gitRepoName()
-	gitOptions, err := e.NewGitOptions(ctx, c, e.GitOpsConfig, writer, fmt.Sprintf("%s/%s", e.ClusterName, repoName))
+	gitOptions, err := e.NewGitOptions(ctx, c, e.GitOpsConfig.ConvertToFluxConfig(), writer, fmt.Sprintf("%s/%s", e.ClusterName, repoName))
 	if err != nil {
 		e.T.Errorf("Error configuring git client for e2e test: %v", err)
 	}
@@ -192,7 +192,7 @@ func (e *ClusterE2ETest) CleanUpGithubRepo() {
 	ctx := context.Background()
 	owner := e.GitOpsConfig.Spec.Flux.Github.Owner
 	repoName := e.gitRepoName()
-	gitOptions, err := e.NewGitOptions(ctx, c, e.GitOpsConfig, writer, fmt.Sprintf("%s/%s", e.ClusterName, repoName))
+	gitOptions, err := e.NewGitOptions(ctx, c, e.GitOpsConfig.ConvertToFluxConfig(), writer, fmt.Sprintf("%s/%s", e.ClusterName, repoName))
 	if err != nil {
 		e.T.Errorf("Error configuring git client for e2e test: %v", err)
 	}

--- a/test/framework/git.go
+++ b/test/framework/git.go
@@ -18,16 +18,16 @@ type GitOptions struct {
 	Writer filewriter.FileWriter
 }
 
-func (e *ClusterE2ETest) NewGitOptions(ctx context.Context, cluster *v1alpha1.Cluster, gitOpsConfig *v1alpha1.GitOpsConfig, writer filewriter.FileWriter, repoPath string) (*GitOptions, error) {
-	if gitOpsConfig == nil {
+func (e *ClusterE2ETest) NewGitOptions(ctx context.Context, cluster *v1alpha1.Cluster, fluxConfig *v1alpha1.FluxConfig, writer filewriter.FileWriter, repoPath string) (*GitOptions, error) {
+	if fluxConfig == nil {
 		return nil, nil
 	}
 
 	var localGitRepoPath string
 	var localGitWriterPath string
 	if repoPath == "" {
-		localGitRepoPath = filepath.Join(cluster.Name, "git", gitOpsConfig.Spec.Flux.Github.Repository)
-		localGitWriterPath = filepath.Join("git", gitOpsConfig.Spec.Flux.Github.Repository)
+		localGitRepoPath = filepath.Join(cluster.Name, "git", fluxConfig.Spec.Github.Repository)
+		localGitWriterPath = filepath.Join("git", fluxConfig.Spec.Github.Repository)
 	} else {
 		localGitRepoPath = repoPath
 		localGitWriterPath = repoPath
@@ -40,7 +40,7 @@ func (e *ClusterE2ETest) NewGitOptions(ctx context.Context, cluster *v1alpha1.Cl
 
 	gitProviderFactoryOptions := gitFactory.Options{GithubGitClient: goGit}
 	gitProviderFactory := gitFactory.New(gitProviderFactoryOptions)
-	gitProvider, err := gitProviderFactory.BuildProvider(ctx, &gitOpsConfig.Spec)
+	gitProvider, err := gitProviderFactory.BuildProvider(ctx, &fluxConfig.Spec)
 	if err != nil {
 		return nil, fmt.Errorf("creating Git provider: %v", err)
 	}


### PR DESCRIPTION
*Issue #, if available:*
[Project](https://github.com/aws/eks-anywhere/projects/9)
[Issue](https://github.com/aws/eks-anywhere/issues/1826)
[Design](https://github.com/aws/eks-anywhere/blob/ed59f2c747c3afe394c5115f0046d3c8f3a85e66/designs/generic-git-provider-gitops.md)

*Description of changes:*
This change lays the groundwork for further development of [Bring Your Own Git.](https://github.com/aws/eks-anywhere/blob/ed59f2c747c3afe394c5115f0046d3c8f3a85e66/designs/generic-git-provider-gitops.md)

The `GitOpsConfig` type is being deprecated in favor of the new `FluxConfig` type, which makes it easy to support multiple Providers (e.g. GitHub, BYO Git, etc). While the feature is in development, usage of a `FluxConfig` as a `GitOpsRef`[ will be feature gated](https://github.com/aws/eks-anywhere/pull/1827/commits/cb74219e736fe0adcad42223a7fee56936d14a60), even though we'll be using the `FluxConfig` internally for all GitOps related workflows end-to-end.

These changes set up the cluster to [automatically generate a `FluxConfig` from a user-provided `GitOpsConfig`](https://github.com/aws/eks-anywhere/pull/1827/commits/9380c11bea0b185401a00ea678efc88f177e394a#diff-c0ac5c9b3e6dfc86e94a13471d3207ef5d2a305a6705039c8951e1ca99d73f63R48), and replace the usage of the `GitOpsConfig` type with the `FluxConfig` type throughout EKS Anywhere; additionally, there are a number of supporting changes in order to allow this, such as making sure that [defaults are set for `FluxConfig`](https://github.com/aws/eks-anywhere/pull/1827/commits/133080581dc353246b97ea394704d6f1f0bb23bc), that [it's marshaled properly](https://github.com/aws/eks-anywhere/pull/1827/commits/2adaaf10a8aef17863d16d5904dffe92e6f6e212), and that [the cluster config deep copy methods support it](https://github.com/aws/eks-anywhere/pull/1827/commits/133080581dc353246b97ea394704d6f1f0bb23bc). 

We will continue to support the `GitOpsConfig` for the time being (deprecation schedule TBD...thinking +2 minor versions?), transparently converting it to a `FluxConfig` internally when provided by a user. Once deprecated the type and the conversion will be removed.

Additional refactoring is going to follow soon after this initial groundwork, including refactoring the E2E tests to use the `FluxConfig` while also testing cases with an existing, user-provided `GitOpsConfig`. 

**UX**
After this PR merges:
- A user can still provide a `GitOpsConfig` in their cluster configuration.
- The user-provided `GitOpsConfig` will be transparently converted to a `FluxConfig` for internal use by the system.
- When a cluster configuration is marshaled to file, the originally provided `GitOpsConfig` will be written, making this internal conversion transparent to the user.

After this feature is GA:
- A user can provide either a `GitOpsConfig` or a `FluxConfig` via their cluster configuration.
- A user-provided `GitOpsConfig` will be transparently convereted a a `FluxConfig` for internal use
- Deprecation warnings will be given to the user regarding the `GitOpsConfig`

Final UX:
- A user may ONLY provide a `FluxConfig` via their cluster configuration.
- Upgrade supports a path to automatically converting a a `GitOpsConfig` to a `FluxConfig` when upgrading between a minor version in which `GitOpsConfig` exists and a version in which it is fully deprecated

**Deprecation Path**
Deprecation path is open to conversation; I was thinking +2 minor versions we remove the `GitOpsConfig` and provide any tooling necessary for a user to easily convert. 

In the mean time, once this feature is ready to go GA and the feature gate is ready to be removed, we'll add deprecation warnings to the `GitOpsConfig` and make note of the deprecation path in the `v0.9.0` release notes.

*Testing (if applicable):*
`make`
`eksctl anywhere create cluster` with a `GitOpsConfig`; modify the cluster via flux.
`eksctl anywhere upgrade cluster` with a `GitOpsConfig`, scaling and upgrading the cluster.
run E2E flux tests

Currently, since we're transparently converting `GitOpsConfig` to `FluxConfig` internally, the current E2E tests work without modification for this change.  Once we introduce the `FluxConfig` externally, we'll add additional E2E tests which test it; then, once `GitOpsConfig` is deprecated fully, we'll remove all the tests that use `GitOpsConfig`.

 E2e tests are being worked on in a separate PR; this currently functions with our existing E2E test suite given the transparent conversion. Once we add the BYO Git functionality we will add e2e tests for the FluxConfig case with both GitHub and Git provider types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

