### PR TITLE
Call ValidateConfig for new cluster specs

### DIFF
--- a/controllers/controllers/resource/reconciler_test.go
+++ b/controllers/controllers/resource/reconciler_test.go
@@ -134,7 +134,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.VSphereMachineConfig{}
@@ -145,7 +145,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.VSphereMachineConfig{}
@@ -156,7 +156,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.VSphereMachineConfig{}
@@ -167,7 +167,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 
 				kubeAdmControlPlane := &controlplanev1.KubeadmControlPlane{}
@@ -260,7 +260,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Name)
 					cluster.Spec = datacenterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 
 				existingVSDatacenter := &anywherev1.VSphereDatacenterConfig{}
@@ -277,14 +277,14 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = machineSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					cluster := obj.(*anywherev1.VSphereMachineConfig)
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = machineSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 
 				existingWorkerNodeGroupConfiguration := &anywherev1.WorkerNodeGroupConfiguration{
@@ -371,7 +371,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.VSphereMachineConfig{}
@@ -382,7 +382,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.VSphereMachineConfig{}
@@ -393,7 +393,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.VSphereMachineConfig{}
@@ -404,7 +404,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 
 				kubeAdmControlPlane := &controlplanev1.KubeadmControlPlane{}
@@ -493,7 +493,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.VSphereMachineConfig{}
@@ -504,7 +504,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.VSphereMachineConfig{}
@@ -515,7 +515,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.VSphereMachineConfig{}
@@ -526,7 +526,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 
 				kubeAdmControlPlane := &controlplanev1.KubeadmControlPlane{}
@@ -643,7 +643,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.CloudStackMachineConfig{}
@@ -654,7 +654,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.CloudStackMachineConfig{}
@@ -665,7 +665,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 
 				kubeAdmControlPlane := &controlplanev1.KubeadmControlPlane{}
@@ -742,7 +742,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Name)
 					cluster.Spec = datacenterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 
 				machineSpec := &anywherev1.CloudStackMachineConfig{}
@@ -755,14 +755,14 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = machineSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					cluster := obj.(*anywherev1.CloudStackMachineConfig)
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = machineSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 
 				existingWorkerNodeGroupConfiguration := &anywherev1.WorkerNodeGroupConfiguration{
@@ -837,7 +837,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.CloudStackMachineConfig{}
@@ -848,7 +848,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.CloudStackMachineConfig{}
@@ -859,7 +859,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 
 				kubeAdmControlPlane := &controlplanev1.KubeadmControlPlane{}
@@ -946,7 +946,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.CloudStackMachineConfig{}
@@ -957,7 +957,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 				fetcher.EXPECT().FetchObject(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, objectKey types.NamespacedName, obj client.Object) {
 					clusterSpec := &anywherev1.CloudStackMachineConfig{}
@@ -968,7 +968,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 					cluster.SetName(objectKey.Name)
 					cluster.SetNamespace(objectKey.Namespace)
 					cluster.Spec = clusterSpec.Spec
-					assert.Equal(t, objectKey.Name, "test_cluster", "expected Name to be test_cluster")
+					assert.Equal(t, objectKey.Name, "test-cluster", "expected Name to be test-cluster")
 				}).Return(nil)
 
 				kubeAdmControlPlane := &controlplanev1.KubeadmControlPlane{}

--- a/controllers/controllers/resource/testdata/cloudstackDatacenterConfigSpec.yaml
+++ b/controllers/controllers/resource/testdata/cloudstackDatacenterConfigSpec.yaml
@@ -2,7 +2,7 @@ apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: CloudStackDatacenterConfig
 metadata:
   creationTimestamp: null
-  name: test_cluster
+  name: test-cluster
 spec:
   domain: domain1
   account: account1

--- a/controllers/controllers/resource/testdata/cloudstackEtcdadmcluster.yaml
+++ b/controllers/controllers/resource/testdata/cloudstackEtcdadmcluster.yaml
@@ -1,7 +1,7 @@
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
 metadata:
-  name: test_cluster-etcd
+  name: test-cluster-etcd
   namespace: eksa-system
 spec:
   replicas: 1
@@ -25,4 +25,4 @@ users:
 infrastructureTemplate:
   apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
   kind: CloudStackMachineTemplate
-  name: test_cluster-etcd-template-v1.19.8-eks-1-19-4
+  name: test-cluster-etcd-template-v1.19.8-eks-1-19-4

--- a/controllers/controllers/resource/testdata/cloudstackKubeadmconfigTemplateSpec.yaml
+++ b/controllers/controllers/resource/testdata/cloudstackKubeadmconfigTemplateSpec.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test_cluster-md-0-template-1234567890000
+  name: test-cluster-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:

