### PR TITLE
Add upgrade support of labels/taints for Docker

### DIFF
--- a/pkg/providers/docker/config/template-md.yaml
+++ b/pkg/providers/docker/config/template-md.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: {{.workerNodeGroupName}}
+  name: {{.workloadkubeadmconfigTemplateName}}
   namespace: {{.eksaSystemNamespace}}
 spec:
   template:
@@ -44,7 +44,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: {{.workerNodeGroupName}}
+          name: {{.workloadkubeadmconfigTemplateName}}
           namespace: {{.eksaSystemNamespace}}
       clusterName: {{.clusterName}}
       infrastructureRef:

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"time"
 
 	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -133,26 +132,6 @@ type DockerTemplateBuilder struct {
 	now types.NowFunc
 }
 
-func (d *DockerTemplateBuilder) WorkerMachineTemplateName(clusterName, workerNodeGroupName string) string {
-	t := d.now().UnixNano() / int64(time.Millisecond)
-	return fmt.Sprintf("%s-%s-%d", clusterName, workerNodeGroupName, t)
-}
-
-func (d *DockerTemplateBuilder) CPMachineTemplateName(clusterName string) string {
-	t := d.now().UnixNano() / int64(time.Millisecond)
-	return fmt.Sprintf("%s-control-plane-template-%d", clusterName, t)
-}
-
-func (d *DockerTemplateBuilder) EtcdMachineTemplateName(clusterName string) string {
-	t := d.now().UnixNano() / int64(time.Millisecond)
-	return fmt.Sprintf("%s-etcd-template-%d", clusterName, t)
-}
-
-func (vs *DockerTemplateBuilder) KubeadmConfigTemplateName(clusterName, workerNodeGroupName string) string {
-	t := vs.now().UnixNano() / int64(time.Millisecond)
-	return fmt.Sprintf("%s-%s-template-%d", clusterName, workerNodeGroupName, t)
-}
-
 func (d *DockerTemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spec, buildOptions ...providers.BuildMapOption) (content []byte, err error) {
 	values := buildTemplateMapCP(clusterSpec)
 	for _, buildOption := range buildOptions {
@@ -171,12 +150,8 @@ func (d *DockerTemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spe
 	workerSpecs := make([][]byte, 0, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
 	for _, workerNodeGroupConfiguration := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
 		values := buildTemplateMapMD(clusterSpec, workerNodeGroupConfiguration)
-		_, ok := workloadTemplateNames[workerNodeGroupConfiguration.Name]
-		if workloadTemplateNames != nil && ok {
-			values["workloadTemplateName"] = workloadTemplateNames[workerNodeGroupConfiguration.Name]
-		} else {
-			values["workloadTemplateName"] = d.WorkerMachineTemplateName(clusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name)
-		}
+		values["workloadTemplateName"] = workloadTemplateNames[workerNodeGroupConfiguration.Name]
+		values["workloadkubeadmconfigTemplateName"] = kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name]
 
 		bytes, err := templater.Execute(defaultCAPIConfigMD, values)
 		if err != nil {
@@ -263,10 +238,15 @@ func NeedsNewControlPlaneTemplate(oldSpec, newSpec *cluster.Spec) bool {
 }
 
 func NeedsNewWorkloadTemplate(oldSpec, newSpec *cluster.Spec) bool {
-	if !v1alpha1.WorkerNodeGroupConfigurationSliceTaintsEqual(oldSpec.Cluster.Spec.WorkerNodeGroupConfigurations, newSpec.Cluster.Spec.WorkerNodeGroupConfigurations) {
+	if !v1alpha1.WorkerNodeGroupConfigurationSliceTaintsEqual(oldSpec.Cluster.Spec.WorkerNodeGroupConfigurations, newSpec.Cluster.Spec.WorkerNodeGroupConfigurations) ||
+		!v1alpha1.WorkerNodeGroupConfigurationsLabelsMapEqual(oldSpec.Cluster.Spec.WorkerNodeGroupConfigurations, newSpec.Cluster.Spec.WorkerNodeGroupConfigurations) {
 		return true
 	}
 	return (oldSpec.Cluster.Spec.KubernetesVersion != newSpec.Cluster.Spec.KubernetesVersion) || (oldSpec.Bundles.Spec.Number != newSpec.Bundles.Spec.Number)
+}
+
+func NeedsNewKubeadmConfigTemplate(newWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration, oldWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration) bool {
+	return !v1alpha1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints) || !v1alpha1.LabelsMapEqual(newWorkerNodeGroup.Labels, oldWorkerNodeGroup.Labels)
 }
 
 func NeedsNewEtcdTemplate(oldSpec, newSpec *cluster.Spec) bool {
@@ -275,7 +255,7 @@ func NeedsNewEtcdTemplate(oldSpec, newSpec *cluster.Spec) bool {
 
 func (p *provider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currentSpec, newClusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	clusterName := newClusterSpec.Cluster.Name
-	var controlPlaneTemplateName, workloadTemplateName, etcdTemplateName string
+	var controlPlaneTemplateName, workloadTemplateName, kubeadmconfigTemplateName, etcdTemplateName string
 	var needsNewEtcdTemplate bool
 
 	needsNewControlPlaneTemplate := NeedsNewControlPlaneTemplate(currentSpec, newClusterSpec)
@@ -286,15 +266,37 @@ func (p *provider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapClus
 		}
 		controlPlaneTemplateName = cp.Spec.MachineTemplate.InfrastructureRef.Name
 	} else {
-		controlPlaneTemplateName = p.templateBuilder.CPMachineTemplateName(clusterName)
+		controlPlaneTemplateName = common.CPMachineTemplateName(clusterName, p.templateBuilder.now)
 	}
 
 	previousWorkerNodeGroupConfigs := cluster.BuildMapForWorkerNodeGroupsByName(currentSpec.Cluster.Spec.WorkerNodeGroupConfigurations)
 
 	workloadTemplateNames := make(map[string]string, len(newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	kubeadmconfigTemplateNames := make(map[string]string, len(newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
 	for _, workerNodeGroupConfiguration := range newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
-		needsNewWorkloadTemplate := NeedsNewWorkloadTemplate(currentSpec, newClusterSpec)
-		if _, ok := previousWorkerNodeGroupConfigs[workerNodeGroupConfiguration.Name]; ok && !needsNewWorkloadTemplate {
+		needsNewWorkloadTemplate, err := p.needsNewMachineTemplate(currentSpec, newClusterSpec, workerNodeGroupConfiguration, previousWorkerNodeGroupConfigs)
+		if err != nil {
+			return nil, nil, err
+		}
+		needsNewKubeadmConfigTemplate, err := p.needsNewKubeadmConfigTemplate(workerNodeGroupConfiguration, previousWorkerNodeGroupConfigs)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if !needsNewKubeadmConfigTemplate {
+			mdName := machineDeploymentName(newClusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name)
+			md, err := p.providerKubectlClient.GetMachineDeployment(ctx, mdName, executables.WithCluster(bootstrapCluster), executables.WithNamespace(constants.EksaSystemNamespace))
+			if err != nil {
+				return nil, nil, err
+			}
+			kubeadmconfigTemplateName = md.Spec.Template.Spec.Bootstrap.ConfigRef.Name
+			kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name] = kubeadmconfigTemplateName
+		} else {
+			kubeadmconfigTemplateName = common.KubeadmConfigTemplateName(clusterName, workerNodeGroupConfiguration.Name, p.templateBuilder.now)
+			kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name] = kubeadmconfigTemplateName
+		}
+
+		if !needsNewWorkloadTemplate {
 			mdName := machineDeploymentName(newClusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name)
 			md, err := p.providerKubectlClient.GetMachineDeployment(ctx, mdName, executables.WithCluster(bootstrapCluster), executables.WithNamespace(constants.EksaSystemNamespace))
 			if err != nil {
@@ -303,13 +305,12 @@ func (p *provider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapClus
 			workloadTemplateName = md.Spec.Template.Spec.InfrastructureRef.Name
 			workloadTemplateNames[workerNodeGroupConfiguration.Name] = workloadTemplateName
 		} else {
-			workloadTemplateName = p.templateBuilder.WorkerMachineTemplateName(clusterName, workerNodeGroupConfiguration.Name)
+			workloadTemplateName = common.WorkerMachineTemplateName(clusterName, workerNodeGroupConfiguration.Name, p.templateBuilder.now)
 			workloadTemplateNames[workerNodeGroupConfiguration.Name] = workloadTemplateName
 		}
 	}
 
 	if newClusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
-		// TODO: replace controlPlaneMachineConfig with etcdMachineConfig once available in final GA spec
 		needsNewEtcdTemplate = NeedsNewEtcdTemplate(currentSpec, newClusterSpec)
 		if !needsNewEtcdTemplate {
 			etcdadmCluster, err := p.providerKubectlClient.GetEtcdadmCluster(ctx, workloadCluster, newClusterSpec.Cluster.Name, executables.WithCluster(bootstrapCluster), executables.WithNamespace(constants.EksaSystemNamespace))
@@ -329,7 +330,7 @@ func (p *provider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapClus
 			if err != nil {
 				return nil, nil, err
 			}
-			etcdTemplateName = p.templateBuilder.EtcdMachineTemplateName(clusterName)
+			etcdTemplateName = common.EtcdMachineTemplateName(clusterName, p.templateBuilder.now)
 		}
 	}
 
@@ -342,25 +343,47 @@ func (p *provider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapClus
 		return nil, nil, err
 	}
 
-	workersSpec, err = p.templateBuilder.GenerateCAPISpecWorkers(newClusterSpec, workloadTemplateNames, nil)
+	workersSpec, err = p.templateBuilder.GenerateCAPISpecWorkers(newClusterSpec, workloadTemplateNames, kubeadmconfigTemplateNames)
 	if err != nil {
 		return nil, nil, err
 	}
 	return controlPlaneSpec, workersSpec, nil
 }
 
+func (p *provider) needsNewMachineTemplate(currentSpec, newClusterSpec *cluster.Spec, workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration, prevWorkerNodeGroupConfigs map[string]v1alpha1.WorkerNodeGroupConfiguration) (bool, error) {
+	if _, ok := prevWorkerNodeGroupConfigs[workerNodeGroupConfiguration.Name]; ok {
+		needsNewWorkloadTemplate := NeedsNewWorkloadTemplate(currentSpec, newClusterSpec)
+		return needsNewWorkloadTemplate, nil
+	}
+	return true, nil
+}
+
+func (p *provider) needsNewKubeadmConfigTemplate(workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration, prevWorkerNodeGroupConfigs map[string]v1alpha1.WorkerNodeGroupConfiguration) (bool, error) {
+	if _, ok := prevWorkerNodeGroupConfigs[workerNodeGroupConfiguration.Name]; ok {
+		existingWorkerNodeGroupConfig := prevWorkerNodeGroupConfigs[workerNodeGroupConfiguration.Name]
+		return NeedsNewKubeadmConfigTemplate(&workerNodeGroupConfiguration, &existingWorkerNodeGroupConfig), nil
+	}
+	return true, nil
+}
+
 func (p *provider) generateCAPISpecForCreate(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	clusterName := clusterSpec.Cluster.Name
 
 	cpOpt := func(values map[string]interface{}) {
-		values["controlPlaneTemplateName"] = p.templateBuilder.CPMachineTemplateName(clusterName)
-		values["etcdTemplateName"] = p.templateBuilder.EtcdMachineTemplateName(clusterName)
+		values["controlPlaneTemplateName"] = common.CPMachineTemplateName(clusterName, p.templateBuilder.now)
+		values["etcdTemplateName"] = common.EtcdMachineTemplateName(clusterName, p.templateBuilder.now)
 	}
 	controlPlaneSpec, err = p.templateBuilder.GenerateCAPISpecControlPlane(clusterSpec, cpOpt)
 	if err != nil {
 		return nil, nil, err
 	}
-	workersSpec, err = p.templateBuilder.GenerateCAPISpecWorkers(clusterSpec, nil, nil)
+	workloadTemplateNames := make(map[string]string, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	kubeadmconfigTemplateNames := make(map[string]string, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	for _, workerNodeGroupConfiguration := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
+		workloadTemplateNames[workerNodeGroupConfiguration.Name] = common.WorkerMachineTemplateName(clusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name, p.templateBuilder.now)
+		kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name] = common.KubeadmConfigTemplateName(clusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name, p.templateBuilder.now)
+	}
+	workersSpec, err = p.templateBuilder.GenerateCAPISpecWorkers(clusterSpec, workloadTemplateNames, kubeadmconfigTemplateNames)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/providers/docker/docker_test.go
+++ b/pkg/providers/docker/docker_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/providers/docker"
@@ -172,7 +173,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 			wantMDFile: "testdata/valid_deployment_md_taints_expected.yaml",
 		},
 		{
-			testName: "valid config multiple worker node groups with machine deplyoment taints",
+			testName: "valid config multiple worker node groups with machine deployment taints",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.Cluster.Name = "test-cluster"
 				s.Cluster.Spec.KubernetesVersion = "1.19"
@@ -303,6 +304,25 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 			bootstrapCluster := &types.Cluster{
 				Name: "bootstrap-test",
 			}
+			for _, nodeGroup := range tt.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
+				md := &clusterv1.MachineDeployment{
+					Spec: clusterv1.MachineDeploymentSpec{
+						Template: clusterv1.MachineTemplateSpec{
+							Spec: clusterv1.MachineSpec{
+								Bootstrap: clusterv1.Bootstrap{
+									ConfigRef: &v1.ObjectReference{
+										Name: fmt.Sprintf("%s-%s-template-1234567890000", tt.clusterSpec.Cluster.Name, nodeGroup.Name),
+									},
+								},
+							},
+						},
+					},
+				}
+				machineDeploymentName := fmt.Sprintf("%s-%s", tt.clusterSpec.Cluster.Name, nodeGroup.Name)
+				kubectl.EXPECT().GetMachineDeployment(ctx, machineDeploymentName,
+					gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster)),
+					gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace))).Return(md, nil)
+			}
 			kubectl.EXPECT().UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", tt.clusterSpec.Cluster.Name),
 				map[string]string{etcdv1.UpgradeInProgressAnnotation: "true"}, gomock.Any(), gomock.Any())
 			cpContent, mdContent, err := p.GenerateCAPISpecForUpgrade(ctx, bootstrapCluster, cluster, currentSpec, tt.clusterSpec)
@@ -313,6 +333,68 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 			test.AssertContentToFile(t, string(mdContent), tt.wantMDFile)
 		})
 	}
+}
+
+func TestProviderGenerateDeploymentFileSuccessUpdateKubeadmConfigTemplate(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	ctx := context.Background()
+	client := dockerMocks.NewMockProviderClient(mockCtrl)
+	kubectl := dockerMocks.NewMockProviderKubectlClient(mockCtrl)
+	clusterSpec := test.NewClusterSpec()
+
+	var cpTaints, wnTaints []v1.Taint
+	cpTaints = append(cpTaints, v1.Taint{Key: "key1", Value: "val1", Effect: "NoSchedule", TimeAdded: nil})
+	cpTaints = append(cpTaints, v1.Taint{Key: "key2", Value: "val2", Effect: "PreferNoSchedule", TimeAdded: nil})
+	cpTaints = append(cpTaints, v1.Taint{Key: "key3", Value: "val3", Effect: "NoExecute", TimeAdded: nil})
+	wnTaints = append(wnTaints, v1.Taint{Key: "key2", Value: "val2", Effect: "PreferNoSchedule", TimeAdded: nil})
+
+	clusterSpec.Cluster.Name = "test-cluster"
+	clusterSpec.Cluster.Spec.KubernetesVersion = "1.19"
+	clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+	clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
+	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints = cpTaints
+	clusterSpec.VersionsBundle = versionsBundle
+	clusterSpec.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
+	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+
+	p := docker.NewProvider(&v1alpha1.DockerDatacenterConfig{}, client, kubectl, test.FakeNow)
+	cluster := &types.Cluster{
+		Name: "test-cluster",
+	}
+	currentSpec := clusterSpec.DeepCopy()
+	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Taints = wnTaints
+	bootstrapCluster := &types.Cluster{
+		Name: "bootstrap-test",
+	}
+
+	cp := &controlplanev1.KubeadmControlPlane{
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
+				InfrastructureRef: v1.ObjectReference{
+					Name: "test-cluster-control-plane-template-1234567890000",
+				},
+			},
+		},
+	}
+	etcdadm := &etcdv1.EtcdadmCluster{
+		Spec: etcdv1.EtcdadmClusterSpec{
+			InfrastructureTemplate: v1.ObjectReference{
+				Name: "test-cluster-etcd-template-1234567890000",
+			},
+		},
+	}
+
+	kubectl.EXPECT().GetKubeadmControlPlane(ctx, cluster, cluster.Name, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(cp, nil)
+	kubectl.EXPECT().GetEtcdadmCluster(ctx, cluster, cluster.Name, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(etcdadm, nil)
+
+	cpContent, mdContent, err := p.GenerateCAPISpecForUpgrade(ctx, bootstrapCluster, cluster, currentSpec, clusterSpec)
+	if err != nil {
+		t.Fatalf("provider.GenerateCAPISpecForUpgrade() error = %v, wantErr nil", err)
+	}
+
+	test.AssertContentToFile(t, string(cpContent), "testdata/valid_deployment_cp_taints_expected.yaml")
+	test.AssertContentToFile(t, string(mdContent), "testdata/valid_deployment_md_taints_expected.yaml")
 }
 
 func TestProviderGenerateDeploymentFileSuccessNotUpdateMachineTemplate(t *testing.T) {
@@ -346,6 +428,11 @@ func TestProviderGenerateDeploymentFileSuccessNotUpdateMachineTemplate(t *testin
 		Spec: clusterv1.MachineDeploymentSpec{
 			Template: clusterv1.MachineTemplateSpec{
 				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &v1.ObjectReference{
+							Name: "test-md-0-original",
+						},
+					},
 					InfrastructureRef: v1.ObjectReference{
 						Name: "test-md-0-original",
 					},
@@ -356,7 +443,7 @@ func TestProviderGenerateDeploymentFileSuccessNotUpdateMachineTemplate(t *testin
 	machineDeploymentName := fmt.Sprintf("%s-%s", clusterSpec.Cluster.Name, clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Name)
 
 	kubectl.EXPECT().GetKubeadmControlPlane(ctx, cluster, cluster.Name, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(cp, nil)
-	kubectl.EXPECT().GetMachineDeployment(ctx, machineDeploymentName, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(md, nil)
+	kubectl.EXPECT().GetMachineDeployment(ctx, machineDeploymentName, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster))).Return(md, nil).Times(2)
 
 	cpContent, mdContent, err := p.GenerateCAPISpecForUpgrade(ctx, bootstrapCluster, cluster, currentSpec, clusterSpec)
 	if err != nil {

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_md_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_md_expected.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-cluster-md-0
+  name: test-cluster-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -31,7 +31,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-cluster-md-0
+          name: test-cluster-md-0-template-1234567890000
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_md_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_md_expected.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-cluster-md-0
+  name: test-cluster-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -31,7 +31,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-cluster-md-0
+          name: test-cluster-md-0-template-1234567890000
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:

--- a/pkg/providers/docker/testdata/no_machinetemplate_update_md_expected.yaml
+++ b/pkg/providers/docker/testdata/no_machinetemplate_update_md_expected.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: fluxAddonTestCluster-md-0
+  name: test-md-0-original
   namespace: eksa-system
 spec:
   template:
@@ -31,7 +31,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: fluxAddonTestCluster-md-0
+          name: test-md-0-original
           namespace: eksa-system
       clusterName: fluxAddonTestCluster
       infrastructureRef:

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_md_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_md_expected.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-cluster-md-0
+  name: test-cluster-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -32,7 +32,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-cluster-md-0
+          name: test-cluster-md-0-template-1234567890000
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:

--- a/pkg/providers/docker/testdata/valid_deployment_md_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_md_expected.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-cluster-md-0
+  name: test-cluster-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -31,7 +31,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-cluster-md-0
+          name: test-cluster-md-0-template-1234567890000
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:

--- a/pkg/providers/docker/testdata/valid_deployment_md_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_md_taints_expected.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-cluster-md-0
+  name: test-cluster-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -34,7 +34,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-cluster-md-0
+          name: test-cluster-md-0-template-1234567890000
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:

--- a/pkg/providers/docker/testdata/valid_deployment_multiple_md_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_multiple_md_taints_expected.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-cluster-md-0
+  name: test-cluster-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -34,7 +34,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-cluster-md-0
+          name: test-cluster-md-0-template-1234567890000
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
@@ -61,7 +61,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-cluster-md-1
+  name: test-cluster-md-1-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -94,7 +94,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-cluster-md-1
+          name: test-cluster-md-1-template-1234567890000
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:

--- a/pkg/providers/docker/testdata/valid_deployment_node_labels_md_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_node_labels_md_expected.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test-cluster-md-0
+  name: test-cluster-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:
@@ -32,7 +32,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test-cluster-md-0
+          name: test-cluster-md-0-template-1234567890000
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -887,10 +887,6 @@ func (p *vsphereProvider) generateCAPISpecForUpgrade(ctx context.Context, bootst
 		if err != nil {
 			return nil, nil, err
 		}
-
-		if err != nil {
-			return nil, nil, err
-		}
 		needsNewKubeadmConfigTemplate, err := p.needsNewKubeadmConfigTemplate(workerNodeGroupConfiguration, previousWorkerNodeGroupConfigs, oldWorkerNodeVmc, newWorkerNodeVmc)
 		if err != nil {
 			return nil, nil, err

--- a/test/e2e/labels_test.go
+++ b/test/e2e/labels_test.go
@@ -32,6 +32,37 @@ func runLabelsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1
 	test.DeleteCluster()
 }
 
+func TestDockerKubernetes122Labels(t *testing.T) {
+	provider := framework.NewDocker(t)
+
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube122),
+			api.WithExternalEtcdTopology(1),
+			api.WithControlPlaneCount(1),
+			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+			api.WithWorkerNodeGroup(worker0, api.WithCount(2),
+				api.WithLabel(key1, val2)),
+			api.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+			api.WithWorkerNodeGroup(worker2, api.WithCount(1),
+				api.WithLabel(key2, val2)),
+		),
+	)
+
+	runLabelsUpgradeFlow(
+		test,
+		v1alpha1.Kube122,
+		framework.WithClusterUpgrade(
+			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+			api.WithWorkerNodeGroup(worker2),
+			api.WithControlPlaneLabel(cpKey1, cpVal1),
+		),
+	)
+}
+
 func TestVSphereKubernetes122Labels(t *testing.T) {
 	provider := ubuntu122ProviderWithLabels(t)
 

--- a/test/e2e/taints_test.go
+++ b/test/e2e/taints_test.go
@@ -30,6 +30,32 @@ func runTaintsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1
 // remove a taint from a node
 // add a taint to a node which already has another taint
 // add a taint to a node which had no taints
+func TestDockerKubernetes122Taints(t *testing.T) {
+	provider := framework.NewDocker(t)
+
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube122),
+			api.WithExternalEtcdTopology(1),
+			api.WithControlPlaneCount(1),
+			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+		),
+	)
+
+	runTaintsUpgradeFlow(
+		test,
+		v1alpha1.Kube122,
+		framework.WithClusterUpgrade(
+			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+		),
+	)
+}
+
 func TestVSphereKubernetes122Taints(t *testing.T) {
 	provider := ubuntu122ProviderWithTaints(t)
 

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -318,5 +318,5 @@ func buildVSphereWorkerNodeGroupClusterFiller(machineConfigName string, workerNo
 	// Set worker node group ref to vsphere machine config
 	workerNodeGroup.MachineConfigKind = anywherev1.VSphereMachineConfigKind
 	workerNodeGroup.MachineConfigName = machineConfigName
-	return workerNodeGroup.clusterFiller()
+	return workerNodeGroup.ClusterFiller()
 }

--- a/test/framework/workergroups.go
+++ b/test/framework/workergroups.go
@@ -15,7 +15,7 @@ func WithWorkerNodeGroup(name string, fillers ...api.WorkerNodeGroupFiller) *Wor
 	}
 }
 
-func (w *WorkerNodeGroup) clusterFiller() api.ClusterFiller {
+func (w *WorkerNodeGroup) ClusterFiller() api.ClusterFiller {
 	wf := make([]api.WorkerNodeGroupFiller, 0, len(w.Fillers)+1)
 	wf = append(wf, api.WithMachineGroupRef(w.MachineConfigName, w.MachineConfigKind))
 	wf = append(wf, w.Fillers...)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/1626

*Description of changes:*
Add support for upgrading labels and taints for the Docker provider which was missing before.

*Testing (if applicable):*
Ran e2e tests while running tilt to update the controller

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

