### PR TITLE
support `upgrade cluster` with `FluxConfig` present

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - bases/anywhere.eks.amazonaws.com_cloudstackdatacenterconfigs.yaml
 - bases/anywhere.eks.amazonaws.com_cloudstackmachineconfigs.yaml
 - bases/anywhere.eks.amazonaws.com_bundles.yaml
+- bases/anywhere.eks.amazonaws.com_fluxconfigs.yaml
 - bases/anywhere.eks.amazonaws.com_gitopsconfigs.yaml
 - bases/anywhere.eks.amazonaws.com_oidcconfigs.yaml
 - bases/anywhere.eks.amazonaws.com_awsiamconfigs.yaml

--- a/controllers/controllers/clusters/vsphere.go
+++ b/controllers/controllers/clusters/vsphere.go
@@ -116,7 +116,7 @@ func (v *VSphereClusterReconciler) bundles(ctx context.Context, name, namespace 
 }
 
 func (v *VSphereClusterReconciler) FetchAppliedSpec(ctx context.Context, cs *anywherev1.Cluster) (*c.Spec, error) {
-	return c.BuildSpecForCluster(ctx, cs, v.bundles, v.eksdRelease, nil, nil)
+	return c.BuildSpecForCluster(ctx, cs, v.bundles, v.eksdRelease, nil, nil, nil)
 }
 
 func (v *VSphereClusterReconciler) Reconcile(ctx context.Context, cluster *anywherev1.Cluster) (reconciler.Result, error) {

--- a/controllers/controllers/resource/fetcher.go
+++ b/controllers/controllers/resource/fetcher.go
@@ -437,7 +437,7 @@ func (r *CapiResourceFetcher) OIDCConfig(ctx context.Context, ref *anywherev1.Re
 }
 
 func (r *CapiResourceFetcher) FetchAppliedSpec(ctx context.Context, cs *anywherev1.Cluster) (*cluster.Spec, error) {
-	return cluster.BuildSpecForCluster(ctx, cs, r.bundles, r.eksdRelease, nil, r.oidcConfig)
+	return cluster.BuildSpecForCluster(ctx, cs, r.bundles, r.eksdRelease, nil, nil, r.oidcConfig)
 }
 
 func (r *CapiResourceFetcher) ExistingVSphereDatacenterConfig(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*anywherev1.VSphereDatacenterConfig, error) {

--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -228,8 +228,7 @@ func (f *FluxAddonClient) UpdateGitEksaSpec(ctx context.Context, clusterSpec *cl
 	if err != nil {
 		return err
 	}
-	logger.V(3).Info("Finished pushing updated cluster config file to git",
-		"repository", fc.repository())
+	logger.V(3).Info("Finished pushing updated cluster config file to git", "repository", fc.repository())
 	return nil
 }
 
@@ -629,11 +628,20 @@ func (fc *fluxForCluster) namespace() string {
 }
 
 func (fc *fluxForCluster) repository() string {
-	return fc.clusterSpec.FluxConfig.Spec.Github.Repository
+	if fc.clusterSpec.FluxConfig.Spec.Github != nil {
+		return fc.clusterSpec.FluxConfig.Spec.Github.Repository
+	}
+	if fc.clusterSpec.FluxConfig.Spec.Git != nil {
+		return fc.clusterSpec.FluxConfig.Spec.Git.RepositoryUrl
+	}
+	return ""
 }
 
 func (fc *fluxForCluster) owner() string {
-	return fc.clusterSpec.FluxConfig.Spec.Github.Owner
+	if fc.clusterSpec.FluxConfig.Spec.Github != nil {
+		return fc.clusterSpec.FluxConfig.Spec.Github.Owner
+	}
+	return ""
 }
 
 func (fc *fluxForCluster) branch() string {
@@ -641,7 +649,10 @@ func (fc *fluxForCluster) branch() string {
 }
 
 func (fc *fluxForCluster) personal() bool {
-	return fc.clusterSpec.FluxConfig.Spec.Github.Personal
+	if fc.clusterSpec.FluxConfig.Spec.Github != nil {
+		return fc.clusterSpec.FluxConfig.Spec.Github.Personal
+	}
+	return false
 }
 
 func (fc *fluxForCluster) path() string {

--- a/pkg/cluster/fetch.go
+++ b/pkg/cluster/fetch.go
@@ -72,7 +72,7 @@ func GetFluxConfigForCluster(ctx context.Context, cluster *v1alpha1.Cluster, fet
 	}
 	fluxConfig, err := fetch(ctx, cluster.Spec.GitOpsRef.Name, cluster.Namespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed fetching FluxCOnfig for cluster: %v", err)
+		return nil, fmt.Errorf("fetching FluxCOnfig for cluster: %v", err)
 	}
 
 	return fluxConfig, nil

--- a/pkg/cluster/fetch_test.go
+++ b/pkg/cluster/fetch_test.go
@@ -72,36 +72,10 @@ func TestGetFluxConfigForCluster(t *testing.T) {
 		},
 	}
 	wantFlux := &v1alpha1.FluxConfig{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "",
-			APIVersion: "",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:                       "",
-			GenerateName:               "",
-			Namespace:                  "",
-			SelfLink:                   "",
-			UID:                        "",
-			ResourceVersion:            "",
-			Generation:                 0,
-			CreationTimestamp:          metav1.Time{},
-			DeletionTimestamp:          nil,
-			DeletionGracePeriodSeconds: nil,
-			Labels:                     nil,
-			Annotations:                nil,
-			OwnerReferences:            nil,
-			Finalizers:                 nil,
-			ClusterName:                "",
-			ManagedFields:              nil,
-		},
-		Spec: v1alpha1.FluxConfigSpec{
-			SystemNamespace:   "",
-			ClusterConfigPath: "",
-			Branch:            "",
-			Github:            nil,
-			Git:               nil,
-		},
-		Status: v1alpha1.FluxConfigStatus{},
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec:       v1alpha1.FluxConfigSpec{},
+		Status:     v1alpha1.FluxConfigStatus{},
 	}
 	mockFetch := func(ctx context.Context, name, namespace string) (*v1alpha1.FluxConfig, error) {
 		g.Expect(name).To(Equal(c.Name))

--- a/pkg/cluster/fetch_test.go
+++ b/pkg/cluster/fetch_test.go
@@ -32,3 +32,85 @@ func TestGetBundlesForCluster(t *testing.T) {
 	g.Expect(err).To(BeNil())
 	g.Expect(gotBundles).To(Equal(wantBundles))
 }
+
+func TestGetFluxConfigForClusterIsNil(t *testing.T) {
+	g := NewWithT(t)
+	c := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eksa-cluster",
+			Namespace: "eksa",
+		},
+		Spec: v1alpha1.ClusterSpec{
+			GitOpsRef: nil,
+		},
+	}
+	var wantFlux *v1alpha1.FluxConfig
+	mockFetch := func(ctx context.Context, name, namespace string) (*v1alpha1.FluxConfig, error) {
+		g.Expect(name).To(Equal(c.Name))
+		g.Expect(namespace).To(Equal(c.Namespace))
+
+		return wantFlux, nil
+	}
+
+	gotFlux, err := cluster.GetFluxConfigForCluster(context.Background(), c, mockFetch)
+	g.Expect(err).To(BeNil())
+	g.Expect(gotFlux).To(Equal(wantFlux))
+}
+
+func TestGetFluxConfigForCluster(t *testing.T) {
+	g := NewWithT(t)
+	c := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eksa-cluster",
+			Namespace: "eksa",
+		},
+		Spec: v1alpha1.ClusterSpec{
+			GitOpsRef: &v1alpha1.Ref{
+				Kind: v1alpha1.FluxConfigKind,
+				Name: "eksa-cluster",
+			},
+		},
+	}
+	wantFlux := &v1alpha1.FluxConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "",
+			APIVersion: "",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:                       "",
+			GenerateName:               "",
+			Namespace:                  "",
+			SelfLink:                   "",
+			UID:                        "",
+			ResourceVersion:            "",
+			Generation:                 0,
+			CreationTimestamp:          metav1.Time{},
+			DeletionTimestamp:          nil,
+			DeletionGracePeriodSeconds: nil,
+			Labels:                     nil,
+			Annotations:                nil,
+			OwnerReferences:            nil,
+			Finalizers:                 nil,
+			ClusterName:                "",
+			ManagedFields:              nil,
+		},
+		Spec: v1alpha1.FluxConfigSpec{
+			SystemNamespace:   "",
+			ClusterConfigPath: "",
+			Branch:            "",
+			Github:            nil,
+			Git:               nil,
+		},
+		Status: v1alpha1.FluxConfigStatus{},
+	}
+	mockFetch := func(ctx context.Context, name, namespace string) (*v1alpha1.FluxConfig, error) {
+		g.Expect(name).To(Equal(c.Name))
+		g.Expect(namespace).To(Equal(c.Namespace))
+
+		return wantFlux, nil
+	}
+
+	gotFlux, err := cluster.GetFluxConfigForCluster(context.Background(), c, mockFetch)
+	g.Expect(err).To(BeNil())
+	g.Expect(gotFlux).To(Equal(wantFlux))
+}

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -128,6 +128,12 @@ func WithEksdRelease(release *eksdv1alpha1.Release) SpecOpt {
 	}
 }
 
