### PR TITLE
Add env var support for lifecycle api work with tilt

### DIFF
--- a/controllers/Tiltfile
+++ b/controllers/Tiltfile
@@ -15,6 +15,8 @@ CONFIG_FOLDER = PROJECT_ROOT + 'config'
 KUSTOMIZE_TILT_FOLDER = CONFIG_FOLDER + '/tilt'
 KUSTOMIZE_BIN = os.path.abspath(PROJECT_ROOT + 'hack/tools/bin/kustomize')
 watch_settings(ignore=[KUSTOMIZE_TILT_FOLDER]) #ignore kustomize tilt folder to avoid infinite loop
+FULL_LIFECYCLE_API_KEY = "FULL_LIFECYCLE_API"
+FULL_LIFECYCLE_API_VALUE = os.getenv(FULL_LIFECYCLE_API_KEY, "false")
 
 def yaml():
     local('cd ' + KUSTOMIZE_TILT_FOLDER + ' && ' + KUSTOMIZE_BIN + ' edit set image controller=' + IMG)
@@ -29,8 +31,15 @@ local_resource(
   deps=[CONTROLLERS_FOLDER, API_FOLDER],
   ignore=[CONTROLLERS_BIN_FOLDER, API_FOLDER + '/*/zz_generated.deepcopy.go'])
 
+FULL_LIFECYCLE_API_ENV = FULL_LIFECYCLE_API_KEY + "=" + FULL_LIFECYCLE_API_VALUE
+
 DOCKERFILE = '''FROM golang:alpine
 WORKDIR /
+ENV ''' + FULL_LIFECYCLE_API_ENV + '''
+RUN apk --no-cache add curl
+RUN curl -L -o - "https://github.com/vmware/govmomi/releases/latest/download/govc_$(uname -s)_$(uname -m).tar.gz" | tar -C /usr/local/bin -xvzf - govc
+RUN curl -L -o - "https://get.helm.sh/helm-v3.8.1-linux-amd64.tar.gz" | tar -C /usr/local/bin -xvzf - linux-amd64/helm
+RUN mv /usr/local/bin/linux-amd64/helm /usr/local/bin/
 COPY ./bin/manager /
 CMD ["/manager"]
 '''

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -108,7 +108,11 @@ func main() {
 
 func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	if features.IsActive(features.FullLifecycleAPI()) {
-		factory := dependencies.NewFactory()
+		// This feature doesn't support running the binaries through docker on the controller image so relying on the
+		// binaries built within the controller image instead. We also can specify a fake executable image for now in
+		// order to get the dependencies to build.
+		os.Setenv("MR_TOOLS_DISABLE", "true")
+		factory := dependencies.NewFactory().UseExecutableImage("test.com/fake-image:1.0")
 		deps, err := factory.WithGovc().Build(ctx)
 		if err != nil {
 			setupLog.Error(err, "unable to build dependencies")

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -25,6 +25,11 @@ func IsActive(feature Feature) bool {
 	return feature.IsActive()
 }
 
+// ClearCache is mainly used for unit tests as of now
+func ClearCache() {
+	globalFeatures.clearCache()
+}
+
 func FullLifecycleAPI() Feature {
 	return Feature{
 		Name:     "Full lifecycle API support through the EKS-A controller",

--- a/pkg/features/internal.go
+++ b/pkg/features/internal.go
@@ -62,3 +62,7 @@ func (f *features) isActiveForEnvVarOrGate(envVar, gateName string) func() bool 
 		return active
 	}
 }
+
+func (f *features) clearCache() {
+	f.cache.clear()
+}

--- a/pkg/features/mutexmap.go
+++ b/pkg/features/mutexmap.go
@@ -25,3 +25,9 @@ func (m *mutexMap) store(key string, value bool) {
 	m.internal[key] = value
 	m.Unlock()
 }
+
+func (m *mutexMap) clear() {
+	m.Lock()
+	m.internal = make(map[string]bool)
+	m.Unlock()
+}

--- a/pkg/features/mutexmap_test.go
+++ b/pkg/features/mutexmap_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestMutextMapLoadAndStore(t *testing.T) {
+func TestMutexMapLoadAndStore(t *testing.T) {
 	g := NewWithT(t)
 	m := newMutexMap()
 
@@ -20,4 +20,21 @@ func TestMutextMapLoadAndStore(t *testing.T) {
 	v, ok = m.load(key)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(v).To(Equal(value))
+}
+
+func TestMutexMapClear(t *testing.T) {
+	g := NewWithT(t)
+	m := newMutexMap()
+
+	key := "key"
+	value := true
+	m.store(key, value)
+	v, ok := m.load(key)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(v).To(Equal(value))
+
+	m.clear()
+	v, ok = m.load(key)
+	g.Expect(ok).To(BeFalse())
+	g.Expect(v).To(BeFalse())
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As of now we had these as local changes whenever we wanted to test the full lifecycle api work so checking some of the automation in. I added the ability to read and set the env var for Tilt, as well as set the env var when running create cluster. 

I debated using the bundle manifest for getting the controller image and copying the govc and helm binaries from that image using a multi-stage build, but for this use case it didn't feel necessary to have to write the logic to parse that file in the Tiltfile and use an image that is built from main instead of from local. I also looked into setting the env vars using kustomize substitutions like they do in cluster-api, but realized that that is more effort than needed for this use case due to the amount of tooling that is required to make that happen. 

I also added the ability to clear the cache for the features for unit testing. Because of how our unit tests are run, there is a chance for env vars to be leftover in the mutexMap, so clearing it for some of the test cases for now.

*Testing (if applicable):*
Ran unit tests and tested this functionality through tilt. Also testing create cluster with and without this env var.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

