### PR TITLE
Adding base64 encoded secret as required env var for cloudstack e2e tests

### DIFF
--- a/test/framework/cloudstack.go
+++ b/test/framework/cloudstack.go
@@ -23,6 +23,7 @@ const (
 	podCidrVar                         = "T_CLOUDSTACK_POD_CIDR"
 	serviceCidrVar                     = "T_CLOUDSTACK_SERVICE_CIDR"
 	cloudstackFeatureGateEnvVar        = "CLOUDSTACK_PROVIDER"
+	cloudstackB64EncodedSecretEnvVar   = "EKSA_CLOUDSTACK_B64ENCODED_SECRET"
 )
 
 var requiredCloudStackEnvVars = []string{
@@ -40,6 +41,7 @@ var requiredCloudStackEnvVars = []string{
 	podCidrVar,
 	serviceCidrVar,
 	cloudstackFeatureGateEnvVar,
+	cloudstackB64EncodedSecretEnvVar,
 }
 
 type CloudStack struct {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding the base64 encoded secret env var to list of required env vars for CloudStack e2e tests

*Testing (if applicable):*
E2e test started successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

