### PR TITLE
Make git commit field static for dry run

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -112,7 +112,7 @@ bin/golangci-lint:
 unit-test: ## Run go test against code.
 	$(GO) test -count=1 ./...
 
-make update-bundle-golden-files: ## Updates testdata files located under pkg/test/testdata
+update-bundle-golden-files: ## Updates testdata files located under pkg/test/testdata
 	$(GO) test -count=1 ./pkg -update
 	$(eval DIFF_LINE_COUNT=$(shell git diff pkg/test/testdata | wc -l))
 	@if [[ $(DIFF_LINE_COUNT) != 0 ]]; then \

--- a/release/pkg/assets_eksd.go
+++ b/release/pkg/assets_eksd.go
@@ -30,6 +30,7 @@ const (
 	kindProjectPath          = "projects/kubernetes-sigs/kind"
 	releasePath              = "release"
 	eksDReleaseComponentsUrl = "https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml"
+	fakeGitCommit = "0123456789abcdef0123456789abcdef01234567"
 )
 
 // GetEksDChannelAssets returns the eks-d artifacts including OVAs and kind node image
@@ -267,12 +268,17 @@ func (r *ReleaseConfig) GetEksDReleaseBundle(eksDReleaseChannel, kubeVer, eksDRe
 		return anywherev1alpha1.EksDRelease{}, err
 	}
 
+	gitCommit := r.BuildRepoHead
+	if r.DryRun {
+		gitCommit = fakeGitCommit
+	}
+
 	bundle := anywherev1alpha1.EksDRelease{
 		Name:           eksdRelease.Name,
 		ReleaseChannel: eksDReleaseChannel,
 		KubeVersion:    kubeVer,
 		EksDReleaseUrl: eksDManifestUrl,
-		GitCommit:      r.BuildRepoHead,
+		GitCommit:      gitCommit,
 		KindNode:       bundleImageArtifacts["kind-node"],
 		Ova: anywherev1alpha1.OSImageBundle{
 			Bottlerocket: anywherev1alpha1.OSImage{

--- a/release/pkg/test/files.go
+++ b/release/pkg/test/files.go
@@ -3,7 +3,6 @@ package test
 import (
 	"io/ioutil"
 	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/aws/eks-anywhere/release/pkg/utils"
@@ -47,5 +46,5 @@ func readFile(filepath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(data)), nil
+	return string(data), nil
 }

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -225,7 +225,7 @@ spec:
     eksD:
       channel: 1-20
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      gitCommit: 4856e970d7c2b80a214cb910d7b57927f44f16a4
+      gitCommit: 0123456789abcdef0123456789abcdef01234567
       kindNode:
         arch:
         - amd64
@@ -927,7 +927,7 @@ spec:
     eksD:
       channel: 1-21
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      gitCommit: 4856e970d7c2b80a214cb910d7b57927f44f16a4
+      gitCommit: 0123456789abcdef0123456789abcdef01234567
       kindNode:
         arch:
         - amd64
@@ -1629,7 +1629,7 @@ spec:
     eksD:
       channel: 1-22
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      gitCommit: 4856e970d7c2b80a214cb910d7b57927f44f16a4
+      gitCommit: 0123456789abcdef0123456789abcdef01234567
       kindNode:
         arch:
         - amd64

--- a/release/pkg/test/testdata/release-0.8-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.8-bundle-release.yaml
@@ -209,7 +209,7 @@ spec:
     eksD:
       channel: 1-20
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      gitCommit: ca6d21db63ba0b653af2f76e0ac92a53b375fde9
+      gitCommit: 0123456789abcdef0123456789abcdef01234567
       kindNode:
         arch:
         - amd64
@@ -721,7 +721,7 @@ spec:
     eksD:
       channel: 1-21
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      gitCommit: ca6d21db63ba0b653af2f76e0ac92a53b375fde9
+      gitCommit: 0123456789abcdef0123456789abcdef01234567
       kindNode:
         arch:
         - amd64
@@ -1233,7 +1233,7 @@ spec:
     eksD:
       channel: 1-22
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      gitCommit: ca6d21db63ba0b653af2f76e0ac92a53b375fde9
+      gitCommit: 0123456789abcdef0123456789abcdef01234567
       kindNode:
         arch:
         - amd64


### PR DESCRIPTION
This prevents us from having to update the testdata files for every new commit on eks-anywhere-build-tooling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

