### PR TITLE
Make all e2e tests default to 1:1:1 topology

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -132,6 +132,14 @@ func WithExternalEtcdTopology(count int) ClusterFiller {
 	}
 }
 
+func WithEtcdCountIfExternal(count int) ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		if c.Spec.ExternalEtcdConfiguration != nil {
+			c.Spec.ExternalEtcdConfiguration.Count = count
+		}
+	}
+}
+
 func WithExternalEtcdMachineRef(kind string) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		if c.Spec.ExternalEtcdConfiguration == nil {

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -279,7 +279,14 @@ func (e *ClusterE2ETest) generateClusterConfigObjects(opts ...CommandOpt) {
 	e.RunEKSA(generateClusterConfigArgs, opts...)
 
 	clusterFillersFromProvider := e.Provider.ClusterConfigFillers()
-	clusterConfigFillers := make([]api.ClusterFiller, 0, len(e.clusterFillers)+len(clusterFillersFromProvider))
+	clusterConfigFillers := make([]api.ClusterFiller, 0, len(e.clusterFillers)+len(clusterFillersFromProvider)+3)
+	// This defaults all tests to a 1:1:1 configuration. Since all the fillers defined on each test are run
+	// after these 3, if the tests is explicit about any of these, the defaults will be overwritten
+	// (@g-gaston) This is a temporary fix to avoid overloading the CI system and we should remove it once we
+	// stabilize the test runs
+	clusterConfigFillers = append(clusterConfigFillers,
+		api.WithControlPlaneCount(1), api.WithWorkerNodeCount(1), api.WithEtcdCountIfExternal(1),
+	)
 	clusterConfigFillers = append(clusterConfigFillers, e.clusterFillers...)
 	clusterConfigFillers = append(clusterConfigFillers, clusterFillersFromProvider...)
 	e.ClusterConfigB = e.customizeClusterConfig(e.ClusterConfigLocation, clusterConfigFillers...)


### PR DESCRIPTION
This is a temporary fix to avoid overloading the CI system.
It should be removed eventually or added explicitly to all tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

