### PR TITLE
Rollout restart cilium during upgrade

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -87,7 +87,6 @@ type ClusterClient interface {
 	GetEksaVSphereMachineConfig(ctx context.Context, VSphereDatacenterName string, kubeconfigFile string, namespace string) (*v1alpha1.VSphereMachineConfig, error)
 	GetEksaCloudStackMachineConfig(ctx context.Context, cloudstackMachineConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.CloudStackMachineConfig, error)
 	SetEksaControllerEnvVar(ctx context.Context, envVar, envVarVal, kubeconfig string) error
-	DaemonSetRolloutRestart(ctx context.Context, dsName, dsNamespace, kubeconfig string) error
 	CreateNamespace(ctx context.Context, kubeconfig string, namespace string) error
 	GetNamespace(ctx context.Context, kubeconfig string, namespace string) error
 	ValidateControlPlaneNodes(ctx context.Context, cluster *types.Cluster, clusterName string) error
@@ -104,6 +103,7 @@ type ClusterClient interface {
 type Networking interface {
 	GenerateManifest(ctx context.Context, clusterSpec *cluster.Spec, namespaces []string) ([]byte, error)
 	Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec, namespaces []string) (*types.ChangeDiff, error)
+	RunPostControlPlaneUpgradeSetup(ctx context.Context, cluster *types.Cluster) error
 }
 
 type AwsIamAuth interface {
@@ -396,13 +396,9 @@ func (c *ClusterManager) UpgradeCluster(ctx context.Context, managementCluster, 
 		return fmt.Errorf("waiting for workload cluster control plane to be ready: %v", err)
 	}
 
-	if provider.Name() == constants.CloudStackProviderName {
-		// TODO: Move this logic to provider implementation: https://github.com/aws/eks-anywhere/issues/2061
-		logger.V(3).Info("Restarting cilium daemonset after upgrade")
-		err = c.clusterClient.DaemonSetRolloutRestart(ctx, "cilium", constants.KubeSystemNamespace, eksaMgmtCluster.KubeconfigFile)
-		if err != nil {
-			return fmt.Errorf("restarting cilium daemonset after upgrade: %v", err)
-		}
+	logger.V(3).Info("Running CNI post control plane upgrade operations")
+	if err = c.networking.RunPostControlPlaneUpgradeSetup(ctx, workloadCluster); err != nil {
+		return fmt.Errorf("running CNI post control plane upgrade operations: %v", err)
 	}
 
 	logger.V(3).Info("Waiting for workload cluster control plane replicas to be ready after upgrade")

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -467,7 +467,6 @@ func TestClusterManagerUpgradeSelfManagedClusterSuccess(t *testing.T) {
 	}
 
 	tt := newSpecChangedTest(t)
-	tt.mocks.provider.EXPECT().Name().Return("test")
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Cluster.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
@@ -484,6 +483,7 @@ func TestClusterManagerUpgradeSelfManagedClusterSuccess(t *testing.T) {
 	tt.mocks.provider.EXPECT().GetDeployments()
 	tt.mocks.writer.EXPECT().Write(clusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
 	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
+	tt.mocks.networking.EXPECT().RunPostControlPlaneUpgradeSetup(tt.ctx, tt.cluster).Return(nil)
 
 	if err := tt.clusterManager.UpgradeCluster(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.mocks.provider); err != nil {
 		t.Errorf("ClusterManager.UpgradeCluster() error = %v, wantErr nil", err)
@@ -503,7 +503,6 @@ func TestClusterManagerUpgradeWorkloadClusterSuccess(t *testing.T) {
 	}
 
 	tt := newSpecChangedTest(t)
-	tt.mocks.provider.EXPECT().Name().Return("test")
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, mCluster, mgmtClusterName).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, mCluster.KubeconfigFile, mCluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
@@ -520,6 +519,7 @@ func TestClusterManagerUpgradeWorkloadClusterSuccess(t *testing.T) {
 	tt.mocks.provider.EXPECT().GetDeployments()
 	tt.mocks.writer.EXPECT().Write(mgmtClusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
 	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, mCluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
+	tt.mocks.networking.EXPECT().RunPostControlPlaneUpgradeSetup(tt.ctx, wCluster).Return(nil)
 
 	if err := tt.clusterManager.UpgradeCluster(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.mocks.provider); err != nil {
 		t.Errorf("ClusterManager.UpgradeCluster() error = %v, wantErr nil", err)
@@ -539,7 +539,6 @@ func TestClusterManagerUpgradeCloudStackWorkloadClusterSuccess(t *testing.T) {
 	}
 
 	tt := newSpecChangedTest(t)
-	tt.mocks.provider.EXPECT().Name().Return(constants.CloudStackProviderName)
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, mCluster, mgmtClusterName).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, mCluster.KubeconfigFile, mCluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
@@ -556,7 +555,7 @@ func TestClusterManagerUpgradeCloudStackWorkloadClusterSuccess(t *testing.T) {
 	tt.mocks.provider.EXPECT().GetDeployments()
 	tt.mocks.writer.EXPECT().Write(mgmtClusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
 	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, mCluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
-	tt.mocks.client.EXPECT().DaemonSetRolloutRestart(tt.ctx, "cilium", constants.KubeSystemNamespace, tt.cluster.KubeconfigFile)
+	tt.mocks.networking.EXPECT().RunPostControlPlaneUpgradeSetup(tt.ctx, wCluster).Return(nil)
 
 	if err := tt.clusterManager.UpgradeCluster(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.mocks.provider); err != nil {
 		t.Errorf("ClusterManager.UpgradeCluster() error = %v, wantErr nil", err)
@@ -649,7 +648,6 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForCAPITimeout(t *testing.T) {
 	}
 
 	tt := newSpecChangedTest(t)
-	tt.mocks.provider.EXPECT().Name().Return("test")
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Cluster.Name).Return(tt.oldClusterConfig, nil)
 	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
 	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
@@ -665,6 +663,7 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForCAPITimeout(t *testing.T) {
 	tt.mocks.client.EXPECT().ValidateWorkerNodes(tt.ctx, wCluster.Name, mCluster.KubeconfigFile).Return(nil)
 	tt.mocks.writer.EXPECT().Write(clusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
 	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
+	tt.mocks.networking.EXPECT().RunPostControlPlaneUpgradeSetup(tt.ctx, wCluster).Return(nil)
 
 	if err := tt.clusterManager.UpgradeCluster(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.mocks.provider); err == nil {
 		t.Error("ClusterManager.UpgradeCluster() error = nil, wantErr not nil")

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -99,20 +99,6 @@ func (mr *MockClusterClientMockRecorder) CreateNamespace(arg0, arg1, arg2 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockClusterClient)(nil).CreateNamespace), arg0, arg1, arg2)
 }
 
-// DaemonSetRolloutRestart mocks base method.
-func (m *MockClusterClient) DaemonSetRolloutRestart(arg0 context.Context, arg1, arg2, arg3 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DaemonSetRolloutRestart", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DaemonSetRolloutRestart indicates an expected call of DaemonSetRolloutRestart.
-func (mr *MockClusterClientMockRecorder) DaemonSetRolloutRestart(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DaemonSetRolloutRestart", reflect.TypeOf((*MockClusterClient)(nil).DaemonSetRolloutRestart), arg0, arg1, arg2, arg3)
-}
-
 // DeleteAWSIamConfig mocks base method.
 func (m *MockClusterClient) DeleteAWSIamConfig(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
@@ -689,6 +675,20 @@ func (m *MockNetworking) GenerateManifest(arg0 context.Context, arg1 *cluster.Sp
 func (mr *MockNetworkingMockRecorder) GenerateManifest(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateManifest", reflect.TypeOf((*MockNetworking)(nil).GenerateManifest), arg0, arg1, arg2)
+}
+
+// RunPostControlPlaneUpgradeSetup mocks base method.
+func (m *MockNetworking) RunPostControlPlaneUpgradeSetup(arg0 context.Context, arg1 *types.Cluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunPostControlPlaneUpgradeSetup", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunPostControlPlaneUpgradeSetup indicates an expected call of RunPostControlPlaneUpgradeSetup.
+func (mr *MockNetworkingMockRecorder) RunPostControlPlaneUpgradeSetup(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunPostControlPlaneUpgradeSetup", reflect.TypeOf((*MockNetworking)(nil).RunPostControlPlaneUpgradeSetup), arg0, arg1)
 }
 
 // Upgrade mocks base method.

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -690,7 +690,7 @@ func (k *Kubectl) ValidateEKSAClustersCRD(ctx context.Context, cluster *types.Cl
 	return nil
 }
 
-func (k *Kubectl) DaemonSetRolloutRestart(ctx context.Context, dsName, dsNamespace, kubeconfig string) error {
+func (k *Kubectl) RolloutRestartDaemonSet(ctx context.Context, dsName, dsNamespace, kubeconfig string) error {
 	params := []string{
 		"rollout", "restart", "ds", dsName,
 		"--kubeconfig", kubeconfig, "--namespace", dsNamespace,

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -1026,11 +1026,11 @@ func TestKubectlSetControllerEnvVarSuccess(t *testing.T) {
 
 	err := k.SetEksaControllerEnvVar(ctx, envVar, envVarValue, cluster.KubeconfigFile)
 	if err != nil {
-		t.Fatalf("Kubectl.DaemonSetRolloutRestart() error = %v, want nil", err)
+		t.Fatalf("Kubectl.RolloutRestartDaemonSet() error = %v, want nil", err)
 	}
 }
 
-func TestKubectlDaemonSetRolloutRestartSuccess(t *testing.T) {
+func TestKubectlRolloutRestartDaemonSetSuccess(t *testing.T) {
 	k, ctx, cluster, e := newKubectl(t)
 	e.EXPECT().Execute(
 		ctx,
@@ -1040,13 +1040,13 @@ func TestKubectlDaemonSetRolloutRestartSuccess(t *testing.T) {
 		},
 	).Return(bytes.Buffer{}, nil)
 
-	err := k.DaemonSetRolloutRestart(ctx, "cilium", constants.KubeSystemNamespace, cluster.KubeconfigFile)
+	err := k.RolloutRestartDaemonSet(ctx, "cilium", constants.KubeSystemNamespace, cluster.KubeconfigFile)
 	if err != nil {
-		t.Fatalf("Kubectl.DaemonSetRolloutRestart() error = %v, want nil", err)
+		t.Fatalf("Kubectl.RolloutRestartDaemonSet() error = %v, want nil", err)
 	}
 }
 
-func TestKubectlDaemonSetRolloutRestartError(t *testing.T) {
+func TestKubectlRolloutRestartDaemonSetError(t *testing.T) {
 	k, ctx, cluster, e := newKubectl(t)
 	e.EXPECT().Execute(
 		ctx,
@@ -1056,9 +1056,9 @@ func TestKubectlDaemonSetRolloutRestartError(t *testing.T) {
 		},
 	).Return(bytes.Buffer{}, fmt.Errorf("error"))
 
-	err := k.DaemonSetRolloutRestart(ctx, "cilium", constants.KubeSystemNamespace, cluster.KubeconfigFile)
+	err := k.RolloutRestartDaemonSet(ctx, "cilium", constants.KubeSystemNamespace, cluster.KubeconfigFile)
 	if err == nil {
-		t.Fatalf("Kubectl.DaemonSetRolloutRestart() expected error, but was nil")
+		t.Fatalf("Kubectl.RolloutRestartDaemonSet() expected error, but was nil")
 	}
 }
 

--- a/pkg/networking/cilium/client.go
+++ b/pkg/networking/cilium/client.go
@@ -22,6 +22,7 @@ type Client interface {
 	DeleteKubeSpecFromBytes(ctx context.Context, cluster *types.Cluster, data []byte) error
 	GetDaemonSet(ctx context.Context, name, namespace, kubeconfig string) (*v1.DaemonSet, error)
 	GetDeployment(ctx context.Context, name, namespace, kubeconfig string) (*v1.Deployment, error)
+	RolloutRestartDaemonSet(ctx context.Context, name, namespace, kubeconfig string) error
 }
 
 type retrierClient struct {
@@ -107,6 +108,14 @@ func (c *retrierClient) WaitForCiliumDaemonSet(ctx context.Context, cluster *typ
 	return c.Retry(
 		func() error {
 			return c.checkCiliumDaemonSetReady(ctx, cluster)
+		},
+	)
+}
+
+func (c *retrierClient) RolloutRestartCiliumDaemonSet(ctx context.Context, cluster *types.Cluster) error {
+	return c.Retry(
+		func() error {
+			return c.RolloutRestartDaemonSet(ctx, ciliumDaemonSetName, namespace, cluster.KubeconfigFile)
 		},
 	)
 }

--- a/pkg/networking/cilium/client_test.go
+++ b/pkg/networking/cilium/client_test.go
@@ -142,6 +142,23 @@ func TestRetrierClientWaitForPreflightDaemonSetError(t *testing.T) {
 	tt.Expect(tt.r.WaitForPreflightDaemonSet(tt.ctx, tt.cluster)).To(MatchError(ContainSubstring("error in get")), "retrierClient.waitForPreflightDaemonSet() should fail after 5 tries")
 }
 
+func TestRetrierClientRolloutRestartDaemonSetSuccess(t *testing.T) {
+	tt := newWaitForCiliumTest(t)
+	tt.c.EXPECT().RolloutRestartDaemonSet(tt.ctx, "cilium", "kube-system", tt.cluster.KubeconfigFile).Return(errors.New("error in rollout")).Times(5)
+	tt.c.EXPECT().RolloutRestartDaemonSet(tt.ctx, "cilium", "kube-system", tt.cluster.KubeconfigFile).Return(nil)
+
+	tt.Expect(tt.r.RolloutRestartCiliumDaemonSet(tt.ctx, tt.cluster)).To(Succeed(), "retrierClient.RolloutRestartDaemonSet() should succeed after 6 tries")
+}
+
+func TestRetrierClientRolloutRestartDaemonSetError(t *testing.T) {
+	tt := newWaitForCiliumTest(t)
+	tt.r.Retrier = retrier.NewWithMaxRetries(5, 0)
+	tt.c.EXPECT().RolloutRestartDaemonSet(tt.ctx, "cilium", "kube-system", tt.cluster.KubeconfigFile).Return(errors.New("error in rollout")).Times(5)
+	tt.c.EXPECT().RolloutRestartDaemonSet(tt.ctx, "cilium", "kube-system", tt.cluster.KubeconfigFile).Return(nil).AnyTimes()
+
+	tt.Expect(tt.r.RolloutRestartCiliumDaemonSet(tt.ctx, tt.cluster)).To(MatchError(ContainSubstring("error in rollout")), "retrierClient.RolloutRestartCiliumDaemonSet() should fail after 5 tries")
+}
+
 func TestRetrierClientWaitForPreflightDeploymentSuccess(t *testing.T) {
 	tt := newWaitForCiliumTest(t)
 	tt.c.EXPECT().GetDeployment(tt.ctx, "cilium-pre-flight-check", "kube-system", tt.cluster.KubeconfigFile).Return(nil, errors.New("error in get")).Times(5)

--- a/pkg/networking/cilium/mocks/clients.go
+++ b/pkg/networking/cilium/mocks/clients.go
@@ -93,3 +93,17 @@ func (mr *MockClientMockRecorder) GetDeployment(ctx, name, namespace, kubeconfig
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeployment", reflect.TypeOf((*MockClient)(nil).GetDeployment), ctx, name, namespace, kubeconfig)
 }
+
+// RolloutRestartDaemonSet mocks base method.
+func (m *MockClient) RolloutRestartDaemonSet(ctx context.Context, name, namespace, kubeconfig string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RolloutRestartDaemonSet", ctx, name, namespace, kubeconfig)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RolloutRestartDaemonSet indicates an expected call of RolloutRestartDaemonSet.
+func (mr *MockClientMockRecorder) RolloutRestartDaemonSet(ctx, name, namespace, kubeconfig interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RolloutRestartDaemonSet", reflect.TypeOf((*MockClient)(nil).RolloutRestartDaemonSet), ctx, name, namespace, kubeconfig)
+}

--- a/pkg/networking/cilium/mocks/upgrader.go
+++ b/pkg/networking/cilium/mocks/upgrader.go
@@ -63,6 +63,20 @@ func (mr *MockupgraderClientMockRecorder) Delete(ctx, cluster, data interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockupgraderClient)(nil).Delete), ctx, cluster, data)
 }
 
+// RolloutRestartCiliumDaemonSet mocks base method.
+func (m *MockupgraderClient) RolloutRestartCiliumDaemonSet(ctx context.Context, cluster *types.Cluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RolloutRestartCiliumDaemonSet", ctx, cluster)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RolloutRestartCiliumDaemonSet indicates an expected call of RolloutRestartCiliumDaemonSet.
+func (mr *MockupgraderClientMockRecorder) RolloutRestartCiliumDaemonSet(ctx, cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RolloutRestartCiliumDaemonSet", reflect.TypeOf((*MockupgraderClient)(nil).RolloutRestartCiliumDaemonSet), ctx, cluster)
+}
+
 // WaitForCiliumDaemonSet mocks base method.
 func (m *MockupgraderClient) WaitForCiliumDaemonSet(ctx context.Context, cluster *types.Cluster) error {
 	m.ctrl.T.Helper()

--- a/pkg/networking/cilium/upgrader_test.go
+++ b/pkg/networking/cilium/upgrader_test.go
@@ -174,3 +174,9 @@ func TestUpgraderUpgradeSuccessValuesChangedUpgradeFromNilCiliumConfigSpec(t *te
 
 	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec, []string{})).To(BeNil(), "upgrader.Upgrade() should succeed and return nil ChangeDiff")
 }
+
+func TestUpgraderRunPostControlPlaneUpgradeSetup(t *testing.T) {
+	tt := newUpgraderTest(t)
+	tt.client.EXPECT().RolloutRestartCiliumDaemonSet(tt.ctx, tt.cluster)
+	tt.Expect(tt.u.RunPostControlPlaneUpgradeSetup(tt.ctx, tt.cluster)).To(Succeed())
+}

--- a/pkg/networking/kindnetd/kindnetd.go
+++ b/pkg/networking/kindnetd/kindnetd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	networking "github.com/aws/eks-anywhere/pkg/networking/internal"
 	"github.com/aws/eks-anywhere/pkg/templater"
+	"github.com/aws/eks-anywhere/pkg/types"
 )
 
 type Kindnetd struct {
@@ -28,6 +29,10 @@ func NewKindnetd(client Client) *Kindnetd {
 
 func (c *Kindnetd) GenerateManifest(ctx context.Context, clusterSpec *cluster.Spec, namespaces []string) ([]byte, error) {
 	return generateManifest(clusterSpec)
+}
+
+func (c *Kindnetd) RunPostControlPlaneUpgradeSetup(_ context.Context, _ *types.Cluster) error {
+	return nil
 }
 
 func generateManifest(clusterSpec *cluster.Spec) ([]byte, error) {

--- a/pkg/networking/kindnetd/kindnetd_test.go
+++ b/pkg/networking/kindnetd/kindnetd_test.go
@@ -61,3 +61,8 @@ func TestKindnetdGenerateManifestWriterError(t *testing.T) {
 		t.Fatalf("Kindnetd.GenerateManifestFile() error = nil, want not nil")
 	}
 }
+
+func TestKindnetdRunPostControlPlaneUpgradeSetup(t *testing.T) {
+	tt := newKindnetdTest(t)
+	tt.Expect(tt.k.RunPostControlPlaneUpgradeSetup(context.Background(), nil)).To(Succeed())
+}


### PR DESCRIPTION
*Issue #, if available:*

#2061 

*Description of changes:*

Follow up to #2057. We run the rollout restart cilium daemonset operation on the target cluster, across all providers during cluster upgrade if using cilium as CNI.

I add a `RunPostControlPlaneUpgradeSetup(ctx context.Context, cluster *types.Cluster) error` method in the networking interface in `cluster_manager` pkg. So that we can define CNI provider specific tasks that need to run after control plane vm is updated.

*Testing (if applicable):*

- unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

