### PR TITLE
convert GitOpsConfig to flux config when reading spec from cluster

### DIFF
--- a/pkg/cluster/fetch.go
+++ b/pkg/cluster/fetch.go
@@ -43,6 +43,7 @@ func BuildSpecForCluster(ctx context.Context, cluster *v1alpha1.Cluster, bundles
 			if err != nil {
 				return nil, err
 			}
+			fluxConfig = gitOpsConfig.ConvertToFluxConfig()
 		}
 	}
 

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -137,7 +137,6 @@ func WithFluxConfig(fluxConfig *eksav1alpha1.FluxConfig) SpecOpt {
 func WithGitOpsConfig(gitOpsConfig *eksav1alpha1.GitOpsConfig) SpecOpt {
 	return func(s *Spec) {
 		s.GitOpsConfig = gitOpsConfig
-		s.FluxConfig = gitOpsConfig.ConvertToFluxConfig()
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
when converting the GitOpsConfig to a FluxConfig in the cluster spec option, it is possible to override it as nil if `WithFluxConfig()` is called as an option after `WithGitOpsConfig()`, as is happening here when performing an upgrade across versions.

By moving the conversion up a level we can ensure that the conversion takes place without being overridden. 

*Testing (if applicable):*
re-ran failing upgrade test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

