### PR TITLE
Git Flux tests create their own repository for use during test

### DIFF
--- a/internal/test/e2e/crypto.go
+++ b/internal/test/e2e/crypto.go
@@ -34,8 +34,8 @@ func pemFromPrivateKeyEcdsa(k *ecdsa.PrivateKey) ([]byte, error) {
 	}
 
 	p := pem.Block{
-		Type:    "PRIVATE KEY",
-		Bytes:   pk,
+		Type:  "PRIVATE KEY",
+		Bytes: pk,
 	}
 
 	return pem.EncodeToMemory(&p), nil

--- a/internal/test/e2e/crypto.go
+++ b/internal/test/e2e/crypto.go
@@ -1,0 +1,46 @@
+package e2e
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"golang.org/x/crypto/ssh"
+)
+
+func generateKeyPairEcdsa() (*ecdsa.PrivateKey, error) {
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating key pair: %v", err)
+	}
+	return k, nil
+}
+
+func pubFromPrivateKeyEcdsa(k *ecdsa.PrivateKey) ([]byte, error) {
+	pub, err := ssh.NewPublicKey(k)
+	if err != nil {
+		return nil, err
+	}
+	return ssh.MarshalAuthorizedKey(pub), nil
+}
+
+func pemFromPrivateKeyEcdsa(k *ecdsa.PrivateKey) ([]byte, error) {
+	pk, err := x509.MarshalPKCS8PrivateKey(k)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling private key to x509 PKCS 8 from private key: %v", err)
+	}
+
+	p := pem.Block{
+		Type:    "ECDSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   pk,
+	}
+
+	kb := pem.EncodeToMemory(&p)
+	if kb == nil {
+		return nil, fmt.Errorf("invalid headers in private key block")
+	}
+	return kb, nil
+}

--- a/internal/test/e2e/crypto.go
+++ b/internal/test/e2e/crypto.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+
 	"golang.org/x/crypto/ssh"
 )
 

--- a/internal/test/e2e/crypto.go
+++ b/internal/test/e2e/crypto.go
@@ -20,7 +20,7 @@ func generateKeyPairEcdsa() (*ecdsa.PrivateKey, error) {
 }
 
 func pubFromPrivateKeyEcdsa(k *ecdsa.PrivateKey) ([]byte, error) {
-	pub, err := ssh.NewPublicKey(k)
+	pub, err := ssh.NewPublicKey(k.Public())
 	if err != nil {
 		return nil, err
 	}
@@ -34,14 +34,9 @@ func pemFromPrivateKeyEcdsa(k *ecdsa.PrivateKey) ([]byte, error) {
 	}
 
 	p := pem.Block{
-		Type:    "ECDSA PRIVATE KEY",
-		Headers: nil,
+		Type:    "PRIVATE KEY",
 		Bytes:   pk,
 	}
 
-	kb := pem.EncodeToMemory(&p)
-	if kb == nil {
-		return nil, fmt.Errorf("invalid headers in private key block")
-	}
-	return kb, nil
+	return pem.EncodeToMemory(&p), nil
 }

--- a/internal/test/e2e/fluxGit.go
+++ b/internal/test/e2e/fluxGit.go
@@ -3,14 +3,14 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/git"
 	"log"
 	"os"
 	"regexp"
 
 	"github.com/aws/eks-anywhere/internal/pkg/ssm"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
+	"github.com/aws/eks-anywhere/pkg/git"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	e2etests "github.com/aws/eks-anywhere/test/framework"
 )
@@ -110,7 +110,7 @@ func (e *E2ESession) setUpSshAgent(privateKeyFile string) error {
 	return nil
 }
 
-func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*git.Repository, error){
+func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*git.Repository, error) {
 	logger.V(1).Info("setting up Github repo for test...")
 	owner := os.Getenv(e2etests.GithubUserVar)
 
@@ -133,7 +133,11 @@ func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*g
 		Description: fmt.Sprintf("repository for use with E2E test job %v", e.jobId),
 		Personal:    true,
 	}
+
 	r, err := g.CreateRepo(ctx, o)
