### PR TITLE
Avoid packaging tools image twice in tarball

### DIFF
--- a/cmd/eksctl-anywhere/cmd/internal/commands/artifacts/download.go
+++ b/cmd/eksctl-anywhere/cmd/internal/commands/artifacts/download.go
@@ -58,7 +58,7 @@ func (d Download) Run(ctx context.Context) error {
 		return fmt.Errorf("downloading images: %v", err)
 	}
 
-	if err = d.BundlesImagesDownloader.Move(ctx, artifactNames(images)...); err != nil {
+	if err = d.BundlesImagesDownloader.Move(ctx, removeFromSlice(artifactNames(images), toolsImage)...); err != nil {
 		return err
 	}
 
@@ -87,4 +87,15 @@ func artifactNames(artifacts []releasev1.Image) []string {
 	}
 
 	return taggedArtifacts
+}
+
+func removeFromSlice(s []string, toRemove string) []string {
+	index := 0
+	for _, i := range s {
+		if i != toRemove {
+			s[index] = i
+			index++
+		}
+	}
+	return s[:index]
 }

--- a/cmd/eksctl-anywhere/cmd/internal/commands/artifacts/download_test.go
+++ b/cmd/eksctl-anywhere/cmd/internal/commands/artifacts/download_test.go
@@ -48,6 +48,10 @@ func newDownloadArtifactsTest(t *testing.T) *downloadArtifactsTest {
 			Name: "image 2",
 			URI:  "image2:1",
 		},
+		{
+			Name: "tools",
+			URI:  "tools:v1.0.0",
+		},
 	}
 
 	charts := []releasev1.Image{


### PR DESCRIPTION
*Description of changes:*
Since the eks-a tools image is already packaged individually, we don't
need to include it in the big tar with the rest of the images.

*Testing (if applicable):*
Ran download-import flow manually.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

