### PR TITLE
Curated packages bugfixes

### DIFF
--- a/cmd/eksctl-anywhere/cmd/applypackages.go
+++ b/cmd/eksctl-anywhere/cmd/applypackages.go
@@ -43,7 +43,7 @@ var applyPackagesCommand = &cobra.Command{
 
 func applyPackages(ctx context.Context) error {
 	kubeConfig := kubeconfig.FromEnvironment()
-	deps, err := newDependenciesForPackages(ctx, kubeConfig)
+	deps, err := curatedpackages.NewDependenciesForPackages(ctx, kubeConfig)
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"context"
-
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/version"
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -27,14 +24,4 @@ func getKubeconfigPath(clusterName, override string) string {
 		return kubeconfig.FromClusterName(clusterName)
 	}
 	return override
-}
-
-func newDependenciesForPackages(ctx context.Context, paths ...string) (*dependencies.Dependencies, error) {
-	return dependencies.NewFactory().
-		WithExecutableMountDirs(paths...).
-		WithExecutableBuilder().
-		WithManifestReader().
-		WithKubectl().
-		WithHelm().
-		Build(ctx)
 }

--- a/cmd/eksctl-anywhere/cmd/createpackages.go
+++ b/cmd/eksctl-anywhere/cmd/createpackages.go
@@ -43,7 +43,7 @@ var createPackagesCommand = &cobra.Command{
 
 func createPackages(ctx context.Context) error {
 	kubeConfig := kubeconfig.FromEnvironment()
-	deps, err := newDependenciesForPackages(ctx, kubeConfig)
+	deps, err := curatedpackages.NewDependenciesForPackages(ctx, kubeConfig)
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/deletepackages.go
+++ b/cmd/eksctl-anywhere/cmd/deletepackages.go
@@ -28,7 +28,7 @@ var deletePackageCommand = &cobra.Command{
 
 func deleteResources(ctx context.Context, args []string) error {
 	kubeConfig := kubeconfig.FromEnvironment()
-	deps, err := newDependenciesForPackages(ctx, kubeConfig)
+	deps, err := curatedpackages.NewDependenciesForPackages(ctx, kubeConfig)
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/describepackages.go
+++ b/cmd/eksctl-anywhere/cmd/describepackages.go
@@ -30,7 +30,7 @@ var describePackagesCommand = &cobra.Command{
 
 func describeResources(ctx context.Context, args []string) error {
 	kubeConfig := kubeconfig.FromEnvironment()
-	deps, err := newDependenciesForPackages(ctx, kubeConfig)
+	deps, err := curatedpackages.NewDependenciesForPackages(ctx, kubeConfig)
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/generatepackage.go
+++ b/cmd/eksctl-anywhere/cmd/generatepackage.go
@@ -50,7 +50,7 @@ func runGeneratePackages(cmd *cobra.Command, args []string) error {
 
 func generatePackages(ctx context.Context, args []string) error {
 	kubeConfig := kubeconfig.FromEnvironment()
-	deps, err := newDependenciesForPackages(ctx, kubeConfig)
+	deps, err := curatedpackages.NewDependenciesForPackages(ctx, kubeConfig)
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/get.go
+++ b/cmd/eksctl-anywhere/cmd/get.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 )
@@ -39,7 +40,7 @@ func preRunPackages(cmd *cobra.Command, args []string) error {
 func getResources(ctx context.Context, resourceType string, output string, args []string) error {
 	kubeConfig := kubeconfig.FromEnvironment()
 
-	deps, err := newDependenciesForPackages(ctx)
+	deps, err := curatedpackages.NewDependenciesForPackages(ctx, kubeConfig)
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
@@ -56,7 +57,7 @@ func getResources(ctx context.Context, resourceType string, output string, args 
 		return fmt.Errorf("kubectl execution failure: \n%v", err)
 	}
 	if len(stdOut.Bytes()) == 0 {
-		fmt.Printf("No resources found in %v namespace", constants.EksaPackagesName)
+		fmt.Printf("No resources found in %v namespace\n", constants.EksaPackagesName)
 		return nil
 	}
 	fmt.Println(&stdOut)

--- a/cmd/eksctl-anywhere/cmd/get.go
+++ b/cmd/eksctl-anywhere/cmd/get.go
@@ -60,6 +60,6 @@ func getResources(ctx context.Context, resourceType string, output string, args 
 		fmt.Printf("No resources found in %v namespace\n", constants.EksaPackagesName)
 		return nil
 	}
-	fmt.Println(&stdOut)
+	fmt.Print(&stdOut)
 	return nil
 }

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -47,7 +47,7 @@ func runInstallPackageController(cmd *cobra.Command, args []string) error {
 func installPackageController(ctx context.Context) error {
 	kubeConfig := kubeconfig.FromEnvironment()
 
-	deps, err := newDependenciesForPackages(ctx, kubeConfig)
+	deps, err := curatedpackages.NewDependenciesForPackages(ctx, kubeConfig)
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
@@ -65,6 +65,8 @@ func installPackageController(ctx context.Context) error {
 		helmChart.Name,
 		helmChart.Tag(),
 	)
+
+	fmt.Println("tag: " + helmChart.Tag() + " Image: " + helmChart.Image())
 
 	if err = ctrlClient.ValidateControllerDoesNotExist(ctx); err != nil {
 		return err

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -66,8 +66,6 @@ func installPackageController(ctx context.Context) error {
 		helmChart.Tag(),
 	)
 
-	fmt.Println("tag: " + helmChart.Tag() + " Image: " + helmChart.Image())
-
 	if err = ctrlClient.ValidateControllerDoesNotExist(ctx); err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/installpackages.go
+++ b/cmd/eksctl-anywhere/cmd/installpackages.go
@@ -55,7 +55,7 @@ func runInstallPackages(cmd *cobra.Command, args []string) error {
 
 func installPackages(ctx context.Context, args []string) error {
 	kubeConfig := kubeconfig.FromEnvironment()
-	deps, err := newDependenciesForPackages(ctx, kubeConfig)
+	deps, err := curatedpackages.NewDependenciesForPackages(ctx, kubeConfig)
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/listpackages.go
+++ b/cmd/eksctl-anywhere/cmd/listpackages.go
@@ -51,7 +51,7 @@ var listPackagesCommand = &cobra.Command{
 
 func listPackages(ctx context.Context) error {
 	kubeConfig := kubeconfig.FromEnvironment()
-	deps, err := newDependenciesForPackages(ctx, kubeConfig)
+	deps, err := curatedpackages.NewDependenciesForPackages(ctx, kubeConfig)
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/upgradepackages.go
+++ b/cmd/eksctl-anywhere/cmd/upgradepackages.go
@@ -42,7 +42,7 @@ var upgradePackagesCommand = &cobra.Command{
 
 func upgradePackages(ctx context.Context) error {
 	kubeConfig := kubeconfig.FromEnvironment()
-	deps, err := newDependenciesForPackages(ctx, kubeConfig)
+	deps, err := curatedpackages.NewDependenciesForPackages(ctx, kubeConfig)
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/pkg/curatedpackages/bundle.go
+++ b/pkg/curatedpackages/bundle.go
@@ -112,7 +112,7 @@ func (b *BundleReader) UpgradeBundle(ctx context.Context, controller *packagesv1
 	if err != nil {
 		return err
 	}
-	params := []string{"create", "-f", "-", "--kubeconfig", b.kubeConfig}
+	params := []string{"apply", "-f", "-", "--kubeconfig", b.kubeConfig}
 	_, err = b.kubectl.CreateFromYaml(ctx, controllerYaml, params...)
 	if err != nil {
 		return err

--- a/pkg/curatedpackages/curatedpackages.go
+++ b/pkg/curatedpackages/curatedpackages.go
@@ -3,8 +3,9 @@ package curatedpackages
 import (
 	"context"
 	"fmt"
-	"github.com/go-logr/logr"
 	"strings"
+
+	"github.com/go-logr/logr"
 
 	"github.com/aws/eks-anywhere-packages/pkg/artifacts"
 	"github.com/aws/eks-anywhere-packages/pkg/bundle"

--- a/pkg/curatedpackages/curatedpackages.go
+++ b/pkg/curatedpackages/curatedpackages.go
@@ -3,9 +3,8 @@ package curatedpackages
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	"github.com/go-logr/logr"
+	"strings"
 
 	"github.com/aws/eks-anywhere-packages/pkg/artifacts"
 	"github.com/aws/eks-anywhere-packages/pkg/bundle"
@@ -16,11 +15,12 @@ import (
 )
 
 const (
-	LICENSE = "The EKS Anywhere package controller and the EKS Anywhere Curated Packages \n" +
-		"(referred to as “features”) are provided as “preview features” subject to the AWS Service Terms, \n" +
-		"(including Section 2 (Betas and Previews)) of the same. During the EKS Anywhere Curated Packages Public Preview, \n" +
-		"the AWS Service Terms are extended to provide customers access to these features free of charge. \n" +
-		"These features will be subject to a service charge and fee structure at ”General Availability“ of the features."
+	LICENSE = `The EKS Anywhere package controller and the EKS Anywhere Curated Packages
+(referred to as “features”) are provided as “preview features” subject to the AWS Service Terms,
+(including Section 2 (Betas and Previews)) of the same. During the EKS Anywhere Curated Packages Public Preview,
+the AWS Service Terms are extended to provide customers access to these features free of charge.
+These features will be subject to a service charge and fee structure at ”General Availability“ of the features.`
+	WIDTH = 112
 )
 
 func NewRegistry(deps *dependencies.Dependencies, registryName, kubeVersion, username, password string) (BundleRegistry, error) {
@@ -82,4 +82,11 @@ func NewDependenciesForPackages(ctx context.Context, paths ...string) (*dependen
 		WithKubectl().
 		WithHelm().
 		Build(ctx)
+}
+
+func PrintLicense() {
+	// Currently, use the width of the longest line to repeat the dashes
+	fmt.Println(strings.Repeat("-", WIDTH))
+	fmt.Println(LICENSE)
+	fmt.Println(strings.Repeat("-", WIDTH))
 }

--- a/pkg/curatedpackages/curatedpackages.go
+++ b/pkg/curatedpackages/curatedpackages.go
@@ -15,6 +15,14 @@ import (
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
+const (
+	LICENSE = "The EKS Anywhere package controller and the EKS Anywhere Curated Packages \n" +
+		"(referred to as “features”) are provided as “preview features” subject to the AWS Service Terms, \n" +
+		"(including Section 2 (Betas and Previews)) of the same. During the EKS Anywhere Curated Packages Public Preview, \n" +
+		"the AWS Service Terms are extended to provide customers access to these features free of charge. " +
+		"These features will be subject to a service charge and fee structure at ”General Availability“ of the features."
+)
+
 func NewRegistry(deps *dependencies.Dependencies, registryName, kubeVersion, username, password string) (BundleRegistry, error) {
 	if registryName != "" {
 		registry := NewCustomRegistry(

--- a/pkg/curatedpackages/curatedpackages.go
+++ b/pkg/curatedpackages/curatedpackages.go
@@ -87,6 +87,14 @@ func NewDependenciesForPackages(ctx context.Context, paths ...string) (*dependen
 
 func PrintLicense() {
 	// Currently, use the width of the longest line to repeat the dashes
+	// Sample Output
+	//----------------------------------------------------------------------------------------------------------------
+	//The EKS Anywhere package controller and the EKS Anywhere Curated Packages
+	//(referred to as “features”) are provided as “preview features” subject to the AWS Service Terms,
+	//(including Section 2 (Betas and Previews)) of the same. During the EKS Anywhere Curated Packages Public Preview,
+	//the AWS Service Terms are extended to provide customers access to these features free of charge.
+	//These features will be subject to a service charge and fee structure at ”General Availability“ of the features.
+	//----------------------------------------------------------------------------------------------------------------
 	fmt.Println(strings.Repeat("-", WIDTH))
 	fmt.Println(LICENSE)
 	fmt.Println(strings.Repeat("-", WIDTH))

--- a/pkg/curatedpackages/curatedpackages.go
+++ b/pkg/curatedpackages/curatedpackages.go
@@ -19,7 +19,7 @@ const (
 	LICENSE = "The EKS Anywhere package controller and the EKS Anywhere Curated Packages \n" +
 		"(referred to as “features”) are provided as “preview features” subject to the AWS Service Terms, \n" +
 		"(including Section 2 (Betas and Previews)) of the same. During the EKS Anywhere Curated Packages Public Preview, \n" +
-		"the AWS Service Terms are extended to provide customers access to these features free of charge. " +
+		"the AWS Service Terms are extended to provide customers access to these features free of charge. \n" +
 		"These features will be subject to a service charge and fee structure at ”General Availability“ of the features."
 )
 

--- a/pkg/curatedpackages/packageclient.go
+++ b/pkg/curatedpackages/packageclient.go
@@ -106,6 +106,7 @@ func (pc *PackageClient) packageMap() map[string]packagesv1.BundlePackage {
 }
 
 func (pc *PackageClient) InstallPackage(ctx context.Context, bp *packagesv1.BundlePackage, customName string, kubeConfig string) error {
+	fmt.Sprintf(LICENSE)
 	p := convertBundlePackageToPackage(*bp, customName, pc.bundle.APIVersion)
 	displayPackage := NewDisplayablePackage(&p)
 	params := []string{"create", "-f", "-", "--kubeconfig", kubeConfig}
@@ -122,6 +123,7 @@ func (pc *PackageClient) InstallPackage(ctx context.Context, bp *packagesv1.Bund
 }
 
 func (pc *PackageClient) ApplyPackages(ctx context.Context, fileName string, kubeConfig string) error {
+	fmt.Sprintf(LICENSE)
 	params := []string{"apply", "-f", fileName, "--kubeconfig", kubeConfig}
 	stdOut, err := pc.kubectl.ExecuteCommand(ctx, params...)
 	if err != nil {
@@ -133,6 +135,7 @@ func (pc *PackageClient) ApplyPackages(ctx context.Context, fileName string, kub
 }
 
 func (pc *PackageClient) CreatePackages(ctx context.Context, fileName string, kubeConfig string) error {
+	fmt.Sprintf(LICENSE)
 	params := []string{"create", "-f", fileName, "--kubeconfig", kubeConfig}
 	stdOut, err := pc.kubectl.ExecuteCommand(ctx, params...)
 	if err != nil {

--- a/pkg/curatedpackages/packageclient.go
+++ b/pkg/curatedpackages/packageclient.go
@@ -106,7 +106,7 @@ func (pc *PackageClient) packageMap() map[string]packagesv1.BundlePackage {
 }
 
 func (pc *PackageClient) InstallPackage(ctx context.Context, bp *packagesv1.BundlePackage, customName string, kubeConfig string) error {
-	fmt.Sprintf(LICENSE)
+	PrintLicense()
 	p := convertBundlePackageToPackage(*bp, customName, pc.bundle.APIVersion)
 	displayPackage := NewDisplayablePackage(&p)
 	params := []string{"create", "-f", "-", "--kubeconfig", kubeConfig}
@@ -123,7 +123,7 @@ func (pc *PackageClient) InstallPackage(ctx context.Context, bp *packagesv1.Bund
 }
 
 func (pc *PackageClient) ApplyPackages(ctx context.Context, fileName string, kubeConfig string) error {
-	fmt.Sprintf(LICENSE)
+	PrintLicense()
 	params := []string{"apply", "-f", fileName, "--kubeconfig", kubeConfig}
 	stdOut, err := pc.kubectl.ExecuteCommand(ctx, params...)
 	if err != nil {
@@ -135,7 +135,7 @@ func (pc *PackageClient) ApplyPackages(ctx context.Context, fileName string, kub
 }
 
 func (pc *PackageClient) CreatePackages(ctx context.Context, fileName string, kubeConfig string) error {
-	fmt.Sprintf(LICENSE)
+	PrintLicense()
 	params := []string{"create", "-f", fileName, "--kubeconfig", kubeConfig}
 	stdOut, err := pc.kubectl.ExecuteCommand(ctx, params...)
 	if err != nil {

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -34,7 +34,7 @@ func NewPackageControllerClient(chartInstaller ChartInstaller, kubectl KubectlRu
 }
 
 func (pc *PackageControllerClient) InstallController(ctx context.Context) error {
-	fmt.Sprintf(LICENSE)
+	PrintLicense()
 	ociUri := fmt.Sprintf("%s%s", "oci://", pc.uri)
 	return pc.chartInstaller.InstallChartFromName(ctx, ociUri, pc.kubeConfig, pc.chartName, pc.chartVersion)
 }

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -34,6 +34,7 @@ func NewPackageControllerClient(chartInstaller ChartInstaller, kubectl KubectlRu
 }
 
 func (pc *PackageControllerClient) InstallController(ctx context.Context) error {
+	fmt.Sprintf(LICENSE)
 	ociUri := fmt.Sprintf("%s%s", "oci://", pc.uri)
 	return pc.chartInstaller.InstallChartFromName(ctx, ociUri, pc.kubeConfig, pc.chartName, pc.chartVersion)
 }

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -68,7 +68,7 @@ func (c *Create) Run(ctx context.Context, clusterSpec *cluster.Spec, validator i
 	}
 
 	if packagesLocation != "" {
-		fmt.Sprintf(curatedpackages.LICENSE)
+		curatedpackages.PrintLicense()
 		err = installCuratedPackages(ctx, clusterSpec, packagesLocation)
 	}
 	return err

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -68,6 +68,7 @@ func (c *Create) Run(ctx context.Context, clusterSpec *cluster.Spec, validator i
 	}
 
 	if packagesLocation != "" {
+		fmt.Sprintf(curatedpackages.LICENSE)
 		err = installCuratedPackages(ctx, clusterSpec, packagesLocation)
 	}
 	return err


### PR DESCRIPTION
*Description of changes:*

### Add License for Curated Packages
Provides the capability to print a license during the following scenarios:
- When installing curated packages as part of cluster creation
- When installing curated packages controller through install packagecontroller
- When creating curated packages through create, apply, and install commands

### Minor Bugfixes 
- Fixes bug with upgrade to use apply instead of create
- Fixes bug for get commands to print a new line carriage
- Fixes bug for kubeconfig outside of current directory

### Move Dependency creation to curatedpackages
- Unify curatedpackages dependencies creation. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

