### PR TITLE
Add support for snow workload cluster creation

### DIFF
--- a/pkg/clients/kubernetes/scheme.go
+++ b/pkg/clients/kubernetes/scheme.go
@@ -6,6 +6,7 @@ import (
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	snowv1 "github.com/aws/eks-anywhere/pkg/providers/snow/api/v1beta1"
 )
 
 type schemeAdder func(s *runtime.Scheme) error
@@ -14,6 +15,7 @@ var schemeAdders = []schemeAdder{
 	clusterv1.AddToScheme,
 	controlplanev1.AddToScheme,
 	anywherev1.AddToScheme,
+	snowv1.AddToScheme,
 }
 
 func addToScheme(scheme *runtime.Scheme, schemeAdder ...schemeAdder) error {

--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -178,7 +178,7 @@ func KubeadmConfigTemplate(clusterSpec *cluster.Spec, workerNodeGroupConfig v1al
 			Kind:       kubeadmConfigTemplateKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      workerNodeGroupConfig.Name, // TODO: diff
+			Name:      DefaultKubeadmConfigTemplateName(clusterSpec, workerNodeGroupConfig),
 			Namespace: constants.EksaSystemNamespace,
 		},
 		Spec: bootstrapv1.KubeadmConfigTemplateSpec{
@@ -225,7 +225,7 @@ func MachineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1
 			Kind:       machineDeploymentKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      MachineDeploymentName(workerNodeGroupConfig),
+			Name:      MachineDeploymentName(clusterSpec, workerNodeGroupConfig),
 			Namespace: constants.EksaSystemNamespace,
 			Labels:    clusterLabels(clusterName),
 		},

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -276,7 +276,7 @@ func wantKubeadmConfigTemplate() *bootstrapv1.KubeadmConfigTemplate {
 			Kind:       "KubeadmConfigTemplate",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "wng-1",
+			Name:      "test-cluster-wng-1-1",
 			Namespace: "eksa-system",
 		},
 		Spec: bootstrapv1.KubeadmConfigTemplateSpec{
@@ -340,7 +340,7 @@ func TestMachineDeployment(t *testing.T) {
 			Kind:       "MachineDeployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "wng-1",
+			Name:      "test-cluster-wng-1",
 			Namespace: "eksa-system",
 			Labels: map[string]string{
 				"cluster.x-k8s.io/cluster-name": "test-cluster",

--- a/pkg/clusterapi/name.go
+++ b/pkg/clusterapi/name.go
@@ -37,6 +37,16 @@ func KubeadmControlPlaneName(clusterSpec *cluster.Spec) string {
 	return clusterSpec.Cluster.GetName()
 }
 
-func MachineDeploymentName(workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) string {
-	return workerNodeGroupConfig.Name
+func MachineDeploymentName(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) string {
+	// Adding cluster name prefix guarantees the machine deployment name uniqueness
+	// among clusters under the same management cluster setting.
+	return clusterWorkerNodeGroupName(clusterSpec, workerNodeGroupConfig)
+}
+
+func DefaultKubeadmConfigTemplateName(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) string {
+	return DefaultObjectName(clusterWorkerNodeGroupName(clusterSpec, workerNodeGroupConfig))
+}
+
+func clusterWorkerNodeGroupName(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) string {
+	return fmt.Sprintf("%s-%s", clusterSpec.Cluster.Name, workerNodeGroupConfig.Name)
 }

--- a/pkg/clusterapi/name_test.go
+++ b/pkg/clusterapi/name_test.go
@@ -109,13 +109,31 @@ func TestMachineDeploymentName(t *testing.T) {
 	}{
 		{
 			name: "wng 1",
-			want: "wng-1",
+			want: "test-cluster-wng-1",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := newApiBuilerTest(t)
-			g.Expect(clusterapi.MachineDeploymentName(*g.workerNodeGroupConfig)).To(Equal(tt.want))
+			g.Expect(clusterapi.MachineDeploymentName(g.clusterSpec, *g.workerNodeGroupConfig)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestDefaultKubeadmConfigTemplateName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "wng 1",
+			want: "test-cluster-wng-1-1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newApiBuilerTest(t)
+			g.Expect(clusterapi.DefaultKubeadmConfigTemplateName(g.clusterSpec, *g.workerNodeGroupConfig)).To(Equal(tt.want))
 		})
 	}
 }

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -246,7 +246,7 @@ func wantKubeadmConfigTemplate() *bootstrapv1.KubeadmConfigTemplate {
 			Kind:       "KubeadmConfigTemplate",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "md-0",
+			Name:      "snow-test-md-0-1",
 			Namespace: "eksa-system",
 		},
 		Spec: bootstrapv1.KubeadmConfigTemplateSpec{
@@ -300,7 +300,7 @@ func wantMachineDeployment() *clusterv1.MachineDeployment {
 			Kind:       "MachineDeployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "md-0",
+			Name:      "snow-test-md-0",
 			Namespace: "eksa-system",
 			Labels: map[string]string{
 				"cluster.x-k8s.io/cluster-name": "snow-test",
@@ -322,7 +322,7 @@ func wantMachineDeployment() *clusterv1.MachineDeployment {
 						ConfigRef: &v1.ObjectReference{
 							APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
 							Kind:       "KubeadmConfigTemplate",
-							Name:       "md-0",
+							Name:       "snow-test-md-0-1",
 						},
 					},
 					ClusterName: "snow-test",

--- a/pkg/providers/snow/fetch.go
+++ b/pkg/providers/snow/fetch.go
@@ -36,9 +36,9 @@ func oldControlPlaneMachineTemplate(ctx context.Context, kubeClient kubernetes.C
 	return mt, nil
 }
 
-func oldWorkerMachineTemplate(ctx context.Context, kubeclient kubernetes.Client, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) (*snowv1.AWSSnowMachineTemplate, error) {
+func oldWorkerMachineTemplate(ctx context.Context, kubeclient kubernetes.Client, clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) (*snowv1.AWSSnowMachineTemplate, error) {
 	md := &clusterv1.MachineDeployment{}
-	err := kubeclient.Get(ctx, clusterapi.MachineDeploymentName(workerNodeGroupConfig), constants.EksaSystemNamespace, md)
+	err := kubeclient.Get(ctx, clusterapi.MachineDeploymentName(clusterSpec, workerNodeGroupConfig), constants.EksaSystemNamespace, md)
 	if apierrors.IsNotFound(err) {
 		return nil, nil
 	}

--- a/pkg/providers/snow/objects.go
+++ b/pkg/providers/snow/objects.go
@@ -95,7 +95,7 @@ func WorkerMachineTemplates(ctx context.Context, kubeClient kubernetes.Client, c
 	for _, workerNodeGroupConfig := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
 		new := SnowMachineTemplate(clusterSpec.SnowMachineConfigs[workerNodeGroupConfig.MachineGroupRef.Name])
 
-		old, err := oldWorkerMachineTemplate(ctx, kubeClient, workerNodeGroupConfig)
+		old, err := oldWorkerMachineTemplate(ctx, kubeClient, clusterSpec, workerNodeGroupConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/providers/snow/objects_test.go
+++ b/pkg/providers/snow/objects_test.go
@@ -152,7 +152,7 @@ func TestWorkersObjects(t *testing.T) {
 	g.kubeconfigClient.EXPECT().
 		Get(
 			g.ctx,
-			clusterapi.MachineDeploymentName(g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
+			clusterapi.MachineDeploymentName(g.clusterSpec, g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
 			constants.EksaSystemNamespace,
 			&clusterv1.MachineDeployment{},
 		).
@@ -190,7 +190,7 @@ func TestWorkersObjectsOldMachineDeploymentNotExists(t *testing.T) {
 	g.kubeconfigClient.EXPECT().
 		Get(
 			g.ctx,
-			clusterapi.MachineDeploymentName(g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
+			clusterapi.MachineDeploymentName(g.clusterSpec, g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
 			constants.EksaSystemNamespace,
 			&clusterv1.MachineDeployment{},
 		).
@@ -207,7 +207,7 @@ func TestWorkersObjectsOldMachineTemplateNotExists(t *testing.T) {
 	g.kubeconfigClient.EXPECT().
 		Get(
 			g.ctx,
-			clusterapi.MachineDeploymentName(g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
+			clusterapi.MachineDeploymentName(g.clusterSpec, g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
 			constants.EksaSystemNamespace,
 			&clusterv1.MachineDeployment{},
 		).
@@ -234,7 +234,7 @@ func TestWorkersObjectsGetMachineDeploymentError(t *testing.T) {
 	g.kubeconfigClient.EXPECT().
 		Get(
 			g.ctx,
-			clusterapi.MachineDeploymentName(g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
+			clusterapi.MachineDeploymentName(g.clusterSpec, g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
 			constants.EksaSystemNamespace,
 			&clusterv1.MachineDeployment{},
 		).
@@ -249,7 +249,7 @@ func TestWorkersObjectsGetMachineTemplateError(t *testing.T) {
 	g.kubeconfigClient.EXPECT().
 		Get(
 			g.ctx,
-			clusterapi.MachineDeploymentName(g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
+			clusterapi.MachineDeploymentName(g.clusterSpec, g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
 			constants.EksaSystemNamespace,
 			&clusterv1.MachineDeployment{},
 		).

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -344,7 +344,7 @@ func TestGenerateCAPISpecForCreate(t *testing.T) {
 	tt.kubeconfigClient.EXPECT().
 		Get(
 			tt.ctx,
-			"md-0",
+			"snow-test-md-0",
 			constants.EksaSystemNamespace,
 			&clusterv1.MachineDeployment{},
 		).
@@ -387,7 +387,7 @@ func TestGenerateCAPISpecForUpgrade(t *testing.T) {
 	tt.kubeconfigClient.EXPECT().
 		Get(
 			tt.ctx,
-			clusterapi.MachineDeploymentName(tt.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
+			clusterapi.MachineDeploymentName(tt.clusterSpec, tt.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]),
 			constants.EksaSystemNamespace,
 			&clusterv1.MachineDeployment{},
 		).

--- a/pkg/providers/snow/testdata/expected_results_main_md.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_md.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/cluster-name: snow-test
-  name: md-0
+  name: snow-test-md-0
   namespace: eksa-system
 spec:
   clusterName: snow-test
@@ -19,7 +19,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: md-0
+          name: snow-test-md-0-1
       clusterName: snow-test
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -38,7 +38,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
   creationTimestamp: null
-  name: md-0
+  name: snow-test-md-0-1
   namespace: eksa-system
 spec:
   template:


### PR DESCRIPTION
*Issue #, if available:*

#1574 

*Description of changes:*

Run `eksctl anywhere create cluster -f snow-workload-1.yaml --kubeconfig mgmt.kubeconfig` and create a eks-a workload cluster on snow.

- Add snow api v1beta1 to kube runtime scheme
- Update `MachineDeployment` and `KubeConfigTemplate` name so that clusters under the same management cluster set have unique names

*Testing (if applicable):*

- Unit tests
- Created a workload cluster on snow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

