### PR TITLE
Remove control plane ip uniqueness check for snow upgrade

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -278,6 +278,7 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 			f.dependencies.Provider = snow.NewProvider(
 				f.dependencies.UnAuthKubeClient,
 				f.dependencies.SnowConfigManager,
+				skipIpCheck,
 			)
 
 		case v1alpha1.TinkerbellDatacenterKind:

--- a/pkg/providers/snow/entry.go
+++ b/pkg/providers/snow/entry.go
@@ -4,8 +4,6 @@ import (
 	"context"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/networkutils"
-	providerValidator "github.com/aws/eks-anywhere/pkg/providers/validator"
 )
 
 type ConfigManager struct {
@@ -45,9 +43,6 @@ func (cm *ConfigManager) snowEntry(ctx context.Context) *cluster.ConfigManagerEn
 			},
 		},
 		Validations: []cluster.Validation{
-			func(c *cluster.Config) error {
-				return providerValidator.ValidateControlPlaneIpUniqueness(c.Cluster, &networkutils.DefaultNetClient{})
-			},
 			func(c *cluster.Config) error {
 				for _, m := range c.SnowMachineConfigs {
 					if err := cm.validator.ValidateEC2ImageExistsOnDevice(ctx, m); err != nil {

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -225,6 +225,7 @@ func newProvider(t *testing.T, kubeUnAuthClient snow.KubeUnAuthClient, mockaws *
 	return snow.NewProvider(
 		kubeUnAuthClient,
 		configManager,
+		false,
 	)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

During upgrade, we do not need to check control plane IP uniqueness since the cluster with that IP exists during create.

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

