### PR TITLE
Add physicalNetworkConnector default when generating snow cluster config

### DIFF
--- a/cmd/eksctl-anywhere/cmd/generateclusterconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generateclusterconfig.go
@@ -35,7 +35,7 @@ var generateClusterConfigCmd = &cobra.Command{
 		}
 		err = generateClusterConfig(clusterName)
 		if err != nil {
-			return fmt.Errorf("failed to generate eks-a cluster config: %v", err) // need to have better error handling here in own func
+			return fmt.Errorf("generating eks-a cluster config: %v", err) // need to have better error handling here in own func
 		}
 		return nil
 	},
@@ -45,7 +45,7 @@ func preRunGenerateClusterConfig(cmd *cobra.Command, args []string) {
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 		err := viper.BindPFlag(flag.Name, flag)
 		if err != nil {
-			log.Fatalf("failed initializing flags: %v", err)
+			log.Fatalf("initializing flags: %v", err)
 		}
 	})
 }
@@ -55,7 +55,7 @@ func init() {
 	generateClusterConfigCmd.Flags().StringP("provider", "p", "", "Provider to use (vsphere or docker)")
 	err := generateClusterConfigCmd.MarkFlagRequired("provider")
 	if err != nil {
-		log.Fatalf("failed marking flag as required: %v", err)
+		log.Fatalf("marking flag as required: %v", err)
 	}
 }
 
@@ -77,7 +77,7 @@ func generateClusterConfig(clusterName string) error {
 		)
 		dcyaml, err := yaml.Marshal(datacenterConfig)
 		if err != nil {
-			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+			return fmt.Errorf("generating cluster yaml: %v", err)
 		}
 		datacenterYaml = dcyaml
 	case constants.VSphereProviderName:
@@ -92,7 +92,7 @@ func generateClusterConfig(clusterName string) error {
 		)
 		dcyaml, err := yaml.Marshal(datacenterConfig)
 		if err != nil {
-			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+			return fmt.Errorf("generating cluster yaml: %v", err)
 		}
 		datacenterYaml = dcyaml
 		// need to default control plane config name to something different from the cluster name based on assumption
@@ -107,15 +107,15 @@ func generateClusterConfig(clusterName string) error {
 		)
 		cpMcYaml, err := yaml.Marshal(cpMachineConfig)
 		if err != nil {
-			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+			return fmt.Errorf("generating cluster yaml: %v", err)
 		}
 		workerMcYaml, err := yaml.Marshal(workerMachineConfig)
 		if err != nil {
-			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+			return fmt.Errorf("generating cluster yaml: %v", err)
 		}
 		etcdMcYaml, err := yaml.Marshal(etcdMachineConfig)
 		if err != nil {
-			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+			return fmt.Errorf("generating cluster yaml: %v", err)
 		}
 		machineGroupYaml = append(machineGroupYaml, cpMcYaml, workerMcYaml, etcdMcYaml)
 	case constants.SnowProviderName:
@@ -132,7 +132,7 @@ func generateClusterConfig(clusterName string) error {
 		)
 		dcyaml, err := yaml.Marshal(datacenterConfig)
 		if err != nil {
-			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+			return fmt.Errorf("generating cluster yaml: %v", err)
 		}
 		datacenterYaml = dcyaml
 
@@ -144,11 +144,11 @@ func generateClusterConfig(clusterName string) error {
 		)
 		cpMcYaml, err := yaml.Marshal(cpMachineConfig)
 		if err != nil {
-			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+			return fmt.Errorf("generating cluster yaml: %v", err)
 		}
 		workerMcYaml, err := yaml.Marshal(workerMachineConfig)
 		if err != nil {
-			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+			return fmt.Errorf("generating cluster yaml: %v", err)
 		}
 		machineGroupYaml = append(machineGroupYaml, cpMcYaml, workerMcYaml)
 	case constants.CloudStackProviderName:
@@ -165,7 +165,7 @@ func generateClusterConfig(clusterName string) error {
 		)
 		dcyaml, err := yaml.Marshal(datacenterConfig)
 		if err != nil {
-			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+			return fmt.Errorf("generating cluster yaml: %v", err)
 		}
 		datacenterYaml = dcyaml
 		// need to default control plane config name to something different from the cluster name based on assumption
@@ -180,15 +180,15 @@ func generateClusterConfig(clusterName string) error {
 		)
 		cpMcYaml, err := yaml.Marshal(cpMachineConfig)
 		if err != nil {
-			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+			return fmt.Errorf("generating cluster yaml: %v", err)
 		}
 		workerMcYaml, err := yaml.Marshal(workerMachineConfig)
 		if err != nil {
-			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+			return fmt.Errorf("generating cluster yaml: %v", err)
 		}
 		etcdMcYaml, err := yaml.Marshal(etcdMachineConfig)
 		if err != nil {
-			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+			return fmt.Errorf("generating cluster yaml: %v", err)
 		}
 		machineGroupYaml = append(machineGroupYaml, cpMcYaml, workerMcYaml, etcdMcYaml)
 	case constants.TinkerbellProviderName:
