### PR TITLE
Create a make target and clean up for generating checksums

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,6 +326,10 @@ generate-attribution:
 update-attribution-files: generate-attribution
 	scripts/create_pr.sh
 
+.PHONY: generate-checksums
+generate-checksums:
+	scripts/generate_checksum.sh
+
 .PHONY: clean
 clean: ## Clean up resources created by make targets
 	rm -rf ./bin/*

--- a/scripts/generate_checksum.sh
+++ b/scripts/generate_checksum.sh
@@ -70,3 +70,6 @@ do
 done
 
 echo "Generated the check sum files inside the ${SHASUM_FILES} folder at the directory where you ran this script from."
+
+rm release.yaml
+rm latest_release.yaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Creates a make target for generating checksums' script. Also cleans up extra unnecessary files.

*Testing (if applicable):*
`make generate-checksums`
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

