### PR TITLE
Initial Implementation of Tinkerbell stack installation

### DIFF
--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -19,6 +19,7 @@ type ClusterClient interface {
 	CreateBootstrapCluster(ctx context.Context, clusterSpec *cluster.Spec, opts ...BootstrapClusterClientOption) (kubeconfig string, err error)
 	DeleteBootstrapCluster(ctx context.Context, cluster *types.Cluster) error
 	WithExtraDockerMounts() BootstrapClusterClientOption
+	WithExtraPortMappings([]int) BootstrapClusterClientOption
 	WithEnv(env map[string]string) BootstrapClusterClientOption
 	WithDefaultCNIDisabled() BootstrapClusterClientOption
 	ApplyKubeSpecFromBytes(ctx context.Context, cluster *types.Cluster, data []byte) error
@@ -124,6 +125,12 @@ func (b *Bootstrapper) getClientOptions(opts []BootstrapClusterOption) []Bootstr
 func WithExtraDockerMounts() BootstrapClusterOption {
 	return func(b *Bootstrapper) BootstrapClusterClientOption {
 		return b.clusterClient.WithExtraDockerMounts()
+	}
+}
+
+func WithExtraPortMappings(ports []int) BootstrapClusterOption {
+	return func(b *Bootstrapper) BootstrapClusterClientOption {
+		return b.clusterClient.WithExtraPortMappings(ports)
 	}
 }
 

--- a/pkg/bootstrapper/mocks/client.go
+++ b/pkg/bootstrapper/mocks/client.go
@@ -213,3 +213,17 @@ func (mr *MockClusterClientMockRecorder) WithExtraDockerMounts() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithExtraDockerMounts", reflect.TypeOf((*MockClusterClient)(nil).WithExtraDockerMounts))
 }
+
+// WithExtraPortMappings mocks base method.
+func (m *MockClusterClient) WithExtraPortMappings(arg0 []int) bootstrapper.BootstrapClusterClientOption {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WithExtraPortMappings", arg0)
+	ret0, _ := ret[0].(bootstrapper.BootstrapClusterClientOption)
+	return ret0
+}
+
+// WithExtraPortMappings indicates an expected call of WithExtraPortMappings.
+func (mr *MockClusterClientMockRecorder) WithExtraPortMappings(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithExtraPortMappings", reflect.TypeOf((*MockClusterClient)(nil).WithExtraPortMappings), arg0)
+}

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -37,10 +37,23 @@ func (p *Provider) BootstrapClusterOpts() ([]bootstrapper.BootstrapClusterOption
 		env["NO_PROXY"] = noProxy
 	}
 
