### PR TITLE
Add disk to Tinkerbell CSV input

### DIFF
--- a/pkg/providers/tinkerbell/hardware/machine.go
+++ b/pkg/providers/tinkerbell/hardware/machine.go
@@ -16,6 +16,11 @@ type Machine struct {
 	Nameservers Nameservers `csv:"nameservers"`
 	MACAddress  string      `csv:"mac"`
 
+	// Disk used to populate the default workflow actions.
+	// Currently needs to be the same for all hardware residing in the same group where a group
+	// is either: control plane hardwar, external etcd hard, or the definable worker node groups.
+	Disk string `csv:"disk"`
+
 	// Labels to be applied to the Hardware resource.
 	Labels Labels `csv:"labels"`
 

--- a/pkg/providers/tinkerbell/hardware/validator_test.go
+++ b/pkg/providers/tinkerbell/hardware/validator_test.go
@@ -153,20 +153,7 @@ func TestUniquenessAssertionsWithDupes(t *testing.T) {
 func TestStaticMachineAssertions_ValidMachine(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	machine := hardware.Machine{
-		ID:           "unique string",
-		IPAddress:    "10.10.10.10",
-		Gateway:      "10.10.10.1",
-		Nameservers:  []string{"nameserver1"},
-		Netmask:      "255.255.255.255",
-		MACAddress:   "00:00:00:00:00:00",
-		Hostname:     "localhost",
-		Labels:       make(hardware.Labels),
-		BMCIPAddress: "10.10.10.11",
-		BMCUsername:  "username",
-		BMCPassword:  "password",
-		BMCVendor:    "dell",
-	}
+	machine := NewValidMachine()
 
 	validate := hardware.StaticMachineAssertions()
 	g.Expect(validate(machine)).ToNot(gomega.HaveOccurred())
@@ -233,6 +220,12 @@ func TestStaticMachineAssertions_InvalidMachines(t *testing.T) {
 		"InvalidLabelValue": func(h *hardware.Machine) {
 			h.Labels["foo"] = "\\/dsa"
 		},
+		"InvalidDisk": func(h *hardware.Machine) {
+			h.Disk = "*&!@#!%"
+		},
+		"InvalidWithJustDev": func(h *hardware.Machine) {
+			h.Disk = "/dev/"
+		},
 	}
 
 	validate := hardware.StaticMachineAssertions()
@@ -255,6 +248,7 @@ func NewValidMachine() hardware.Machine {
 		Netmask:      "255.255.255.255",
 		Hostname:     "localhost",
 		Labels:       make(hardware.Labels),
+		Disk:         "/dev/sda",
 		BMCIPAddress: "10.10.10.11",
 		BMCUsername:  "username",
 		BMCPassword:  "password",


### PR DESCRIPTION
Builds on #2268 

Add `Disk` to the Tinkerbell CSV so it can be consumed for `TinkerbellMachineTemplate` generation. The `Disk` will be validated in a subsequent PR where it will need to be consistent among hardware expected to be provisioned for control plane, external etcd or individual node groups.

The PR only adds CSV input data - it doesn't introduce any functional changes beyond that.