### PR TITLE
Generic git env var validations and repository

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -216,7 +216,7 @@ func (cc *createClusterOptions) directoriesToMount(clusterSpec *cluster.Spec, cl
 func buildCliConfig(clusterSpec *cluster.Spec) *config.CliConfig {
 	cliConfig := &config.CliConfig{}
 	if clusterSpec.FluxConfig != nil && clusterSpec.FluxConfig.Spec.Git != nil {
-		cliConfig.GitPassword = os.Getenv(config.EksaGitPasswordTokenEnv)
+		cliConfig.GitSshKeyPassphrase = os.Getenv(config.EksaGitPassphraseTokenEnv)
 		cliConfig.GitPrivateKeyFile = os.Getenv(config.EksaGitPrivateKeyTokenEnv)
 		cliConfig.GitKnownHostsFile = os.Getenv(config.EksaGitKnownHostsFileEnv)
 	}

--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -38,6 +38,7 @@ env:
     T_GITHUB_USER: "github-eks-anywhere-flux-bot:github-user"
     T_GIT_REPOSITORY: "github-eks-anywhere-flux-bot:github-repository"
     T_GIT_SSH_AUTHORIZED_KEY: "github-eks-anywhere-flux-bot:github-ssh-key"
+    T_GIT_SSH_REPO_URL: "github-eks-anywhere-flux-bot:generic-git-repository-url"
     T_HTTP_PROXY: "proxy-config-data:httpProxy"
     T_HTTPS_PROXY: "proxy-config-data:httpsProxy"
     T_NO_PROXY: "proxy-config-data:noProxy"

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/yaml"
 
+	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
@@ -582,9 +584,17 @@ func validateGitOps(clusterConfig *Cluster) error {
 	gitOpsRefKind := gitOpsRef.Kind
 	fluxConfigActive := features.IsActive(features.GenericGitProviderSupport())
 
-	if gitOpsRefKind == FluxConfigKind && !fluxConfigActive {
-		return fmt.Errorf("FluxConfig and the generic git provider are not currently supported; " +
-			"to use this experimental feature, please set the environment variable GENERIC_GIT_PROVIDER_SUPPORT to true")
+	if gitOpsRefKind == FluxConfigKind {
+		if !fluxConfigActive {
+			return fmt.Errorf("FluxConfig and the generic git provider are not currently supported; " +
+				"to use this experimental feature, please set the environment variable GENERIC_GIT_PROVIDER_SUPPORT to true")
+		}
+		if privateKeyFile, ok := os.LookupEnv(config.EksaGitPrivateKeyTokenEnv); !ok || len(privateKeyFile) <= 0 {
+			return fmt.Errorf("%s is not set or is empty: %t", config.EksaGitPrivateKeyTokenEnv, ok)
+		}
+		if gitKnownHosts, ok := os.LookupEnv(config.EksaGitKnownHostsFileEnv); !ok || len(gitKnownHosts) <= 0 {
+			return fmt.Errorf("%s is not set or is empty: %t", config.EksaGitKnownHostsFileEnv, ok)
+		}
 	}
 
 	if gitOpsRefKind != GitOpsConfigKind && !fluxConfigActive {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,14 +1,14 @@
 package config
 
 const (
-	EksaGitPasswordTokenEnv   = "EKSA_GIT_PASSWORD"
+	EksaGitPassphraseTokenEnv = "EKSA_GIT_SSH_KEY_PASSPHRASE"
 	EksaGitPrivateKeyTokenEnv = "EKSA_GIT_PRIVATE_KEY"
 	EksaGitKnownHostsFileEnv  = "EKSA_GIT_KNOWN_HOSTS"
 	SshKnownHostsEnv          = "SSH_KNOWN_HOSTS"
 )
 
 type CliConfig struct {
-	GitPassword       string
-	GitPrivateKeyFile string
-	GitKnownHostsFile string
+	GitSshKeyPassphrase string
+	GitPrivateKeyFile   string
+	GitKnownHostsFile   string
 }

--- a/pkg/executables/flux.go
+++ b/pkg/executables/flux.go
@@ -79,8 +79,8 @@ func (f *Flux) BootstrapToolkitsComponentsGit(ctx context.Context, cluster *type
 	}
 
 	params = setUpCommonParamsBootstrap(cluster, fluxConfig, params)
-	if cliConfig.GitPassword != "" {
-		params = append(params, "--password", cliConfig.GitPassword)
+	if cliConfig.GitSshKeyPassphrase != "" {
+		params = append(params, "--password", cliConfig.GitSshKeyPassphrase)
 	}
 
 	env := make(map[string]string)

--- a/pkg/executables/flux_test.go
+++ b/pkg/executables/flux_test.go
@@ -472,9 +472,9 @@ func TestFluxBootstrapToolkitsComponentsGitSuccess(t *testing.T) {
 				"bootstrap", gitProvider, "--url", repoUrl, "--path", path, "--private-key-file", privateKeyFilePath, "--ssh-key-algorithm", "ecdsa", "--silent", "--kubeconfig", "f.kubeconfig", "--password", password,
 			},
 			cliConfig: &config.CliConfig{
-				GitPassword:       validPassword,
-				GitPrivateKeyFile: validPrivateKeyfilePath,
-				GitKnownHostsFile: validGitKnownHostsFilePath,
+				GitSshKeyPassphrase: validPassword,
+				GitPrivateKeyFile:   validPrivateKeyfilePath,
+				GitKnownHostsFile:   validGitKnownHostsFilePath,
 			},
 		},
 		{
@@ -494,9 +494,9 @@ func TestFluxBootstrapToolkitsComponentsGitSuccess(t *testing.T) {
 				"bootstrap", gitProvider, "--url", repoUrl, "--path", path, "--private-key-file", privateKeyFilePath, "--ssh-key-algorithm", "ecdsa", "--silent", "--branch", "main",
 			},
 			cliConfig: &config.CliConfig{
-				GitPassword:       "",
-				GitPrivateKeyFile: validPrivateKeyfilePath,
-				GitKnownHostsFile: validGitKnownHostsFilePath,
+				GitSshKeyPassphrase: "",
+				GitPrivateKeyFile:   validPrivateKeyfilePath,
+				GitKnownHostsFile:   validGitKnownHostsFilePath,
 			},
 		},
 		{
@@ -516,9 +516,9 @@ func TestFluxBootstrapToolkitsComponentsGitSuccess(t *testing.T) {
 				"--password", password,
 			},
 			cliConfig: &config.CliConfig{
-				GitPassword:       validPassword,
-				GitPrivateKeyFile: validPrivateKeyfilePath,
-				GitKnownHostsFile: validGitKnownHostsFilePath,
+				GitSshKeyPassphrase: validPassword,
+				GitPrivateKeyFile:   validPrivateKeyfilePath,
+				GitKnownHostsFile:   validGitKnownHostsFilePath,
 			},
 		},
 		{
@@ -530,9 +530,9 @@ func TestFluxBootstrapToolkitsComponentsGitSuccess(t *testing.T) {
 				},
 			},
 			cliConfig: &config.CliConfig{
-				GitPassword:       validPassword,
-				GitPrivateKeyFile: validPrivateKeyfilePath,
-				GitKnownHostsFile: validGitKnownHostsFilePath,
+				GitSshKeyPassphrase: validPassword,
+				GitPrivateKeyFile:   validPrivateKeyfilePath,
+				GitKnownHostsFile:   validGitKnownHostsFilePath,
 			},
 			wantExecArgs: []interface{}{
 				"bootstrap", gitProvider, "--url", "", "--path", "", "--private-key-file", privateKeyFilePath, "--ssh-key-algorithm", "ecdsa", "--silent", "--password", password,

--- a/pkg/git/factory/gitfactory.go
+++ b/pkg/git/factory/gitfactory.go
@@ -56,12 +56,12 @@ func Build(ctx context.Context, cluster *v1alpha1.Cluster, fluxConfig *v1alpha1.
 		repoUrl = github.RepoUrl(fluxConfig.Spec.Github.Owner, repo)
 	case fluxConfig.Spec.Git != nil:
 		privateKeyFile := os.Getenv(config.EksaGitPrivateKeyTokenEnv)
-		privateKeyPassword := os.Getenv(config.EksaGitPasswordTokenEnv)
+		privateKeyPassphrase := os.Getenv(config.EksaGitPassphraseTokenEnv)
 		gitKnownHosts := os.Getenv(config.EksaGitKnownHostsFileEnv)
 		if err = os.Setenv(config.SshKnownHostsEnv, gitKnownHosts); err != nil {
 			return nil, fmt.Errorf("unable to set %s: %v", config.SshKnownHostsEnv, err)
 		}
-		gitAuth, err = getSshAuthFromPrivateKey(privateKeyFile, privateKeyPassword)
+		gitAuth, err = getSshAuthFromPrivateKey(privateKeyFile, privateKeyPassphrase)
 		if err != nil {
 			return nil, err
 		}
@@ -148,6 +148,9 @@ func getSignerFromPrivateKeyFile(privateKeyFile string, passphrase string) (ssh.
 	if passphrase == "" {
 		signer, err = ssh.ParsePrivateKey(sshKey)
 		if err != nil {
+			if _, ok := err.(*ssh.PassphraseMissingError); ok {
+				return nil, fmt.Errorf("%s, please set the EKSA_GIT_SSH_KEY_PASSPHRASE environment variable", err)
+			}
 			return nil, err
 		}
 		return signer, nil

--- a/pkg/validations/createvalidations/gitops_test.go
+++ b/pkg/validations/createvalidations/gitops_test.go
@@ -337,9 +337,9 @@ func TestValidateGitOpsGitProviderNoAuthForWorkloadCluster(t *testing.T) {
 				RepositoryUrl: "testRepo",
 			},
 			cliConfig: &config.CliConfig{
-				GitPrivateKeyFile: emptyVar,
-				GitPassword:       emptyVar,
-				GitKnownHostsFile: "testdata/git_nonempty_ssh_known_hosts",
+				GitPrivateKeyFile:   emptyVar,
+				GitSshKeyPassphrase: emptyVar,
+				GitKnownHostsFile:   "testdata/git_nonempty_ssh_known_hosts",
 			},
 		},
 		{
@@ -355,9 +355,9 @@ func TestValidateGitOpsGitProviderNoAuthForWorkloadCluster(t *testing.T) {
 				RepositoryUrl: "testRepo",
 			},
 			cliConfig: &config.CliConfig{
-				GitPrivateKeyFile: testEnvVar,
-				GitPassword:       emptyVar,
-				GitKnownHostsFile: "testdata/git_nonempty_ssh_known_hosts",
+				GitPrivateKeyFile:   testEnvVar,
+				GitSshKeyPassphrase: emptyVar,
+				GitKnownHostsFile:   "testdata/git_nonempty_ssh_known_hosts",
 			},
 		},
 		{
@@ -367,9 +367,9 @@ func TestValidateGitOpsGitProviderNoAuthForWorkloadCluster(t *testing.T) {
 				RepositoryUrl: "testRepo",
 			},
 			cliConfig: &config.CliConfig{
-				GitPrivateKeyFile: "testdata/git_empty_file",
-				GitPassword:       emptyVar,
-				GitKnownHostsFile: "testdata/git_nonempty_ssh_known_hosts",
+				GitPrivateKeyFile:   "testdata/git_empty_file",
+				GitSshKeyPassphrase: emptyVar,
+				GitKnownHostsFile:   "testdata/git_nonempty_ssh_known_hosts",
 			},
 		},
 		{
@@ -379,9 +379,9 @@ func TestValidateGitOpsGitProviderNoAuthForWorkloadCluster(t *testing.T) {
 				RepositoryUrl: "testRepo",
 			},
 			cliConfig: &config.CliConfig{
-				GitPrivateKeyFile: emptyVar,
-				GitPassword:       testEnvVar,
-				GitKnownHostsFile: "testdata/git_nonempty_ssh_known_hosts",
+				GitPrivateKeyFile:   emptyVar,
+				GitSshKeyPassphrase: testEnvVar,
+				GitKnownHostsFile:   "testdata/git_nonempty_ssh_known_hosts",
 			},
 		},
 		{
@@ -391,9 +391,9 @@ func TestValidateGitOpsGitProviderNoAuthForWorkloadCluster(t *testing.T) {
 				RepositoryUrl: "testRepo",
 			},
 			cliConfig: &config.CliConfig{
-				GitPrivateKeyFile: "testdata/git_nonempty_private_key",
-				GitPassword:       testEnvVar,
-				GitKnownHostsFile: "testdata/git_nonempty_ssh_known_hosts",
+				GitPrivateKeyFile:   "testdata/git_nonempty_private_key",
+				GitSshKeyPassphrase: testEnvVar,
+				GitKnownHostsFile:   "testdata/git_nonempty_ssh_known_hosts",
 			},
 		},
 		{
@@ -403,9 +403,9 @@ func TestValidateGitOpsGitProviderNoAuthForWorkloadCluster(t *testing.T) {
 				RepositoryUrl: "testRepo",
 			},
 			cliConfig: &config.CliConfig{
-				GitPrivateKeyFile: "testdata/git_nonempty_private_key",
-				GitPassword:       testEnvVar,
-				GitKnownHostsFile: "testdata/git_empty_file",
+				GitPrivateKeyFile:   "testdata/git_nonempty_private_key",
+				GitSshKeyPassphrase: testEnvVar,
+				GitKnownHostsFile:   "testdata/git_empty_file",
 			},
 		},
 		{
@@ -415,9 +415,9 @@ func TestValidateGitOpsGitProviderNoAuthForWorkloadCluster(t *testing.T) {
 				RepositoryUrl: "testRepo",
 			},
 			cliConfig: &config.CliConfig{
-				GitPrivateKeyFile: "testdata/git_nonempty_private_key",
-				GitPassword:       testEnvVar,
-				GitKnownHostsFile: "testdata/git_empty_file",
+				GitPrivateKeyFile:   "testdata/git_nonempty_private_key",
+				GitSshKeyPassphrase: testEnvVar,
+				GitKnownHostsFile:   "testdata/git_empty_file",
 			},
 		},
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR makes a few changes:
 1. Renames git variables to use `Passphrase` instead of `Password` to avoid ambiguity & maintain consistency with git terminolgy
 2. Adds repository URL for the generic git repo to the e2e test environment variables
 3. Adds validations to ensure that the known hosts and private key file environment variables are set

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

