### PR TITLE
Support host paths to mount for cloudstack (#2097)

### DIFF
--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -95,7 +95,10 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 	}
 
 	cliConfig := buildCliConfig(clusterSpec)
-	dirs := cc.directoriesToMount(clusterSpec, cliConfig)
+	dirs, err := cc.directoriesToMount(clusterSpec, cliConfig)
+	if err != nil {
+		return err
+	}
 
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).WithExecutableMountDirs(dirs...).
 		WithBootstrapper().

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -74,7 +74,10 @@ func (uc *upgradeClusterOptions) upgradeCluster(ctx context.Context) error {
 	}
 
 	cliConfig := buildCliConfig(clusterSpec)
-	dirs := cc.directoriesToMount(clusterSpec, cliConfig)
+	dirs, err := cc.directoriesToMount(clusterSpec, cliConfig)
+	if err != nil {
+		return err
+	}
 
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).WithExecutableMountDirs(dirs...).
 		WithBootstrapper().

--- a/pkg/providers/cloudstack/decoder/decoder.go
+++ b/pkg/providers/cloudstack/decoder/decoder.go
@@ -12,6 +12,7 @@ import (
 const (
 	EksacloudStackCloudConfigB64SecretKey = "EKSA_CLOUDSTACK_B64ENCODED_SECRET"
 	CloudStackCloudConfigB64SecretKey     = "CLOUDSTACK_B64ENCODED_SECRET"
+	EksaCloudStackHostPathToMount         = "EKSA_CLOUDSTACK_HOST_PATHS_TO_MOUNT"
 )
 
 // ParseCloudStackSecret parses the input b64 string into the ini object to extract out the api key, secret key, and url


### PR DESCRIPTION
* Make verify-ssl optional
Add unit tests for decoder.go

* Support cloudstack specific host paths to mount for CLI executable container

* Fix formatting error

* Add a validation for the host paths to mount

* Throw an error when the specified host path does not exist

Co-authored-by: Wonkun Kim <wonkun@amazon.com>

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

