### PR TITLE
Fix Tinkerbell hardware CSV labels format

### DIFF
--- a/pkg/providers/tinkerbell/hardware/csv_test.go
+++ b/pkg/providers/tinkerbell/hardware/csv_test.go
@@ -53,6 +53,54 @@ func TestCSVReaderReadsWithNoIDSpecified(t *testing.T) {
 	g.Expect(machine).To(gomega.BeEquivalentTo(expect))
 }
 
+func TestCSVReaderWithMultipleLabels(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	buf := NewBufferedCSV()
+
+	expect := NewValidMachine()
+	expect.Labels["foo"] = "bar"
+	expect.Labels["qux"] = "baz"
+
+	err := csv.MarshalCSV([]hardware.Machine{expect}, buf)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	const uuid = "unique-id"
+	reader, err := hardware.NewCSVReaderWithUUIDGenerator(buf.Buffer, func() string { return uuid })
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	machine, err := reader.Read()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(machine).To(gomega.BeEquivalentTo(expect))
+}
+
+func TestCSVReaderFromFile(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	reader, err := hardware.NewCSVReaderFromFile("./testdata/hardware.csv")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	machine, err := reader.Read()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(machine).To(gomega.Equal(
+		hardware.Machine{
+			ID:           "worker1",
+			Labels:       map[string]string{"type": "cp"},
+			Nameservers:  []string{"1.1.1.1"},
+			Gateway:      "10.10.10.1",
+			Netmask:      "255.255.255.0",
+			IPAddress:    "10.10.10.10",
+			MACAddress:   "00:00:00:00:00:01",
+			Hostname:     "worker1",
+			Disk:         "/dev/sda",
+			BMCIPAddress: "192.168.0.10",
+			BMCUsername:  "Admin",
+			BMCPassword:  "admin",
+			BMCVendor:    "HP",
+		},
+	))
+}
+
 func TestNewCSVReaderWithIOReaderError(t *testing.T) {
 	g := gomega.NewWithT(t)
 

--- a/pkg/providers/tinkerbell/hardware/machine.go
+++ b/pkg/providers/tinkerbell/hardware/machine.go
@@ -58,6 +58,9 @@ func (n *Nameservers) MarshalCSV() (string, error) {
 	return n.String(), nil
 }
 
+// LabelSSeparator is used to separate key value label pairs.
+const LabelsSeparator = "|"
+
 // Labels defines a lebsl set. It satisfies https://pkg.go.dev/k8s.io/apimachinery/pkg/labels#Labels.
 type Labels map[string]string
 
@@ -77,13 +80,13 @@ func (l *Labels) UnmarshalCSV(s string) error {
 	*l = make(Labels)
 
 	// Cater for no labels being specified.
-	split := strings.Split(s, ",")
+	split := strings.Split(s, LabelsSeparator)
 	if len(split) == 1 && split[0] == "" {
 		return nil
 	}
 
-	for _, pair := range strings.Split(s, ",") {
-		keyValue := strings.Split(pair, "=")
+	for _, pair := range split {
+		keyValue := strings.Split(strings.TrimSpace(pair), "=")
 		if len(keyValue) != 2 {
 			return fmt.Errorf("badly formatted key-value pair: %v", pair)
 		}
@@ -100,7 +103,7 @@ func (l Labels) String() string {
 	}
 	// Sort for determinism.
 	sort.StringSlice(labels).Sort()
-	return strings.Join(labels, ",")
+	return strings.Join(labels, LabelsSeparator)
 }
 
 func newEmptyFieldError(s string) error {

--- a/pkg/providers/tinkerbell/hardware/testdata/hardware.csv
+++ b/pkg/providers/tinkerbell/hardware/testdata/hardware.csv
@@ -1,0 +1,2 @@
+hostname,bmc_ip,bmc_username,bmc_password,bmc_vendor,mac,ip_address,netmask,gateway,nameservers,labels,disk,id
+worker1,192.168.0.10,Admin,admin,HP,00:00:00:00:00:01,10.10.10.10,255.255.255.0,10.10.10.1,1.1.1.1,type=cp,/dev/sda,worker1


### PR DESCRIPTION
Labels in the Tinkerbell hardware CSV required separation by comma which, for hopefully obvious reasons, doesn't work in CSVs (🤦). This changes to using pipe delimeted which is consistent with other multi-value fields.*Issue #, if available:*