--- a/controllers/controllers/resource/testdata/cloudstackKubeadmcontrolplane.yaml
+++ b/controllers/controllers/resource/testdata/cloudstackKubeadmcontrolplane.yaml
@@ -1,13 +1,13 @@
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
-  name: test_cluster
+  name: test-cluster
   namespace: default
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: CloudStackMachineTemplate
-    name: test_cluster-control-plane-template-v1.19.8-eks-1-19-4
+    name: test-cluster-control-plane-template-v1.19.8-eks-1-19-4
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes

--- a/controllers/controllers/resource/testdata/cloudstackMachineConfigSpec.yaml
+++ b/controllers/controllers/resource/testdata/cloudstackMachineConfigSpec.yaml
@@ -2,7 +2,7 @@ apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: CloudStackMachineConfig
 metadata:
   creationTimestamp: null
-  name: test_cluster
+  name: test-cluster
 spec:
   computeoffering:
     name: large

--- a/controllers/controllers/resource/testdata/cloudstackMachineDeployment.yaml
+++ b/controllers/controllers/resource/testdata/cloudstackMachineDeployment.yaml
@@ -2,27 +2,27 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: test_cluster
-  name: test_cluster-md-0
+    cluster.x-k8s.io/cluster-name: test-cluster
+  name: test-cluster-md-0
   namespace: eksa-system
 spec:
-  clusterName: test_cluster
+  clusterName: test-cluster
   replicas: 1
   selector:
     matchLabels: {}
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: test_cluster
+        cluster.x-k8s.io/cluster-name: test-cluster
     spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test_cluster-md-0
-      clusterName: test_cluster
+          name: test-cluster-md-0
+      clusterName: test-cluster
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: CloudStackMachineTemplate
-        name: test_cluster-workload-template-1
+        name: test-cluster-workload-template-1
       version: v1.19.8-eks-1-19-4

--- a/controllers/controllers/resource/testdata/cloudstackMachineTemplate.yaml
+++ b/controllers/controllers/resource/testdata/cloudstackMachineTemplate.yaml
@@ -1,7 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: CloudStackMachineTemplate
 metadata:
-  name: test_cluster-worker-node-template-1234567890000
+  name: test-cluster-worker-node-template-1234567890000
   namespace: eksa-system
 spec:
   template:

--- a/controllers/controllers/resource/testdata/eksa-cluster-cloudstack.yaml
+++ b/controllers/controllers/resource/testdata/eksa-cluster-cloudstack.yaml
@@ -1,7 +1,7 @@
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Cluster
 metadata:
-  name: test_cluster
+  name: test-cluster
 spec:
   clusterNetwork:
     cni: cilium
@@ -17,22 +17,22 @@ spec:
       host: "192.168.1.71"
     machineGroupRef:
       kind: CloudStackMachineConfig
-      name: test_cluster
+      name: test-cluster
   datacenterRef:
     kind: CloudStackDatacenterConfig
-    name: test_cluster
+    name: test-cluster
   kubernetesVersion: "1.21"
   workerNodeGroupConfigurations:
     - count: 3
       machineGroupRef:
         kind: CloudStackMachineConfig
-        name: test_cluster
+        name: test-cluster
 
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: CloudStackDatacenterConfig
 metadata:
-  name: test_cluster
+  name: test-cluster
 spec:
   domain: "root"
   account: "admin"
@@ -48,7 +48,7 @@ spec:
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: CloudStackMachineConfig
 metadata:
-  name: test_cluster
+  name: test-cluster
 spec:
   computeOffering:
     name: "Large Instance"

--- a/controllers/controllers/resource/testdata/eksa-cluster-cloudstack_no_changes.yaml
+++ b/controllers/controllers/resource/testdata/eksa-cluster-cloudstack_no_changes.yaml
@@ -1,24 +1,24 @@
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Cluster
 metadata:
-  name: test_cluster
+  name: test-cluster
 spec:
   controlPlaneConfiguration:
     count: 1
     endpoint:
       host: "198.18.40.234"
     machineGroupRef:
-      name: test_cluster
+      name: test-cluster
       kind: CloudStackMachineConfig
   kubernetesVersion: "1.20"
   workerNodeGroupConfigurations:
     - count: 3
       machineGroupRef:
-        name: test_cluster
+        name: test-cluster
         kind: CloudStackMachineConfig
   datacenterRef:
     kind: CloudStackDatacenterConfig
-    name: test_cluster
+    name: test-cluster
   clusterNetwork:
     cni: "cilium"
     pods:
