### PR TITLE
Fix bug in specifying proxy configuration for helm template

### DIFF
--- a/docs/content/en/docs/reference/changelog.md
+++ b/docs/content/en/docs/reference/changelog.md
@@ -20,6 +20,7 @@ menu:
 
 ### Fixed
 - Fix issue with downloading artifacts [#1753](https://github.com/aws/eks-anywhere/issues/1753)
+- Fix issue specifying proxy configuration for helm template command [#2009](https://github.com/aws/eks-anywhere/issues/2009)
 
 ## [v0.8.0](https://github.com/aws/eks-anywhere/releases/tag/v0.8.0)
 ### Added

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -291,6 +291,19 @@ func (c *Cluster) RegistryMirror() string {
 	return net.JoinHostPort(c.Spec.RegistryMirrorConfiguration.Endpoint, c.Spec.RegistryMirrorConfiguration.Port)
 }
 
+func (c *Cluster) ProxyConfiguration() map[string]string {
+	if c.Spec.ProxyConfiguration == nil {
+		return nil
+	}
+	noProxyList := append(c.Spec.ProxyConfiguration.NoProxy, c.Spec.ClusterNetwork.Pods.CidrBlocks...)
+	noProxyList = append(noProxyList, c.Spec.ClusterNetwork.Services.CidrBlocks...)
+	return map[string]string{
+		"HTTP_PROXY":  c.Spec.ProxyConfiguration.HttpProxy,
+		"HTTPS_PROXY": c.Spec.ProxyConfiguration.HttpsProxy,
+		"NO_PROXY":    strings.Join(noProxyList[:], ","),
+	}
+}
+
 func (c *Cluster) IsReconcilePaused() bool {
 	if s, ok := c.Annotations[pausedAnnotation]; ok {
 		return s == "true"

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -2099,3 +2099,40 @@ func TestClusterRegistryMirror(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterProxyConfiguration(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *Cluster
+		want    map[string]string
+	}{
+		{
+			name: "with proxy configuration",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					ProxyConfiguration: &ProxyConfiguration{
+						HttpProxy:  "test-http",
+						HttpsProxy: "test-https",
+						NoProxy:    []string{"test-noproxy-1", "test-noproxy-2", "test-noproxy-3"},
+					},
+				},
+			},
+			want: map[string]string{
+				"HTTP_PROXY":  "test-http",
+				"HTTPS_PROXY": "test-https",
+				"NO_PROXY":    "test-noproxy-1,test-noproxy-2,test-noproxy-3",
+			},
+		},
+		{
+			name:    "without proxy configuration",
+			cluster: &Cluster{},
+			want:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.cluster.ProxyConfiguration()).To(Equal(tt.want))
+		})
+	}
+}

--- a/pkg/executables/helm.go
+++ b/pkg/executables/helm.go
@@ -15,13 +15,10 @@ const (
 	insecureSkipVerifyFlag = "--insecure-skip-tls-verify"
 )
 
-var helmTemplateEnvVars = map[string]string{
-	"HELM_EXPERIMENTAL_OCI": "1",
-}
-
 type Helm struct {
 	executable     Executable
 	registryMirror string
+	env            map[string]string
 }
 
 type HelmOpt func(*Helm)
@@ -32,9 +29,21 @@ func WithRegistryMirror(mirror string) HelmOpt {
 	}
 }
 
+// join the default and the provided maps together
+func WithEnv(env map[string]string) HelmOpt {
+	return func(h *Helm) {
+		for k, v := range env {
+			h.env[k] = v
+		}
+	}
+}
+
 func NewHelm(executable Executable, opts ...HelmOpt) *Helm {
 	h := &Helm{
 		executable: executable,
+		env: map[string]string{
+			"HELM_EXPERIMENTAL_OCI": "1",
+		},
 	}
 
 	for _, o := range opts {
@@ -52,7 +61,7 @@ func (h *Helm) Template(ctx context.Context, ociURI, version, namespace string, 
 
 	result, err := h.executable.Command(
 		ctx, "template", h.url(ociURI), "--version", version, insecureSkipVerifyFlag, "--namespace", namespace, "-f", "-",
-	).WithStdIn(valuesYaml).WithEnvVars(helmTemplateEnvVars).Run()
+	).WithStdIn(valuesYaml).WithEnvVars(h.env).Run()
 	if err != nil {
 		return nil, err
 	}
@@ -62,25 +71,26 @@ func (h *Helm) Template(ctx context.Context, ociURI, version, namespace string, 
 
 func (h *Helm) PullChart(ctx context.Context, ociURI, version string) error {
 	_, err := h.executable.Command(ctx, "pull", h.url(ociURI), "--version", version, insecureSkipVerifyFlag).
-		WithEnvVars(helmTemplateEnvVars).Run()
+		WithEnvVars(h.env).Run()
 	return err
 }
 
 func (h *Helm) PushChart(ctx context.Context, chart, registry string) error {
 	logger.Info("Pushing", "chart", chart)
-	_, err := h.executable.Command(ctx, "push", chart, registry, insecureSkipVerifyFlag).WithEnvVars(helmTemplateEnvVars).Run()
+	_, err := h.executable.Command(ctx, "push", chart, registry, insecureSkipVerifyFlag).WithEnvVars(h.env).Run()
 	return err
 }
 
 func (h *Helm) RegistryLogin(ctx context.Context, registry, username, password string) error {
 	logger.Info("Logging in to helm registry", "registry", registry)
-	_, err := h.executable.Command(ctx, "registry", "login", registry, "--username", username, "--password", password, "--insecure").WithEnvVars(helmTemplateEnvVars).Run()
+	_, err := h.executable.Command(ctx, "registry", "login", registry, "--username", username, "--password", password, "--insecure").WithEnvVars(h.env).Run()
 	return err
 }
 
 func (h *Helm) SaveChart(ctx context.Context, ociURI, version, folder string) error {
+	fmt.Println(h.env)
 	_, err := h.executable.Command(ctx, "pull", h.url(ociURI), "--version", version, insecureSkipVerifyFlag, "--destination", folder).
-		WithEnvVars(helmTemplateEnvVars).Run()
+		WithEnvVars(h.env).Run()
 	return err
 }
 
@@ -91,7 +101,7 @@ func (h *Helm) InstallChart(ctx context.Context, chart, ociURI, version, kubecon
 	params = append(params, "--kubeconfig", kubeconfigFilePath)
 
 	logger.Info("Installing helm chart on cluster", "chart", chart, "version", version)
-	_, err := h.executable.Command(ctx, params...).WithEnvVars(helmTemplateEnvVars).Run()
+	_, err := h.executable.Command(ctx, params...).WithEnvVars(h.env).Run()
 	return err
 }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/2009

*Description of changes:*
Adding support for passing in proxy configuration env vars if specified to the helm template command. This was not seen before when using the manifest directly because it just applies the yaml, not through oci. Refactoring some of the building of these env vars and will follow up with another issue to make use of these functions for the providers. 

*Testing (if applicable):*
unit tests and E2E tests with proxy configuration

/hold
/approve

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

