### PR TITLE
Add the packages controller to the build artifacts.

### DIFF
--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -48,6 +48,10 @@ func (vb *VersionsBundle) Manifests() map[string][]*string {
 		"cilium": {
 			&vb.Cilium.Manifest.URI,
 		},
+		"packages": {
+			&vb.PackageController.HelmChart.URI,
+			&vb.PackageController.Controller.URI,
+		},
 		"kindnetd": {
 			&vb.Kindnetd.Manifest.URI,
 		},
@@ -136,6 +140,7 @@ func (vb *VersionsBundle) SharedImages() []Image {
 		vb.ExternalEtcdController.Controller,
 		vb.ExternalEtcdController.KubeProxy,
 		vb.Haproxy.Image,
+		vb.PackageController.Controller,
 	}
 }
 


### PR DESCRIPTION
The intent here is to make sure that artifacts for curated packages (namely our controller image and our helm chart) get included in builds.

/cc @jonahjon  @ivyostosh 