### PR TITLE
Remove unused SetupCLITools method

### DIFF
--- a/pkg/executables/docker.go
+++ b/pkg/executables/docker.go
@@ -40,15 +40,6 @@ func (d *Docker) PullImage(ctx context.Context, image string) error {
 	}
 }
 
-func (d *Docker) SetUpCLITools(ctx context.Context, image string) error {
-	logger.V(1).Info("Setting up cli docker dependencies")
-	if err := d.PullImage(ctx, image); err != nil {
-		return err
-	} else {
-		return nil
-	}
-}
-
 func (d *Docker) Version(ctx context.Context) (int, error) {
 	cmdOutput, err := d.Execute(ctx, "version", "--format", "{{.Client.Version}}")
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

`make unit-test`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

