### PR TITLE
Rename providors validator pkg to validation

### DIFF
--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
 	"github.com/aws/eks-anywhere/pkg/providers"
-	providerValidator "github.com/aws/eks-anywhere/pkg/providers/validator"
+	"github.com/aws/eks-anywhere/pkg/providers/validation"
 	"github.com/aws/eks-anywhere/pkg/retrier"
 	"github.com/aws/eks-anywhere/pkg/templater"
 	"github.com/aws/eks-anywhere/pkg/types"
@@ -72,7 +72,7 @@ func (p *SnowProvider) SetupAndValidateCreateCluster(ctx context.Context, cluste
 		return fmt.Errorf("setting defaults and validate snow config: %v", err)
 	}
 	if !p.skipIpCheck {
-		if err := providerValidator.ValidateControlPlaneIpUniqueness(clusterSpec.Cluster, &networkutils.DefaultNetClient{}); err != nil {
+		if err := validation.ValidateControlPlaneIpUniqueness(clusterSpec.Cluster, &networkutils.DefaultNetClient{}); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/providers/validation/validate.go
+++ b/pkg/providers/validation/validate.go
@@ -1,4 +1,4 @@
-package validator
+package validation
 
 import (
 	"fmt"

--- a/pkg/providers/validation/validate_test.go
+++ b/pkg/providers/validation/validate_test.go
@@ -1,4 +1,4 @@
-package validator_test
+package validation_test
 
 import (
 	"errors"
@@ -9,7 +9,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/networkutils/mocks"
-	"github.com/aws/eks-anywhere/pkg/providers/validator"
+	"github.com/aws/eks-anywhere/pkg/providers/validation"
 )
 
 func TestValidateControlPlaneIpUniqueness(t *testing.T) {
@@ -28,5 +28,5 @@ func TestValidateControlPlaneIpUniqueness(t *testing.T) {
 	client.EXPECT().DialTimeout(gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(5).
 		Return(nil, errors.New("no connection"))
-	g.Expect(validator.ValidateControlPlaneIpUniqueness(cluster, client)).To(Succeed())
+	g.Expect(validation.ValidateControlPlaneIpUniqueness(cluster, client)).To(Succeed())
 }


### PR DESCRIPTION
Rename the provider specific `validator` package, which is a noun, to `validation` to align with coding guidelines. 