### PR TITLE
Adding provider specific collectors/analyzers to management cluster support bundle

### DIFF
--- a/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
@@ -101,5 +101,5 @@ func (gsbo *generateSupportBundleOptions) generateBundleConfig(ctx context.Conte
 	}
 	defer close(ctx, deps)
 
-	return deps.DignosticCollectorFactory.DiagnosticBundleFromSpec(clusterSpec, deps.Provider, kubeconfig.FromClusterName(clusterSpec.Cluster.Name))
+	return deps.DignosticCollectorFactory.DiagnosticBundleWorkloadCluster(clusterSpec, deps.Provider, kubeconfig.FromClusterName(clusterSpec.Cluster.Name))
 }

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -634,7 +634,7 @@ func (c *ClusterManager) generateAwsIamAuthKubeconfig(ctx context.Context, manag
 	return nil
 }
 
-func (c *ClusterManager) SaveLogsManagementCluster(ctx context.Context, cluster *types.Cluster) error {
+func (c *ClusterManager) SaveLogsManagementCluster(ctx context.Context, spec *cluster.Spec, cluster *types.Cluster) error {
 	if cluster == nil {
 		return nil
 	}
@@ -643,9 +643,9 @@ func (c *ClusterManager) SaveLogsManagementCluster(ctx context.Context, cluster 
 		return nil
 	}
 
-	bundle, err := c.diagnosticsFactory.DiagnosticBundleManagementCluster(cluster.KubeconfigFile)
+	bundle, err := c.diagnosticsFactory.DiagnosticBundleManagementCluster(spec, cluster.KubeconfigFile)
 	if err != nil {
-		logger.V(5).Info("Error generating support bundle for bootstrap cluster", "error", err)
+		logger.V(5).Info("Error generating support bundle for management cluster", "error", err)
 		return nil
 	}
 	return collectDiagnosticBundle(ctx, bundle)
@@ -660,7 +660,7 @@ func (c *ClusterManager) SaveLogsWorkloadCluster(ctx context.Context, provider p
 		return nil
 	}
 
-	bundle, err := c.diagnosticsFactory.DiagnosticBundleFromSpec(spec, provider, cluster.KubeconfigFile)
+	bundle, err := c.diagnosticsFactory.DiagnosticBundleWorkloadCluster(spec, provider, cluster.KubeconfigFile)
 	if err != nil {
 		logger.V(5).Info("Error generating support bundle for workload cluster", "error", err)
 		return nil

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -205,13 +205,13 @@ func TestClusterManagerSaveLogsSuccess(t *testing.T) {
 	c, m := newClusterManager(t)
 
 	b := m.diagnosticsBundle
-	m.diagnosticsFactory.EXPECT().DiagnosticBundleManagementCluster(bootstrapCluster.KubeconfigFile).Return(b, nil)
+	m.diagnosticsFactory.EXPECT().DiagnosticBundleManagementCluster(clusterSpec, bootstrapCluster.KubeconfigFile).Return(b, nil)
 	b.EXPECT().CollectAndAnalyze(ctx, gomock.AssignableToTypeOf(&time.Time{}))
 
-	m.diagnosticsFactory.EXPECT().DiagnosticBundleFromSpec(clusterSpec, m.provider, workloadCluster.KubeconfigFile).Return(b, nil)
+	m.diagnosticsFactory.EXPECT().DiagnosticBundleWorkloadCluster(clusterSpec, m.provider, workloadCluster.KubeconfigFile).Return(b, nil)
 	b.EXPECT().CollectAndAnalyze(ctx, gomock.AssignableToTypeOf(&time.Time{}))
 
-	if err := c.SaveLogsManagementCluster(ctx, bootstrapCluster); err != nil {
+	if err := c.SaveLogsManagementCluster(ctx, clusterSpec, bootstrapCluster); err != nil {
 		t.Errorf("ClusterManager.SaveLogsManagementCluster() error = %v, wantErr nil", err)
 	}
 

--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -82,6 +82,10 @@ func (a *analyzerFactory) managementClusterDeploymentAnalyzers() []*Analyze {
 			Namespace:        constants.CapvSystemNamespace,
 			ExpectedReplicas: 1,
 		}, {
+			Name:             "capc-controller-manager",
+			Namespace:        constants.CapcSystemNamespace,
+			ExpectedReplicas: 1,
+		}, {
 			Name:             "cert-manager-webhook",
 			Namespace:        constants.CertManagerNamespace,
 			ExpectedReplicas: 1,

--- a/pkg/diagnostics/analyzers_test.go
+++ b/pkg/diagnostics/analyzers_test.go
@@ -1,0 +1,27 @@
+package diagnostics_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/eks-anywhere/pkg/diagnostics"
+)
+
+func TestManagementClusterAnalyzers(t *testing.T) {
+	factory := diagnostics.NewAnalyzerFactory()
+	analyzers := factory.ManagementClusterAnalyzers()
+	assert.Equal(t, len(analyzers), 11, "DataCenterConfigCollectors() mismatch between desired collectors and actual")
+	assert.NotNilf(t, getDeploymentStatusAnalyzer(analyzers, "capc-controller-manager"), "capc controller manager analyzer should be present")
+	assert.NotNilf(t, getDeploymentStatusAnalyzer(analyzers, "capv-controller-manager"), "capv controller manager analyzer should be present")
+}
+
+func getDeploymentStatusAnalyzer(analyzers []*diagnostics.Analyze, name string) *diagnostics.Analyze {
+	for _, analyzer := range analyzers {
+		if analyzer.DeploymentStatus != nil && analyzer.DeploymentStatus.Name == name {
+			return analyzer
+		}
+	}
+
+	return nil
+}

--- a/pkg/diagnostics/diagnostic_bundle.go
+++ b/pkg/diagnostics/diagnostic_bundle.go
@@ -46,7 +46,7 @@ type EksaDiagnosticBundle struct {
 	analysis         []*executables.SupportBundleAnalysis
 }
 
-func newDiagnosticBundleManagementCluster(af AnalyzerFactory, cf CollectorFactory, client BundleClient,
+func newDiagnosticBundleManagementCluster(af AnalyzerFactory, cf CollectorFactory, spec *cluster.Spec, client BundleClient,
 	kubectl *executables.Kubectl, kubeconfig string, writer filewriter.FileWriter,
 ) (*EksaDiagnosticBundle, error) {
 	b := &EksaDiagnosticBundle{
@@ -69,7 +69,7 @@ func newDiagnosticBundleManagementCluster(af AnalyzerFactory, cf CollectorFactor
 		writer:           writer,
 	}
 
-	b.WithDefaultCollectors().WithDefaultAnalyzers().WithManagementCluster(true)
+	b.WithDefaultCollectors().WithDefaultAnalyzers().WithManagementCluster(true).WithDatacenterConfig(spec.Cluster.Spec.DatacenterRef)
 
 	err := b.WriteBundleConfig()
 	if err != nil {

--- a/pkg/diagnostics/diagnostic_bundle_test.go
+++ b/pkg/diagnostics/diagnostic_bundle_test.go
@@ -135,7 +135,7 @@ func TestGenerateBundleConfigWithExternalEtcd(t *testing.T) {
 		}
 
 		f := diagnostics.NewFactory(opts)
-		_, _ = f.DiagnosticBundleFromSpec(spec, p, "")
+		_, _ = f.DiagnosticBundleWorkloadCluster(spec, p, "")
 	})
 }
 
@@ -189,7 +189,7 @@ func TestGenerateBundleConfigWithOidc(t *testing.T) {
 		}
 
 		f := diagnostics.NewFactory(opts)
-		_, _ = f.DiagnosticBundleFromSpec(spec, p, "")
+		_, _ = f.DiagnosticBundleWorkloadCluster(spec, p, "")
 	})
 }
 
@@ -243,7 +243,7 @@ func TestGenerateBundleConfigWithGitOps(t *testing.T) {
 		}
 
 		f := diagnostics.NewFactory(opts)
-		_, _ = f.DiagnosticBundleFromSpec(spec, p, "")
+		_, _ = f.DiagnosticBundleWorkloadCluster(spec, p, "")
 	})
 }
 
