### PR TITLE
For bare metal, increase node startup timeout in MachineHealthCheck...

### DIFF
--- a/pkg/providers/tinkerbell/config/machine-health-check-template.yaml
+++ b/pkg/providers/tinkerbell/config/machine-health-check-template.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterName: {{.clusterName}}
   maxUnhealthy: 40%
-  nodeStartupTimeout: 10m
+  nodeStartupTimeout: 20m
   selector:
     matchLabels:
       cluster.x-k8s.io/deployment-name: "{{.clusterName}}-md-0"


### PR DESCRIPTION
...configuration to allow for longer Hook and Ubuntu/OS streaming times and workflow runs

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

