### PR TITLE
Add .ignore directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ eks-anywhere-downloads*
 hardware-manifests/
 *.env
 support-bundle*
+/.ignore


### PR DESCRIPTION
It can be useful to keep files around in a repository that you use
frequently but we don't have a dedicated directory for housing them.
Now we do, `.ignore` :)