### PR TITLE
Generate CAPI objects for snow upgrade and create

### DIFF
--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -120,11 +120,11 @@ func SnowCluster(clusterSpec *cluster.Spec) *snowv1.AWSSnowCluster {
 	return cluster
 }
 
-func SnowMachineTemplates(clusterSpec *cluster.Spec, machineConfigs map[string]*v1alpha1.SnowMachineConfig) map[string]*snowv1.AWSSnowMachineTemplate {
+func SnowMachineTemplates(clusterSpec *cluster.Spec) map[string]*snowv1.AWSSnowMachineTemplate {
 	m := map[string]*snowv1.AWSSnowMachineTemplate{}
 
 	for _, workerNodeGroupConfig := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
-		smt := SnowMachineTemplate(machineConfigs[workerNodeGroupConfig.MachineGroupRef.Name])
+		smt := SnowMachineTemplate(clusterSpec.SnowMachineConfigs[workerNodeGroupConfig.MachineGroupRef.Name])
 		m[workerNodeGroupConfig.MachineGroupRef.Name] = smt
 	}
 	return m
@@ -138,7 +138,7 @@ func SnowMachineTemplate(machineConfig *v1alpha1.SnowMachineConfig) *snowv1.AWSS
 			Kind:       SnowMachineTemplateKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      machineConfig.GetName(), // TODO: capinamegenerator
+			Name:      clusterapi.DefaultObjectName(machineConfig.GetName()),
 			Namespace: constants.EksaSystemNamespace,
 		},
 		Spec: snowv1.AWSSnowMachineTemplateSpec{

--- a/pkg/providers/snow/fetch.go
+++ b/pkg/providers/snow/fetch.go
@@ -1,0 +1,58 @@
+package snow
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	snowv1 "github.com/aws/eks-anywhere/pkg/providers/snow/api/v1beta1"
+)
+
+func oldControlPlaneMachineTemplate(ctx context.Context, kubeClient kubernetes.Client, oldSpec *cluster.Spec) (*snowv1.AWSSnowMachineTemplate, error) {
+	cp := &controlplanev1.KubeadmControlPlane{}
+	err := kubeClient.Get(ctx, clusterapi.KubeadmControlPlaneName(oldSpec), constants.EksaSystemNamespace, cp)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	mt := &snowv1.AWSSnowMachineTemplate{}
+	err = kubeClient.Get(ctx, cp.Spec.MachineTemplate.InfrastructureRef.Name, constants.EksaSystemNamespace, mt)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return mt, nil
+}
+
+func oldWorkerMachineTemplate(ctx context.Context, kubeclient kubernetes.Client, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) (*snowv1.AWSSnowMachineTemplate, error) {
+	md := &clusterv1.MachineDeployment{}
+	err := kubeclient.Get(ctx, clusterapi.MachineDeploymentName(workerNodeGroupConfig), constants.EksaSystemNamespace, md)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	mt := &snowv1.AWSSnowMachineTemplate{}
+	err = kubeclient.Get(ctx, md.Spec.Template.Spec.InfrastructureRef.Name, constants.EksaSystemNamespace, mt)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return mt, nil
+}

