### PR TITLE
Remove redundant Tinkerbell CSV fields

### DIFF
--- a/internal/pkg/api/hardware.go
+++ b/internal/pkg/api/hardware.go
@@ -52,8 +52,8 @@ func HardwareSliceToMap(slice []*Hardware) map[string]*Hardware {
 	hardwareMap := make(map[string]*Hardware)
 
 	for _, h := range slice {
-		if _, exists := hardwareMap[h.ID]; !exists {
-			hardwareMap[h.ID] = h
+		if _, exists := hardwareMap[h.MACAddress]; !exists {
+			hardwareMap[h.MACAddress] = h
 		}
 	}
 

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
@@ -114,7 +114,7 @@ func hardwareFromMachine(m Machine) *v1alpha1.Hardware {
 					PlanSlug:     "c2.medium.x86",
 				},
 				Instance: &v1alpha1.MetadataInstance{
-					ID:       m.ID,
+					ID:       m.MACAddress,
 					Hostname: m.Hostname,
 					Ips: []*v1alpha1.MetadataInstanceIP{
 						{

--- a/pkg/providers/tinkerbell/hardware/csv.go
+++ b/pkg/providers/tinkerbell/hardware/csv.go
@@ -7,14 +7,12 @@ import (
 	"os"
 
 	csv "github.com/gocarina/gocsv"
-	"github.com/google/uuid"
 )
 
 // CSVReader reads a CSV file and provides Machine instances. It satisfies the MachineReader interface. The ID field of
 // the Machine is optional in the CSV. If unspecified, CSVReader will generate a UUID and apply it to the machine.
 type CSVReader struct {
-	reader        *csv.Unmarshaller
-	uuidGenerator func() string
+	reader *csv.Unmarshaller
 }
 
 // NewCSVReader returns a new CSVReader instance that consumes csv data from r. r should return io.EOF when no more
@@ -27,7 +25,7 @@ func NewCSVReader(r io.Reader) (CSVReader, error) {
 		return CSVReader{}, err
 	}
 
-	return CSVReader{reader: reader, uuidGenerator: uuid.NewString}, nil
+	return CSVReader{reader: reader}, nil
 }
 
 // NewCSVReaderFromFile creates a CSVReader instance that reads from path.
@@ -40,27 +38,11 @@ func NewCSVReaderFromFile(path string) (CSVReader, error) {
 	return NewCSVReader(bufio.NewReader(fh))
 }
 
-// NewCSVReaderWithUUIDGenerator returns a new CSVReader instance as defined in NewCSVReader with its internal
-// UUID generator configured as generator.
-func NewCSVReaderWithUUIDGenerator(r io.Reader, generator func() string) (CSVReader, error) {
-	reader, err := NewCSVReader(r)
-	if err != nil {
-		return CSVReader{}, err
-	}
-
-	reader.uuidGenerator = generator
-	return reader, nil
-}
-
 // Read reads a single entry from the CSV data source and returns a new Machine representation.
 func (cr CSVReader) Read() (Machine, error) {
 	machine, err := cr.reader.Read()
 	if err != nil {
 		return Machine{}, err
 	}
-	m := machine.(Machine)
-	if m.ID == "" {
-		m.ID = cr.uuidGenerator()
-	}
-	return m, nil
+	return machine.(Machine), nil
 }

--- a/pkg/providers/tinkerbell/hardware/csv_test.go
+++ b/pkg/providers/tinkerbell/hardware/csv_test.go
@@ -31,28 +31,6 @@ func TestCSVReaderReads(t *testing.T) {
 	g.Expect(machine).To(gomega.BeEquivalentTo(expect))
 }
 
-func TestCSVReaderReadsWithNoIDSpecified(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	buf := NewBufferedCSV()
-
-	expect := NewValidMachine()
-	expect.ID = ""
-
-	err := csv.MarshalCSV([]hardware.Machine{expect}, buf)
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-
-	const uuid = "unique-id"
-	reader, err := hardware.NewCSVReaderWithUUIDGenerator(buf.Buffer, func() string { return uuid })
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-
-	machine, err := reader.Read()
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-
-	expect.ID = uuid // patch the expected machine with the expected uuid
-	g.Expect(machine).To(gomega.BeEquivalentTo(expect))
-}
-
 func TestCSVReaderWithMultipleLabels(t *testing.T) {
 	g := gomega.NewWithT(t)
 
@@ -65,8 +43,7 @@ func TestCSVReaderWithMultipleLabels(t *testing.T) {
 	err := csv.MarshalCSV([]hardware.Machine{expect}, buf)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
-	const uuid = "unique-id"
-	reader, err := hardware.NewCSVReaderWithUUIDGenerator(buf.Buffer, func() string { return uuid })
+	reader, err := hardware.NewCSVReader(buf.Buffer)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	machine, err := reader.Read()
@@ -84,7 +61,6 @@ func TestCSVReaderFromFile(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(machine).To(gomega.Equal(
 		hardware.Machine{
-			ID:           "worker1",
 			Labels:       map[string]string{"type": "cp"},
 			Nameservers:  []string{"1.1.1.1"},
 			Gateway:      "10.10.10.1",
@@ -96,7 +72,6 @@ func TestCSVReaderFromFile(t *testing.T) {
 			BMCIPAddress: "192.168.0.10",
 			BMCUsername:  "Admin",
 			BMCPassword:  "admin",
-			BMCVendor:    "HP",
 		},
 	))
 }

--- a/pkg/providers/tinkerbell/hardware/machine.go
+++ b/pkg/providers/tinkerbell/hardware/machine.go
@@ -8,7 +8,6 @@ import (
 
 // Machine is a machine configuration with optional BMC interface configuration.
 type Machine struct {
-	ID          string      `csv:"id"`
 	Hostname    string      `csv:"hostname"`
 	IPAddress   string      `csv:"ip_address"`
 	Netmask     string      `csv:"netmask"`
@@ -27,13 +26,12 @@ type Machine struct {
 	BMCIPAddress string `csv:"bmc_ip"`
 	BMCUsername  string `csv:"bmc_username"`
 	BMCPassword  string `csv:"bmc_password"`
-	BMCVendor    string `csv:"bmc_vendor"`
 }
 
 // HasBMC determines if m has a BMC configuration. A BMC configuration is present if any of the BMC fields
 // contain non-empty strings.
 func (m *Machine) HasBMC() bool {
-	return m.BMCIPAddress != "" || m.BMCUsername != "" || m.BMCPassword != "" || m.BMCVendor != ""
+	return m.BMCIPAddress != "" || m.BMCUsername != "" || m.BMCPassword != ""
 }
 
 // NameserversSeparator is used to unmarshal Nameservers.

--- a/pkg/providers/tinkerbell/hardware/multi_test.go
+++ b/pkg/providers/tinkerbell/hardware/multi_test.go
@@ -18,9 +18,7 @@ func TestTeeWriterWritesToAllWriters(t *testing.T) {
 	writer1 := mocks.NewMockMachineWriter(ctrl)
 	writer2 := mocks.NewMockMachineWriter(ctrl)
 
-	expect := hardware.Machine{
-		ID: "quxer",
-	}
+	expect := hardware.Machine{Hostname: "quxer"}
 
 	var machine1, machine2 hardware.Machine
 
@@ -54,7 +52,7 @@ func TestTeeWriterFirstWriterErrors(t *testing.T) {
 	writer1 := mocks.NewMockMachineWriter(ctrl)
 	writer2 := mocks.NewMockMachineWriter(ctrl)
 
-	machine := hardware.Machine{ID: "qux-foo"}
+	machine := hardware.Machine{Hostname: "qux-foo"}
 
 	expect := errors.New("first writer error")
 
@@ -76,7 +74,7 @@ func TestTeeWriterSecondWriterErrors(t *testing.T) {
 	writer1 := mocks.NewMockMachineWriter(ctrl)
 	writer2 := mocks.NewMockMachineWriter(ctrl)
 
-	machine := hardware.Machine{ID: "qux-foo"}
+	machine := hardware.Machine{Hostname: "qux-foo"}
 
 	expect := errors.New("first writer error")
 

--- a/pkg/providers/tinkerbell/hardware/testdata/hardware.csv
+++ b/pkg/providers/tinkerbell/hardware/testdata/hardware.csv
@@ -1,2 +1,2 @@
-hostname,bmc_ip,bmc_username,bmc_password,bmc_vendor,mac,ip_address,netmask,gateway,nameservers,labels,disk,id
-worker1,192.168.0.10,Admin,admin,HP,00:00:00:00:00:01,10.10.10.10,255.255.255.0,10.10.10.1,1.1.1.1,type=cp,/dev/sda,worker1
+hostname,bmc_ip,bmc_username,bmc_password,mac,ip_address,netmask,gateway,nameservers,labels,disk
+worker1,192.168.0.10,Admin,admin,00:00:00:00:00:01,10.10.10.10,255.255.255.0,10.10.10.1,1.1.1.1,type=cp,/dev/sda

--- a/pkg/providers/tinkerbell/hardware/translate_test.go
+++ b/pkg/providers/tinkerbell/hardware/translate_test.go
@@ -21,7 +21,6 @@ func TestTranslateReadsAndWrites(t *testing.T) {
 	validator := mocks.NewMockMachineValidator(ctrl)
 
 	machine := hardware.Machine{
-		ID:       "lucky-number-10",
 		Hostname: "foot-bar",
 	}
 
@@ -66,9 +65,7 @@ func TestTranslateWithWriteError(t *testing.T) {
 	writer := mocks.NewMockMachineWriter(ctrl)
 	validator := mocks.NewMockMachineValidator(ctrl)
 
-	machine := hardware.Machine{
-		ID: "lucky-number-10",
-	}
+	machine := hardware.Machine{Hostname: "lucky-number-10"}
 	expect := errors.New("luck-number-10")
 
 	reader.EXPECT().Read().Return(machine, (error)(nil))
@@ -120,9 +117,7 @@ func TestTranslateAllReadsAndWritesMaskingEOF(t *testing.T) {
 	writer := mocks.NewMockMachineWriter(ctrl)
 	validator := mocks.NewMockMachineValidator(ctrl)
 
-	machine := hardware.Machine{
-		ID: "lucky-number-10",
-	}
+	machine := hardware.Machine{Hostname: "lucky-number-10"}
 
 	// use readCount to track how many times the Read() call has been made. On
 	// the second call we return io.EOF.
@@ -175,9 +170,7 @@ func TestTranslateAllWithWriteError(t *testing.T) {
 	writer := mocks.NewMockMachineWriter(ctrl)
 	validator := mocks.NewMockMachineValidator(ctrl)
 
-	machine := hardware.Machine{
-		ID: "lucky-number-10",
-	}
+	machine := hardware.Machine{Hostname: "lucky-number-10"}
 	expect := errors.New("luck-number-10")
 
 	reader.EXPECT().Read().Return(machine, (error)(nil))

--- a/pkg/providers/tinkerbell/hardware/validator.go
+++ b/pkg/providers/tinkerbell/hardware/validator.go
@@ -52,10 +52,6 @@ var (
 // StaticMachineAssertions defines all static data assertions performed on a Machine.
 func StaticMachineAssertions() MachineAssertion {
 	return func(m Machine) error {
-		if m.ID == "" {
-			return newEmptyFieldError("ID")
-		}
-
 		if m.IPAddress == "" {
 			return newEmptyFieldError("IPAddress")
 		}
@@ -135,26 +131,7 @@ func StaticMachineAssertions() MachineAssertion {
 			if m.BMCPassword == "" {
 				return newEmptyFieldError("BMCPassword")
 			}
-
-			if m.BMCVendor == "" {
-				return newEmptyFieldError("BMCVendor")
-			}
 		}
-
-		return nil
-	}
-}
-
-// UniqueIDs asserts a given Machine instance has a unique ID field relative to previously seen Machine instances.
-// It is not thread safe. It has a 1 time use.
-func UniqueIDs() MachineAssertion {
-	ids := make(map[string]struct{})
-	return func(m Machine) error {
-		if _, seen := ids[m.ID]; seen {
-			return fmt.Errorf("duplicate ID: %v", m.ID)
-		}
-
-		ids[m.ID] = struct{}{}
 
 		return nil
 	}
@@ -216,7 +193,7 @@ func UniqueBMCIPAddress() MachineAssertion {
 		}
 
 		if m.BMCIPAddress == "" {
-			return fmt.Errorf("missing BMCIPAddress (id=\"%v\")", m.ID)
+			return fmt.Errorf("missing BMCIPAddress (mac=\"%v\")", m.MACAddress)
 		}
 
 		if _, seen := ips[m.BMCIPAddress]; seen {
@@ -234,7 +211,6 @@ func UniqueBMCIPAddress() MachineAssertion {
 func RegisterDefaultAssertions(validator *DefaultMachineValidator) {
 	validator.Register([]MachineAssertion{
 		StaticMachineAssertions(),
-		UniqueIDs(),
 		UniqueIPAddress(),
 		UniqueMACAddress(),
 		UniqueHostnames(),

--- a/pkg/providers/tinkerbell/hardware/validator_test.go
+++ b/pkg/providers/tinkerbell/hardware/validator_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/onsi/gomega"
 
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
@@ -53,13 +52,6 @@ func TestUniquenessAssertions(t *testing.T) {
 		Assertion hardware.MachineAssertion
 		Machines  []hardware.Machine
 	}{
-		"IDs": {
-			Assertion: hardware.UniqueIDs(),
-			Machines: []hardware.Machine{
-				{ID: "foo"},
-				{ID: "bar"},
-			},
-		},
 		"IPAddresses": {
 			Assertion: hardware.UniqueIPAddress(),
 			Machines: []hardware.Machine{
@@ -104,13 +96,6 @@ func TestUniquenessAssertionsWithDupes(t *testing.T) {
 		Assertion hardware.MachineAssertion
 		Machines  []hardware.Machine
 	}{
-		"IDs": {
-			Assertion: hardware.UniqueIDs(),
-			Machines: []hardware.Machine{
-				{ID: "foo"},
-				{ID: "foo"},
-			},
-		},
 		"IPAddresses": {
 			Assertion: hardware.UniqueIPAddress(),
 			Machines: []hardware.Machine{
@@ -163,9 +148,6 @@ func TestStaticMachineAssertions_InvalidMachines(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	cases := map[string]func(*hardware.Machine){
-		"EmptyID": func(h *hardware.Machine) {
-			h.ID = ""
-		},
 		"EmptyIPAddress": func(h *hardware.Machine) {
 			h.IPAddress = ""
 		},
@@ -211,9 +193,6 @@ func TestStaticMachineAssertions_InvalidMachines(t *testing.T) {
 		"EmptyBMCPassword": func(h *hardware.Machine) {
 			h.BMCPassword = ""
 		},
-		"EmptyBMCVendor": func(h *hardware.Machine) {
-			h.BMCVendor = ""
-		},
 		"InvalidLabelKey": func(h *hardware.Machine) {
 			h.Labels["?$?$?"] = "foo"
 		},
@@ -240,7 +219,6 @@ func TestStaticMachineAssertions_InvalidMachines(t *testing.T) {
 
 func NewValidMachine() hardware.Machine {
 	return hardware.Machine{
-		ID:           uuid.NewString(),
 		IPAddress:    "10.10.10.10",
 		Gateway:      "10.10.10.1",
 		Nameservers:  []string{"ns1"},
@@ -252,6 +230,5 @@ func NewValidMachine() hardware.Machine {
 		BMCIPAddress: "10.10.10.11",
 		BMCUsername:  "username",
 		BMCPassword:  "password",
-		BMCVendor:    "dell",
 	}
 }

--- a/pkg/providers/tinkerbell/hardware/yaml.go
+++ b/pkg/providers/tinkerbell/hardware/yaml.go
@@ -28,26 +28,26 @@ func NewTinkerbellManifestYAML(w io.Writer) *TinkerbellManifestYAML {
 func (yw *TinkerbellManifestYAML) Write(m Machine) error {
 	hardware, err := marshalTinkerbellHardwareYAML(m)
 	if err != nil {
-		return fmt.Errorf("marshalling tinkerbell hardware yaml (id=%v): %v", m.ID, err)
+		return fmt.Errorf("marshalling tinkerbell hardware yaml (mac=%v): %v", m.MACAddress, err)
 	}
 	if err := yw.writeWithPrependedSeparator(hardware); err != nil {
-		return fmt.Errorf("writing tinkerbell hardware yaml (id=%v): %v", m.ID, err)
+		return fmt.Errorf("writing tinkerbell hardware yaml (mac=%v): %v", m.MACAddress, err)
 	}
 
 	bmc, err := marshalTinkerbellBMCYAML(m)
 	if err != nil {
-		return fmt.Errorf("marshalling tinkerbell bmc yaml (id=%v): %v", m.ID, err)
+		return fmt.Errorf("marshalling tinkerbell bmc yaml (mac=%v): %v", m.MACAddress, err)
 	}
 	if err := yw.writeWithPrependedSeparator(bmc); err != nil {
-		return fmt.Errorf("writing tinkerbell bmc yaml (id=%v): %v", m.ID, err)
+		return fmt.Errorf("writing tinkerbell bmc yaml (mac=%v): %v", m.MACAddress, err)
 	}
 
 	secret, err := marshalSecretYAML(m)
 	if err != nil {
-		return fmt.Errorf("marshalling bmc secret yaml (id=%v): %v", m.ID, err)
+		return fmt.Errorf("marshalling bmc secret yaml (mac=%v): %v", m.MACAddress, err)
 	}
 	if err := yw.writeWithPrependedSeparator(secret); err != nil {
-		return fmt.Errorf("writing bmc secret yaml (id=%v): %v", m.ID, err)
+		return fmt.Errorf("writing bmc secret yaml (mac=%v): %v", m.MACAddress, err)
 	}
 
 	return nil

--- a/pkg/providers/tinkerbell/hardware/yaml_test.go
+++ b/pkg/providers/tinkerbell/hardware/yaml_test.go
@@ -66,7 +66,6 @@ func TestTinkerbellManifestYAMLWriteErrors(t *testing.T) {
 
 func AssertTinkerbellHardwareRepresentsMachine(g *gomega.WithT, h tinkv1alpha1.Hardware, m hardware.Machine) {
 	g.Expect(h.ObjectMeta.Name).To(gomega.Equal(m.Hostname))
-	g.Expect(h.Spec.Metadata.Instance.ID).To(gomega.Equal(m.ID))
 }
 
 func AssertTinkerbellBMCRepresentsMachine(g *gomega.WithT, b rufiov1alpha1.BaseboardManagement, m hardware.Machine) {

--- a/test/e2e/forceflow_test.go
+++ b/test/e2e/forceflow_test.go
@@ -26,7 +26,7 @@ func TestTinkerbellKubernetes121ForceFlow(t *testing.T) {
 		framework.NewTinkerbell(t, framework.WithUbuntu121Tinkerbell()),
 		framework.WithEnvVar("TINKERBELL_PROVIDER", "true"),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithHardware(api.HardwareVendorUnspecified, 2),
+		framework.WithHardware(2),
 	)
 	runTinkerbellForceFlow(test)
 }
@@ -37,7 +37,7 @@ func TestTinkerbellKubernetes122ForceFlow(t *testing.T) {
 		framework.NewTinkerbell(t, framework.WithUbuntu122Tinkerbell()),
 		framework.WithEnvVar("TINKERBELL_PROVIDER", "true"),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		framework.WithHardware(api.HardwareVendorUnspecified, 2),
+		framework.WithHardware(2),
 	)
 	runTinkerbellForceFlow(test)
 }
@@ -50,7 +50,7 @@ func TestTinkerbellKubernetes121ThreeReplicasTwoWorkersForceFlow(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(2)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithHardware(api.HardwareVendorUnspecified, 5),
+		framework.WithHardware(5),
 	)
 	runTinkerbellForceFlow(test)
 }

--- a/test/e2e/simpleflow_test.go
+++ b/test/e2e/simpleflow_test.go
@@ -212,7 +212,7 @@ func TestTinkerbellKubernetes120SimpleFlow(t *testing.T) {
 		framework.NewTinkerbell(t, framework.WithUbuntu120Tinkerbell()),
 		framework.WithEnvVar("TINKERBELL_PROVIDER", "true"),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithHardware(api.HardwareVendorUnspecified, 2),
+		framework.WithHardware(2),
 	)
 	runTinkerbellSimpleFlow(test)
 }
@@ -223,7 +223,7 @@ func TestTinkerbellKubernetes121SimpleFlow(t *testing.T) {
 		framework.NewTinkerbell(t, framework.WithUbuntu121Tinkerbell()),
 		framework.WithEnvVar("TINKERBELL_PROVIDER", "true"),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithHardware(api.HardwareVendorUnspecified, 2),
+		framework.WithHardware(2),
 	)
 	runTinkerbellSimpleFlow(test)
 }
@@ -234,7 +234,7 @@ func TestTinkerbellKubernetes121ExternalEtcdSimpleFlow(t *testing.T) {
 		framework.NewTinkerbell(t, framework.WithUbuntu121Tinkerbell(), framework.WithTinkerbellExternalEtcdTopology(1)),
 		framework.WithEnvVar("TINKERBELL_PROVIDER", "true"),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithHardware(api.HardwareVendorUnspecified, 3),
+		framework.WithHardware(3),
 	)
 	runTinkerbellSimpleFlow(test)
 }
@@ -247,7 +247,7 @@ func TestTinkerbellKubernetes121ExternalEtcdThreeReplicasTwoWorkersSimpleFlow(t 
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(2)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithHardware(api.HardwareVendorUnspecified, 6),
+		framework.WithHardware(6),
 	)
 	runTinkerbellSimpleFlow(test)
 }
@@ -260,7 +260,7 @@ func TestTinkerbellKubernetes121ThreeReplicasTwoWorkersSimpleFlow(t *testing.T) 
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(2)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithHardware(api.HardwareVendorUnspecified, 5),
+		framework.WithHardware(5),
 	)
 	runTinkerbellSimpleFlow(test)
 }
@@ -269,7 +269,7 @@ func TestTinkerbellKubernetes121SuperMicroSimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewTinkerbell(t, framework.WithUbuntu121Tinkerbell()),
-		framework.WithHardware(api.HardwareVendorSuperMicro, 2),
+		framework.WithHardware(2),
 		framework.WithEnvVar("TINKERBELL_PROVIDER", "true"),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 	)
@@ -280,7 +280,7 @@ func TestTinkerbellKubernetes121DellSimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewTinkerbell(t, framework.WithUbuntu121Tinkerbell()),
-		framework.WithHardware(api.HardwareVendorDell, 2),
+		framework.WithHardware(2),
 		framework.WithEnvVar("TINKERBELL_PROVIDER", "true"),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 	)
@@ -291,7 +291,7 @@ func TestTinkerbellKubernetes121HPSimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewTinkerbell(t, framework.WithUbuntu121Tinkerbell()),
-		framework.WithHardware(api.HardwareVendorHP, 2),
+		framework.WithHardware(2),
 		framework.WithEnvVar("TINKERBELL_PROVIDER", "true"),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 	)

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -98,7 +98,7 @@ func NewClusterE2ETest(t *testing.T, provider Provider, opts ...ClusterE2ETestOp
 	return e
 }
 
-func WithHardware(vendor string, requiredCount int) ClusterE2ETestOpt {
+func WithHardware(requiredCount int) ClusterE2ETestOpt {
 	return func(e *ClusterE2ETest) {
 		hardwarePool := e.GetHardwarePool()
 
@@ -108,20 +108,18 @@ func WithHardware(vendor string, requiredCount int) ClusterE2ETestOpt {
 
 		var count int
 		for id, h := range hardwarePool {
-			if strings.ToLower(h.BMCVendor) == vendor || vendor == api.HardwareVendorUnspecified {
-				if _, exists := e.TestHardware[id]; !exists {
-					count++
-					e.TestHardware[id] = h
-				}
+			if _, exists := e.TestHardware[id]; !exists {
+				count++
+				e.TestHardware[id] = h
+			}
 
-				if count == requiredCount {
-					break
-				}
+			if count == requiredCount {
+				break
 			}
 		}
 
 		if count < requiredCount {
-			e.T.Errorf("this test requires at least %d piece(s) of %s hardware", requiredCount, vendor)
+			e.T.Errorf("this test requires at least %d piece(s) of hardware", requiredCount)
 		}
 	}
 }


### PR DESCRIPTION
Builds on #2288. This PR is composed of a single commit.

The ID and BMC Vendor fields are no longer required by the Kubeified stack. This PR strips them from the system.