### PR TITLE
Adding cleanup script for cloudstack vms for e2e test

### DIFF
--- a/cmd/eks-a-tool/cmd/cloudstackrmvms.go
+++ b/cmd/eks-a-tool/cmd/cloudstackrmvms.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
-	"github.com/aws/eks-anywhere/internal/test/e2e"
 	"log"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/aws/eks-anywhere/internal/test/e2e"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
 

--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -113,6 +113,10 @@ phases:
         ./bin/test e2e cleanup vsphere
         -n ${CLUSTER_NAME_PREFIX}
         -v 4
+      - >
+        ./bin/test e2e cleanup cloudstack
+        -n ${CLUSTER_NAME_PREFIX}
+        -v 4
 reports:
   e2e-reports:
     files:

--- a/cmd/integration_test/cmd/cleanupcloudstack.go
+++ b/cmd/integration_test/cmd/cleanupcloudstack.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/aws/eks-anywhere/internal/test/e2e"
+	"github.com/aws/eks-anywhere/pkg/logger"
+)
+
+var cleanUpCloudstackCmd = &cobra.Command{
+	Use:          "cloudstack",
+	Short:        "Clean up e2e vms on cloudstack",
+	Long:         "Clean up vms created for e2e testing on cloudstack",
+	SilenceUsage: true,
+	PreRun:       preRunCleanUpCloudstackSetup,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := cleanUpCloudstackTestResources(cmd.Context())
+		if err != nil {
+			logger.Fatal(err, "Failed to cleanup e2e vms on cloudstack")
+		}
+		return nil
+	},
+}
+
+func preRunCleanUpCloudstackSetup(cmd *cobra.Command, args []string) {
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		err := viper.BindPFlag(flag.Name, flag)
+		if err != nil {
+			log.Fatalf("Error initializing flags: %v", err)
+		}
+	})
+}
+
+var requiredCloudstackCleanUpFlags = []string{clusterNameFlagName}
+
+func init() {
+	cleanUpInstancesCmd.AddCommand(cleanUpCloudstackCmd)
+	cleanUpCloudstackCmd.Flags().StringP(clusterNameFlagName, "n", "", "Cluster name for associated vms")
+
+	for _, flag := range requiredCloudstackCleanUpFlags {
+		if err := cleanUpCloudstackCmd.MarkFlagRequired(flag); err != nil {
+			log.Fatalf("Error marking flag %s as required: %v", flag, err)
+		}
+	}
+}
+
+func cleanUpCloudstackTestResources(ctx context.Context) error {
+	clusterName := viper.GetString(clusterNameFlagName)
+	err := e2e.CleanUpCloudstackTestResources(ctx, clusterName)
+	if err != nil {
+		return fmt.Errorf("running cleanup for cloudstack vms: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/integration_test/cmd/cleanupcloudstack.go
+++ b/cmd/integration_test/cmd/cleanupcloudstack.go
@@ -52,7 +52,7 @@ func init() {
 
 func cleanUpCloudstackTestResources(ctx context.Context) error {
 	clusterName := viper.GetString(clusterNameFlagName)
-	err := e2e.CleanUpCloudstackTestResources(ctx, clusterName)
+	err := e2e.CleanUpCloudstackTestResources(ctx, clusterName, false)
 	if err != nil {
 		return fmt.Errorf("running cleanup for cloudstack vms: %v", err)
 	}

--- a/internal/test/e2e/cleanup.go
+++ b/internal/test/e2e/cleanup.go
@@ -71,7 +71,7 @@ func CleanUpVsphereTestResources(ctx context.Context, clusterName string) error 
 	return nil
 }
 
-func CleanUpCloudstackTestResources(ctx context.Context, clusterName string) error {
+func CleanUpCloudstackTestResources(ctx context.Context, clusterName string, dryRun bool) error {
 	executableBuilder, close, err := executables.NewExecutableBuilder(ctx, executables.DefaultEksaImage())
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
@@ -92,5 +92,5 @@ func CleanUpCloudstackTestResources(ctx context.Context, clusterName string) err
 		return fmt.Errorf("validating cloudstack connection with cloudmonkey: %v", err)
 	}
 
-	return cmk.CleanupVms(ctx, clusterName, false)
+	return cmk.CleanupVms(ctx, clusterName, dryRun)
 }

--- a/internal/test/e2e/cleanup.go
+++ b/internal/test/e2e/cleanup.go
@@ -3,6 +3,9 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/filewriter"
+	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -66,4 +69,28 @@ func CleanUpVsphereTestResources(ctx context.Context, clusterName string) error 
 	}
 	logger.V(1).Info("Vsphere vcenter vms cleanup complete")
 	return nil
+}
+
+func CleanUpCloudstackTestResources(ctx context.Context, clusterName string) error {
+	executableBuilder, close, err := executables.NewExecutableBuilder(ctx, executables.DefaultEksaImage())
+	if err != nil {
+		return fmt.Errorf("unable to initialize executables: %v", err)
+	}
+	defer close.CheckErr(ctx)
+	tmpWriter, err := filewriter.NewWriter("rmvms")
+	if err != nil {
+		return fmt.Errorf("creating filewriter for directory rmvms: %v", err)
+	}
+	execConfig, err := decoder.ParseCloudStackSecret()
+	if err != nil {
+		return fmt.Errorf("building cmk executable: %v", err)
+	}
+	cmk := executableBuilder.BuildCmkExecutable(tmpWriter, *execConfig)
+	defer cmk.Close(ctx)
+
+	if err := cmk.ValidateCloudStackConnection(ctx); err != nil {
+		return fmt.Errorf("validating cloudstack connection with cloudmonkey: %v", err)
+	}
+
+	return cmk.CleanupVms(ctx, clusterName, false)
 }

--- a/internal/test/e2e/cleanup.go
+++ b/internal/test/e2e/cleanup.go
@@ -3,16 +3,16 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"github.com/aws/eks-anywhere/pkg/executables"
-	"github.com/aws/eks-anywhere/pkg/filewriter"
-	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 
 	"github.com/aws/eks-anywhere/internal/pkg/ec2"
 	"github.com/aws/eks-anywhere/internal/pkg/s3"
+	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
One of the issues we have observed with the cloudstack e2e tests is the inability of the tests to clean up after itself, so it leaves all the VM's dangling after the test run. This change makes it so cloudstack can clean up after itself instead

*Testing (if applicable):*
`make e2e`, followed by

```
➜  eks-anywhere git:(cleanup-cloudstack-e2e) ✗ ./bin/test e2e cleanup cloudstack -n main-i -v 4
2022-05-23T11:06:13.341-0500	V4	Logger init completed	{"vlevel": 4}
2022-05-23T11:06:13.342-0500	V2	Pulling docker image	{"image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.7.2-eks-a-v0.0.0-dev-build.1864"}
2022-05-23T11:06:19.421-0500	V3	Initializing long running container	{"name": "eksa_1653321973342049000", "image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.7.2-eks-a-v0.0.0-dev-build.1864"}
2022-05-23T11:06:29.280-0500	V0	✅ Connected to CloudStack server
2022-05-23T11:06:47.207-0500	V0	Deleted 	{"vm_name": "main-i-01e892d7b7f9d301b-control-plane-template-1653077938jhblt", "vm_id": "9d173ffd-2801-4f1a-8f1f-425fece01dee"}
...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

