### PR TITLE
Rename TestVSphereDownloadArtifacts E2E test

### DIFF
--- a/test/e2e/download_artifacts_test.go
+++ b/test/e2e/download_artifacts_test.go
@@ -16,7 +16,7 @@ func runDownloadArtifactsFlow(test *framework.ClusterE2ETest) {
 	test.DownloadArtifacts()
 }
 
-func TestDownloadArtifacts(t *testing.T) {
+func TestVSphereDownloadArtifacts(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithUbuntu122(), framework.WithPrivateNetwork()),


### PR DESCRIPTION
*Description of changes:*
This test needs the env vars for vsphere clusters. Adding 'VSphere' in
the test name will take care of this automatically.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

