### PR TITLE
pull before push to avoid non-fast-forward updates in gitops validations

### DIFF
--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -807,10 +807,13 @@ func (e *ClusterE2ETest) pushConfigChanges() error {
 	p := e.clusterConfGitPath()
 	g := e.GitClient
 	if err := g.Add(p); err != nil {
-		return err
+		return fmt.Errorf("adding cluster config changes at path %s: %v", p, err)
 	}
 	if err := g.Commit("EKS-A E2E Flux test configuration update"); err != nil {
-		return err
+		return fmt.Errorf("commiting cluster config changes: %v", err)
+	}
+	if err := g.Pull(context.Background(), e.gitBranch()); err != nil {
+		return fmt.Errorf("pulling from remote before pushing config changes: %v", err)
 	}
 	return g.Push(context.Background())
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
we previously created a new git repo for each test. now, we re-use the same repo for BYO git tests. 

this means we need to pull changes before pushing updates when validating flux, since we'll run into non-fast-forward updates otherwise. 

we already do pull-before-push in the actual business logic of the product, this is a test framework issue that didn't show up previously. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

