### PR TITLE
check that full cluster path exists in git validations

### DIFF
--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -646,7 +646,7 @@ func (fc *fluxForCluster) initializeLocalRepository() error {
 // This is done so that we avoid clobbering existing cluster configurations in the user-provided git repository.
 func (fc *fluxForCluster) validateLocalConfigPathDoesNotExist() error {
 	if fc.clusterSpec.Cluster.IsSelfManaged() {
-		p := path.Join(fc.gitTools.Writer.Dir(), fc.path())
+		p := path.Join(fc.gitTools.Writer.Dir(), fc.path(), fc.clusterSpec.Cluster.Name)
 		if validations.FileExists(p) {
 			return fmt.Errorf("a cluster configuration file already exists at path %s", p)
 		}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
when using a custom path, we need to validate that the cluster configuration file path does not exist, rather than the base path; when using the base path, this validation fails if the fluxConfig is present (which it is, as we push it prior to pushing the cluster configuration)

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