+func WithFluxConfig(fluxConfig *eksav1alpha1.FluxConfig) SpecOpt {
+	return func(s *Spec) {
+		s.FluxConfig = fluxConfig
+	}
+}
+
 func WithGitOpsConfig(gitOpsConfig *eksav1alpha1.GitOpsConfig) SpecOpt {
 	return func(s *Spec) {
 		s.GitOpsConfig = gitOpsConfig

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -66,6 +66,7 @@ type ClusterClient interface {
 	WaitForManagedExternalEtcdReady(ctx context.Context, cluster *types.Cluster, timeout string, newClusterName string) error
 	GetWorkloadKubeconfig(ctx context.Context, clusterName string, cluster *types.Cluster) ([]byte, error)
 	GetEksaGitOpsConfig(ctx context.Context, gitOpsConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.GitOpsConfig, error)
+	GetEksaFluxConfig(ctx context.Context, fluxConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.FluxConfig, error)
 	GetEksaOIDCConfig(ctx context.Context, oidcConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.OIDCConfig, error)
 	DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster) error
 	DeleteGitOpsConfig(ctx context.Context, managementCluster *types.Cluster, gitOpsName, namespace string) error
@@ -975,7 +976,7 @@ func (c *ClusterManager) GetCurrentClusterSpec(ctx context.Context, clus *types.
 }
 
 func (c *ClusterManager) buildSpecForCluster(ctx context.Context, clus *types.Cluster, eksaCluster *v1alpha1.Cluster) (*cluster.Spec, error) {
-	return cluster.BuildSpecForCluster(ctx, eksaCluster, c.bundlesFetcher(clus), c.eksdReleaseFetcher(clus), c.gitOpsFetcher(clus), c.oidcFetcher(clus))
+	return cluster.BuildSpecForCluster(ctx, eksaCluster, c.bundlesFetcher(clus), c.eksdReleaseFetcher(clus), c.gitOpsFetcher(clus), c.fluxConfigFetcher(clus), c.oidcFetcher(clus))
 }
 
 func (c *ClusterManager) bundlesFetcher(cluster *types.Cluster) cluster.BundlesFetch {
@@ -993,6 +994,12 @@ func (c *ClusterManager) eksdReleaseFetcher(cluster *types.Cluster) cluster.Eksd
 func (c *ClusterManager) gitOpsFetcher(cluster *types.Cluster) cluster.GitOpsFetch {
 	return func(ctx context.Context, name, namespace string) (*v1alpha1.GitOpsConfig, error) {
 		return c.clusterClient.GetEksaGitOpsConfig(ctx, name, cluster.KubeconfigFile, namespace)
+	}
+}
+
+func (c *ClusterManager) fluxConfigFetcher(cluster *types.Cluster) cluster.FluxConfigFetch {
+	return func(ctx context.Context, name, namespace string) (*v1alpha1.FluxConfig, error) {
+		return c.clusterClient.GetEksaFluxConfig(ctx, name, cluster.KubeconfigFile, namespace)
 	}
 }
 

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -288,6 +288,21 @@ func (mr *MockClusterClientMockRecorder) GetEksaCluster(arg0, arg1, arg2 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEksaCluster", reflect.TypeOf((*MockClusterClient)(nil).GetEksaCluster), arg0, arg1, arg2)
 }
 
+// GetEksaFluxConfig mocks base method.
+func (m *MockClusterClient) GetEksaFluxConfig(arg0 context.Context, arg1, arg2, arg3 string) (*v1alpha1.FluxConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEksaFluxConfig", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*v1alpha1.FluxConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEksaFluxConfig indicates an expected call of GetEksaFluxConfig.
+func (mr *MockClusterClientMockRecorder) GetEksaFluxConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEksaFluxConfig", reflect.TypeOf((*MockClusterClient)(nil).GetEksaFluxConfig), arg0, arg1, arg2, arg3)
+}
+
 // GetEksaGitOpsConfig mocks base method.
 func (m *MockClusterClient) GetEksaGitOpsConfig(arg0 context.Context, arg1, arg2, arg3 string) (*v1alpha1.GitOpsConfig, error) {
 	m.ctrl.T.Helper()

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -48,6 +48,7 @@ var (
 	eksaCloudStackMachineResourceType    = fmt.Sprintf("cloudstackmachineconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaAwsResourceType                  = fmt.Sprintf("awsdatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaGitOpsResourceType               = fmt.Sprintf("gitopsconfigs.%s", v1alpha1.GroupVersion.Group)
+	eksaFluxConfigResourceType           = fmt.Sprintf("fluxconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaOIDCResourceType                 = fmt.Sprintf("oidcconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaAwsIamResourceType               = fmt.Sprintf("awsiamconfigs.%s", v1alpha1.GroupVersion.Group)
 	etcdadmClustersResourceType          = fmt.Sprintf("etcdadmclusters.%s", etcdv1.GroupVersion.Group)
@@ -312,6 +313,15 @@ func (k *Kubectl) DeleteGitOpsConfig(ctx context.Context, managementCluster *typ
 	_, err := k.Execute(ctx, params...)
 	if err != nil {
 		return fmt.Errorf("deleting gitops config %s apply: %v", gitOpsConfigName, err)
+	}
+	return nil
+}
+
+func (k *Kubectl) DeleteFluxConfig(ctx context.Context, managementCluster *types.Cluster, fluxConfigName, fluxConfigNamespace string) error {
+	params := []string{"delete", eksaFluxConfigResourceType, fluxConfigName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", fluxConfigNamespace, "--ignore-not-found=true"}
+	_, err := k.Execute(ctx, params...)
+	if err != nil {
+		return fmt.Errorf("deleting gitops config %s apply: %v", fluxConfigName, err)
 	}
 	return nil
 }
@@ -1063,6 +1073,22 @@ func (k *Kubectl) SearchEksaGitOpsConfig(ctx context.Context, gitOpsConfigName s
 	}
 
 	return response.Items, nil
+}
+
+func (k *Kubectl) GetEksaFluxConfig(ctx context.Context, gitOpsConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.FluxConfig, error) {
+	params := []string{"get", eksaFluxConfigResourceType, gitOpsConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
+	stdOut, err := k.Execute(ctx, params...)
+	if err != nil {
+		return nil, fmt.Errorf("getting eksa GitOpsConfig: %v", err)
+	}
+
+	response := &v1alpha1.FluxConfig{}
+	err = json.Unmarshal(stdOut.Bytes(), response)
+	if err != nil {
+		return nil, fmt.Errorf("parsing GitOpsConfig response: %v", err)
+	}
+
+	return response, nil
 }
 
 func (k *Kubectl) GetEksaGitOpsConfig(ctx context.Context, gitOpsConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.GitOpsConfig, error) {

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -1079,13 +1079,13 @@ func (k *Kubectl) GetEksaFluxConfig(ctx context.Context, gitOpsConfigName string
 	params := []string{"get", eksaFluxConfigResourceType, gitOpsConfigName, "-o", "json", "--kubeconfig", kubeconfigFile, "--namespace", namespace}
 	stdOut, err := k.Execute(ctx, params...)
 	if err != nil {
-		return nil, fmt.Errorf("getting eksa GitOpsConfig: %v", err)
+		return nil, fmt.Errorf("getting eksa FluxConfig: %v", err)
 	}
 
 	response := &v1alpha1.FluxConfig{}
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
-		return nil, fmt.Errorf("parsing GitOpsConfig response: %v", err)
+		return nil, fmt.Errorf("parsing FluxConfig response: %v", err)
 	}
 
 	return response, nil

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -1795,3 +1795,45 @@ func TestKubectlGetObjectNotFound(t *testing.T) {
 		})
 	}
 }
+
+func TestKubectlGetEksaFluxConfig(t *testing.T) {
+	kubeconfig := "/my/kubeconfig"
+	namespace := "eksa-system"
+	eksaFluxConfigResourceType := fmt.Sprintf("fluxconfigs.%s", v1alpha1.GroupVersion.Group)
+
+	returnConfig := &v1alpha1.FluxConfig{}
+	returnConfigBytes, err := json.Marshal(returnConfig)
+	if err != nil {
+		t.Errorf("failed to create output object for test")
+	}
+
+	k, ctx, _, e := newKubectl(t)
+	expectedParam := []string{"get", eksaFluxConfigResourceType, "testFluxConfig", "-o", "json", "--kubeconfig", kubeconfig, "--namespace", namespace}
+	e.EXPECT().Execute(ctx, gomock.Eq(expectedParam)).Return(*bytes.NewBuffer(returnConfigBytes), nil)
+	_, err = k.GetEksaFluxConfig(ctx, "testFluxConfig", kubeconfig, namespace)
+	if err != nil {
+		t.Errorf("Kubectl.GetEksaFluxConfig() error = %v, want error = nil", err)
+	}
+}
+
+func TestKubectlDeleteFluxConfig(t *testing.T) {
+	namespace := "eksa-system"
+	kubeconfig := "/my/kubeconfig"
+	eksaFluxConfigResourceType := fmt.Sprintf("fluxconfigs.%s", v1alpha1.GroupVersion.Group)
+
+	returnConfig := &v1alpha1.FluxConfig{}
+	returnConfigBytes, err := json.Marshal(returnConfig)
+	if err != nil {
+		t.Errorf("failed to create output object for test")
+	}
+
+	mgmtCluster := &types.Cluster{KubeconfigFile: kubeconfig}
+
+	k, ctx, _, e := newKubectl(t)
+	expectedParam := []string{"delete", eksaFluxConfigResourceType, "testFluxConfig", "--kubeconfig", mgmtCluster.KubeconfigFile, "--namespace", namespace, "--ignore-not-found=true"}
+	e.EXPECT().Execute(ctx, gomock.Eq(expectedParam)).Return(*bytes.NewBuffer(returnConfigBytes), nil)
+	err = k.DeleteFluxConfig(ctx, mgmtCluster, "testFluxConfig", namespace)
+	if err != nil {
+		t.Errorf("Kubectl.DeleteFluxConfig() error = %v, want error = nil", err)
+	}
+}

--- a/pkg/validations/kubectl.go
+++ b/pkg/validations/kubectl.go
@@ -22,6 +22,7 @@ type KubectlClient interface {
 	GetClusters(ctx context.Context, cluster *types.Cluster) ([]types.CAPICluster, error)
 	GetEksaCluster(ctx context.Context, cluster *types.Cluster, clusterName string) (*v1alpha1.Cluster, error)
 	GetEksaGitOpsConfig(ctx context.Context, gitOpsConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.GitOpsConfig, error)
+	GetEksaFluxConfig(ctx context.Context, fluxConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.FluxConfig, error)
 	GetEksaOIDCConfig(ctx context.Context, oidcConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.OIDCConfig, error)
 	GetEksaVSphereDatacenterConfig(ctx context.Context, vsphereDatacenterConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.VSphereDatacenterConfig, error)
 	GetEksaAWSIamConfig(ctx context.Context, awsIamConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.AWSIamConfig, error)

--- a/pkg/validations/mocks/kubectl.go
+++ b/pkg/validations/mocks/kubectl.go
@@ -82,6 +82,21 @@ func (mr *MockKubectlClientMockRecorder) GetEksaCluster(ctx, cluster, clusterNam
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEksaCluster", reflect.TypeOf((*MockKubectlClient)(nil).GetEksaCluster), ctx, cluster, clusterName)
 }
 
+// GetEksaFluxConfig mocks base method.
+func (m *MockKubectlClient) GetEksaFluxConfig(ctx context.Context, fluxConfigName, kubeconfigFile, namespace string) (*v1alpha1.FluxConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEksaFluxConfig", ctx, fluxConfigName, kubeconfigFile, namespace)
+	ret0, _ := ret[0].(*v1alpha1.FluxConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEksaFluxConfig indicates an expected call of GetEksaFluxConfig.
+func (mr *MockKubectlClientMockRecorder) GetEksaFluxConfig(ctx, fluxConfigName, kubeconfigFile, namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEksaFluxConfig", reflect.TypeOf((*MockKubectlClient)(nil).GetEksaFluxConfig), ctx, fluxConfigName, kubeconfigFile, namespace)
+}
+
 // GetEksaGitOpsConfig mocks base method.
 func (m *MockKubectlClient) GetEksaGitOpsConfig(ctx context.Context, gitOpsConfigName, kubeconfigFile, namespace string) (*v1alpha1.GitOpsConfig, error) {
 	m.ctrl.T.Helper()

--- a/pkg/validations/upgradevalidations/immutableFields.go
+++ b/pkg/validations/upgradevalidations/immutableFields.go
@@ -39,28 +39,69 @@ func ValidateImmutableFields(ctx context.Context, k validations.KubectlClient, c
 	}
 
 	if nSpec.GitOpsRef != nil {
-		prevGitOps, err := k.GetEksaGitOpsConfig(ctx, nSpec.GitOpsRef.Name, cluster.KubeconfigFile, spec.Cluster.Namespace)
-		if err != nil {
-			return err
+		if nSpec.GitOpsRef.Kind == v1alpha1.GitOpsConfigKind {
+			prevGitOps, err := k.GetEksaGitOpsConfig(ctx, nSpec.GitOpsRef.Name, cluster.KubeconfigFile, spec.Cluster.Namespace)
+			if err != nil {
+				return err
+			}
+
+			if prevGitOps.Spec.Flux.Github.Owner != spec.GitOpsConfig.Spec.Flux.Github.Owner {
+				return fmt.Errorf("gitOps spec.flux.github.owner is immutable")
+			}
+			if prevGitOps.Spec.Flux.Github.Repository != spec.GitOpsConfig.Spec.Flux.Github.Repository {
+				return fmt.Errorf("gitOps spec.flux.github.repository is immutable")
+			}
+			if prevGitOps.Spec.Flux.Github.Personal != spec.GitOpsConfig.Spec.Flux.Github.Personal {
+				return fmt.Errorf("gitOps spec.flux.github.personal is immutable")
+			}
+			if spec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace != "" && prevGitOps.Spec.Flux.Github.FluxSystemNamespace != spec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace {
+				return fmt.Errorf("gitOps spec.flux.github.fluxSystemNamespace is immutable")
+			}
+			if spec.GitOpsConfig.Spec.Flux.Github.Branch != "" && prevGitOps.Spec.Flux.Github.Branch != spec.GitOpsConfig.Spec.Flux.Github.Branch {
+				return fmt.Errorf("gitOps spec.flux.github.branch is immutable")
+			}
+			if spec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath != "" && prevGitOps.Spec.Flux.Github.ClusterConfigPath != spec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath {
+				return fmt.Errorf("gitOps spec.flux.github.clusterConfigPath is immutable")
+			}
 		}
 
-		if prevGitOps.Spec.Flux.Github.Owner != spec.GitOpsConfig.Spec.Flux.Github.Owner {
-			return fmt.Errorf("gitOps spec.flux.github.owner is immutable")
-		}
-		if prevGitOps.Spec.Flux.Github.Repository != spec.GitOpsConfig.Spec.Flux.Github.Repository {
-			return fmt.Errorf("gitOps spec.flux.github.repository is immutable")
-		}
-		if prevGitOps.Spec.Flux.Github.Personal != spec.GitOpsConfig.Spec.Flux.Github.Personal {
-			return fmt.Errorf("gitOps spec.flux.github.personal is immutable")
-		}
-		if spec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace != "" && prevGitOps.Spec.Flux.Github.FluxSystemNamespace != spec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace {
-			return fmt.Errorf("gitOps spec.flux.github.fluxSystemNamespace is immutable")
-		}
-		if spec.GitOpsConfig.Spec.Flux.Github.Branch != "" && prevGitOps.Spec.Flux.Github.Branch != spec.GitOpsConfig.Spec.Flux.Github.Branch {
-			return fmt.Errorf("gitOps spec.flux.github.branch is immutable")
-		}
-		if spec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath != "" && prevGitOps.Spec.Flux.Github.ClusterConfigPath != spec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath {
-			return fmt.Errorf("gitOps spec.flux.github.clusterConfigPath is immutable")
+		if nSpec.GitOpsRef.Kind == v1alpha1.FluxConfigKind {
+			prevGitOps, err := k.GetEksaFluxConfig(ctx, nSpec.GitOpsRef.Name, cluster.KubeconfigFile, spec.Cluster.Namespace)
+			if err != nil {
+				return err
+			}
+
+			if prevGitOps.Spec.Git != nil {
+				if prevGitOps.Spec.Git.RepositoryUrl != spec.FluxConfig.Spec.Git.RepositoryUrl {
+					return fmt.Errorf("fluxConfig spec.fluxConfig.spec.git.repositoryUrl is immutable")
+				}
+			}
+
+			if prevGitOps.Spec.Github != nil {
+				if prevGitOps.Spec.Github.Repository != spec.FluxConfig.Spec.Github.Repository {
+					return fmt.Errorf("fluxConfig spec.github.repository is immutable")
+				}
+
+				if prevGitOps.Spec.Github.Owner != spec.FluxConfig.Spec.Github.Owner {
+					return fmt.Errorf("fluxConfig spec.github.owner is immutable")
+				}
+
+				if prevGitOps.Spec.Github.Personal != spec.FluxConfig.Spec.Github.Personal {
+					return fmt.Errorf("fluxConfig spec.github.personal is immutable")
+				}
+			}
+
+			if prevGitOps.Spec.Branch != spec.FluxConfig.Spec.Branch {
+				return fmt.Errorf("fluxConfig spec.branch is immutable")
+			}
+
+			if prevGitOps.Spec.ClusterConfigPath != spec.FluxConfig.Spec.ClusterConfigPath {
+				return fmt.Errorf("fluxConfig spec.clusterConfigPath is immutable")
+			}
+
+			if prevGitOps.Spec.SystemNamespace != spec.FluxConfig.Spec.SystemNamespace {
+				return fmt.Errorf("fluxConfig spec.systemNamespace is immutable")
+			}
 		}
 	}
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/1986

*Description of changes:*
Set up to support `eksctl anywhere upgrade cluster` with the `fluxConfig` present on the cluster.

Many of the methods in the fetcher and cluster spec builder shadow the existing GitOpsConfig methods. I've captured an issue to come back and remove these redundant methods once we deprecate the GitOpsConfig, will link this PR so that in +2 minor versions we can remove the redundant methods. https://github.com/aws/eks-anywhere/issues/1987 

*Testing (if applicable):*
create a cluster with the `fluxConfig`; upgrade the cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

