### PR TITLE
Fix AWS IAM auth format

### DIFF
--- a/pkg/clusterapi/identity.go
+++ b/pkg/clusterapi/identity.go
@@ -11,21 +11,21 @@ import (
 const awsIamKubeconfig = `
 # clusters refers to the remote service.
 clusters:
-	- name: aws-iam-authenticator
-	cluster:
-		certificate-authority: /var/aws-iam-authenticator/cert.pem
-		server: https://localhost:21362/authenticate
+  - name: aws-iam-authenticator
+    cluster:
+      certificate-authority: /var/aws-iam-authenticator/cert.pem
+      server: https://localhost:21362/authenticate
 # users refers to the API Server's webhook configuration
 # (we don't need to authenticate the API server).
 users:
-	- name: apiserver
+  - name: apiserver
 # kubeconfig files require a context. Provide one for the API Server.
 current-context: webhook
 contexts:
 - name: webhook
-	context:
-	cluster: aws-iam-authenticator
-	user: apiserver
+  context:
+    cluster: aws-iam-authenticator
+    user: apiserver
 `
 
 var awsIamMounts = []bootstrapv1.HostPathMount{

--- a/pkg/clusterapi/identity_test.go
+++ b/pkg/clusterapi/identity_test.go
@@ -128,21 +128,21 @@ func TestConfigureAWSIAMAuthInKubeadmControlPlane(t *testing.T) {
 								Content: `
 # clusters refers to the remote service.
 clusters:
-	- name: aws-iam-authenticator
-	cluster:
-		certificate-authority: /var/aws-iam-authenticator/cert.pem
-		server: https://localhost:21362/authenticate
+  - name: aws-iam-authenticator
+    cluster:
+      certificate-authority: /var/aws-iam-authenticator/cert.pem
+      server: https://localhost:21362/authenticate
 # users refers to the API Server's webhook configuration
 # (we don't need to authenticate the API server).
 users:
-	- name: apiserver
+  - name: apiserver
 # kubeconfig files require a context. Provide one for the API Server.
 current-context: webhook
 contexts:
 - name: webhook
-	context:
-	cluster: aws-iam-authenticator
-	user: apiserver
+  context:
+    cluster: aws-iam-authenticator
+    user: apiserver
 `,
 							},
 							{


### PR DESCRIPTION
*Issue #, if available:*

#1574 

*Description of changes:*

Fix API builder IAM kubeconfig indentation.

*Testing (if applicable):*

- Unit test
- Manual local e2e on snow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

