### PR TITLE
set git client in Flux Validation flow

### DIFF
--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -196,6 +196,7 @@ func (e *ClusterE2ETest) ValidateFlux() {
 	if err != nil {
 		e.T.Errorf("Error configuring git client for e2e test: %v", err)
 	}
+	e.GitClient = g.Client
 	e.GitProvider = g.Provider
 	e.GitWriter = g.Writer
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
we were not setting the GitClient in the flux validation flow. This was a miss on my part that caused an issue with the tests.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

