### PR TITLE
k8s 21 certification expires 5/4

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Its goal is to include full lifecycle management of multiple Kubernetes clusters
 Here are the steps for [getting started](https://anywhere.eks.amazonaws.com/docs/getting-started/) with EKS Anywhere.
 Full documentation for releases can be found on [https://anywhere.eks.amazonaws.com](https://anywhere.eks.amazonaws.com/).
 
-[<img src="docs/static/certified-kubernetes-1.21-color.svg" height=150>](https://github.com/cncf/k8s-conformance/pull/1605)
 [<img src="docs/static/images/certified-kubernetes-1.22-color.svg" height=150>](https://github.com/cncf/k8s-conformance/pull/1872)
 <!-- 
 Source: https://github.com/cncf/artwork/tree/master/projects/kubernetes/certified-kubernetes


### PR DESCRIPTION
 The Certified Kubernetes Marks and Participant Kubernetes Combinations may be used with a Qualifying Offering for a particular version of Kubernetes (e.g., Kubernetes x.y) until the later of:
12 months after the release date of Kubernetes x.y, or
9 months after the release date of the next minor release (e.g., Kubernetes x.y+1)
v1.21.0 was released on April 8, 2021
https://github.com/kubernetes/kubernetes/releases/tag/v1.21.0

v1.22.0 was released on August 4, 2021
https://github.com/kubernetes/kubernetes/releases/tag/v1.22.0

Therefore, the expiration date for v1.21 is May 4, 2022.

