### PR TITLE
Fix e2e taint test for docker

### DIFF
--- a/test/e2e/taints_test.go
+++ b/test/e2e/taints_test.go
@@ -41,6 +41,9 @@ func TestDockerKubernetes122Taints(t *testing.T) {
 			api.WithExternalEtcdTopology(1),
 			api.WithControlPlaneCount(1),
 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoScheduleTaint()), api.WithCount(2)),
+			api.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+			api.WithWorkerNodeGroup(worker2, api.WithTaint(framework.PreferNoScheduleTaint()), api.WithCount(1)),
 		),
 	)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
These changes were missed from https://github.com/aws/eks-anywhere/pull/1851 causing the test to fail. 

*Testing (if applicable):*
Ran `TestDockerKubernetes122Taints`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

