### PR TITLE
Rename existing WithFlux spec opt to WithFluxLegacy

### DIFF
--- a/test/e2e/flux_test.go
+++ b/test/e2e/flux_test.go
@@ -35,37 +35,37 @@ func runFluxFlow(test *framework.ClusterE2ETest) {
 	test.DeleteCluster()
 }
 
-func TestDockerKubernetes120Flux(t *testing.T) {
+func TestDockerKubernetes120FluxLegacy(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
-		framework.WithFlux(),
+		framework.WithFluxLegacy(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
 	)
 	runFluxFlow(test)
 }
 
-func TestDockerKubernetes121Flux(t *testing.T) {
+func TestDockerKubernetes121FluxLegacy(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
-		framework.WithFlux(),
+		framework.WithFluxLegacy(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 	)
 	runFluxFlow(test)
 }
 
-func TestDockerKubernetes122Flux(t *testing.T) {
+func TestDockerKubernetes122FluxLegacy(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
-		framework.WithFlux(),
+		framework.WithFluxLegacy(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 	)
 	runFluxFlow(test)
 }
 
-func TestVSphereKubernetes120Flux(t *testing.T) {
+func TestVSphereKubernetes120FluxLegacy(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu120()),
-		framework.WithFlux(),
+		framework.WithFluxLegacy(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
@@ -74,10 +74,10 @@ func TestVSphereKubernetes120Flux(t *testing.T) {
 	runFluxFlow(test)
 }
 
-func TestVSphereKubernetes121Flux(t *testing.T) {
+func TestVSphereKubernetes121FluxLegacy(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu121()),
-		framework.WithFlux(),
+		framework.WithFluxLegacy(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
@@ -86,10 +86,10 @@ func TestVSphereKubernetes121Flux(t *testing.T) {
 	runFluxFlow(test)
 }
 
-func TestVSphereKubernetes122Flux(t *testing.T) {
+func TestVSphereKubernetes122FluxLegacy(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu122()),
-		framework.WithFlux(),
+		framework.WithFluxLegacy(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
@@ -98,10 +98,10 @@ func TestVSphereKubernetes122Flux(t *testing.T) {
 	runFluxFlow(test)
 }
 
-func TestVSphereKubernetes120BottleRocketFlux(t *testing.T) {
+func TestVSphereKubernetes120BottleRocketFluxLegacy(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket120()),
-		framework.WithFlux(),
+		framework.WithFluxLegacy(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
@@ -110,10 +110,10 @@ func TestVSphereKubernetes120BottleRocketFlux(t *testing.T) {
 	runFluxFlow(test)
 }
 
-func TestVSphereKubernetes121BottleRocketFlux(t *testing.T) {
+func TestVSphereKubernetes121BottleRocketFluxLegacy(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket121()),
-		framework.WithFlux(),
+		framework.WithFluxLegacy(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
@@ -122,24 +122,24 @@ func TestVSphereKubernetes121BottleRocketFlux(t *testing.T) {
 	runFluxFlow(test)
 }
 
-func TestVSphereKubernetes122ThreeReplicasThreeWorkersFlux(t *testing.T) {
+func TestVSphereKubernetes122ThreeReplicasThreeWorkersFluxLegacy(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu122()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithFlux(),
+		framework.WithFluxLegacy(),
 	)
 	runFluxFlow(test)
 }
 
-func TestDockerKubernetes122GitopsOptionsFlux(t *testing.T) {
+func TestDockerKubernetes122GitopsOptionsFluxLegacy(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithFlux(
+		framework.WithFluxLegacy(
 			api.WithFluxBranch(fluxUserProvidedBranch),
 			api.WithFluxNamespace(fluxUserProvidedNamespace),
 			api.WithFluxConfigurationPath(fluxUserProvidedPath),
@@ -148,14 +148,14 @@ func TestDockerKubernetes122GitopsOptionsFlux(t *testing.T) {
 	runFluxFlow(test)
 }
 
-func TestVSphereKubernetes122GitopsOptionsFlux(t *testing.T) {
+func TestVSphereKubernetes122GitopsOptionsFluxLegacy(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu122()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithFlux(
+		framework.WithFluxLegacy(
 			api.WithFluxBranch(fluxUserProvidedBranch),
 			api.WithFluxNamespace(fluxUserProvidedNamespace),
 			api.WithFluxConfigurationPath(fluxUserProvidedPath),
@@ -164,12 +164,12 @@ func TestVSphereKubernetes122GitopsOptionsFlux(t *testing.T) {
 	runFluxFlow(test)
 }
 
-func TestCloudStackKubernetes120GitopsOptionsFlux(t *testing.T) {
+func TestCloudStackKubernetes120GitopsOptionsFluxLegacy(t *testing.T) {
 	provider := framework.NewCloudStack(t, framework.WithRedhat120())
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
-		framework.WithFlux(),
+		framework.WithFluxLegacy(),
 		framework.WithClusterFiller(
 			api.WithKubernetesVersion(v1alpha1.Kube120),
 			api.WithControlPlaneCount(1),
@@ -188,11 +188,11 @@ func TestCloudStackKubernetes120GitopsOptionsFlux(t *testing.T) {
 	)
 }
 
-func TestVSphereKubernetes121To122FluxUpgrade(t *testing.T) {
+func TestVSphereKubernetes121To122FluxUpgradeLegacy(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu121())
 	test := framework.NewClusterE2ETest(t,
 		provider,
-		framework.WithFlux(),
+		framework.WithFluxLegacy(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -109,11 +109,11 @@ func TestVSphereKubernetes121UbuntuTo122MultipleFieldsUpgrade(t *testing.T) {
 	)
 }
 
-func TestVSphereKubernetes121UbuntuTo122WithFluxUpgrade(t *testing.T) {
+func TestVSphereKubernetes121UbuntuTo122WithFluxLegacyUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu121())
 	test := framework.NewClusterE2ETest(t,
 		provider,
-		framework.WithFlux(),
+		framework.WithFluxLegacy(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
@@ -127,11 +127,11 @@ func TestVSphereKubernetes121UbuntuTo122WithFluxUpgrade(t *testing.T) {
 	)
 }
 
-func TestVSphereKubernetes121UbuntuTo122DifferentNamespaceWithFluxUpgrade(t *testing.T) {
+func TestVSphereKubernetes121UbuntuTo122DifferentNamespaceWithFluxLegacyUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu121(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace)))
 	test := framework.NewClusterE2ETest(t,
 		provider,
-		framework.WithFlux(api.WithGitOpsNamespace(clusterNamespace)),
+		framework.WithFluxLegacy(api.WithGitOpsNamespace(clusterNamespace)),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
@@ -220,11 +220,11 @@ func TestVSphereKubernetes121BottlerocketTo122MultipleFieldsUpgrade(t *testing.T
 	)
 }
 
-func TestVSphereKubernetes121BottlerocketTo122WithFluxUpgrade(t *testing.T) {
+func TestVSphereKubernetes121BottlerocketTo122WithFluxLegacyUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithBottleRocket121())
 	test := framework.NewClusterE2ETest(t,
 		provider,
-		framework.WithFlux(),
+		framework.WithFluxLegacy(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
@@ -238,11 +238,11 @@ func TestVSphereKubernetes121BottlerocketTo122WithFluxUpgrade(t *testing.T) {
 	)
 }
 
-func TestVSphereKubernetes121BottlerocketTo122DifferentNamespaceWithFluxUpgrade(t *testing.T) {
+func TestVSphereKubernetes121BottlerocketTo122DifferentNamespaceWithFluxLegacyUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithBottleRocket121(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace)))
 	test := framework.NewClusterE2ETest(t,
 		provider,
-		framework.WithFlux(api.WithGitOpsNamespace(clusterNamespace)),
+		framework.WithFluxLegacy(api.WithGitOpsNamespace(clusterNamespace)),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),

--- a/test/e2e/workload_clusters_test.go
+++ b/test/e2e/workload_clusters_test.go
@@ -64,14 +64,14 @@ func TestVSphereKubernetes121MulticlusterWorkloadCluster(t *testing.T) {
 	runWorkloadClusterFlow(test)
 }
 
-func TestVSphereUpgradeMulticlusterWorkloadClusterWithFlux(t *testing.T) {
+func TestVSphereUpgradeMulticlusterWorkloadClusterWithFluxLegacy(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu120())
 	test := framework.NewMulticlusterE2ETest(
 		t,
 		framework.NewClusterE2ETest(
 			t,
 			provider,
-			framework.WithFlux(),
+			framework.WithFluxLegacy(),
 			framework.WithClusterFiller(
 				api.WithKubernetesVersion(v1alpha1.Kube120),
 				api.WithControlPlaneCount(1),
@@ -82,7 +82,7 @@ func TestVSphereUpgradeMulticlusterWorkloadClusterWithFlux(t *testing.T) {
 		framework.NewClusterE2ETest(
 			t,
 			provider,
-			framework.WithFlux(),
+			framework.WithFluxLegacy(),
 			framework.WithClusterFiller(
 				api.WithKubernetesVersion(v1alpha1.Kube120),
 				api.WithControlPlaneCount(1),
@@ -104,14 +104,14 @@ func TestVSphereUpgradeMulticlusterWorkloadClusterWithFlux(t *testing.T) {
 	)
 }
 
-func TestDockerUpgradeWorkloadClusterWithFlux(t *testing.T) {
+func TestDockerUpgradeWorkloadClusterWithFluxLegacy(t *testing.T) {
 	provider := framework.NewDocker(t)
 	test := framework.NewMulticlusterE2ETest(
 		t,
 		framework.NewClusterE2ETest(
 			t,
 			provider,
-			framework.WithFlux(),
+			framework.WithFluxLegacy(),
 			framework.WithClusterFiller(
 				api.WithKubernetesVersion(v1alpha1.Kube120),
 				api.WithControlPlaneCount(1),
@@ -121,7 +121,7 @@ func TestDockerUpgradeWorkloadClusterWithFlux(t *testing.T) {
 		framework.NewClusterE2ETest(
 			t,
 			provider,
-			framework.WithFlux(),
+			framework.WithFluxLegacy(),
 			framework.WithClusterFiller(
 				api.WithKubernetesVersion(v1alpha1.Kube120),
 				api.WithControlPlaneCount(1),
@@ -170,14 +170,14 @@ func TestCloudStackKubernetes121WorkloadCluster(t *testing.T) {
 	runWorkloadClusterFlow(test)
 }
 
-func TestCloudStackUpgradeMulticlusterWorkloadClusterWithFlux(t *testing.T) {
+func TestCloudStackUpgradeMulticlusterWorkloadClusterWithFluxLegacy(t *testing.T) {
 	provider := framework.NewCloudStack(t, framework.WithRedhat120())
 	test := framework.NewMulticlusterE2ETest(
 		t,
 		framework.NewClusterE2ETest(
 			t,
 			provider,
-			framework.WithFlux(),
+			framework.WithFluxLegacy(),
 			framework.WithClusterFiller(
 				api.WithKubernetesVersion(v1alpha1.Kube120),
 				api.WithControlPlaneCount(1),
@@ -188,7 +188,7 @@ func TestCloudStackUpgradeMulticlusterWorkloadClusterWithFlux(t *testing.T) {
 		framework.NewClusterE2ETest(
 			t,
 			provider,
-			framework.WithFlux(),
+			framework.WithFluxLegacy(),
 			framework.WithClusterFiller(
 				api.WithKubernetesVersion(v1alpha1.Kube120),
 				api.WithControlPlaneCount(1),

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -39,7 +39,7 @@ var fluxRequiredEnvVars = []string{
 	githubTokenVar,
 }
 
-func WithFlux(opts ...api.GitOpsConfigOpt) ClusterE2ETestOpt {
+func WithFluxLegacy(opts ...api.GitOpsConfigOpt) ClusterE2ETestOpt {
 	return func(e *ClusterE2ETest) {
 		checkRequiredEnvVars(e.T, fluxRequiredEnvVars)
 		gitOpsConfigName := gitOpsConfigName()
@@ -71,7 +71,7 @@ func WithClusterUpgradeGit(fillers ...api.ClusterFiller) ClusterE2ETestOpt {
 	return func(e *ClusterE2ETest) {
 		e.ClusterConfigB = e.customizeClusterConfig(e.clusterConfigGitPath(), fillers...)
 
-		// TODO: e.GitopsConfig is defined from api.NewGitOpsConfig in WithFlux()
+		// TODO: e.GitopsConfig is defined from api.NewGitOpsConfig in WithFluxLegacy()
 		// instead of marshalling from the actual file in git repo.
 		// By default it does not include the namespace field. But Flux requires namespace always
 		// exist for all the objects managed by its kustomization controller.


### PR DESCRIPTION
*Issue #, if available:*
#1961 

*Description of changes:*
Renaming this from `WithFlux` to `WithFluxLegacy` since GitOpsConfig will eventually be deprecated. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

