### PR TITLE
Add e2e test for download artifacts command

### DIFF
--- a/test/e2e/download_artifacts_test.go
+++ b/test/e2e/download_artifacts_test.go
@@ -1,0 +1,30 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/test/framework"
+)
+
+func runDownloadArtifactsFlow(test *framework.ClusterE2ETest) {
+	test.GenerateClusterConfig()
+	test.DownloadArtifacts()
+}
+
+func TestDownloadArtifacts(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewVSphere(t, framework.WithUbuntu122(), framework.WithPrivateNetwork()),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
+		framework.WithRegistryMirrorEndpointAndCert(),
+	)
+	runDownloadArtifactsFlow(test)
+}

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -353,6 +353,16 @@ func (e *ClusterE2ETest) ImportImages(opts ...CommandOpt) {
 	e.RunEKSA(importImagesArgs, opts...)
 }
 
+func (e *ClusterE2ETest) DownloadArtifacts(opts ...CommandOpt) {
+	downloadArtifactsArgs := []string{"download", "artifacts", "-f", e.ClusterConfigLocation}
+	e.RunEKSA(downloadArtifactsArgs, opts...)
+	if _, err := os.Stat("eks-anywhere-downloads.tar.gz"); err != nil {
+		e.T.Fatal(err)
+	} else {
+		e.T.Log("Downloaded artifacts saved at eks-anywhere-downloads.tar.gz")
+	}
+}
+
 func (e *ClusterE2ETest) CreateCluster(opts ...CommandOpt) {
 	e.createCluster(opts...)
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/eks-anywhere/issues/1329

*Description of changes:*
Runs download artifacts command only to make sure it generates the tarball

*Testing (if applicable):*
Ran the test locally 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

