### PR TITLE
Bump number of workers for docker image processing

### DIFF
--- a/pkg/docker/registry.go
+++ b/pkg/docker/registry.go
@@ -19,7 +19,7 @@ func NewRegistryDestination(client ImageTaggerPusher, registryEndpoint string) *
 	return &ImageRegistryDestination{
 		client:    client,
 		endpoint:  registryEndpoint,
-		processor: NewConcurrentImageProcessor(runtime.GOMAXPROCS(0) / 2),
+		processor: NewConcurrentImageProcessor(runtime.GOMAXPROCS(0)),
 	}
 }
 
@@ -55,7 +55,7 @@ type ImageOriginalRegistrySource struct {
 func NewOriginalRegistrySource(client ImagePuller) *ImageOriginalRegistrySource {
 	return &ImageOriginalRegistrySource{
 		client:    client,
-		processor: NewConcurrentImageProcessor(runtime.GOMAXPROCS(0) / 2),
+		processor: NewConcurrentImageProcessor(runtime.GOMAXPROCS(0)),
 	}
 }
 


### PR DESCRIPTION
*Description of changes:*
It used to use half the number of machine cores. Now it uses the full
number of cores. This saves around 1 minute in download and import with
8 cores.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

