### PR TITLE
Rename tinkerbellProvider to Provider

### DIFF
--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -22,7 +22,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 
-func (p *tinkerbellProvider) BootstrapClusterOpts() ([]bootstrapper.BootstrapClusterOption, error) {
+func (p *Provider) BootstrapClusterOpts() ([]bootstrapper.BootstrapClusterOption, error) {
 	env := map[string]string{}
 	// Adding proxy environment vars to the bootstrap cluster
 	if p.clusterConfig.Spec.ProxyConfiguration != nil {
@@ -40,11 +40,11 @@ func (p *tinkerbellProvider) BootstrapClusterOpts() ([]bootstrapper.BootstrapClu
 	return []bootstrapper.BootstrapClusterOption{bootstrapper.WithEnv(env)}, nil
 }
 
-func (p *tinkerbellProvider) PreCAPIInstallOnBootstrap(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
+func (p *Provider) PreCAPIInstallOnBootstrap(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	return nil
 }
 
-func (p *tinkerbellProvider) PostBootstrapSetup(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error {
+func (p *Provider) PostBootstrapSetup(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error {
 	// TODO: figure out if we need something else here
 	hardwareSpec, err := p.catalogue.HardwareSpecMarshallable()
 	if err != nil {
@@ -57,7 +57,7 @@ func (p *tinkerbellProvider) PostBootstrapSetup(ctx context.Context, clusterConf
 	return nil
 }
 
-func (p *tinkerbellProvider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpec *cluster.Spec) error {
+func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpec *cluster.Spec) error {
 	logger.Info("Warning: The tinkerbell infrastructure provider is still in development and should not be used in production")
 
 	tinkHardware, err := p.providerTinkClient.GetHardware(ctx)
@@ -138,7 +138,7 @@ func (p *tinkerbellProvider) SetupAndValidateCreateCluster(ctx context.Context, 
 	return nil
 }
 
-func (p *tinkerbellProvider) setHardwareStateToProvisining(ctx context.Context) error {
+func (p *Provider) setHardwareStateToProvisining(ctx context.Context) error {
 	for _, hardware := range p.catalogue.Hardware {
 		tinkHardware, err := p.providerTinkClient.GetHardwareByUuid(ctx, hardware.Spec.ID)
 		if err != nil {
@@ -165,7 +165,7 @@ func (p *tinkerbellProvider) setHardwareStateToProvisining(ctx context.Context) 
 
 // setMachinesToPXEBoot iterates over all catalogue.BMCs and instructs them to turn off, one-time
 // PXE boot, then turn on.
-func (p *tinkerbellProvider) setMachinesToPXEBoot(ctx context.Context) error {
+func (p *Provider) setMachinesToPXEBoot(ctx context.Context) error {
 	secrets := make(map[string]corev1.Secret, len(p.catalogue.Secrets))
 	for _, secret := range p.catalogue.Secrets {
 		secrets[secret.Name] = secret
@@ -204,7 +204,7 @@ func (p *tinkerbellProvider) setMachinesToPXEBoot(ctx context.Context) error {
 // scrubWorkflowsFromTinkerbell removes all workflows in the Tinkerbell stack that feature in hardware by retrieving
 // hardware MAC addresses using tinkerbellHardware. tinkerbellHardware is necessary because MAC addresses aren't
 // available on the Hardware object type.
-func (p *tinkerbellProvider) scrubWorkflowsFromTinkerbell(ctx context.Context, hardware []tinkv1alpha1.Hardware, tinkerbellHardware []*tinkhardware.Hardware) error {
+func (p *Provider) scrubWorkflowsFromTinkerbell(ctx context.Context, hardware []tinkv1alpha1.Hardware, tinkerbellHardware []*tinkhardware.Hardware) error {
 	workflows, err := p.providerTinkClient.GetWorkflow(ctx)
 	if err != nil {
 		return fmt.Errorf("retrieving workflows: %w", err)

--- a/pkg/providers/tinkerbell/delete.go
+++ b/pkg/providers/tinkerbell/delete.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 
-func (p *tinkerbellProvider) SetupAndValidateDeleteCluster(ctx context.Context, cluster *types.Cluster) error {
+func (p *Provider) SetupAndValidateDeleteCluster(ctx context.Context, cluster *types.Cluster) error {
 	// TODO: validations?
 	if err := setupEnvVars(p.datacenterConfig); err != nil {
 		return fmt.Errorf("failed setup and validations: %v", err)
@@ -48,7 +48,7 @@ func filterHardwareForCluster(hardwares []tinkv1alpha1.Hardware, clusterName str
 	return filteredHardwareList, nil
 }
 
-func (p *tinkerbellProvider) DeleteResources(ctx context.Context, clusterSpec *cluster.Spec) error {
+func (p *Provider) DeleteResources(ctx context.Context, clusterSpec *cluster.Spec) error {
 	for _, mc := range p.machineConfigs {
 		if err := p.providerKubectlClient.DeleteEksaMachineConfig(ctx, eksaTinkerbellDatacenterResourceType, mc.Name, clusterSpec.ManagementCluster.KubeconfigFile, mc.Namespace); err != nil {
 			return err
@@ -57,7 +57,7 @@ func (p *tinkerbellProvider) DeleteResources(ctx context.Context, clusterSpec *c
 	return p.providerKubectlClient.DeleteEksaDatacenterConfig(ctx, eksaTinkerbellMachineResourceType, p.datacenterConfig.Name, clusterSpec.ManagementCluster.KubeconfigFile, p.datacenterConfig.Namespace)
 }
 
-func (p *tinkerbellProvider) PostClusterDeleteValidate(ctx context.Context, managementCluster *types.Cluster) error {
+func (p *Provider) PostClusterDeleteValidate(ctx context.Context, managementCluster *types.Cluster) error {
 	// We want to validate cluster nodes are powered off.
 	// We wait on BMC status.powerState to check for power off.
 	bmcRefs := make([]string, 0, len(p.hardwares))

--- a/pkg/providers/tinkerbell/ssh.go
+++ b/pkg/providers/tinkerbell/ssh.go
@@ -49,7 +49,7 @@ func stripCommentsFromSshKeys(machines map[string]*v1alpha1.TinkerbellMachineCon
 	return nil
 }
 
-func (p *tinkerbellProvider) configureSshKeys() error {
+func (p *Provider) configureSshKeys() error {
 	ensureMachineConfigsHaveAtLeast1User(p.machineConfigs)
 
 	users := extractUserConfigurationsWithoutSshKeys(p.machineConfigs)

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -107,7 +107,7 @@ func (tb *TinkerbellTemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluste
 	return templater.AppendYamlResources(workerSpecs...), nil
 }
 
-func (p *tinkerbellProvider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currentSpec, newClusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
+func (p *Provider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currentSpec, newClusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	clusterName := newClusterSpec.Cluster.Name
 	var controlPlaneTemplateName, workloadTemplateName, kubeadmconfigTemplateName, etcdTemplateName string
 	var needsNewEtcdTemplate bool
@@ -230,7 +230,7 @@ func (p *tinkerbellProvider) generateCAPISpecForUpgrade(ctx context.Context, boo
 	return controlPlaneSpec, workersSpec, nil
 }
 
-func (p *tinkerbellProvider) GenerateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currentSpec, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
+func (p *Provider) GenerateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currentSpec, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	controlPlaneSpec, workersSpec, err = p.generateCAPISpecForUpgrade(ctx, bootstrapCluster, workloadCluster, currentSpec, clusterSpec)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error generating cluster api spec contents: %v", err)
@@ -238,15 +238,16 @@ func (p *tinkerbellProvider) GenerateCAPISpecForUpgrade(ctx context.Context, boo
 	return controlPlaneSpec, workersSpec, nil
 }
 
-func (p *tinkerbellProvider) GenerateCAPISpecForCreate(ctx context.Context, _ *types.Cluster, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
+func (p *Provider) GenerateCAPISpecForCreate(ctx context.Context, _ *types.Cluster, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	controlPlaneSpec, workersSpec, err = p.generateCAPISpecForCreate(ctx, clusterSpec)
+
 	if err != nil {
 		return nil, nil, fmt.Errorf("generating cluster api spec contents: %v", err)
 	}
 	return controlPlaneSpec, workersSpec, nil
 }
 
-func (p *tinkerbellProvider) generateCAPISpecForCreate(ctx context.Context, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
+func (p *Provider) generateCAPISpecForCreate(ctx context.Context, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	clusterName := clusterSpec.Cluster.Name
 
 	cpOpt := func(values map[string]interface{}) {
@@ -276,12 +277,12 @@ func (p *tinkerbellProvider) generateCAPISpecForCreate(ctx context.Context, clus
 	return controlPlaneSpec, workersSpec, nil
 }
 
-func (p *tinkerbellProvider) GenerateStorageClass() []byte {
+func (p *Provider) GenerateStorageClass() []byte {
 	// TODO: determine if we need something else here
 	return nil
 }
 
-func (p *tinkerbellProvider) GenerateMHC() ([]byte, error) {
+func (p *Provider) GenerateMHC() ([]byte, error) {
 	data := map[string]string{
 		"clusterName":         p.clusterConfig.Name,
 		"eksaSystemNamespace": constants.EksaSystemNamespace,
@@ -293,7 +294,7 @@ func (p *tinkerbellProvider) GenerateMHC() ([]byte, error) {
 	return mhc, nil
 }
 
-func (p *tinkerbellProvider) needsNewMachineTemplate(ctx context.Context, workloadCluster *types.Cluster, currentSpec, newClusterSpec *cluster.Spec, workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration, vdc *v1alpha1.TinkerbellDatacenterConfig, prevWorkerNodeGroupConfigs map[string]v1alpha1.WorkerNodeGroupConfiguration) (bool, error) {
+func (p *Provider) needsNewMachineTemplate(ctx context.Context, workloadCluster *types.Cluster, currentSpec, newClusterSpec *cluster.Spec, workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration, vdc *v1alpha1.TinkerbellDatacenterConfig, prevWorkerNodeGroupConfigs map[string]v1alpha1.WorkerNodeGroupConfiguration) (bool, error) {
 	if _, ok := prevWorkerNodeGroupConfigs[workerNodeGroupConfiguration.Name]; ok {
 		workerMachineConfig := p.machineConfigs[workerNodeGroupConfiguration.MachineGroupRef.Name]
 		workerTmc, err := p.providerKubectlClient.GetEksaTinkerbellMachineConfig(ctx, workerNodeGroupConfiguration.MachineGroupRef.Name, workloadCluster.KubeconfigFile, newClusterSpec.Cluster.Namespace)
@@ -306,7 +307,7 @@ func (p *tinkerbellProvider) needsNewMachineTemplate(ctx context.Context, worklo
 	return true, nil
 }
 
-func (p *tinkerbellProvider) needsNewKubeadmConfigTemplate(workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration, prevWorkerNodeGroupConfigs map[string]v1alpha1.WorkerNodeGroupConfiguration) (bool, error) {
+func (p *Provider) needsNewKubeadmConfigTemplate(workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration, prevWorkerNodeGroupConfigs map[string]v1alpha1.WorkerNodeGroupConfiguration) (bool, error) {
 	if _, ok := prevWorkerNodeGroupConfigs[workerNodeGroupConfiguration.Name]; ok {
 		existingWorkerNodeGroupConfig := prevWorkerNodeGroupConfigs[workerNodeGroupConfiguration.Name]
 		return NeedsNewKubeadmConfigTemplate(&workerNodeGroupConfiguration, &existingWorkerNodeGroupConfig), nil

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -50,7 +50,7 @@ func givenMachineConfigs(t *testing.T, fileName string) map[string]*v1alpha1.Tin
 	return machineConfigs
 }
 
-func newProviderWithKubectlWithTink(t *testing.T, datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineConfigs map[string]*v1alpha1.TinkerbellMachineConfig, clusterConfig *v1alpha1.Cluster, writer filewriter.FileWriter, kubectl ProviderKubectlClient, tinkerbellClients TinkerbellClients) *tinkerbellProvider {
+func newProviderWithKubectlWithTink(t *testing.T, datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineConfigs map[string]*v1alpha1.TinkerbellMachineConfig, clusterConfig *v1alpha1.Cluster, writer filewriter.FileWriter, kubectl ProviderKubectlClient, tinkerbellClients TinkerbellClients) *Provider {
 	return newProvider(
 		datacenterConfig,
 		machineConfigs,
@@ -61,7 +61,7 @@ func newProviderWithKubectlWithTink(t *testing.T, datacenterConfig *v1alpha1.Tin
 	)
 }
 
-func newProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineConfigs map[string]*v1alpha1.TinkerbellMachineConfig, clusterConfig *v1alpha1.Cluster, writer filewriter.FileWriter, kubectl ProviderKubectlClient, tinkerbellClients TinkerbellClients) *tinkerbellProvider {
+func newProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineConfigs map[string]*v1alpha1.TinkerbellMachineConfig, clusterConfig *v1alpha1.Cluster, writer filewriter.FileWriter, kubectl ProviderKubectlClient, tinkerbellClients TinkerbellClients) *Provider {
 	return NewProvider(
 		datacenterConfig,
 		machineConfigs,

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -61,7 +61,7 @@ func AnyImmutableFieldChanged(oldVdc, newVdc *v1alpha1.TinkerbellDatacenterConfi
 	return false
 }
 
-func (p *tinkerbellProvider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
+func (p *Provider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	logger.Info("Warning: The tinkerbell infrastructure provider is still in development and should not be used in production")
 
 	hardware, err := p.providerTinkClient.GetHardware(ctx)
@@ -111,7 +111,7 @@ func (p *tinkerbellProvider) SetupAndValidateUpgradeCluster(ctx context.Context,
 	return nil
 }
 
-func (p *tinkerbellProvider) RunPostControlPlaneUpgrade(ctx context.Context, oldClusterSpec *cluster.Spec, clusterSpec *cluster.Spec, workloadCluster *types.Cluster, managementCluster *types.Cluster) error {
+func (p *Provider) RunPostControlPlaneUpgrade(ctx context.Context, oldClusterSpec *cluster.Spec, clusterSpec *cluster.Spec, workloadCluster *types.Cluster, managementCluster *types.Cluster) error {
 	// @TODO: do we need this for bare metal upgrade?
 
 	// Use retrier so that cluster upgrade does not fail due to any intermittent failure while connecting to kube-api server
@@ -131,7 +131,7 @@ func (p *tinkerbellProvider) RunPostControlPlaneUpgrade(ctx context.Context, old
 	return nil
 }
 
-func (p *tinkerbellProvider) UpgradeNeeded(_ context.Context, _, _ *cluster.Spec, _ *types.Cluster) (bool, error) {
+func (p *Provider) UpgradeNeeded(_ context.Context, _, _ *cluster.Spec, _ *types.Cluster) (bool, error) {
 	// TODO: Figure out if something is needed here
 	return false, nil
 }


### PR DESCRIPTION
The provider is in tinkerbell package and should be exported, hence its renamed to `Provider` meaning consumers refer to it as `tinkerbell.Provider`.

_There are no functional changes_