### PR TITLE
Remove unused RequiredTinkerbellEnvVars method

### DIFF
--- a/test/framework/tinkerbell.go
+++ b/test/framework/tinkerbell.go
@@ -35,10 +35,6 @@ var requiredTinkerbellEnvVars = []string{
 	tinkerbellSSHAuthorizedKey,
 }
 
-func RequiredTinkerbellEnvVars() []string {
-	return requiredEnvVars
-}
-
 type TinkerbellOpt func(*Tinkerbell)
 
 type Tinkerbell struct {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove unused tinkerbell e2e method which wrongly returns vsphere vars.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

