### PR TITLE
Add OIDC, pod IAM and AWS IAM support for snow

### DIFF
--- a/pkg/aws/creds_test.go
+++ b/pkg/aws/creds_test.go
@@ -35,6 +35,8 @@ func TestAwsCredentialsFile(t *testing.T) {
 
 func TestAwsCredentialsFileEnvNotSet(t *testing.T) {
 	tt := newAwsTest(t)
+	setupContext(t, aws.EksaAwsCredentialsFileKey, credentialsFile)
+	os.Unsetenv(aws.EksaAwsCredentialsFileKey)
 	_, err := aws.AwsCredentialsFile()
 	tt.Expect(err).To((MatchError(ContainSubstring("env 'EKSA_AWS_CREDENTIALS_FILE' is not set or is empty"))))
 }
@@ -55,6 +57,8 @@ func TestAwsCABundlesFile(t *testing.T) {
 
 func TestAwsCABundlesFileEnvNotSet(t *testing.T) {
 	tt := newAwsTest(t)
+	setupContext(t, aws.EksaAwsCABundlesFileKey, "testdata/valid_certificates")
+	os.Unsetenv(aws.EksaAwsCABundlesFileKey)
 	_, err := aws.AwsCABundlesFile()
 	tt.Expect(err).To((MatchError(ContainSubstring("env 'EKSA_AWS_CA_BUNDLES_FILE' is not set or is empty"))))
 }

--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -135,7 +135,8 @@ func KubeadmControlPlane(clusterSpec *cluster.Spec, infrastructureObject APIObje
 					Etcd: etcd,
 					APIServer: bootstrapv1.APIServer{
 						ControlPlaneComponent: bootstrapv1.ControlPlaneComponent{
-							ExtraArgs: map[string]string{},
+							ExtraArgs:    map[string]string{},
+							ExtraVolumes: []bootstrapv1.HostPathMount{},
 						},
 					},
 					ControllerManager: bootstrapv1.ControlPlaneComponent{
@@ -161,14 +162,12 @@ func KubeadmControlPlane(clusterSpec *cluster.Spec, infrastructureObject APIObje
 		},
 	}
 
-	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {
-		containerdFiles, containerdCommands, err := registryMirrorConfig(clusterSpec.Cluster.Spec.RegistryMirrorConfiguration)
-		if err != nil {
-			return nil, fmt.Errorf("failed setting registry mirror configuration: %v", err)
-		}
-		kcp.Spec.KubeadmConfigSpec.Files = append(kcp.Spec.KubeadmConfigSpec.Files, containerdFiles...)
-		kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands = append(kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands, containerdCommands...)
+	if err := SetRegistryMirrorInKubeadmControlPlane(kcp, clusterSpec.Cluster.Spec.RegistryMirrorConfiguration); err != nil {
+		return nil, err
 	}
+
+	SetIdentityAuthInKubeadmControlPlane(kcp, clusterSpec)
+
 	return kcp, nil
 }
 
@@ -207,14 +206,11 @@ func KubeadmConfigTemplate(clusterSpec *cluster.Spec, workerNodeGroupConfig v1al
 			},
 		},
 	}
-	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {
-		containerdFiles, containerdCommands, err := registryMirrorConfig(clusterSpec.Cluster.Spec.RegistryMirrorConfiguration)
-		if err != nil {
-			return nil, fmt.Errorf("failed setting registry mirror configuration: %v", err)
-		}
-		kct.Spec.Template.Spec.Files = append(kct.Spec.Template.Spec.Files, containerdFiles...)
-		kct.Spec.Template.Spec.PreKubeadmCommands = append(kct.Spec.Template.Spec.PreKubeadmCommands, containerdCommands...)
+
+	if err := SetRegistryMirrorInKubeadmConfigTemplate(kct, clusterSpec.Cluster.Spec.RegistryMirrorConfiguration); err != nil {
+		return nil, err
 	}
+
 	return kct, nil
 }
 

--- a/pkg/clusterapi/identity.go
+++ b/pkg/clusterapi/identity.go
@@ -1,0 +1,121 @@
+package clusterapi
+
+import (
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+)
+
+const awsIamKubeconfig = `
+# clusters refers to the remote service.
+clusters:
+	- name: aws-iam-authenticator
+	cluster:
+		certificate-authority: /var/aws-iam-authenticator/cert.pem
+		server: https://localhost:21362/authenticate
+# users refers to the API Server's webhook configuration
+# (we don't need to authenticate the API server).
+users:
+	- name: apiserver
+# kubeconfig files require a context. Provide one for the API Server.
+current-context: webhook
+contexts:
+- name: webhook
+	context:
+	cluster: aws-iam-authenticator
+	user: apiserver
+`
+
+var awsIamMounts = []bootstrapv1.HostPathMount{
+	{
+		Name:      "authconfig",
+		HostPath:  "/var/lib/kubeadm/aws-iam-authenticator/",
+		MountPath: "/etc/kubernetes/aws-iam-authenticator/",
+		ReadOnly:  false,
+	},
+	{
+		Name:      "awsiamcert",
+		HostPath:  "/var/lib/kubeadm/aws-iam-authenticator/pki/",
+		MountPath: "/var/aws-iam-authenticator/",
+		ReadOnly:  false,
+	},
+}
+
+var awsIamFiles = []bootstrapv1.File{
+	{
+		Path:        "/var/lib/kubeadm/aws-iam-authenticator/kubeconfig.yaml",
+		Owner:       "root:root",
+		Permissions: "0640",
+		Content:     awsIamKubeconfig,
+	},
+	{
+		Path:        "/var/lib/kubeadm/aws-iam-authenticator/pki/cert.pem",
+		Owner:       "root:root",
+		Permissions: "0640",
+		ContentFrom: &bootstrapv1.FileSource{
+			Secret: bootstrapv1.SecretFileSource{
+				Name: "aws-iam-authenticator-ca",
+				Key:  "cert.pem",
+			},
+		},
+	},
+	{
+		Path:        "/var/lib/kubeadm/aws-iam-authenticator/pki/key.pem",
+		Owner:       "root:root",
+		Permissions: "0640",
+		ContentFrom: &bootstrapv1.FileSource{
+			Secret: bootstrapv1.SecretFileSource{
+				Name: "aws-iam-authenticator-ca",
+				Key:  "key.pem",
+			},
+		},
+	},
+}
+
+func configureAWSIAMAuthInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, awsIamConfig *v1alpha1.AWSIamConfig) {
+	if awsIamConfig == nil {
+		return
+	}
+
+	apiServerExtraArgs := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraArgs
+	for k, v := range AwsIamAuthExtraArgs(awsIamConfig) {
+		apiServerExtraArgs[k] = v
+	}
+
+	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraVolumes = append(
+		kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraVolumes,
+		awsIamMounts...,
+	)
+
+	kcp.Spec.KubeadmConfigSpec.Files = append(kcp.Spec.KubeadmConfigSpec.Files, awsIamFiles...)
+}
+
+func configureOIDCInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, oidcConfig *v1alpha1.OIDCConfig) {
+	if oidcConfig == nil {
+		return
+	}
+
+	apiServerExtraArgs := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraArgs
+	for k, v := range OIDCToExtraArgs(oidcConfig) {
+		apiServerExtraArgs[k] = v
+	}
+}
+
+func configurePodIamAuthInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, podIamConfig *v1alpha1.PodIAMConfig) {
+	if podIamConfig == nil {
+		return
+	}
+
+	apiServerExtraArgs := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraArgs
+	for k, v := range PodIAMAuthExtraArgs(podIamConfig) {
+		apiServerExtraArgs[k] = v
+	}
+}
+
+func SetIdentityAuthInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, clusterSpec *cluster.Spec) {
+	configureOIDCInKubeadmControlPlane(kcp, clusterSpec.OIDCConfig)
+	configureAWSIAMAuthInKubeadmControlPlane(kcp, clusterSpec.AWSIamConfig)
+	configurePodIamAuthInKubeadmControlPlane(kcp, clusterSpec.Cluster.Spec.PodIAMConfig)
+}

