### PR TITLE
only clean up git tests if file is left behind

### DIFF
--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -286,7 +286,7 @@ func (e *ClusterE2ETest) CleanUpGitRepo() {
 		e.T.Errorf("configuring git client for e2e test: %v", err)
 	}
 	dirEntries, err := os.ReadDir(gitTools.RepositoryDirectory)
-	if errors.Is(err, os.ErrNotExist){
+	if errors.Is(err, os.ErrNotExist) {
 		e.T.Logf("repository directory %s does not exist; skipping cleanup", gitTools.RepositoryDirectory)
 		return
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
if the git repository does not exist (failed to clone, already cleaned up by delete, etc) do not attempt to clean it up after running FluxGit tests.

*Testing (if applicable):*
ran this via the framework from my local and confirmed working

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