-	return []bootstrapper.BootstrapClusterOption{bootstrapper.WithEnv(env)}, nil
+	opts := []bootstrapper.BootstrapClusterOption{bootstrapper.WithEnv(env)}
+
+	if p.setupTinkerbell {
+		opts = append(opts, bootstrapper.WithExtraPortMappings(tinkerbellStackPorts))
+	}
+
+	return opts, nil
 }
 
 func (p *Provider) PreCAPIInstallOnBootstrap(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
+	if p.setupTinkerbell {
+		logger.V(4).Info("Installing Tinkerbell stack on the bootstrap cluster")
+		if err := p.InstallTinkerbellStack(ctx, cluster, clusterSpec); err != nil {
+			return fmt.Errorf("installing tinkerbell stack on the bootstrap cluster: %v", err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/providers/tinkerbell/mocks/client.go
+++ b/pkg/providers/tinkerbell/mocks/client.go
@@ -48,6 +48,20 @@ func (m *MockProviderKubectlClient) EXPECT() *MockProviderKubectlClientMockRecor
 	return m.recorder
 }
 
+// ApplyKubeSpec mocks base method.
+func (m *MockProviderKubectlClient) ApplyKubeSpec(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyKubeSpec", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyKubeSpec indicates an expected call of ApplyKubeSpec.
+func (mr *MockProviderKubectlClientMockRecorder) ApplyKubeSpec(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyKubeSpec", reflect.TypeOf((*MockProviderKubectlClient)(nil).ApplyKubeSpec), arg0, arg1, arg2)
+}
+
 // ApplyKubeSpecFromBytesForce mocks base method.
 func (m *MockProviderKubectlClient) ApplyKubeSpecFromBytesForce(arg0 context.Context, arg1 *types.Cluster, arg2 []byte) error {
 	m.ctrl.T.Helper()
@@ -262,6 +276,20 @@ func (mr *MockProviderKubectlClientMockRecorder) UpdateAnnotation(arg0, arg1, ar
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAnnotation", reflect.TypeOf((*MockProviderKubectlClient)(nil).UpdateAnnotation), varargs...)
+}
+
+// WaitForDeployment mocks base method.
+func (m *MockProviderKubectlClient) WaitForDeployment(arg0 context.Context, arg1 *types.Cluster, arg2, arg3, arg4, arg5 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForDeployment", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForDeployment indicates an expected call of WaitForDeployment.
+func (mr *MockProviderKubectlClientMockRecorder) WaitForDeployment(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForDeployment", reflect.TypeOf((*MockProviderKubectlClient)(nil).WaitForDeployment), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // MockProviderTinkClient is a mock of ProviderTinkClient interface.

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -2,11 +2,14 @@ package tinkerbell
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	tinkhardware "github.com/tinkerbell/tink/protos/hardware"
 	tinkworkflow "github.com/tinkerbell/tink/protos/workflow"
 
@@ -19,6 +22,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/mocks"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/pbnj"
 	"github.com/aws/eks-anywhere/pkg/types"
+	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 const (
@@ -300,4 +304,103 @@ func TestTinkerbellProviderGenerateDeploymentFileMultipleWorkerNodeGroups(t *tes
 
 	test.AssertContentToFile(t, string(cp), "testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml")
 	test.AssertContentToFile(t, string(md), "testdata/expected_results_tinkerbell_md_multiple_node_groups.yaml")
+}
+
+func TestTinkerbellProviderPreCAPIInstallOnBootstrapSuccess(t *testing.T) {
+	setupContext(t)
+	clusterSpecManifest := "cluster_tinkerbell_stacked_etcd.yaml"
+	mockCtrl := gomock.NewController(t)
+	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	tink := mocks.NewMockProviderTinkClient(mockCtrl)
+	pbnjClient := mocks.NewMockProviderPbnjClient(mockCtrl)
+	writer := filewritermocks.NewMockFileWriter(mockCtrl)
+	tinkerbellClients := TinkerbellClients{tink, pbnjClient}
+	cluster := &types.Cluster{Name: "test"}
+
+	clusterSpec := givenClusterSpec(t, clusterSpecManifest)
+	datacenterConfig := givenDatacenterConfig(t, clusterSpecManifest)
+	machineConfigs := givenMachineConfigs(t, clusterSpecManifest)
+	ctx := context.Background()
+
+	clusterSpec.VersionsBundle.Tinkerbell.TinkerbellStack = releasev1alpha1.TinkerbellStackBundle{
+		Tink: releasev1alpha1.TinkBundle{
+			Manifest: releasev1alpha1.Manifest{URI: "tink.yaml"},
+		},
+	}
+
+	kubectl.EXPECT().ApplyKubeSpec(ctx, cluster, "tink.yaml")
+	kubectl.EXPECT().WaitForDeployment(ctx, cluster, deploymentWaitTimeout, "Available", "tink-server", tinkNamespace)
+	kubectl.EXPECT().WaitForDeployment(ctx, cluster, deploymentWaitTimeout, "Available", "tink-controller-manager", tinkNamespace)
+
+	provider := newProviderWithKubectlWithTink(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, kubectl, tinkerbellClients)
+
+	err := provider.InstallTinkerbellStack(ctx, cluster, clusterSpec)
+	if err != nil {
+		t.Fatalf("failed to install Tinkerbell stack: %v", err)
+	}
+}
+
+func TestTinkerbellProviderPreCAPIInstallOnBootstrapFailureApplyingManifest(t *testing.T) {
+	setupContext(t)
+	clusterSpecManifest := "cluster_tinkerbell_stacked_etcd.yaml"
+	mockCtrl := gomock.NewController(t)
+	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	tink := mocks.NewMockProviderTinkClient(mockCtrl)
+	pbnjClient := mocks.NewMockProviderPbnjClient(mockCtrl)
+	writer := filewritermocks.NewMockFileWriter(mockCtrl)
+	tinkerbellClients := TinkerbellClients{tink, pbnjClient}
+	cluster := &types.Cluster{Name: "test"}
+
+	clusterSpec := givenClusterSpec(t, clusterSpecManifest)
+	datacenterConfig := givenDatacenterConfig(t, clusterSpecManifest)
+	machineConfigs := givenMachineConfigs(t, clusterSpecManifest)
+	ctx := context.Background()
+
+	clusterSpec.VersionsBundle.Tinkerbell.TinkerbellStack = releasev1alpha1.TinkerbellStackBundle{
+		Tink: releasev1alpha1.TinkBundle{
+			Manifest: releasev1alpha1.Manifest{URI: "tink.yaml"},
+		},
+	}
+
+	provider := newProviderWithKubectlWithTink(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, kubectl, tinkerbellClients)
+
+	kubectlError := "kubectl error"
+	expectedError := fmt.Sprintf("applying tink manifest: %s", kubectlError)
+	kubectl.EXPECT().ApplyKubeSpec(ctx, cluster, "tink.yaml").Return(errors.New(kubectlError))
+
+	err := provider.InstallTinkerbellStack(ctx, cluster, clusterSpec)
+	assert.EqualError(t, err, expectedError, "Error should be: %v, got: %v", expectedError, err)
+}
+
+func TestTinkerbellProviderPreCAPIInstallOnBootstrapFailureWaitingForDeployment(t *testing.T) {
+	setupContext(t)
+	clusterSpecManifest := "cluster_tinkerbell_stacked_etcd.yaml"
+	mockCtrl := gomock.NewController(t)
+	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	tink := mocks.NewMockProviderTinkClient(mockCtrl)
+	pbnjClient := mocks.NewMockProviderPbnjClient(mockCtrl)
+	writer := filewritermocks.NewMockFileWriter(mockCtrl)
+	tinkerbellClients := TinkerbellClients{tink, pbnjClient}
+	cluster := &types.Cluster{Name: "test"}
+
+	clusterSpec := givenClusterSpec(t, clusterSpecManifest)
+	datacenterConfig := givenDatacenterConfig(t, clusterSpecManifest)
+	machineConfigs := givenMachineConfigs(t, clusterSpecManifest)
+	ctx := context.Background()
+
+	clusterSpec.VersionsBundle.Tinkerbell.TinkerbellStack = releasev1alpha1.TinkerbellStackBundle{
+		Tink: releasev1alpha1.TinkBundle{
+			Manifest: releasev1alpha1.Manifest{URI: "tink.yaml"},
+		},
+	}
+
+	provider := newProviderWithKubectlWithTink(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, kubectl, tinkerbellClients)
+
+	kubectlError := "kubectl error"
+	expectedError := fmt.Sprintf("waiting for deployment tink-server: %s", kubectlError)
+	kubectl.EXPECT().ApplyKubeSpec(ctx, cluster, "tink.yaml")
+	kubectl.EXPECT().WaitForDeployment(ctx, cluster, deploymentWaitTimeout, "Available", "tink-server", tinkNamespace).Return(errors.New(kubectlError))
+
+	err := provider.InstallTinkerbellStack(ctx, cluster, clusterSpec)
+	assert.EqualError(t, err, expectedError, "Error should be: %v, got: %v", expectedError, err)
 }


### PR DESCRIPTION
*Description of changes:*
This PR covers the following:
- Adds extraPortMappings on the Kind cluster if the `--setup-tinkerbell` flag is specified
- Installs `tink-server` and `tink-controller` on the bootstrap cluster
- TODOs for installing boots, hegel and rufio when those are built and added to the bundle. This step is pending on Tinkerbell changes to support K8S model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

