### PR TITLE
Add `Delete` method to kube client

### DIFF
--- a/pkg/clients/kubernetes/mocks/kubectl.go
+++ b/pkg/clients/kubernetes/mocks/kubectl.go
@@ -35,6 +35,20 @@ func (m *MockKubectlGetter) EXPECT() *MockKubectlGetterMockRecorder {
 	return m.recorder
 }
 
+// Delete mocks base method.
+func (m *MockKubectlGetter) Delete(ctx context.Context, resourceType, name, namespace, kubeconfig string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, resourceType, name, namespace, kubeconfig)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockKubectlGetterMockRecorder) Delete(ctx, resourceType, name, namespace, kubeconfig interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockKubectlGetter)(nil).Delete), ctx, resourceType, name, namespace, kubeconfig)
+}
+
 // GetObject mocks base method.
 func (m *MockKubectlGetter) GetObject(ctx context.Context, resourceType, name, namespace, kubeconfig string, obj runtime.Object) error {
 	m.ctrl.T.Helper()

--- a/pkg/clients/kubernetes/unauth.go
+++ b/pkg/clients/kubernetes/unauth.go
@@ -11,6 +11,7 @@ import (
 
 type KubectlGetter interface {
 	GetObject(ctx context.Context, resourceType, name, namespace, kubeconfig string, obj runtime.Object) error
+	Delete(ctx context.Context, resourceType, name, namespace, kubeconfig string) error
 }
 
 // UnAuthClient is a generic kubernetes API client that takes a kubeconfig
@@ -37,18 +38,36 @@ func (c *UnAuthClient) Init() error {
 // Get performs a GET call to the kube API server authenticating with a kubeconfig file
 // and unmarshalls the response into the provdied Object
 func (c *UnAuthClient) Get(ctx context.Context, name, namespace, kubeconfig string, obj runtime.Object) error {
-	groupVersionKind, err := apiutil.GVKForObject(obj, c.scheme)
+	resourceType, err := c.resourceTypeForObj(obj)
 	if err != nil {
 		return fmt.Errorf("getting kubernetes resource: %v", err)
 	}
 
-	resourceType := groupVersionToKubectlResourceType(groupVersionKind)
 	return c.kubectl.GetObject(ctx, resourceType, name, namespace, kubeconfig, obj)
 }
 
 // KubeconfigClient returns an equivalent authenticated client
 func (c *UnAuthClient) KubeconfigClient(kubeconfig string) *KubeconfigClient {
 	return NewKubeconfigClient(c, kubeconfig)
+}
+
+// Delete performs a DELETE call to the kube API server authenticating with a kubeconfig file
+func (c *UnAuthClient) Delete(ctx context.Context, name, namespace, kubeconfig string, obj runtime.Object) error {
+	resourceType, err := c.resourceTypeForObj(obj)
+	if err != nil {
+		return fmt.Errorf("deleting kubernetes resource: %v", err)
+	}
+
+	return c.kubectl.Delete(ctx, resourceType, name, namespace, kubeconfig)
+}
+
+func (c *UnAuthClient) resourceTypeForObj(obj runtime.Object) (string, error) {
+	groupVersionKind, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return "", err
+	}
+
+	return groupVersionToKubectlResourceType(groupVersionKind), nil
 }
 
 func groupVersionToKubectlResourceType(g schema.GroupVersionKind) string {

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -1481,3 +1481,11 @@ func (k *Kubectl) GetBmcsPowerState(ctx context.Context, bmcNames []string, kube
 func (k *Kubectl) ExecuteCommand(ctx context.Context, opts ...string) (bytes.Buffer, error) {
 	return k.Execute(ctx, opts...)
 }
+
+// Delete performs a DELETE call to the kube API server authenticating with a kubeconfig file
+func (k *Kubectl) Delete(ctx context.Context, resourceType, name, namespace, kubeconfig string) error {
+	if _, err := k.Execute(ctx, "delete", resourceType, name, "--namespace", namespace, "--kubeconfig", kubeconfig); err != nil {
+		return fmt.Errorf("deleting %s %s in namespace %s: %v", name, resourceType, namespace, err)
+	}
+	return nil
+}

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -1837,3 +1837,15 @@ func TestKubectlDeleteFluxConfig(t *testing.T) {
 		t.Errorf("Kubectl.DeleteFluxConfig() error = %v, want error = nil", err)
 	}
 }
+
+func TestKubectlDelete(t *testing.T) {
+	tt := newKubectlTest(t)
+	name := "my-cluster"
+	resourceType := "cluster.x-k8s.io"
+	tt.e.EXPECT().Execute(
+		tt.ctx,
+		"delete", resourceType, name, "--namespace", tt.namespace, "--kubeconfig", tt.kubeconfig,
+	).Return(bytes.Buffer{}, nil)
+
+	tt.Expect(tt.k.Delete(tt.ctx, resourceType, name, tt.namespace, tt.kubeconfig)).To(Succeed())
+}


### PR DESCRIPTION
Part of https://github.com/aws/eks-anywhere/issues/1106, needed only in snow cli provider and not in the controller for now

*Testing (if applicable):*
Uni tests
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

