### PR TITLE
Remove obsolete flags from generatehardware cmd

### DIFF
--- a/cmd/eksctl-anywhere/cmd/generatehardware.go
+++ b/cmd/eksctl-anywhere/cmd/generatehardware.go
@@ -1,38 +1,22 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
 
-	"github.com/aws/eks-anywhere/pkg/executables"
-	"github.com/aws/eks-anywhere/pkg/networkutils"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
-	"github.com/aws/eks-anywhere/pkg/types"
 )
 
 type hardwareOptions struct {
-	csvPath          string
-	outputPath       string
-	tinkerbellIp     string
-	grpcPort         string
-	certPort         string
-	skipRegistration bool
+	csvPath    string
+	outputPath string
 }
 
-const (
-	defaultGrpcPort = "42113"
-	defaultCertPort = "42114"
-)
-
 // Flag name constants
-const (
-	generateHardwareFilenameFlagName     = "filename"
-	generateHardwareTinkerbellIpFlagName = "tinkerbell-ip"
-)
+const generateHardwareFilenameFlagName = "filename"
 
 var hOpts = &hardwareOptions{}
 
@@ -40,9 +24,7 @@ var generateHardwareCmd = &cobra.Command{
 	Use:   "hardware",
 	Short: "Generate hardware files",
 	Long: `
-Generate hardware JSON and YAML files used for Tinkerbell provider. Tinkerbell 
-hardware JSON are registered with a Tinkerbell stack. Use --skip-registration 
-to prevent Tinkerbell stack interactions.
+Generate Kubernetes hardware YAML manifests for each Hardware entry in the source.
 `,
 	RunE: hOpts.generateHardware,
 }
@@ -57,30 +39,10 @@ func init() {
 		panic(err)
 	}
 
-	flags.StringVar(&hOpts.tinkerbellIp, generateHardwareTinkerbellIpFlagName, "", "Tinkerbell stack IP address; not required with --skip-registration")
 	flags.StringVarP(&hOpts.outputPath, "output", "o", "", "directory path to output hardware files; Tinkerbell JSON files are stored under a \"json\" subdirectory")
-	flags.StringVar(&hOpts.grpcPort, "grpc-port", defaultGrpcPort, "Tinkerbell GRPC Authority port")
-	flags.StringVar(&hOpts.certPort, "cert-port", defaultCertPort, "Tinkerbell Cert URL port")
-	flags.BoolVar(&hOpts.skipRegistration, "skip-registration", false, "skip hardware registration with the Tinkerbell stack")
 }
 
 func (hOpts *hardwareOptions) generateHardware(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
-	if !hOpts.skipRegistration {
-		// If we aren't skipping registration we want to make the tinkerbell IP mandatory.
-		if err := cmd.MarkFlagRequired(generateHardwareTinkerbellIpFlagName); err != nil {
-			return err
-		}
-
-		if err := cmd.ParseFlags(args); err != nil {
-			return err
-		}
-
-		if err := validateOptions(hOpts); err != nil {
-			return err
-		}
-	}
-
 	csvFile, err := os.Open(hOpts.csvPath)
 	if err != nil {
 		return fmt.Errorf("csv: %v", err)
@@ -91,75 +53,22 @@ func (hOpts *hardwareOptions) generateHardware(cmd *cobra.Command, args []string
 		return err
 	}
 
-	jsonDir, err := hardware.CreateDefaultJSONDir(outputDir)
-	if err != nil {
-		return err
-	}
-
 	hardwareYAML, err := os.Create(filepath.Join(outputDir, hardware.DefaultHardwareManifestYAMLFilename))
 	if err != nil {
 		return fmt.Errorf("tinkerbell manifest yaml: %v", err)
 	}
 	yamlWriter := hardware.NewTinkerbellManifestYAML(hardwareYAML)
 
-	var journal hardware.Journal
-	jsonFactory, err := hardware.RecordingTinkerbellHardwareJSONFactory(jsonDir, &journal)
-	if err != nil {
-		return err
-	}
-	jsonWriter := hardware.NewTinkerbellHardwareJSONWriter(jsonFactory)
-
 	reader, err := hardware.NewCSVReader(csvFile)
 	if err != nil {
 		return fmt.Errorf("csv: %v", err)
 	}
 
-	writer := hardware.MultiMachineWriter(yamlWriter, jsonWriter)
 	validator := hardware.NewDefaultMachineValidator()
 
-	if err := hardware.TranslateAll(reader, writer, validator); err != nil {
+	if err := hardware.TranslateAll(reader, yamlWriter, validator); err != nil {
 		return err
 	}
 
-	if !hOpts.skipRegistration {
-		tink, closer, err := tinkExecutableFromOpts(ctx, hOpts)
-		if err != nil {
-			return err
-		}
-		defer closer.Close(ctx)
-
-		if err := hardware.RegisterTinkerbellHardware(ctx, tink, journal); err != nil {
-			return err
-		}
-	}
-
 	return nil
-}
-
-func validateOptions(opts *hardwareOptions) error {
-	if err := networkutils.ValidateIP(opts.tinkerbellIp); err != nil {
-		return fmt.Errorf("invalid tinkerbell-ip: %v", err)
-	}
-
-	if !networkutils.IsPortValid(opts.grpcPort) {
-		return fmt.Errorf("invalid grpc-port: %v", opts.certPort)
-	}
-
-	if !networkutils.IsPortValid(opts.certPort) {
-		return fmt.Errorf("invalid cert-port: %v", opts.certPort)
-	}
-
-	return nil
-}
-
-func tinkExecutableFromOpts(ctx context.Context, opts *hardwareOptions) (*executables.Tink, types.Closer, error) {
-	executableBuilder, close, err := executables.NewExecutableBuilder(ctx, executables.DefaultEksaImage())
-	if err != nil {
-		return nil, nil, fmt.Errorf("initialize executables: %v", err)
-	}
-
-	cert := fmt.Sprintf("http://%s:%s/cert", opts.tinkerbellIp, opts.certPort)
-	grpc := fmt.Sprintf("%s:%s", opts.tinkerbellIp, opts.grpcPort)
-
-	return executableBuilder.BuildTinkExecutable(cert, grpc), close, nil
 }


### PR DESCRIPTION
With the kubeification of the Tinkerbell stack we no longer need flags pecific to registering with a pre-deployed Tinkerbell stack.

This doesn't update anything to generate new `Hardware` types. That work will be on a separate PR. 



