### PR TITLE
Set ssh key algorithm for Git Provider Config

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_fluxconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_fluxconfigs.yaml
@@ -54,6 +54,10 @@ spec:
                     description: Repository URL for the repository to be used with
                       flux. Can be either an SSH or HTTPS url.
                     type: string
+                  sshKeyAlgorithm:
+                    description: SSH public key algorithm for the private key specified
+                      (rsa, ecdsa, ed25519) (default ecdsa)
+                    type: string
                 required:
                 - repositoryUrl
                 type: object

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -3898,6 +3898,10 @@ spec:
                     description: Repository URL for the repository to be used with
                       flux. Can be either an SSH or HTTPS url.
                     type: string
+                  sshKeyAlgorithm:
+                    description: SSH public key algorithm for the private key specified
+                      (rsa, ecdsa, ed25519) (default ecdsa)
+                    type: string
                 required:
                 - repositoryUrl
                 type: object

--- a/designs/generic-git-provider-gitops.md
+++ b/designs/generic-git-provider-gitops.md
@@ -58,7 +58,7 @@ spec:
   branch: "main"
   git:
     repositoryUrl: myClusterGitopsRepo
-    username: myGitProviderUserName    
+    sshKeyAlgorithm: mySshKeyAlgorithm    
 ---
 ```
 
@@ -118,7 +118,7 @@ spec:
   branch: ""
   git:
     repositoryUrl: ""
-    username: ""
+    sshKeyAlgorithm: ""
   github:
     repository: ""
     personal: false

--- a/pkg/api/v1alpha1/fluxconfig_test.go
+++ b/pkg/api/v1alpha1/fluxconfig_test.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"reflect"
 	"testing"
@@ -57,12 +59,14 @@ func TestGetAndValidateFluxConfig(t *testing.T) {
 		clusterConfig  *Cluster
 		wantErr        bool
 		gitProvider    bool
+		error          error
 	}{
 		{
 			testName:       "file doesn't exist",
 			fileName:       "testdata/fake_file.yaml",
 			wantFluxConfig: nil,
 			wantErr:        true,
+			error:          errors.New("unable to read file due to: open testdata/fake_file.yaml: no such file or directory"),
 		},
 		{
 			testName:       "not parseable file",
@@ -100,6 +104,7 @@ func TestGetAndValidateFluxConfig(t *testing.T) {
 				},
 			},
 			wantErr: false,
+			error:   nil,
 		},
 		{
 			testName: "valid 1.19 git",
@@ -116,7 +121,83 @@ func TestGetAndValidateFluxConfig(t *testing.T) {
 				},
 				Spec: FluxConfigSpec{
 					Git: &GitProviderConfig{
-						RepositoryUrl: "https://git.com/test/test.git",
+						RepositoryUrl: "ssh://git@github.com/username/repo.git",
+					},
+				},
+			},
+			clusterConfig: &Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       ClusterKind,
+					APIVersion: SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+			},
+			gitProvider: true,
+			wantErr:     false,
+			error:       nil,
+		},
+		{
+			testName: "refName doesn't match",
+			fileName: "testdata/cluster_1_19_flux_github.yaml",
+			refName:  "wrongName",
+			wantErr:  true,
+			error:    errors.New("FluxConfig retrieved with name test-flux-github does not match name (wrongName) specified in gitOpsRef"),
+		},
+		{
+			testName:       "empty owner",
+			fileName:       "testdata/cluster_invalid_flux_unset_gitowner.yaml",
+			wantFluxConfig: nil,
+			wantErr:        true,
+			error:          errors.New("'owner' is not set or empty in githubProviderConfig; owner is a required field"),
+		},
+		{
+			testName:       "empty repo",
+			fileName:       "testdata/cluster_invalid_flux_unset_gitrepo.yaml",
+			wantFluxConfig: nil,
+			wantErr:        true,
+			error:          errors.New("'repository' is not set or empty in githubProviderConfig; repository is a required field"),
+		},
+		{
+			testName:       "empty repo url",
+			fileName:       "testdata/cluster_invalid_flux_unset_gitrepourl.yaml",
+			wantFluxConfig: nil,
+			wantErr:        true,
+			error:          errors.New("'repositoryUrl' is not set or empty in gitProviderConfig; repositoryUrl is a required field"),
+		},
+		{
+			testName:       "invalid repo url",
+			fileName:       "testdata/cluster_invalid_flux_gitrepourl.yaml",
+			wantFluxConfig: nil,
+			wantErr:        true,
+			gitProvider:    true,
+			error:          fmt.Errorf("invalid repository url scheme: %s", "http"),
+		},
+		{
+			testName:       "invalid sshkey algo",
+			fileName:       "testdata/cluster_invalid_flux_wrong_gitsshkeyalgo.yaml",
+			wantFluxConfig: nil,
+			wantErr:        true,
+			error:          fmt.Errorf("'sshKeyAlgorithm' does not have a valid value in gitProviderConfig; sshKeyAlgorithm must be amongst %s, %s, %s", RsaAlgorithm, EcdsaAlgorithm, Ed25519Algorithm),
+		},
+		{
+			testName: "valid ssh key algo",
+			fileName: "testdata/cluster_1_19_flux_validgit_sshkey.yaml",
+			refName:  "test-flux-git",
+			wantFluxConfig: &FluxConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       FluxConfigKind,
+					APIVersion: SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-flux-git",
+					Namespace: "default",
+				},
+				Spec: FluxConfigSpec{
+					Git: &GitProviderConfig{
+						RepositoryUrl:   "ssh://git@github.com/username/repo.git",
+						SshKeyAlgorithm: RsaAlgorithm,
 					},
 				},
 			},
@@ -131,42 +212,7 @@ func TestGetAndValidateFluxConfig(t *testing.T) {
 			},
 			wantErr:     false,
 			gitProvider: true,
-		},
-		{
-			testName: "refName doesn't match",
-			fileName: "testdata/cluster_1_19_flux_github.yaml",
-			refName:  "wrongName",
-			wantErr:  true,
-		},
-		{
-			testName:       "empty owner",
-			fileName:       "testdata/cluster_invalid_flux_unset_gitowner.yaml",
-			wantFluxConfig: nil,
-			wantErr:        true,
-		},
-		{
-			testName:       "empty repo",
-			fileName:       "testdata/cluster_invalid_flux_unset_gitrepo.yaml",
-			wantFluxConfig: nil,
-			wantErr:        true,
-		},
-		{
-			testName:       "empty username",
-			fileName:       "testdata/cluster_invalid_flux_unset_gitusername.yaml",
-			wantFluxConfig: nil,
-			wantErr:        true,
-		},
-		{
-			testName:       "empty repo url",
-			fileName:       "testdata/cluster_invalid_flux_unset_gitrepourl.yaml",
-			wantFluxConfig: nil,
-			wantErr:        true,
-		},
-		{
-			testName:       "invalid repo url",
-			fileName:       "testdata/cluster_invalid_flux_gitrepourl.yaml",
-			wantFluxConfig: nil,
-			wantErr:        true,
+			error:       nil,
 		},
 	}
 
@@ -178,6 +224,11 @@ func TestGetAndValidateFluxConfig(t *testing.T) {
 			got, err := GetAndValidateFluxConfig(tt.fileName, tt.refName, tt.clusterConfig)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("GetAndValidateFluxConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.error != nil {
+				if !reflect.DeepEqual(err, tt.error) {
+					t.Fatalf("GetAndValidateFluxConfig() = %#v, want %#v", err, tt.error)
+				}
 			}
 			if !reflect.DeepEqual(got, tt.wantFluxConfig) {
 				t.Fatalf("GetAndValidateFluxConfig() = %#v, want %#v", got, tt.wantFluxConfig)

--- a/pkg/api/v1alpha1/fluxconfig_types.go
+++ b/pkg/api/v1alpha1/fluxconfig_types.go
@@ -51,6 +51,9 @@ type GithubProviderConfig struct {
 type GitProviderConfig struct {
 	// Repository URL for the repository to be used with flux. Can be either an SSH or HTTPS url.
 	RepositoryUrl string `json:"repositoryUrl"`
+
+	// SSH public key algorithm for the private key specified (rsa, ecdsa, ed25519) (default ecdsa)
+	SshKeyAlgorithm string `json:"sshKeyAlgorithm,omitempty"`
 }
 
 // FluxConfigStatus defines the observed state of FluxConfig

--- a/pkg/api/v1alpha1/fluxconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/fluxconfig_webhook_test.go
@@ -33,6 +33,19 @@ func TestClusterValidateUpdateFluxRepoUrlImmutable(t *testing.T) {
 	f.Expect(c.ValidateUpdate(&fOld)).NotTo(Succeed())
 }
 
+func TestClusterValidateUpdateFluxSshKeyAlgoImmutable(t *testing.T) {
+	fOld := fluxConfig()
+	fOld.Spec.Git = &v1alpha1.GitProviderConfig{
+		RepositoryUrl:   "https://test.git/test",
+		SshKeyAlgorithm: "rsa",
+	}
+	c := fOld.DeepCopy()
+
+	c.Spec.Git.SshKeyAlgorithm = "rsa2"
+	f := NewWithT(t)
+	f.Expect(c.ValidateUpdate(&fOld)).NotTo(Succeed())
+}
+
 func TestClusterValidateUpdateFluxBranchImmutable(t *testing.T) {
 	fOld := fluxConfig()
 	fOld.Spec.Branch = "oldMain"

--- a/pkg/api/v1alpha1/testdata/cluster_1_19_flux_git.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_1_19_flux_git.yaml
@@ -69,4 +69,4 @@ metadata:
   namespace: default
 spec:
   git:
-    repositoryUrl: https://git.com/test/test.git
+    repositoryUrl: ssh://git@github.com/username/repo.git

--- a/pkg/api/v1alpha1/testdata/cluster_1_19_flux_validgit_sshkey.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_1_19_flux_validgit_sshkey.yaml
@@ -30,7 +30,7 @@ spec:
         - 10.96.0.0/12
   gitOpsRef:
     kind: FluxConfig
-    name: test-flux-github
+    name: test-flux-git
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: VSphereMachineConfig
@@ -65,8 +65,9 @@ spec:
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: FluxConfig
 metadata:
-  name: test-flux-github
+  name: test-flux-git
   namespace: default
 spec:
   git:
-    repositoryUrl: "http://test.git/test"
+    repositoryUrl: ssh://git@github.com/username/repo.git
+    sshKeyAlgorithm: "rsa"

--- a/pkg/api/v1alpha1/testdata/cluster_invalid_flux_unset_gitrepourl.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_invalid_flux_unset_gitrepourl.yaml
@@ -69,4 +69,4 @@ metadata:
   namespace: default
 spec:
   git:
-    username: "test"
+    sshKeyAlgorithm: "rsa"

--- a/pkg/api/v1alpha1/testdata/cluster_invalid_flux_wrong_gitsshkeyalgo.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_invalid_flux_wrong_gitsshkeyalgo.yaml
@@ -69,4 +69,5 @@ metadata:
   namespace: default
 spec:
   git:
-    repositoryUrl: "http://test.git/test"
+    repositoryUrl: https://git.com/test/test.git
+    sshKeyAlgorithm: notrsa

--- a/pkg/executables/flux.go
+++ b/pkg/executables/flux.go
@@ -11,11 +11,11 @@ import (
 )
 
 const (
-	fluxPath            = "flux"
-	githubTokenEnv      = "GITHUB_TOKEN"
-	githubProvider      = "github"
-	gitProvider         = "git"
-	privateKeyAlgorithm = "ecdsa"
+	fluxPath                   = "flux"
+	githubTokenEnv             = "GITHUB_TOKEN"
+	githubProvider             = "github"
+	gitProvider                = "git"
+	defaultPrivateKeyAlgorithm = "ecdsa"
 )
 
 type Flux struct {
@@ -39,7 +39,7 @@ func (f *Flux) BootstrapToolkitsComponentsGithub(ctx context.Context, cluster *t
 		"--repository", c.Github.Repository,
 		"--owner", c.Github.Owner,
 		"--path", c.ClusterConfigPath,
-		"--ssh-key-algorithm", privateKeyAlgorithm,
+		"--ssh-key-algorithm", defaultPrivateKeyAlgorithm,
 	}
 	params = setUpCommonParamsBootstrap(cluster, fluxConfig, params)
 
@@ -74,11 +74,16 @@ func (f *Flux) BootstrapToolkitsComponentsGit(ctx context.Context, cluster *type
 		"--url", c.Git.RepositoryUrl,
 		"--path", c.ClusterConfigPath,
 		"--private-key-file", cliConfig.GitPrivateKeyFile,
-		"--ssh-key-algorithm", privateKeyAlgorithm,
 		"--silent",
 	}
 
 	params = setUpCommonParamsBootstrap(cluster, fluxConfig, params)
+	if fluxConfig.Spec.Git.SshKeyAlgorithm != "" {
+		params = append(params, "--ssh-key-algorithm", fluxConfig.Spec.Git.SshKeyAlgorithm)
+	} else {
+		params = append(params, "--ssh-key-algorithm", defaultPrivateKeyAlgorithm)
+	}
+
 	if cliConfig.GitSshKeyPassphrase != "" {
 		params = append(params, "--password", cliConfig.GitSshKeyPassphrase)
 	}

--- a/pkg/executables/flux_test.go
+++ b/pkg/executables/flux_test.go
@@ -439,7 +439,7 @@ func TestFluxReconcile(t *testing.T) {
 	}
 }
 
-func TestFluxBootstrapToolkitsComponentsGitSuccess(t *testing.T) {
+func TestFluxInstallGitToolkitsSuccess(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 
 	repoUrl := "ssh://git@example.com/repository.git"
@@ -469,7 +469,7 @@ func TestFluxBootstrapToolkitsComponentsGitSuccess(t *testing.T) {
 				},
 			},
 			wantExecArgs: []interface{}{
-				"bootstrap", gitProvider, "--url", repoUrl, "--path", path, "--private-key-file", privateKeyFilePath, "--ssh-key-algorithm", "ecdsa", "--silent", "--kubeconfig", "f.kubeconfig", "--password", password,
+				"bootstrap", gitProvider, "--url", repoUrl, "--path", path, "--private-key-file", privateKeyFilePath, "--silent", "--kubeconfig", "f.kubeconfig", "--ssh-key-algorithm", "ecdsa", "--password", password,
 			},
 			cliConfig: &config.CliConfig{
 				GitSshKeyPassphrase: validPassword,
@@ -491,7 +491,8 @@ func TestFluxBootstrapToolkitsComponentsGitSuccess(t *testing.T) {
 			},
 
 			wantExecArgs: []interface{}{
-				"bootstrap", gitProvider, "--url", repoUrl, "--path", path, "--private-key-file", privateKeyFilePath, "--ssh-key-algorithm", "ecdsa", "--silent", "--branch", "main",
+				"bootstrap", gitProvider, "--url", repoUrl, "--path", path, "--private-key-file", privateKeyFilePath, "--silent", "--branch", "main",
+				"--ssh-key-algorithm", "ecdsa",
 			},
 			cliConfig: &config.CliConfig{
 				GitSshKeyPassphrase: "",
@@ -512,8 +513,30 @@ func TestFluxBootstrapToolkitsComponentsGitSuccess(t *testing.T) {
 				},
 			},
 			wantExecArgs: []interface{}{
-				"bootstrap", gitProvider, "--url", repoUrl, "--path", path, "--private-key-file", privateKeyFilePath, "--ssh-key-algorithm", "ecdsa", "--silent", "--namespace", "flux-system",
-				"--password", password,
+				"bootstrap", gitProvider, "--url", repoUrl, "--path", path, "--private-key-file", privateKeyFilePath, "--silent", "--namespace", "flux-system",
+				"--ssh-key-algorithm", "ecdsa", "--password", password,
+			},
+			cliConfig: &config.CliConfig{
+				GitSshKeyPassphrase: validPassword,
+				GitPrivateKeyFile:   validPrivateKeyfilePath,
+				GitKnownHostsFile:   validGitKnownHostsFilePath,
+			},
+		},
+		{
+			testName: "with ssh key algorithm",
+			cluster:  &types.Cluster{},
+			fluxConfig: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					ClusterConfigPath: path,
+					Git: &v1alpha1.GitProviderConfig{
+						RepositoryUrl:   repoUrl,
+						SshKeyAlgorithm: "rsa",
+					},
+				},
+			},
+			wantExecArgs: []interface{}{
+				"bootstrap", gitProvider, "--url", repoUrl, "--path", path, "--private-key-file", privateKeyFilePath, "--silent",
+				"--ssh-key-algorithm", "rsa", "--password", password,
 			},
 			cliConfig: &config.CliConfig{
 				GitSshKeyPassphrase: validPassword,
@@ -535,7 +558,8 @@ func TestFluxBootstrapToolkitsComponentsGitSuccess(t *testing.T) {
 				GitKnownHostsFile:   validGitKnownHostsFilePath,
 			},
 			wantExecArgs: []interface{}{
-				"bootstrap", gitProvider, "--url", "", "--path", "", "--private-key-file", privateKeyFilePath, "--ssh-key-algorithm", "ecdsa", "--silent", "--password", password,
+				"bootstrap", gitProvider, "--url", "", "--path", "", "--private-key-file", privateKeyFilePath, "--silent", "--ssh-key-algorithm", "ecdsa",
+				"--password", password,
 			},
 		},
 	}

--- a/pkg/validations/upgradevalidations/immutableFields.go
+++ b/pkg/validations/upgradevalidations/immutableFields.go
@@ -75,6 +75,9 @@ func ValidateImmutableFields(ctx context.Context, k validations.KubectlClient, c
 				if prevGitOps.Spec.Git.RepositoryUrl != spec.FluxConfig.Spec.Git.RepositoryUrl {
 					return fmt.Errorf("fluxConfig spec.fluxConfig.spec.git.repositoryUrl is immutable")
 				}
+				if prevGitOps.Spec.Git.SshKeyAlgorithm != spec.FluxConfig.Spec.Git.SshKeyAlgorithm {
+					return fmt.Errorf("fluxConfig spec.fluxConfig.spec.git.sshKeyAlgorithm is immutable")
+				}
 			}
 
 			if prevGitOps.Spec.Github != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
These code changes let the users set the ssh key algorithm field in the cluster spec.
The new cluster spec would look like:

````
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: FluxConfig
metadata:
  name: fc-byog
spec:
  git:
    repositoryUrl: ssh://git@github.com/owner/byog.git
    sshKeyAlgorithm: ed25519
```

*Testing (if applicable):*
- Unit tests
- Cluster creation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

