### PR TITLE
Temporarily remove git env var validations

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/url"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -17,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/yaml"
 
-	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
@@ -584,17 +582,9 @@ func validateGitOps(clusterConfig *Cluster) error {
 	gitOpsRefKind := gitOpsRef.Kind
 	fluxConfigActive := features.IsActive(features.GenericGitProviderSupport())
 
-	if gitOpsRefKind == FluxConfigKind {
-		if !fluxConfigActive {
-			return fmt.Errorf("FluxConfig and the generic git provider are not currently supported; " +
-				"to use this experimental feature, please set the environment variable GENERIC_GIT_PROVIDER_SUPPORT to true")
-		}
-		if privateKeyFile, ok := os.LookupEnv(config.EksaGitPrivateKeyTokenEnv); !ok || len(privateKeyFile) <= 0 {
-			return fmt.Errorf("%s is not set or is empty: %t", config.EksaGitPrivateKeyTokenEnv, ok)
-		}
-		if gitKnownHosts, ok := os.LookupEnv(config.EksaGitKnownHostsFileEnv); !ok || len(gitKnownHosts) <= 0 {
-			return fmt.Errorf("%s is not set or is empty: %t", config.EksaGitKnownHostsFileEnv, ok)
-		}
+	if gitOpsRefKind == FluxConfigKind && !fluxConfigActive {
+		return fmt.Errorf("FluxConfig and the generic git provider are not currently supported; " +
+			"to use this experimental feature, please set the environment variable GENERIC_GIT_PROVIDER_SUPPORT to true")
 	}
 
 	if gitOpsRefKind != GitOpsConfigKind && !fluxConfigActive {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Temporarily remove git env var validations to unblock github provider operations. Will find a more effective way to validate this

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

