### PR TITLE
Rufio integration for create cluster

### DIFF
--- a/pkg/providers/tinkerbell/hardware/catalogue_bmc.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_bmc.go
@@ -97,10 +97,13 @@ func baseboardManagementComputerFromMachine(m Machine) *v1alpha1.BaseboardManage
 			Connection: v1alpha1.Connection{
 				Host: m.BMCIPAddress,
 				AuthSecretRef: corev1.SecretReference{
-					Name: formatBMCSecretRef(m),
+					Name:      formatBMCSecretRef(m),
+					Namespace: constants.EksaSystemNamespace,
 				},
 				InsecureTLS: true,
 			},
+			// TODO(pokearu) remove this field once upstream API is changed.
+			Power: v1alpha1.Off,
 		},
 	}
 }

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
@@ -2,6 +2,7 @@ package hardware
 
 import (
 	"github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/pkg/constants"
@@ -107,7 +108,8 @@ func hardwareFromMachine(m Machine) *v1alpha1.Hardware {
 			Labels:    m.Labels,
 		},
 		Spec: v1alpha1.HardwareSpec{
-			Disks: []v1alpha1.Disk{{Device: m.Disk}},
+			BMCRef: newBMCRefFromMachine(m),
+			Disks:  []v1alpha1.Disk{{Device: m.Disk}},
 			Metadata: &v1alpha1.HardwareMetadata{
 				Facility: &v1alpha1.MetadataFacility{
 					FacilityCode: "onprem",
@@ -161,4 +163,16 @@ func hardwareFromMachine(m Machine) *v1alpha1.Hardware {
 			},
 		},
 	}
+}
+
+// newBMCRefFromMachine returns a BMCRef pointer for Hardware.
+func newBMCRefFromMachine(m Machine) *corev1.TypedLocalObjectReference {
+	if m.HasBMC() {
+		return &corev1.TypedLocalObjectReference{
+			Name: formatBMCRef(m),
+			Kind: tinkerbellBMCKind,
+		}
+	}
+
+	return nil
 }

--- a/pkg/providers/tinkerbell/hardware/typemeta.go
+++ b/pkg/providers/tinkerbell/hardware/typemeta.go
@@ -4,6 +4,8 @@ import v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // TypeMeta constants for defining Kubernetes TypeMeta data in Kubernetes objects.
 const (
+	// TODO(pokearu) update API version once upstream is changed.
+	rufioAPIVersion        = "bmc.tinkerbell.org/v1alpha1"
 	tinkerbellAPIVersion   = "tinkerbell.org/v1alpha1"
 	tinkerbellHardwareKind = "Hardware"
 	tinkerbellBMCKind      = "BaseboardManagement"
@@ -22,7 +24,7 @@ func newHardwareTypeMeta() v1.TypeMeta {
 func newBaseboardManagementTypeMeta() v1.TypeMeta {
 	return v1.TypeMeta{
 		Kind:       tinkerbellBMCKind,
-		APIVersion: tinkerbellAPIVersion,
+		APIVersion: rufioAPIVersion,
 	}
 }
 

--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -25,11 +25,12 @@ const (
 	hegel          = "hegel"
 	tinkController = "tinkController"
 	tinkServer     = "tinkServer"
+	rufio          = "rufio"
 	grpcPort       = "42113"
 
 	// TODO: remove this once the chart is added to bundle
-	helmChartOci     = "oci://public.ecr.aws/h6q6q4n4/tinkerbell"
-	helmChartName    = "tinkerbell"
+	helmChartOci     = "oci://public.ecr.aws/i7k6m1j7/tinkerbell/tinkerbell-chart"
+	helmChartName    = "tinkerbell-chart"
 	helmChartVersion = "0.1.0"
 )
 
@@ -140,6 +141,10 @@ func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 			deploy: !s.bootsOnDocker,
 			image:  bundle.Boots.Image.URI,
 			env:    bootEnv,
+		},
+		rufio: map[string]interface{}{
+			deploy: true,
+			image:  bundle.Rufio.Image.URI,
 		},
 	}
 

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -24,8 +24,8 @@ const (
 	testIP            = "1.2.3.4"
 
 	// TODO: remove this once the chart is added to bundle
-	helmChartOci     = "oci://public.ecr.aws/h6q6q4n4/tinkerbell"
-	helmChartName    = "tinkerbell"
+	helmChartOci     = "oci://public.ecr.aws/i7k6m1j7/tinkerbell/tinkerbell-chart"
+	helmChartName    = "tinkerbell-chart"
 	helmChartVersion = "0.1.0"
 )
 


### PR DESCRIPTION
*Description of changes:*
Changes contain adding required fields to hardware and baseboardmanagement objects. Also updated the helm chart to include Rufio controller.

*Testing:*
`eksctl-anywhere create cluster -f tink.yaml --hardware-csv tink.csv --setup-tinkerbell
`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

