### PR TITLE
Default to fetching eks-d release from url if it can't be fetched from the cluster

### DIFF
--- a/pkg/cluster/fetch.go
+++ b/pkg/cluster/fetch.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 
@@ -12,8 +11,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/logger"
 	v1alpha1release "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
-
-const eksdReleaseObjDoesNotExist = "the server doesn't have a resource type \"releases\""
 
 type BundlesFetch func(ctx context.Context, name, namespace string) (*v1alpha1release.Bundles, error)
 
@@ -74,12 +71,8 @@ func GetEksdReleaseForCluster(ctx context.Context, cluster *v1alpha1.Cluster, bu
 	}
 	eksd, err := fetch(ctx, versionsBundle.EksD.Name, constants.EksaSystemNamespace)
 	if err != nil {
-		if strings.Contains(err.Error(), eksdReleaseObjDoesNotExist) {
-			logger.V(4).Info("EKS-D release objects are not present on the cluster. EKS-D release manifest will be retrieved from the URL in the bundle")
-			return nil, nil
-		} else {
-			return nil, fmt.Errorf("failed fetching EKS-D release for cluster: %v", err)
-		}
+		logger.V(4).Info("EKS-D release objects cannot be retrieved from the cluster. Fetching EKS-D release manifest from the URL in the bundle")
+		return nil, nil
 	}
 
 	return eksd, nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fetching the EKS-D release manifest could return a number of different errors if those release objs aren't present on the cluster. We should default to fetching the EKS-D object from the URL & then applying it to the cluster after upgrade.

*Testing (if applicable):*
Tilt, cluster created with 0.7 and upgraded with 0.8.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

