### PR TITLE
Adding cloudstack support bundle components for debugging

### DIFF
--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -149,6 +149,8 @@ func (a *analyzerFactory) DataCenterConfigAnalyzers(datacenter v1alpha1.Ref) []*
 		return a.eksaVsphereAnalyzers()
 	case v1alpha1.DockerDatacenterKind:
 		return a.eksaDockerAnalyzers()
+	case v1alpha1.CloudStackDatacenterKind:
+		return a.eksaCloudstackAnalyzers()
 	default:
 		return nil
 	}
@@ -158,6 +160,14 @@ func (a *analyzerFactory) eksaVsphereAnalyzers() []*Analyze {
 	crds := []string{
 		fmt.Sprintf("vspheredatacenterconfigs.%s", v1alpha1.GroupVersion.Group),
 		fmt.Sprintf("vspheremachineconfigs.%s", v1alpha1.GroupVersion.Group),
+	}
+	return a.generateCrdAnalyzers(crds)
+}
+
+func (a *analyzerFactory) eksaCloudstackAnalyzers() []*Analyze {
+	crds := []string{
+		fmt.Sprintf("cloudstackdatacenterconfigs.%s", v1alpha1.GroupVersion.Group),
+		fmt.Sprintf("cloudstackmachineconfigs.%s", v1alpha1.GroupVersion.Group),
 	}
 	return a.generateCrdAnalyzers(crds)
 }

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -65,6 +65,8 @@ func (c *collectorFactory) DataCenterConfigCollectors(datacenter v1alpha1.Ref) [
 		return c.eksaVsphereCollectors()
 	case v1alpha1.DockerDatacenterKind:
 		return c.eksaDockerCollectors()
+	case v1alpha1.CloudStackDatacenterKind:
+		return c.eksaCloudstackCollectors()
 	default:
 		return nil
 	}
@@ -80,6 +82,18 @@ func (c *collectorFactory) eksaVsphereCollectors() []*Collect {
 		},
 	}
 	return append(vsphereLogs, c.vsphereCrdCollectors()...)
+}
+
+func (c *collectorFactory) eksaCloudstackCollectors() []*Collect {
+	cloudstackLogs := []*Collect{
+		{
+			Logs: &logs{
+				Namespace: constants.CapcSystemNamespace,
+				Name:      logpath(constants.CapcSystemNamespace),
+			},
+		},
+	}
+	return append(cloudstackLogs, c.cloudstackCrdCollectors()...)
 }
 
 func (c *collectorFactory) eksaDockerCollectors() []*Collect {
@@ -263,6 +277,21 @@ func (c *collectorFactory) vsphereCrdCollectors() []*Collect {
 		"vspheremachines.infrastructure.cluster.x-k8s.io",
 		"vspheremachinetemplates.infrastructure.cluster.x-k8s.io",
 		"vspherevms.infrastructure.cluster.x-k8s.io",
+	}
+	return c.generateCrdCollectors(capvCrds)
+}
+
+func (c *collectorFactory) cloudstackCrdCollectors() []*Collect {
+	capvCrds := []string{
+		"cloudstackaffinitygroups.infrastructure.cluster.x-k8s.io",
+		"cloudstackclusters.infrastructure.cluster.x-k8s.io",
+		"cloudstackdatacenterconfigs.anywhere.eks.amazonaws.com",
+		"cloudstackisolatednetworks.infrastructure.cluster.x-k8s.io",
+		"cloudstackmachineconfigs.anywhere.eks.amazonaws.com",
+		"cloudstackmachines.infrastructure.cluster.x-k8s.io",
+		"cloudstackmachinestatecheckers.infrastructure.cluster.x-k8s.io",
+		"cloudstackmachinetemplates.infrastructure.cluster.x-k8s.io",
+		"cloudstackzones.infrastructure.cluster.x-k8s.io",
 	}
 	return c.generateCrdCollectors(capvCrds)
 }

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -282,7 +282,7 @@ func (c *collectorFactory) vsphereCrdCollectors() []*Collect {
 }
 
 func (c *collectorFactory) cloudstackCrdCollectors() []*Collect {
-	capvCrds := []string{
+	crds := []string{
 		"cloudstackaffinitygroups.infrastructure.cluster.x-k8s.io",
 		"cloudstackclusters.infrastructure.cluster.x-k8s.io",
 		"cloudstackdatacenterconfigs.anywhere.eks.amazonaws.com",
@@ -293,7 +293,7 @@ func (c *collectorFactory) cloudstackCrdCollectors() []*Collect {
 		"cloudstackmachinetemplates.infrastructure.cluster.x-k8s.io",
 		"cloudstackzones.infrastructure.cluster.x-k8s.io",
 	}
-	return c.generateCrdCollectors(capvCrds)
+	return c.generateCrdCollectors(crds)
 }
 
 func (c *collectorFactory) packagesCrdCollectors() []*Collect {

--- a/pkg/diagnostics/collectors_test.go
+++ b/pkg/diagnostics/collectors_test.go
@@ -1,0 +1,24 @@
+package diagnostics_test
+
+import (
+	"fmt"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	"testing"
+
+	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/diagnostics"
+)
+
+func TestCloudStackDataCenterConfigCollectors(t *testing.T) {
+	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.CloudStackDatacenterKind}
+	factory := diagnostics.NewDefaultCollectorFactory()
+	collectors := factory.DataCenterConfigCollectors(datacenter)
+	assert.Equal(t, len(collectors), 10, "DataCenterConfigCollectors() mismatch between desired collectors and actual")
+	assert.Equal(t, constants.CapcSystemNamespace, collectors[0].Logs.Namespace)
+	assert.Equal(t, fmt.Sprintf("logs/%s", constants.CapcSystemNamespace), collectors[0].Logs.Name)
+	for _, collector := range collectors[1:] {
+		assert.Equal(t,  []string{"kubectl"}, collector.Run.Command)
+		assert.Equal(t,  "eksa-diagnostics", collector.Run.Namespace)
+	}
+}

--- a/pkg/diagnostics/collectors_test.go
+++ b/pkg/diagnostics/collectors_test.go
@@ -2,11 +2,12 @@ package diagnostics_test
 
 import (
 	"fmt"
-	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/diagnostics"
 )
 
@@ -18,7 +19,7 @@ func TestCloudStackDataCenterConfigCollectors(t *testing.T) {
 	assert.Equal(t, constants.CapcSystemNamespace, collectors[0].Logs.Namespace)
 	assert.Equal(t, fmt.Sprintf("logs/%s", constants.CapcSystemNamespace), collectors[0].Logs.Name)
 	for _, collector := range collectors[1:] {
-		assert.Equal(t,  []string{"kubectl"}, collector.Run.Command)
-		assert.Equal(t,  "eksa-diagnostics", collector.Run.Namespace)
+		assert.Equal(t, []string{"kubectl"}, collector.Run.Command)
+		assert.Equal(t, "eksa-diagnostics", collector.Run.Namespace)
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I noticed the capc-system resources and logs were not being populated in the support bundle generated by eks-a so this PR attempts to mitigate that issue

*Testing (if applicable):*
E2E test failure resulted in desired logs and CRD's present in support-bundle. Unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->



