### PR TITLE
Implement retry logic for Skopeo copy

### DIFF
--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -225,7 +225,7 @@ spec:
     eksD:
       channel: 1-20
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      gitCommit: 1e23a4c549b46e293bc2c1c6be53f3a3b0e3679c
+      gitCommit: 76bee84aeb63dee2507413dae39fea7c7c4ffef3
       kindNode:
         arch:
         - amd64
@@ -926,7 +926,7 @@ spec:
     eksD:
       channel: 1-21
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      gitCommit: 1e23a4c549b46e293bc2c1c6be53f3a3b0e3679c
+      gitCommit: 76bee84aeb63dee2507413dae39fea7c7c4ffef3
       kindNode:
         arch:
         - amd64
@@ -1627,7 +1627,7 @@ spec:
     eksD:
       channel: 1-22
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      gitCommit: 1e23a4c549b46e293bc2c1c6be53f3a3b0e3679c
+      gitCommit: 76bee84aeb63dee2507413dae39fea7c7c4ffef3
       kindNode:
         arch:
         - amd64

--- a/release/pkg/utils/utils.go
+++ b/release/pkg/utils/utils.go
@@ -27,12 +27,12 @@ import (
 const hexAlphabet = "0123456789abcdef"
 
 func ExecCommand(cmd *exec.Cmd) (string, error) {
-	stdout, err := cmd.Output()
-	stdoutStr := strings.TrimSpace(string(stdout))
+	commandOutput, err := cmd.CombinedOutput()
+	commandOutputStr := strings.TrimSpace(string(commandOutput))
 	if err != nil {
-		return stdoutStr, errors.Cause(err)
+		return commandOutputStr, errors.Cause(err)
 	}
-	return stdoutStr, nil
+	return commandOutputStr, nil
 }
 
 func SliceContains(s []string, str string) bool {


### PR DESCRIPTION
Skopeo copy sometimes fails due to flaky reasons. This PR
(i) implements retry logic around skopeo copy
(ii) Returns the combined standard output and standard error of command executions for debugging

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

