### PR TITLE
Support node CIDR mask config

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -67,6 +67,14 @@ spec:
                             type: string
                         type: object
                     type: object
+                  nodes:
+                    properties:
+                      cidrMaskSize:
+                        description: CIDRMaskSize defines the mask size for node cidr
+                          in the cluster, default for ipv4 is 24. This is an optional
+                          field
+                        type: integer
+                    type: object
                   pods:
                     description: Comma-separated list of CIDR blocks to use for pod
                       and service subnets. Defaults to 192.168.0.0/16 for pod subnet.

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	ClusterKind         = "Cluster"
-	YamlSeparator       = "\n---\n"
-	RegistryMirrorCAKey = "EKSA_REGISTRY_MIRROR_CA"
+	ClusterKind              = "Cluster"
+	YamlSeparator            = "\n---\n"
+	RegistryMirrorCAKey      = "EKSA_REGISTRY_MIRROR_CA"
+	podSubnetNodeMaskMaxDiff = 16
 )
 
 // +kubebuilder:object:generate=false
@@ -463,28 +464,45 @@ func validateEtcdReplicas(clusterConfig *Cluster) error {
 }
 
 func validateNetworking(clusterConfig *Cluster) error {
-	if len(clusterConfig.Spec.ClusterNetwork.Pods.CidrBlocks) <= 0 {
+	clusterNetwork := clusterConfig.Spec.ClusterNetwork
+
+	if len(clusterNetwork.Pods.CidrBlocks) <= 0 {
 		return errors.New("pods CIDR block not specified or empty")
 	}
-	if len(clusterConfig.Spec.ClusterNetwork.Services.CidrBlocks) <= 0 {
+	if len(clusterNetwork.Services.CidrBlocks) <= 0 {
 		return errors.New("services CIDR block not specified or empty")
 	}
-	if len(clusterConfig.Spec.ClusterNetwork.Pods.CidrBlocks) > 1 {
+	if len(clusterNetwork.Pods.CidrBlocks) > 1 {
 		return fmt.Errorf("multiple CIDR blocks for Pods are not yet supported")
 	}
-	if len(clusterConfig.Spec.ClusterNetwork.Services.CidrBlocks) > 1 {
+	if len(clusterNetwork.Services.CidrBlocks) > 1 {
 		return fmt.Errorf("multiple CIDR blocks for Services are not yet supported")
 	}
-	_, _, err := net.ParseCIDR(clusterConfig.Spec.ClusterNetwork.Pods.CidrBlocks[0])
+	_, podCIDRIpNet, err := net.ParseCIDR(clusterNetwork.Pods.CidrBlocks[0])
 	if err != nil {
-		return fmt.Errorf("invalid CIDR block format for Pods: %s. Please specify a valid CIDR block for pod subnet", clusterConfig.Spec.ClusterNetwork.Pods)
+		return fmt.Errorf("invalid CIDR block format for Pods: %s. Please specify a valid CIDR block for pod subnet", clusterNetwork.Pods)
 	}
-	_, _, err = net.ParseCIDR(clusterConfig.Spec.ClusterNetwork.Services.CidrBlocks[0])
+	_, _, err = net.ParseCIDR(clusterNetwork.Services.CidrBlocks[0])
 	if err != nil {
-		return fmt.Errorf("invalid CIDR block for Services: %s. Please specify a valid CIDR block for service subnet", clusterConfig.Spec.ClusterNetwork.Services)
+		return fmt.Errorf("invalid CIDR block for Services: %s. Please specify a valid CIDR block for service subnet", clusterNetwork.Services)
 	}
 
-	return validateCNIPlugin(clusterConfig.Spec.ClusterNetwork)
+	if clusterNetwork.Nodes != nil && clusterNetwork.Nodes.CIDRMaskSize != nil {
+		podMaskSize, _ := podCIDRIpNet.Mask.Size()
+		nodeCidrMaskSize := clusterNetwork.Nodes.CIDRMaskSize
+		// the pod subnet mask needs to allow one or multiple node-masks
+		// i.e. if it has a /24 the node mask must be between 24 and 32 for ipv4
+		// the below validations are run by kubeadm and we are bubbling those up here for better customer experience
+		if podMaskSize > *nodeCidrMaskSize {
+			return fmt.Errorf("the size of pod subnet with mask %d is smaller than the size of node subnet with mask %d", podMaskSize, *nodeCidrMaskSize)
+		} else if (*nodeCidrMaskSize - podMaskSize) > podSubnetNodeMaskMaxDiff {
+			// PodSubnetNodeMaskMaxDiff is limited to 16 due to an issue with uncompressed IP bitmap in core
+			// The node subnet mask size must be no more than the pod subnet mask size + 16
+			return fmt.Errorf("pod subnet mask (%d) and node-mask (%d) difference is greater than %d", podMaskSize, *nodeCidrMaskSize, podSubnetNodeMaskMaxDiff)
+		}
+	}
+
+	return validateCNIPlugin(clusterNetwork)
 }
 
 func validateCNIPlugin(network ClusterNetwork) error {

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -321,6 +321,7 @@ type ClusterNetwork struct {
 	// CNIConfig specifies the CNI plugin to be installed in the cluster
 	CNIConfig *CNIConfig `json:"cniConfig,omitempty"`
 	DNS       DNS        `json:"dns,omitempty"`
+	Nodes     *Nodes     `json:"nodes,omitempty"`
 }
 
 func (n *ClusterNetwork) Equal(o *ClusterNetwork) bool {
@@ -524,6 +525,11 @@ type DNS struct {
 type ResolvConf struct {
 	// Path defines the path to the file that contains the DNS resolver configuration
 	Path string `json:"path,omitempty"`
+}
+
+type Nodes struct {
+	// CIDRMaskSize defines the mask size for node cidr in the cluster, default for ipv4 is 24. This is an optional field
+	CIDRMaskSize *int `json:"cidrMaskSize,omitempty"`
 }
 
 func (n *ResolvConf) Equal(o *ResolvConf) bool {

--- a/pkg/clusterapi/extraargs.go
+++ b/pkg/clusterapi/extraargs.go
@@ -3,6 +3,7 @@ package clusterapi
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -48,6 +49,15 @@ func PodIAMAuthExtraArgs(podIAMConfig *v1alpha1.PodIAMConfig) ExtraArgs {
 	}
 	args := ExtraArgs{}
 	args.AddIfNotEmpty("service-account-issuer", podIAMConfig.ServiceAccountIssuer)
+	return args
+}
+
+func NodeCIDRMaskExtraArgs(clusterNetwork *v1alpha1.ClusterNetwork) ExtraArgs {
+	if clusterNetwork == nil || clusterNetwork.Nodes == nil || clusterNetwork.Nodes.CIDRMaskSize == nil {
+		return nil
+	}
+	args := ExtraArgs{}
+	args.AddIfNotEmpty("node-cidr-mask-size", strconv.Itoa(*clusterNetwork.Nodes.CIDRMaskSize))
 	return args
 }
 

--- a/pkg/clusterapi/extraargs_test.go
+++ b/pkg/clusterapi/extraargs_test.go
@@ -426,3 +426,50 @@ func TestAppend(t *testing.T) {
 		})
 	}
 }
+
+func TestNodeCIDRMaskExtraArgs(t *testing.T) {
+	nodeCidrMaskSize := new(int)
+	*nodeCidrMaskSize = 28
+	tests := []struct {
+		testName       string
+		clusterNetwork *v1alpha1.ClusterNetwork
+		want           clusterapi.ExtraArgs
+	}{
+		{
+			testName:       "no cluster network config",
+			clusterNetwork: nil,
+			want:           nil,
+		},
+		{
+			testName: "no nodes config",
+			clusterNetwork: &v1alpha1.ClusterNetwork{
+				Pods: v1alpha1.Pods{CidrBlocks: []string{"test", "test"}},
+			},
+			want: nil,
+		},
+		{
+			testName: "with nodes config",
+			clusterNetwork: &v1alpha1.ClusterNetwork{
+				Nodes: &v1alpha1.Nodes{CIDRMaskSize: nodeCidrMaskSize},
+			},
+			want: clusterapi.ExtraArgs{
+				"node-cidr-mask-size": "28",
+			},
+		},
+		{
+			testName: "with nodes config empty",
+			clusterNetwork: &v1alpha1.ClusterNetwork{
+				Nodes: &v1alpha1.Nodes{},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			if got := clusterapi.NodeCIDRMaskExtraArgs(tt.clusterNetwork); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NodeCIDRMaskExtraArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -12,7 +12,6 @@ const (
 	CapiWebhookSystemNamespace              = "capi-webhook-system"
 	CapvSystemNamespace                     = "capv-system"
 	CapaSystemNamespace                     = "capa-system"
-	CapasSystemNamespace                    = "capas-system"
 	CertManagerNamespace                    = "cert-manager"
 	DefaultNamespace                        = "default"
 	EtcdAdmBootstrapProviderSystemNamespace = "etcdadm-bootstrap-provider-system"

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -628,6 +628,8 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterConfigSpec v1alpha1
 		Append(clusterapi.AwsIamAuthExtraArgs(clusterSpec.AWSIamConfig)).
 		Append(clusterapi.PodIAMAuthExtraArgs(clusterSpec.Cluster.Spec.PodIAMConfig)).
 		Append(sharedExtraArgs)
+	controllerManagerExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
+		Append(clusterapi.NodeCIDRMaskExtraArgs(&clusterSpec.Cluster.Spec.ClusterNetwork))
 
 	values := map[string]interface{}{
 		"clusterName":                                  clusterSpec.Cluster.Name,
@@ -690,7 +692,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterConfigSpec v1alpha1
 		"kubeletExtraArgs":                             kubeletExtraArgs.ToPartialYaml(),
 		"etcdExtraArgs":                                etcdExtraArgs.ToPartialYaml(),
 		"etcdCipherSuites":                             crypto.SecureCipherSuitesString(),
-		"controllermanagerExtraArgs":                   sharedExtraArgs.ToPartialYaml(),
+		"controllermanagerExtraArgs":                   controllerManagerExtraArgs.ToPartialYaml(),
 		"schedulerExtraArgs":                           sharedExtraArgs.ToPartialYaml(),
 		"format":                                       format,
 		"externalEtcdVersion":                          bundle.KubeDistro.EtcdVersion,

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -186,6 +186,8 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) map[string]interface{} {
 		Append(clusterapi.AwsIamAuthExtraArgs(clusterSpec.AWSIamConfig)).
 		Append(clusterapi.PodIAMAuthExtraArgs(clusterSpec.Cluster.Spec.PodIAMConfig)).
 		Append(sharedExtraArgs)
+	controllerManagerExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
+		Append(clusterapi.NodeCIDRMaskExtraArgs(&clusterSpec.Cluster.Spec.ClusterNetwork))
 
 	values := map[string]interface{}{
 		"clusterName":                clusterSpec.Cluster.Name,
@@ -200,7 +202,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) map[string]interface{} {
 		"etcdExtraArgs":              etcdExtraArgs.ToPartialYaml(),
 		"etcdCipherSuites":           crypto.SecureCipherSuitesString(),
 		"apiserverExtraArgs":         apiServerExtraArgs.ToPartialYaml(),
-		"controllermanagerExtraArgs": sharedExtraArgs.ToPartialYaml(),
+		"controllermanagerExtraArgs": controllerManagerExtraArgs.ToPartialYaml(),
 		"schedulerExtraArgs":         sharedExtraArgs.ToPartialYaml(),
 		"kubeletExtraArgs":           kubeletExtraArgs.ToPartialYaml(),
 		"externalEtcdVersion":        bundle.KubeDistro.EtcdVersion,

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -171,8 +171,8 @@ spec:
         extraArgs:
           cloud-provider: external
           profiling: "false"
-{{- if .controllermanagerExtraArgs }}
-{{ .controllermanagerExtraArgs.ToYaml | indent 10 }}
+{{- if .controllerManagerExtraArgs }}
+{{ .controllerManagerExtraArgs.ToYaml | indent 10 }}
 {{- end }}
 {{- if (eq .format "bottlerocket") }}
         extraVolumes:

--- a/pkg/providers/vsphere/testdata/cluster_main.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_main.yaml
@@ -34,6 +34,8 @@ spec:
     services:
       cidrBlocks:
         - 10.96.0.0/12
+    node:
+      cidrMaskSize: 8
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: VSphereMachineConfig

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -693,6 +693,8 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		Append(clusterapi.AwsIamAuthExtraArgs(clusterSpec.AWSIamConfig)).
 		Append(clusterapi.PodIAMAuthExtraArgs(clusterSpec.Cluster.Spec.PodIAMConfig)).
 		Append(sharedExtraArgs)
+	controllerManagerExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
+		Append(clusterapi.NodeCIDRMaskExtraArgs(&clusterSpec.Cluster.Spec.ClusterNetwork))
 
 	eksaVsphereUsername := os.Getenv(EksavSphereUsernameKey)
 	eksaVspherePassword := os.Getenv(EksavSpherePasswordKey)
@@ -750,7 +752,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		"etcdExtraArgs":                        etcdExtraArgs.ToPartialYaml(),
 		"etcdCipherSuites":                     crypto.SecureCipherSuitesString(),
 		"apiserverExtraArgs":                   apiServerExtraArgs.ToPartialYaml(),
-		"controllermanagerExtraArgs":           sharedExtraArgs.ToPartialYaml(),
+		"controllerManagerExtraArgs":           controllerManagerExtraArgs.ToPartialYaml(),
 		"schedulerExtraArgs":                   sharedExtraArgs.ToPartialYaml(),
 		"kubeletExtraArgs":                     kubeletExtraArgs.ToPartialYaml(),
 		"format":                               format,

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -46,7 +46,7 @@ func (u *CreateValidations) PreflightValidations(ctx context.Context) (err error
 				Err:         ValidateGitOps(ctx, k, u.Opts.ManagementCluster, u.Opts.Spec, u.Opts.CliConfig),
 			},
 			validations.ValidationResult{
-				Name:        "validate identityproviders name",
+				Name:        "validate identity providers' name",
 				Remediation: "",
 				Err:         ValidateIdentityProviderNameIsUnique(ctx, k, targetCluster, u.Opts.Spec),
 			},


### PR DESCRIPTION
*Issue #, if available:*

#488 

*Description of changes:*
Currently we default the ipv4 node cidr mask size to 24, which can restrict some users from spinning up lesser number of pods on each node. Defaulting to 24 gives the cluster 256 IPs to use for nodes.

In this PR we expose that flag in our eksa config for users to set. This needs to be tied in with the pod CIDR mask as well as that value decides the number of IPs that are available for the entire network to use.


This is how the new clusterNetwork config would look like:
```
  clusterNetwork:
     nodes:
      cidrMaskSize: 28
```

This field is an optional field, and would not be generated using `generate clusterconfig`

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

