### PR TITLE
Inject the Tinkerbell `TemplateBuilder` to the `Provider`

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -294,15 +294,24 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 				return err
 			}
 
+			templateBuilder, err := tinkerbell.NewTemplateBuilder(
+				&datacenterConfig.Spec,
+				clusterConfig,
+				machineConfigs,
+			)
+			if err != nil {
+				return fmt.Errorf("construct template builder: %v", err)
+			}
+
 			f.dependencies.Provider = tinkerbell.NewProvider(
 				datacenterConfig,
 				machineConfigs,
 				clusterConfig,
 				machines,
+				templateBuilder,
 				f.dependencies.Writer,
 				f.dependencies.DockerClient,
 				f.dependencies.Kubectl,
-				time.Now,
 				skipIpCheck,
 				setupTinkerbell,
 			)


### PR DESCRIPTION
The TemplateBuilder was constructed inline. This moves it so its injected into the Tinkerbell provider moving is incrementally to creating more testable code.

A subsequent PR should swap the concrete type injected into `tinkerbell.NewProvider()` with an interface so we can isolate template tests from the `tinkerbell.Provider` type.