@@ -203,18 +203,18 @@ func generateClusterConfig(clusterName string) error {
 			)
 			dcyaml, err := yaml.Marshal(datacenterConfig)
 			if err != nil {
-				return fmt.Errorf("failed to generate cluster yaml: %v", err)
+				return fmt.Errorf("generating cluster yaml: %v", err)
 			}
 			datacenterYaml = dcyaml
 			versionBundle, err := cluster.GetVersionsBundleForVersion(version.Get(), v1alpha1.GetClusterDefaultKubernetesVersion())
 			if err != nil {
-				return fmt.Errorf("failed to generate cluster yaml: %v", err)
+				return fmt.Errorf("generating cluster yaml: %v", err)
 			}
 
 			tinkTmpConfig := v1alpha1.NewDefaultTinkerbellTemplateConfigGenerate(clusterName, *versionBundle)
 			tinkTmpYaml, err := yaml.Marshal(tinkTmpConfig)
 			if err != nil {
-				return fmt.Errorf("failed to generate cluster yaml: %v", err)
+				return fmt.Errorf("generating cluster yaml: %v", err)
 			}
 			tinkerbellTemplateYaml = tinkTmpYaml
 
@@ -228,11 +228,11 @@ func generateClusterConfig(clusterName string) error {
 			)
 			cpMcYaml, err := yaml.Marshal(cpMachineConfig)
 			if err != nil {
-				return fmt.Errorf("failed to generate cluster yaml: %v", err)
+				return fmt.Errorf("generating cluster yaml: %v", err)
 			}
 			workerMcYaml, err := yaml.Marshal(workerMachineConfig)
 			if err != nil {
-				return fmt.Errorf("failed to generate cluster yaml: %v", err)
+				return fmt.Errorf("generating cluster yaml: %v", err)
 			}
 			machineGroupYaml = append(machineGroupYaml, cpMcYaml, workerMcYaml)
 		} else {
@@ -245,11 +245,11 @@ func generateClusterConfig(clusterName string) error {
 
 	configMarshal, err := yaml.Marshal(config)
 	if err != nil {
-		return fmt.Errorf("failed to generate cluster yaml: %v", err)
+		return fmt.Errorf("generating cluster yaml: %v", err)
 	}
 	clusterYaml, err := api.CleanupPathsFromYaml(configMarshal, removeFromDefaultConfig)
 	if err != nil {
-		return fmt.Errorf("failed to clean up paths from yaml: %v", err)
+		return fmt.Errorf("cleaning up paths from yaml: %v", err)
 	}
 	resources = append(resources, clusterYaml, datacenterYaml)
 	if len(machineGroupYaml) > 0 {

--- a/pkg/api/v1alpha1/snowmachineconfig.go
+++ b/pkg/api/v1alpha1/snowmachineconfig.go
@@ -26,9 +26,10 @@ func NewSnowMachineConfigGenerate(name string) *SnowMachineConfigGenerate {
 			Name: name,
 		},
 		Spec: SnowMachineConfigSpec{
-			AMIID:        "",
-			InstanceType: DefaultSnowInstanceType,
-			SshKeyName:   DefaultSnowSshKeyName,
+			AMIID:                    "",
+			InstanceType:             DefaultSnowInstanceType,
+			SshKeyName:               DefaultSnowSshKeyName,
+			PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
 		},
 	}
 }

--- a/pkg/api/v1alpha1/snowmachineconfig_test.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestSnowSetDefaults(t *testing.T) {
@@ -136,4 +137,24 @@ func TestSetEtcdAnnotation(t *testing.T) {
 	m := &SnowMachineConfig{}
 	m.SetEtcdAnnotation()
 	g.Expect(m.Annotations).To(Equal(map[string]string{"anywhere.eks.amazonaws.com/etcd": "true"}))
+}
+
+func TestNewSnowMachineConfigGenerate(t *testing.T) {
+	g := NewWithT(t)
+	want := &SnowMachineConfigGenerate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       SnowMachineConfigKind,
+			APIVersion: SchemeBuilder.GroupVersion.String(),
+		},
+		ObjectMeta: ObjectMeta{
+			Name: "snow-cluster",
+		},
+		Spec: SnowMachineConfigSpec{
+			AMIID:                    "",
+			InstanceType:             DefaultSnowInstanceType,
+			SshKeyName:               DefaultSnowSshKeyName,
+			PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
+		},
+	}
+	g.Expect(NewSnowMachineConfigGenerate("snow-cluster")).To(Equal(want))
 }


### PR DESCRIPTION
*Issue #, if available:*

#2166 

*Description of changes:*

Add `physicalNetworkConnector` field to snowmachineconfig obj when generating cluster config.

*Testing (if applicable):*

unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

