### PR TITLE
Implement Tinkerbell hardware catalogue indexes

### DIFF
--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -76,7 +76,7 @@ func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpe
 		return err
 	}
 
-	if err := hardware.ParseYAMLCatalogueFromFile(&p.catalogue, p.hardwareManifestPath); err != nil {
+	if err := hardware.ParseYAMLCatalogueFromFile(p.catalogue, p.hardwareManifestPath); err != nil {
 		return err
 	}
 
@@ -166,7 +166,7 @@ func (p *Provider) setHardwareStateToProvisining(ctx context.Context) error {
 // setMachinesToPXEBoot iterates over all catalogue.BMCs and instructs them to turn off, one-time
 // PXE boot, then turn on.
 func (p *Provider) setMachinesToPXEBoot(ctx context.Context) error {
-	secrets := make(map[string]corev1.Secret, len(p.catalogue.Secrets))
+	secrets := make(map[string]*corev1.Secret, len(p.catalogue.Secrets))
 	for _, secret := range p.catalogue.Secrets {
 		secrets[secret.Name] = secret
 	}
@@ -204,7 +204,7 @@ func (p *Provider) setMachinesToPXEBoot(ctx context.Context) error {
 // scrubWorkflowsFromTinkerbell removes all workflows in the Tinkerbell stack that feature in hardware by retrieving
 // hardware MAC addresses using tinkerbellHardware. tinkerbellHardware is necessary because MAC addresses aren't
 // available on the Hardware object type.
-func (p *Provider) scrubWorkflowsFromTinkerbell(ctx context.Context, hardware []tinkv1alpha1.Hardware, tinkerbellHardware []*tinkhardware.Hardware) error {
+func (p *Provider) scrubWorkflowsFromTinkerbell(ctx context.Context, hardware []*tinkv1alpha1.Hardware, tinkerbellHardware []*tinkhardware.Hardware) error {
 	workflows, err := p.providerTinkClient.GetWorkflow(ctx)
 	if err != nil {
 		return fmt.Errorf("retrieving workflows: %w", err)
@@ -244,7 +244,7 @@ func createHardwareIDToMACMapping(hardware []*tinkhardware.Hardware) (map[string
 	return hardwareMACLookup, nil
 }
 
-func createMACSetFromHardwareManifests(hardwareMACLookup map[string]string, hardware []tinkv1alpha1.Hardware) (macAddressSet, error) {
+func createMACSetFromHardwareManifests(hardwareMACLookup map[string]string, hardware []*tinkv1alpha1.Hardware) (macAddressSet, error) {
 	manifestHardwareMACs := make(macAddressSet)
 	for _, h := range hardware {
 		mac, found := hardwareMACLookup[h.Spec.ID]

--- a/pkg/providers/tinkerbell/hardware/catalogue.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue.go
@@ -2,7 +2,6 @@ package hardware
 
 import (
 	"bufio"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -10,275 +9,63 @@ import (
 
 	pbnjv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/pbnj/api/v1alpha1"
 	tinkv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/tink/api/v1alpha1"
-	tinkhardware "github.com/tinkerbell/tink/protos/hardware"
-	tinkworkflow "github.com/tinkerbell/tink/protos/workflow"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	apimachineryvalidation "k8s.io/apimachinery/pkg/util/validation"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
-
-	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/logger"
-	"github.com/aws/eks-anywhere/pkg/networkutils"
-	"github.com/aws/eks-anywhere/pkg/templater"
 )
 
 const Provisioning = "provisioning"
 
+// Indexer provides indexing behavior for objects.
+type Indexer interface {
+	// Lookup retrieves objects associated with the index => value pair.
+	Lookup(index, value string) ([]interface{}, error)
+	// Insert inserts v int the index.
+	Insert(v interface{}) error
+	// IndexField associated index with fn such that Lookup may be used to retrieve objects.
+	IndexField(index string, fn KeyExtractorFunc)
+}
+
+// Catalogue represents a catalogue of Tinkerbell hardware manifests to be used with Tinkerbells
+// Kubefied back-end.
 type Catalogue struct {
-	Hardware []tinkv1alpha1.Hardware
-	BMCs     []pbnjv1alpha1.BMC
-	Secrets  []corev1.Secret
+	Hardware      []*tinkv1alpha1.Hardware
+	hardwareIndex Indexer
+
+	BMCs     []*pbnjv1alpha1.BMC
+	bmcIndex Indexer
+
+	Secrets     []*corev1.Secret
+	secretIndex Indexer
 }
 
-func (c *Catalogue) ValidateHardware(skipPowerActions, force bool, tinkHardwareMap map[string]*tinkhardware.Hardware, tinkWorkflowMap map[string]*tinkworkflow.Workflow) error {
-	bmcRefMap := map[string]*tinkv1alpha1.Hardware{}
-	if !skipPowerActions {
-		bmcRefMap = c.initBmcRefMap()
+// CatalogueOption defines an option to be applied in Catalogue instantiation.
+type CatalogueOption func(*Catalogue)
+
+// NewCatalogue creates a new Catalogue instance.
+func NewCatalogue(opts ...CatalogueOption) *Catalogue {
+	catalogue := &Catalogue{
+		hardwareIndex: NewFieldIndexer(&tinkv1alpha1.Hardware{}),
+		bmcIndex:      NewFieldIndexer(&pbnjv1alpha1.BMC{}),
+		secretIndex:   NewFieldIndexer(&corev1.Secret{}),
 	}
 
-	// A database of observed hardware IDs so we can check for uniqueness.
-	hardwareIdsDb := make(map[string]struct{}, len(c.Hardware))
-
-	for _, hw := range c.Hardware {
-		if hw.Name == "" {
-			return fmt.Errorf("hardware name is required")
-		}
-
-		if errs := apimachineryvalidation.IsDNS1123Subdomain(hw.Name); len(errs) > 0 {
-			return fmt.Errorf("invalid hardware name: %v: %v", hw.Name, errs)
-		}
-
-		if hw.Spec.ID == "" {
-			return fmt.Errorf("hardware: %s ID is required", hw.Name)
-		}
-
-		if _, found := hardwareIdsDb[hw.Spec.ID]; found {
-			return fmt.Errorf("duplicate hardware id: %v", hw.Spec.ID)
-		}
-		hardwareIdsDb[hw.Spec.ID] = struct{}{}
-
-		if _, ok := tinkHardwareMap[hw.Spec.ID]; !ok {
-			return fmt.Errorf("hardware id '%s' is not registered with tinkerbell stack", hw.Spec.ID)
-		}
-
-		hardwareInterface := tinkHardwareMap[hw.Spec.ID].GetNetwork().GetInterfaces()
-		for _, interfaces := range hardwareInterface {
-			mac := interfaces.GetDhcp()
-			if _, ok := tinkWorkflowMap[mac.Mac]; ok {
-				message := fmt.Sprintf("workflow %s already exixts for the hardware id %s", tinkWorkflowMap[mac.Mac].Id, hw.Spec.ID)
-
-				// If the --force-cleanup flag was set we have to warn. This is beacuse we haven't separated static
-				// and interactive validations so there's no opportunity, after performing static yaml validation, to
-				// delete any workflows before we check if workflows alredy exist. To avoid erroring out before getting
-				// the chance to delete workflows this code assumes workflows will be deleted at a later stage,
-				// therefore warns only.
-				if !force {
-					return fmt.Errorf(message)
-				}
-				logger.V(2).Info(fmt.Sprintf("Warn: %v", message))
-			}
-		}
-
-		if !force {
-			hardwareMetadata := make(map[string]interface{})
-			tinkHardware := tinkHardwareMap[hw.Spec.ID]
-
-			if err := json.Unmarshal([]byte(tinkHardware.GetMetadata()), &hardwareMetadata); err != nil {
-				return fmt.Errorf("unmarshaling hardware metadata: %v", err)
-			}
-
-			if hardwareMetadata["state"] != Provisioning {
-				return fmt.Errorf("expecting hardware state to be '%s' but it is '%s'; use --force-cleanup flag to reset the state", "provisioning", hardwareMetadata["state"])
-			}
-		}
-
-		if !skipPowerActions {
-			if hw.Spec.BmcRef == "" {
-				return fmt.Errorf("bmcRef not present in hardware %s", hw.Name)
-			}
-
-			h, ok := bmcRefMap[hw.Spec.BmcRef]
-			if ok && h != nil {
-				return fmt.Errorf("bmcRef %s present in both hardware %s and hardware %s", hw.Spec.BmcRef, hw.Name, h.Name)
-			}
-			if !ok {
-				return fmt.Errorf("bmcRef %s not found in hardware config", hw.Spec.BmcRef)
-			}
-
-			bmcRefMap[hw.Spec.BmcRef] = &hw
-		}
+	for _, opt := range opts {
+		opt(catalogue)
 	}
 
-	return nil
-}
-
-func (c *Catalogue) ValidateBMC() error {
-	secretRefMap := c.initSecretRefMap()
-	bmcIpMap := make(map[string]struct{}, len(c.BMCs))
-	for _, bmc := range c.BMCs {
-		if bmc.Name == "" {
-			return fmt.Errorf("bmc name is required")
-		}
-
-		if bmc.Spec.AuthSecretRef.Name == "" {
-			return fmt.Errorf("authSecretRef name required for bmc %s", bmc.Name)
-		}
-
-		if bmc.Spec.AuthSecretRef.Namespace != constants.EksaSystemNamespace {
-			return fmt.Errorf("invalid authSecretRef namespace: %s for bmc %s", bmc.Spec.AuthSecretRef.Namespace, bmc.Name)
-		}
-
-		if _, ok := secretRefMap[bmc.Spec.AuthSecretRef.Name]; !ok {
-			return fmt.Errorf("bmc authSecretRef: %s not present in hardware config", bmc.Spec.AuthSecretRef.String())
-		}
-
-		if _, ok := bmcIpMap[bmc.Spec.Host]; ok {
-			return fmt.Errorf("duplicate host IP: %s for bmc %s", bmc.Spec.Host, bmc.Name)
-		} else {
-			bmcIpMap[bmc.Spec.Host] = struct{}{}
-		}
-
-		if err := networkutils.ValidateIP(bmc.Spec.Host); err != nil {
-			return fmt.Errorf("bmc host IP: %v", err)
-		}
-
-		if bmc.Spec.Vendor == "" {
-			return fmt.Errorf("bmc: %s vendor is required", bmc.Name)
-		}
-	}
-
-	return nil
-}
-
-func (c *Catalogue) ValidateBmcSecretRefs() error {
-	for _, s := range c.Secrets {
-		if s.Name == "" {
-			return fmt.Errorf("secret name is required")
-		}
-		if s.Namespace != constants.EksaSystemNamespace {
-			return fmt.Errorf("invalid secret namespace: %s for secret: %s expected: %s", s.Namespace, s.Name, constants.EksaSystemNamespace)
-		}
-		dUsr, dOk := s.Data["username"]
-		sdUsr, sdOk := s.StringData["username"]
-		if !dOk && !sdOk {
-			return fmt.Errorf("secret: %s must contain key username", s.Name)
-		}
-		if (dOk && len(dUsr) == 0) || (sdOk && sdUsr == "") {
-			return fmt.Errorf("username can not be empty for secret: %s", s.Name)
-		}
-
-		dPwd, dOk := s.Data["password"]
-		sdPwd, sdOk := s.StringData["password"]
-		if !dOk && !sdOk {
-			return fmt.Errorf("secret: %s must contain key password", s.Name)
-		}
-		if (dOk && len(dPwd) == 0) || (sdOk && sdPwd == "") {
-			return fmt.Errorf("password can not be empty for secret: %s", s.Name)
-		}
-	}
-
-	return nil
-}
-
-func (c *Catalogue) initBmcRefMap() map[string]*tinkv1alpha1.Hardware {
-	bmcRefMap := make(map[string]*tinkv1alpha1.Hardware, len(c.BMCs))
-	for _, bmc := range c.BMCs {
-		bmcRefMap[bmc.Name] = nil
-	}
-
-	return bmcRefMap
-}
-
-func (c *Catalogue) initSecretRefMap() map[string]struct{} {
-	secretRefMap := make(map[string]struct{}, len(c.Secrets))
-	for _, s := range c.Secrets {
-		secretRefMap[s.Name] = struct{}{}
-	}
-
-	return secretRefMap
-}
-
-func (c *Catalogue) HardwareSpecMarshallable() ([]byte, error) {
-	var marshallables []v1alpha1.Marshallable
-
-	for _, hw := range c.Hardware {
-		marshallables = append(marshallables, hardwareMarshallable(hw))
-	}
-	for _, bmc := range c.BMCs {
-		marshallables = append(marshallables, bmcMarshallable(bmc))
-	}
-	for _, secret := range c.Secrets {
-		marshallables = append(marshallables, secretsMarshallable(secret))
-	}
-
-	resources := make([][]byte, 0, len(marshallables))
-	for _, marshallable := range marshallables {
-		resource, err := yaml.Marshal(marshallable)
-		if err != nil {
-			return nil, fmt.Errorf("failed marshalling resource for hardware spec: %v", err)
-		}
-		resources = append(resources, resource)
-	}
-	return templater.AppendYamlResources(resources...), nil
-}
-
-func hardwareMarshallable(hw tinkv1alpha1.Hardware) *tinkv1alpha1.Hardware {
-	config := &tinkv1alpha1.Hardware{
-		TypeMeta: hw.TypeMeta,
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        hw.Name,
-			Annotations: hw.Annotations,
-			Namespace:   hw.Namespace,
-			Labels:      hw.Labels,
-		},
-		Spec: hw.Spec,
-	}
-
-	return config
-}
-
-func bmcMarshallable(bmc pbnjv1alpha1.BMC) *pbnjv1alpha1.BMC {
-	config := &pbnjv1alpha1.BMC{
-		TypeMeta: bmc.TypeMeta,
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        bmc.Name,
-			Annotations: bmc.Annotations,
-			Namespace:   bmc.Namespace,
-			Labels:      bmc.Labels,
-		},
-		Spec: bmc.Spec,
-	}
-
-	return config
-}
-
-func secretsMarshallable(secret corev1.Secret) *corev1.Secret {
-	config := &corev1.Secret{
-		TypeMeta: secret.TypeMeta,
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        secret.Name,
-			Annotations: secret.Annotations,
-			Namespace:   secret.Namespace,
-			Labels:      secret.Labels,
-		},
-		Data: secret.Data,
-	}
-
-	return config
+	return catalogue
 }
 
 // ParseYAMLCatalogueFromFile parses filename, a YAML document, using ParseYamlCatalogue.
-func ParseYAMLCatalogueFromFile(config *Catalogue, filename string) error {
+func ParseYAMLCatalogueFromFile(catalogue *Catalogue, filename string) error {
 	fh, err := os.Open(filename)
 	if err != nil {
 		return err
 	}
 
-	return ParseYAMLCatalogue(config, fh)
+	return ParseYAMLCatalogue(catalogue, fh)
 }
 
 // ParseCatalogue parses a YAML document, r, that represents a set of Kubernetes manifests.
@@ -301,26 +88,50 @@ func ParseYAMLCatalogue(catalogue *Catalogue, r io.Reader) error {
 
 		switch resource.GetKind() {
 		case "Hardware":
-			var hardware tinkv1alpha1.Hardware
-			err = yaml.UnmarshalStrict(manifest, &hardware)
-			if err != nil {
-				return fmt.Errorf("unable to parse hardware manifest: %v", err)
+			if err := catalogueSerializedHardware(catalogue, manifest); err != nil {
+				return err
 			}
-			catalogue.Hardware = append(catalogue.Hardware, hardware)
 		case "BMC":
-			var bmc pbnjv1alpha1.BMC
-			err = yaml.UnmarshalStrict(manifest, &bmc)
-			if err != nil {
-				return fmt.Errorf("unable to parse bmc manifest: %v", err)
+			if err := catalogueSerializedBMC(catalogue, manifest); err != nil {
+				return err
 			}
-			catalogue.BMCs = append(catalogue.BMCs, bmc)
 		case "Secret":
-			var secret corev1.Secret
-			err = yaml.UnmarshalStrict(manifest, &secret)
-			if err != nil {
-				return fmt.Errorf("unable to parse secret manifest: %v", err)
+			if err := catalogueSerializedSecret(catalogue, manifest); err != nil {
+				return err
 			}
-			catalogue.Secrets = append(catalogue.Secrets, secret)
 		}
 	}
+}
+
+func catalogueSerializedHardware(catalogue *Catalogue, manifest []byte) error {
+	var hardware tinkv1alpha1.Hardware
+	if err := yaml.UnmarshalStrict(manifest, &hardware); err != nil {
+		return fmt.Errorf("unable to parse hardware manifest: %v", err)
+	}
+	if err := catalogue.InsertHardware(&hardware); err != nil {
+		return err
+	}
+	return nil
+}
+
+func catalogueSerializedBMC(catalogue *Catalogue, manifest []byte) error {
+	var bmc pbnjv1alpha1.BMC
+	if err := yaml.UnmarshalStrict(manifest, &bmc); err != nil {
+		return fmt.Errorf("unable to parse bmc manifest: %v", err)
+	}
+	if err := catalogue.InsertBMC(&bmc); err != nil {
+		return err
+	}
+	return nil
+}
+
+func catalogueSerializedSecret(catalogue *Catalogue, manifest []byte) error {
+	var secret corev1.Secret
+	if err := yaml.UnmarshalStrict(manifest, &secret); err != nil {
+		return fmt.Errorf("unable to parse secret manifest: %v", err)
+	}
+	if err := catalogue.InsertSecret(&secret); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/providers/tinkerbell/hardware/catalogue_bmc.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_bmc.go
@@ -1,0 +1,57 @@
+package hardware
+
+import pbnjv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/pbnj/api/v1alpha1"
+
+// IndexBMCs indexes BMC instances on index by extracfting the key using fn.
+func (c *Catalogue) IndexBMCs(index string, fn KeyExtractorFunc) {
+	c.bmcIndex.IndexField(index, fn)
+}
+
+// InsertBMC inserts BMCs into the catalogue. If any indexes exist, the BMC is indexed.
+func (c *Catalogue) InsertBMC(bmc *pbnjv1alpha1.BMC) error {
+	if err := c.bmcIndex.Insert(bmc); err != nil {
+		return err
+	}
+	c.BMCs = append(c.BMCs, bmc)
+	return nil
+}
+
+// AllBMCs retrieves a copy of the catalogued BMC instances.
+func (c *Catalogue) AllBMCs() []*pbnjv1alpha1.BMC {
+	bmcs := make([]*pbnjv1alpha1.BMC, len(c.BMCs))
+	copy(bmcs, c.BMCs)
+	return bmcs
+}
+
+// LookupBMC retrieves BMC instances on index with a key of key. Multiple BMCs _may_
+// have the same key hence it can return multiple BMCs.
+func (c *Catalogue) LookupBMC(index, key string) ([]*pbnjv1alpha1.BMC, error) {
+	untyped, err := c.bmcIndex.Lookup(index, key)
+	if err != nil {
+		return nil, err
+	}
+
+	bmcs := make([]*pbnjv1alpha1.BMC, len(untyped))
+	for i, v := range untyped {
+		bmcs[i] = v.(*pbnjv1alpha1.BMC)
+	}
+
+	return bmcs, nil
+}
+
+// TotalBMCs returns the total BMCs registered in the catalogue.
+func (c *Catalogue) TotalBMCs() int {
+	return len(c.BMCs)
+}
+
+const BMCNameIndex = ".ObjectMeta.Name"
+
+// WithBMCNameIndex creates a BMC index using BMCNameIndex on BMC.ObjectMeta.Name.
+func WithBMCNameIndex() CatalogueOption {
+	return func(c *Catalogue) {
+		c.IndexBMCs(BMCNameIndex, func(o interface{}) string {
+			bmc := o.(*pbnjv1alpha1.BMC)
+			return bmc.ObjectMeta.Name
+		})
+	}
+}

--- a/pkg/providers/tinkerbell/hardware/catalogue_bmc_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_bmc_test.go
@@ -1,0 +1,64 @@
+package hardware_test
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/tinkerbell/cluster-api-provider-tinkerbell/pbnj/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
+)
+
+func TestCatalogue_BMC_Insert(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+
+	err := catalogue.InsertBMC(&v1alpha1.BMC{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(catalogue.TotalBMCs()).To(gomega.Equal(1))
+}
+
+func TestCatalogue_BMC_UnknownIndexErrors(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+
+	_, err := catalogue.LookupBMC(hardware.BMCNameIndex, "Name")
+	g.Expect(err).To(gomega.HaveOccurred())
+}
+
+func TestCatalogue_BMC_Indexed(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue(hardware.WithBMCNameIndex())
+
+	const name = "hello"
+	expect := &v1alpha1.BMC{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	err := catalogue.InsertBMC(expect)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	received, err := catalogue.LookupBMC(hardware.BMCNameIndex, name)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(received).To(gomega.HaveLen(1))
+	g.Expect(received[0]).To(gomega.Equal(expect))
+}
+
+func TestCatalogue_BMC_AllBMCsReceivesCopy(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue(hardware.WithHardwareIDIndex())
+
+	const totalHardware = 1
+	err := catalogue.InsertBMC(&v1alpha1.BMC{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	changedHardware := catalogue.AllBMCs()
+	g.Expect(changedHardware).To(gomega.HaveLen(totalHardware))
+
+	changedHardware[0] = &v1alpha1.BMC{ObjectMeta: metav1.ObjectMeta{Name: "qux"}}
+
+	unchangedHardware := catalogue.AllBMCs()
+	g.Expect(unchangedHardware).ToNot(gomega.Equal(changedHardware))
+}

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
@@ -1,0 +1,70 @@
+package hardware
+
+import tinkv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/tink/api/v1alpha1"
+
+// IndexHardware indexes Hardware instances on index by extracfting the key using fn.
+func (c *Catalogue) IndexHardware(index string, fn KeyExtractorFunc) {
+	c.hardwareIndex.IndexField(index, fn)
+}
+
+// InsertHardware inserts Hardware into the catalogue. If any indexes exist, the hardware is
+// indexed.
+func (c *Catalogue) InsertHardware(hardware *tinkv1alpha1.Hardware) error {
+	if err := c.hardwareIndex.Insert(hardware); err != nil {
+		return err
+	}
+	c.Hardware = append(c.Hardware, hardware)
+	return nil
+}
+
+// AllHardware retrieves a copy of the catalogued Hardware instances.
+func (c *Catalogue) AllHardware() []*tinkv1alpha1.Hardware {
+	hardware := make([]*tinkv1alpha1.Hardware, len(c.Hardware))
+	copy(hardware, c.Hardware)
+	return hardware
+}
+
+// LookupHardware retrieves Hardware instances on index with a key of key. Multiple hardware _may_
+// have the same key hence it can return multiple Hardware.
+func (c *Catalogue) LookupHardware(index, key string) ([]*tinkv1alpha1.Hardware, error) {
+	untyped, err := c.hardwareIndex.Lookup(index, key)
+	if err != nil {
+		return nil, err
+	}
+
+	hardware := make([]*tinkv1alpha1.Hardware, len(untyped))
+	for i, v := range untyped {
+		hardware[i] = v.(*tinkv1alpha1.Hardware)
+	}
+
+	return hardware, nil
+}
+
+// TotalHardware returns the total hardware registered in the catalogue.
+func (c *Catalogue) TotalHardware() int {
+	return len(c.Hardware)
+}
+
+const HardwareIDIndex = ".Spec.ID"
+
+// WithHardwareIDIndex creates a Hardware index using HardwareIDIndex on Hardware.Spec.ID values.
+func WithHardwareIDIndex() CatalogueOption {
+	return func(c *Catalogue) {
+		c.IndexHardware(HardwareIDIndex, func(o interface{}) string {
+			hardware := o.(*tinkv1alpha1.Hardware)
+			return hardware.Spec.ID
+		})
+	}
+}
+
+const HardwareBMCRefIndex = ".Spec.BmcRef"
+
+// WithHardwareBMCRefIndex creates a Hardware index using HardwareBMCRefIndex on Hardware.Spec.BmcRef.
+func WithHardwareBMCRefIndex() CatalogueOption {
+	return func(c *Catalogue) {
+		c.IndexHardware(HardwareBMCRefIndex, func(o interface{}) string {
+			hardware := o.(*tinkv1alpha1.Hardware)
+			return hardware.Spec.BmcRef
+		})
+	}
+}

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware_test.go
@@ -1,0 +1,79 @@
+package hardware_test
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/tinkerbell/cluster-api-provider-tinkerbell/tink/api/v1alpha1"
+
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
+)
+
+func TestCatalogue_Hardware_Insert(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+
+	err := catalogue.InsertHardware(&v1alpha1.Hardware{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(1))
+}
+
+func TestCatalogue_Hardware_UnknownIndexErrors(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+
+	_, err := catalogue.LookupHardware(hardware.HardwareIDIndex, "ID")
+	g.Expect(err).To(gomega.HaveOccurred())
+}
+
+func TestCatalogue_Hardware_IDIndex(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue(hardware.WithHardwareIDIndex())
+
+	const id = "hello"
+	expect := &v1alpha1.Hardware{Spec: v1alpha1.HardwareSpec{ID: id}}
+	err := catalogue.InsertHardware(expect)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	received, err := catalogue.LookupHardware(hardware.HardwareIDIndex, id)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(received).To(gomega.HaveLen(1))
+	g.Expect(received[0]).To(gomega.Equal(expect))
+}
+
+func TestCatalogue_Hardware_BmcRefIndex(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue(hardware.WithHardwareBMCRefIndex())
+
+	const ref = "bmc-ref"
+	expect := &v1alpha1.Hardware{Spec: v1alpha1.HardwareSpec{BmcRef: ref}}
+	err := catalogue.InsertHardware(expect)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	received, err := catalogue.LookupHardware(hardware.HardwareBMCRefIndex, ref)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(received).To(gomega.HaveLen(1))
+	g.Expect(received[0]).To(gomega.Equal(expect))
+}
+
+func TestCatalogue_Hardware_AllHardwareReceivesCopy(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue(hardware.WithHardwareIDIndex())
+
+	const totalHardware = 1
+	err := catalogue.InsertHardware(&v1alpha1.Hardware{Spec: v1alpha1.HardwareSpec{ID: "foo"}})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	changedHardware := catalogue.AllHardware()
+	g.Expect(changedHardware).To(gomega.HaveLen(totalHardware))
+
+	changedHardware[0] = &v1alpha1.Hardware{Spec: v1alpha1.HardwareSpec{ID: "qux"}}
+
+	unchangedHardware := catalogue.AllHardware()
+	g.Expect(unchangedHardware).ToNot(gomega.Equal(changedHardware))
+}

--- a/pkg/providers/tinkerbell/hardware/catalogue_secret.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_secret.go
@@ -1,0 +1,57 @@
+package hardware
+
+import corev1 "k8s.io/api/core/v1"
+
+// IndexSecret indexes Secret instances on index by extracfting the key using fn.
+func (c *Catalogue) IndexSecret(index string, fn KeyExtractorFunc) {
+	c.secretIndex.IndexField(index, fn)
+}
+
+// InsertSecret inserts Secrets into the catalogue. If any indexes exist, the Secret is indexed.
+func (c *Catalogue) InsertSecret(secret *corev1.Secret) error {
+	if err := c.secretIndex.Insert(secret); err != nil {
+		return err
+	}
+	c.Secrets = append(c.Secrets, secret)
+	return nil
+}
+
+// AllSecrets retrieves a copy of the catalogued Secret instances.
+func (c *Catalogue) AllSecrets() []*corev1.Secret {
+	secrets := make([]*corev1.Secret, len(c.Secrets))
+	copy(secrets, c.Secrets)
+	return secrets
+}
+
+// LookupSecret retrieves Secret instances on index with a key of key. Multiple Secrets _may_
+// have the same key hence it can return multiple Secrets.
+func (c *Catalogue) LookupSecret(index, key string) ([]*corev1.Secret, error) {
+	untyped, err := c.secretIndex.Lookup(index, key)
+	if err != nil {
+		return nil, err
+	}
+
+	secrets := make([]*corev1.Secret, len(untyped))
+	for i, v := range untyped {
+		secrets[i] = v.(*corev1.Secret)
+	}
+
+	return secrets, nil
+}
+
+// TotalSecrets returns the total Secrets registered in the catalogue.
+func (c *Catalogue) TotalSecrets() int {
+	return len(c.Secrets)
+}
+
+const SecretNameIndex = ".ObjectMeta.Name"
+
+// WithSecretNameIndex creates a Secret index using SecretNameIndex on Secret.ObjectMeta.Name.
+func WithSecretNameIndex() CatalogueOption {
+	return func(c *Catalogue) {
+		c.IndexSecret(SecretNameIndex, func(o interface{}) string {
+			secret := o.(*corev1.Secret)
+			return secret.ObjectMeta.Name
+		})
+	}
+}

--- a/pkg/providers/tinkerbell/hardware/catalogue_secret_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_secret_test.go
@@ -1,0 +1,64 @@
+package hardware_test
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
+)
+
+func TestCatalogue_Secret_Insert(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+
+	err := catalogue.InsertSecret(&corev1.Secret{})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(catalogue.TotalSecrets()).To(gomega.Equal(1))
+}
+
+func TestCatalogue_Secret_UnknownIndexErrors(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+
+	_, err := catalogue.LookupSecret(hardware.SecretNameIndex, "Name")
+	g.Expect(err).To(gomega.HaveOccurred())
+}
+
+func TestCatalogue_Secret_Indexed(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue(hardware.WithSecretNameIndex())
+
+	const name = "hello"
+	expect := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	err := catalogue.InsertSecret(expect)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	received, err := catalogue.LookupSecret(hardware.SecretNameIndex, name)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(received).To(gomega.HaveLen(1))
+	g.Expect(received[0]).To(gomega.Equal(expect))
+}
+
+func TestCatalogue_Secret_AllSecretsReceivesCopy(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue(hardware.WithHardwareIDIndex())
+
+	const totalHardware = 1
+	err := catalogue.InsertSecret(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	changedHardware := catalogue.AllSecrets()
+	g.Expect(changedHardware).To(gomega.HaveLen(totalHardware))
+
+	changedHardware[0] = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "qux"}}
+
+	unchangedHardware := catalogue.AllSecrets()
+	g.Expect(unchangedHardware).ToNot(gomega.Equal(changedHardware))
+}

--- a/pkg/providers/tinkerbell/hardware/catalogue_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_test.go
@@ -1,0 +1,84 @@
+package hardware_test
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
+)
+
+const hardwareManifestsYAML = `
+apiVersion: tinkerbell.org/v1alpha1
+kind: Hardware
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: worker1
+  namespace: eksa-system
+spec:
+  bmcRef: bmc-worker1
+  id: b14d7f5b-8903-4a4c-b38d-55889ba820ba
+status: {}
+---
+apiVersion: tinkerbell.org/v1alpha1
+kind: BMC
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: bmc-worker1
+  namespace: eksa-system
+spec:
+  authSecretRef:
+    name: bmc-worker1-auth
+    namespace: eksa-system
+  host: 192.168.0.10
+  vendor: supermicro
+status: {}
+---
+apiVersion: v1
+data:
+  password: QWRtaW4=
+  username: YWRtaW4=
+kind: Secret
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: bmc-worker1-auth
+  namespace: eksa-system
+type: kubernetes.io/basic-auth
+`
+
+func TestParseYAMLCatalogueWithData(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	buffer := bufio.NewReader(bytes.NewBufferString(hardwareManifestsYAML))
+	catalogue := hardware.NewCatalogue()
+
+	err := hardware.ParseYAMLCatalogue(catalogue, buffer)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	g.Expect(catalogue.Hardware).To(gomega.HaveLen(1))
+	g.Expect(catalogue.BMCs).To(gomega.HaveLen(1))
+	g.Expect(catalogue.Secrets).To(gomega.HaveLen(1))
+}
+
+func TestParseYAMLCatalogueWithoutData(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	var buf bytes.Buffer
+	buffer := bufio.NewReader(&buf)
+	catalogue := hardware.NewCatalogue()
+
+	err := hardware.ParseYAMLCatalogue(catalogue, buffer)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	g.Expect(catalogue.Hardware).To(gomega.HaveLen(0))
+	g.Expect(catalogue.BMCs).To(gomega.HaveLen(0))
+	g.Expect(catalogue.Secrets).To(gomega.HaveLen(0))
+}
+
+func TestCatalogue_Thing(t *testing.T) {
+}

--- a/pkg/providers/tinkerbell/hardware/catalogue_validations.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_validations.go
@@ -1,0 +1,214 @@
+package hardware
+
+import (
+	"encoding/json"
+	"fmt"
+
+	tinkv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/tink/api/v1alpha1"
+	tinkhardware "github.com/tinkerbell/tink/protos/hardware"
+	tinkworkflow "github.com/tinkerbell/tink/protos/workflow"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/networkutils"
+	"github.com/aws/eks-anywhere/pkg/templater"
+)
+
+// todo(chrisdoheryt4)
+// This file is temporary. The validation logic will be extracted to its own validation construct
+// and any remaining functions either turned into stand-alone funcs or moved elsewhere.
+
+func (c *Catalogue) ValidateHardware(skipPowerActions, force bool, tinkHardwareMap map[string]*tinkhardware.Hardware, tinkWorkflowMap map[string]*tinkworkflow.Workflow) error {
+	bmcRefMap := map[string]*tinkv1alpha1.Hardware{}
+	if !skipPowerActions {
+		bmcRefMap = c.initBmcRefMap()
+	}
+
+	// A database of observed hardware IDs so we can check for uniqueness.
+	hardwareIdsDb := make(map[string]struct{}, len(c.Hardware))
+
+	for _, hw := range c.Hardware {
+		if hw.Name == "" {
+			return fmt.Errorf("hardware name is required")
+		}
+
+		if errs := apimachineryvalidation.IsDNS1123Subdomain(hw.Name); len(errs) > 0 {
+			return fmt.Errorf("invalid hardware name: %v: %v", hw.Name, errs)
+		}
+
+		if hw.Spec.ID == "" {
+			return fmt.Errorf("hardware: %s ID is required", hw.Name)
+		}
+
+		if _, found := hardwareIdsDb[hw.Spec.ID]; found {
+			return fmt.Errorf("duplicate hardware id: %v", hw.Spec.ID)
+		}
+		hardwareIdsDb[hw.Spec.ID] = struct{}{}
+
+		if _, ok := tinkHardwareMap[hw.Spec.ID]; !ok {
+			return fmt.Errorf("hardware id '%s' is not registered with tinkerbell stack", hw.Spec.ID)
+		}
+
+		hardwareInterface := tinkHardwareMap[hw.Spec.ID].GetNetwork().GetInterfaces()
+		for _, interfaces := range hardwareInterface {
+			mac := interfaces.GetDhcp()
+			if _, ok := tinkWorkflowMap[mac.Mac]; ok {
+				message := fmt.Sprintf("workflow %s already exixts for the hardware id %s", tinkWorkflowMap[mac.Mac].Id, hw.Spec.ID)
+
+				// If the --force-cleanup flag was set we have to warn. This is beacuse we haven't separated static
+				// and interactive validations so there's no opportunity, after performing static yaml validation, to
+				// delete any workflows before we check if workflows alredy exist. To avoid erroring out before getting
+				// the chance to delete workflows this code assumes workflows will be deleted at a later stage,
+				// therefore warns only.
+				if !force {
+					return fmt.Errorf(message)
+				}
+				logger.V(2).Info(fmt.Sprintf("Warn: %v", message))
+			}
+		}
+
+		if !force {
+			hardwareMetadata := make(map[string]interface{})
+			tinkHardware := tinkHardwareMap[hw.Spec.ID]
+
+			if err := json.Unmarshal([]byte(tinkHardware.GetMetadata()), &hardwareMetadata); err != nil {
+				return fmt.Errorf("unmarshaling hardware metadata: %v", err)
+			}
+
+			if hardwareMetadata["state"] != Provisioning {
+				return fmt.Errorf("expecting hardware state to be '%s' but it is '%s'; use --force-cleanup flag to reset the state", "provisioning", hardwareMetadata["state"])
+			}
+		}
+
+		if !skipPowerActions {
+			if hw.Spec.BmcRef == "" {
+				return fmt.Errorf("bmcRef not present in hardware %s", hw.Name)
+			}
+
+			h, ok := bmcRefMap[hw.Spec.BmcRef]
+			if ok && h != nil {
+				return fmt.Errorf("bmcRef %s present in both hardware %s and hardware %s", hw.Spec.BmcRef, hw.Name, h.Name)
+			}
+			if !ok {
+				return fmt.Errorf("bmcRef %s not found in hardware config", hw.Spec.BmcRef)
+			}
+
+			bmcRefMap[hw.Spec.BmcRef] = hw
+		}
+	}
+
+	return nil
+}
+
+func (c *Catalogue) ValidateBMC() error {
+	secretRefMap := c.initSecretRefMap()
+	bmcIpMap := make(map[string]struct{}, len(c.BMCs))
+	for _, bmc := range c.BMCs {
+		if bmc.Name == "" {
+			return fmt.Errorf("bmc name is required")
+		}
+
+		if bmc.Spec.AuthSecretRef.Name == "" {
+			return fmt.Errorf("authSecretRef name required for bmc %s", bmc.Name)
+		}
+
+		if bmc.Spec.AuthSecretRef.Namespace != constants.EksaSystemNamespace {
+			return fmt.Errorf("invalid authSecretRef namespace: %s for bmc %s", bmc.Spec.AuthSecretRef.Namespace, bmc.Name)
+		}
+
+		if _, ok := secretRefMap[bmc.Spec.AuthSecretRef.Name]; !ok {
+			return fmt.Errorf("bmc authSecretRef: %s not present in hardware config", bmc.Spec.AuthSecretRef.String())
+		}
+
+		if _, ok := bmcIpMap[bmc.Spec.Host]; ok {
+			return fmt.Errorf("duplicate host IP: %s for bmc %s", bmc.Spec.Host, bmc.Name)
+		} else {
+			bmcIpMap[bmc.Spec.Host] = struct{}{}
+		}
+
+		if err := networkutils.ValidateIP(bmc.Spec.Host); err != nil {
+			return fmt.Errorf("bmc host IP: %v", err)
+		}
+
+		if bmc.Spec.Vendor == "" {
+			return fmt.Errorf("bmc: %s vendor is required", bmc.Name)
+		}
+	}
+
+	return nil
+}
+
+func (c *Catalogue) ValidateBmcSecretRefs() error {
+	for _, s := range c.Secrets {
+		if s.Name == "" {
+			return fmt.Errorf("secret name is required")
+		}
+		if s.Namespace != constants.EksaSystemNamespace {
+			return fmt.Errorf("invalid secret namespace: %s for secret: %s expected: %s", s.Namespace, s.Name, constants.EksaSystemNamespace)
+		}
+		dUsr, dOk := s.Data["username"]
+		sdUsr, sdOk := s.StringData["username"]
+		if !dOk && !sdOk {
+			return fmt.Errorf("secret: %s must contain key username", s.Name)
+		}
+		if (dOk && len(dUsr) == 0) || (sdOk && sdUsr == "") {
+			return fmt.Errorf("username can not be empty for secret: %s", s.Name)
+		}
+
+		dPwd, dOk := s.Data["password"]
+		sdPwd, sdOk := s.StringData["password"]
+		if !dOk && !sdOk {
+			return fmt.Errorf("secret: %s must contain key password", s.Name)
+		}
+		if (dOk && len(dPwd) == 0) || (sdOk && sdPwd == "") {
+			return fmt.Errorf("password can not be empty for secret: %s", s.Name)
+		}
+	}
+
+	return nil
+}
+
+func (c *Catalogue) initBmcRefMap() map[string]*tinkv1alpha1.Hardware {
+	bmcRefMap := make(map[string]*tinkv1alpha1.Hardware, len(c.BMCs))
+	for _, bmc := range c.BMCs {
+		bmcRefMap[bmc.Name] = nil
+	}
+
+	return bmcRefMap
+}
+
+func (c *Catalogue) initSecretRefMap() map[string]struct{} {
+	secretRefMap := make(map[string]struct{}, len(c.Secrets))
+	for _, s := range c.Secrets {
+		secretRefMap[s.Name] = struct{}{}
+	}
+
+	return secretRefMap
+}
+
+func (c *Catalogue) HardwareSpecMarshallable() ([]byte, error) {
+	var marshallables []v1alpha1.Marshallable
+
+	for _, hw := range c.Hardware {
+		marshallables = append(marshallables, hw)
+	}
+	for _, bmc := range c.BMCs {
+		marshallables = append(marshallables, bmc)
+	}
+	for _, secret := range c.Secrets {
+		marshallables = append(marshallables, secret)
+	}
+
+	resources := make([][]byte, 0, len(marshallables))
+	for _, marshallable := range marshallables {
+		resource, err := yaml.Marshal(marshallable)
+		if err != nil {
+			return nil, fmt.Errorf("failed marshalling resource for hardware spec: %v", err)
+		}
+		resources = append(resources, resource)
+	}
+	return templater.AppendYamlResources(resources...), nil
+}

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -65,7 +65,7 @@ type Provider struct {
 
 	hardwareManifestPath string
 	// catalogue is a cache initialized during SetupAndValidateCreateCluster() from hardwareManifestPath.
-	catalogue hardware.Catalogue
+	catalogue *hardware.Catalogue
 
 	skipIpCheck      bool
 	skipPowerActions bool
@@ -195,9 +195,11 @@ func NewProviderCustomDep(
 			etcdMachineSpec:             etcdMachineSpec,
 			now:                         now,
 		},
+		validator: NewValidator(providerTinkClient, netClient, pbnjClient),
+		writer:    writer,
+
 		hardwareManifestPath: hardwareManifestPath,
-		validator:            NewValidator(providerTinkClient, netClient, pbnjClient),
-		writer:               writer,
+		catalogue:            hardware.NewCatalogue(),
 
 		// (chrisdoherty4) We're hard coding the dependency and monkey patching in testing because the provider
 		// isn't very testable right now and we already have tests in the `tinkerbell` package so can monkey patch

--- a/pkg/providers/tinkerbell/validator.go
+++ b/pkg/providers/tinkerbell/validator.go
@@ -123,7 +123,7 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, tinkerbel
 	return nil
 }
 
-func (v *Validator) ValidateHardwareCatalogue(ctx context.Context, catalogue hardware.Catalogue, hardwares []*tinkhardware.Hardware, skipPowerActions, force bool) error {
+func (v *Validator) ValidateHardwareCatalogue(ctx context.Context, catalogue *hardware.Catalogue, hardwares []*tinkhardware.Hardware, skipPowerActions, force bool) error {
 	tinkHardwareMap := getHardwareMap(hardwares)
 
 	workflows, err := v.tink.GetWorkflow(ctx)
@@ -159,7 +159,7 @@ func (v *Validator) ValidateHardwareCatalogue(ctx context.Context, catalogue har
 	return nil
 }
 
-func (v *Validator) ValidateBMCSecretCreds(ctx context.Context, catalogue hardware.Catalogue) error {
+func (v *Validator) ValidateBMCSecretCreds(ctx context.Context, catalogue *hardware.Catalogue) error {
 	for index, bmc := range catalogue.BMCs {
 		bmcInfo := pbnj.BmcSecretConfig{
 			Host:     bmc.Spec.Host,
@@ -227,13 +227,7 @@ func (v *Validator) ValidateAndPopulateTemplate(ctx context.Context, datacenterC
 // ValidateMinHardwareAvailableForCreate ensures there is sufficient hardware registered relative to the
 // sum of requested control plane, etcd and worker node counts.
 // The system requires hardware >= to requested provisioning.
-// ValidateMinHardwareAvailableForCreate requires v.ValidateHardwareConfig() to be called first.
-func (v *Validator) ValidateMinHardwareAvailableForCreate(spec v1alpha1.ClusterSpec, catalogue hardware.Catalogue) error {
-	// ValidateMinHardwareAvailableForCreate relies on v.hardwareConfig being valid. A call to
-	// v.ValidateHardwareConfig parses the hardware config file. Consequently, we need to validate the hardware config
-	// prior to calling ValidateMinHardwareAvailableForCreate. We should decouple validation including
-	// isolation of io in the parsing of hardware config.
-
+func (v *Validator) ValidateMinHardwareAvailableForCreate(spec v1alpha1.ClusterSpec, catalogue *hardware.Catalogue) error {
 	requestedNodesCount := spec.ControlPlaneConfiguration.Count +
 		sumWorkerNodeCounts(spec.WorkerNodeGroupConfigurations)
 
@@ -285,8 +279,8 @@ func (v *Validator) ValidateMinHardwareAvailableForUpgrade(spec v1alpha1.Cluster
 }
 
 // ValidateMachinesPoweredOff validates the hardware submitted for provisioning is powered off.
-func (v *Validator) ValidateMachinesPoweredOff(ctx context.Context, catalogue hardware.Catalogue) error {
-	secrets := make(map[string]corev1.Secret)
+func (v *Validator) ValidateMachinesPoweredOff(ctx context.Context, catalogue *hardware.Catalogue) error {
+	secrets := make(map[string]*corev1.Secret)
 	for _, s := range catalogue.Secrets {
 		secrets[s.Name] = s
 	}

--- a/pkg/providers/tinkerbell/validator_test.go
+++ b/pkg/providers/tinkerbell/validator_test.go
@@ -137,10 +137,10 @@ func newValidClusterSpec(cp, etcd, worker int) v1alpha1.ClusterSpec {
 	}
 }
 
-func newCatalogueWithHardware(hardwareCount int) hardware.Catalogue {
-	return hardware.Catalogue{
-		Hardware: make([]tinkv1alpha1.Hardware, hardwareCount),
-	}
+func newCatalogueWithHardware(hardwareCount int) *hardware.Catalogue {
+	catalogue := hardware.NewCatalogue()
+	catalogue.Hardware = make([]*tinkv1alpha1.Hardware, hardwareCount)
+	return catalogue
 }
 
 func newValidTinkerbellDatacenterConfig() *v1alpha1.TinkerbellDatacenterConfig {


### PR DESCRIPTION
This PR wires indexing into the `Catalogue` construct and introduces the method set required to operate with the `Catalogue`. The slices the `Catalogue` maintains for Hardware, BMCs and Secrets are still exposed to accommodate existing validation logic. A subsequent PR will unexport these fields and change the validation logic to take advantage of indexing and the various behaviors. 

There are 4 indexes defined for the `Catalogue` as options. These indexes are based on the existing needs of the validation logic. A future PR will introduce a builder that considers `force` and `skip-power-actions` flags to construct the right indexes and validations for validating hardware configuration. This, in turn, will remove the need for any business logic to know about flags.

Existing validation functions on the `Catalogue` construct have been isolated to their own source file in preparation for refactoring. 