### PR TITLE
Fix manifestURL injection in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ build: eks-a eks-a-tool unit-test ## Generate binaries and run unit tests
 release: eks-a-release unit-test ## Generate release binary and run unit tests
 
 .PHONY: eks-a-binary
-eks-a-binary: ALL_LINKER_FLAGS := $(LINKER_FLAGS) -X github.com/aws/eks-anywhere/pkg/version.gitVersion=$(GIT_VERSION) -X github.com/aws/eks-anywhere/pkg/cluster.releasesManifestURL=$(RELEASE_MANIFEST_URL) -X github.com/aws/eks-anywhere/pkg/releases.manifestURL=$(RELEASE_MANIFEST_URL)
+eks-a-binary: ALL_LINKER_FLAGS := $(LINKER_FLAGS) -X github.com/aws/eks-anywhere/pkg/version.gitVersion=$(GIT_VERSION) -X github.com/aws/eks-anywhere/pkg/cluster.releasesManifestURL=$(RELEASE_MANIFEST_URL) -X github.com/aws/eks-anywhere/pkg/manifests/releases.manifestURL=$(RELEASE_MANIFEST_URL)
 eks-a-binary: LINKER_FLAGS_ARG := -ldflags "$(ALL_LINKER_FLAGS)"
 eks-a-binary: BUILD_TAGS_ARG := -tags "$(BUILD_TAGS)"
 eks-a-binary: OUTPUT_FILE ?= bin/eksctl-anywhere


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`eksctl anywhere download images` was failing with the following error:
```
Error: unable to initialize executables: retrieving executable tools image from bundle in dependency factory: invalid version v0.9.0, no matching release found
```

It seems like we had some refactoring that changed where this variable was injecting, so this wasn't actually injecting the value here like it was supposed to and using the default dev release url instead: https://github.com/aws/eks-anywhere/blob/2318acd63b7fffae95937bedac49feba08fbeff0/pkg/manifests/releases/read.go#L15

*Testing (if applicable):*
Tested binary after building binary with the following target
```
GOOS=darwin GOARCH=amd64 /usr/local/go/bin/go build -tags "" -ldflags "-s -w -X github.com/aws/eks-anywhere/pkg/version.gitVersion=v0.9.0 -X github.com/aws/eks-anywhere/pkg/cluster.releasesManifestURL=https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml -X github.com/aws/eks-anywhere/pkg/manifests/releases.manifestURL=https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml" -trimpath -o bin/darwin/amd64/eksctl-anywhere github.com/aws/eks-anywhere/cmd/eksctl-anywhere
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

