### PR TITLE
Fix flux tests to clone repository in the right path

### DIFF
--- a/pkg/git/factory/gitfactory_test.go
+++ b/pkg/git/factory/gitfactory_test.go
@@ -21,10 +21,16 @@ func TestGitFactoryHappyPath(t *testing.T) {
 	tests := []struct {
 		testName     string
 		authTokenEnv string
+		opt          gitFactory.GitToolsOpt
 	}{
 		{
 			testName:     "valid token var",
 			authTokenEnv: validPATValue,
+		},
+		{
+			testName:     "valid token var with opt",
+			authTokenEnv: validPATValue,
+			opt:          gitFactory.WithRepositoryDirectory("test"),
 		},
 	}
 
@@ -54,7 +60,7 @@ func TestGitFactoryHappyPath(t *testing.T) {
 
 			_, w := test.NewWriter(t)
 
-			_, err := gitFactory.Build(context.Background(), cluster, fluxConfig, w)
+			_, err := gitFactory.Build(context.Background(), cluster, fluxConfig, w, tt.opt)
 			if err != nil {
 				t.Errorf("gitfactory.BuldProvider returned err, wanted nil. err: %v", err)
 			}

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -216,7 +216,7 @@ func (e *ClusterE2ETest) ValidateFlux() {
 		e.T.Errorf("Error configuring filewriter for e2e test: %v", err)
 	}
 	repoName := e.gitRepoName()
-	gitTools, err := e.NewGitTools(ctx, c, e.GitOpsConfig.ConvertToFluxConfig(), writer, fmt.Sprintf("%s/%s", e.ClusterName, repoName))
+	gitTools, err := e.NewGitTools(ctx, c, e.GitOpsConfig.ConvertToFluxConfig(), writer, e.validateGitopsRepoContentPath(repoName))
 	if err != nil {
 		e.T.Errorf("Error configuring git client for e2e test: %v", err)
 	}
@@ -326,10 +326,14 @@ func (e *ClusterE2ETest) validateWorkerNodeMultiConfigUpdates(ctx context.Contex
 	}
 }
 
+func (e *ClusterE2ETest) validateGitopsRepoContentPath(repoName string) string {
+	return filepath.Join(e.ClusterName, "e2e-validate", repoName)
+}
+
 func (e *ClusterE2ETest) validateGitopsRepoContent(gitTools *gitfactory.GitTools) {
 	repoName := e.gitRepoName()
 	gitFilePath := e.clusterConfigGitPath()
-	localFilePath := filepath.Join(e.ClusterName, repoName, e.clusterConfGitPath())
+	localFilePath := filepath.Join(e.validateGitopsRepoContentPath(repoName), e.clusterConfGitPath())
 	ctx := context.Background()
 	gc := gitTools.Client
 	err := gc.Clone(ctx)

--- a/test/framework/git.go
+++ b/test/framework/git.go
@@ -8,15 +8,8 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
-	"github.com/aws/eks-anywhere/pkg/git"
 	gitFactory "github.com/aws/eks-anywhere/pkg/git/factory"
 )
-
-type GitTools struct {
-	GitProvider git.ProviderClient
-	GitClient   git.Client
-	Writer      filewriter.FileWriter
-}
 
 func (e *ClusterE2ETest) NewGitTools(ctx context.Context, cluster *v1alpha1.Cluster, fluxConfig *v1alpha1.FluxConfig, writer filewriter.FileWriter, repoPath string) (*gitFactory.GitTools, error) {
 	if fluxConfig == nil {
@@ -24,13 +17,16 @@ func (e *ClusterE2ETest) NewGitTools(ctx context.Context, cluster *v1alpha1.Clus
 	}
 
 	var localGitWriterPath string
+	var localGitRepoPath string
 	if repoPath == "" {
 		localGitWriterPath = filepath.Join("git", fluxConfig.Spec.Github.Repository)
+		localGitRepoPath = filepath.Join(cluster.Name, "git", fluxConfig.Spec.Github.Repository)
 	} else {
 		localGitWriterPath = repoPath
+		localGitRepoPath = repoPath
 	}
 
-	tools, err := gitFactory.Build(ctx, cluster, fluxConfig, writer)
+	tools, err := gitFactory.Build(ctx, cluster, fluxConfig, writer, gitFactory.WithRepositoryDirectory(localGitRepoPath))
 	if err != nil {
 		return nil, fmt.Errorf("creating Git provider: %v", err)
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Recent changes in refactoring resulted in the clone path to follow the same path as where we edit the cluster config file for the flux tests, causing the tests to fail. Added the option to override the default path that is set so we don't affect the CLI code as well just for e2e test validations.

*Testing (if applicable):*
Ran e2e test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