@@ -362,7 +362,7 @@ func TestBundleFromSpecComplete(t *testing.T) {
 		}
 
 		f := diagnostics.NewFactory(opts)
-		b, _ := f.DiagnosticBundleFromSpec(spec, p, kubeconfig)
+		b, _ := f.DiagnosticBundleWorkloadCluster(spec, p, kubeconfig)
 		err = b.CollectAndAnalyze(ctx, sinceTimeValue)
 		if err != nil {
 			t.Errorf("CollectAndAnalyze() error = %v, wantErr nil", err)

--- a/pkg/diagnostics/factory.go
+++ b/pkg/diagnostics/factory.go
@@ -37,17 +37,17 @@ func NewFactory(opts EksaDiagnosticBundleFactoryOpts) *eksaDiagnosticBundleFacto
 
 func (f *eksaDiagnosticBundleFactory) DiagnosticBundle(spec *cluster.Spec, provider providers.Provider, kubeconfig string, bundlePath string) (DiagnosticBundle, error) {
 	if bundlePath == "" && spec != nil {
-		b, err := f.DiagnosticBundleFromSpec(spec, provider, kubeconfig)
+		b, err := f.DiagnosticBundleWorkloadCluster(spec, provider, kubeconfig)
 		return b, err
 	}
 	return f.DiagnosticBundleCustom(kubeconfig, bundlePath), nil
 }
 
-func (f *eksaDiagnosticBundleFactory) DiagnosticBundleManagementCluster(kubeconfig string) (DiagnosticBundle, error) {
-	return newDiagnosticBundleManagementCluster(f.analyzerFactory, f.collectorFactory, f.client, f.kubectl, kubeconfig, f.writer)
+func (f *eksaDiagnosticBundleFactory) DiagnosticBundleManagementCluster(spec *cluster.Spec, kubeconfig string) (DiagnosticBundle, error) {
+	return newDiagnosticBundleManagementCluster(f.analyzerFactory, f.collectorFactory, spec, f.client, f.kubectl, kubeconfig, f.writer)
 }
 
-func (f *eksaDiagnosticBundleFactory) DiagnosticBundleFromSpec(spec *cluster.Spec, provider providers.Provider, kubeconfig string) (DiagnosticBundle, error) {
+func (f *eksaDiagnosticBundleFactory) DiagnosticBundleWorkloadCluster(spec *cluster.Spec, provider providers.Provider, kubeconfig string) (DiagnosticBundle, error) {
 	return newDiagnosticBundleFromSpec(f.analyzerFactory, f.collectorFactory, spec, provider, f.client, f.kubectl, kubeconfig, f.writer)
 }
 

--- a/pkg/diagnostics/interfaces.go
+++ b/pkg/diagnostics/interfaces.go
@@ -17,8 +17,8 @@ type BundleClient interface {
 
 type DiagnosticBundleFactory interface {
 	DiagnosticBundle(spec *cluster.Spec, provider providers.Provider, kubeconfig string, bundlePath string) (DiagnosticBundle, error)
-	DiagnosticBundleFromSpec(spec *cluster.Spec, provider providers.Provider, kubeconfig string) (DiagnosticBundle, error)
-	DiagnosticBundleManagementCluster(kubeconfig string) (DiagnosticBundle, error)
+	DiagnosticBundleWorkloadCluster(spec *cluster.Spec, provider providers.Provider, kubeconfig string) (DiagnosticBundle, error)
+	DiagnosticBundleManagementCluster(spec *cluster.Spec, kubeconfig string) (DiagnosticBundle, error)
 	DiagnosticBundleDefault() DiagnosticBundle
 	DiagnosticBundleCustom(kubeconfig string, bundlePath string) DiagnosticBundle
 }

--- a/pkg/diagnostics/interfaces/mocks/diagnostics.go
+++ b/pkg/diagnostics/interfaces/mocks/diagnostics.go
@@ -136,34 +136,34 @@ func (mr *MockDiagnosticBundleFactoryMockRecorder) DiagnosticBundleDefault() *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiagnosticBundleDefault", reflect.TypeOf((*MockDiagnosticBundleFactory)(nil).DiagnosticBundleDefault))
 }
 
-// DiagnosticBundleFromSpec mocks base method.
-func (m *MockDiagnosticBundleFactory) DiagnosticBundleFromSpec(spec *cluster.Spec, provider providers.Provider, kubeconfig string) (diagnostics.DiagnosticBundle, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DiagnosticBundleFromSpec", spec, provider, kubeconfig)
-	ret0, _ := ret[0].(diagnostics.DiagnosticBundle)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DiagnosticBundleFromSpec indicates an expected call of DiagnosticBundleFromSpec.
-func (mr *MockDiagnosticBundleFactoryMockRecorder) DiagnosticBundleFromSpec(spec, provider, kubeconfig interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiagnosticBundleFromSpec", reflect.TypeOf((*MockDiagnosticBundleFactory)(nil).DiagnosticBundleFromSpec), spec, provider, kubeconfig)
-}
-
 // DiagnosticBundleManagementCluster mocks base method.
-func (m *MockDiagnosticBundleFactory) DiagnosticBundleManagementCluster(kubeconfig string) (diagnostics.DiagnosticBundle, error) {
+func (m *MockDiagnosticBundleFactory) DiagnosticBundleManagementCluster(spec *cluster.Spec, kubeconfig string) (diagnostics.DiagnosticBundle, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DiagnosticBundleManagementCluster", kubeconfig)
+	ret := m.ctrl.Call(m, "DiagnosticBundleManagementCluster", spec, kubeconfig)
 	ret0, _ := ret[0].(diagnostics.DiagnosticBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DiagnosticBundleManagementCluster indicates an expected call of DiagnosticBundleManagementCluster.
-func (mr *MockDiagnosticBundleFactoryMockRecorder) DiagnosticBundleManagementCluster(kubeconfig interface{}) *gomock.Call {
+func (mr *MockDiagnosticBundleFactoryMockRecorder) DiagnosticBundleManagementCluster(spec, kubeconfig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiagnosticBundleManagementCluster", reflect.TypeOf((*MockDiagnosticBundleFactory)(nil).DiagnosticBundleManagementCluster), kubeconfig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiagnosticBundleManagementCluster", reflect.TypeOf((*MockDiagnosticBundleFactory)(nil).DiagnosticBundleManagementCluster), spec, kubeconfig)
+}
+
+// DiagnosticBundleWorkloadCluster mocks base method.
+func (m *MockDiagnosticBundleFactory) DiagnosticBundleWorkloadCluster(spec *cluster.Spec, provider providers.Provider, kubeconfig string) (diagnostics.DiagnosticBundle, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DiagnosticBundleWorkloadCluster", spec, provider, kubeconfig)
+	ret0, _ := ret[0].(diagnostics.DiagnosticBundle)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DiagnosticBundleWorkloadCluster indicates an expected call of DiagnosticBundleWorkloadCluster.
+func (mr *MockDiagnosticBundleFactoryMockRecorder) DiagnosticBundleWorkloadCluster(spec, provider, kubeconfig interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiagnosticBundleWorkloadCluster", reflect.TypeOf((*MockDiagnosticBundleFactory)(nil).DiagnosticBundleWorkloadCluster), spec, provider, kubeconfig)
 }
 
 // MockDiagnosticBundle is a mock of DiagnosticBundle interface.

--- a/pkg/workflows/diagnostics.go
+++ b/pkg/workflows/diagnostics.go
@@ -45,7 +45,7 @@ func (s *CollectWorkloadClusterDiagnosticsTask) Name() string {
 
 func (s *CollectMgmtClusterDiagnosticsTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("collecting management cluster diagnostics")
-	_ = commandContext.ClusterManager.SaveLogsManagementCluster(ctx, commandContext.BootstrapCluster)
+	_ = commandContext.ClusterManager.SaveLogsManagementCluster(ctx, commandContext.ClusterSpec, commandContext.BootstrapCluster)
 	return nil
 }
 

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -24,7 +24,7 @@ type ClusterManager interface {
 	InstallNetworking(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	UpgradeNetworking(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec, provider providers.Provider) (*types.ChangeDiff, error)
 	InstallStorageClass(ctx context.Context, cluster *types.Cluster, provider providers.Provider) error
-	SaveLogsManagementCluster(ctx context.Context, cluster *types.Cluster) error
+	SaveLogsManagementCluster(ctx context.Context, spec *cluster.Spec, cluster *types.Cluster) error
 	SaveLogsWorkloadCluster(ctx context.Context, provider providers.Provider, spec *cluster.Spec, cluster *types.Cluster) error
 	InstallCustomComponents(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
 	CreateEKSAResources(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, datacenterConfig providers.DatacenterConfig, machineConfigs []providers.MachineConfig) error

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -329,17 +329,17 @@ func (mr *MockClusterManagerMockRecorder) ResumeEKSAControllerReconcile(arg0, ar
 }
 
 // SaveLogsManagementCluster mocks base method.
-func (m *MockClusterManager) SaveLogsManagementCluster(arg0 context.Context, arg1 *types.Cluster) error {
+func (m *MockClusterManager) SaveLogsManagementCluster(arg0 context.Context, arg1 *cluster.Spec, arg2 *types.Cluster) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveLogsManagementCluster", arg0, arg1)
+	ret := m.ctrl.Call(m, "SaveLogsManagementCluster", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SaveLogsManagementCluster indicates an expected call of SaveLogsManagementCluster.
-func (mr *MockClusterManagerMockRecorder) SaveLogsManagementCluster(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClusterManagerMockRecorder) SaveLogsManagementCluster(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveLogsManagementCluster", reflect.TypeOf((*MockClusterManager)(nil).SaveLogsManagementCluster), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveLogsManagementCluster", reflect.TypeOf((*MockClusterManager)(nil).SaveLogsManagementCluster), arg0, arg1, arg2)
 }
 
 // SaveLogsWorkloadCluster mocks base method.

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -339,7 +339,7 @@ func (c *upgradeTestSetup) expectVerifyClusterSpecChanged(expectedCluster *types
 
 func (c *upgradeTestSetup) expectSaveLogs(expectedWorkloadCluster *types.Cluster) {
 	gomock.InOrder(
-		c.clusterManager.EXPECT().SaveLogsManagementCluster(c.ctx, c.bootstrapCluster).Return(nil),
+		c.clusterManager.EXPECT().SaveLogsManagementCluster(c.ctx, c.newClusterSpec, c.bootstrapCluster).Return(nil),
 		c.clusterManager.EXPECT().SaveLogsWorkloadCluster(c.ctx, c.provider, c.newClusterSpec, expectedWorkloadCluster),
 	)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I was trying to debug a failure in the eks-a cloudstack e2e tests when I noticed that the bootstrap support bundle doesn't actually have logs for the capc controller, so I am blocked to continue debugging the e2e test failures.

This PR plumbs the spec through to the bundle generation logic so we can grab the provider specific logs and crds even on the bootstrap/management cluster

*Testing (if applicable):*
Tested by setting control plane ready timeout to 1 minute and observed capc logs were captured.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

