### PR TITLE
Wire hardware catalogue with Tinkerbell provider

### DIFF
--- a/pkg/providers/tinkerbell/hardware/catalogue.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue.go
@@ -30,13 +30,13 @@ type Indexer interface {
 // Catalogue represents a catalogue of Tinkerbell hardware manifests to be used with Tinkerbells
 // Kubefied back-end.
 type Catalogue struct {
-	Hardware      []*tinkv1alpha1.Hardware
+	hardware      []*tinkv1alpha1.Hardware
 	hardwareIndex Indexer
 
-	BMCs     []*pbnjv1alpha1.BMC
+	bmcs     []*pbnjv1alpha1.BMC
 	bmcIndex Indexer
 
-	Secrets     []*corev1.Secret
+	secrets     []*corev1.Secret
 	secretIndex Indexer
 }
 

--- a/pkg/providers/tinkerbell/hardware/catalogue_bmc.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_bmc.go
@@ -12,14 +12,14 @@ func (c *Catalogue) InsertBMC(bmc *pbnjv1alpha1.BMC) error {
 	if err := c.bmcIndex.Insert(bmc); err != nil {
 		return err
 	}
-	c.BMCs = append(c.BMCs, bmc)
+	c.bmcs = append(c.bmcs, bmc)
 	return nil
 }
 
 // AllBMCs retrieves a copy of the catalogued BMC instances.
 func (c *Catalogue) AllBMCs() []*pbnjv1alpha1.BMC {
-	bmcs := make([]*pbnjv1alpha1.BMC, len(c.BMCs))
-	copy(bmcs, c.BMCs)
+	bmcs := make([]*pbnjv1alpha1.BMC, len(c.bmcs))
+	copy(bmcs, c.bmcs)
 	return bmcs
 }
 
@@ -41,7 +41,7 @@ func (c *Catalogue) LookupBMC(index, key string) ([]*pbnjv1alpha1.BMC, error) {
 
 // TotalBMCs returns the total BMCs registered in the catalogue.
 func (c *Catalogue) TotalBMCs() int {
-	return len(c.BMCs)
+	return len(c.bmcs)
 }
 
 const BMCNameIndex = ".ObjectMeta.Name"

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
@@ -1,6 +1,6 @@
 package hardware
 
-import tinkv1alpha1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/tink/api/v1alpha1"
+import "github.com/tinkerbell/cluster-api-provider-tinkerbell/tink/api/v1alpha1"
 
 // IndexHardware indexes Hardware instances on index by extracfting the key using fn.
 func (c *Catalogue) IndexHardware(index string, fn KeyExtractorFunc) {
@@ -9,32 +9,32 @@ func (c *Catalogue) IndexHardware(index string, fn KeyExtractorFunc) {
 
 // InsertHardware inserts Hardware into the catalogue. If any indexes exist, the hardware is
 // indexed.
-func (c *Catalogue) InsertHardware(hardware *tinkv1alpha1.Hardware) error {
+func (c *Catalogue) InsertHardware(hardware *v1alpha1.Hardware) error {
 	if err := c.hardwareIndex.Insert(hardware); err != nil {
 		return err
 	}
-	c.Hardware = append(c.Hardware, hardware)
+	c.hardware = append(c.hardware, hardware)
 	return nil
 }
 
 // AllHardware retrieves a copy of the catalogued Hardware instances.
-func (c *Catalogue) AllHardware() []*tinkv1alpha1.Hardware {
-	hardware := make([]*tinkv1alpha1.Hardware, len(c.Hardware))
-	copy(hardware, c.Hardware)
+func (c *Catalogue) AllHardware() []*v1alpha1.Hardware {
+	hardware := make([]*v1alpha1.Hardware, len(c.hardware))
+	copy(hardware, c.hardware)
 	return hardware
 }
 
 // LookupHardware retrieves Hardware instances on index with a key of key. Multiple hardware _may_
 // have the same key hence it can return multiple Hardware.
-func (c *Catalogue) LookupHardware(index, key string) ([]*tinkv1alpha1.Hardware, error) {
+func (c *Catalogue) LookupHardware(index, key string) ([]*v1alpha1.Hardware, error) {
 	untyped, err := c.hardwareIndex.Lookup(index, key)
 	if err != nil {
 		return nil, err
 	}
 
-	hardware := make([]*tinkv1alpha1.Hardware, len(untyped))
+	hardware := make([]*v1alpha1.Hardware, len(untyped))
 	for i, v := range untyped {
-		hardware[i] = v.(*tinkv1alpha1.Hardware)
+		hardware[i] = v.(*v1alpha1.Hardware)
 	}
 
 	return hardware, nil
@@ -42,7 +42,7 @@ func (c *Catalogue) LookupHardware(index, key string) ([]*tinkv1alpha1.Hardware,
 
 // TotalHardware returns the total hardware registered in the catalogue.
 func (c *Catalogue) TotalHardware() int {
-	return len(c.Hardware)
+	return len(c.hardware)
 }
 
 const HardwareIDIndex = ".Spec.ID"
@@ -51,7 +51,7 @@ const HardwareIDIndex = ".Spec.ID"
 func WithHardwareIDIndex() CatalogueOption {
 	return func(c *Catalogue) {
 		c.IndexHardware(HardwareIDIndex, func(o interface{}) string {
-			hardware := o.(*tinkv1alpha1.Hardware)
+			hardware := o.(*v1alpha1.Hardware)
 			return hardware.Spec.ID
 		})
 	}
@@ -63,7 +63,7 @@ const HardwareBMCRefIndex = ".Spec.BmcRef"
 func WithHardwareBMCRefIndex() CatalogueOption {
 	return func(c *Catalogue) {
 		c.IndexHardware(HardwareBMCRefIndex, func(o interface{}) string {
-			hardware := o.(*tinkv1alpha1.Hardware)
+			hardware := o.(*v1alpha1.Hardware)
 			return hardware.Spec.BmcRef
 		})
 	}

--- a/pkg/providers/tinkerbell/hardware/catalogue_secret.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_secret.go
@@ -12,14 +12,14 @@ func (c *Catalogue) InsertSecret(secret *corev1.Secret) error {
 	if err := c.secretIndex.Insert(secret); err != nil {
 		return err
 	}
-	c.Secrets = append(c.Secrets, secret)
+	c.secrets = append(c.secrets, secret)
 	return nil
 }
 
 // AllSecrets retrieves a copy of the catalogued Secret instances.
 func (c *Catalogue) AllSecrets() []*corev1.Secret {
-	secrets := make([]*corev1.Secret, len(c.Secrets))
-	copy(secrets, c.Secrets)
+	secrets := make([]*corev1.Secret, len(c.secrets))
+	copy(secrets, c.secrets)
 	return secrets
 }
 
@@ -41,7 +41,7 @@ func (c *Catalogue) LookupSecret(index, key string) ([]*corev1.Secret, error) {
 
 // TotalSecrets returns the total Secrets registered in the catalogue.
 func (c *Catalogue) TotalSecrets() int {
-	return len(c.Secrets)
+	return len(c.secrets)
 }
 
 const SecretNameIndex = ".ObjectMeta.Name"

--- a/pkg/providers/tinkerbell/hardware/catalogue_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_test.go
@@ -60,9 +60,9 @@ func TestParseYAMLCatalogueWithData(t *testing.T) {
 	err := hardware.ParseYAMLCatalogue(catalogue, buffer)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
-	g.Expect(catalogue.Hardware).To(gomega.HaveLen(1))
-	g.Expect(catalogue.BMCs).To(gomega.HaveLen(1))
-	g.Expect(catalogue.Secrets).To(gomega.HaveLen(1))
+	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(1))
+	g.Expect(catalogue.TotalBMCs()).To(gomega.Equal(1))
+	g.Expect(catalogue.TotalSecrets()).To(gomega.Equal(1))
 }
 
 func TestParseYAMLCatalogueWithoutData(t *testing.T) {
@@ -75,10 +75,7 @@ func TestParseYAMLCatalogueWithoutData(t *testing.T) {
 	err := hardware.ParseYAMLCatalogue(catalogue, buffer)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
-	g.Expect(catalogue.Hardware).To(gomega.HaveLen(0))
-	g.Expect(catalogue.BMCs).To(gomega.HaveLen(0))
-	g.Expect(catalogue.Secrets).To(gomega.HaveLen(0))
-}
-
-func TestCatalogue_Thing(t *testing.T) {
+	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(0))
+	g.Expect(catalogue.TotalBMCs()).To(gomega.Equal(0))
+	g.Expect(catalogue.TotalSecrets()).To(gomega.Equal(0))
 }

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -205,7 +205,15 @@ func NewProviderCustomDep(
 		writer:    writer,
 
 		hardwareManifestPath: hardwareManifestPath,
-		catalogue:            hardware.NewCatalogue(),
+
+		// todo(chrisdoherty4)
+		// Inject the catalogue dependency so we can dynamically construcft the indexing capabilities.
+		catalogue: hardware.NewCatalogue(
+			hardware.WithHardwareIDIndex(),
+			hardware.WithHardwareBMCRefIndex(),
+			hardware.WithBMCNameIndex(),
+			hardware.WithSecretNameIndex(),
+		),
 
 		// (chrisdoherty4) We're hard coding the dependency and monkey patching in testing because the provider
 		// isn't very testable right now and we already have tests in the `tinkerbell` package so can monkey patch

--- a/pkg/providers/tinkerbell/validator_test.go
+++ b/pkg/providers/tinkerbell/validator_test.go
@@ -139,7 +139,11 @@ func newValidClusterSpec(cp, etcd, worker int) v1alpha1.ClusterSpec {
 
 func newCatalogueWithHardware(hardwareCount int) *hardware.Catalogue {
 	catalogue := hardware.NewCatalogue()
-	catalogue.Hardware = make([]*tinkv1alpha1.Hardware, hardwareCount)
+	for i := 0; i < hardwareCount; i++ {
+		if err := catalogue.InsertHardware(&tinkv1alpha1.Hardware{}); err != nil {
+			panic(err)
+		}
+	}
 	return catalogue
 }
 


### PR DESCRIPTION
# Summary 

Build on #2016 

Having implemented indexing this change swaps out existing functions to use the public API of the catalogue construct and unexports fields that need to be controlled by the catalogue. This ensures indexing capabilities are consistently applied and avoids any accidental mutation of internal data structures.
