### PR TITLE
Hide/default TinkerbellTemplateConfig

### DIFF
--- a/cmd/eksctl-anywhere/cmd/generateclusterconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generateclusterconfig.go
@@ -12,13 +12,11 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/templater"
 	"github.com/aws/eks-anywhere/pkg/validations"
-	"github.com/aws/eks-anywhere/pkg/version"
 )
 
 var removeFromDefaultConfig = []string{"spec.clusterNetwork.dns"}
@@ -63,7 +61,6 @@ func generateClusterConfig(clusterName string) error {
 	var resources [][]byte
 	var datacenterYaml []byte
 	var machineGroupYaml [][]byte
-	var tinkerbellTemplateYaml []byte
 	var clusterConfigOpts []v1alpha1.ClusterGenerateOpt
 	switch strings.ToLower(viper.GetString("provider")) {
 	case constants.DockerProviderName:
@@ -206,22 +203,9 @@ func generateClusterConfig(clusterName string) error {
 				return fmt.Errorf("generating cluster yaml: %v", err)
 			}
 			datacenterYaml = dcyaml
-			versionBundle, err := cluster.GetVersionsBundleForVersion(version.Get(), v1alpha1.GetClusterDefaultKubernetesVersion())
-			if err != nil {
-				return fmt.Errorf("generating cluster yaml: %v", err)
-			}
 
-			tinkTmpConfig := v1alpha1.NewDefaultTinkerbellTemplateConfigGenerate(clusterName, *versionBundle)
-			tinkTmpYaml, err := yaml.Marshal(tinkTmpConfig)
-			if err != nil {
-				return fmt.Errorf("generating cluster yaml: %v", err)
-			}
-			tinkerbellTemplateYaml = tinkTmpYaml
-
-			cpMachineConfig := v1alpha1.NewTinkerbellMachineConfigGenerate(providers.GetControlPlaneNodeName(clusterName),
-				v1alpha1.WithTemplateRef(tinkTmpConfig))
-			workerMachineConfig := v1alpha1.NewTinkerbellMachineConfigGenerate(clusterName,
-				v1alpha1.WithTemplateRef(tinkTmpConfig))
+			cpMachineConfig := v1alpha1.NewTinkerbellMachineConfigGenerate(providers.GetControlPlaneNodeName(clusterName))
+			workerMachineConfig := v1alpha1.NewTinkerbellMachineConfigGenerate(clusterName)
 			clusterConfigOpts = append(clusterConfigOpts,
 				v1alpha1.WithCPMachineGroupRef(cpMachineConfig),
 				v1alpha1.WithWorkerMachineGroupRef(workerMachineConfig),
@@ -255,9 +239,7 @@ func generateClusterConfig(clusterName string) error {
 	if len(machineGroupYaml) > 0 {
 		resources = append(resources, machineGroupYaml...)
 	}
-	if len(tinkerbellTemplateYaml) > 0 {
-		resources = append(resources, tinkerbellTemplateYaml)
-	}
+
 	fmt.Println(string(templater.AppendYamlResources(resources...)))
 	return nil
 }

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig.go
@@ -17,14 +17,14 @@ const TinkerbellTemplateConfigKind = "TinkerbellTemplateConfig"
 // +kubebuilder:object:generate=false
 type ActionOpt func(action *[]tinkerbell.Action)
 
-// NewDefaultTinkerbellTemplateConfigGenerate returns a default TinkerbellTemplateConfig with the required Tasks and Actions
-func NewDefaultTinkerbellTemplateConfigGenerate(name string, versionBundle v1alpha1.VersionsBundle) *TinkerbellTemplateConfigGenerate {
-	config := &TinkerbellTemplateConfigGenerate{
+// NewDefaultTinkerbellTemplateConfigCreate returns a default TinkerbellTemplateConfig with the required Tasks and Actions
+func NewDefaultTinkerbellTemplateConfigCreate(name string, versionBundle v1alpha1.VersionsBundle) *TinkerbellTemplateConfig {
+	config := &TinkerbellTemplateConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       TinkerbellTemplateConfigKind,
 			APIVersion: SchemeBuilder.GroupVersion.String(),
 		},
-		ObjectMeta: ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Spec: TinkerbellTemplateConfigSpec{
@@ -78,14 +78,11 @@ func GetTinkerbellTemplateConfig(fileName string) (map[string]*TinkerbellTemplat
 		}
 
 		if template.Kind() == template.ExpectedKind() {
-			if err = yaml.UnmarshalStrict([]byte(c), &template); err == nil {
-				templates[template.Name] = &template
-				continue
+			if err = yaml.UnmarshalStrict([]byte(c), &template); err != nil {
+				return nil, fmt.Errorf("invalid template config content: %v", err)
 			}
+			templates[template.Name] = &template
 		}
-	}
-	if len(templates) == 0 {
-		return nil, fmt.Errorf("unable to find kind %v in file", TinkerbellTemplateConfigKind)
 	}
 	return templates, nil
 }

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_test.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_test.go
@@ -29,12 +29,6 @@ func TestGetTinkerbellTemplateConfig(t *testing.T) {
 			wantErr:     true,
 		},
 		{
-			testName:    "invalid kind",
-			fileName:    "testdata/cluster_invalid_kinds_tinkerbell.yaml",
-			wantConfigs: nil,
-			wantErr:     true,
-		},
-		{
 			testName: "valid tinkerbell template config",
 			fileName: "testdata/cluster_1_21_valid_tinkerbell.yaml",
 			wantConfigs: map[string]*TinkerbellTemplateConfig{


### PR DESCRIPTION
*Description of changes:*
We are hiding TinkerbellTemplateConfig from the tinkerbell cluster config file and defaulting all the values of the field to avoid human error. However, a user can pass their own TinkerbellTemplateConfig to override default template.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

