### PR TITLE
Add example for configuring proxies on tinkerbell k8s nodes

### DIFF
--- a/examples/tinkerbell/setup-proxy-on-nodes.md
+++ b/examples/tinkerbell/setup-proxy-on-nodes.md
@@ -1,0 +1,37 @@
+# Add proxy config to the `TinkerbellTempalteConfiguration`
+
+The `configure-containerd-proxy` action configures proxy for containerd on all the Kubernetes nodes. You can add the following section in your cluster config to 
+setup proxy on the nodes:
+
+```yaml
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellTemplateConfig
+metadata:
+  name: template-name
+spec:
+  template:
+    global_timeout: 6000
+    id: ""
+    name: template-name
+    tasks:
+    - actions:
+      // Append to existing actions.
+      - environment:
+          CONTENTS: |
+            [Service]
+            Environment:"HTTP_PROXY=<HTTP-PROXY-IP:PORT>"
+            Environment:"HTTPS_PROXY=<HTTPS-PROXY-IP:PORT>"
+            Environment:"NO_PROXY=<Comma-separated-list-of-no-proxies>"
+          DEST_DISK: /dev/sda2
+          DEST_PATH: /etc/systemd/system/containerd.service.d/http-proxy.conf
+          DIRMODE: "0700"
+          FS_TYPE: ext4
+          GID: "0"
+          MODE: "0600"
+          UID: "0"
+        image: writefile:v1.0.0
+        name: configure-containerd-proxy
+        timeout: 90
+```
+
+Note the you have to provide values for `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` in the config above.


### PR DESCRIPTION
*Description of changes:*
Adding an example for configuring `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` for containerd on baremetal Kubernetes nodes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

