### PR TITLE
Remove git tag from cluster-controller manifest path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ KUBE_RBAC_PROXY_IMAGE_NAME_OVERRIDE="${IMAGE_REPO}/brancz/kube-rbac-proxy"
 KUBE_RBAC_PROXY_IMAGE_TAG_OVERRIDE="latest"
 KUSTOMIZATION_CONFIG=./config/prod/kustomization.yaml
 
-CONTROLLER_MANIFEST_OUTPUT_DIR=$(OUTPUT_DIR)/manifests/cluster-controller/$(GIT_TAG)
+CONTROLLER_MANIFEST_OUTPUT_DIR=$(OUTPUT_DIR)/manifests/cluster-controller
 
 BUILD_TAGS :=
 BUILD_FLAGS?=

--- a/release/pkg/assets_cluster_controller.go
+++ b/release/pkg/assets_cluster_controller.go
@@ -110,13 +110,13 @@ func (r *ReleaseConfig) GetClusterControllerAssets() ([]Artifact, error) {
 	latestPath := getLatestUploadDestination(sourcedFromBranch)
 
 	if r.DevRelease || r.ReleaseEnvironment == "development" {
-		sourceS3Prefix = fmt.Sprintf("%s/%s/manifests/cluster-controller/%s", eksAnywhereProjectPath, latestPath, gitTag)
+		sourceS3Prefix = fmt.Sprintf("%s/%s/manifests/cluster-controller", eksAnywhereProjectPath, latestPath)
 	} else {
 		sourceS3Prefix = fmt.Sprintf("releases/bundles/%d/artifacts/eks-anywhere-cluster-controller/manifests/%s", r.BundleNumber, gitTag)
 	}
 
 	if r.DevRelease {
-		releaseS3Path = fmt.Sprintf("artifacts/%s/eks-anywhere/manifests/cluster-controller/%s", r.DevReleaseUriVersion, gitTag)
+		releaseS3Path = fmt.Sprintf("artifacts/%s/eks-anywhere/manifests/cluster-controller", r.DevReleaseUriVersion)
 	} else {
 		releaseS3Path = fmt.Sprintf("releases/bundles/%d/artifacts/eks-anywhere-cluster-controller/manifests/%s", r.BundleNumber, gitTag)
 	}


### PR DESCRIPTION
The cluster-controller git tag is obtained by getting the latest git tag across all branches, but this doesnt work for new release branches because the new tag corresponding to the release branch has not been cut yet, so there would be a mismatch between the tag and the branch.

Hence removing this tag name from the S3 URI path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

