### PR TITLE
make sure to assign a git client for the tests, DAN

### DIFF
--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -173,6 +173,7 @@ func (e *ClusterE2ETest) initGit(ctx context.Context) {
 	}
 	e.GitProvider = g.Provider
 	e.GitWriter = g.Writer
+	e.GitClient = g.Client
 }
 
 func (e *ClusterE2ETest) buildClusterConfigFileForGit() {
@@ -230,12 +231,12 @@ func (e *ClusterE2ETest) CleanUpGithubRepo() {
 	ctx := context.Background()
 	owner := e.GitOpsConfig.Spec.Flux.Github.Owner
 	repoName := e.gitRepoName()
-	gitOptions, err := e.NewGitTools(ctx, c, e.GitOpsConfig.ConvertToFluxConfig(), writer, fmt.Sprintf("%s/%s", e.ClusterName, repoName))
+	gitTools, err := e.NewGitTools(ctx, c, e.GitOpsConfig.ConvertToFluxConfig(), writer, fmt.Sprintf("%s/%s", e.ClusterName, repoName))
 	if err != nil {
 		e.T.Errorf("Error configuring git client for e2e test: %v", err)
 	}
 	opts := git.DeleteRepoOpts{Owner: owner, Repository: repoName}
-	repo, err := gitOptions.Provider.GetRepo(ctx)
+	repo, err := gitTools.Provider.GetRepo(ctx)
 	if err != nil {
 		e.T.Errorf("error getting Github repo %s: %v", repoName, err)
 	}
@@ -243,7 +244,7 @@ func (e *ClusterE2ETest) CleanUpGithubRepo() {
 		e.T.Logf("Skipped repo deletion: remote repo %s does not exist", repoName)
 		return
 	}
-	err = gitOptions.Provider.DeleteRepo(ctx, opts)
+	err = gitTools.Provider.DeleteRepo(ctx, opts)
 	if err != nil {
 		e.T.Errorf("error while deleting Github repo %s: %v", repoName, err)
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Forgot to assign the git client to the e2e test. caused a failure in the tests when attempting to use the client.

also found a quick rename that needed to happen.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

