### PR TITLE
Adding cloudstackEntry to enable marshalling cloudstack yamls

### DIFF
--- a/controllers/controllers/resource/testdata/eksa-cluster-cloudstack_no_changes.yaml
+++ b/controllers/controllers/resource/testdata/eksa-cluster-cloudstack_no_changes.yaml
@@ -39,7 +39,7 @@ spec:
   template:
     name: rhel8-1.20
   userCustomDetails:
-    - foo: bar
+    foo: bar
   users:
     - name: capc
       sshAuthorizedKeys:

--- a/pkg/api/v1alpha1/cloudstackdatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackdatacenterconfig_types.go
@@ -138,6 +138,10 @@ func (v *CloudStackDatacenterConfig) Marshallable() Marshallable {
 	return v.ConvertConfigToConfigGenerateStruct()
 }
 
+func (v *CloudStackDatacenterConfig) Validate() error {
+	return nil
+}
+
 func (s *CloudStackDatacenterConfigSpec) Equal(o *CloudStackDatacenterConfigSpec) bool {
 	if s == o {
 		return true

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
@@ -95,6 +95,10 @@ func (c *CloudStackMachineConfig) GetName() string {
 	return c.Name
 }
 
+func (c *CloudStackMachineConfig) Validate() error {
+	return nil
+}
+
 // CloudStackMachineConfigStatus defines the observed state of CloudStackMachineConfig
 type CloudStackMachineConfigStatus struct { // INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file

--- a/pkg/cluster/cloudstack.go
+++ b/pkg/cluster/cloudstack.go
@@ -1,0 +1,85 @@
+package cluster
+
+import anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+
+func cloudstackEntry() *ConfigManagerEntry {
+	return &ConfigManagerEntry{
+		APIObjectMapping: map[string]APIObjectGenerator{
+			anywherev1.CloudStackDatacenterKind: func() APIObject {
+				return &anywherev1.CloudStackDatacenterConfig{}
+			},
+			anywherev1.CloudStackMachineConfigKind: func() APIObject {
+				return &anywherev1.CloudStackMachineConfig{}
+			},
+		},
+		Processors: []ParsedProcessor{
+			processCloudStackDatacenter,
+			machineConfigsProcessor(processCloudStackMachineConfig),
+		},
+		Defaulters: []Defaulter{
+			func(c *Config) error {
+				return nil
+			},
+		},
+		Validations: []Validation{
+			func(c *Config) error {
+				if c.CloudStackDatacenter != nil {
+					return c.CloudStackDatacenter.Validate()
+				}
+				return nil
+			},
+			func(c *Config) error {
+				for _, m := range c.CloudStackMachineConfigs {
+					if err := m.Validate(); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			func(c *Config) error {
+				if c.CloudStackDatacenter != nil {
+					if err := validateSameNamespace(c, c.CloudStackDatacenter); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			func(c *Config) error {
+				for _, v := range c.CloudStackMachineConfigs {
+					if err := validateSameNamespace(c, v); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		},
+	}
+}
+
+func processCloudStackDatacenter(c *Config, objects ObjectLookup) {
+	if c.Cluster.Spec.DatacenterRef.Kind == anywherev1.CloudStackDatacenterKind {
+		datacenter := objects.GetFromRef(c.Cluster.APIVersion, c.Cluster.Spec.DatacenterRef)
+		c.CloudStackDatacenter = datacenter.(*anywherev1.CloudStackDatacenterConfig)
+	}
+}
+
+func processCloudStackMachineConfig(c *Config, objects ObjectLookup, machineRef *anywherev1.Ref) {
+	if machineRef == nil {
+		return
+	}
+
+	if machineRef.Kind != anywherev1.CloudStackMachineConfigKind {
+		return
+	}
+
+	if c.CloudStackMachineConfigs == nil {
+		c.CloudStackMachineConfigs = map[string]*anywherev1.CloudStackMachineConfig{}
+	}
+
+	m := objects.GetFromRef(c.Cluster.APIVersion, *machineRef)
+	if m == nil {
+		return
+	}
+
+	c.CloudStackMachineConfigs[m.GetName()] = m.(*anywherev1.CloudStackMachineConfig)
+}

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -5,20 +5,26 @@ import (
 )
 
 type Config struct {
-	Cluster               *anywherev1.Cluster
-	VSphereDatacenter     *anywherev1.VSphereDatacenterConfig
-	DockerDatacenter      *anywherev1.DockerDatacenterConfig
-	SnowDatacenter        *anywherev1.SnowDatacenterConfig
-	VSphereMachineConfigs map[string]*anywherev1.VSphereMachineConfig
-	SnowMachineConfigs    map[string]*anywherev1.SnowMachineConfig
-	OIDCConfigs           map[string]*anywherev1.OIDCConfig
-	AWSIAMConfigs         map[string]*anywherev1.AWSIamConfig
-	GitOpsConfig          *anywherev1.GitOpsConfig
-	FluxConfig            *anywherev1.FluxConfig
+	Cluster                  *anywherev1.Cluster
+	CloudStackDatacenter     *anywherev1.CloudStackDatacenterConfig
+	VSphereDatacenter        *anywherev1.VSphereDatacenterConfig
+	DockerDatacenter         *anywherev1.DockerDatacenterConfig
+	SnowDatacenter           *anywherev1.SnowDatacenterConfig
+	VSphereMachineConfigs    map[string]*anywherev1.VSphereMachineConfig
+	CloudStackMachineConfigs map[string]*anywherev1.CloudStackMachineConfig
+	SnowMachineConfigs       map[string]*anywherev1.SnowMachineConfig
+	OIDCConfigs              map[string]*anywherev1.OIDCConfig
+	AWSIAMConfigs            map[string]*anywherev1.AWSIamConfig
+	GitOpsConfig             *anywherev1.GitOpsConfig
+	FluxConfig               *anywherev1.FluxConfig
 }
 
 func (c *Config) VsphereMachineConfig(name string) *anywherev1.VSphereMachineConfig {
 	return c.VSphereMachineConfigs[name]
+}
+
+func (c *Config) CloudStackMachineConfig(name string) *anywherev1.CloudStackMachineConfig {
+	return c.CloudStackMachineConfigs[name]
 }
 
 func (c *Config) SnowMachineConfig(name string) *anywherev1.SnowMachineConfig {
@@ -35,18 +41,27 @@ func (c *Config) AWSIamConfig(name string) *anywherev1.AWSIamConfig {
 
 func (c *Config) DeepCopy() *Config {
 	c2 := &Config{
-		Cluster:           c.Cluster.DeepCopy(),
-		VSphereDatacenter: c.VSphereDatacenter.DeepCopy(),
-		DockerDatacenter:  c.DockerDatacenter.DeepCopy(),
-		GitOpsConfig:      c.GitOpsConfig.DeepCopy(),
-		FluxConfig:        c.FluxConfig.DeepCopy(),
+		Cluster:              c.Cluster.DeepCopy(),
+		CloudStackDatacenter: c.CloudStackDatacenter.DeepCopy(),
+		VSphereDatacenter:    c.VSphereDatacenter.DeepCopy(),
+		DockerDatacenter:     c.DockerDatacenter.DeepCopy(),
+		GitOpsConfig:         c.GitOpsConfig.DeepCopy(),
+		FluxConfig:           c.FluxConfig.DeepCopy(),
 	}
 
 	if c.VSphereMachineConfigs != nil {
 		c2.VSphereMachineConfigs = make(map[string]*anywherev1.VSphereMachineConfig, len(c.VSphereMachineConfigs))
 	}
+
 	for k, v := range c.VSphereMachineConfigs {
 		c2.VSphereMachineConfigs[k] = v.DeepCopy()
+	}
+
+	if c.CloudStackMachineConfigs != nil {
+		c2.CloudStackMachineConfigs = make(map[string]*anywherev1.CloudStackMachineConfig, len(c.CloudStackMachineConfigs))
+	}
+	for k, v := range c.CloudStackMachineConfigs {
+		c2.CloudStackMachineConfigs[k] = v.DeepCopy()
 	}
 
 	if c.OIDCConfigs != nil {

--- a/pkg/cluster/default_manager.go
+++ b/pkg/cluster/default_manager.go
@@ -11,6 +11,7 @@ func init() {
 		gitOpsEntry(),
 		fluxEntry(),
 		vsphereEntry(),
+		cloudstackEntry(),
 		dockerEntry(),
 		snowEntry(),
 		tinkerbellEntry(),

--- a/pkg/cluster/parse_test.go
+++ b/pkg/cluster/parse_test.go
@@ -13,18 +13,20 @@ import (
 
 func TestParseConfig(t *testing.T) {
 	tests := []struct {
-		name                      string
-		yamlManifest              []byte
-		wantCluster               *anywherev1.Cluster
-		wantVsphereDatacenter     *anywherev1.VSphereDatacenterConfig
-		wantDockerDatacenter      *anywherev1.DockerDatacenterConfig
-		wantSnowDatacenter        *anywherev1.SnowDatacenterConfig
-		wantVsphereMachineConfigs []*anywherev1.VSphereMachineConfig
-		wantSnowMachineConfigs    []*anywherev1.SnowMachineConfig
-		wantOIDCConfigs           []*anywherev1.OIDCConfig
-		wantAWSIamConfigs         []*anywherev1.AWSIamConfig
-		wantGitOpsConfig          *anywherev1.GitOpsConfig
-		wantFluxConfig            *anywherev1.FluxConfig
+		name                         string
+		yamlManifest                 []byte
+		wantCluster                  *anywherev1.Cluster
+		wantCloudStackDatacenter     *anywherev1.CloudStackDatacenterConfig
+		wantVsphereDatacenter        *anywherev1.VSphereDatacenterConfig
+		wantDockerDatacenter         *anywherev1.DockerDatacenterConfig
+		wantSnowDatacenter           *anywherev1.SnowDatacenterConfig
+		wantVsphereMachineConfigs    []*anywherev1.VSphereMachineConfig
+		wantCloudStackMachineConfigs []*anywherev1.CloudStackMachineConfig
+		wantSnowMachineConfigs       []*anywherev1.SnowMachineConfig
+		wantOIDCConfigs              []*anywherev1.OIDCConfig
+		wantAWSIamConfigs            []*anywherev1.AWSIamConfig
+		wantGitOpsConfig             *anywherev1.GitOpsConfig
+		wantFluxConfig               *anywherev1.FluxConfig
 	}{
 		{
 			name:         "vsphere cluster",
@@ -125,6 +127,99 @@ func TestParseConfig(t *testing.T) {
 							Name:              "mySshUsername",
 							SshAuthorizedKeys: []string{"mySshAuthorizedKey"},
 						}},
+					},
+				},
+			},
+		},
+		{
+			name:         "cloudstack cluster",
+			yamlManifest: []byte(test.ReadFile(t, "testdata/cluster_1_20_cloudstack.yaml")),
+			wantCluster: &anywherev1.Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       anywherev1.ClusterKind,
+					APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: anywherev1.ClusterSpec{
+					KubernetesVersion: "1.20",
+					ControlPlaneConfiguration: anywherev1.ControlPlaneConfiguration{
+						Count:    3,
+						Endpoint: &anywherev1.Endpoint{Host: "test-ip"},
+						MachineGroupRef: &anywherev1.Ref{
+							Kind: "CloudStackMachineConfig",
+							Name: "eksa-unit-test",
+						},
+					},
+					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+						{
+							Count: 3,
+							MachineGroupRef: &anywherev1.Ref{
+								Kind: "CloudStackMachineConfig",
+								Name: "eksa-unit-test",
+							},
+						},
+					},
+					DatacenterRef: anywherev1.Ref{
+						Kind: "CloudStackDatacenterConfig",
+						Name: "eksa-unit-test",
+					},
+					ClusterNetwork: anywherev1.ClusterNetwork{
+						Pods: anywherev1.Pods{
+							CidrBlocks: []string{"192.168.0.0/16"},
+						},
+						Services: anywherev1.Services{
+							CidrBlocks: []string{"10.96.0.0/12"},
+						},
+						CNI: "cilium",
+					},
+				},
+			},
+			wantCloudStackDatacenter: &anywherev1.CloudStackDatacenterConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       anywherev1.CloudStackDatacenterKind,
+					APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: anywherev1.CloudStackDatacenterConfigSpec{
+					Account: "admin",
+					Domain:  "domain1",
+					Zones: []anywherev1.CloudStackZone{
+						{
+							Name: "zone1",
+							Network: anywherev1.CloudStackResourceIdentifier{
+								Name: "net1",
+							},
+						},
+					},
+					ManagementApiEndpoint: "https://127.0.0.1:8080/client/api",
+				},
+			},
+			wantCloudStackMachineConfigs: []*anywherev1.CloudStackMachineConfig{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       anywherev1.CloudStackMachineConfigKind,
+						APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "eksa-unit-test",
+					},
+					Spec: anywherev1.CloudStackMachineConfigSpec{
+						ComputeOffering: anywherev1.CloudStackResourceIdentifier{
+							Name: "m4-large",
+						},
+						Template: anywherev1.CloudStackResourceIdentifier{
+							Name: "centos7-k8s-120",
+						},
+						Users: []anywherev1.UserConfiguration{{
+							Name:              "mySshUsername",
+							SshAuthorizedKeys: []string{"mySshAuthorizedKey"},
+						}},
+						Affinity:          "pro",
+						UserCustomDetails: map[string]string{"foo": "bar"},
 					},
 				},
 			},

--- a/pkg/cluster/testdata/cluster_1_20_cloudstack.yaml
+++ b/pkg/cluster/testdata/cluster_1_20_cloudstack.yaml
@@ -1,0 +1,61 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  clusterNetwork:
+    cni: cilium
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      kind: CloudStackMachineConfig
+      name: eksa-unit-test
+  datacenterRef:
+    kind: CloudStackDatacenterConfig
+    name: eksa-unit-test
+  kubernetesVersion: "1.20"
+  workerNodeGroupConfigurations:
+    - count: 3
+      machineGroupRef:
+        kind: CloudStackMachineConfig
+        name: eksa-unit-test
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackDatacenterConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  account: "admin"
+  domain: "domain1"
+  zones:
+    - name: "zone1"
+      network:
+        name: "net1"
+  managementApiEndpoint: "https://127.0.0.1:8080/client/api"
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackMachineConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  computeOffering:
+    name: "m4-large"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+  template:
+    name: "centos7-k8s-120"
+  userCustomDetails:
+    foo: bar
+  affinity: pro


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR was implemented at the suggestion of @jiayiwang7 to enable marshalling of cloudstack yamls, and it uncovered a broken unit test. The implementation is heavily based on VSphere's

*Testing (if applicable):*
Unit tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

