### PR TITLE
Catch up to date pull err

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -73,12 +73,10 @@ func (e *RepositoryIsEmptyError) Error() string {
 	return fmt.Sprintf("repository %s is empty can cannot be cloned", e.Repository)
 }
 
-type RepositoryUpToDateError struct {
-	Repository string
-}
+type RepositoryUpToDateError struct{}
 
 func (e *RepositoryUpToDateError) Error() string {
-	return fmt.Sprintf("error pulling from repository %s: already up-to-date", e.Repository)
+	return "error pulling from repository: already up-to-date"
 }
 
 type RemoteBranchDoesNotExistError struct {

--- a/pkg/git/gitclient/gitclient.go
+++ b/pkg/git/gitclient/gitclient.go
@@ -174,7 +174,7 @@ func (g *GitClient) Pull(ctx context.Context, branch string) error {
 
 	if errors.Is(err, gogit.NoErrAlreadyUpToDate) {
 		logger.V(3).Info("Local repo already up-to-date", "repo", g.RepoDirectory, "remote", gogit.DefaultRemoteName)
-		return &git.RepositoryUpToDateError{Repository: g.RepoDirectory}
+		return &git.RepositoryUpToDateError{}
 	}
 
 	if err != nil {

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -817,7 +817,7 @@ func (e *ClusterE2ETest) pushConfigChanges() error {
 	repoUpToDateErr := &git.RepositoryUpToDateError{}
 	err := g.Pull(context.Background(), e.gitBranch())
 	if err != nil {
-		if !errors.As(err, repoUpToDateErr) {
+		if !errors.Is(err, repoUpToDateErr) {
 			return fmt.Errorf("pulling from remote before pushing config changes: %v", err)
 		}
 		e.T.Log(err.Error())
@@ -825,7 +825,7 @@ func (e *ClusterE2ETest) pushConfigChanges() error {
 
 	err = g.Push(context.Background())
 	if err != nil {
-		if !errors.As(err, repoUpToDateErr) {
+		if !errors.Is(err, repoUpToDateErr) {
 			return fmt.Errorf("pushing config changes to remote: %v", err)
 		}
 		e.T.Log(err.Error())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When a remote repository is 'up to date' and we pull, go-git returns an error, which they intentionally call [`NoErrAlreadyUpToDate`
](https://github.com/go-git/go-git/blob/f0b111ab70e4e90013658b0835929b2083902017/remote.go#L32).

In our code, we mimic that, and return our own up-to-date error if we pull and the repo is up-to-date.

This change makes sure that the git test validations catch that up-to-date error and continue if it's present.

I've created [a ticket to re-visit this and simplify it](https://github.com/aws/eks-anywhere/issues/2092); there's a place in the FluxAddonClient where we use a retrier to Pull, and it retries on this up-to-date error, creating noisy logs; we do this because in our original testing if we pulled from the remote too quickly after pushing to github we would sometimes get the up-to-date error one or twice before the pull changes were reflected. However, this is not apparent in the code and should be addressed and simplified/documented. I'm not doing it now in order to minimize the surface area of this PR for release v0.9.0, but have captured the issue. 



*Testing (if applicable):*

built locally and ran docker gitops tests via the framework; `main` threw the up-to-date errors, this branch resolved the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

