### PR TITLE
Remove registry mirror from download artifacts e2e

### DIFF
--- a/test/e2e/download_artifacts_test.go
+++ b/test/e2e/download_artifacts_test.go
@@ -24,7 +24,6 @@ func TestVSphereDownloadArtifacts(t *testing.T) {
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithRegistryMirrorEndpointAndCert(),
 	)
 	runDownloadArtifactsFlow(test)
 }


### PR DESCRIPTION
This test doesn't need registry mirror configuration. It's failing currently because it expects those vars to be set but the test name doesn't have the required regex. This PR removes the registry mirror config and so the need for those env vars

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