@@ -32,7 +32,7 @@ apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: CloudStackMachineConfig
 metadata:
   creationTimestamp: null
-  name: test_cluster
+  name: test-cluster
 spec:
   computeoffering:
     name: large
@@ -49,7 +49,7 @@ apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: CloudStackDatacenterConfig
 metadata:
   creationTimestamp: null
-  name: test_cluster
+  name: test-cluster
 spec:
   domain: domain1
   account: account1

--- a/controllers/controllers/resource/testdata/eksa-cluster.yaml
+++ b/controllers/controllers/resource/testdata/eksa-cluster.yaml
@@ -1,30 +1,30 @@
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Cluster
 metadata:
-  name: test_cluster
+  name: test-cluster
 spec:
   controlPlaneConfiguration:
     count: 3
     endpoint:
       host: "198.18.40.234"
     machineGroupRef:
-      name: test_cluster
+      name: test-cluster
       kind: VSphereMachineConfig
   kubernetesVersion: "1.19"
   workerNodeGroupConfigurations:
     - count: 4
       machineGroupRef:
-        name: test_cluster
+        name: test-cluster
         kind: VSphereMachineConfig
       name: md-0
   externalEtcdConfiguration:
     count: 3
     machineGroupRef:
-      name: test_cluster
+      name: test-cluster
       kind: VSphereMachineConfig
   datacenterRef:
     kind: VSphereDatacenterConfig
-    name: test_cluster
+    name: test-cluster
   clusterNetwork:
     cni: "cilium"
     pods:
@@ -38,7 +38,7 @@ apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: VSphereMachineConfig
 metadata:
   creationTimestamp: null
-  name: test_cluster
+  name: test-cluster
 spec:
   diskGiB: 25
   datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
@@ -57,7 +57,7 @@ apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: VSphereDatacenterConfig
 metadata:
   creationTimestamp: null
-  name: test_cluster
+  name: test-cluster
 spec:
   datacenter: SDDC-Datacenter
   network: /SDDC-Datacenter/network/sddc-cgw-network-1

--- a/controllers/controllers/resource/testdata/eksa-cluster_no_changes.yaml
+++ b/controllers/controllers/resource/testdata/eksa-cluster_no_changes.yaml
@@ -1,25 +1,25 @@
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Cluster
 metadata:
-  name: test_cluster
+  name: test-cluster
 spec:
   controlPlaneConfiguration:
     count: 1
     endpoint:
       host: "198.18.40.234"
     machineGroupRef:
-      name: test_cluster
+      name: test-cluster
       kind: VSphereMachineConfig
   kubernetesVersion: "1.19"
   workerNodeGroupConfigurations:
     - count: 3
       machineGroupRef:
-        name: test_cluster
+        name: test-cluster
         kind: VSphereMachineConfig
       name: md-0
   datacenterRef:
     kind: VSphereDatacenterConfig
-    name: test_cluster
+    name: test-cluster
   clusterNetwork:
     cni: "cilium"
     pods:
@@ -33,7 +33,7 @@ apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: VSphereMachineConfig
 metadata:
   creationTimestamp: null
-  name: test_cluster
+  name: test-cluster
 spec:
   diskGiB: 25
   datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
@@ -52,7 +52,7 @@ apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: VSphereDatacenterConfig
 metadata:
   creationTimestamp: null
-  name: test_cluster
+  name: test-cluster
 spec:
   datacenter: SDDC-Datacenter
   network: /SDDC-Datacenter/network/sddc-cgw-network-1

--- a/controllers/controllers/resource/testdata/expectedCloudStackMachineDeployment.yaml
+++ b/controllers/controllers/resource/testdata/expectedCloudStackMachineDeployment.yaml
@@ -2,27 +2,27 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: test_cluster
-  name: test_cluster-md-0
+    cluster.x-k8s.io/cluster-name: test-cluster
+  name: test-cluster-md-0
   namespace: eksa-system
 spec:
-  clusterName: test_cluster
+  clusterName: test-cluster
   replicas: 3
   selector:
     matchLabels: {}
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: test_cluster
+        cluster.x-k8s.io/cluster-name: test-cluster
     spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test_cluster-md-0
-      clusterName: test_cluster
+          name: test-cluster-md-0
+      clusterName: test-cluster
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: CloudStackMachineTemplate
-        name: test_cluster-md-0-1234567890000
+        name: test-cluster-md-0-1234567890000
       version: v1.21.2-eks-1-21-4

