### PR TITLE
Remove diskSetup and mount for etcdadmcluster in cloudstack

### DIFF
--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -420,25 +420,6 @@ spec:
     - echo "127.0.0.1   localhost" >>/etc/hosts
     - echo "127.0.0.1   {{`{{ ds.meta_data.local_hostname }}`}}" >>/etc/hosts
     - echo "{{`{{ ds.meta_data.local_hostname }}`}}" >/etc/hostname
-{{- if .cloudstackEtcdDiskOfferingProvided }}
-    diskSetup:
-      filesystems:
-        - device: {{ .cloudstackEtcdDiskOfferingDevice }}1
-          overwrite: false
-          extraOpts:
-            - -E
-            - lazy_itable_init=1,lazy_journal_init=1
-          filesystem: {{ .cloudstackEtcdDiskOfferingFilesystem }}
-          label: data_disk
-      partitions:
-        - device: {{ .cloudstackEtcdDiskOfferingDevice }}
-          layout: true
-          overwrite: false
-          tableType: gpt
-    mounts:
-      - - LABEL={{ .cloudstackEtcdDiskOfferingLabel }}
-        - {{ .cloudstackEtcdDiskOfferingPath }}
-{{- end }}
 {{- if .etcdCipherSuites }}
     cipherSuites: {{.etcdCipherSuites}}
 {{- end }}

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
@@ -401,23 +401,6 @@ spec:
     - echo "127.0.0.1   localhost" >>/etc/hosts
     - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
     - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
-    diskSetup:
-      filesystems:
-        - device: /dev/vdb1
-          overwrite: false
-          extraOpts:
-            - -E
-            - lazy_itable_init=1,lazy_journal_init=1
-          filesystem: ext4
-          label: data_disk
-      partitions:
-        - device: /dev/vdb
-          layout: true
-          overwrite: false
-          tableType: gpt
-    mounts:
-      - - LABEL=data_disk
-        - /data-small
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
     - name: mySshUsername

--- a/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -401,23 +401,6 @@ spec:
     - echo "127.0.0.1   localhost" >>/etc/hosts
     - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
     - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
-    diskSetup:
-      filesystems:
-        - device: /dev/vdb1
-          overwrite: false
-          extraOpts:
-            - -E
-            - lazy_itable_init=1,lazy_journal_init=1
-          filesystem: ext4
-          label: data_disk
-      partitions:
-        - device: /dev/vdb
-          layout: true
-          overwrite: false
-          tableType: gpt
-    mounts:
-      - - LABEL=data_disk
-        - /data-small
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
     - name: mySshUsername

--- a/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
@@ -403,23 +403,6 @@ spec:
     - echo "127.0.0.1   localhost" >>/etc/hosts
     - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
     - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
-    diskSetup:
-      filesystems:
-        - device: /dev/vdb1
-          overwrite: false
-          extraOpts:
-            - -E
-            - lazy_itable_init=1,lazy_journal_init=1
-          filesystem: ext4
-          label: data_disk
-      partitions:
-        - device: /dev/vdb
-          layout: true
-          overwrite: false
-          tableType: gpt
-    mounts:
-      - - LABEL=data_disk
-        - /data-small
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
     - name: mySshUsername


### PR DESCRIPTION
*Issue #, if available:*

diskSetup and mount are not supported in etcdadm controller.

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

