### PR TITLE
Add more validations for FluxConfig

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/yaml"
 
+	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
@@ -168,7 +170,6 @@ var clusterConfigValidations = []func(*Cluster) error{
 	validateControlPlaneReplicas,
 	validateWorkerNodeGroups,
 	validateNetworking,
-	validateGitOps,
 	validateEtcdReplicas,
 	validateIdentityProviderRefs,
 	validateProxyConfig,
@@ -194,11 +195,23 @@ func GetClusterConfig(fileName string) (*Cluster, error) {
 // GetClusterConfigFromContent parses a Cluster object from a multiobject yaml content
 func GetClusterConfigFromContent(content []byte) (*Cluster, error) {
 	clusterConfig := &Cluster{}
-	err := ParseClusterConfigFromContent(content, clusterConfig)
+	err := ParseConfigFromContent(content, clusterConfig)
 	if err != nil {
 		return clusterConfig, err
 	}
 	return clusterConfig, nil
+}
+
+// GetFluxConfig parses a Cluster object from a multiobject yaml file in disk
+// and sets defaults if necessary
+func GetFluxConfig(fileName string) (*FluxConfig, error) {
+	fluxConfig := &FluxConfig{}
+	err := ParseClusterConfig(fileName, fluxConfig)
+	if err != nil {
+		return fluxConfig, err
+	}
+
+	return fluxConfig, nil
 }
 
 // GetClusterConfig parses a Cluster object from a multiobject yaml file in disk
@@ -211,6 +224,19 @@ func GetAndValidateClusterConfig(fileName string) (*Cluster, error) {
 	err = ValidateClusterConfigContent(clusterConfig)
 	if err != nil {
 		return nil, err
+	}
+
+	if clusterConfig.Spec.GitOpsRef != nil {
+		var fluxConfig *FluxConfig
+		if clusterConfig.Spec.GitOpsRef.Kind == FluxConfigKind {
+			if fluxConfig, err = GetFluxConfig(fileName); err != nil {
+				return nil, err
+			}
+		}
+		err = validateGitOps(clusterConfig, fluxConfig)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return clusterConfig, nil
@@ -240,7 +266,7 @@ func ParseClusterConfig(fileName string, clusterConfig KindAccessor) error {
 		return fmt.Errorf("unable to read file due to: %v", err)
 	}
 
-	if err = ParseClusterConfigFromContent(content, clusterConfig); err != nil {
+	if err = ParseConfigFromContent(content, clusterConfig); err != nil {
 		return fmt.Errorf("unable to parse %s file: %v", fileName, err)
 	}
 
@@ -251,21 +277,21 @@ type kindObject struct {
 	Kind string `json:"kind,omitempty"`
 }
 
-// ParseClusterConfigFromContent unmarshalls an API object implementing the KindAccessor interface
+// ParseConfigFromContent unmarshalls an API object implementing the KindAccessor interface
 // from a multiobject yaml content. It doesn't set defaults nor validates the object
-func ParseClusterConfigFromContent(content []byte, clusterConfig KindAccessor) error {
+func ParseConfigFromContent(content []byte, config KindAccessor) error {
 	for _, c := range strings.Split(string(content), YamlSeparator) {
 		k := &kindObject{}
 		if err := yaml.Unmarshal([]byte(c), k); err != nil {
 			return err
 		}
 
-		if k.Kind == clusterConfig.ExpectedKind() {
-			return yaml.UnmarshalStrict([]byte(c), clusterConfig)
+		if k.Kind == config.ExpectedKind() {
+			return yaml.UnmarshalStrict([]byte(c), config)
 		}
 	}
 
-	return fmt.Errorf("yamlop content is invalid or does not contain kind %s", clusterConfig.ExpectedKind())
+	return fmt.Errorf("yamlop content is invalid or does not contain kind %s", config.ExpectedKind())
 }
 
 func (c *Cluster) PauseReconcile() {
@@ -573,7 +599,7 @@ func validateIdentityProviderRefs(clusterConfig *Cluster) error {
 	return nil
 }
 
-func validateGitOps(clusterConfig *Cluster) error {
+func validateGitOps(clusterConfig *Cluster, fluxConfig *FluxConfig) error {
 	gitOpsRef := clusterConfig.Spec.GitOpsRef
 	if gitOpsRef == nil {
 		return nil
@@ -582,9 +608,22 @@ func validateGitOps(clusterConfig *Cluster) error {
 	gitOpsRefKind := gitOpsRef.Kind
 	fluxConfigActive := features.IsActive(features.GenericGitProviderSupport())
 
-	if gitOpsRefKind == FluxConfigKind && !fluxConfigActive {
-		return fmt.Errorf("FluxConfig and the generic git provider are not currently supported; " +
-			"to use this experimental feature, please set the environment variable GENERIC_GIT_PROVIDER_SUPPORT to true")
+	if gitOpsRefKind == FluxConfigKind {
+		if !fluxConfigActive {
+			return fmt.Errorf("FluxConfig and the generic git provider are not currently supported; " +
+				"to use this experimental feature, please set the environment variable GENERIC_GIT_PROVIDER_SUPPORT to true")
+		}
+		if fluxConfig.Spec.Git != nil {
+			if fluxConfig.Spec.Github != nil {
+				return errors.New("only one provider can be specified in FluxConfig. Please only specify either git or github")
+			}
+			if privateKeyFile, ok := os.LookupEnv(config.EksaGitPrivateKeyTokenEnv); !ok || len(privateKeyFile) <= 0 {
+				return fmt.Errorf("%s is not set or is empty", config.EksaGitPrivateKeyTokenEnv)
+			}
+			if gitKnownHosts, ok := os.LookupEnv(config.EksaGitKnownHostsFileEnv); !ok || len(gitKnownHosts) <= 0 {
+				return fmt.Errorf("%s is not set or is empty", config.EksaGitKnownHostsFileEnv)
+			}
+		}
 	}
 
 	if gitOpsRefKind != GitOpsConfigKind && !fluxConfigActive {

--- a/pkg/api/v1alpha1/fluxconfig.go
+++ b/pkg/api/v1alpha1/fluxconfig.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
+
+	"github.com/aws/eks-anywhere/pkg/config"
 )
 
 const (
@@ -66,12 +69,18 @@ func validateFluxConfig(config *FluxConfig) error {
 	return nil
 }
 
-func validateGitProviderConfig(config GitProviderConfig) error {
-	if len(config.RepositoryUrl) <= 0 {
+func validateGitProviderConfig(gitProviderConfig GitProviderConfig) error {
+	if len(gitProviderConfig.RepositoryUrl) <= 0 {
 		return errors.New("'repositoryUrl' is not set or empty in gitProviderConfig; repositoryUrl is a required field")
 	}
+	if privateKeyFile, ok := os.LookupEnv(config.EksaGitPrivateKeyTokenEnv); !ok || len(privateKeyFile) <= 0 {
+		return fmt.Errorf("%s is not set or is empty", config.EksaGitPrivateKeyTokenEnv)
+	}
+	if gitKnownHosts, ok := os.LookupEnv(config.EksaGitKnownHostsFileEnv); !ok || len(gitKnownHosts) <= 0 {
+		return fmt.Errorf("%s is not set or is empty", config.EksaGitKnownHostsFileEnv)
+	}
 
-	return validateRepositoryUrl(config.RepositoryUrl)
+	return validateRepositoryUrl(gitProviderConfig.RepositoryUrl)
 }
 
 func validateGithubProviderConfig(config GithubProviderConfig) error {

--- a/pkg/api/v1alpha1/fluxconfig_test.go
+++ b/pkg/api/v1alpha1/fluxconfig_test.go
@@ -1,11 +1,52 @@
 package v1alpha1
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const (
+	EksaGitPrivateKeyTokenEnv = "EKSA_GIT_PRIVATE_KEY"
+	EksaGitKnownHostsFileEnv  = "EKSA_GIT_KNOWN_HOSTS"
+)
+
+type testContext struct {
+	privateKeyFile         string
+	isprivateKeyFileSet    bool
+	gitKnownHostsFile      string
+	isGitKnownHostsFileSet bool
+}
+
+func (tctx *testContext) SaveContext() {
+	tctx.privateKeyFile, tctx.isprivateKeyFileSet = os.LookupEnv(EksaGitPrivateKeyTokenEnv)
+	tctx.gitKnownHostsFile, tctx.isGitKnownHostsFileSet = os.LookupEnv(EksaGitKnownHostsFileEnv)
+	os.Setenv(EksaGitPrivateKeyTokenEnv, "my/private/key")
+	os.Setenv(EksaGitKnownHostsFileEnv, "my/known/hosts")
+}
+
+func (tctx *testContext) RestoreContext() {
+	if tctx.isprivateKeyFileSet {
+		os.Setenv(EksaGitPrivateKeyTokenEnv, tctx.privateKeyFile)
+	} else {
+		os.Unsetenv(EksaGitPrivateKeyTokenEnv)
+	}
+	if tctx.isGitKnownHostsFileSet {
+		os.Setenv(EksaGitKnownHostsFileEnv, tctx.gitKnownHostsFile)
+	} else {
+		os.Unsetenv(EksaGitKnownHostsFileEnv)
+	}
+}
+
+func setupContext(t *testing.T) {
+	var tctx testContext
+	tctx.SaveContext()
+	t.Cleanup(func() {
+		tctx.RestoreContext()
+	})
+}
 
 func TestGetAndValidateFluxConfig(t *testing.T) {
 	tests := []struct {
@@ -15,6 +56,7 @@ func TestGetAndValidateFluxConfig(t *testing.T) {
 		wantFluxConfig *FluxConfig
 		clusterConfig  *Cluster
 		wantErr        bool
+		gitProvider    bool
 	}{
 		{
 			testName:       "file doesn't exist",
@@ -87,7 +129,8 @@ func TestGetAndValidateFluxConfig(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			wantErr: false,
+			wantErr:     false,
+			gitProvider: true,
 		},
 		{
 			testName: "refName doesn't match",
@@ -129,6 +172,9 @@ func TestGetAndValidateFluxConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
+			if tt.gitProvider {
+				setupContext(t)
+			}
 			got, err := GetAndValidateFluxConfig(tt.fileName, tt.refName, tt.clusterConfig)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("GetAndValidateFluxConfig() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We needed a way to access the FluxConfig spec for validations. We already have a `ParseClusterConfigFromContent` function that accepts any `KindAccessor` type (such as Cluster, FluxConfig, etc.) to parse those contents. So I renamed that function to `ParseConfigFromContent` since it isn't exclusive to the cluster config, and I am using it to pass in the FluxConfig type and parse those contents so that we can have access to that spec is the gitops validations function.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

