### PR TITLE
Add clustermesh.enabled false to cilium template override

### DIFF
--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -125,6 +125,11 @@ func (c values) set(value interface{}, path ...string) {
 
 func templateValues(spec *cluster.Spec) values {
 	val := values{
+		"clustermesh": values{
+			"config": values{
+				"enabled": false,
+			},
+		},
 		"cni": values{
 			"chainingMode": "portmap",
 		},

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -91,6 +91,11 @@ func (e *mapMatcher) String() string {
 
 func TestTemplaterGenerateUpgradePreflightManifestSuccess(t *testing.T) {
 	wantValues := map[string]interface{}{
+		"clustermesh": map[string]interface{}{
+			"config": map[string]interface{}{
+				"enabled": false,
+			},
+		},
 		"cni": map[string]interface{}{
 			"chainingMode": "portmap",
 		},
@@ -144,6 +149,11 @@ func TestTemplaterGenerateUpgradePreflightManifestError(t *testing.T) {
 
 func TestTemplaterGenerateManifestSuccess(t *testing.T) {
 	wantValues := map[string]interface{}{
+		"clustermesh": map[string]interface{}{
+			"config": map[string]interface{}{
+				"enabled": false,
+			},
+		},
 		"cni": map[string]interface{}{
 			"chainingMode": "portmap",
 		},
@@ -179,6 +189,11 @@ func TestTemplaterGenerateManifestSuccess(t *testing.T) {
 
 func TestTemplaterGenerateManifestPolicyEnforcementModeSuccess(t *testing.T) {
 	wantValues := map[string]interface{}{
+		"clustermesh": map[string]interface{}{
+			"config": map[string]interface{}{
+				"enabled": false,
+			},
+		},
 		"cni": map[string]interface{}{
 			"chainingMode": "portmap",
 		},
@@ -224,6 +239,11 @@ func TestTemplaterGenerateManifestError(t *testing.T) {
 
 func TestTemplaterGenerateUpgradeManifestSuccess(t *testing.T) {
 	wantValues := map[string]interface{}{
+		"clustermesh": map[string]interface{}{
+			"config": map[string]interface{}{
+				"enabled": false,
+			},
+		},
 		"cni": map[string]interface{}{
 			"chainingMode": "portmap",
 		},


### PR DESCRIPTION
The new verison of cilium added clustermesh to the helm chart
but we are not enabling that for eks-a clusters

Goes with https://github.com/aws/eks-anywhere-build-tooling/pull/802

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

