### PR TITLE
Fix concurrent image push race condition

### DIFF
--- a/pkg/docker/concurrent.go
+++ b/pkg/docker/concurrent.go
@@ -32,6 +32,8 @@ func (c *ConcurrentImageProcessor) Process(ctx context.Context, images []string,
 			waitGroup:   wg,
 			errorReturn: errors,
 		}
+
+		wg.Add(1)
 		go w.start()
 	}
 
@@ -125,13 +127,10 @@ type worker struct {
 }
 
 func (w *worker) start() {
-	w.waitGroup.Add(1)
-
+	defer w.waitGroup.Done()
 	for j := range w.jobs {
 		if err := w.process(j.ctx, j.image); err != nil {
 			w.errorReturn <- err
 		}
 	}
-
-	w.waitGroup.Done()
 }


### PR DESCRIPTION
When using a WaitGroup its important to add the managed routines to the wait group from _outside_ the managed routine. This is because goroutine scheduling is non-deterministic making it possible for wg.Wait() to be called _before_ all wg.Add() calls resulting in a panic.