--- a/controllers/controllers/resource/testdata/expectedCloudStackMachineDeploymentOnlyReplica.yaml
+++ b/controllers/controllers/resource/testdata/expectedCloudStackMachineDeploymentOnlyReplica.yaml
@@ -2,27 +2,27 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: test_cluster
-  name: test_cluster-md-0
+    cluster.x-k8s.io/cluster-name: test-cluster
+  name: test-cluster-md-0
   namespace: eksa-system
 spec:
-  clusterName: test_cluster
+  clusterName: test-cluster
   replicas: 3
   selector:
     matchLabels: {}
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: test_cluster
+        cluster.x-k8s.io/cluster-name: test-cluster
     spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test_cluster-md-0
-      clusterName: test_cluster
+          name: test-cluster-md-0
+      clusterName: test-cluster
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: CloudStackMachineTemplate
-        name: test_cluster-md-0-1234567890000
+        name: test-cluster-md-0-1234567890000
       version: v1.20.4-eks-1-20-1

--- a/controllers/controllers/resource/testdata/expectedCloudStackMachineDeploymentTemplateChanged.yaml
+++ b/controllers/controllers/resource/testdata/expectedCloudStackMachineDeploymentTemplateChanged.yaml
@@ -2,27 +2,27 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: test_cluster
-  name: test_cluster-md-0
+    cluster.x-k8s.io/cluster-name: test-cluster
+  name: test-cluster-md-0
   namespace: eksa-system
 spec:
-  clusterName: test_cluster
+  clusterName: test-cluster
   replicas: 3
   selector:
     matchLabels: {}
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: test_cluster
+        cluster.x-k8s.io/cluster-name: test-cluster
     spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test_cluster-md-0-template-1234567890000
-      clusterName: test_cluster
+          name: test-cluster-md-0-template-1234567890000
+      clusterName: test-cluster
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: CloudStackMachineTemplate
-        name: test_cluster-md-0-1234567890000
+        name: test-cluster-md-0-1234567890000
       version: v1.21.2-eks-1-21-4

--- a/controllers/controllers/resource/testdata/expectedVSphereMachineDeployment.yaml
+++ b/controllers/controllers/resource/testdata/expectedVSphereMachineDeployment.yaml
@@ -2,27 +2,27 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: test_cluster
-  name: test_cluster-md-0
+    cluster.x-k8s.io/cluster-name: test-cluster
+  name: test-cluster-md-0
   namespace: eksa-system
 spec:
-  clusterName: test_cluster
+  clusterName: test-cluster
   replicas: 4
   selector:
     matchLabels: {}
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: test_cluster
+        cluster.x-k8s.io/cluster-name: test-cluster
     spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test_cluster-md-0
-      clusterName: test_cluster
+          name: test-cluster-md-0
+      clusterName: test-cluster
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: VSphereMachineTemplate
-        name: test_cluster-md-0-1234567890000
+        name: test-cluster-md-0-1234567890000
       version: v1.19.8-eks-1-19-4

--- a/controllers/controllers/resource/testdata/expectedVSphereMachineDeploymentOnlyReplica.yaml
+++ b/controllers/controllers/resource/testdata/expectedVSphereMachineDeploymentOnlyReplica.yaml
@@ -2,27 +2,27 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: test_cluster
-  name: test_cluster-md-0
+    cluster.x-k8s.io/cluster-name: test-cluster
+  name: test-cluster-md-0
   namespace: eksa-system
 spec:
-  clusterName: test_cluster
+  clusterName: test-cluster
   replicas: 3
   selector:
     matchLabels: {}
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: test_cluster
+        cluster.x-k8s.io/cluster-name: test-cluster
     spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test_cluster-md-0
-      clusterName: test_cluster
+          name: test-cluster-md-0
+      clusterName: test-cluster
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: VSphereMachineTemplate
-        name: test_cluster-md-0-1234567890000
+        name: test-cluster-md-0-1234567890000
       version: v1.19.8-eks-1-19-4

--- a/controllers/controllers/resource/testdata/expectedVSphereMachineDeploymentTemplateChanged.yaml
+++ b/controllers/controllers/resource/testdata/expectedVSphereMachineDeploymentTemplateChanged.yaml
@@ -2,27 +2,27 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: test_cluster
-  name: test_cluster-md-0
+    cluster.x-k8s.io/cluster-name: test-cluster
+  name: test-cluster-md-0
   namespace: eksa-system
 spec:
-  clusterName: test_cluster
+  clusterName: test-cluster
   replicas: 4
   selector:
     matchLabels: {}
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: test_cluster
+        cluster.x-k8s.io/cluster-name: test-cluster
     spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test_cluster-md-0-template-1234567890000
-      clusterName: test_cluster
+          name: test-cluster-md-0-template-1234567890000
+      clusterName: test-cluster
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: VSphereMachineTemplate
-        name: test_cluster-md-0-1234567890000
+        name: test-cluster-md-0-1234567890000
       version: v1.19.8-eks-1-19-4

