### PR TITLE
Adding CAPC artifacts into prod bundle

### DIFF
--- a/release/pkg/assets_eksd.go
+++ b/release/pkg/assets_eksd.go
@@ -30,7 +30,7 @@ const (
 	kindProjectPath          = "projects/kubernetes-sigs/kind"
 	releasePath              = "release"
 	eksDReleaseComponentsUrl = "https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml"
-	fakeGitCommit = "0123456789abcdef0123456789abcdef01234567"
+	fakeGitCommit            = "0123456789abcdef0123456789abcdef01234567"
 )
 
 // GetEksDChannelAssets returns the eks-d artifacts including OVAs and kind node image

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -165,12 +165,9 @@ func (r *ReleaseConfig) GetVersionsBundles(imageDigests map[string]string) ([]an
 		}
 	}
 
-	var cloudStackBundle anywherev1alpha1.CloudStackBundle
-	if r.DevRelease && (r.BuildRepoBranchName == "main" || r.BuildRepoBranchName == "cloudstack") {
-		cloudStackBundle, err = r.GetCloudStackBundle(imageDigests)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Error getting bundle for CloudStack infrastructure provider")
-		}
+	cloudStackBundle, err := r.GetCloudStackBundle(imageDigests)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error getting bundle for CloudStack infrastructure provider")
 	}
 
 	eksDReleaseMap, err := readEksDReleases(r)
