### PR TITLE
Hardware CSV file reading is only needed for create flow

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -34,7 +34,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers/docker"
 	"github.com/aws/eks-anywhere/pkg/providers/snow"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
-	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
 	"github.com/aws/eks-anywhere/pkg/providers/vsphere"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/utils/urls"
@@ -289,16 +288,11 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 				return fmt.Errorf("unable to get machine config from file %s: %v", clusterConfigFile, err)
 			}
 
-			machines, err := hardware.NewCSVReaderFromFile(hardwareCSVPath)
-			if err != nil {
-				return err
-			}
-
 			f.dependencies.Provider = tinkerbell.NewProvider(
 				datacenterConfig,
 				machineConfigs,
 				clusterConfig,
-				machines,
+				hardwareCSVPath,
 				f.dependencies.Writer,
 				f.dependencies.DockerClient,
 				f.dependencies.Helm,

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -136,7 +136,12 @@ func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpe
 	// Translate all Machine instances from the p.machines source into Kubernetes object types.
 	// The PostBootstrapSetup() call invoked elsewhere in the program serializes the catalogue
 	// and submits it to the clsuter.
-	if err := hardware.TranslateAll(p.machines, writer, machineValidator); err != nil {
+	machines, err := hardware.NewCSVReaderFromFile(p.hardwareCSVFile)
+	if err != nil {
+		return err
+	}
+
+	if err := hardware.TranslateAll(machines, writer, machineValidator); err != nil {
 		return err
 	}
 

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -50,8 +50,8 @@ type Provider struct {
 	writer                filewriter.FileWriter
 	keyGenerator          SSHAuthKeyGenerator
 
-	machines  hardware.MachineReader
-	catalogue *hardware.Catalogue
+	hardwareCSVFile string
+	catalogue       *hardware.Catalogue
 
 	// TODO(chrisdoheryt4) Temporarily depend on the netclient until the validator can be injected.
 	// This is already a dependency, just uncached, because we require it during the initializing
@@ -90,7 +90,7 @@ func NewProvider(
 	datacenterConfig *v1alpha1.TinkerbellDatacenterConfig,
 	machineConfigs map[string]*v1alpha1.TinkerbellMachineConfig,
 	clusterConfig *v1alpha1.Cluster,
-	machines hardware.MachineReader,
+	hardwareCSVPath string,
 	writer filewriter.FileWriter,
 	docker stack.Docker,
 	helm stack.Helm,
@@ -128,8 +128,8 @@ func NewProvider(
 			etcdMachineSpec:             etcdMachineSpec,
 			now:                         now,
 		},
-		writer:   writer,
-		machines: machines,
+		writer:          writer,
+		hardwareCSVFile: hardwareCSVPath,
 		// TODO(chrisdoherty4) Inject the catalogue dependency so we can dynamically construcft the
 		// indexing capabilities.
 		catalogue: hardware.NewCatalogue(

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	filewritermocks "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
-	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/mocks"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/stack"
 	stackmocks "github.com/aws/eks-anywhere/pkg/providers/tinkerbell/stack/mocks"
@@ -44,16 +43,12 @@ func givenMachineConfigs(t *testing.T, fileName string) map[string]*v1alpha1.Tin
 }
 
 func newProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineConfigs map[string]*v1alpha1.TinkerbellMachineConfig, clusterConfig *v1alpha1.Cluster, writer filewriter.FileWriter, docker stack.Docker, helm stack.Helm, kubectl ProviderKubectlClient) *Provider {
-	reader, err := hardware.NewCSVReaderFromFile("./testdata/hardware.csv")
-	if err != nil {
-		panic(err)
-	}
-
+	hardwareFile := "./testdata/hardware.csv"
 	return NewProvider(
 		datacenterConfig,
 		machineConfigs,
 		clusterConfig,
-		reader,
+		hardwareFile,
 		writer,
 		docker,
 		helm,


### PR DESCRIPTION
Delete flow does not require or take a hardware csv file. So the reading of CSV file should only be done for the create flow.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