--- a/pkg/providers/snow/objects.go
+++ b/pkg/providers/snow/objects.go
@@ -1,0 +1,109 @@
+package snow
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	snowv1 "github.com/aws/eks-anywhere/pkg/providers/snow/api/v1beta1"
+)
+
+func ControlPlaneObjects(ctx context.Context, clusterSpec *cluster.Spec, kubeClient kubernetes.Client) ([]runtime.Object, error) {
+	snowCluster := SnowCluster(clusterSpec)
+	new := SnowMachineTemplate(clusterSpec.SnowMachineConfigs[clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name])
+
+	old, err := oldControlPlaneMachineTemplate(ctx, kubeClient, clusterSpec)
+	if err != nil {
+		return nil, err
+	}
+	if err := UpdateMachineTemplateName(new, old); err != nil {
+		return nil, err
+	}
+
+	kubeadmControlPlane, err := KubeadmControlPlane(clusterSpec, new)
+	if err != nil {
+		return nil, err
+	}
+	capiCluster := CAPICluster(clusterSpec, snowCluster, kubeadmControlPlane)
+
+	return []runtime.Object{capiCluster, snowCluster, kubeadmControlPlane, new}, nil
+}
+
+func WorkersObjects(ctx context.Context, clusterSpec *cluster.Spec, kubeClient kubernetes.Client) ([]runtime.Object, error) {
+	kubeadmConfigTemplates, err := KubeadmConfigTemplates(clusterSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	workerMachineTemplates, err := WorkerMachineTemplates(ctx, kubeClient, clusterSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	machineDeployments := MachineDeployments(clusterSpec, kubeadmConfigTemplates, workerMachineTemplates)
+
+	return concatWorkersObjects(machineDeployments, kubeadmConfigTemplates, workerMachineTemplates), nil
+}
+
+func concatWorkersObjects(machineDeployments map[string]*clusterv1.MachineDeployment,
+	kubeadmConfigTemplates map[string]*v1beta1.KubeadmConfigTemplate,
+	workerMachineTemplates map[string]*snowv1.AWSSnowMachineTemplate,
+) []runtime.Object {
+	workersObjs := make([]runtime.Object, 0, len(machineDeployments)+len(kubeadmConfigTemplates)+len(workerMachineTemplates))
+	for _, item := range machineDeployments {
+		workersObjs = append(workersObjs, item)
+	}
+	for _, item := range kubeadmConfigTemplates {
+		workersObjs = append(workersObjs, item)
+	}
+	for _, item := range workerMachineTemplates {
+		workersObjs = append(workersObjs, item)
+	}
+	return workersObjs
+}
+
+func NewMachineTemplateName(new, old *snowv1.AWSSnowMachineTemplate) (string, error) {
+	if old == nil {
+		return new.GetName(), nil
+	}
+
+	if equality.Semantic.DeepDerivative(new.Spec, old.Spec) {
+		return old.GetName(), nil
+	}
+
+	return clusterapi.IncrementName(old.GetName())
+}
+
+func UpdateMachineTemplateName(new, old *snowv1.AWSSnowMachineTemplate) error {
+	name, err := NewMachineTemplateName(new, old)
+	if err != nil {
+		return err
+	}
+	new.SetName(name)
+	return nil
+}
+
+func WorkerMachineTemplates(ctx context.Context, kubeClient kubernetes.Client, clusterSpec *cluster.Spec) (map[string]*snowv1.AWSSnowMachineTemplate, error) {
+	m := map[string]*snowv1.AWSSnowMachineTemplate{}
+
+	for _, workerNodeGroupConfig := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
+		new := SnowMachineTemplate(clusterSpec.SnowMachineConfigs[workerNodeGroupConfig.MachineGroupRef.Name])
+
+		old, err := oldWorkerMachineTemplate(ctx, kubeClient, workerNodeGroupConfig)
+		if err != nil {
+			return nil, err
+		}
+		if err := UpdateMachineTemplateName(new, old); err != nil {
+			return nil, err
+		}
+
+		m[workerNodeGroupConfig.MachineGroupRef.Name] = new
+	}
+	return m, nil
+}

--- a/pkg/providers/snow/objects_test.go
+++ b/pkg/providers/snow/objects_test.go
@@ -1,0 +1,268 @@
+package snow_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/api/node/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/providers/snow"
+	snowv1 "github.com/aws/eks-anywhere/pkg/providers/snow/api/v1beta1"
+)
+
+func TestControlPlaneObjects(t *testing.T) {
+	g := newSnowTest(t)
+	mt := wantSnowMachineTemplate()
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			clusterapi.KubeadmControlPlaneName(g.clusterSpec),
+			constants.EksaSystemNamespace,
+			&controlplanev1.KubeadmControlPlane{},
+		).
+		DoAndReturn(func(_ context.Context, _, _ string, obj *controlplanev1.KubeadmControlPlane) error {
+			obj.Spec.MachineTemplate.InfrastructureRef.Name = "test-cp-1"
+			return nil
+		})
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			"test-cp-1",
+			constants.EksaSystemNamespace,
+			&snowv1.AWSSnowMachineTemplate{},
+		).
+		DoAndReturn(func(_ context.Context, _, _ string, obj *snowv1.AWSSnowMachineTemplate) error {
+			mt.DeepCopyInto(obj)
+			obj.SetName("test-cp-1")
+			obj.Spec.Template.Spec.InstanceType = "updated-instance-type"
+			return nil
+		})
+
+	wantMachineTemplateName := "test-cp-2"
+	mt.SetName(wantMachineTemplateName)
+	mt.Spec.Template.Spec.InstanceType = "sbe-c.large"
+	kcp := wantKubeadmControlPlane()
+	kcp.Spec.MachineTemplate.InfrastructureRef.Name = wantMachineTemplateName
+
+	got, err := snow.ControlPlaneObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	g.Expect(err).To(Succeed())
+	g.Expect(got).To(Equal([]runtime.Object{wantCAPICluster(), wantSnowCluster(), kcp, mt}))
+}
+
+func TestControlPlaneObjectsOldControlPlaneNotExists(t *testing.T) {
+	g := newSnowTest(t)
+	mt := wantSnowMachineTemplate()
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			clusterapi.KubeadmControlPlaneName(g.clusterSpec),
+			constants.EksaSystemNamespace,
+			&controlplanev1.KubeadmControlPlane{},
+		).
+		Return(apierrors.NewNotFound(v1alpha1.Resource("foo"), "kind not found"))
+
+	mt.SetName("test-cp-1")
+	mt.Spec.Template.Spec.InstanceType = "sbe-c.large"
+
+	got, err := snow.ControlPlaneObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	g.Expect(err).To(Succeed())
+	g.Expect(got).To(Equal([]runtime.Object{wantCAPICluster(), wantSnowCluster(), wantKubeadmControlPlane(), mt}))
+}
+
+func TestControlPlaneObjectsOldMachineTemplateNotExists(t *testing.T) {
+	g := newSnowTest(t)
+	mt := wantSnowMachineTemplate()
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			clusterapi.KubeadmControlPlaneName(g.clusterSpec),
+			constants.EksaSystemNamespace,
+			&controlplanev1.KubeadmControlPlane{},
+		).
+		DoAndReturn(func(_ context.Context, _, _ string, obj *controlplanev1.KubeadmControlPlane) error {
+			obj.Spec.MachineTemplate.InfrastructureRef.Name = "test-cp-1"
+			return nil
+		})
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			"test-cp-1",
+			constants.EksaSystemNamespace,
+			&snowv1.AWSSnowMachineTemplate{},
+		).
+		Return(apierrors.NewNotFound(v1alpha1.Resource("foo"), "kind not found"))
+
+	mt.SetName("test-cp-1")
+	mt.Spec.Template.Spec.InstanceType = "sbe-c.large"
+
+	got, err := snow.ControlPlaneObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	g.Expect(err).To(Succeed())
+	g.Expect(got).To(Equal([]runtime.Object{wantCAPICluster(), wantSnowCluster(), wantKubeadmControlPlane(), mt}))
+}
+
+func TestControlPlaneObjectsGetOldControlPlaneError(t *testing.T) {
+	g := newSnowTest(t)
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			clusterapi.KubeadmControlPlaneName(g.clusterSpec),
+			constants.EksaSystemNamespace,
+			&controlplanev1.KubeadmControlPlane{},
+		).
+		Return(errors.New("get cp error"))
+
+	_, err := snow.ControlPlaneObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	g.Expect(err).NotTo(Succeed())
+}
+
+func TestControlPlaneObjectsGetOldMachineTemplateError(t *testing.T) {
+	g := newSnowTest(t)
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			clusterapi.KubeadmControlPlaneName(g.clusterSpec),
+			constants.EksaSystemNamespace,
+			&controlplanev1.KubeadmControlPlane{},
+		).
+		Return(nil)
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			"",
+			constants.EksaSystemNamespace,
+			&snowv1.AWSSnowMachineTemplate{},
+		).
+		Return(errors.New("get mt error"))
+
+	_, err := snow.ControlPlaneObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	g.Expect(err).NotTo(Succeed())
+}
+
+func TestWorkersObjects(t *testing.T) {
+	g := newSnowTest(t)
+	mt := wantSnowMachineTemplate()
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			clusterapi.MachineDeploymentName(g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
+			constants.EksaSystemNamespace,
+			&clusterv1.MachineDeployment{},
+		).
+		DoAndReturn(func(_ context.Context, _, _ string, obj *clusterv1.MachineDeployment) error {
+			obj.Spec.Template.Spec.InfrastructureRef.Name = "test-wn-1"
+			return nil
+		})
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			"test-wn-1",
+			constants.EksaSystemNamespace,
+			&snowv1.AWSSnowMachineTemplate{},
+		).
+		DoAndReturn(func(_ context.Context, _, _ string, obj *snowv1.AWSSnowMachineTemplate) error {
+			mt.DeepCopyInto(obj)
+			obj.SetName("test-wn-1")
+			obj.Spec.Template.Spec.InstanceType = "updated-instance-type"
+			return nil
+		})
+
+	wantMachineTemplateName := "test-wn-2"
+	mt.SetName(wantMachineTemplateName)
+	md := wantMachineDeployment()
+	md.Spec.Template.Spec.InfrastructureRef.Name = wantMachineTemplateName
+
+	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	g.Expect(err).To(Succeed())
+	g.Expect(got).To(Equal([]runtime.Object{md, wantKubeadmConfigTemplate(), mt}))
+}
+
+func TestWorkersObjectsOldMachineDeploymentNotExists(t *testing.T) {
+	g := newSnowTest(t)
+	mt := wantSnowMachineTemplate()
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			clusterapi.MachineDeploymentName(g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
+			constants.EksaSystemNamespace,
+			&clusterv1.MachineDeployment{},
+		).
+		Return(apierrors.NewNotFound(v1alpha1.Resource("foo"), "kind not found"))
+
+	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	g.Expect(err).To(Succeed())
+	g.Expect(got).To(Equal([]runtime.Object{wantMachineDeployment(), wantKubeadmConfigTemplate(), mt}))
+}
+
+func TestWorkersObjectsOldMachineTemplateNotExists(t *testing.T) {
+	g := newSnowTest(t)
+	mt := wantSnowMachineTemplate()
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			clusterapi.MachineDeploymentName(g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
+			constants.EksaSystemNamespace,
+			&clusterv1.MachineDeployment{},
+		).
+		DoAndReturn(func(_ context.Context, _, _ string, obj *clusterv1.MachineDeployment) error {
+			obj.Spec.Template.Spec.InfrastructureRef.Name = "test-wn-1"
+			return nil
+		})
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			"test-wn-1",
+			constants.EksaSystemNamespace,
+			&snowv1.AWSSnowMachineTemplate{},
+		).
+		Return(apierrors.NewNotFound(v1alpha1.Resource("foo"), "kind not found"))
+
+	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	g.Expect(err).To(Succeed())
+	g.Expect(got).To(Equal([]runtime.Object{wantMachineDeployment(), wantKubeadmConfigTemplate(), mt}))
+}
+
+func TestWorkersObjectsGetMachineDeploymentError(t *testing.T) {
+	g := newSnowTest(t)
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			clusterapi.MachineDeploymentName(g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
+			constants.EksaSystemNamespace,
+			&clusterv1.MachineDeployment{},
+		).
+		Return(errors.New("get md error"))
+
+	_, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	g.Expect(err).NotTo(Succeed())
+}
+
+func TestWorkersObjectsGetMachineTemplateError(t *testing.T) {
+	g := newSnowTest(t)
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			clusterapi.MachineDeploymentName(g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
+			constants.EksaSystemNamespace,
+			&clusterv1.MachineDeployment{},
+		).
+		Return(nil)
+	g.kubeconfigClient.EXPECT().
+		Get(
+			g.ctx,
+			"",
+			constants.EksaSystemNamespace,
+			&snowv1.AWSSnowMachineTemplate{},
+		).
+		Return(errors.New("get mt error"))
+
+	_, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	g.Expect(err).NotTo(Succeed())
+}

