### PR TITLE
Add e2e test for curated packages

### DIFF
--- a/pkg/executables/helm.go
+++ b/pkg/executables/helm.go
@@ -84,6 +84,26 @@ func (h *Helm) SaveChart(ctx context.Context, ociURI, version, folder string) er
 	return err
 }
 
+func (h *Helm) InstallChart(ctx context.Context, chart, ociURI, version, kubeconfigFilePath string, values []string) error {
+	valueArgs := GetHelmValueArgs(values)
+	params := []string{"install", chart, ociURI, "--version", version, insecureSkipVerifyFlag}
+	params = append(params, valueArgs...)
+	params = append(params, "--kubeconfig", kubeconfigFilePath)
+
+	logger.Info("Installing helm chart on cluster", "chart", chart, "version", version)
+	_, err := h.executable.Command(ctx, params...).WithEnvVars(helmTemplateEnvVars).Run()
+	return err
+}
+
 func (h *Helm) url(originalURL string) string {
 	return urls.ReplaceHost(originalURL, h.registryMirror)
+}
+
+func GetHelmValueArgs(values []string) []string {
+	valueArgs := []string{}
+	for _, value := range values {
+		valueArgs = append(valueArgs, "--set", value)
+	}
+
+	return valueArgs
 }

--- a/pkg/executables/helpers_test.go
+++ b/pkg/executables/helpers_test.go
@@ -35,3 +35,24 @@ func (c *commandExpect) withStdIn(stdIn []byte) *commandExpect {
 func (c *commandExpect) to() *gomock.Call {
 	return c.e.EXPECT().Run(c.command)
 }
+
+func sliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	m := make(map[string]int, len(a))
+	for _, v := range a {
+		m[v]++
+	}
+	for _, v := range b {
+		if _, ok := m[v]; !ok {
+			return false
+		}
+		m[v] -= 1
+		if m[v] == 0 {
+			delete(m, v)
+		}
+	}
+	return len(m) == 0
+}

--- a/test/e2e/curated_packages_test.go
+++ b/test/e2e/curated_packages_test.go
@@ -1,0 +1,30 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/test/framework"
+)
+
+const (
+	eksAnywherePackagesHelmChartName = "eks-anywhere-packages"
+	eksAnywherePackagesHelmUri       = "oci://public.ecr.aws/l0g8r8j6/eks-anywhere-packages"
+	eksAnywherePackagesHelmVersion   = "0.1.6-eks-a-v0.0.0-dev-build.2404"
+)
+
+var eksAnywherePackagesHelmValues = []string{"sourceRegistry=public.ecr.aws/l0g8r8j6"}
+
+func TestKubernetes122PackagesInstallSimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewVSphere(t, framework.WithBottleRocket122()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
+		framework.WithHelmInstallConfig(t, eksAnywherePackagesHelmChartName, eksAnywherePackagesHelmUri, eksAnywherePackagesHelmVersion, eksAnywherePackagesHelmValues),
+	)
+	runHelmInstallSimpleFlow(test)
+}

--- a/test/e2e/simpleflow_test.go
+++ b/test/e2e/simpleflow_test.go
@@ -20,6 +20,13 @@ func init() {
 	}
 }
 
+func runHelmInstallSimpleFlow(test *framework.ClusterE2ETest) {
+	test.GenerateClusterConfig()
+	test.CreateCluster()
+	test.InstallHelmChart()
+	test.DeleteCluster()
+}
+
 func runTinkerbellSimpleFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.GenerateHardwareConfig()

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -63,6 +63,7 @@ type ClusterE2ETest struct {
 	KubectlClient          *executables.Kubectl
 	GitProvider            git.ProviderClient
 	GitClient              git.Client
+	HelmInstallConfig      *HelmInstallConfig
 	GitWriter              filewriter.FileWriter
 	OIDCConfig             *v1alpha1.OIDCConfig
 	GitOpsConfig           *v1alpha1.GitOpsConfig
@@ -657,4 +658,14 @@ func setEksctlVersionEnvVar() error {
 		}
 	}
 	return nil
+}
+
+func (e *ClusterE2ETest) InstallHelmChart() {
+	kubeconfig := e.kubeconfigFilePath()
+	ctx := context.Background()
+
+	err := e.HelmInstallConfig.HelmClient.InstallChart(ctx, e.HelmInstallConfig.chartName, e.HelmInstallConfig.chartURI, e.HelmInstallConfig.chartVersion, kubeconfig, e.HelmInstallConfig.chartValues)
+	if err != nil {
+		e.T.Fatalf("Error installing %s helm chart on the cluster: %v", e.HelmInstallConfig.chartName, err)
+	}
 }

--- a/test/framework/executables.go
+++ b/test/framework/executables.go
@@ -50,3 +50,10 @@ func buildGovc(t *testing.T) *executables.Govc {
 func buildDocker(t *testing.T) *executables.Docker {
 	return executables.BuildDockerExecutable()
 }
+
+func buildHelm(t *testing.T) *executables.Helm {
+	ctx := context.Background()
+	helm := executableBuilder(t, ctx).BuildHelmExecutable()
+
+	return helm
+}

--- a/test/framework/helm.go
+++ b/test/framework/helm.go
@@ -1,0 +1,27 @@
+package framework
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/pkg/executables"
+)
+
+type HelmInstallConfig struct {
+	chartName    string
+	chartURI     string
+	chartVersion string
+	chartValues  []string
+	HelmClient   *executables.Helm
+}
+
+func WithHelmInstallConfig(t *testing.T, chartName, chartURI, chartVersion string, chartValues []string) ClusterE2ETestOpt {
+	return func(e *ClusterE2ETest) {
+		e.HelmInstallConfig = &HelmInstallConfig{
+			chartName:    chartName,
+			chartURI:     chartURI,
+			chartVersion: chartVersion,
+			chartValues:  chartValues,
+			HelmClient:   buildHelm(t),
+		}
+	}
+}


### PR DESCRIPTION
Adding E2E tests for curated packages install workflow. This test performs Helm install of eks-anywhere-packages helm chart on the e2e test cluster.

```bash
$ helm list --kubeconfig /etc/kubernetes/admin.conf 
NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                                                   APP VERSION                                    
eks-anywhere-packages   default         1               2022-04-28 02:58:40.9813308 +0000 UTC   deployed        eks-anywhere-packages-0.1.6+3fec792b394e5eae46937edaa2b14afa32a9ad77    v0.1.6-3fec792b394e5eae46937edaa2b14afa32a9ad77

$ kubectl get po --kubeconfig=/etc/kubernetes/admin.conf -n eksa-packages
NAME                                    READY   STATUS    RESTARTS   AGE
eks-anywhere-packages-ddb85f7f5-blbpk   2/2     Running   0          6m17s
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

