### PR TITLE
Remove old flag fields from Tinkerbell provider

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -297,9 +297,7 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 				time.Now,
 				skipIpCheck,
 				hardwareConfigFile,
-				skipPowerActions,
 				setupTinkerbell,
-				force,
 			)
 
 		case v1alpha1.DockerDatacenterKind:

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -64,11 +64,9 @@ type Provider struct {
 	// constructor call for constructing the validator in-line.
 	netClient networkutils.NetClient
 
-	skipIpCheck      bool
-	skipPowerActions bool
-	setupTinkerbell  bool
-	force            bool
-	Retrier          *retrier.Retrier
+	skipIpCheck     bool
+	setupTinkerbell bool
+	Retrier         *retrier.Retrier
 }
 
 // TODO: Add necessary kubectl functions here
@@ -104,9 +102,7 @@ func NewProvider(
 	now types.NowFunc,
 	skipIpCheck bool,
 	hardwareManifestPath string,
-	skipPowerActions bool,
 	setupTinkerbell bool,
-	force bool,
 ) *Provider {
 	return NewProviderCustomDep(
 		datacenterConfig,
@@ -118,9 +114,7 @@ func NewProvider(
 		now,
 		skipIpCheck,
 		hardwareManifestPath,
-		skipPowerActions,
 		setupTinkerbell,
-		force,
 	)
 }
 
@@ -134,9 +128,7 @@ func NewProviderCustomDep(
 	now types.NowFunc,
 	skipIpCheck bool,
 	hardwareManifestPath string,
-	skipPowerActions bool,
 	setupTinkerbell bool,
-	force bool,
 ) *Provider {
 	var controlPlaneMachineSpec, workerNodeGroupMachineSpec, etcdMachineSpec *v1alpha1.TinkerbellMachineConfigSpec
 	if clusterConfig.Spec.ControlPlaneConfiguration.MachineGroupRef != nil && machineConfigs[clusterConfig.Spec.ControlPlaneConfiguration.MachineGroupRef.Name] != nil {
@@ -188,11 +180,9 @@ func NewProviderCustomDep(
 		netClient: netClient,
 
 		// Behavioral flags.
-		skipIpCheck:      skipIpCheck,
-		skipPowerActions: skipPowerActions,
-		setupTinkerbell:  setupTinkerbell,
-		force:            force,
-		Retrier:          retrier,
+		skipIpCheck:     skipIpCheck,
+		setupTinkerbell: setupTinkerbell,
+		Retrier:         retrier,
 	}
 }
 

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -54,8 +54,6 @@ func newProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineC
 		true,
 		"testdata/hardware_config.yaml",
 		false,
-		false,
-		false,
 	)
 }
 


### PR DESCRIPTION
Remove now redundant fields from the Tinkerbell provider. These fields are redundant because of an overhaul in validation logic and a change in design.