### PR TITLE
Make insecure flag and thumbprint in datacenter config mutable

### DIFF
--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1228,6 +1228,14 @@ func (p *vsphereProvider) ValidateNewSpec(ctx context.Context, cluster *types.Cl
 		return fmt.Errorf("spec.network is immutable. Previous value %s, new value %s", oSpec.Network, nSpec.Network)
 	}
 
+	if nSpec.Insecure != oSpec.Insecure {
+		return fmt.Errorf("spec.insecure is immutable. Previous value %t, new value %t", oSpec.Insecure, nSpec.Insecure)
+	}
+
+	if nSpec.Thumbprint != oSpec.Thumbprint {
+		return fmt.Errorf("spec.thumbprint is immutable. Previous value %s, new value %s", oSpec.Thumbprint, nSpec.Thumbprint)
+	}
+
 	secretChanged, err := p.secretContentsChanged(ctx, cluster)
 	if err != nil {
 		return err

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1228,14 +1228,6 @@ func (p *vsphereProvider) ValidateNewSpec(ctx context.Context, cluster *types.Cl
 		return fmt.Errorf("spec.network is immutable. Previous value %s, new value %s", oSpec.Network, nSpec.Network)
 	}
 
-	if nSpec.Insecure != oSpec.Insecure {
-		return fmt.Errorf("spec.insecure is immutable. Previous value %t, new value %t", oSpec.Insecure, nSpec.Insecure)
-	}
-
-	if nSpec.Thumbprint != oSpec.Thumbprint {
-		return fmt.Errorf("spec.thumbprint is immutable. Previous value %s, new value %s", oSpec.Thumbprint, nSpec.Thumbprint)
-	}
-
 	secretChanged, err := p.secretContentsChanged(ctx, cluster)
 	if err != nil {
 		return err

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -2699,60 +2699,6 @@ func TestValidateNewSpecStoragePolicyNameImmutableWorker(t *testing.T) {
 	assert.Error(t, err, "StoragePolicyName should be immutable")
 }
 
-func TestValidateNewSpecTLSInsecureImmutable(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	clusterConfig := givenClusterConfig(t, testClusterConfigMainFilename)
-
-	provider := givenProvider(t)
-	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
-	provider.providerKubectlClient = kubectl
-
-	newProviderConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
-	newProviderConfig.Spec.Insecure = !newProviderConfig.Spec.Insecure
-
-	newMachineConfigs := givenMachineConfigs(t, testClusterConfigMainFilename)
-
-	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Cluster.Namespace = "test-namespace"
-		s.Cluster = clusterConfig
-	})
-
-	kubectl.EXPECT().GetEksaCluster(context.TODO(), gomock.Any(), gomock.Any()).Return(clusterConfig, nil)
-	kubectl.EXPECT().GetEksaVSphereDatacenterConfig(context.TODO(), clusterConfig.Spec.DatacenterRef.Name, gomock.Any(), clusterConfig.Namespace).Return(newProviderConfig, nil)
-	for _, config := range newMachineConfigs {
-		kubectl.EXPECT().GetEksaVSphereMachineConfig(context.TODO(), gomock.Any(), gomock.Any(), clusterConfig.Namespace).Return(config, nil)
-	}
-	err := provider.ValidateNewSpec(context.TODO(), &types.Cluster{}, clusterSpec)
-	assert.Error(t, err, "Insecure should be immutable")
-}
-
-func TestValidateNewSpecTLSThumbprintImmutable(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	clusterConfig := givenClusterConfig(t, testClusterConfigMainFilename)
-
-	provider := givenProvider(t)
-	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
-	provider.providerKubectlClient = kubectl
-
-	newProviderConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
-	newProviderConfig.Spec.Thumbprint = "new-" + newProviderConfig.Spec.Thumbprint
-
-	newMachineConfigs := givenMachineConfigs(t, testClusterConfigMainFilename)
-
-	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Cluster.Namespace = "test-namespace"
-		s.Cluster = clusterConfig
-	})
-
-	kubectl.EXPECT().GetEksaCluster(context.TODO(), gomock.Any(), gomock.Any()).Return(clusterConfig, nil)
-	kubectl.EXPECT().GetEksaVSphereDatacenterConfig(context.TODO(), clusterConfig.Spec.DatacenterRef.Name, gomock.Any(), clusterConfig.Namespace).Return(newProviderConfig, nil)
-	for _, config := range newMachineConfigs {
-		kubectl.EXPECT().GetEksaVSphereMachineConfig(context.TODO(), gomock.Any(), gomock.Any(), clusterConfig.Namespace).Return(config, nil)
-	}
-	err := provider.ValidateNewSpec(context.TODO(), &types.Cluster{}, clusterSpec)
-	assert.Error(t, err, "Thumbprint should be immutable")
-}
-
 func TestGetMHCSuccess(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -2699,7 +2699,7 @@ func TestValidateNewSpecStoragePolicyNameImmutableWorker(t *testing.T) {
 	assert.Error(t, err, "StoragePolicyName should be immutable")
 }
 
-func TestValidateNewSpecTLSInsecureImmutable(t *testing.T) {
+func TestValidateNewSpecTLSInsecureMutable(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	clusterConfig := givenClusterConfig(t, testClusterConfigMainFilename)
 
@@ -2711,7 +2711,14 @@ func TestValidateNewSpecTLSInsecureImmutable(t *testing.T) {
 	newProviderConfig.Spec.Insecure = !newProviderConfig.Spec.Insecure
 
 	newMachineConfigs := givenMachineConfigs(t, testClusterConfigMainFilename)
-
+	clusterVsphereSecret := &v1.Secret{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Data: map[string][]byte{
+			"username": []byte(expectedVSphereUsername),
+			"password": []byte(expectedVSpherePassword),
+		},
+	}
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Namespace = "test-namespace"
 		s.Cluster = clusterConfig
@@ -2719,14 +2726,15 @@ func TestValidateNewSpecTLSInsecureImmutable(t *testing.T) {
 
 	kubectl.EXPECT().GetEksaCluster(context.TODO(), gomock.Any(), gomock.Any()).Return(clusterConfig, nil)
 	kubectl.EXPECT().GetEksaVSphereDatacenterConfig(context.TODO(), clusterConfig.Spec.DatacenterRef.Name, gomock.Any(), clusterConfig.Namespace).Return(newProviderConfig, nil)
+	kubectl.EXPECT().GetSecret(gomock.Any(), CredentialsObjectName, gomock.Any()).Return(clusterVsphereSecret, nil)
 	for _, config := range newMachineConfigs {
 		kubectl.EXPECT().GetEksaVSphereMachineConfig(context.TODO(), gomock.Any(), gomock.Any(), clusterConfig.Namespace).Return(config, nil)
 	}
 	err := provider.ValidateNewSpec(context.TODO(), &types.Cluster{}, clusterSpec)
-	assert.Error(t, err, "Insecure should be immutable")
+	assert.NoError(t, err, nil)
 }
 
-func TestValidateNewSpecTLSThumbprintImmutable(t *testing.T) {
+func TestValidateNewSpecTLSThumbprintMutable(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	clusterConfig := givenClusterConfig(t, testClusterConfigMainFilename)
 
@@ -2743,14 +2751,24 @@ func TestValidateNewSpecTLSThumbprintImmutable(t *testing.T) {
 		s.Cluster.Namespace = "test-namespace"
 		s.Cluster = clusterConfig
 	})
+	clusterVsphereSecret := &v1.Secret{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Data: map[string][]byte{
+			"username": []byte(expectedVSphereUsername),
+			"password": []byte(expectedVSpherePassword),
+		},
+	}
 
 	kubectl.EXPECT().GetEksaCluster(context.TODO(), gomock.Any(), gomock.Any()).Return(clusterConfig, nil)
 	kubectl.EXPECT().GetEksaVSphereDatacenterConfig(context.TODO(), clusterConfig.Spec.DatacenterRef.Name, gomock.Any(), clusterConfig.Namespace).Return(newProviderConfig, nil)
+	kubectl.EXPECT().GetSecret(gomock.Any(), CredentialsObjectName, gomock.Any()).Return(clusterVsphereSecret, nil)
+
 	for _, config := range newMachineConfigs {
 		kubectl.EXPECT().GetEksaVSphereMachineConfig(context.TODO(), gomock.Any(), gomock.Any(), clusterConfig.Namespace).Return(config, nil)
 	}
 	err := provider.ValidateNewSpec(context.TODO(), &types.Cluster{}, clusterSpec)
-	assert.Error(t, err, "Thumbprint should be immutable")
+	assert.NoError(t, err, nil)
 }
 
 func TestGetMHCSuccess(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
#1879 
*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

