### PR TITLE
Add Hardware flag to upgrade cmd

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -27,8 +27,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/workflows"
 )
 
-const tinkerbellHardwareCSVFlag = "hardware-csv"
-
 type createClusterOptions struct {
 	clusterOptions
 	forceClean      bool
@@ -52,7 +50,7 @@ func init() {
 	createCmd.AddCommand(createClusterCmd)
 	createClusterCmd.Flags().StringVarP(&cc.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
 	if features.IsActive(features.TinkerbellProvider()) {
-		createClusterCmd.Flags().StringVar(&cc.hardwareCSVPath, tinkerbellHardwareCSVFlag, "", "A file path to a CSV file containing hardware data to be submitted to the cluster for provisioning")
+		PopulateTinkerbelHardwareCSVFlag(&cc.hardwareCSVPath, createClusterCmd.Flags())
 	}
 	createClusterCmd.Flags().BoolVar(&cc.forceClean, "force-cleanup", false, "Force deletion of previously created bootstrap cluster")
 	createClusterCmd.Flags().BoolVar(&cc.skipIpCheck, "skip-ip-check", false, "Skip check for whether cluster control plane ip is in use")
@@ -89,7 +87,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 	}
 
 	if clusterConfig.Spec.DatacenterRef.Kind == v1alpha1.TinkerbellDatacenterKind {
-		flag := cmd.Flags().Lookup(tinkerbellHardwareCSVFlag)
+		flag := cmd.Flags().Lookup(TinkerbellHardwareCSVFlagName)
 
 		// If no flag was returned there is a developer error as the flag has been removed
 		// from the program rendering it invalid.
@@ -97,8 +95,8 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 			panic("'hardwarefile' flag not configured")
 		}
 
-		if !viper.IsSet(tinkerbellHardwareCSVFlag) || viper.GetString(tinkerbellHardwareCSVFlag) == "" {
-			return fmt.Errorf("required flag \"%v\" not set", tinkerbellHardwareCSVFlag)
+		if !viper.IsSet(TinkerbellHardwareCSVFlagName) || viper.GetString(TinkerbellHardwareCSVFlagName) == "" {
+			return fmt.Errorf("required flag \"%v\" not set", TinkerbellHardwareCSVFlagName)
 		}
 
 		if !validations.FileExists(cc.hardwareCSVPath) {

--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -50,7 +50,13 @@ func init() {
 	createCmd.AddCommand(createClusterCmd)
 	createClusterCmd.Flags().StringVarP(&cc.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
 	if features.IsActive(features.TinkerbellProvider()) {
-		PopulateTinkerbelHardwareCSVFlag(&cc.hardwareCSVPath, createClusterCmd.Flags())
+		createClusterCmd.Flags().StringVarP(
+			&cc.hardwareCSVPath,
+			TinkerbellHardwareCSVFlagName,
+			TinkerbellHardwareCSVFlagAlias,
+			"",
+			TinkerbellHardwareCSVFlagDescription,
+		)
 	}
 	createClusterCmd.Flags().BoolVar(&cc.forceClean, "force-cleanup", false, "Force deletion of previously created bootstrap cluster")
 	createClusterCmd.Flags().BoolVar(&cc.skipIpCheck, "skip-ip-check", false, "Skip check for whether cluster control plane ip is in use")

--- a/cmd/eksctl-anywhere/cmd/generatehardware.go
+++ b/cmd/eksctl-anywhere/cmd/generatehardware.go
@@ -30,13 +30,12 @@ func init() {
 	generateCmd.AddCommand(generateHardwareCmd)
 
 	flags := generateHardwareCmd.Flags()
+	flags.StringVarP(&hOpts.outputPath, "output", "o", "", "Path to output hardware YAML.")
+	PopulateTinkerbelHardwareCSVFlag(&hOpts.csvPath, flags)
 
-	flags.StringVarP(&hOpts.csvPath, tinkerbellHardwareCSVFlag, "w", "", "CSV file path")
-	if err := generateHardwareCmd.MarkFlagRequired(tinkerbellHardwareCSVFlag); err != nil {
+	if err := generateHardwareCmd.MarkFlagRequired(TinkerbellHardwareCSVFlagName); err != nil {
 		panic(err)
 	}
-
-	flags.StringVarP(&hOpts.outputPath, "output", "o", "", "directory path to output hardware YAML")
 }
 
 func (hOpts *hardwareOptions) generateHardware(cmd *cobra.Command, args []string) error {

--- a/cmd/eksctl-anywhere/cmd/generatehardware.go
+++ b/cmd/eksctl-anywhere/cmd/generatehardware.go
@@ -31,7 +31,13 @@ func init() {
 
 	flags := generateHardwareCmd.Flags()
 	flags.StringVarP(&hOpts.outputPath, "output", "o", "", "Path to output hardware YAML.")
-	PopulateTinkerbelHardwareCSVFlag(&hOpts.csvPath, flags)
+	flags.StringVarP(
+		&cc.hardwareCSVPath,
+		TinkerbellHardwareCSVFlagName,
+		TinkerbellHardwareCSVFlagAlias,
+		"",
+		TinkerbellHardwareCSVFlagDescription,
+	)
 
 	if err := generateHardwareCmd.MarkFlagRequired(TinkerbellHardwareCSVFlagName); err != nil {
 		panic(err)

--- a/cmd/eksctl-anywhere/cmd/tinkerbell.go
+++ b/cmd/eksctl-anywhere/cmd/tinkerbell.go
@@ -8,7 +8,8 @@ import (
 // provider.
 const TinkerbellHardwareCSVFlagName = "hardware-csv"
 
-// PopulateTinkerbellHardwareCSVFlag populates set with the TinkerbellHardwareCSVFlagName.
+// PopulateTinkerbellHardwareCSVFlag populates s with the TinkerbellHardwareCSVFlagName.
+// The value provided to the CLI will be written to field.
 func PopulateTinkerbelHardwareCSVFlag(field *string, s *pflag.FlagSet) {
 	s.StringVar(field, TinkerbellHardwareCSVFlagName, "",
 		"A file path to a CSV file containing hardware data to be submitted to the cluster for provisioning.")

--- a/cmd/eksctl-anywhere/cmd/tinkerbell.go
+++ b/cmd/eksctl-anywhere/cmd/tinkerbell.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// TinkerbellHardwareCSVFlagName is the flag used for providing hardware CSV used by the Tinkerbell
+// provider.
+const TinkerbellHardwareCSVFlagName = "hardware-csv"
+
+// PopulateTinkerbellHardwareCSVFlag populates set with the TinkerbellHardwareCSVFlagName.
+func PopulateTinkerbelHardwareCSVFlag(field *string, s *pflag.FlagSet) {
+	s.StringVar(field, TinkerbellHardwareCSVFlagName, "",
+		"A file path to a CSV file containing hardware data to be submitted to the cluster for provisioning.")
+}

--- a/cmd/eksctl-anywhere/cmd/tinkerbell.go
+++ b/cmd/eksctl-anywhere/cmd/tinkerbell.go
@@ -1,16 +1,7 @@
 package cmd
 
-import (
-	"github.com/spf13/pflag"
+const (
+	TinkerbellHardwareCSVFlagName        = "hardware-csv"
+	TinkerbellHardwareCSVFlagAlias       = "z"
+	TinkerbellHardwareCSVFlagDescription = "Path to a CSV file containing hardware data."
 )
-
-// TinkerbellHardwareCSVFlagName is the flag used for providing hardware CSV used by the Tinkerbell
-// provider.
-const TinkerbellHardwareCSVFlagName = "hardware-csv"
-
-// PopulateTinkerbellHardwareCSVFlag populates s with the TinkerbellHardwareCSVFlagName.
-// The value provided to the CLI will be written to field.
-func PopulateTinkerbelHardwareCSVFlag(field *string, s *pflag.FlagSet) {
-	s.StringVar(field, TinkerbellHardwareCSVFlagName, "",
-		"A file path to a CSV file containing hardware data to be submitted to the cluster for provisioning.")
-}

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -20,9 +20,9 @@ import (
 
 type upgradeClusterOptions struct {
 	clusterOptions
-	wConfig          string
-	forceClean       bool
-	hardwareFileName string
+	wConfig         string
+	forceClean      bool
+	hardwareCSVPath string
 }
 
 var uc = &upgradeClusterOptions{}
@@ -58,8 +58,9 @@ func init() {
 	upgradeClusterCmd.Flags().BoolVar(&uc.forceClean, "force-cleanup", false, "Force deletion of previously created bootstrap cluster")
 	upgradeClusterCmd.Flags().StringVar(&uc.bundlesOverride, "bundles-override", "", "Override default Bundles manifest (not recommended)")
 	upgradeClusterCmd.Flags().StringVar(&uc.managementKubeconfig, "kubeconfig", "", "Management cluster kubeconfig file")
-	err := upgradeClusterCmd.MarkFlagRequired("filename")
-	if err != nil {
+	PopulateTinkerbelHardwareCSVFlag(&uc.hardwareCSVPath, upgradeClusterCmd.Flags())
+
+	if err := upgradeClusterCmd.MarkFlagRequired("filename"); err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
 	}
 }
@@ -82,7 +83,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(ctx context.Context) error {
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).WithExecutableMountDirs(dirs...).
 		WithBootstrapper().
 		WithClusterManager(clusterSpec.Cluster).
-		WithProvider(uc.fileName, clusterSpec.Cluster, cc.skipIpCheck, uc.hardwareFileName, uc.forceClean).
+		WithProvider(uc.fileName, clusterSpec.Cluster, cc.skipIpCheck, uc.hardwareCSVPath, uc.forceClean).
 		WithFluxAddonClient(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().
 		WithCAPIManager().

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -58,7 +58,13 @@ func init() {
 	upgradeClusterCmd.Flags().BoolVar(&uc.forceClean, "force-cleanup", false, "Force deletion of previously created bootstrap cluster")
 	upgradeClusterCmd.Flags().StringVar(&uc.bundlesOverride, "bundles-override", "", "Override default Bundles manifest (not recommended)")
 	upgradeClusterCmd.Flags().StringVar(&uc.managementKubeconfig, "kubeconfig", "", "Management cluster kubeconfig file")
-	PopulateTinkerbelHardwareCSVFlag(&uc.hardwareCSVPath, upgradeClusterCmd.Flags())
+	upgradeClusterCmd.Flags().StringVarP(
+		&cc.hardwareCSVPath,
+		TinkerbellHardwareCSVFlagName,
+		TinkerbellHardwareCSVFlagAlias,
+		"",
+		TinkerbellHardwareCSVFlagDescription,
+	)
 
 	if err := upgradeClusterCmd.MarkFlagRequired("filename"); err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)

--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -78,7 +78,7 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 
 	deps, err := dependencies.ForSpec(ctx, newClusterSpec).
 		WithClusterManager(newClusterSpec.Cluster).
-		WithProvider(uc.fileName, newClusterSpec.Cluster, cc.skipIpCheck, uc.hardwareFileName, uc.forceClean).
+		WithProvider(uc.fileName, newClusterSpec.Cluster, false, uc.hardwareCSVPath, uc.forceClean).
 		WithFluxAddonClient(newClusterSpec.Cluster, newClusterSpec.FluxConfig, nil).
 		WithCAPIManager().
 		Build(ctx)


### PR DESCRIPTION
The hardware CSV flag is necessary for upgrade in-case the user wishes to provide the additional Hardware per node group (including control plane). The flag is optional as hardware may already be registered with the cluster that satisfies the upgrade requirements.

A following PR will leverage the input CSV by validating it and cataloging the additional hardware along with existing hardware so we can validate sufficient hardware is available. 