--- a/controllers/controllers/resource/testdata/vsphereDatacenterConfigSpec.yaml
+++ b/controllers/controllers/resource/testdata/vsphereDatacenterConfigSpec.yaml
@@ -2,7 +2,7 @@ apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: VSphereDatacenterConfig
 metadata:
   creationTimestamp: null
-  name: test_cluster
+  name: test-cluster
 spec:
   datacenter: SDDC-Datacenter
   network: /SDDC-Datacenter/network/sddc-cgw-network-1

--- a/controllers/controllers/resource/testdata/vsphereEtcdadmcluster.yaml
+++ b/controllers/controllers/resource/testdata/vsphereEtcdadmcluster.yaml
@@ -1,7 +1,7 @@
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
 metadata:
-  name: test_cluster-etcd
+  name: test-cluster-etcd
   namespace: eksa-system
 spec:
   replicas: 1
@@ -25,4 +25,4 @@ users:
 infrastructureTemplate:
   apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
   kind: VSphereMachineTemplate
-  name: test_cluster-etcd-template-v1.19.8-eks-1-19-4
+  name: test-cluster-etcd-template-v1.19.8-eks-1-19-4

--- a/controllers/controllers/resource/testdata/vsphereKubeadmconfigTemplateSpec.yaml
+++ b/controllers/controllers/resource/testdata/vsphereKubeadmconfigTemplateSpec.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: test_cluster-md-0-template-1234567890000
+  name: test-cluster-md-0-template-1234567890000
   namespace: eksa-system
 spec:
   template:

--- a/controllers/controllers/resource/testdata/vsphereKubeadmcontrolplane.yaml
+++ b/controllers/controllers/resource/testdata/vsphereKubeadmcontrolplane.yaml
@@ -1,14 +1,14 @@
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
-  name: test_cluster
+  name: test-cluster
   namespace: default
 spec:
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: VSphereMachineTemplate
-      name: test_cluster-control-plane-template-v1.19.8-eks-1-19-4
+      name: test-cluster-control-plane-template-v1.19.8-eks-1-19-4
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes

--- a/controllers/controllers/resource/testdata/vsphereMachineConfigSpec.yaml
+++ b/controllers/controllers/resource/testdata/vsphereMachineConfigSpec.yaml
@@ -2,7 +2,7 @@ apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: VSphereMachineConfig
 metadata:
   creationTimestamp: null
-  name: test_cluster
+  name: test-cluster
 spec:
   diskGiB: 25
   datastore: /SDDC-Datacenter/datastore/WorkloadDatastore

--- a/controllers/controllers/resource/testdata/vsphereMachineDeployment.yaml
+++ b/controllers/controllers/resource/testdata/vsphereMachineDeployment.yaml
@@ -2,27 +2,27 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: test_cluster
-  name: test_cluster-md-0
+    cluster.x-k8s.io/cluster-name: test-cluster
+  name: test-cluster-md-0
   namespace: eksa-system
 spec:
-  clusterName: test_cluster
+  clusterName: test-cluster
   replicas: 1
   selector:
     matchLabels: {}
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: test_cluster
+        cluster.x-k8s.io/cluster-name: test-cluster
     spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: test_cluster-md-0
-      clusterName: test_cluster
+          name: test-cluster-md-0
+      clusterName: test-cluster
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: VSphereMachineTemplate
-        name: test_cluster-md-0-worker-node-template-1234567890000
+        name: test-cluster-md-0-worker-node-template-1234567890000
       version: v1.19.8-eks-1-19-4

--- a/controllers/controllers/resource/testdata/vsphereMachineTemplate.yaml
+++ b/controllers/controllers/resource/testdata/vsphereMachineTemplate.yaml
@@ -1,7 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
-  name: test_cluster-md-0-worker-node-template-1234567890000
+  name: test-cluster-md-0-worker-node-template-1234567890000
   namespace: eksa-system
 spec:
   template:

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -178,6 +178,9 @@ func NewSpecFromClusterConfig(clusterConfigPath string, cliVersion version.Info,
 	if err = SetConfigDefaults(clusterConfig); err != nil {
 		return nil, err
 	}
+	if err = ValidateConfig(clusterConfig); err != nil {
+		return nil, err
+	}
 
 	bundlesManifest, err := s.GetBundles(cliVersion)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We weren't validating the cluster config for new specs. That PR adds that call in `pkg/cluster/spec.go`. Now that we validate that, the unit tests caught cluster naming errors in some test files so renaming all of those to fix that error

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

