### PR TITLE
Log storage class install only for supported providers

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -647,6 +647,7 @@ func (c *ClusterManager) InstallStorageClass(ctx context.Context, cluster *types
 		return nil
 	}
 
+	logger.Info("Installing storage class on cluster")
 	err := c.Retrier.Retry(
 		func() error {
 			return c.clusterClient.ApplyKubeSpecFromBytes(ctx, cluster, storageClass)

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -198,7 +198,6 @@ func (s *CreateWorkloadClusterTask) Run(ctx context.Context, commandContext *tas
 		}
 	}
 
-	logger.Info("Installing storage class on workload cluster")
 	err = commandContext.ClusterManager.InstallStorageClass(ctx, workloadCluster, commandContext.Provider)
 	if err != nil {
 		commandContext.SetError(err)


### PR DESCRIPTION
*Description of changes:*
It was confusing that we were logging this for all providers, even when
there wasn't any storage class being installed. Now it only logs when
the provider returns a storage class.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