--- a/pkg/providers/snow/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_cp.yaml
@@ -101,7 +101,7 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: AWSSnowMachineTemplate
-      name: test-cp
+      name: test-cp-1
     metadata: {}
   replicas: 3
   version: v1.21.5-eks-1-21-9
@@ -118,7 +118,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSSnowMachineTemplate
 metadata:
   creationTimestamp: null
-  name: test-cp
+  name: test-cp-1
   namespace: eksa-system
 spec:
   template:

--- a/pkg/providers/snow/testdata/expected_results_main_md.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_md.yaml
@@ -24,7 +24,7 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AWSSnowMachineTemplate
-        name: test-wn
+        name: test-wn-1
       version: v1.21.5-eks-1-21-9
 status:
   availableReplicas: 0
@@ -73,7 +73,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSSnowMachineTemplate
 metadata:
   creationTimestamp: null
-  name: test-wn
+  name: test-wn-1
   namespace: eksa-system
 spec:
   template:


### PR DESCRIPTION
*Issue #, if available:*

#1106 

Break down the POC upgrade PR #1968 

*Description of changes:*

This PR compares the existing snowmachinetemplate in cluster and the snowmachinetemplate generated from cluster spec, to determine whether to create new machinetemplate since the object is immutable.

The `snow.CAPIObjects(ctx context.Context, clusterSpec *cluster.Spec, kubeClient kubernetes.Client)` is sharable between cli and controller.

*Testing (if applicable):*

- unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

