### PR TITLE
Wire hardware CSV into Tinkerbell provider on create

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -31,7 +31,7 @@ type createClusterOptions struct {
 	clusterOptions
 	forceClean       bool
 	skipIpCheck      bool
-	hardwareFileName string
+	hardwareCSVPath  string
 	skipPowerActions bool
 	setupTinkerbell  bool
 	installPackages  string
@@ -52,7 +52,7 @@ func init() {
 	createCmd.AddCommand(createClusterCmd)
 	createClusterCmd.Flags().StringVarP(&cc.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
 	if features.IsActive(features.TinkerbellProvider()) {
-		createClusterCmd.Flags().StringVarP(&cc.hardwareFileName, "hardwarefile", "w", "", "Filename that contains datacenter hardware information")
+		createClusterCmd.Flags().StringVar(&cc.hardwareCSVPath, "hardware-csv", "", "A file path to a CSV file containing hardware data to be submitted to the cluster for provisioning")
 		createClusterCmd.Flags().BoolVar(&cc.skipPowerActions, "skip-power-actions", false, "Skip IPMI power actions on the hardware for Tinkerbell provider")
 		if features.IsActive(features.TinkerbellStackSetup()) {
 			createClusterCmd.Flags().BoolVar(&cc.setupTinkerbell, "setup-tinkerbell", false, "Setup Tinkerbell stack during baremetal cluster creation")
@@ -105,8 +105,8 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 			return fmt.Errorf("required flag \"hardwarefile\" not set")
 		}
 
-		if !validations.FileExists(cc.hardwareFileName) {
-			return fmt.Errorf("hardware config file %s does not exist", cc.hardwareFileName)
+		if !validations.FileExists(cc.hardwareCSVPath) {
+			return fmt.Errorf("hardware config file %s does not exist", cc.hardwareCSVPath)
 		}
 	}
 
@@ -146,7 +146,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).WithExecutableMountDirs(dirs...).
 		WithBootstrapper().
 		WithClusterManager(clusterSpec.Cluster).
-		WithProvider(cc.fileName, clusterSpec.Cluster, cc.skipIpCheck, cc.hardwareFileName, cc.skipPowerActions, cc.setupTinkerbell, cc.forceClean).
+		WithProvider(cc.fileName, clusterSpec.Cluster, cc.skipIpCheck, cc.hardwareCSVPath, cc.skipPowerActions, cc.setupTinkerbell, cc.forceClean).
 		WithFluxAddonClient(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().
 		WithEksdInstaller().

--- a/pkg/providers/tinkerbell/hardware/catalogue_bmc.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_bmc.go
@@ -4,6 +4,8 @@ import (
 	"github.com/tinkerbell/rufio/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
 )
 
 // IndexBMCs indexes BMC instances on index by extracfting the key using fn.
@@ -88,7 +90,8 @@ func baseboardManagementComputerFromMachine(m Machine) *v1alpha1.BaseboardManage
 	return &v1alpha1.BaseboardManagement{
 		TypeMeta: newBaseboardManagementTypeMeta(),
 		ObjectMeta: v1.ObjectMeta{
-			Name: formatBMCRef(m),
+			Name:      formatBMCRef(m),
+			Namespace: constants.EksaSystemNamespace,
 		},
 		Spec: v1alpha1.BaseboardManagementSpec{
 			Connection: v1alpha1.Connection{

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
@@ -3,6 +3,8 @@ package hardware
 import (
 	"github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
 )
 
 // IndexHardware indexes Hardware instances on index by extracfting the key using fn.
@@ -100,8 +102,9 @@ func hardwareFromMachine(m Machine) *v1alpha1.Hardware {
 	return &v1alpha1.Hardware{
 		TypeMeta: newHardwareTypeMeta(),
 		ObjectMeta: v1.ObjectMeta{
-			Name:   m.Hostname,
-			Labels: m.Labels,
+			Name:      m.Hostname,
+			Namespace: constants.EksaSystemNamespace,
+			Labels:    m.Labels,
 		},
 		Spec: v1alpha1.HardwareSpec{
 			Disks: []v1alpha1.Disk{{Device: m.Disk}},

--- a/pkg/providers/tinkerbell/hardware/catalogue_secret.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_secret.go
@@ -3,6 +3,8 @@ package hardware
 import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
 )
 
 // IndexSecret indexes Secret instances on index by extracfting the key using fn.
@@ -81,13 +83,11 @@ func (w *SecretCatalogueWriter) Write(m Machine) error {
 }
 
 func baseboardManagementSecretFromMachine(m Machine) *corev1.Secret {
-	// TODO(chrisdoherty4)
-	// 	- Set the namespace to the CAPT namespace.
-	// 	- Patch through insecure TLS.
 	return &corev1.Secret{
 		TypeMeta: newSecretTypeMeta(),
 		ObjectMeta: v1.ObjectMeta{
-			Name: formatBMCSecretRef(m),
+			Name:      formatBMCSecretRef(m),
+			Namespace: constants.EksaSystemNamespace,
 		},
 		Type: "kubernetes.io/basic-auth",
 		Data: map[string][]byte{

--- a/pkg/providers/tinkerbell/hardware/csv.go
+++ b/pkg/providers/tinkerbell/hardware/csv.go
@@ -1,8 +1,10 @@
 package hardware
 
 import (
+	"bufio"
 	stdcsv "encoding/csv"
 	"io"
+	"os"
 
 	csv "github.com/gocarina/gocsv"
 	"github.com/google/uuid"
@@ -26,6 +28,16 @@ func NewCSVReader(r io.Reader) (CSVReader, error) {
 	}
 
 	return CSVReader{reader: reader, uuidGenerator: uuid.NewString}, nil
+}
+
+// NewCSVReaderFromFile creates a CSVReader instance that reads from path.
+func NewCSVReaderFromFile(path string) (CSVReader, error) {
+	fh, err := os.Open(path)
+	if err != nil {
+		return CSVReader{}, err
+	}
+
+	return NewCSVReader(bufio.NewReader(fh))
 }
 
 // NewCSVReaderWithUUIDGenerator returns a new CSVReader instance as defined in NewCSVReader with its internal

--- a/pkg/providers/tinkerbell/testdata/hardware.csv
+++ b/pkg/providers/tinkerbell/testdata/hardware.csv
@@ -1,0 +1,5 @@
+hostname,bmc_ip,bmc_username,bmc_password,bmc_vendor,mac,ip_address,netmask,gateway,nameservers,labels,disk,id
+worker1,192.168.0.10,Admin,admin,HP,00:00:00:00:00:01,10.10.10.10,255.255.255.0,10.10.10.1,1.1.1.1,type=cp,/dev/sda,worker1
+worker2,192.168.0.11,Admin,admin,HP,00:00:00:00:00:02,10.10.10.11,255.255.255.0,10.10.10.1,1.1.1.1,type=cp,/dev/sda,worker2
+worker3,192.168.0.12,Admin,admin,HP,00:00:00:00:00:03,10.10.10.12,255.255.255.0,10.10.10.1,1.1.1.1,type=cp,/dev/sda,worker3
+worker4,192.168.0.13,Admin,admin,HP,00:00:00:00:00:04,10.10.10.13,255.255.255.0,10.10.10.1,1.1.1.1,type=cp,/dev/sda,worker4

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -53,8 +53,7 @@ type Provider struct {
 	writer                filewriter.FileWriter
 	keyGenerator          SSHAuthKeyGenerator
 
-	hardwareManifestPath string
-	// catalogue is a cache initialized during SetupAndValidateCreateCluster() from hardwareManifestPath.
+	machines  hardware.MachineReader
 	catalogue *hardware.Catalogue
 
 	// TODO(chrisdoheryt4) Temporarily depend on the netclient until the validator can be injected.
@@ -64,7 +63,7 @@ type Provider struct {
 
 	skipIpCheck     bool
 	setupTinkerbell bool
-	Retrier         *retrier.Retrier
+	retrier         *retrier.Retrier
 }
 
 type Docker interface {
@@ -99,40 +98,12 @@ func NewProvider(
 	datacenterConfig *v1alpha1.TinkerbellDatacenterConfig,
 	machineConfigs map[string]*v1alpha1.TinkerbellMachineConfig,
 	clusterConfig *v1alpha1.Cluster,
+	machines hardware.MachineReader,
 	writer filewriter.FileWriter,
 	docker Docker,
 	providerKubectlClient ProviderKubectlClient,
 	now types.NowFunc,
 	skipIpCheck bool,
-	hardwareManifestPath string,
-	setupTinkerbell bool,
-) *Provider {
-	return NewProviderCustomDep(
-		datacenterConfig,
-		machineConfigs,
-		clusterConfig,
-		writer,
-		docker,
-		providerKubectlClient,
-		&networkutils.DefaultNetClient{},
-		now,
-		skipIpCheck,
-		hardwareManifestPath,
-		setupTinkerbell,
-	)
-}
-
-func NewProviderCustomDep(
-	datacenterConfig *v1alpha1.TinkerbellDatacenterConfig,
-	machineConfigs map[string]*v1alpha1.TinkerbellMachineConfig,
-	clusterConfig *v1alpha1.Cluster,
-	writer filewriter.FileWriter,
-	docker Docker,
-	providerKubectlClient ProviderKubectlClient,
-	netClient networkutils.NetClient,
-	now types.NowFunc,
-	skipIpCheck bool,
-	hardwareManifestPath string,
 	setupTinkerbell bool,
 ) *Provider {
 	var controlPlaneMachineSpec, workerNodeGroupMachineSpec, etcdMachineSpec *v1alpha1.TinkerbellMachineConfigSpec
@@ -151,7 +122,6 @@ func NewProviderCustomDep(
 			etcdMachineSpec = &machineConfigs[clusterConfig.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name].Spec
 		}
 	}
-	retrier := retrier.NewWithMaxRetries(maxRetries, backOffPeriod)
 	return &Provider{
 		clusterConfig:         clusterConfig,
 		datacenterConfig:      datacenterConfig,
@@ -165,30 +135,25 @@ func NewProviderCustomDep(
 			etcdMachineSpec:             etcdMachineSpec,
 			now:                         now,
 		},
-		writer: writer,
-
-		hardwareManifestPath: hardwareManifestPath,
-
-		// todo(chrisdoherty4)
-		// Inject the catalogue dependency so we can dynamically construcft the indexing capabilities.
+		writer:   writer,
+		machines: machines,
+		// TODO(chrisdoherty4) Inject the catalogue dependency so we can dynamically construcft the
+		// indexing capabilities.
 		catalogue: hardware.NewCatalogue(
 			hardware.WithHardwareIDIndex(),
 			hardware.WithHardwareBMCRefIndex(),
 			hardware.WithBMCNameIndex(),
 			hardware.WithSecretNameIndex(),
 		),
-
+		netClient: &networkutils.DefaultNetClient{},
+		retrier:   retrier.NewWithMaxRetries(maxRetries, backOffPeriod),
 		// (chrisdoherty4) We're hard coding the dependency and monkey patching in testing because the provider
 		// isn't very testable right now and we already have tests in the `tinkerbell` package so can monkey patch
 		// directly. This is very much a hack for testability.
 		keyGenerator: common.SshAuthKeyGenerator{},
-
-		netClient: netClient,
-
 		// Behavioral flags.
 		skipIpCheck:     skipIpCheck,
 		setupTinkerbell: setupTinkerbell,
-		Retrier:         retrier,
 	}
 }
 

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	filewritermocks "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -45,16 +46,21 @@ func givenMachineConfigs(t *testing.T, fileName string) map[string]*v1alpha1.Tin
 }
 
 func newProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineConfigs map[string]*v1alpha1.TinkerbellMachineConfig, clusterConfig *v1alpha1.Cluster, writer filewriter.FileWriter, docker Docker, kubectl ProviderKubectlClient) *Provider {
+	reader, err := hardware.NewCSVReaderFromFile("./testdata/hardware.csv")
+	if err != nil {
+		panic(err)
+	}
+
 	return NewProvider(
 		datacenterConfig,
 		machineConfigs,
 		clusterConfig,
+		reader,
 		writer,
 		docker,
 		kubectl,
 		test.FakeNow,
 		true,
-		"testdata/hardware_config.yaml",
 		false,
 	)
 }

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -88,7 +88,7 @@ func (p *Provider) RunPostControlPlaneUpgrade(ctx context.Context, oldClusterSpe
 	// Even if we create a new ClusterResourceSet, if such resources already exist in the cluster, they won't be reapplied
 	// The long term solution is to add this capability to the cluster-api controller,
 	// with a new mode like "ReApplyOnChanges" or "ReApplyOnCreate" vs the current "ReApplyOnce"
-	/* err := p.Retrier.Retry(
+	/* err := p.retrier.Retry(
 		func() error {
 			return p.resourceSetManager.ForceUpdate(ctx, resourceSetName(clusterSpec), constants.EksaSystemNamespace, managementCluster, workloadCluster)
 		},


### PR DESCRIPTION
Builds on #2266 

Wire the CSV into the Tinkerbell provider such that we can pass a CSV path to the `create` cmd and it is used by the Tinkerbell provider to catalogue hardware ready for submission post-boostrap cluster creation.