### PR TITLE
Remove unused envs from required env for tinkerbell

### DIFF
--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -28,24 +28,20 @@ import (
 )
 
 const (
-	tinkerbellCertURLKey           = "TINKERBELL_CERT_URL"
-	tinkerbellGRPCAuthKey          = "TINKERBELL_GRPC_AUTHORITY"
-	tinkerbellIPKey                = "TINKERBELL_IP"
-	tinkerbellPBnJGRPCAuthorityKey = "PBNJ_GRPC_AUTHORITY"
-	tinkerbellHegelURLKey          = "TINKERBELL_HEGEL_URL"
-	bmcStatePowerActionHardoff     = "POWER_ACTION_HARDOFF"
-	tinkerbellOwnerNameLabel       = "v1alpha1.tinkerbell.org/ownerName"
-	Provisioning                   = "provisioning"
-	maxRetries                     = 30
-	backOffPeriod                  = 5 * time.Second
-	deploymentWaitTimeout          = "5m"
-	tinkNamespace                  = "tink-system"
+	tinkerbellIPKey            = "TINKERBELL_IP"
+	bmcStatePowerActionHardoff = "POWER_ACTION_HARDOFF"
+	tinkerbellOwnerNameLabel   = "v1alpha1.tinkerbell.org/ownerName"
+	Provisioning               = "provisioning"
+	maxRetries                 = 30
+	backOffPeriod              = 5 * time.Second
+	deploymentWaitTimeout      = "5m"
+	tinkNamespace              = "tink-system"
 )
 
 var (
 	eksaTinkerbellDatacenterResourceType = fmt.Sprintf("tinkerbelldatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaTinkerbellMachineResourceType    = fmt.Sprintf("tinkerbellmachineconfigs.%s", v1alpha1.GroupVersion.Group)
-	requiredEnvs                         = []string{tinkerbellCertURLKey, tinkerbellGRPCAuthKey, tinkerbellIPKey, tinkerbellPBnJGRPCAuthorityKey, tinkerbellHegelURLKey}
+	requiredEnvs                         = []string{tinkerbellIPKey}
 	tinkerbellStackPorts                 = []int{42113, 50051, 50061}
 )
 


### PR DESCRIPTION
*Description of changes:*
Remove `tinkerbellCertURLKey`, `tinkerbellGRPCAuthKey`, `tinkerbellPBnJGRPCAuthorityKey` and `tinkerbellHegelURLKey` from required env as they are no longer needed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

