### PR TITLE
Set SSH_KNOWN_HOSTS to same value as EKSA_GIT_KNOWN_HOSTS

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ const (
 	EksaGitPasswordTokenEnv   = "EKSA_GIT_PASSWORD"
 	EksaGitPrivateKeyTokenEnv = "EKSA_GIT_PRIVATE_KEY"
 	EksaGitKnownHostsFileEnv  = "EKSA_GIT_KNOWN_HOSTS"
+	SshKnownHostsEnv          = "SSH_KNOWN_HOSTS"
 )
 
 type CliConfig struct {

--- a/pkg/git/factory/gitfactory.go
+++ b/pkg/git/factory/gitfactory.go
@@ -57,6 +57,10 @@ func Build(ctx context.Context, cluster *v1alpha1.Cluster, fluxConfig *v1alpha1.
 	case fluxConfig.Spec.Git != nil:
 		privateKeyFile := os.Getenv(config.EksaGitPrivateKeyTokenEnv)
 		privateKeyPassword := os.Getenv(config.EksaGitPasswordTokenEnv)
+		gitKnownHosts := os.Getenv(config.EksaGitKnownHostsFileEnv)
+		if err = os.Setenv(config.SshKnownHostsEnv, gitKnownHosts); err != nil {
+			return nil, fmt.Errorf("unable to set %s: %v", config.SshKnownHostsEnv, err)
+		}
 		gitAuth, err = getSshAuthFromPrivateKey(privateKeyFile, privateKeyPassword)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
*Issue #, if available:*
#2000 

*Description of changes:*
Set `SSH_KNOWN_HOSTS` to same value as `EKSA_GIT_KNOWN_HOSTS` to avoid key mismatch errors

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

