### PR TITLE
Update etcdadm controller references to use AWS org

### DIFF
--- a/release/pkg/assets_etcdadm_bootstrap.go
+++ b/release/pkg/assets_etcdadm_bootstrap.go
@@ -24,7 +24,7 @@ import (
 	anywherev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
-const etcdadmBootstrapProviderProjectPath = "projects/mrajashree/etcdadm-bootstrap-provider"
+const etcdadmBootstrapProviderProjectPath = "projects/aws/etcdadm-bootstrap-provider"
 
 // GetEtcdadmBootstrapAssets returns the eks-a artifacts for etcdadm bootstrap provider
 func (r *ReleaseConfig) GetEtcdadmBootstrapAssets() ([]Artifact, error) {
@@ -34,7 +34,7 @@ func (r *ReleaseConfig) GetEtcdadmBootstrapAssets() ([]Artifact, error) {
 	}
 
 	name := "etcdadm-bootstrap-provider"
-	repoName := fmt.Sprintf("mrajashree/%s", name)
+	repoName := fmt.Sprintf("aws/%s", name)
 	tagOptions := map[string]string{
 		"gitTag":      gitTag,
 		"projectPath": etcdadmBootstrapProviderProjectPath,

--- a/release/pkg/assets_etcdadm_controller.go
+++ b/release/pkg/assets_etcdadm_controller.go
@@ -24,7 +24,7 @@ import (
 	anywherev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
-const etcdadmControllerProjectPath = "projects/mrajashree/etcdadm-controller"
+const etcdadmControllerProjectPath = "projects/aws/etcdadm-controller"
 
 // GetEtcdadmControllerAssets returns the eks-a artifacts for etcdadm controller
 func (r *ReleaseConfig) GetEtcdadmControllerAssets() ([]Artifact, error) {
@@ -34,7 +34,7 @@ func (r *ReleaseConfig) GetEtcdadmControllerAssets() ([]Artifact, error) {
 	}
 
 	name := "etcdadm-controller"
-	repoName := fmt.Sprintf("mrajashree/%s", name)
+	repoName := fmt.Sprintf("aws/%s", name)
 	tagOptions := map[string]string{
 		"gitTag":      gitTag,
 		"projectPath": etcdadmControllerProjectPath,

--- a/release/pkg/generate_spec_test.go
+++ b/release/pkg/generate_spec_test.go
@@ -74,11 +74,11 @@ func TestGenerateBundleManifest(t *testing.T) {
 			cliMaxVersion:       "v0.7.2",
 		},
 		{
-			testName:            "Dev-release from release-0.8",
-			buildRepoBranchName: "release-0.8",
-			cliRepoBranchName:   "release-0.8",
-			cliMinVersion:       "v0.8.0",
-			cliMaxVersion:       "v0.8.0",
+			testName:            "Dev-release from release-0.9",
+			buildRepoBranchName: "release-0.9",
+			cliRepoBranchName:   "release-0.9",
+			cliMinVersion:       "v0.9.0",
+			cliMaxVersion:       "v0.9.0",
 		},
 	}
 

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -70,7 +70,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-15-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-16-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -112,26 +112,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:e0c5180610dd7a2bac4ed271309b07eb6102d0bd74ed7dd33fb619879cc006f3
+        imageDigest: sha256:9674f67425c28e820c72cf07e26e1d4303d4c2a8226b15273647d6eb84684510
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.9.13-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.10.11-eksa.2
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:5982a9b5feded74c14a0b410006bba6d748655f8bc01f393b4519c9b10a463d0
+        imageDigest: sha256:b4b6f8524313658d412829d3d281918ac1e4432073123fc38b0650ab1a45e2e1
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.9.13-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.10.11-eksa.2
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.9.13-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.10.11-eksa.2/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:fd78027e876b00ea850f875e87a9ce81f6e4e6b4d963f115e978e8e7d180f478
+        imageDigest: sha256:5e52535b615b0c59996926c509ebb1401a3ea384f91e275e90bdccda352a6f67
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.9.13-eksa.2
-      version: v1.9.13-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.10.11-eksa.2
+      version: v1.10.11-eksa.2
     cloudStack:
       clusterAPIController:
         arch:
@@ -140,9 +140,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-cloudstack-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.3-RC1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.5-rc2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.3-RC1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc2/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -152,8 +152,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.3-RC1/metadata.yaml
-      version: v0.4.3-RC1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc2/metadata.yaml
+      version: v0.4.5-rc2+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.1.3/core-components.yaml
@@ -233,23 +233,23 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-15-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.20.15
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-15.yaml
-      name: kubernetes-1-20-eks-15
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-16.yaml
+      name: kubernetes-1-20-eks-16
       ova:
         bottlerocket:
           arch:
           - amd64
           crictl: {}
-          description: Bottlerocket OVA for EKS-D 1-20-15 release
+          description: Bottlerocket OVA for EKS-D 1-20-16 release
           etcdadm: {}
-          name: bottlerocket-v1.20.15-eks-d-1-20-15-eks-a-v0.0.0-dev-build.0-amd64.ova
+          name: bottlerocket-v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-20/1-20-15/bottlerocket-v1.20.15-eks-d-1-20-15-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-20/1-20-16/bottlerocket-v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-build.0-amd64.ova
         ubuntu:
           arch:
           - amd64
@@ -262,7 +262,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-20-15 release
+          description: Ubuntu OVA for EKS-D 1-20-16 release
           etcdadm:
             arch:
             - amd64
@@ -272,12 +272,12 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.20.15-eks-d-1-20-15-eks-a-v0.0.0-dev-build.0-amd64.ova
+          name: ubuntu-v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: ubuntu
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-20/1-20-15/ubuntu-v1.20.15-eks-d-1-20-15-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-20/1-20-16/ubuntu-v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           crictl: {}
@@ -294,7 +294,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-20-15 release
+          description: Ubuntu OVA for EKS-D 1-20-16 release
           etcdadm:
             arch:
             - amd64
@@ -304,12 +304,12 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.20.15-eks-d-1-20-15-eks-a-v0.0.0-dev-build.0-amd64.gz
+          name: ubuntu-v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-build.0-amd64.gz
           os: linux
           osName: ubuntu
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-20/1-20-15/ubuntu-v1.20.15-eks-d-1-20-15-eks-a-v0.0.0-dev-build.0-amd64.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-20/1-20-16/ubuntu-v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-build.0-amd64.gz
     eksa:
       cliTools:
         arch:
@@ -326,7 +326,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.9.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.9.1-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
       diagnosticCollector:
@@ -340,7 +340,7 @@ spec:
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.0-rc6/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -348,7 +348,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/mrajashree/etcdadm-bootstrap-provider:v1.0.0-rc6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -358,11 +358,11 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.0-rc6/metadata.yaml
-      version: v1.0.0-rc6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.2/metadata.yaml
+      version: v1.0.2+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0-rc9/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -370,7 +370,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/mrajashree/etcdadm-controller:v1.0.0-rc9-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.0-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -380,8 +380,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0-rc9/metadata.yaml
-      version: v1.0.0-rc9+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0/metadata.yaml
+      version: v1.0.0+abcdef1
     flux:
       helmController:
         arch:
@@ -475,11 +475,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:af0464c206b9e105be6f042e3db908006c0a9eed-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:ee045e095565f7943179a98f8d6567f56c3d3bcd-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/af0464c206b9e105be6f042e3db908006c0a9eed/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/ee045e095565f7943179a98f8d6567f56c3d3bcd/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/af0464c206b9e105be6f042e3db908006c0a9eed/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/ee045e095565f7943179a98f8d6567f56c3d3bcd/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -489,7 +489,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/af0464c206b9e105be6f042e3db908006c0a9eed/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/ee045e095565f7943179a98f8d6567f56c3d3bcd/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -540,7 +540,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: boots
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/boots:ab716aac37cfff2869952ea2e44a67cb6d1fe1c1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-build.1
           manifest: {}
         cfssl:
           arch:
@@ -652,7 +652,7 @@ spec:
             name: tink-worker
             os: linux
             uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:7a8ca47540c5800c1d0cac075cf7e2c5da69b186-eks-a-v0.0.0-dev-build.1
-      version: af0464c206b9e105be6f042e3db908006c0a9eed+abcdef1
+      version: ee045e095565f7943179a98f8d6567f56c3d3bcd+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -772,7 +772,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-13-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-14-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -814,26 +814,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:e0c5180610dd7a2bac4ed271309b07eb6102d0bd74ed7dd33fb619879cc006f3
+        imageDigest: sha256:9674f67425c28e820c72cf07e26e1d4303d4c2a8226b15273647d6eb84684510
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.9.13-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.10.11-eksa.2
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:5982a9b5feded74c14a0b410006bba6d748655f8bc01f393b4519c9b10a463d0
+        imageDigest: sha256:b4b6f8524313658d412829d3d281918ac1e4432073123fc38b0650ab1a45e2e1
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.9.13-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.10.11-eksa.2
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.9.13-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.10.11-eksa.2/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:fd78027e876b00ea850f875e87a9ce81f6e4e6b4d963f115e978e8e7d180f478
+        imageDigest: sha256:5e52535b615b0c59996926c509ebb1401a3ea384f91e275e90bdccda352a6f67
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.9.13-eksa.2
-      version: v1.9.13-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.10.11-eksa.2
+      version: v1.10.11-eksa.2
     cloudStack:
       clusterAPIController:
         arch:
@@ -842,9 +842,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-cloudstack-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.3-RC1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.5-rc2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.3-RC1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc2/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -854,8 +854,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.3-RC1/metadata.yaml
-      version: v0.4.3-RC1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc2/metadata.yaml
+      version: v0.4.5-rc2+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.1.3/core-components.yaml
@@ -935,23 +935,23 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.9-eks-d-1-21-13-eks-a-v0.0.0-dev-build.1
-      kubeVersion: v1.21.9
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-13.yaml
-      name: kubernetes-1-21-eks-13
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-build.1
+      kubeVersion: v1.21.12
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-14.yaml
+      name: kubernetes-1-21-eks-14
       ova:
         bottlerocket:
           arch:
           - amd64
           crictl: {}
-          description: Bottlerocket OVA for EKS-D 1-21-13 release
+          description: Bottlerocket OVA for EKS-D 1-21-14 release
           etcdadm: {}
-          name: bottlerocket-v1.21.9-eks-d-1-21-13-eks-a-v0.0.0-dev-build.0-amd64.ova
+          name: bottlerocket-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-21/1-21-13/bottlerocket-v1.21.9-eks-d-1-21-13-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-21/1-21-14/bottlerocket-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-build.0-amd64.ova
         ubuntu:
           arch:
           - amd64
@@ -964,7 +964,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-21-13 release
+          description: Ubuntu OVA for EKS-D 1-21-14 release
           etcdadm:
             arch:
             - amd64
@@ -974,12 +974,12 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.21.9-eks-d-1-21-13-eks-a-v0.0.0-dev-build.0-amd64.ova
+          name: ubuntu-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: ubuntu
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-21/1-21-13/ubuntu-v1.21.9-eks-d-1-21-13-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-21/1-21-14/ubuntu-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           crictl: {}
@@ -996,7 +996,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-21-13 release
+          description: Ubuntu OVA for EKS-D 1-21-14 release
           etcdadm:
             arch:
             - amd64
@@ -1006,12 +1006,12 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.21.9-eks-d-1-21-13-eks-a-v0.0.0-dev-build.0-amd64.gz
+          name: ubuntu-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-build.0-amd64.gz
           os: linux
           osName: ubuntu
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-21/1-21-13/ubuntu-v1.21.9-eks-d-1-21-13-eks-a-v0.0.0-dev-build.0-amd64.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-21/1-21-14/ubuntu-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-build.0-amd64.gz
     eksa:
       cliTools:
         arch:
@@ -1028,7 +1028,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.9.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.9.1-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
       diagnosticCollector:
@@ -1042,7 +1042,7 @@ spec:
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.0-rc6/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1050,7 +1050,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/mrajashree/etcdadm-bootstrap-provider:v1.0.0-rc6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1060,11 +1060,11 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.0-rc6/metadata.yaml
-      version: v1.0.0-rc6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.2/metadata.yaml
+      version: v1.0.2+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0-rc9/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1072,7 +1072,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/mrajashree/etcdadm-controller:v1.0.0-rc9-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.0-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1082,8 +1082,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0-rc9/metadata.yaml
-      version: v1.0.0-rc9+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0/metadata.yaml
+      version: v1.0.0+abcdef1
     flux:
       helmController:
         arch:
@@ -1177,11 +1177,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:af0464c206b9e105be6f042e3db908006c0a9eed-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:ee045e095565f7943179a98f8d6567f56c3d3bcd-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/af0464c206b9e105be6f042e3db908006c0a9eed/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/ee045e095565f7943179a98f8d6567f56c3d3bcd/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/af0464c206b9e105be6f042e3db908006c0a9eed/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/ee045e095565f7943179a98f8d6567f56c3d3bcd/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -1191,7 +1191,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/af0464c206b9e105be6f042e3db908006c0a9eed/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/ee045e095565f7943179a98f8d6567f56c3d3bcd/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -1242,7 +1242,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: boots
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/boots:ab716aac37cfff2869952ea2e44a67cb6d1fe1c1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-build.1
           manifest: {}
         cfssl:
           arch:
@@ -1354,7 +1354,7 @@ spec:
             name: tink-worker
             os: linux
             uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:7a8ca47540c5800c1d0cac075cf7e2c5da69b186-eks-a-v0.0.0-dev-build.1
-      version: af0464c206b9e105be6f042e3db908006c0a9eed+abcdef1
+      version: ee045e095565f7943179a98f8d6567f56c3d3bcd+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -1474,7 +1474,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-7-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -1516,26 +1516,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:e0c5180610dd7a2bac4ed271309b07eb6102d0bd74ed7dd33fb619879cc006f3
+        imageDigest: sha256:9674f67425c28e820c72cf07e26e1d4303d4c2a8226b15273647d6eb84684510
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.9.13-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.10.11-eksa.2
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:5982a9b5feded74c14a0b410006bba6d748655f8bc01f393b4519c9b10a463d0
+        imageDigest: sha256:b4b6f8524313658d412829d3d281918ac1e4432073123fc38b0650ab1a45e2e1
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.9.13-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.10.11-eksa.2
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.9.13-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.10.11-eksa.2/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:fd78027e876b00ea850f875e87a9ce81f6e4e6b4d963f115e978e8e7d180f478
+        imageDigest: sha256:5e52535b615b0c59996926c509ebb1401a3ea384f91e275e90bdccda352a6f67
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.9.13-eksa.2
-      version: v1.9.13-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.10.11-eksa.2
+      version: v1.10.11-eksa.2
     cloudStack:
       clusterAPIController:
         arch:
@@ -1544,9 +1544,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-cloudstack-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.3-RC1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.5-rc2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.3-RC1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc2/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -1556,8 +1556,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.3-RC1/metadata.yaml
-      version: v0.4.3-RC1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc2/metadata.yaml
+      version: v0.4.5-rc2+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.1.3/core-components.yaml
@@ -1637,23 +1637,23 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.6-eks-d-1-22-6-eks-a-v0.0.0-dev-build.1
-      kubeVersion: v1.22.6
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-6.yaml
-      name: kubernetes-1-22-eks-6
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-build.1
+      kubeVersion: v1.22.9
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-7.yaml
+      name: kubernetes-1-22-eks-7
       ova:
         bottlerocket:
           arch:
           - amd64
           crictl: {}
-          description: Bottlerocket OVA for EKS-D 1-22-6 release
+          description: Bottlerocket OVA for EKS-D 1-22-7 release
           etcdadm: {}
-          name: bottlerocket-v1.22.6-eks-d-1-22-6-eks-a-v0.0.0-dev-build.0-amd64.ova
+          name: bottlerocket-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-22/1-22-6/bottlerocket-v1.22.6-eks-d-1-22-6-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-22/1-22-7/bottlerocket-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-build.0-amd64.ova
         ubuntu:
           arch:
           - amd64
@@ -1666,7 +1666,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-22-6 release
+          description: Ubuntu OVA for EKS-D 1-22-7 release
           etcdadm:
             arch:
             - amd64
@@ -1676,12 +1676,12 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.22.6-eks-d-1-22-6-eks-a-v0.0.0-dev-build.0-amd64.ova
+          name: ubuntu-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: ubuntu
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-22/1-22-6/ubuntu-v1.22.6-eks-d-1-22-6-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-22/1-22-7/ubuntu-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           crictl: {}
@@ -1698,7 +1698,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-22-6 release
+          description: Ubuntu OVA for EKS-D 1-22-7 release
           etcdadm:
             arch:
             - amd64
@@ -1708,12 +1708,12 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.22.6-eks-d-1-22-6-eks-a-v0.0.0-dev-build.0-amd64.gz
+          name: ubuntu-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-build.0-amd64.gz
           os: linux
           osName: ubuntu
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-22/1-22-6/ubuntu-v1.22.6-eks-d-1-22-6-eks-a-v0.0.0-dev-build.0-amd64.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-22/1-22-7/ubuntu-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-build.0-amd64.gz
     eksa:
       cliTools:
         arch:
@@ -1730,7 +1730,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.9.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.9.1-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
       diagnosticCollector:
@@ -1744,7 +1744,7 @@ spec:
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.0-rc6/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1752,7 +1752,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/mrajashree/etcdadm-bootstrap-provider:v1.0.0-rc6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1762,11 +1762,11 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.0-rc6/metadata.yaml
-      version: v1.0.0-rc6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.2/metadata.yaml
+      version: v1.0.2+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0-rc9/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1774,7 +1774,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/mrajashree/etcdadm-controller:v1.0.0-rc9-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.0-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1784,8 +1784,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0-rc9/metadata.yaml
-      version: v1.0.0-rc9+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0/metadata.yaml
+      version: v1.0.0+abcdef1
     flux:
       helmController:
         arch:
@@ -1879,11 +1879,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:af0464c206b9e105be6f042e3db908006c0a9eed-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:ee045e095565f7943179a98f8d6567f56c3d3bcd-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/af0464c206b9e105be6f042e3db908006c0a9eed/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/ee045e095565f7943179a98f8d6567f56c3d3bcd/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/af0464c206b9e105be6f042e3db908006c0a9eed/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/ee045e095565f7943179a98f8d6567f56c3d3bcd/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -1893,7 +1893,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/af0464c206b9e105be6f042e3db908006c0a9eed/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/ee045e095565f7943179a98f8d6567f56c3d3bcd/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -1944,7 +1944,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: boots
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/boots:ab716aac37cfff2869952ea2e44a67cb6d1fe1c1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-build.1
           manifest: {}
         cfssl:
           arch:
@@ -2056,7 +2056,7 @@ spec:
             name: tink-worker
             os: linux
             uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:7a8ca47540c5800c1d0cac075cf7e2c5da69b186-eks-a-v0.0.0-dev-build.1
-      version: af0464c206b9e105be6f042e3db908006c0a9eed+abcdef1
+      version: ee045e095565f7943179a98f8d6567f56c3d3bcd+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -2176,7 +2176,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-2-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -2218,26 +2218,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:e0c5180610dd7a2bac4ed271309b07eb6102d0bd74ed7dd33fb619879cc006f3
+        imageDigest: sha256:9674f67425c28e820c72cf07e26e1d4303d4c2a8226b15273647d6eb84684510
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.9.13-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.10.11-eksa.2
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:5982a9b5feded74c14a0b410006bba6d748655f8bc01f393b4519c9b10a463d0
+        imageDigest: sha256:b4b6f8524313658d412829d3d281918ac1e4432073123fc38b0650ab1a45e2e1
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.9.13-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.10.11-eksa.2
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.9.13-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.10.11-eksa.2/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:fd78027e876b00ea850f875e87a9ce81f6e4e6b4d963f115e978e8e7d180f478
+        imageDigest: sha256:5e52535b615b0c59996926c509ebb1401a3ea384f91e275e90bdccda352a6f67
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.9.13-eksa.2
-      version: v1.9.13-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.10.11-eksa.2
+      version: v1.10.11-eksa.2
     cloudStack:
       clusterAPIController:
         arch:
@@ -2246,9 +2246,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-cloudstack-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.3-RC1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.5-rc2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.3-RC1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc2/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2258,8 +2258,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.3-RC1/metadata.yaml
-      version: v0.4.3-RC1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc2/metadata.yaml
+      version: v0.4.5-rc2+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.1.3/core-components.yaml
@@ -2339,10 +2339,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.6-eks-d-1-23-1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.6-eks-d-1-23-2-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.23.6
-      manifestUrl: https://eks-d-postsubmit-artifacts.s3.us-west-2.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-1.yaml
-      name: kubernetes-1-23-eks-1
+      manifestUrl: https://eks-d-postsubmit-artifacts.s3.us-west-2.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-2.yaml
+      name: kubernetes-1-23-eks-2
       ova:
         bottlerocket:
           crictl: {}
@@ -2359,7 +2359,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-23-1 release
+          description: Ubuntu OVA for EKS-D 1-23-2 release
           etcdadm:
             arch:
             - amd64
@@ -2369,12 +2369,12 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.23.6-eks-d-1-23-1-eks-a-v0.0.0-dev-build.0-amd64.ova
+          name: ubuntu-v1.23.6-eks-d-1-23-2-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: ubuntu
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-23/1-23-1/ubuntu-v1.23.6-eks-d-1-23-1-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-23/1-23-2/ubuntu-v1.23.6-eks-d-1-23-2-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           crictl: {}
@@ -2391,7 +2391,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-23-1 release
+          description: Ubuntu OVA for EKS-D 1-23-2 release
           etcdadm:
             arch:
             - amd64
@@ -2401,12 +2401,12 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.23.6-eks-d-1-23-1-eks-a-v0.0.0-dev-build.0-amd64.gz
+          name: ubuntu-v1.23.6-eks-d-1-23-2-eks-a-v0.0.0-dev-build.0-amd64.gz
           os: linux
           osName: ubuntu
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-23/1-23-1/ubuntu-v1.23.6-eks-d-1-23-1-eks-a-v0.0.0-dev-build.0-amd64.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-23/1-23-2/ubuntu-v1.23.6-eks-d-1-23-2-eks-a-v0.0.0-dev-build.0-amd64.gz
     eksa:
       cliTools:
         arch:
@@ -2423,7 +2423,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.9.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.9.1-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
       diagnosticCollector:
@@ -2437,7 +2437,7 @@ spec:
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.0-rc6/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2445,7 +2445,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/mrajashree/etcdadm-bootstrap-provider:v1.0.0-rc6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2455,11 +2455,11 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.0-rc6/metadata.yaml
-      version: v1.0.0-rc6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.2/metadata.yaml
+      version: v1.0.2+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0-rc9/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2467,7 +2467,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/mrajashree/etcdadm-controller:v1.0.0-rc9-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.0-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2477,8 +2477,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0-rc9/metadata.yaml
-      version: v1.0.0-rc9+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0/metadata.yaml
+      version: v1.0.0+abcdef1
     flux:
       helmController:
         arch:
@@ -2572,11 +2572,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:af0464c206b9e105be6f042e3db908006c0a9eed-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:ee045e095565f7943179a98f8d6567f56c3d3bcd-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/af0464c206b9e105be6f042e3db908006c0a9eed/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/ee045e095565f7943179a98f8d6567f56c3d3bcd/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/af0464c206b9e105be6f042e3db908006c0a9eed/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/ee045e095565f7943179a98f8d6567f56c3d3bcd/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2586,7 +2586,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/af0464c206b9e105be6f042e3db908006c0a9eed/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/ee045e095565f7943179a98f8d6567f56c3d3bcd/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -2637,7 +2637,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: boots
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/boots:ab716aac37cfff2869952ea2e44a67cb6d1fe1c1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-build.1
           manifest: {}
         cfssl:
           arch:
@@ -2749,7 +2749,7 @@ spec:
             name: tink-worker
             os: linux
             uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:7a8ca47540c5800c1d0cac075cf7e2c5da69b186-eks-a-v0.0.0-dev-build.1
-      version: af0464c206b9e105be6f042e3db908006c0a9eed+abcdef1
+      version: ee045e095565f7943179a98f8d6567f56c3d3bcd+abcdef1
     vSphere:
       clusterAPIController:
         arch:

--- a/release/pkg/test/testdata/release-0.9-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.9-bundle-release.yaml
@@ -3,15 +3,15 @@ kind: Bundles
 metadata:
   creationTimestamp: "1970-01-01T00:00:00Z"
 spec:
-  cliMaxVersion: v0.8.0
-  cliMinVersion: v0.8.0
+  cliMaxVersion: v0.9.0
+  cliMinVersion: v0.9.0
   number: 1
   versionsBundles:
   - aws:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
       controller:
         arch:
         - amd64
@@ -19,7 +19,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-aws-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -27,13 +27,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
       version: v0.6.4+abcdef1
     bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.0.2/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.1.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -41,7 +41,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.0.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -49,19 +49,19 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.0.2/metadata.yaml
-      version: v1.0.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.1.3/metadata.yaml
+      version: v1.1.3+abcdef1
     bottlerocketAdmin:
       admin:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:ce84dd6e6280f8bb40ca8917304ce0526187c7f66c81017020d3503c7a9f821e
+        imageDigest: sha256:279ff0b939c8ebfae8fb5086751de831edee4c1ef307b6f0a27b553b1c2c9b52
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.4
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.8.0
     bottlerocketBootstrap:
       bootstrap:
         arch:
@@ -70,7 +70,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-13-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-16-eks-a-v0.0.0-dev-release-0.9-build.1
     certManager:
       acmesolver:
         arch:
@@ -79,7 +79,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-acmesolver:v1.5.3-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-acmesolver:v1.5.3-eks-a-v0.0.0-dev-release-0.9-build.1
       cainjector:
         arch:
         - amd64
@@ -87,7 +87,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-cainjector:v1.5.3-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-cainjector:v1.5.3-eks-a-v0.0.0-dev-release-0.9-build.1
       controller:
         arch:
         - amd64
@@ -95,9 +95,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-controller:v1.5.3-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-controller:v1.5.3-eks-a-v0.0.0-dev-release-0.9-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cert-manager/manifests/v1.5.3/cert-manager.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cert-manager/manifests/v1.5.3/cert-manager.yaml
       version: v1.5.3+abcdef1
       webhook:
         arch:
@@ -106,7 +106,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-webhook:v1.5.3-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-webhook:v1.5.3-eks-a-v0.0.0-dev-release-0.9-build.1
     cilium:
       cilium:
         arch:
@@ -122,7 +122,7 @@ spec:
         name: cilium-chart
         uri: public.ecr.aws/isovalent/cilium:1.9.13-eksa.2
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cilium/manifests/cilium/v1.9.13-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cilium/manifests/cilium/v1.9.13-eksa.2/cilium.yaml
       operator:
         arch:
         - amd64
@@ -140,9 +140,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-cloudstack-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.1-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.5-rc2-eks-a-v0.0.0-dev-release-0.9-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc2/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -150,13 +150,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.1/metadata.yaml
-      version: v0.4.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc2/metadata.yaml
+      version: v0.4.5-rc2+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/cluster-api/v1.0.2/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/cluster-api/v1.1.3/core-components.yaml
       controller:
         arch:
         - amd64
@@ -164,7 +164,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.0.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -172,13 +172,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/cluster-api/v1.0.2/metadata.yaml
-      version: v1.0.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/cluster-api/v1.1.3/metadata.yaml
+      version: v1.1.3+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/control-plane-kubeadm/v1.0.2/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/control-plane-kubeadm/v1.1.3/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -186,7 +186,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.0.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -194,15 +194,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/control-plane-kubeadm/v1.0.2/metadata.yaml
-      version: v1.0.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/control-plane-kubeadm/v1.1.3/metadata.yaml
+      version: v1.1.3+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/infrastructure-docker/v1.0.2/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/infrastructure-docker/v1.0.2/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -210,7 +210,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       manager:
         arch:
         - amd64
@@ -218,10 +218,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: capd-manager
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.0.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.1.3-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/infrastructure-docker/v1.0.2/metadata.yaml
-      version: v1.0.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/metadata.yaml
+      version: v1.1.3+abcdef1
     eksD:
       channel: 1-20
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
@@ -233,23 +233,23 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-13-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeVersion: v1.20.15
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-13.yaml
-      name: kubernetes-1-20-eks-13
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-16.yaml
+      name: kubernetes-1-20-eks-16
       ova:
         bottlerocket:
           arch:
           - amd64
           crictl: {}
-          description: Bottlerocket OVA for EKS-D 1-20-13 release
+          description: Bottlerocket OVA for EKS-D 1-20-16 release
           etcdadm: {}
-          name: bottlerocket-v1.20.15-eks-d-1-20-13-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.ova
+          name: bottlerocket-v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-distro/ova/1-20/1-20-13/bottlerocket-v1.20.15-eks-d-1-20-13-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/eks-distro/ova/1-20/1-20-16/bottlerocket-v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
         ubuntu:
           arch:
           - amd64
@@ -257,27 +257,27 @@ spec:
             arch:
             - amd64
             description: cri-tools tarball for linux/amd64
-            name: cri-tools-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
+            name: cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
             os: linux
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-20-13 release
+            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
+          description: Ubuntu OVA for EKS-D 1-20-16 release
           etcdadm:
             arch:
             - amd64
             description: etcdadm tarball for linux/amd64
-            name: etcdadm-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
+            name: etcdadm-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
             os: linux
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.20.15-eks-d-1-20-13-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.ova
+            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
+          name: ubuntu-v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
           os: linux
           osName: ubuntu
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-distro/ova/1-20/1-20-13/ubuntu-v1.20.15-eks-d-1-20-13-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/eks-distro/ova/1-20/1-20-16/ubuntu-v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
       raw:
         bottlerocket:
           crictl: {}
@@ -289,27 +289,27 @@ spec:
             arch:
             - amd64
             description: cri-tools tarball for linux/amd64
-            name: cri-tools-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
+            name: cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
             os: linux
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-20-13 release
+            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
+          description: Ubuntu OVA for EKS-D 1-20-16 release
           etcdadm:
             arch:
             - amd64
             description: etcdadm tarball for linux/amd64
-            name: etcdadm-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
+            name: etcdadm-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
             os: linux
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.20.15-eks-d-1-20-13-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.gz
+            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
+          name: ubuntu-v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.gz
           os: linux
           osName: ubuntu
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-distro/raw/1-20/1-20-13/ubuntu-v1.20.15-eks-d-1-20-13-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/eks-distro/raw/1-20/1-20-16/ubuntu-v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.gz
     eksa:
       cliTools:
         arch:
@@ -318,7 +318,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.7.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.7.2-eks-a-v0.0.0-dev-release-0.9-build.1
       clusterController:
         arch:
         - amd64
@@ -326,9 +326,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.9.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.9.1-eks-a-v0.0.0-dev-release-0.9-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -336,11 +336,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.7.2-eks-a-v0.0.0-dev-release-0.8-build.1
-      version: v0.0.0-dev-release-0.8+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.7.2-eks-a-v0.0.0-dev-release-0.9-build.1
+      version: v0.0.0-dev-release-0.9+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.0-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -348,7 +348,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/mrajashree/etcdadm-bootstrap-provider:v1.0.0-rc5-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.2-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -356,13 +356,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.0-rc5/metadata.yaml
-      version: v1.0.0-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.2/metadata.yaml
+      version: v1.0.2+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0-rc7/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -370,7 +370,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/mrajashree/etcdadm-controller:v1.0.0-rc7-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.0-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -378,10 +378,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0-rc7/metadata.yaml
-      version: v1.0.0-rc7+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0/metadata.yaml
+      version: v1.0.0+abcdef1
     flux:
       helmController:
         arch:
@@ -390,7 +390,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.15.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.20.1-eks-a-v0.0.0-dev-release-0.9-build.1
       kustomizeController:
         arch:
         - amd64
@@ -398,7 +398,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.19.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.24.3-eks-a-v0.0.0-dev-release-0.9-build.1
       notificationController:
         arch:
         - amd64
@@ -406,7 +406,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.20.1-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.23.4-eks-a-v0.0.0-dev-release-0.9-build.1
       sourceController:
         arch:
         - amd64
@@ -414,8 +414,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.20.1-eks-a-v0.0.0-dev-release-0.8-build.1
-      version: v0.25.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.24.2-eks-a-v0.0.0-dev-release-0.9-build.1
+      version: v0.29.4+abcdef1
     haproxy:
       image:
         arch:
@@ -424,18 +424,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.11.1-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.12.0-eks-a-v0.0.0-dev-release-0.9-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/kind/manifests/kindnetd/v0.11.1/kindnetd.yaml
-      version: v0.11.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/kind/manifests/kindnetd/v0.12.0/kindnetd.yaml
+      version: v0.12.0+abcdef1
     kubeVersion: "1.20"
     packageController:
       helmChart:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.10-eks-a-v0.0.0-dev-release-0.9-build.1
       packageController:
         arch:
         - amd64
@@ -443,8 +443,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.2-eks-a-v0.0.0-dev-release-0.8-build.1
-      version: v0.1.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.10-eks-a-v0.0.0-dev-release-0.9-build.1
+      version: v0.1.10+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -499,11 +499,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-vsphere-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.0.1-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.1.1-eks-a-v0.0.0-dev-release-0.9-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.0.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.0.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -511,7 +511,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -519,7 +519,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeVip:
         arch:
         - amd64
@@ -527,7 +527,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.9-build.1
       manager:
         arch:
         - amd64
@@ -535,9 +535,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.20.0-eks-d-1-20-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.20.0-eks-d-1-20-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.0.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -545,13 +545,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.8-build.1
-      version: v1.0.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.9-build.1
+      version: v1.1.1+abcdef1
   - aws:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
       controller:
         arch:
         - amd64
@@ -559,7 +559,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-aws-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -567,13 +567,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
       version: v0.6.4+abcdef1
     bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.0.2/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.1.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -581,7 +581,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.0.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -589,19 +589,19 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.0.2/metadata.yaml
-      version: v1.0.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.1.3/metadata.yaml
+      version: v1.1.3+abcdef1
     bottlerocketAdmin:
       admin:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:ce84dd6e6280f8bb40ca8917304ce0526187c7f66c81017020d3503c7a9f821e
+        imageDigest: sha256:279ff0b939c8ebfae8fb5086751de831edee4c1ef307b6f0a27b553b1c2c9b52
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.4
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.8.0
     bottlerocketBootstrap:
       bootstrap:
         arch:
@@ -610,7 +610,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-11-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-14-eks-a-v0.0.0-dev-release-0.9-build.1
     certManager:
       acmesolver:
         arch:
@@ -619,7 +619,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-acmesolver:v1.5.3-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-acmesolver:v1.5.3-eks-a-v0.0.0-dev-release-0.9-build.1
       cainjector:
         arch:
         - amd64
@@ -627,7 +627,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-cainjector:v1.5.3-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-cainjector:v1.5.3-eks-a-v0.0.0-dev-release-0.9-build.1
       controller:
         arch:
         - amd64
@@ -635,9 +635,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-controller:v1.5.3-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-controller:v1.5.3-eks-a-v0.0.0-dev-release-0.9-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cert-manager/manifests/v1.5.3/cert-manager.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cert-manager/manifests/v1.5.3/cert-manager.yaml
       version: v1.5.3+abcdef1
       webhook:
         arch:
@@ -646,7 +646,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-webhook:v1.5.3-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-webhook:v1.5.3-eks-a-v0.0.0-dev-release-0.9-build.1
     cilium:
       cilium:
         arch:
@@ -662,7 +662,7 @@ spec:
         name: cilium-chart
         uri: public.ecr.aws/isovalent/cilium:1.9.13-eksa.2
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cilium/manifests/cilium/v1.9.13-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cilium/manifests/cilium/v1.9.13-eksa.2/cilium.yaml
       operator:
         arch:
         - amd64
@@ -680,9 +680,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-cloudstack-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.1-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.5-rc2-eks-a-v0.0.0-dev-release-0.9-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc2/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -690,13 +690,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.1/metadata.yaml
-      version: v0.4.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc2/metadata.yaml
+      version: v0.4.5-rc2+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/cluster-api/v1.0.2/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/cluster-api/v1.1.3/core-components.yaml
       controller:
         arch:
         - amd64
@@ -704,7 +704,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.0.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -712,13 +712,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/cluster-api/v1.0.2/metadata.yaml
-      version: v1.0.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/cluster-api/v1.1.3/metadata.yaml
+      version: v1.1.3+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/control-plane-kubeadm/v1.0.2/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/control-plane-kubeadm/v1.1.3/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -726,7 +726,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.0.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -734,15 +734,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/control-plane-kubeadm/v1.0.2/metadata.yaml
-      version: v1.0.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/control-plane-kubeadm/v1.1.3/metadata.yaml
+      version: v1.1.3+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/infrastructure-docker/v1.0.2/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/infrastructure-docker/v1.0.2/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -750,7 +750,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       manager:
         arch:
         - amd64
@@ -758,10 +758,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: capd-manager
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.0.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.1.3-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/infrastructure-docker/v1.0.2/metadata.yaml
-      version: v1.0.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/metadata.yaml
+      version: v1.1.3+abcdef1
     eksD:
       channel: 1-21
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
@@ -773,23 +773,23 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.9-eks-d-1-21-11-eks-a-v0.0.0-dev-release-0.8-build.1
-      kubeVersion: v1.21.9
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-11.yaml
-      name: kubernetes-1-21-eks-11
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-release-0.9-build.1
+      kubeVersion: v1.21.12
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-14.yaml
+      name: kubernetes-1-21-eks-14
       ova:
         bottlerocket:
           arch:
           - amd64
           crictl: {}
-          description: Bottlerocket OVA for EKS-D 1-21-11 release
+          description: Bottlerocket OVA for EKS-D 1-21-14 release
           etcdadm: {}
-          name: bottlerocket-v1.21.9-eks-d-1-21-11-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.ova
+          name: bottlerocket-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-distro/ova/1-21/1-21-11/bottlerocket-v1.21.9-eks-d-1-21-11-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/eks-distro/ova/1-21/1-21-14/bottlerocket-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
         ubuntu:
           arch:
           - amd64
@@ -797,27 +797,27 @@ spec:
             arch:
             - amd64
             description: cri-tools tarball for linux/amd64
-            name: cri-tools-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
+            name: cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
             os: linux
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-21-11 release
+            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
+          description: Ubuntu OVA for EKS-D 1-21-14 release
           etcdadm:
             arch:
             - amd64
             description: etcdadm tarball for linux/amd64
-            name: etcdadm-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
+            name: etcdadm-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
             os: linux
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.21.9-eks-d-1-21-11-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.ova
+            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
+          name: ubuntu-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
           os: linux
           osName: ubuntu
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-distro/ova/1-21/1-21-11/ubuntu-v1.21.9-eks-d-1-21-11-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/eks-distro/ova/1-21/1-21-14/ubuntu-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
       raw:
         bottlerocket:
           crictl: {}
@@ -829,27 +829,27 @@ spec:
             arch:
             - amd64
             description: cri-tools tarball for linux/amd64
-            name: cri-tools-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
+            name: cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
             os: linux
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-21-11 release
+            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
+          description: Ubuntu OVA for EKS-D 1-21-14 release
           etcdadm:
             arch:
             - amd64
             description: etcdadm tarball for linux/amd64
-            name: etcdadm-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
+            name: etcdadm-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
             os: linux
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.21.9-eks-d-1-21-11-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.gz
+            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
+          name: ubuntu-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.gz
           os: linux
           osName: ubuntu
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-distro/raw/1-21/1-21-11/ubuntu-v1.21.9-eks-d-1-21-11-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/eks-distro/raw/1-21/1-21-14/ubuntu-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.gz
     eksa:
       cliTools:
         arch:
@@ -858,7 +858,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.7.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.7.2-eks-a-v0.0.0-dev-release-0.9-build.1
       clusterController:
         arch:
         - amd64
@@ -866,9 +866,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.9.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.9.1-eks-a-v0.0.0-dev-release-0.9-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -876,11 +876,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.7.2-eks-a-v0.0.0-dev-release-0.8-build.1
-      version: v0.0.0-dev-release-0.8+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.7.2-eks-a-v0.0.0-dev-release-0.9-build.1
+      version: v0.0.0-dev-release-0.9+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.0-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -888,7 +888,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/mrajashree/etcdadm-bootstrap-provider:v1.0.0-rc5-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.2-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -896,13 +896,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.0-rc5/metadata.yaml
-      version: v1.0.0-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.2/metadata.yaml
+      version: v1.0.2+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0-rc7/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -910,7 +910,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/mrajashree/etcdadm-controller:v1.0.0-rc7-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.0-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -918,10 +918,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0-rc7/metadata.yaml
-      version: v1.0.0-rc7+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0/metadata.yaml
+      version: v1.0.0+abcdef1
     flux:
       helmController:
         arch:
@@ -930,7 +930,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.15.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.20.1-eks-a-v0.0.0-dev-release-0.9-build.1
       kustomizeController:
         arch:
         - amd64
@@ -938,7 +938,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.19.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.24.3-eks-a-v0.0.0-dev-release-0.9-build.1
       notificationController:
         arch:
         - amd64
@@ -946,7 +946,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.20.1-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.23.4-eks-a-v0.0.0-dev-release-0.9-build.1
       sourceController:
         arch:
         - amd64
@@ -954,8 +954,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.20.1-eks-a-v0.0.0-dev-release-0.8-build.1
-      version: v0.25.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.24.2-eks-a-v0.0.0-dev-release-0.9-build.1
+      version: v0.29.4+abcdef1
     haproxy:
       image:
         arch:
@@ -964,18 +964,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.11.1-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.12.0-eks-a-v0.0.0-dev-release-0.9-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/kind/manifests/kindnetd/v0.11.1/kindnetd.yaml
-      version: v0.11.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/kind/manifests/kindnetd/v0.12.0/kindnetd.yaml
+      version: v0.12.0+abcdef1
     kubeVersion: "1.21"
     packageController:
       helmChart:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.10-eks-a-v0.0.0-dev-release-0.9-build.1
       packageController:
         arch:
         - amd64
@@ -983,8 +983,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.2-eks-a-v0.0.0-dev-release-0.8-build.1
-      version: v0.1.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.10-eks-a-v0.0.0-dev-release-0.9-build.1
+      version: v0.1.10+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -1039,11 +1039,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-vsphere-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.0.1-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.1.1-eks-a-v0.0.0-dev-release-0.9-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.0.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.0.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -1051,7 +1051,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1059,7 +1059,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeVip:
         arch:
         - amd64
@@ -1067,7 +1067,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.9-build.1
       manager:
         arch:
         - amd64
@@ -1075,9 +1075,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.21.0-eks-d-1-21-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.21.0-eks-d-1-21-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.0.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -1085,13 +1085,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.8-build.1
-      version: v1.0.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.9-build.1
+      version: v1.1.1+abcdef1
   - aws:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
       controller:
         arch:
         - amd64
@@ -1099,7 +1099,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-aws-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1107,13 +1107,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
       version: v0.6.4+abcdef1
     bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.0.2/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.1.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1121,7 +1121,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.0.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1129,19 +1129,19 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.0.2/metadata.yaml
-      version: v1.0.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.1.3/metadata.yaml
+      version: v1.1.3+abcdef1
     bottlerocketAdmin:
       admin:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:ce84dd6e6280f8bb40ca8917304ce0526187c7f66c81017020d3503c7a9f821e
+        imageDigest: sha256:279ff0b939c8ebfae8fb5086751de831edee4c1ef307b6f0a27b553b1c2c9b52
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.7.4
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.8.0
     bottlerocketBootstrap:
       bootstrap:
         arch:
@@ -1150,7 +1150,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-4-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-7-eks-a-v0.0.0-dev-release-0.9-build.1
     certManager:
       acmesolver:
         arch:
@@ -1159,7 +1159,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-acmesolver:v1.5.3-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-acmesolver:v1.5.3-eks-a-v0.0.0-dev-release-0.9-build.1
       cainjector:
         arch:
         - amd64
@@ -1167,7 +1167,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-cainjector:v1.5.3-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-cainjector:v1.5.3-eks-a-v0.0.0-dev-release-0.9-build.1
       controller:
         arch:
         - amd64
@@ -1175,9 +1175,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-controller:v1.5.3-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-controller:v1.5.3-eks-a-v0.0.0-dev-release-0.9-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cert-manager/manifests/v1.5.3/cert-manager.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cert-manager/manifests/v1.5.3/cert-manager.yaml
       version: v1.5.3+abcdef1
       webhook:
         arch:
@@ -1186,7 +1186,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-webhook:v1.5.3-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-webhook:v1.5.3-eks-a-v0.0.0-dev-release-0.9-build.1
     cilium:
       cilium:
         arch:
@@ -1202,7 +1202,7 @@ spec:
         name: cilium-chart
         uri: public.ecr.aws/isovalent/cilium:1.9.13-eksa.2
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cilium/manifests/cilium/v1.9.13-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cilium/manifests/cilium/v1.9.13-eksa.2/cilium.yaml
       operator:
         arch:
         - amd64
@@ -1220,9 +1220,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-cloudstack-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.1-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-cloudstack/release/manager:v0.4.5-rc2-eks-a-v0.0.0-dev-release-0.9-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc2/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -1230,13 +1230,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.1/metadata.yaml
-      version: v0.4.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc2/metadata.yaml
+      version: v0.4.5-rc2+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/cluster-api/v1.0.2/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/cluster-api/v1.1.3/core-components.yaml
       controller:
         arch:
         - amd64
@@ -1244,7 +1244,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.0.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1252,13 +1252,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/cluster-api/v1.0.2/metadata.yaml
-      version: v1.0.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/cluster-api/v1.1.3/metadata.yaml
+      version: v1.1.3+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/control-plane-kubeadm/v1.0.2/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/control-plane-kubeadm/v1.1.3/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -1266,7 +1266,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.0.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1274,15 +1274,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/control-plane-kubeadm/v1.0.2/metadata.yaml
-      version: v1.0.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/control-plane-kubeadm/v1.1.3/metadata.yaml
+      version: v1.1.3+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/infrastructure-docker/v1.0.2/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/infrastructure-docker/v1.0.2/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -1290,7 +1290,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       manager:
         arch:
         - amd64
@@ -1298,10 +1298,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: capd-manager
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.0.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.1.3-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api/manifests/infrastructure-docker/v1.0.2/metadata.yaml
-      version: v1.0.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/metadata.yaml
+      version: v1.1.3+abcdef1
     eksD:
       channel: 1-22
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
@@ -1313,23 +1313,23 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.6-eks-d-1-22-4-eks-a-v0.0.0-dev-release-0.8-build.1
-      kubeVersion: v1.22.6
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-4.yaml
-      name: kubernetes-1-22-eks-4
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-release-0.9-build.1
+      kubeVersion: v1.22.9
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-7.yaml
+      name: kubernetes-1-22-eks-7
       ova:
         bottlerocket:
           arch:
           - amd64
           crictl: {}
-          description: Bottlerocket OVA for EKS-D 1-22-4 release
+          description: Bottlerocket OVA for EKS-D 1-22-7 release
           etcdadm: {}
-          name: bottlerocket-v1.22.6-eks-d-1-22-4-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.ova
+          name: bottlerocket-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-distro/ova/1-22/1-22-4/bottlerocket-v1.22.6-eks-d-1-22-4-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/eks-distro/ova/1-22/1-22-7/bottlerocket-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
         ubuntu:
           arch:
           - amd64
@@ -1337,27 +1337,27 @@ spec:
             arch:
             - amd64
             description: cri-tools tarball for linux/amd64
-            name: cri-tools-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
+            name: cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
             os: linux
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-22-4 release
+            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
+          description: Ubuntu OVA for EKS-D 1-22-7 release
           etcdadm:
             arch:
             - amd64
             description: etcdadm tarball for linux/amd64
-            name: etcdadm-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
+            name: etcdadm-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
             os: linux
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.22.6-eks-d-1-22-4-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.ova
+            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
+          name: ubuntu-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
           os: linux
           osName: ubuntu
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-distro/ova/1-22/1-22-4/ubuntu-v1.22.6-eks-d-1-22-4-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/eks-distro/ova/1-22/1-22-7/ubuntu-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
       raw:
         bottlerocket:
           crictl: {}
@@ -1369,27 +1369,27 @@ spec:
             arch:
             - amd64
             description: cri-tools tarball for linux/amd64
-            name: cri-tools-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
+            name: cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
             os: linux
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-22-4 release
+            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
+          description: Ubuntu OVA for EKS-D 1-22-7 release
           etcdadm:
             arch:
             - amd64
             description: etcdadm tarball for linux/amd64
-            name: etcdadm-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
+            name: etcdadm-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
             os: linux
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.8+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.22.6-eks-d-1-22-4-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.gz
+            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
+          name: ubuntu-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.gz
           os: linux
           osName: ubuntu
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-distro/raw/1-22/1-22-4/ubuntu-v1.22.6-eks-d-1-22-4-eks-a-v0.0.0-dev-release-0.8-build.0-amd64.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/eks-distro/raw/1-22/1-22-7/ubuntu-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.gz
     eksa:
       cliTools:
         arch:
@@ -1398,7 +1398,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.7.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.7.2-eks-a-v0.0.0-dev-release-0.9-build.1
       clusterController:
         arch:
         - amd64
@@ -1406,9 +1406,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.9.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.9.1-eks-a-v0.0.0-dev-release-0.9-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/eks-anywhere/manifests/cluster-controller/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1416,11 +1416,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.7.2-eks-a-v0.0.0-dev-release-0.8-build.1
-      version: v0.0.0-dev-release-0.8+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.7.2-eks-a-v0.0.0-dev-release-0.9-build.1
+      version: v0.0.0-dev-release-0.9+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.0-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1428,7 +1428,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/mrajashree/etcdadm-bootstrap-provider:v1.0.0-rc5-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.2-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1436,13 +1436,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.0-rc5/metadata.yaml
-      version: v1.0.0-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.2/metadata.yaml
+      version: v1.0.2+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0-rc7/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1450,7 +1450,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/mrajashree/etcdadm-controller:v1.0.0-rc7-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.0-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1458,10 +1458,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0-rc7/metadata.yaml
-      version: v1.0.0-rc7+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.0/metadata.yaml
+      version: v1.0.0+abcdef1
     flux:
       helmController:
         arch:
@@ -1470,7 +1470,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.15.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.20.1-eks-a-v0.0.0-dev-release-0.9-build.1
       kustomizeController:
         arch:
         - amd64
@@ -1478,7 +1478,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.19.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.24.3-eks-a-v0.0.0-dev-release-0.9-build.1
       notificationController:
         arch:
         - amd64
@@ -1486,7 +1486,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.20.1-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.23.4-eks-a-v0.0.0-dev-release-0.9-build.1
       sourceController:
         arch:
         - amd64
@@ -1494,8 +1494,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.20.1-eks-a-v0.0.0-dev-release-0.8-build.1
-      version: v0.25.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.24.2-eks-a-v0.0.0-dev-release-0.9-build.1
+      version: v0.29.4+abcdef1
     haproxy:
       image:
         arch:
@@ -1504,18 +1504,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.11.1-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.12.0-eks-a-v0.0.0-dev-release-0.9-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/kind/manifests/kindnetd/v0.11.1/kindnetd.yaml
-      version: v0.11.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/kind/manifests/kindnetd/v0.12.0/kindnetd.yaml
+      version: v0.12.0+abcdef1
     kubeVersion: "1.22"
     packageController:
       helmChart:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.2-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.10-eks-a-v0.0.0-dev-release-0.9-build.1
       packageController:
         arch:
         - amd64
@@ -1523,8 +1523,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.2-eks-a-v0.0.0-dev-release-0.8-build.1
-      version: v0.1.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.10-eks-a-v0.0.0-dev-release-0.9-build.1
+      version: v0.1.10+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -1579,11 +1579,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-vsphere-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.0.1-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.1.1-eks-a-v0.0.0-dev-release-0.9-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.0.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.0.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -1591,7 +1591,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1599,7 +1599,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.9-build.1
       kubeVip:
         arch:
         - amd64
@@ -1607,7 +1607,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.9-build.1
       manager:
         arch:
         - amd64
@@ -1615,9 +1615,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.22.5-eks-d-1-22-eks-a-v0.0.0-dev-release-0.8-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.22.5-eks-d-1-22-eks-a-v0.0.0-dev-release-0.9-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.8-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.0.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -1625,6 +1625,6 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.8-build.1
-      version: v1.0.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.9-build.1
+      version: v1.1.1+abcdef1
 status: {}


### PR DESCRIPTION
Backporting #2309 to release-0.9 branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

