### PR TITLE
Make codecov project optional

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,8 @@ coverage:
       default:
         target: 80%
         informational: true
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+        informational: true


### PR DESCRIPTION
This makes the project check just informational. It also adds a 0.5%
threshold to account for flakiness when measuring coverage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

