### PR TITLE
Validate credentials at the start of import images

### DIFF
--- a/cmd/eksctl-anywhere/cmd/import_images.go
+++ b/cmd/eksctl-anywhere/cmd/import_images.go
@@ -61,6 +61,11 @@ type ImportImagesCommand struct {
 }
 
 func (c ImportImagesCommand) Call(ctx context.Context) error {
+	username, password, err := readRegistryCredentials()
+	if err != nil {
+		return err
+	}
+
 	factory := dependencies.NewFactory()
 	deps, err := factory.
 		WithManifestReader().
@@ -104,11 +109,6 @@ func (c ImportImagesCommand) Call(ctx context.Context) error {
 		return err
 	}
 	defer deps.Close(ctx)
-
-	username, password, err := readRegistryCredentials()
-	if err != nil {
-		return err
-	}
 
 	imagesFile := filepath.Join(artifactsFolder, "images.tar")
 	importArtifacts := artifacts.Import{


### PR DESCRIPTION
*Description of changes:*
This will throw an error if credential env vars are not set before
even trying to untar the tarball.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

