### PR TITLE
Fix up cluster delete for kubefied tinkerbell stack changes

### DIFF
--- a/pkg/providers/tinkerbell/delete.go
+++ b/pkg/providers/tinkerbell/delete.go
@@ -53,11 +53,18 @@ func (p *Provider) DeleteResources(ctx context.Context, clusterSpec *cluster.Spe
 }
 
 func (p *Provider) PostClusterDeleteValidate(ctx context.Context, managementCluster *types.Cluster) error {
+	if err := p.stackInstaller.UninstallLocal(ctx); err != nil {
+		return err
+	}
 	// We want to validate cluster nodes are powered off.
 	// We wait on BMC status.powerState to check for power off.
 	bmcRefs := make([]string, 0, len(p.hardwares))
 	for _, hw := range p.hardwares {
 		bmcRefs = append(bmcRefs, hw.Spec.BmcRef)
+	}
+
+	if len(bmcRefs) == 0 {
+		return nil
 	}
 
 	// TODO (pokearu): The retry logic can be substituted by changing GetBmcsPowerState to use kubectl wait --for

--- a/pkg/workflows/delete.go
+++ b/pkg/workflows/delete.go
@@ -101,6 +101,12 @@ func (s *createManagementCluster) Run(ctx context.Context, commandContext *task.
 	}
 	commandContext.BootstrapCluster = bootstrapCluster
 
+	logger.Info("Provider specific pre-capi-install-setup on bootstrap cluster")
+	if err = commandContext.Provider.PreCAPIInstallOnBootstrap(ctx, bootstrapCluster, commandContext.ClusterSpec); err != nil {
+		commandContext.SetError(err)
+		return &CollectMgmtClusterDiagnosticsTask{}
+	}
+
 	return &installCAPI{}
 }
 

--- a/pkg/workflows/delete_test.go
+++ b/pkg/workflows/delete_test.go
@@ -66,6 +66,7 @@ func (c *deleteTestSetup) expectCreateBootstrap() {
 			c.ctx, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()),
 		).Return(c.bootstrapCluster, nil),
 
+		c.provider.EXPECT().PreCAPIInstallOnBootstrap(c.ctx, c.bootstrapCluster, c.clusterSpec),
 		c.clusterManager.EXPECT().InstallCAPI(c.ctx, gomock.Not(gomock.Nil()), c.bootstrapCluster, c.provider),
 	)
 }


### PR DESCRIPTION
* Install tinkerbell stack components onto kind cluster during delete
flow as an additional step for management move
* When deleting the bootstrap cluster, the boots docker container needs
to be deleted. Add this step to the delete flow, similar to create.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

