### PR TITLE
Fix doc typo

### DIFF
--- a/docs/content/en/docs/tasks/packages/_index.md
+++ b/docs/content/en/docs/tasks/packages/_index.md
@@ -31,7 +31,7 @@ Skip the following installation steps if the returned result is not empty.
 
 1. Install the package controller
     ```bash
-    eksctl anywhere install packagecontroller —-kube-version 1.21
+    eksctl anywhere install packagecontroller --kube-version 1.21
     ```
 
 1. Check the package controller


### PR DESCRIPTION
The original command includes an invalid (long) dash

*Issue #, if available:* N/A

*Description of changes:* Update eksctl command

*Testing (if applicable):* Ran the updated command and it worked locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

