### PR TITLE
make sure FluxConfig is included in cluster deepcopy

### DIFF
--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -39,6 +39,7 @@ func (c *Config) DeepCopy() *Config {
 		VSphereDatacenter: c.VSphereDatacenter.DeepCopy(),
 		DockerDatacenter:  c.DockerDatacenter.DeepCopy(),
 		GitOpsConfig:      c.GitOpsConfig.DeepCopy(),
+		FluxConfig:        c.FluxConfig.DeepCopy(),
 	}
 
 	if c.VSphereMachineConfigs != nil {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/1826

*Description of changes:*
Make sure that the FluxConfig is included in the cluster DeepCopy

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

