### PR TITLE
Validate Tinkerbell datacenter config on create

### DIFF
--- a/pkg/providers/tinkerbell/cluster.go
+++ b/pkg/providers/tinkerbell/cluster.go
@@ -85,6 +85,7 @@ func NewClusterSpecValidator(assertions ...ClusterSpecAssertion) *ClusterSpecVal
 	// Register mandatory assertions. If an assertion becomes optional dependent on context move it
 	// to a New* func and register it dynamically. See assert.go for examples.
 	v.Register(
+		AssertDatacenterConfigValid,
 		AssertControlPlaneMachineRefExists,
 		AssertEtcdMachineRefExists,
 		AssertWorkerNodeGroupMachineRefsExists,


### PR DESCRIPTION
As part of the Tinkerbell validation refactoring we isolated datacenter config validation. It was left out of the core set of assertions we run. This adds it ensuring we validate everything in there.