### PR TITLE
make sure that classic gitops tests have the namespace set correctly …

### DIFF
--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -136,16 +136,20 @@ func WithClusterUpgradeGit(fillers ...api.ClusterFiller) ClusterE2ETestOpt {
 	return func(e *ClusterE2ETest) {
 		e.ClusterConfigB = e.customizeClusterConfig(e.clusterConfigGitPath(), fillers...)
 
-		if e.GitOpsConfig != nil {
-			e.FluxConfig = e.GitOpsConfig.ConvertToFluxConfig()
-		}
-
 		// TODO: e.GitopsConfig is defined from api.NewGitOpsConfig in WithFluxLegacy()
 		// instead of marshalling from the actual file in git repo.
 		// By default it does not include the namespace field. But Flux requires namespace always
 		// exist for all the objects managed by its kustomization controller.
 		// Need to refactor this to read gitopsconfig directly from file in git repo
 		// which always has the namespace field.
+
+		if e.GitOpsConfig != nil {
+			if e.GitOpsConfig.GetNamespace() == "" {
+				e.GitOpsConfig.SetNamespace("default")
+			}
+			e.FluxConfig = e.GitOpsConfig.ConvertToFluxConfig()
+		}
+
 		if e.FluxConfig.GetNamespace() == "" {
 			e.FluxConfig.SetNamespace("default")
 		}


### PR DESCRIPTION
…for multicluster

*Issue #, if available:*

*Description of changes:*
this was breaking GitOpsConfig-only tests, as the namespace was not being set on the GitOpsConfig, only the converted FluxConfig.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

