### PR TITLE
Gzip artifacts tarball

### DIFF
--- a/cmd/eksctl-anywhere/cmd/downloadimages.go
+++ b/cmd/eksctl-anywhere/cmd/downloadimages.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"log"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -80,8 +81,21 @@ func (c downloadImagesCommand) Run(ctx context.Context) error {
 		Version:          version.Get(),
 		TmpDowloadFolder: downloadFolder,
 		DstFile:          c.outputFile,
-		Packager:         tar.NewPackager(),
+		Packager:         packagerForFile(c.outputFile),
 	}
 
 	return downloadArtifacts.Run(ctx)
+}
+
+type packager interface {
+	UnPackage(orgFile, dstFolder string) error
+	Package(sourceFolder, dstFile string) error
+}
+
+func packagerForFile(file string) packager {
+	if strings.HasSuffix(file, ".tar.gz") {
+		return tar.NewGzipPackager()
+	} else {
+		return tar.NewPackager()
+	}
 }

--- a/cmd/eksctl-anywhere/cmd/import_images.go
+++ b/cmd/eksctl-anywhere/cmd/import_images.go
@@ -19,7 +19,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/helm"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
-	"github.com/aws/eks-anywhere/pkg/tar"
 )
 
 // imagesCmd represents the images command
@@ -84,7 +83,7 @@ func (c ImportImagesCommand) Call(ctx context.Context) error {
 		Bundles:            bundle,
 		InputFile:          c.InputFile,
 		TmpArtifactsFolder: artifactsFolder,
-		UnPackager:         tar.NewPackager(),
+		UnPackager:         packagerForFile(c.InputFile),
 		ImageMover: docker.NewImageMover(
 			docker.NewDiskSource(dockerClient, toolsImageFile),
 			docker.NewRegistryDestination(dockerClient, c.RegistryEndpoint),

--- a/pkg/tar/gzip.go
+++ b/pkg/tar/gzip.go
@@ -1,0 +1,39 @@
+package tar
+
+import (
+	"compress/gzip"
+	"fmt"
+	"os"
+)
+
+func GzipTarFolder(sourceFolder, dstFile string) error {
+	tarfile, err := os.Create(dstFile)
+	if err != nil {
+		return fmt.Errorf("creating dst tar file: %v", err)
+	}
+	defer tarfile.Close()
+	gw := gzip.NewWriter(tarfile)
+	defer gw.Close()
+
+	if err := tarFolderToWriter(sourceFolder, gw); err != nil {
+		return fmt.Errorf("gzip taring folder [%s] to [%s]: %v", sourceFolder, dstFile, err)
+	}
+
+	return nil
+}
+
+func UnGzipTarFile(tarFile, dstFolder string) error {
+	tarball, err := os.Open(tarFile)
+	if err != nil {
+		return err
+	}
+	defer tarball.Close()
+
+	gr, err := gzip.NewReader(tarball)
+	if err != nil {
+		return err
+	}
+	defer gr.Close()
+
+	return Untar(gr, NewFolderRouter(dstFolder))
+}

--- a/pkg/tar/gzip_packager.go
+++ b/pkg/tar/gzip_packager.go
@@ -1,0 +1,15 @@
+package tar
+
+type GzipPackager struct{}
+
+func NewGzipPackager() GzipPackager {
+	return GzipPackager{}
+}
+
+func (GzipPackager) Package(sourceFolder, dstFile string) error {
+	return GzipTarFolder(sourceFolder, dstFile)
+}
+
+func (GzipPackager) UnPackage(orgFile, dstFolder string) error {
+	return UnGzipTarFile(orgFile, dstFolder)
+}

--- a/pkg/tar/gzip_test.go
+++ b/pkg/tar/gzip_test.go
@@ -1,0 +1,32 @@
+package tar_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/tar"
+)
+
+func TestUnGzipTarFile(t *testing.T) {
+	g := NewWithT(t)
+	dstFile := "dst.tar.gz"
+	untarFolder := "dst-untar"
+	g.Expect(os.MkdirAll(untarFolder, os.ModePerm))
+	t.Cleanup(func() {
+		os.Remove(dstFile)
+		os.RemoveAll(untarFolder)
+	})
+
+	g.Expect(tar.GzipTarFolder("testdata", dstFile)).To(Succeed())
+	g.Expect(dstFile).To(BeAnExistingFile())
+
+	g.Expect(tar.UnGzipTarFile(dstFile, untarFolder)).To(Succeed())
+	g.Expect(untarFolder).To(BeADirectory())
+	g.Expect(filepath.Join(untarFolder, "dummy1")).To(BeARegularFile())
+	g.Expect(filepath.Join(untarFolder, "dummy2")).To(BeARegularFile())
+	g.Expect(filepath.Join(untarFolder, "dummy3")).To(BeADirectory())
+	g.Expect(filepath.Join(untarFolder, "dummy3", "dummy4")).To(BeARegularFile())
+}

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -14,13 +14,16 @@ func TarFolder(sourceFolder, dstFile string) error {
 	}
 	defer tarfile.Close()
 
-	walker := NewFolderWalker(sourceFolder)
-
-	if err := Tar(walker, tarfile); err != nil {
+	if err := tarFolderToWriter(sourceFolder, tarfile); err != nil {
 		return fmt.Errorf("taring folder [%s] to [%s]: %v", sourceFolder, dstFile, err)
 	}
 
 	return nil
+}
+
+func tarFolderToWriter(sourceFolder string, dst io.Writer) error {
+	walker := NewFolderWalker(sourceFolder)
+	return Tar(walker, dst)
 }
 
 type TarFunc func(file string, info os.FileInfo, header *tar.Header) error


### PR DESCRIPTION
*Description of changes:*
This decreases the tarball size from 9.5GB to 2.9 GB.
It increases the time `download images` takes from ~6:30 to ~12:30

*Testing (if applicable):*
Run download and import images manually
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

