### PR TITLE
Add Kubectl Wrappers for Curated Packages

### DIFF
--- a/cmd/eksctl-anywhere/cmd/apply.go
+++ b/cmd/eksctl-anywhere/cmd/apply.go
@@ -1,0 +1,13 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var applyCmd = &cobra.Command{
+	Use:   "apply",
+	Short: "Apply resources",
+	Long:  "Use eksctl anywhere apply to apply resources",
+}
+
+func init() {
+	rootCmd.AddCommand(applyCmd)
+}

--- a/cmd/eksctl-anywhere/cmd/applypackages.go
+++ b/cmd/eksctl-anywhere/cmd/applypackages.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aws/eks-anywhere/pkg/curatedpackages"
+	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+)
+
+type applyPackageOptions struct {
+	fileName string
+}
+
+var apo = &applyPackageOptions{}
+
+func init() {
+	applyCmd.AddCommand(applyPackagesCommand)
+	applyPackagesCommand.Flags().StringVarP(&apo.fileName, "filename", "f", "", "File with curated packages to apply")
+	err := applyPackagesCommand.MarkFlagRequired("filename")
+	if err != nil {
+		log.Fatalf("Error marking flag as required: %v", err)
+	}
+}
+
+var applyPackagesCommand = &cobra.Command{
+	Use:          "packages",
+	Short:        "Apply curated packages",
+	PreRunE:      preRunPackages,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := applyPackages(cmd.Context()); err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func applyPackages(ctx context.Context) error {
+	kubeConfig := kubeconfig.FromEnvironment()
+	deps, err := newDependenciesForPackages(ctx, kubeConfig)
+	if err != nil {
+		return fmt.Errorf("unable to initialize executables: %v", err)
+	}
+	packages := curatedpackages.NewPackageClient(
+		nil,
+		deps.Kubectl,
+	)
+
+	err = packages.ApplyPackages(ctx, apo.fileName, kubeConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/eksctl-anywhere/cmd/applypackages.go
+++ b/cmd/eksctl-anywhere/cmd/applypackages.go
@@ -19,7 +19,7 @@ var apo = &applyPackageOptions{}
 
 func init() {
 	applyCmd.AddCommand(applyPackagesCommand)
-	applyPackagesCommand.Flags().StringVarP(&apo.fileName, "filename", "f", "", "File with curated packages to apply")
+	applyPackagesCommand.Flags().StringVarP(&apo.fileName, "filename", "f", "", "Filename that contains curated packages custom resources to apply")
 	err := applyPackagesCommand.MarkFlagRequired("filename")
 	if err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
@@ -27,8 +27,10 @@ func init() {
 }
 
 var applyPackagesCommand = &cobra.Command{
-	Use:          "packages",
+	Use:          "package(s) [flags]",
 	Short:        "Apply curated packages",
+	Long:         "Apply Curated Packages Custom Resources to the cluster",
+	Aliases:      []string{"package", "packages"},
 	PreRunE:      preRunPackages,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/eksctl-anywhere/cmd/createpackages.go
+++ b/cmd/eksctl-anywhere/cmd/createpackages.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aws/eks-anywhere/pkg/curatedpackages"
+	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+)
+
+type createPackageOptions struct {
+	fileName string
+}
+
+var cpo = &createPackageOptions{}
+
+func init() {
+	createCmd.AddCommand(createPackagesCommand)
+	createPackagesCommand.Flags().StringVarP(&cpo.fileName, "filename", "f", "", "File with curated packages to create")
+	err := createPackagesCommand.MarkFlagRequired("filename")
+	if err != nil {
+		log.Fatalf("Error marking flag as required: %v", err)
+	}
+}
+
+var createPackagesCommand = &cobra.Command{
+	Use:          "packages",
+	Short:        "Create curated packages",
+	PreRunE:      preRunPackages,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := createPackages(cmd.Context()); err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func createPackages(ctx context.Context) error {
+	kubeConfig := kubeconfig.FromEnvironment()
+	deps, err := newDependenciesForPackages(ctx, kubeConfig)
+	if err != nil {
+		return fmt.Errorf("unable to initialize executables: %v", err)
+	}
+	packages := curatedpackages.NewPackageClient(
+		nil,
+		deps.Kubectl,
+	)
+
+	err = packages.CreatePackages(ctx, apo.fileName, kubeConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/eksctl-anywhere/cmd/createpackages.go
+++ b/cmd/eksctl-anywhere/cmd/createpackages.go
@@ -50,7 +50,7 @@ func createPackages(ctx context.Context) error {
 		deps.Kubectl,
 	)
 
-	err = packages.CreatePackages(ctx, apo.fileName, kubeConfig)
+	err = packages.CreatePackages(ctx, cpo.fileName, kubeConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/createpackages.go
+++ b/cmd/eksctl-anywhere/cmd/createpackages.go
@@ -19,7 +19,7 @@ var cpo = &createPackageOptions{}
 
 func init() {
 	createCmd.AddCommand(createPackagesCommand)
-	createPackagesCommand.Flags().StringVarP(&cpo.fileName, "filename", "f", "", "File with curated packages to create")
+	createPackagesCommand.Flags().StringVarP(&cpo.fileName, "filename", "f", "", "Filename that contains curated packages custom resources to create")
 	err := createPackagesCommand.MarkFlagRequired("filename")
 	if err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
@@ -27,8 +27,10 @@ func init() {
 }
 
 var createPackagesCommand = &cobra.Command{
-	Use:          "packages",
+	Use:          "package(s) [flags]",
 	Short:        "Create curated packages",
+	Long:         "Create Curated Packages Custom Resources to the cluster",
+	Aliases:      []string{"package", "packages"},
 	PreRunE:      preRunPackages,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/eksctl-anywhere/cmd/deletepackages.go
+++ b/cmd/eksctl-anywhere/cmd/deletepackages.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aws/eks-anywhere/pkg/curatedpackages"
+	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+)
+
+func init() {
+	deleteCmd.AddCommand(deletePackageCommand)
+}
+
+var deletePackageCommand = &cobra.Command{
+	Use:          "package(s) [flags]",
+	Aliases:      []string{"package", "packages"},
+	Short:        "Delete package(s)",
+	Long:         "This command is used to delete the curated packages installed in the cluster",
+	PreRunE:      preRunPackages,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return deleteResources(cmd.Context(), args)
+	},
+}
+
+func deleteResources(ctx context.Context, args []string) error {
+	kubeConfig := kubeconfig.FromEnvironment()
+	deps, err := newDependenciesForPackages(ctx, kubeConfig)
+	if err != nil {
+		return fmt.Errorf("unable to initialize executables: %v", err)
+	}
+	packages := curatedpackages.NewPackageClient(
+		nil,
+		deps.Kubectl,
+	)
+
+	err = packages.DeletePackages(ctx, args, kubeConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/eksctl-anywhere/cmd/deletepackages.go
+++ b/cmd/eksctl-anywhere/cmd/deletepackages.go
@@ -18,7 +18,7 @@ var deletePackageCommand = &cobra.Command{
 	Use:          "package(s) [flags]",
 	Aliases:      []string{"package", "packages"},
 	Short:        "Delete package(s)",
-	Long:         "This command is used to delete the curated packages installed in the cluster",
+	Long:         "This command is used to delete the curated packages custom resources installed in the cluster",
 	PreRunE:      preRunPackages,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/eksctl-anywhere/cmd/describe.go
+++ b/cmd/eksctl-anywhere/cmd/describe.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var describeCmd = &cobra.Command{
+	Use:   "describe",
+	Short: "Describe resources",
+	Long:  "Use eksctl anywhere describe to show details of a specific resource or group of resources",
+}
+
+func init() {
+	rootCmd.AddCommand(describeCmd)
+}

--- a/cmd/eksctl-anywhere/cmd/describepackages.go
+++ b/cmd/eksctl-anywhere/cmd/describepackages.go
@@ -15,8 +15,9 @@ func init() {
 }
 
 var describePackagesCommand = &cobra.Command{
-	Use:          "packages",
-	Short:        "Describe curated packages",
+	Use:          "package(s) [flags]",
+	Short:        "Describe curated packages in the cluster",
+	Aliases:      []string{"package", "packages"},
 	PreRunE:      preRunPackages,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/eksctl-anywhere/cmd/describepackages.go
+++ b/cmd/eksctl-anywhere/cmd/describepackages.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aws/eks-anywhere/pkg/curatedpackages"
+	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+)
+
+func init() {
+	describeCmd.AddCommand(describePackagesCommand)
+}
+
+var describePackagesCommand = &cobra.Command{
+	Use:          "packages",
+	Short:        "Describe curated packages",
+	PreRunE:      preRunPackages,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := describeResources(cmd.Context(), args); err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func describeResources(ctx context.Context, args []string) error {
+	kubeConfig := kubeconfig.FromEnvironment()
+	deps, err := newDependenciesForPackages(ctx, kubeConfig)
+	if err != nil {
+		return fmt.Errorf("unable to initialize executables: %v", err)
+	}
+	packages := curatedpackages.NewPackageClient(
+		nil,
+		deps.Kubectl,
+	)
+
+	err = packages.DescribePackages(ctx, args, kubeConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/eksctl-anywhere/cmd/upgradepackages.go
+++ b/cmd/eksctl-anywhere/cmd/upgradepackages.go
@@ -29,7 +29,7 @@ func init() {
 
 var upgradePackagesCommand = &cobra.Command{
 	Use:          "packages",
-	Short:        "Upgrade curated packages to the latest version",
+	Short:        "Upgrade all curated packages to the latest version",
 	PreRunE:      preRunPackages,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/eksctl-anywhere/cmd/upgradepackages.go
+++ b/cmd/eksctl-anywhere/cmd/upgradepackages.go
@@ -19,8 +19,8 @@ var upo = &upgradePackageOptions{}
 
 func init() {
 	upgradeCmd.AddCommand(upgradePackagesCommand)
-	upgradePackagesCommand.Flags().StringVar(&upo.bundleVersion, "bundleversion", "", "Bundle version to use")
-	err := upgradePackagesCommand.MarkFlagRequired("bundleversion")
+	upgradePackagesCommand.Flags().StringVar(&upo.bundleVersion, "bundle-version", "", "Bundle version to use")
+	err := upgradePackagesCommand.MarkFlagRequired("bundle-version")
 	if err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/upgradepackages.go
+++ b/cmd/eksctl-anywhere/cmd/upgradepackages.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/eks-anywhere/pkg/curatedpackages"
+	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/version"
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+type upgradePackageOptions struct {
+	bundleVersion string
+}
+
+var upo = &upgradePackageOptions{}
+
+func init() {
+	upgradeCmd.AddCommand(upgradePackagesCommand)
+	upgradePackagesCommand.Flags().StringVar(&upo.bundleVersion, "bundleversion", "", "Bundle version to use")
+	err := upgradePackagesCommand.MarkFlagRequired("bundleversion")
+	if err != nil {
+		log.Fatalf("Error marking flag as required: %v", err)
+	}
+}
+
+var upgradePackagesCommand = &cobra.Command{
+	Use:          "packages",
+	Short:        "Upgrade curated packages to the latest version",
+	PreRunE:      preRunPackages,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := upgradePackages(cmd.Context()); err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func upgradePackages(ctx context.Context) error {
+	kubeConfig := kubeconfig.FromEnvironment()
+	deps, err := newDependenciesForPackages(ctx, kubeConfig)
+	if err != nil {
+		return fmt.Errorf("unable to initialize executables: %v", err)
+	}
+
+	b := curatedpackages.NewBundleReader(
+		kubeConfig,
+		ipo.kubeVersion,
+		ipo.source,
+		deps.Kubectl,
+		nil,
+		version.Get(),
+		nil,
+	)
+	activeController, err := b.GetActiveController(ctx)
+	if err != nil {
+		return err
+	}
+	err = b.UpgradeBundle(ctx, activeController, upo.bundleVersion)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/eksctl-anywhere/cmd/upgradepackages.go
+++ b/cmd/eksctl-anywhere/cmd/upgradepackages.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/aws/eks-anywhere/pkg/curatedpackages"
-	"github.com/aws/eks-anywhere/pkg/kubeconfig"
-	"github.com/aws/eks-anywhere/pkg/version"
 	"log"
 
 	"github.com/spf13/cobra"
+
+	"github.com/aws/eks-anywhere/pkg/curatedpackages"
+	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/version"
 )
 
 type upgradePackageOptions struct {

--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b // indirect
 	oras.land/oras-go v1.1.0 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.2.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )
 
 // TODO: Once the repo is public, remove this so we use a versioned module

--- a/go.sum
+++ b/go.sum
@@ -2643,8 +2643,9 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
-sigs.k8s.io/structured-merge-diff/v4 v4.2.0 h1:kDvPBbnPk+qYmkHmSo8vKGp438IASWofnbbUKDE/bv0=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.0/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
+sigs.k8s.io/structured-merge-diff/v4 v4.2.1 h1:bKCqE9GvQ5tiVHn5rfn1r+yao3aLQEaLzkkmAkf+A6Y=
+sigs.k8s.io/structured-merge-diff/v4 v4.2.1/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=

--- a/pkg/curatedpackages/bundle.go
+++ b/pkg/curatedpackages/bundle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"sigs.k8s.io/yaml"
 
 	packagesv1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"

--- a/pkg/curatedpackages/packageclient.go
+++ b/pkg/curatedpackages/packageclient.go
@@ -117,7 +117,7 @@ func (pc *PackageClient) InstallPackage(ctx context.Context, bp *packagesv1.Bund
 	if err != nil {
 		return err
 	}
-	fmt.Println(&stdOut)
+	fmt.Print(&stdOut)
 	return nil
 }
 
@@ -166,7 +166,7 @@ func (pc *PackageClient) DescribePackages(ctx context.Context, args []string, ku
 	if len(stdOut.Bytes()) == 0 {
 		return errors.New("no resources found")
 	}
-	fmt.Println(&stdOut)
+	fmt.Print(&stdOut)
 	return nil
 }
 

--- a/pkg/curatedpackages/packageclient.go
+++ b/pkg/curatedpackages/packageclient.go
@@ -143,9 +143,9 @@ func (pc *PackageClient) CreatePackages(ctx context.Context, fileName string, ku
 	return nil
 }
 
-func (pc *PackageClient) DeletePackages(ctx context.Context, args []string, kubeConfig string) error {
+func (pc *PackageClient) DeletePackages(ctx context.Context, packages []string, kubeConfig string) error {
 	params := []string{"delete", "packages", "--kubeconfig", kubeConfig, "--namespace", constants.EksaPackagesName}
-	params = append(params, args...)
+	params = append(params, packages...)
 	stdOut, err := pc.kubectl.ExecuteCommand(ctx, params...)
 	if err != nil {
 		fmt.Print(&stdOut)
@@ -155,9 +155,9 @@ func (pc *PackageClient) DeletePackages(ctx context.Context, args []string, kube
 	return nil
 }
 
-func (pc *PackageClient) DescribePackages(ctx context.Context, args []string, kubeConfig string) error {
+func (pc *PackageClient) DescribePackages(ctx context.Context, packages []string, kubeConfig string) error {
 	params := []string{"describe", "packages", "--kubeconfig", kubeConfig, "--namespace", constants.EksaPackagesName}
-	params = append(params, args...)
+	params = append(params, packages...)
 	stdOut, err := pc.kubectl.ExecuteCommand(ctx, params...)
 	if err != nil {
 		fmt.Print(&stdOut)

--- a/pkg/curatedpackages/packageclient.go
+++ b/pkg/curatedpackages/packageclient.go
@@ -123,21 +123,36 @@ func (pc *PackageClient) InstallPackage(ctx context.Context, bp *packagesv1.Bund
 
 func (pc *PackageClient) ApplyPackages(ctx context.Context, fileName string, kubeConfig string) error {
 	params := []string{"apply", "-f", fileName, "--kubeconfig", kubeConfig}
-	_, err := pc.kubectl.ExecuteCommand(ctx, params...)
-	return err
+	stdOut, err := pc.kubectl.ExecuteCommand(ctx, params...)
+	if err != nil {
+		fmt.Print(&stdOut)
+		return err
+	}
+	fmt.Print(&stdOut)
+	return nil
 }
 
 func (pc *PackageClient) CreatePackages(ctx context.Context, fileName string, kubeConfig string) error {
 	params := []string{"create", "-f", fileName, "--kubeconfig", kubeConfig}
-	_, err := pc.kubectl.ExecuteCommand(ctx, params...)
-	return err
+	stdOut, err := pc.kubectl.ExecuteCommand(ctx, params...)
+	if err != nil {
+		fmt.Print(&stdOut)
+		return err
+	}
+	fmt.Print(&stdOut)
+	return nil
 }
 
 func (pc *PackageClient) DeletePackages(ctx context.Context, args []string, kubeConfig string) error {
 	params := []string{"delete", "packages", "--kubeconfig", kubeConfig, "--namespace", constants.EksaPackagesName}
 	params = append(params, args...)
-	_, err := pc.kubectl.ExecuteCommand(ctx, params...)
-	return err
+	stdOut, err := pc.kubectl.ExecuteCommand(ctx, params...)
+	if err != nil {
+		fmt.Print(&stdOut)
+		return err
+	}
+	fmt.Print(&stdOut)
+	return nil
 }
 
 func (pc *PackageClient) DescribePackages(ctx context.Context, args []string, kubeConfig string) error {

--- a/pkg/curatedpackages/packageclient_test.go
+++ b/pkg/curatedpackages/packageclient_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -102,4 +103,91 @@ func TestInstallPackagesFails(t *testing.T) {
 
 	err := tt.command.InstallPackage(tt.ctx, &tt.bundle.Spec.Packages[0], "my-harbor", "")
 	tt.Expect(err).To(MatchError(ContainSubstring("error installing package. Package exists")))
+}
+
+func TestApplyPackagesPass(t *testing.T) {
+	tt := newPackageTest(t)
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, gomock.Any()).Return(convertJsonToBytes(tt.bundle.Spec.Packages[0]), nil)
+	packages := []string{"harbor-test"}
+	tt.command = curatedpackages.NewPackageClient(tt.bundle, tt.kubectl, packages...)
+
+	err := tt.command.ApplyPackages(tt.ctx, "test_file.yaml", "")
+	tt.Expect(err).To(BeNil())
+}
+
+func TestApplyPackagesFail(t *testing.T) {
+	tt := newPackageTest(t)
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, gomock.Any()).Return(bytes.Buffer{}, errors.New("file doesn't exist"))
+	packages := []string{"harbor-test"}
+	tt.command = curatedpackages.NewPackageClient(tt.bundle, tt.kubectl, packages...)
+
+	err := tt.command.ApplyPackages(tt.ctx, "test_file.yaml", "")
+	tt.Expect(err).To(MatchError(ContainSubstring("file doesn't exist")))
+}
+
+func TestCreatePackagesPass(t *testing.T) {
+	tt := newPackageTest(t)
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, gomock.Any()).Return(convertJsonToBytes(tt.bundle.Spec.Packages[0]), nil)
+	packages := []string{"harbor-test"}
+	tt.command = curatedpackages.NewPackageClient(tt.bundle, tt.kubectl, packages...)
+
+	err := tt.command.CreatePackages(tt.ctx, "test_file.yaml", "")
+	fmt.Println()
+	tt.Expect(err).To(BeNil())
+}
+
+func TestCreatePackagesFail(t *testing.T) {
+	tt := newPackageTest(t)
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, gomock.Any()).Return(bytes.Buffer{}, errors.New("file doesn't exist"))
+	packages := []string{"harbor-test"}
+	tt.command = curatedpackages.NewPackageClient(tt.bundle, tt.kubectl, packages...)
+
+	err := tt.command.CreatePackages(tt.ctx, "test_file.yaml", "")
+	tt.Expect(err).To(MatchError(ContainSubstring("file doesn't exist")))
+}
+
+func TestDeletePackagesPass(t *testing.T) {
+	tt := newPackageTest(t)
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, gomock.Any()).Return(convertJsonToBytes(tt.bundle.Spec.Packages[0]), nil)
+	packages := []string{"harbor-test"}
+	args := []string{"harbor-test"}
+	tt.command = curatedpackages.NewPackageClient(tt.bundle, tt.kubectl, packages...)
+
+	err := tt.command.DeletePackages(tt.ctx, args, "")
+	fmt.Println()
+	tt.Expect(err).To(BeNil())
+}
+
+func TestDeletePackagesFail(t *testing.T) {
+	tt := newPackageTest(t)
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, gomock.Any()).Return(bytes.Buffer{}, errors.New("package doesn't exist"))
+	packages := []string{"harbor-test"}
+	args := []string{"non-working-package"}
+	tt.command = curatedpackages.NewPackageClient(tt.bundle, tt.kubectl, packages...)
+
+	err := tt.command.DeletePackages(tt.ctx, args, "")
+	tt.Expect(err).To(MatchError(ContainSubstring("package doesn't exist")))
+}
+
+func TestDescribePackagesPass(t *testing.T) {
+	tt := newPackageTest(t)
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, gomock.Any()).Return(convertJsonToBytes(tt.bundle.Spec.Packages[0]), nil)
+	packages := []string{"harbor-test"}
+	args := []string{"harbor-test"}
+	tt.command = curatedpackages.NewPackageClient(tt.bundle, tt.kubectl, packages...)
+
+	err := tt.command.DescribePackages(tt.ctx, args, "")
+	fmt.Println()
+	tt.Expect(err).To(BeNil())
+}
+
+func TestDescribePackagesFail(t *testing.T) {
+	tt := newPackageTest(t)
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, gomock.Any()).Return(bytes.Buffer{}, errors.New("package doesn't exist"))
+	packages := []string{"harbor-test"}
+	args := []string{"non-working-package"}
+	tt.command = curatedpackages.NewPackageClient(tt.bundle, tt.kubectl, packages...)
+
+	err := tt.command.DescribePackages(tt.ctx, args, "")
+	tt.Expect(err).To(MatchError(ContainSubstring("package doesn't exist")))
 }

--- a/pkg/curatedpackages/packageclient_test.go
+++ b/pkg/curatedpackages/packageclient_test.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/aws/eks-anywhere/pkg/constants"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 
 	packagesv1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/curatedpackages/mocks"
 )
@@ -213,4 +213,18 @@ func TestDescribePackagesFail(t *testing.T) {
 
 	err := tt.command.DescribePackages(tt.ctx, args, tt.kubeConfig)
 	tt.Expect(err).To(MatchError(ContainSubstring("package doesn't exist")))
+}
+
+func TestDescribePackagesWhenEmptyResources(t *testing.T) {
+	tt := newPackageTest(t)
+	packages := []string{"harbor-test"}
+	var args []string
+	params := []string{"describe", "packages", "--kubeconfig", tt.kubeConfig, "--namespace", constants.EksaPackagesName}
+	params = append(params, args...)
+
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, nil)
+	tt.command = curatedpackages.NewPackageClient(tt.bundle, tt.kubectl, packages...)
+
+	err := tt.command.DescribePackages(tt.ctx, args, tt.kubeConfig)
+	tt.Expect(err).To(MatchError(ContainSubstring("no resources found")))
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR includes the following the functionalities:
### Deleting Curated Packages
 Using Kubectl, delete all curated packages provided by the user through eksctl anywhere delete packages.
### Describe Curated Packages
Using Kubectl, describe all curated packages requested by the user.
### Upgrading the Active Package Bundle in a bundle controller
Find the active bundle controller and update the active bundle used. 
### Creating Curated Packages
Using Kubectl, create curated packages from file(s) provided by the user.
### Applying Curated Packages
Using kubectl, apply curated packages from file(s) provided by the user.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