+	if err != nil {
+		return nil, fmt.Errorf("creating repository in Github for test: %v", err)
+	}
 
 	pk, pub, err := e.generateKeyPairForGitTest()
 	if err != nil {

--- a/internal/test/e2e/fluxGit.go
+++ b/internal/test/e2e/fluxGit.go
@@ -78,7 +78,7 @@ func buildFluxGitFiles(envVars map[string]string) []s3Files {
 func (e *E2ESession) writeFileToInstance(file fileFromBytes) error {
 	logger.V(1).Info("Writing bytes to file in instance", "file", file.dstPath)
 
-	command := fmt.Sprintf("echo \"%s\" >> %s && chmod %d %[2]s", file.contentString(), file.dstPath, file.permission)
+	command := fmt.Sprintf("echo $'%s' >> %s && chmod %d %[2]s", file.contentString(), file.dstPath, file.permission)
 	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
 		return fmt.Errorf("writing file in instance: %v", err)
 	}
@@ -111,7 +111,7 @@ func (e *E2ESession) setUpSshAgent(privateKeyFile string) error {
 }
 
 func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*git.Repository, error) {
-	logger.V(1).Info("setting up Github repo for test...")
+	logger.V(1).Info("setting up Github repo for test")
 	owner := os.Getenv(e2etests.GithubUserVar)
 
 	c := &v1alpha1.GithubProviderConfig{
@@ -141,7 +141,7 @@ func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*g
 
 	pk, pub, err := e.generateKeyPairForGitTest()
 	if err != nil {
-		return nil, fmt.Errorf("genearting key pair for git tests: %v", err)
+		return nil, fmt.Errorf("generating key pair for git tests: %v", err)
 	}
 
 	// Add the newly generated public key to the newly created repository as a deploy key

--- a/internal/test/e2e/fluxGit.go
+++ b/internal/test/e2e/fluxGit.go
@@ -1,7 +1,9 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"os"
 	"regexp"
 
@@ -80,4 +82,19 @@ func (e *E2ESession) setUpSshAgent(privateKeyFile string) error {
 	logger.V(1).Info("Successfully started SSH agent on instance")
 
 	return nil
+}
+
+func (e *E2ESession) setupGithubRepoForTest() {
+	logger.V(1).Info("Creating Github repo for test setup...")
+	c := &v1alpha1.GithubProviderConfig{
+		Owner:      os.Getenv(e2etests.GithubUserVar),
+		Repository: fmt.Sprintf("%s-%s", e., e.jobId),
+		Personal:   true,
+	}
+
+	g, err := e.TestGithubClient(context.Background(), os.Getenv(e2etests.GithubTokenVar), e.TestGithubOptions.Owner, e.TestGithubOptions.Repository, e.TestGithubOptions.Personal)
+	if err != nil {
+		e.T.Fatalf("couldn't create Github client for test setup: %v", err)
+	}
+	e.TestGithubProvider = g
 }

--- a/internal/test/e2e/fluxGit.go
+++ b/internal/test/e2e/fluxGit.go
@@ -49,7 +49,7 @@ func (e *E2ESession) setupFluxGitEnv(testRegex string) error {
 		return fmt.Errorf("setting up github repo for test: %v", err)
 	}
 	// add the newly generated repository to the test
-	e.testEnvVars[e2etests.GitRepoSshUrl] = gitRepoSshUrl(repo.Name, repo.Owner)
+	e.testEnvVars[e2etests.GitRepoSshUrl] = gitRepoSshUrl(repo.Name, e.testEnvVars[e2etests.GithubUserVar])
 
 	for _, file := range buildFluxGitFiles(e.testEnvVars) {
 		if err := e.downloadFileInInstance(file); err != nil {
@@ -112,7 +112,7 @@ func (e *E2ESession) setUpSshAgent(privateKeyFile string) error {
 
 func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*git.Repository, error) {
 	logger.V(1).Info("setting up Github repo for test")
-	owner := os.Getenv(e2etests.GithubUserVar)
+	owner := envVars[e2etests.GithubUserVar]
 
 	c := &v1alpha1.GithubProviderConfig{
 		Owner:      owner,
@@ -121,7 +121,7 @@ func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*g
 	}
 
 	ctx := context.Background()
-	g, err := e.TestGithubClient(ctx, os.Getenv(e2etests.GithubTokenVar), c.Owner, c.Repository, c.Personal)
+	g, err := e.TestGithubClient(ctx, envVars[e2etests.GithubTokenVar], c.Owner, c.Repository, c.Personal)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create Github client for test setup: %v", err)
 	}
@@ -195,5 +195,5 @@ func (e *E2ESession) generateKeyPairForGitTest() (privateKeyBytes, publicKeyByte
 
 func gitRepoSshUrl(repo, owner string) string {
 	t := "ssh://git@github.com/%s/%s.git"
-	return fmt.Sprintf(t, repo, owner)
+	return fmt.Sprintf(t, owner, repo)
 }

--- a/internal/test/e2e/github.go
+++ b/internal/test/e2e/github.go
@@ -1,0 +1,30 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/git"
+	"github.com/aws/eks-anywhere/pkg/git/gogithub"
+	"github.com/aws/eks-anywhere/pkg/git/providers/github"
+)
+
+func (e *E2ESession) TestGithubClient(ctx context.Context, githubToken string, owner string, repository string, personal bool) (git.ProviderClient, error) {
+	auth := git.TokenAuth{Token: githubToken, Username: owner}
+	gogithubOpts := gogithub.Options{Auth: auth}
+	githubProviderClient := gogithub.New(ctx, gogithubOpts)
+
+	config := &v1alpha1.GithubProviderConfig{
+		Owner:      owner,
+		Repository: repository,
+		Personal:   personal,
+	}
+	provider, err := github.New(githubProviderClient, config, auth)
+	if err != nil {
+		return nil, fmt.Errorf("creating test git provider: %v", err)
+	}
+
+	return provider, nil
+}
+

--- a/internal/test/e2e/github.go
+++ b/internal/test/e2e/github.go
@@ -27,4 +27,3 @@ func (e *E2ESession) TestGithubClient(ctx context.Context, githubToken string, o
 
 	return provider, nil
 }
-

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -21,6 +21,7 @@ type ProviderClient interface {
 	GetRepo(ctx context.Context) (repo *Repository, err error)
 	CreateRepo(ctx context.Context, opts CreateRepoOpts) (repo *Repository, err error)
 	DeleteRepo(ctx context.Context, opts DeleteRepoOpts) error
+	AddDeployKeyToRepo(ctx context.Context, opts AddDeployKeyOpts) error
 	Validate(ctx context.Context) error
 	PathExists(ctx context.Context, owner, repo, branch, path string) (bool, error)
 }
@@ -41,6 +42,14 @@ type GetRepoOpts struct {
 type DeleteRepoOpts struct {
 	Owner      string
 	Repository string
+}
+
+type AddDeployKeyOpts struct {
+	Owner      string
+	Repository string
+	Key        string
+	Title      string
+	ReadOnly   bool
 }
 
 type Repository struct {

--- a/pkg/git/gitclient/gitclient.go
+++ b/pkg/git/gitclient/gitclient.go
@@ -218,6 +218,7 @@ func (g *GitClient) Branch(name string) error {
 		Name:   name,
 		Remote: gogit.DefaultRemoteName,
 		Merge:  localBranchRef,
+		Rebase: "true",
 	}
 
 	err = g.Client.CreateBranch(r, branchOpts)

--- a/pkg/git/gitclient/gitclient_test.go
+++ b/pkg/git/gitclient/gitclient_test.go
@@ -232,6 +232,7 @@ func TestGoGitBranch(t *testing.T) {
 		Name:   "testBranch",
 		Remote: "origin",
 		Merge:  "refs/heads/testBranch",
+		Rebase: "true",
 	}
 	cOpts := &goGit.CheckoutOptions{
 		Branch: plumbing.NewBranchReferenceName("testBranch"),
@@ -268,6 +269,7 @@ func TestGoGitBranchRemoteExists(t *testing.T) {
 		Name:   "testBranch",
 		Remote: "origin",
 		Merge:  "refs/heads/testBranch",
+		Rebase: "true",
 	}
 	localBranchRef := plumbing.NewBranchReferenceName("testBranch")
 	cOpts := &goGit.CheckoutOptions{

--- a/pkg/git/gogithub/gogithub.go
+++ b/pkg/git/gogithub/gogithub.go
@@ -209,9 +209,9 @@ func (g *GoGithub) PathExists(ctx context.Context, owner, repo, branch, path str
 func (g *GoGithub) AddDeployKeyToRepo(ctx context.Context, opts git.AddDeployKeyOpts) error {
 	logger.V(3).Info("Adding deploy key to repository", "repository", opts.Repository)
 	k := &goGithub.Key{
-		Key:       &opts.Key,
-		Title:     &opts.Title,
-		ReadOnly:  &opts.ReadOnly,
+		Key:      &opts.Key,
+		Title:    &opts.Title,
+		ReadOnly: &opts.ReadOnly,
 	}
 	return g.Client.AddDeployKeyToRepo(ctx, opts.Owner, opts.Repository, k)
 }

--- a/pkg/git/gogithub/gogithub.go
+++ b/pkg/git/gogithub/gogithub.go
@@ -91,7 +91,13 @@ func (ggc *githubClient) AddDeployKeyToRepo(ctx context.Context, owner, repo str
 // file must be added to it via the github api before it can be successfully cloned.
 func (g *GoGithub) CreateRepo(ctx context.Context, opts git.CreateRepoOpts) (repository *git.Repository, err error) {
 	logger.V(3).Info("Attempting to create new Github repo", "repo", opts.Name, "owner", opts.Owner)
-	r := &goGithub.Repository{Name: &opts.Name, Private: &opts.Privacy, Description: &opts.Description}
+	autoInit := true
+	r := &goGithub.Repository{
+		Name:        &opts.Name,
+		Private:     &opts.Privacy,
+		Description: &opts.Description,
+		AutoInit:    &autoInit,
+	}
 
 	org := ""
 	if !opts.Personal {

--- a/pkg/git/gogithub/gogithub.go
+++ b/pkg/git/gogithub/gogithub.go
@@ -38,6 +38,7 @@ type HTTPClient interface {
 
 type Client interface {
 	CreateRepo(ctx context.Context, org string, repo *goGithub.Repository) (*goGithub.Repository, *goGithub.Response, error)
+	AddDeployKeyToRepo(ctx context.Context, owner, repo string, key *goGithub.Key) error
 	Repo(ctx context.Context, owner, repo string) (*goGithub.Repository, *goGithub.Response, error)
 	User(ctx context.Context, user string) (*goGithub.User, *goGithub.Response, error)
 	Organization(ctx context.Context, org string) (*goGithub.Organization, *goGithub.Response, error)
@@ -79,6 +80,11 @@ func (ggc *githubClient) GetContents(ctx context.Context, owner, repo, path stri
 
 func (ggc *githubClient) DeleteRepo(ctx context.Context, owner, repo string) (*goGithub.Response, error) {
 	return ggc.client.Repositories.Delete(ctx, owner, repo)
+}
+
+func (ggc *githubClient) AddDeployKeyToRepo(ctx context.Context, owner, repo string, key *goGithub.Key) error {
+	_, _, err := ggc.client.Repositories.CreateKey(ctx, owner, repo, key)
+	return err
 }
 
 // CreateRepo creates an empty Github Repository. The repository must be initialized locally or
@@ -198,6 +204,11 @@ func (g *GoGithub) PathExists(ctx context.Context, owner, repo, branch, path str
 	}
 
 	return true, nil
+}
+
+func (g *GoGithub) AddDeployKeyToRepo(ctx context.Context, owner, repo string, key *goGithub.Key) error {
+	logger.V(3).Info("Adding deploy key to repository", "repository", repo)
+	return g.Client.AddDeployKeyToRepo(ctx, owner, repo, key)
 }
 
 // DeleteRepo deletes a Github repository.

--- a/pkg/git/gogithub/gogithub.go
+++ b/pkg/git/gogithub/gogithub.go
@@ -206,9 +206,14 @@ func (g *GoGithub) PathExists(ctx context.Context, owner, repo, branch, path str
 	return true, nil
 }
 
-func (g *GoGithub) AddDeployKeyToRepo(ctx context.Context, owner, repo string, key *goGithub.Key) error {
-	logger.V(3).Info("Adding deploy key to repository", "repository", repo)
-	return g.Client.AddDeployKeyToRepo(ctx, owner, repo, key)
+func (g *GoGithub) AddDeployKeyToRepo(ctx context.Context, opts git.AddDeployKeyOpts) error {
+	logger.V(3).Info("Adding deploy key to repository", "repository", opts.Repository)
+	k := &goGithub.Key{
+		Key:       &opts.Key,
+		Title:     &opts.Title,
+		ReadOnly:  &opts.ReadOnly,
+	}
+	return g.Client.AddDeployKeyToRepo(ctx, opts.Owner, opts.Repository, k)
 }
 
 // DeleteRepo deletes a Github repository.

--- a/pkg/git/gogithub/gogithub_test.go
+++ b/pkg/git/gogithub/gogithub_test.go
@@ -312,6 +312,55 @@ func TestGoGithubDeleteRepoFail(t *testing.T) {
 	}
 }
 
+func TestGoGithubAddDeployKeySuccess(t *testing.T) {
+	type fields struct {
+		opts gogithub.Options
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    git.AddDeployKeyOpts
+		wantErr error
+	}{
+		{
+			name: "github repo deleted successfully",
+			args: git.AddDeployKeyOpts{
+				Owner:      "owner1",
+				Repository: "repo1",
+				Key:        "KEY STRING YO",
+				Title:      "My test key",
+				ReadOnly:   false,
+			},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			mockCtrl := gomock.NewController(t)
+			client := mockGoGithub.NewMockClient(mockCtrl)
+
+			k := &github.Key{
+				Key:      &tt.args.Key,
+				Title:    &tt.args.Title,
+				ReadOnly: &tt.args.ReadOnly,
+			}
+
+			client.EXPECT().AddDeployKeyToRepo(ctx, tt.args.Owner, tt.args.Repository, k).Return(tt.wantErr)
+
+			g := &gogithub.GoGithub{
+				Opts:   tt.fields.opts,
+				Client: client,
+			}
+			err := g.AddDeployKeyToRepo(ctx, tt.args)
+			if err != tt.wantErr {
+				t.Errorf("AddDeployKeyToRepo() got error: %v want error: %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestGoGithub_CheckAccessTokenPermissions(t *testing.T) {
 	type fields struct {
 		opts gogithub.Options

--- a/pkg/git/gogithub/mocks/client.go
+++ b/pkg/git/gogithub/mocks/client.go
@@ -35,6 +35,20 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// AddDeployKeyToRepo mocks base method.
+func (m *MockClient) AddDeployKeyToRepo(arg0 context.Context, arg1, arg2 string, arg3 *github.Key) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddDeployKeyToRepo", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddDeployKeyToRepo indicates an expected call of AddDeployKeyToRepo.
+func (mr *MockClientMockRecorder) AddDeployKeyToRepo(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDeployKeyToRepo", reflect.TypeOf((*MockClient)(nil).AddDeployKeyToRepo), arg0, arg1, arg2, arg3)
+}
+
 // CreateRepo mocks base method.
 func (m *MockClient) CreateRepo(arg0 context.Context, arg1 string, arg2 *github.Repository) (*github.Repository, *github.Response, error) {
 	m.ctrl.T.Helper()

--- a/pkg/git/mocks/git.go
+++ b/pkg/git/mocks/git.go
@@ -184,6 +184,20 @@ func (m *MockProviderClient) EXPECT() *MockProviderClientMockRecorder {
 	return m.recorder
 }
 
+// AddDeployKeyToRepo mocks base method.
+func (m *MockProviderClient) AddDeployKeyToRepo(arg0 context.Context, arg1 git.AddDeployKeyOpts) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddDeployKeyToRepo", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddDeployKeyToRepo indicates an expected call of AddDeployKeyToRepo.
+func (mr *MockProviderClientMockRecorder) AddDeployKeyToRepo(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDeployKeyToRepo", reflect.TypeOf((*MockProviderClient)(nil).AddDeployKeyToRepo), arg0, arg1)
+}
+
 // CreateRepo mocks base method.
 func (m *MockProviderClient) CreateRepo(arg0 context.Context, arg1 git.CreateRepoOpts) (*git.Repository, error) {
 	m.ctrl.T.Helper()

--- a/pkg/git/providers/github/github.go
+++ b/pkg/git/providers/github/github.go
@@ -40,6 +40,7 @@ type Options struct {
 type GithubClient interface {
 	GetRepo(ctx context.Context, opts git.GetRepoOpts) (repo *git.Repository, err error)
 	CreateRepo(ctx context.Context, opts git.CreateRepoOpts) (repo *git.Repository, err error)
+	AddDeployKeyToRepo(ctx context.Context) (repo *git.Repository, err error)
 	AuthenticatedUser(ctx context.Context) (*goGithub.User, error)
 	Organization(ctx context.Context, org string) (*goGithub.Organization, error)
 	GetAccessTokenPermissions(accessToken string) (string, error)

--- a/pkg/git/providers/github/github.go
+++ b/pkg/git/providers/github/github.go
@@ -40,7 +40,7 @@ type Options struct {
 type GithubClient interface {
 	GetRepo(ctx context.Context, opts git.GetRepoOpts) (repo *git.Repository, err error)
 	CreateRepo(ctx context.Context, opts git.CreateRepoOpts) (repo *git.Repository, err error)
-	AddDeployKeyToRepo(ctx context.Context) (repo *git.Repository, err error)
+	AddDeployKeyToRepo(ctx context.Context, opts git.AddDeployKeyOpts) error
 	AuthenticatedUser(ctx context.Context) (*goGithub.User, error)
 	Organization(ctx context.Context, org string) (*goGithub.Organization, error)
 	GetAccessTokenPermissions(accessToken string) (string, error)
@@ -79,6 +79,10 @@ func (g *githubProvider) GetRepo(ctx context.Context) (*git.Repository, error) {
 		return nil, fmt.Errorf("unexpected error when describing repository %s: %w", r, err)
 	}
 	return repo, err
+}
+
+func (g *githubProvider) AddDeployKeyToRepo(ctx context.Context, opts git.AddDeployKeyOpts) error {
+	return g.githubProviderClient.AddDeployKeyToRepo(ctx, opts)
 }
 
 // validates the github setup and access

--- a/pkg/git/providers/github/mocks/github.go
+++ b/pkg/git/providers/github/mocks/github.go
@@ -36,6 +36,20 @@ func (m *MockGithubClient) EXPECT() *MockGithubClientMockRecorder {
 	return m.recorder
 }
 
+// AddDeployKeyToRepo mocks base method.
+func (m *MockGithubClient) AddDeployKeyToRepo(arg0 context.Context, arg1 git.AddDeployKeyOpts) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddDeployKeyToRepo", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddDeployKeyToRepo indicates an expected call of AddDeployKeyToRepo.
+func (mr *MockGithubClientMockRecorder) AddDeployKeyToRepo(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDeployKeyToRepo", reflect.TypeOf((*MockGithubClient)(nil).AddDeployKeyToRepo), arg0, arg1)
+}
+
 // AuthenticatedUser mocks base method.
 func (m *MockGithubClient) AuthenticatedUser(arg0 context.Context) (*github.User, error) {
 	m.ctrl.T.Helper()

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -32,24 +32,30 @@ import (
 const (
 	eksaConfigFileName  = "eksa-cluster.yaml"
 	fluxSystemNamespace = "flux-system"
-	gitRepositoryVar    = "T_GIT_REPOSITORY"
-	gitRepoSshUrl       = "T_GIT_SSH_REPO_URL"
-	githubUserVar       = "T_GITHUB_USER"
-	githubTokenVar      = "EKSA_GITHUB_TOKEN"
-	gitKnownHosts       = "EKSA_GIT_KNOWN_HOSTS"
-	gitPrivateKeyFile   = "EKSA_GIT_PRIVATE_KEY"
+	GitRepositoryVar    = "T_GIT_REPOSITORY"
+	GitRepoSshUrl       = "T_GIT_SSH_REPO_URL"
+	GithubUserVar       = "T_GITHUB_USER"
+	GithubTokenVar      = "EKSA_GITHUB_TOKEN"
+	GitKnownHosts       = "EKSA_GIT_KNOWN_HOSTS"
+	GitPrivateKeyFile   = "EKSA_GIT_PRIVATE_KEY"
 )
 
 var fluxGithubRequiredEnvVars = []string{
-	gitRepositoryVar,
-	githubUserVar,
-	githubTokenVar,
+	GitRepositoryVar,
+	GithubUserVar,
+	GithubTokenVar,
 }
 
 var fluxGitRequiredEnvVars = []string{
-	gitKnownHosts,
-	gitPrivateKeyFile,
-	gitRepoSshUrl,
+	GitKnownHosts,
+	GitPrivateKeyFile,
+	GitRepoSshUrl,
+}
+
+var fluxGitCreateGenerateRepoEnvVars = []string{
+	GitKnownHosts,
+	GitRepositoryVar,
+	GithubUserVar,
 }
 
 func WithFluxGit(opts ...api.FluxConfigOpt) ClusterE2ETestOpt {
@@ -59,7 +65,7 @@ func WithFluxGit(opts ...api.FluxConfigOpt) ClusterE2ETestOpt {
 		fluxConfigName := fluxConfigName()
 		e.FluxConfig = api.NewFluxConfig(fluxConfigName,
 			api.WithGenericGitProvider(
-				api.WithStringFromEnvVarGenericGitProviderConfig(gitRepoSshUrl, api.WithGitRepositoryUrl),
+				api.WithStringFromEnvVarGenericGitProviderConfig(GitRepoSshUrl, api.WithGitRepositoryUrl),
 			),
 			api.WithSystemNamespace("default"),
 			api.WithClusterConfigPath(jobId),
@@ -83,8 +89,8 @@ func WithFluxGithub(opts ...api.FluxConfigOpt) ClusterE2ETestOpt {
 		e.FluxConfig = api.NewFluxConfig(fluxConfigName,
 			api.WithGithubProvider(
 				api.WithPersonalGithubRepository(true),
-				api.WithStringFromEnvVarGithubProviderConfig(gitRepositoryVar, api.WithGithubRepository),
-				api.WithStringFromEnvVarGithubProviderConfig(githubUserVar, api.WithGithubOwner),
+				api.WithStringFromEnvVarGithubProviderConfig(GitRepositoryVar, api.WithGithubRepository),
+				api.WithStringFromEnvVarGithubProviderConfig(GithubUserVar, api.WithGithubOwner),
 			),
 			api.WithSystemNamespace("default"),
 			api.WithClusterConfigPath("path2"),
@@ -112,8 +118,8 @@ func WithFluxLegacy(opts ...api.GitOpsConfigOpt) ClusterE2ETestOpt {
 		gitOpsConfigName := fluxConfigName()
 		e.GitOpsConfig = api.NewGitOpsConfig(gitOpsConfigName,
 			api.WithPersonalFluxRepository(true),
-			api.WithStringFromEnvVarGitOpsConfig(gitRepositoryVar, api.WithFluxRepository),
-			api.WithStringFromEnvVarGitOpsConfig(githubUserVar, api.WithFluxOwner),
+			api.WithStringFromEnvVarGitOpsConfig(GitRepositoryVar, api.WithFluxRepository),
+			api.WithStringFromEnvVarGitOpsConfig(GithubUserVar, api.WithFluxOwner),
 			api.WithFluxNamespace("default"),
 			api.WithFluxConfigurationPath("path2"),
 			api.WithFluxBranch("main"),
@@ -462,7 +468,7 @@ func (e *ClusterE2ETest) validateGitopsRepoContent(gitTools *gitfactory.GitTools
 		e.T.Errorf("Error opening file from the newly created repo directory: %v", err)
 	}
 	if !bytes.Equal(gitFile, localFile) {
-		e.T.Errorf("Error validating the content of github repo: %v", err)
+		e.T.Errorf("Error validating the content of git repo: %v", err)
 	}
 }
 
@@ -820,9 +826,6 @@ func (e *ClusterE2ETest) pushConfigChanges(ctx context.Context) error {
 	if err := g.Add(p); err != nil {
 		return fmt.Errorf("adding cluster config changes at path %s: %v", p, err)
 	}
-	if err := g.Commit("EKS-A E2E Flux test configuration update"); err != nil {
-		return fmt.Errorf("commiting cluster config changes: %v", err)
-	}
 
 	repoUpToDateErr := &git.RepositoryUpToDateError{}
 	if err := g.Push(ctx); err != nil {
@@ -906,4 +909,8 @@ func RequiredFluxGithubEnvVars() []string {
 
 func RequiredFluxGitEnvVars() []string {
 	return fluxGitRequiredEnvVars
+}
+
+func RequiredFluxGitCreateRepoEnvVars() []string {
+	return fluxGitCreateGenerateRepoEnvVars
 }

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -54,6 +54,7 @@ var fluxGitRequiredEnvVars = []string{
 
 var fluxGitCreateGenerateRepoEnvVars = []string{
 	GitKnownHosts,
+	GitPrivateKeyFile,
 	GitRepositoryVar,
 	GithubUserVar,
 }

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -793,6 +793,15 @@ func (e *ClusterE2ETest) waitForWorkerScaling(name string, targetvalue int) erro
 }
 
 func (e *ClusterE2ETest) updateEKSASpecInGit(ctx context.Context, s *cluster.Spec, providersConfig providerConfig) (string, error) {
+	g := e.GitClient
+	repoUpToDateErr := &git.RepositoryUpToDateError{}
+	if err := g.Pull(ctx, e.gitBranch()); err != nil {
+		if !errors.Is(err, repoUpToDateErr) {
+			e.T.Errorf("pulling from remote before pushing config changes: %v", err)
+		}
+		e.T.Log(err.Error())
+	}
+
 	p, err := e.writeEKSASpec(s, providersConfig.datacenterConfig, providersConfig.machineConfigs)
 	if err != nil {
 		return "", err

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -55,7 +55,6 @@ var fluxGitRequiredEnvVars = []string{
 var fluxGitCreateGenerateRepoEnvVars = []string{
 	GitKnownHosts,
 	GitPrivateKeyFile,
-	GitRepositoryVar,
 	GithubUserVar,
 }
 
@@ -826,6 +825,10 @@ func (e *ClusterE2ETest) pushConfigChanges(ctx context.Context) error {
 	g := e.GitClient
 	if err := g.Add(p); err != nil {
 		return fmt.Errorf("adding cluster config changes at path %s: %v", p, err)
+	}
+
+	if err := g.Commit("EKS-A E2E Flux test configuration update"); err != nil {
+		return fmt.Errorf("commiting cluster config changes: %v", err)
 	}
 
 	repoUpToDateErr := &git.RepositoryUpToDateError{}

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -907,10 +907,6 @@ func RequiredFluxGithubEnvVars() []string {
 	return fluxGithubRequiredEnvVars
 }
 
-func RequiredFluxGitEnvVars() []string {
-	return fluxGitRequiredEnvVars
-}
-
 func RequiredFluxGitCreateRepoEnvVars() []string {
 	return fluxGitCreateGenerateRepoEnvVars
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The Git Flux tests have been using the same git repository, pushing and pulling their flux configs and cluster configs at the same time. These concurrent git actions have caused frequent failures in the validations. Specifically, multiple simultaneous 'local' commits by validation code led to divergent histories among the clones on the test instances, causing the validation code to fail when attempting to push and pull from the remote and encountering non-fast-forward updates. This was not resolved by setting the default behavior to `rebase`, and it seems that the `pull` behavior of `go-git`, the library we are using for git actions, can't handle non-fast-forward updates even when the given branch is configured to rebase instead of merge. 

So, now, instead of using the same repository for each of the tests, we're instead going to imitate what the existing Github tests do anyway: create a github repository for use by each test.

So, here, when running through the framework, the tests for FluxGit now accept the github token and username, and use that to create a github repo (and add a generated deploy key to it) during test setup. This repo is then used by the test itself.

When running outside of the framework you will still provide an existing repository. This makes it easy for folks to run the tests individually without additional setup, and without requiring that the setup logic for the repository be included in the tests themselves -- instead, it's confined to the setup code in the framework.

Additionally, I've adjusted the behavior of the branches we use to default to `rebase` instead of `merge`, and added a few `pulls` before `push` to the test code in order to try and eliminate other cases where simultaneous modification of the repository could interfere and make the behavior more predictable.

Follow-on is going to be clean up for the git repos in the test framework; we're currently leaving them behaind and need to add cleanup code. This is in progress but wanted to get this PR open and reviewed. 

*Testing (if applicable):*

run the tests via the framework from my local machine; confirmed that the correct repository with the right deploy key was created and that the tests ran successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

