### PR TITLE
make test git path unique depending on test

### DIFF
--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -646,7 +646,7 @@ func (fc *fluxForCluster) initializeLocalRepository() error {
 // This is done so that we avoid clobbering existing cluster configurations in the user-provided git repository.
 func (fc *fluxForCluster) validateLocalConfigPathDoesNotExist() error {
 	if fc.clusterSpec.Cluster.IsSelfManaged() {
-		p := path.Join(fc.gitTools.Writer.Dir(), fc.path(), fc.clusterSpec.Cluster.Name)
+		p := path.Join(fc.gitTools.Writer.Dir(), fc.path())
 		if validations.FileExists(p) {
 			return fmt.Errorf("a cluster configuration file already exists at path %s", p)
 		}

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -61,7 +61,7 @@ func WithFluxGit(opts ...api.FluxConfigOpt) ClusterE2ETestOpt {
 				api.WithStringFromEnvVarGenericGitProviderConfig(gitRepoSshUrl, api.WithGitRepositoryUrl),
 			),
 			api.WithSystemNamespace("default"),
-			api.WithClusterConfigPath("path2"),
+			api.WithClusterConfigPath(e.ClusterName),
 			api.WithBranch("main"),
 		)
 		e.clusterFillers = append(e.clusterFillers,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
make the path that the tests use to write the Git config to the test git repo variable based on the cluster name (which is a hash of the test name).

change the path validation back so that if something writes to the top-level path we validate it and fail faster.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

