### PR TITLE
use jobId not cluster name as config path in gitops tests

### DIFF
--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -55,13 +55,14 @@ var fluxGitRequiredEnvVars = []string{
 func WithFluxGit(opts ...api.FluxConfigOpt) ClusterE2ETestOpt {
 	return func(e *ClusterE2ETest) {
 		checkRequiredEnvVars(e.T, fluxGitRequiredEnvVars)
+		jobId := strings.Replace(e.getJobIdFromEnv(), ":", "-", -1)
 		fluxConfigName := fluxConfigName()
 		e.FluxConfig = api.NewFluxConfig(fluxConfigName,
 			api.WithGenericGitProvider(
 				api.WithStringFromEnvVarGenericGitProviderConfig(gitRepoSshUrl, api.WithGitRepositoryUrl),
 			),
 			api.WithSystemNamespace("default"),
-			api.WithClusterConfigPath(e.ClusterName),
+			api.WithClusterConfigPath(jobId),
 			api.WithBranch("main"),
 		)
 		e.clusterFillers = append(e.clusterFillers,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
we can end up with the same cluster name if the tests run on the same instance, leading to collision between gitops test configurations; let's use jobId (unique based on instance and test name) as the path to always avoid this.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

