### PR TITLE
make sure to replace . with - in cluster names

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -97,6 +97,7 @@ phases:
     commands:
       - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE
       - export GIT_HASH=$(cat bin/githash)
+      - export CLUSTER_NAME_PREFIX="${BRANCH_NAME//./-}"
       - >
         ./cmd/integration_test/build/script/upload_artifacts.sh
         $ARTIFACTS_BUCKET
@@ -109,7 +110,7 @@ phases:
         false
       - >
         ./bin/test e2e cleanup vsphere
-        -n ${BRANCH_NAME}
+        -n ${CLUSTER_NAME_PREFIX}
         -v 4
 reports:
   e2e-reports:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
the cluster names are based off of the branch name but have `.` replaced with `-`; this is a quick fix to get the release branch tests to clean up the right clusters by doing a replace on `.` with `-` in the branch name var

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

