### PR TITLE
Remove packages image and chart from manifest list

### DIFF
--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -48,10 +48,6 @@ func (vb *VersionsBundle) Manifests() map[string][]*string {
 		"cilium": {
 			&vb.Cilium.Manifest.URI,
 		},
-		"packages": {
-			&vb.PackageController.HelmChart.URI,
-			&vb.PackageController.Controller.URI,
-		},
 		"kindnetd": {
 			&vb.Kindnetd.Manifest.URI,
 		},

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -225,7 +225,7 @@ spec:
     eksD:
       channel: 1-20
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      gitCommit: fc58772a67ea7af9bc7cf7bcc2be10cc7526c643
+      gitCommit: 4856e970d7c2b80a214cb910d7b57927f44f16a4
       kindNode:
         arch:
         - amd64
@@ -435,7 +435,7 @@ spec:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.7-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -443,8 +443,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.6-eks-a-v0.0.0-dev-build.1
-      version: v0.1.6+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.7-eks-a-v0.0.0-dev-build.1
+      version: v0.1.7+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.4/infrastructure-components.yaml
@@ -927,7 +927,7 @@ spec:
     eksD:
       channel: 1-21
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      gitCommit: fc58772a67ea7af9bc7cf7bcc2be10cc7526c643
+      gitCommit: 4856e970d7c2b80a214cb910d7b57927f44f16a4
       kindNode:
         arch:
         - amd64
@@ -1137,7 +1137,7 @@ spec:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.7-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1145,8 +1145,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.6-eks-a-v0.0.0-dev-build.1
-      version: v0.1.6+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.7-eks-a-v0.0.0-dev-build.1
+      version: v0.1.7+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.4/infrastructure-components.yaml
@@ -1629,7 +1629,7 @@ spec:
     eksD:
       channel: 1-22
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      gitCommit: fc58772a67ea7af9bc7cf7bcc2be10cc7526c643
+      gitCommit: 4856e970d7c2b80a214cb910d7b57927f44f16a4
       kindNode:
         arch:
         - amd64
@@ -1839,7 +1839,7 @@ spec:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.7-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1847,8 +1847,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.6-eks-a-v0.0.0-dev-build.1
-      version: v0.1.6+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.7-eks-a-v0.0.0-dev-build.1
+      version: v0.1.7+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.4/infrastructure-components.yaml


### PR DESCRIPTION
*Description of changes:*
We expect all the artifacts URIs to be http/s urls to publicly downloadable
files. These two are OCI artifacts.
*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