@@ -260,32 +257,32 @@ func (r *ReleaseConfig) GenerateBundleArtifactsTable() (map[string][]Artifact, e
 
 	artifactsTable := map[string][]Artifact{}
 	eksAArtifactsFuncs := map[string]func() ([]Artifact, error){
-		"eks-a-tools":                  r.GetEksAToolsAssets,
-		"cluster-api":                  r.GetCAPIAssets,
-		"cluster-api-provider-aws":     r.GetCapaAssets,
-		"cluster-api-provider-docker":  r.GetDockerAssets,
-		"cluster-api-provider-vsphere": r.GetCapvAssets,
-		"vsphere-csi-driver":           r.GetVsphereCsiAssets,
-		"cert-manager":                 r.GetCertManagerAssets,
-		"cilium":                       r.GetCiliumAssets,
-		"local-path-provisioner":       r.GetLocalPathProvisionerAssets,
-		"kube-rbac-proxy":              r.GetKubeRbacProxyAssets,
-		"kube-vip":                     r.GetKubeVipAssets,
-		"flux":                         r.GetFluxAssets,
-		"etcdadm-bootstrap-provider":   r.GetEtcdadmBootstrapAssets,
-		"etcdadm-controller":           r.GetEtcdadmControllerAssets,
-		"cluster-controller":           r.GetClusterControllerAssets,
-		"kindnetd":                     r.GetKindnetdAssets,
-		"etcdadm":                      r.GetEtcdadmAssets,
-		"cri-tools":                    r.GetCriToolsAssets,
-		"diagnostic-collector":         r.GetDiagnosticCollectorAssets,
-		"haproxy":                      r.GetHaproxyAssets,
-		"eks-anywhere-packages":        r.GetPackagesAssets,
+		"eks-a-tools":                     r.GetEksAToolsAssets,
+		"cluster-api":                     r.GetCAPIAssets,
+		"cluster-api-provider-aws":        r.GetCapaAssets,
+		"cluster-api-provider-docker":     r.GetDockerAssets,
+		"cluster-api-provider-vsphere":    r.GetCapvAssets,
+		"cluster-api-provider-cloudstack": r.GetCapcAssets,
+		"vsphere-csi-driver":              r.GetVsphereCsiAssets,
+		"cert-manager":                    r.GetCertManagerAssets,
+		"cilium":                          r.GetCiliumAssets,
+		"local-path-provisioner":          r.GetLocalPathProvisionerAssets,
+		"kube-rbac-proxy":                 r.GetKubeRbacProxyAssets,
+		"kube-vip":                        r.GetKubeVipAssets,
+		"flux":                            r.GetFluxAssets,
+		"etcdadm-bootstrap-provider":      r.GetEtcdadmBootstrapAssets,
+		"etcdadm-controller":              r.GetEtcdadmControllerAssets,
+		"cluster-controller":              r.GetClusterControllerAssets,
+		"kindnetd":                        r.GetKindnetdAssets,
+		"etcdadm":                         r.GetEtcdadmAssets,
+		"cri-tools":                       r.GetCriToolsAssets,
+		"diagnostic-collector":            r.GetDiagnosticCollectorAssets,
+		"haproxy":                         r.GetHaproxyAssets,
+		"eks-anywhere-packages":           r.GetPackagesAssets,
 	}
 
 	if r.DevRelease && (r.BuildRepoBranchName == "main" || r.BuildRepoBranchName == "cloudstack") {
 		eksAArtifactsFuncs["cluster-api-provider-tinkerbell"] = r.GetCaptAssets
-		eksAArtifactsFuncs["cluster-api-provider-cloudstack"] = r.GetCapcAssets
 		eksAArtifactsFuncs["tink"] = r.GetTinkAssets
 		eksAArtifactsFuncs["hegel"] = r.GetHegelAssets
 		eksAArtifactsFuncs["cfssl"] = r.GetCfsslAssets

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -140,9 +140,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-cloudstack-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.3-RC1-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.2/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.3-RC1/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -152,8 +152,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.2/metadata.yaml
-      version: v0.4.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.3-RC1/metadata.yaml
+      version: v0.4.3-RC1+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.1.3/core-components.yaml
@@ -328,7 +328,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.8.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.8.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -435,7 +435,7 @@ spec:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.8-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.10-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -443,8 +443,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.8-eks-a-v0.0.0-dev-build.1
-      version: v0.1.8+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.10-eks-a-v0.0.0-dev-build.1
+      version: v0.1.10+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.4/infrastructure-components.yaml
@@ -842,9 +842,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-cloudstack-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.3-RC1-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.2/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.3-RC1/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -854,8 +854,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.2/metadata.yaml
-      version: v0.4.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.3-RC1/metadata.yaml
+      version: v0.4.3-RC1+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.1.3/core-components.yaml
@@ -1030,7 +1030,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.8.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.8.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1137,7 +1137,7 @@ spec:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.8-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.10-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1145,8 +1145,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.8-eks-a-v0.0.0-dev-build.1
-      version: v0.1.8+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.10-eks-a-v0.0.0-dev-build.1
+      version: v0.1.10+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.4/infrastructure-components.yaml
@@ -1544,9 +1544,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-cloudstack-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.3-RC1-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.2/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.3-RC1/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -1556,8 +1556,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.2/metadata.yaml
-      version: v0.4.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.3-RC1/metadata.yaml
+      version: v0.4.3-RC1+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.1.3/core-components.yaml
@@ -1732,7 +1732,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.8.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.8.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1839,7 +1839,7 @@ spec:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.8-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.10-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1847,8 +1847,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.8-eks-a-v0.0.0-dev-build.1
-      version: v0.1.8+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.10-eks-a-v0.0.0-dev-build.1
+      version: v0.1.10+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.4/infrastructure-components.yaml

--- a/release/pkg/test/testdata/release-0.8-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.8-bundle-release.yaml
@@ -133,11 +133,27 @@ spec:
         uri: public.ecr.aws/isovalent/operator-generic:v1.9.13-eksa.2
       version: v1.9.13-eksa.2
     cloudStack:
-      clusterAPIController: {}
-      components: {}
-      kubeVip: {}
-      metadata: {}
-      version: ""
+      clusterAPIController:
+        arch:
+        - amd64
+        description: Container image for cluster-api-cloudstack-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-cloudstack-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.1-eks-a-v0.0.0-dev-release-0.8-build.1
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.1/infrastructure-components.yaml
+      kubeVip:
+        arch:
+        - amd64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-release-0.8-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.1/metadata.yaml
+      version: v0.4.1+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/cluster-api/v1.0.2/core-components.yaml
@@ -312,7 +328,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.8.2-eks-a-v0.0.0-dev-release-0.8-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-anywhere/manifests/cluster-controller/v0.8.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -657,11 +673,27 @@ spec:
         uri: public.ecr.aws/isovalent/operator-generic:v1.9.13-eksa.2
       version: v1.9.13-eksa.2
     cloudStack:
-      clusterAPIController: {}
-      components: {}
-      kubeVip: {}
-      metadata: {}
-      version: ""
+      clusterAPIController:
+        arch:
+        - amd64
+        description: Container image for cluster-api-cloudstack-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-cloudstack-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.1-eks-a-v0.0.0-dev-release-0.8-build.1
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.1/infrastructure-components.yaml
+      kubeVip:
+        arch:
+        - amd64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-release-0.8-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.1/metadata.yaml
+      version: v0.4.1+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/cluster-api/v1.0.2/core-components.yaml
@@ -836,7 +868,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.8.2-eks-a-v0.0.0-dev-release-0.8-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-anywhere/manifests/cluster-controller/v0.8.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1181,11 +1213,27 @@ spec:
         uri: public.ecr.aws/isovalent/operator-generic:v1.9.13-eksa.2
       version: v1.9.13-eksa.2
     cloudStack:
-      clusterAPIController: {}
-      components: {}
-      kubeVip: {}
-      metadata: {}
-      version: ""
+      clusterAPIController:
+        arch:
+        - amd64
+        description: Container image for cluster-api-cloudstack-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-cloudstack-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.1-eks-a-v0.0.0-dev-release-0.8-build.1
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.1/infrastructure-components.yaml
+      kubeVip:
+        arch:
+        - amd64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-release-0.8-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.1/metadata.yaml
+      version: v0.4.1+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/cluster-api/v1.0.2/core-components.yaml
@@ -1360,7 +1408,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.8.2-eks-a-v0.0.0-dev-release-0.8-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-anywhere/manifests/cluster-controller/v0.8.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As part of incorporating the CAPC artifacts into the prod release, we need to build them here so they are populated in the bundle manifest. This PR was based on https://github.com/aws/eks-anywhere/pull/2052/files

*Testing (if applicable):*
Unit tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