--- a/pkg/clusterapi/identity_test.go
+++ b/pkg/clusterapi/identity_test.go
@@ -1,0 +1,403 @@
+package clusterapi_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+)
+
+func TestConfigureAWSIAMAuthInKubeadmControlPlane(t *testing.T) {
+	replicas := int32(3)
+	tests := []struct {
+		name         string
+		awsIamConfig *v1alpha1.AWSIamConfig
+		want         *controlplanev1.KubeadmControlPlane
+	}{
+		{
+			name:         "no iam auth",
+			awsIamConfig: nil,
+			want:         wantKubeadmControlPlane(),
+		},
+		{
+			name: "with iam auth",
+			awsIamConfig: &v1alpha1.AWSIamConfig{
+				Spec: v1alpha1.AWSIamConfigSpec{
+					AWSRegion:   "test-region",
+					BackendMode: []string{"mode1", "mode2"},
+					MapRoles: []v1alpha1.MapRoles{
+						{
+							RoleARN:  "test-role-arn",
+							Username: "test",
+							Groups:   []string{"group1", "group2"},
+						},
+					},
+					MapUsers: []v1alpha1.MapUsers{
+						{
+							UserARN:  "test-user-arn",
+							Username: "test",
+							Groups:   []string{"group1", "group2"},
+						},
+					},
+					Partition: "aws",
+				},
+			},
+			want: &controlplanev1.KubeadmControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+					Kind:       "KubeadmControlPlane",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "eksa-system",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
+						InfrastructureRef: v1.ObjectReference{
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+							Kind:       "ProviderMachineTemplate",
+							Name:       "provider-template",
+						},
+					},
+					KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{
+						ClusterConfiguration: &bootstrapv1.ClusterConfiguration{
+							ImageRepository: "public.ecr.aws/eks-distro/kubernetes",
+							DNS: bootstrapv1.DNS{
+								ImageMeta: bootstrapv1.ImageMeta{
+									ImageRepository: "public.ecr.aws/eks-distro/coredns",
+									ImageTag:        "v1.8.4-eks-1-21-9",
+								},
+							},
+							Etcd: bootstrapv1.Etcd{
+								Local: &bootstrapv1.LocalEtcd{
+									ImageMeta: bootstrapv1.ImageMeta{
+										ImageRepository: "public.ecr.aws/eks-distro/etcd-io",
+										ImageTag:        "v3.4.16-eks-1-21-9",
+									},
+									ExtraArgs: map[string]string{},
+								},
+							},
+							APIServer: bootstrapv1.APIServer{
+								ControlPlaneComponent: bootstrapv1.ControlPlaneComponent{
+									ExtraArgs: map[string]string{
+										"authentication-token-webhook-config-file": "/etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml",
+									},
+									ExtraVolumes: []bootstrapv1.HostPathMount{
+										{
+											Name:      "authconfig",
+											HostPath:  "/var/lib/kubeadm/aws-iam-authenticator/",
+											MountPath: "/etc/kubernetes/aws-iam-authenticator/",
+											ReadOnly:  false,
+										},
+										{
+											Name:      "awsiamcert",
+											HostPath:  "/var/lib/kubeadm/aws-iam-authenticator/pki/",
+											MountPath: "/var/aws-iam-authenticator/",
+											ReadOnly:  false,
+										},
+									},
+								},
+							},
+							ControllerManager: bootstrapv1.ControlPlaneComponent{
+								ExtraArgs: map[string]string{},
+							},
+						},
+						InitConfiguration: &bootstrapv1.InitConfiguration{
+							NodeRegistration: bootstrapv1.NodeRegistrationOptions{
+								KubeletExtraArgs: map[string]string{},
+							},
+						},
+						JoinConfiguration: &bootstrapv1.JoinConfiguration{
+							NodeRegistration: bootstrapv1.NodeRegistrationOptions{
+								KubeletExtraArgs: map[string]string{},
+							},
+						},
+						PreKubeadmCommands:  []string{},
+						PostKubeadmCommands: []string{},
+						Files: []bootstrapv1.File{
+							{
+								Path:        "/var/lib/kubeadm/aws-iam-authenticator/kubeconfig.yaml",
+								Owner:       "root:root",
+								Permissions: "0640",
+								Content: `
+# clusters refers to the remote service.
+clusters:
+	- name: aws-iam-authenticator
+	cluster:
+		certificate-authority: /var/aws-iam-authenticator/cert.pem
+		server: https://localhost:21362/authenticate
+# users refers to the API Server's webhook configuration
+# (we don't need to authenticate the API server).
+users:
+	- name: apiserver
+# kubeconfig files require a context. Provide one for the API Server.
+current-context: webhook
+contexts:
+- name: webhook
+	context:
+	cluster: aws-iam-authenticator
+	user: apiserver
+`,
+							},
+							{
+								Path:        "/var/lib/kubeadm/aws-iam-authenticator/pki/cert.pem",
+								Owner:       "root:root",
+								Permissions: "0640",
+								ContentFrom: &bootstrapv1.FileSource{
+									Secret: bootstrapv1.SecretFileSource{
+										Name: "aws-iam-authenticator-ca",
+										Key:  "cert.pem",
+									},
+								},
+							},
+							{
+								Path:        "/var/lib/kubeadm/aws-iam-authenticator/pki/key.pem",
+								Owner:       "root:root",
+								Permissions: "0640",
+								ContentFrom: &bootstrapv1.FileSource{
+									Secret: bootstrapv1.SecretFileSource{
+										Name: "aws-iam-authenticator-ca",
+										Key:  "key.pem",
+									},
+								},
+							},
+						},
+					},
+					Replicas: &replicas,
+					Version:  "v1.21.5-eks-1-21-9",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newApiBuilerTest(t)
+			got := wantKubeadmControlPlane()
+			g.clusterSpec.AWSIamConfig = tt.awsIamConfig
+			clusterapi.SetIdentityAuthInKubeadmControlPlane(got, g.clusterSpec)
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestConfigureOIDCInKubeadmControlPlane(t *testing.T) {
+	replicas := int32(3)
+	tests := []struct {
+		name       string
+		oidcConfig *v1alpha1.OIDCConfig
+		want       *controlplanev1.KubeadmControlPlane
+	}{
+		{
+			name:       "no oidc",
+			oidcConfig: nil,
+			want:       wantKubeadmControlPlane(),
+		},
+		{
+			name: "with oidc",
+			oidcConfig: &v1alpha1.OIDCConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "OIDCConfig",
+					APIVersion: v1alpha1.SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: v1alpha1.OIDCConfigSpec{
+					ClientId:     "id1",
+					GroupsClaim:  "claim1",
+					GroupsPrefix: "prefix-for-groups",
+					IssuerUrl:    "https://mydomain.com/issuer",
+					RequiredClaims: []v1alpha1.OIDCConfigRequiredClaim{
+						{
+							Claim: "sub",
+							Value: "test",
+						},
+					},
+					UsernameClaim:  "username-claim",
+					UsernamePrefix: "username-prefix",
+				},
+			},
+			want: &controlplanev1.KubeadmControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+					Kind:       "KubeadmControlPlane",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "eksa-system",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
+						InfrastructureRef: v1.ObjectReference{
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+							Kind:       "ProviderMachineTemplate",
+							Name:       "provider-template",
+						},
+					},
+					KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{
+						ClusterConfiguration: &bootstrapv1.ClusterConfiguration{
+							ImageRepository: "public.ecr.aws/eks-distro/kubernetes",
+							DNS: bootstrapv1.DNS{
+								ImageMeta: bootstrapv1.ImageMeta{
+									ImageRepository: "public.ecr.aws/eks-distro/coredns",
+									ImageTag:        "v1.8.4-eks-1-21-9",
+								},
+							},
+							Etcd: bootstrapv1.Etcd{
+								Local: &bootstrapv1.LocalEtcd{
+									ImageMeta: bootstrapv1.ImageMeta{
+										ImageRepository: "public.ecr.aws/eks-distro/etcd-io",
+										ImageTag:        "v3.4.16-eks-1-21-9",
+									},
+									ExtraArgs: map[string]string{},
+								},
+							},
+							APIServer: bootstrapv1.APIServer{
+								ControlPlaneComponent: bootstrapv1.ControlPlaneComponent{
+									ExtraArgs: map[string]string{
+										"oidc-client-id":       "id1",
+										"oidc-groups-claim":    "claim1",
+										"oidc-groups-prefix":   "prefix-for-groups",
+										"oidc-issuer-url":      "https://mydomain.com/issuer",
+										"oidc-required-claim":  "sub=test",
+										"oidc-username-claim":  "username-claim",
+										"oidc-username-prefix": "username-prefix",
+									},
+									ExtraVolumes: []bootstrapv1.HostPathMount{},
+								},
+							},
+							ControllerManager: bootstrapv1.ControlPlaneComponent{
+								ExtraArgs: map[string]string{},
+							},
+						},
+						InitConfiguration: &bootstrapv1.InitConfiguration{
+							NodeRegistration: bootstrapv1.NodeRegistrationOptions{
+								KubeletExtraArgs: map[string]string{},
+							},
+						},
+						JoinConfiguration: &bootstrapv1.JoinConfiguration{
+							NodeRegistration: bootstrapv1.NodeRegistrationOptions{
+								KubeletExtraArgs: map[string]string{},
+							},
+						},
+						PreKubeadmCommands:  []string{},
+						PostKubeadmCommands: []string{},
+						Files:               []bootstrapv1.File{},
+					},
+					Replicas: &replicas,
+					Version:  "v1.21.5-eks-1-21-9",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newApiBuilerTest(t)
+			got := wantKubeadmControlPlane()
+			g.clusterSpec.OIDCConfig = tt.oidcConfig
+			clusterapi.SetIdentityAuthInKubeadmControlPlane(got, g.clusterSpec)
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestConfigurePodIamAuthInKubeadmControlPlane(t *testing.T) {
+	replicas := int32(3)
+	tests := []struct {
+		name         string
+		podIAMConfig *v1alpha1.PodIAMConfig
+		want         *controlplanev1.KubeadmControlPlane
+	}{
+		{
+			name:         "no pod iam",
+			podIAMConfig: nil,
+			want:         wantKubeadmControlPlane(),
+		},
+		{
+			name: "with pod iam",
+			podIAMConfig: &v1alpha1.PodIAMConfig{
+				ServiceAccountIssuer: "https://test",
+			},
+			want: &controlplanev1.KubeadmControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+					Kind:       "KubeadmControlPlane",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "eksa-system",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
+						InfrastructureRef: v1.ObjectReference{
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+							Kind:       "ProviderMachineTemplate",
+							Name:       "provider-template",
+						},
+					},
+					KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{
+						ClusterConfiguration: &bootstrapv1.ClusterConfiguration{
+							ImageRepository: "public.ecr.aws/eks-distro/kubernetes",
+							DNS: bootstrapv1.DNS{
+								ImageMeta: bootstrapv1.ImageMeta{
+									ImageRepository: "public.ecr.aws/eks-distro/coredns",
+									ImageTag:        "v1.8.4-eks-1-21-9",
+								},
+							},
+							Etcd: bootstrapv1.Etcd{
+								Local: &bootstrapv1.LocalEtcd{
+									ImageMeta: bootstrapv1.ImageMeta{
+										ImageRepository: "public.ecr.aws/eks-distro/etcd-io",
+										ImageTag:        "v3.4.16-eks-1-21-9",
+									},
+									ExtraArgs: map[string]string{},
+								},
+							},
+							APIServer: bootstrapv1.APIServer{
+								ControlPlaneComponent: bootstrapv1.ControlPlaneComponent{
+									ExtraArgs: map[string]string{
+										"service-account-issuer": "https://test",
+									},
+									ExtraVolumes: []bootstrapv1.HostPathMount{},
+								},
+							},
+							ControllerManager: bootstrapv1.ControlPlaneComponent{
+								ExtraArgs: map[string]string{},
+							},
+						},
+						InitConfiguration: &bootstrapv1.InitConfiguration{
+							NodeRegistration: bootstrapv1.NodeRegistrationOptions{
+								KubeletExtraArgs: map[string]string{},
+							},
+						},
+						JoinConfiguration: &bootstrapv1.JoinConfiguration{
+							NodeRegistration: bootstrapv1.NodeRegistrationOptions{
+								KubeletExtraArgs: map[string]string{},
+							},
+						},
+						PreKubeadmCommands:  []string{},
+						PostKubeadmCommands: []string{},
+						Files:               []bootstrapv1.File{},
+					},
+					Replicas: &replicas,
+					Version:  "v1.21.5-eks-1-21-9",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newApiBuilerTest(t)
+			got := wantKubeadmControlPlane()
+			g.clusterSpec.Cluster.Spec.PodIAMConfig = tt.podIAMConfig
+			clusterapi.SetIdentityAuthInKubeadmControlPlane(got, g.clusterSpec)
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}

--- a/pkg/clusterapi/registryMirror_test.go
+++ b/pkg/clusterapi/registryMirror_test.go
@@ -1,0 +1,123 @@
+package clusterapi_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+)
+
+var registryMirrorTests = []struct {
+	name                 string
+	registryMirrorConfig *v1alpha1.RegistryMirrorConfiguration
+	wantFiles            []bootstrapv1.File
+}{
+	{
+		name: "with ca cert",
+		registryMirrorConfig: &v1alpha1.RegistryMirrorConfiguration{
+			Endpoint:      "1.2.3.4",
+			Port:          "443",
+			CACertContent: "xyz",
+		},
+		wantFiles: []bootstrapv1.File{
+			{
+				Path:  "/etc/containerd/config_append.toml",
+				Owner: "root:root",
+				Content: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
+    endpoint = ["https://1.2.3.4:443"]
+  [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:443".tls]
+    ca_file = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"`,
+			},
+			{
+				Path:    "/etc/containerd/certs.d/1.2.3.4:443/ca.crt",
+				Owner:   "root:root",
+				Content: "xyz",
+			},
+		},
+	},
+	{
+		name: "with insecure skip",
+		registryMirrorConfig: &v1alpha1.RegistryMirrorConfiguration{
+			Endpoint:           "1.2.3.4",
+			Port:               "443",
+			InsecureSkipVerify: true,
+		},
+		wantFiles: []bootstrapv1.File{
+			{
+				Path:  "/etc/containerd/config_append.toml",
+				Owner: "root:root",
+				Content: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
+    endpoint = ["https://1.2.3.4:443"]
+  [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:443".tls]
+    insecure_skip_verify = true`,
+			},
+		},
+	},
+	{
+		name: "with ca cert and insecure skip",
+		registryMirrorConfig: &v1alpha1.RegistryMirrorConfiguration{
+			Endpoint:           "1.2.3.4",
+			Port:               "443",
+			CACertContent:      "xyz",
+			InsecureSkipVerify: true,
+		},
+		wantFiles: []bootstrapv1.File{
+			{
+				Path:  "/etc/containerd/config_append.toml",
+				Owner: "root:root",
+				Content: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
+    endpoint = ["https://1.2.3.4:443"]
+  [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:443".tls]
+    ca_file = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
+    insecure_skip_verify = true`,
+			},
+			{
+				Path:    "/etc/containerd/certs.d/1.2.3.4:443/ca.crt",
+				Owner:   "root:root",
+				Content: "xyz",
+			},
+		},
+	},
+}
+
+func wantRegistryMirrorCommands() []string {
+	return []string{
+		"cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml",
+		"sudo systemctl daemon-reload",
+		"sudo systemctl restart containerd",
+	}
+}
+
+func TestSetRegistryMirrorInKubeadmControlPlane(t *testing.T) {
+	for _, tt := range registryMirrorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newApiBuilerTest(t)
+			got := wantKubeadmControlPlane()
+			g.Expect(clusterapi.SetRegistryMirrorInKubeadmControlPlane(got, tt.registryMirrorConfig)).To(Succeed())
+			want := wantKubeadmControlPlane()
+			want.Spec.KubeadmConfigSpec.Files = tt.wantFiles
+			want.Spec.KubeadmConfigSpec.PreKubeadmCommands = wantRegistryMirrorCommands()
+			g.Expect(got).To(Equal(want))
+		})
+	}
+}
+
+func TestSetRegistryMirrorInKubeadmConfigTemplate(t *testing.T) {
+	for _, tt := range registryMirrorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newApiBuilerTest(t)
+			got := wantKubeadmConfigTemplate()
+			g.Expect(clusterapi.SetRegistryMirrorInKubeadmConfigTemplate(got, tt.registryMirrorConfig)).To(Succeed())
+			want := wantKubeadmConfigTemplate()
+			want.Spec.Template.Spec.Files = tt.wantFiles
+			want.Spec.Template.Spec.PreKubeadmCommands = wantRegistryMirrorCommands()
+			g.Expect(got).To(Equal(want))
+		})
+	}
+}

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -119,7 +119,8 @@ func wantKubeadmControlPlane() *controlplanev1.KubeadmControlPlane {
 					},
 					APIServer: bootstrapv1.APIServer{
 						ControlPlaneComponent: bootstrapv1.ControlPlaneComponent{
-							ExtraArgs: map[string]string{},
+							ExtraArgs:    map[string]string{},
+							ExtraVolumes: []bootstrapv1.HostPathMount{},
 						},
 					},
 					ControllerManager: bootstrapv1.ControlPlaneComponent{


### PR DESCRIPTION
*Issue #, if available:*

#1574 

*Description of changes:*

Add support in snow provider:
- OIDC
- AWS IAM Auth
- Pod IAM

*Testing (if applicable):*

- unit tests

** adding identity support exceeds snow ec2 user data limit. will test once we increase the data limit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

