### PR TITLE
Make codecov patch check optional

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 80%
+        informational: true


### PR DESCRIPTION
This won't gate PRs based on the patch coverage but will still provide
coverage information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

