### PR TITLE
Revert "Add clustermesh.enabled false to cilium template override"

### DIFF
--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -125,11 +125,6 @@ func (c values) set(value interface{}, path ...string) {
 
 func templateValues(spec *cluster.Spec) values {
 	val := values{
-		"clustermesh": values{
-			"config": values{
-				"enabled": false,
-			},
-		},
 		"cni": values{
 			"chainingMode": "portmap",
 		},

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -91,11 +91,6 @@ func (e *mapMatcher) String() string {
 
 func TestTemplaterGenerateUpgradePreflightManifestSuccess(t *testing.T) {
 	wantValues := map[string]interface{}{
-		"clustermesh": map[string]interface{}{
-			"config": map[string]interface{}{
-				"enabled": false,
-			},
-		},
 		"cni": map[string]interface{}{
 			"chainingMode": "portmap",
 		},
@@ -149,11 +144,6 @@ func TestTemplaterGenerateUpgradePreflightManifestError(t *testing.T) {
 
 func TestTemplaterGenerateManifestSuccess(t *testing.T) {
 	wantValues := map[string]interface{}{
-		"clustermesh": map[string]interface{}{
-			"config": map[string]interface{}{
-				"enabled": false,
-			},
-		},
 		"cni": map[string]interface{}{
 			"chainingMode": "portmap",
 		},
@@ -189,11 +179,6 @@ func TestTemplaterGenerateManifestSuccess(t *testing.T) {
 
 func TestTemplaterGenerateManifestPolicyEnforcementModeSuccess(t *testing.T) {
 	wantValues := map[string]interface{}{
-		"clustermesh": map[string]interface{}{
-			"config": map[string]interface{}{
-				"enabled": false,
-			},
-		},
 		"cni": map[string]interface{}{
 			"chainingMode": "portmap",
 		},
@@ -239,11 +224,6 @@ func TestTemplaterGenerateManifestError(t *testing.T) {
 
 func TestTemplaterGenerateUpgradeManifestSuccess(t *testing.T) {
 	wantValues := map[string]interface{}{
-		"clustermesh": map[string]interface{}{
-			"config": map[string]interface{}{
-				"enabled": false,
-			},
-		},
 		"cni": map[string]interface{}{
 			"chainingMode": "portmap",
 		},


### PR DESCRIPTION
Reverts aws/eks-anywhere#2160

The chart was fixed in 1.10.11 so we no longer need this override.