### PR TITLE
Fix snow upgrade flow

### DIFF
--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -135,7 +135,7 @@ func (p *SnowProvider) GenerateCAPISpecForCreate(ctx context.Context, cluster *t
 	return p.generateCAPISpec(ctx, cluster, clusterSpec)
 }
 
-func (p *SnowProvider) GenerateCAPISpecForUpgrade(ctx context.Context, managementCluster, _ *types.Cluster, _ *cluster.Spec, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
+func (p *SnowProvider) GenerateCAPISpecForUpgrade(ctx context.Context, _, managementCluster *types.Cluster, _ *cluster.Spec, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	return p.generateCAPISpec(ctx, managementCluster, clusterSpec)
 }
 

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -408,7 +408,7 @@ func TestGenerateCAPISpecForUpgrade(t *testing.T) {
 			return nil
 		})
 
-	gotCp, gotMd, err := tt.provider.GenerateCAPISpecForUpgrade(tt.ctx, tt.cluster, nil, nil, tt.clusterSpec)
+	gotCp, gotMd, err := tt.provider.GenerateCAPISpecForUpgrade(tt.ctx, nil, tt.cluster, nil, tt.clusterSpec)
 	tt.Expect(err).To(Succeed())
 	test.AssertContentToFile(t, string(gotCp), "testdata/expected_results_main_cp.yaml")
 	test.AssertContentToFile(t, string(gotMd), "testdata/expected_results_main_md.yaml")


### PR DESCRIPTION
*Issue #, if available:*

When generating CAPI objects for snow upgrade, we need to pass in the cluster that has CAPI components.

*Description of changes:*

After #1814 , we also need to update `GenerateCAPISpecForUpgrade` to use `eksaMgmtCluster` instead of the original managementCluster. So that we can fetch CAPI from the cluster holds these components.

*Testing (if applicable):*

- Unit tests
- Manual e2e

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

