### PR TITLE
Remove lazy loading of hardware in tinkerbell validation

### DIFF
--- a/pkg/providers/tinkerbell/validator_helper_test.go
+++ b/pkg/providers/tinkerbell/validator_helper_test.go
@@ -1,8 +1,0 @@
-package tinkerbell
-
-import "github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
-
-// SetValidatorHardwareConfig sets v internal hardwareConfig member to cfg.
-func SetValidatorHardwareConfig(v *Validator, cfg hardware.HardwareConfig) {
-	v.hardwareConfig = cfg
-}


### PR DESCRIPTION
We lazily load hardware manifests during a set of validation functions. Consequently, validation functions must be called in a specific order creating fragility and hard to understand validation logic.

