### PR TITLE
Change doc urls to remove underescore

### DIFF
--- a/docs/content/en/docs/concepts/clusterworkflow.md
+++ b/docs/content/en/docs/concepts/clusterworkflow.md
@@ -79,7 +79,7 @@ This section steps through an example of an EKS Anywhere cluster being created o
 Once you understand this process, you can use the following documentation to create your own cluster:
 
 * [Create production cluster]({{< relref "../getting-started/production-environment" >}}) for the exact procedure to create a cluster on vSphere.
-* [Troubleshooting]({{< relref "../tasks/troubleshoot/_troubleshooting" >}}) if you encounter problems along the way.
+* [Troubleshooting]({{< relref "../tasks/troubleshoot/troubleshooting" >}}) if you encounter problems along the way.
 
 ### Starting the process
 

--- a/docs/content/en/docs/tasks/troubleshoot/packages.md
+++ b/docs/content/en/docs/tasks/troubleshoot/packages.md
@@ -1,8 +1,12 @@
 
 ---
-title: "Curating Packages Troubleshooting"
-linkTitle: "Curating Packages Troubleshooting"
+title: "Curated Packages Troubleshooting"
+linkTitle: "Curated Packages Troubleshooting"
 weight: 50
+description: >
+  Troubleshooting specific to curated packages
+aliases:
+   - /docs/tasks/troubleshoot/_packages
 ---
 
 

--- a/docs/content/en/docs/tasks/troubleshoot/supportbundle.md
+++ b/docs/content/en/docs/tasks/troubleshoot/supportbundle.md
@@ -4,6 +4,8 @@ linkTitle: "Generating a Support Bundle"
 weight: 30
 description: >
     Using the Support Bundle with your EKS Anywhere Cluster
+aliases:
+   - /docs/tasks/troubleshoot/_supportbundle
 ---
 
 This guide covers the use of the EKS Anywhere Support Bundle for troubleshooting and support.

--- a/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
+++ b/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
@@ -4,6 +4,8 @@ linkTitle: "Troubleshooting"
 weight: 40
 description: >
   Troubleshooting EKS Anywhere clusters
+aliases:
+   - /docs/tasks/troubleshoot/_troubleshooting
 ---
 
 This guide covers some generic troubleshooting techniques and then cover more detailed examples. You may want to search this document for a fragment of the error you are seeing.


### PR DESCRIPTION
Remove underscores from docs urls and add aliases to redirect to new location. Add description for curated packages as well.
