### PR TITLE
Remove internal use of `gitOpts` struct from FluxAddonClient

### DIFF
--- a/pkg/addonmanager/addonclients/files.go
+++ b/pkg/addonmanager/addonclients/files.go
@@ -53,7 +53,7 @@ func (f *FluxAddonClient) UpdateLegacyFileStructure(ctx context.Context, current
 		return err
 	}
 
-	if err := nfc.gitOpts.Git.Add(nfc.path()); err != nil {
+	if err := nfc.git.Add(nfc.path()); err != nil {
 		return &ConfigVersionControlFailedError{Err: fmt.Errorf("adding %s to git: %v", nfc.path(), err)}
 	}
 
@@ -67,8 +67,8 @@ func (f *FluxAddonClient) UpdateLegacyFileStructure(ctx context.Context, current
 }
 
 func (fc *fluxForCluster) filesUpdateNeeded(oldPath string) (bool, error) {
-	fluxSystemPath := filepath.Join(fc.gitOpts.Writer.Dir(), fc.fluxSystemDir())
-	eksaSystemPath := filepath.Join(fc.gitOpts.Writer.Dir(), fc.eksaSystemDir())
+	fluxSystemPath := filepath.Join(fc.writer.Dir(), fc.fluxSystemDir())
+	eksaSystemPath := filepath.Join(fc.writer.Dir(), fc.eksaSystemDir())
 	if !validations.FileExists(fluxSystemPath) {
 		return false, fmt.Errorf("unrecognized file structure, missing flux-system path at %s", fluxSystemPath)
 	}
@@ -78,7 +78,7 @@ func (fc *fluxForCluster) filesUpdateNeeded(oldPath string) (bool, error) {
 func updateEksaSystemFiles(ofc, nfc *fluxForCluster) error {
 	// in older version (<= 0.5.0), flux-system and eksa-system folders are under the same parent directory
 	oldEksaPath := filepath.Join(ofc.path(), eksaSystemDirName)
-	eksaSpec, err := nfc.updateGitOpsConfig(filepath.Join(nfc.gitOpts.Writer.Dir(), oldEksaPath, clusterConfigFileName))
+	eksaSpec, err := nfc.updateGitOpsConfig(filepath.Join(nfc.writer.Dir(), oldEksaPath, clusterConfigFileName))
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func updateEksaSystemFiles(ofc, nfc *fluxForCluster) error {
 	}
 
 	if oldEksaPath != nfc.eksaSystemDir() {
-		err = nfc.gitOpts.Git.Remove(oldEksaPath)
+		err = nfc.git.Remove(oldEksaPath)
 		if err != nil {
 			return &ConfigVersionControlFailedError{Err: fmt.Errorf("removing %s in git: %v", oldEksaPath, err)}
 		}

--- a/pkg/addonmanager/addonclients/upgrader.go
+++ b/pkg/addonmanager/addonclients/upgrader.go
@@ -102,7 +102,7 @@ func (fc *fluxForCluster) commitFluxUpgradeFilesToGit(ctx context.Context) error
 		return err
 	}
 
-	if err := fc.gitOpts.Git.Add(fc.path()); err != nil {
+	if err := fc.git.Add(fc.path()); err != nil {
 		return &ConfigVersionControlFailedError{Err: fmt.Errorf("adding %s to git: %v", fc.path(), err)}
 	}
 
@@ -130,7 +130,7 @@ func (fc *fluxForCluster) writeFluxUpgradeFiles() error {
 }
 
 func (fc *fluxForCluster) writeEksaUpgradeFiles() error {
-	eksaSpec, err := fc.generateUpdatedEksaConfig(filepath.Join(fc.gitOpts.Writer.Dir(), fc.eksaSystemDir(), clusterConfigFileName))
+	eksaSpec, err := fc.generateUpdatedEksaConfig(filepath.Join(fc.writer.Dir(), fc.eksaSystemDir(), clusterConfigFileName))
 	if err != nil {
 		return err
 	}

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -79,7 +79,7 @@ func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
 	tt.Expect(deps.Bootstrapper).NotTo(BeNil())
 	tt.Expect(deps.ClusterManager).NotTo(BeNil())
 	tt.Expect(deps.Provider).NotTo(BeNil())
-	tt.Expect(deps.FluxAddonClient).NotTo(BeNil())
+	tt.Expect(deps.FluxAddonClient).To(BeNil())
 	tt.Expect(deps.Writer).NotTo(BeNil())
 	tt.Expect(deps.AnalyzerFactory).NotTo(BeNil())
 	tt.Expect(deps.CollectorFactory).NotTo(BeNil())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
removing internal use of the unneeded `gitOpts` struct from the FluxAddonClient. The whole options argument will be removed in favor of directly injecting dependencies in an upcoming pr.

this is an intermediate step to factoring out the `git.Provider` interface into two parts, a GitClient (responsible for local repo actions) and a GitProvider (responsible for actions on a remote provider), which will be generated by the factory and injected directly into the FluxAddonClient (along with the writer) rather than using the intermediate `gitOpts` struct.

*Testing (if applicable):*
`make`, created a cluster with gitops, upgrade it, and deleted it.
created a cluster w/out gitops.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

