### PR TITLE
Add method to generate FluxConfig in e2e tests

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -117,9 +117,9 @@ func WithOIDCIdentityProviderRef(name string) ClusterFiller {
 	}
 }
 
-func WithGitOpsRef(name string) ClusterFiller {
+func WithGitOpsRef(name, kind string) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
-		c.Spec.GitOpsRef = &anywherev1.Ref{Name: name, Kind: anywherev1.GitOpsConfigKind}
+		c.Spec.GitOpsRef = &anywherev1.Ref{Name: name, Kind: kind}
 	}
 }
 

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -65,6 +65,7 @@ type ClusterE2ETest struct {
 	GitWriter              filewriter.FileWriter
 	OIDCConfig             *v1alpha1.OIDCConfig
 	GitOpsConfig           *v1alpha1.GitOpsConfig
+	FluxConfig             *v1alpha1.FluxConfig
 	ProxyConfig            *v1alpha1.ProxyConfiguration
 	AWSIamConfig           *v1alpha1.AWSIamConfig
 	eksaBinaryLocation     string


### PR DESCRIPTION
*Issue #, if available:*
#1960 

*Description of changes:*
Adds method to generate FluxConfig in e2e tests

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

