### PR TITLE
Set TINKERBELL_IP when retrieving Tinkerbell provider environment

### DIFF
--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -208,8 +208,22 @@ func (p *Provider) Version(clusterSpec *cluster.Spec) string {
 	return clusterSpec.VersionsBundle.Tinkerbell.Version
 }
 
-func (p *Provider) EnvMap(_ *cluster.Spec) (map[string]string, error) {
-	return map[string]string{}, nil
+func (p *Provider) EnvMap(spec *cluster.Spec) (map[string]string, error) {
+	return map[string]string{
+		// The TINKERBELL_IP is input for the CAPT deployment and used as part of default template
+		// generation. However, we use custom templates and leverage the template override
+		// functionality of CAPT hence this never gets used.
+		//
+		// Deployment manifest requiring the env var for replacement.
+		// https://github.com/tinkerbell/cluster-api-provider-tinkerbell/blob/main/config/manager/manager.yaml#L23
+		//
+		// Template override
+		// https://github.com/chrisdoherty4/cluster-api-provider-tinkerbell/blob/main/controllers/machine.go#L182
+		//
+		// Env read having set TINKERBELL_IP in the deployment manifest.
+		// https://github.com/chrisdoherty4/cluster-api-provider-tinkerbell/blob/main/controllers/machine.go#L192
+		"TINKERBELL_IP": "<set in eks-a tinkerbell provider>",
+	}, nil
 }
 
 func (p *Provider) GetDeployments() map[string][]string {


### PR DESCRIPTION
Define the `TINKERBELL_IP` that gets propogated to CAPT installation code where its used as a value replacement so CAPT knows what address to specify in `Userdata` for contacting Hegel. 

This, in our context, is totally unnecessary. The only code that uses it is https://github.com/chrisdoherty4/cluster-api-provider-tinkerbell/blob/main/controllers/machine.go#L192 which renders a default template. Given we override the template the configuration is meaningless for us and only necessary to satisfy CAPT's [`Deployment` spec](https://github.com/chrisdoherty4/cluster-api-provider-tinkerbell/blob/main/config/manager/manager.yaml#L23).