### PR TITLE
Read Hardware CSV and existing cluster Hardware on Tinkerbell Enabled Management Cluster upgrade

### DIFF
--- a/pkg/executables/testdata/kubectl_tinkerbellhardware.json
+++ b/pkg/executables/testdata/kubectl_tinkerbellhardware.json
@@ -1,24 +1,18 @@
 {
-    "items": [
-        {
-            "apiVersion": "tinkerbell.org/v1alpha1",
-            "kind": "Hardware",
-            "metadata": {
-              "labels": {
-                "v1alpha1.tinkerbell.org/ownerName": "tink-test-md-0-clc85"
-              },
-              "name": "hw1"
-            }
-        },
-        {
-            "apiVersion": "tinkerbell.org/v1alpha1",
-            "kind": "Hardware",
-            "metadata": {
-              "labels": {
-                "v1alpha1.tinkerbell.org/ownerName": "tink-test-controlplane-0-ccl90"
-              },
-              "name": "hw2"
-            }
-        }
-    ]
+  "items": [
+    {
+      "apiVersion": "tinkerbell.org/v1alpha1",
+      "kind": "Hardware",
+      "metadata": {
+        "name": "hw1"
+      }
+    },
+    {
+      "apiVersion": "tinkerbell.org/v1alpha1",
+      "kind": "Hardware",
+      "metadata": {
+        "name": "hw2"
+      }
+    }
+  ]
 }

--- a/pkg/providers/tinkerbell/mocks/client.go
+++ b/pkg/providers/tinkerbell/mocks/client.go
@@ -14,6 +14,7 @@ import (
 	types "github.com/aws/eks-anywhere/pkg/types"
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
+	v1alpha10 "github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	v1beta10 "sigs.k8s.io/cluster-api/api/v1beta1"
 	v1beta11 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -221,6 +222,21 @@ func (mr *MockProviderKubectlClientMockRecorder) GetSecret(arg0, arg1 interface{
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockProviderKubectlClient)(nil).GetSecret), varargs...)
+}
+
+// GetUnprovisionedTinkerbellHardware mocks base method.
+func (m *MockProviderKubectlClient) GetUnprovisionedTinkerbellHardware(arg0 context.Context, arg1, arg2 string) ([]v1alpha10.Hardware, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnprovisionedTinkerbellHardware", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]v1alpha10.Hardware)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnprovisionedTinkerbellHardware indicates an expected call of GetUnprovisionedTinkerbellHardware.
+func (mr *MockProviderKubectlClientMockRecorder) GetUnprovisionedTinkerbellHardware(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnprovisionedTinkerbellHardware", reflect.TypeOf((*MockProviderKubectlClient)(nil).GetUnprovisionedTinkerbellHardware), arg0, arg1, arg2)
 }
 
 // UpdateAnnotation mocks base method.

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
+	tinkv1alpha1 "github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -72,6 +73,7 @@ type ProviderKubectlClient interface {
 	GetSecret(ctx context.Context, secretObjectName string, opts ...executables.KubectlOpt) (*corev1.Secret, error)
 	UpdateAnnotation(ctx context.Context, resourceType, objectName string, annotations map[string]string, opts ...executables.KubectlOpt) error
 	WaitForDeployment(ctx context.Context, cluster *types.Cluster, timeout string, condition string, target string, namespace string) error
+	GetUnprovisionedTinkerbellHardware(_ context.Context, kubeconfig, namespace string) ([]tinkv1alpha1.Hardware, error)
 }
 
 // KeyGenerator generates ssh keys and writes them to a FileWriter.
@@ -177,10 +179,10 @@ func (p *Provider) EnvMap(spec *cluster.Spec) (map[string]string, error) {
 		// https://github.com/tinkerbell/cluster-api-provider-tinkerbell/blob/main/config/manager/manager.yaml#L23
 		//
 		// Template override
-		// https://github.com/chrisdoherty4/cluster-api-provider-tinkerbell/blob/main/controllers/machine.go#L182
+		// https://github.com/tinkerbell/cluster-api-provider-tinkerbell/blob/main/controllers/machine.go#L182
 		//
 		// Env read having set TINKERBELL_IP in the deployment manifest.
-		// https://github.com/chrisdoherty4/cluster-api-provider-tinkerbell/blob/main/controllers/machine.go#L192
+		// https://github.com/tinkerbell/cluster-api-provider-tinkerbell/blob/main/controllers/machine.go#L192
 		"TINKERBELL_IP": "<set in eks-a tinkerbell provider>",
 	}, nil
 }

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
 	"github.com/aws/eks-anywhere/pkg/types"
@@ -69,35 +70,56 @@ func (p *Provider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *
 		return err
 	}
 
-	if len(p.hardwareCSVFile) == 0 {
-		return nil
-	}
-
 	tinkerbellClusterSpec := NewClusterSpec(clusterSpec, p.machineConfigs, p.datacenterConfig)
 
-	// TODO(chrisdoherty4) Look to inject the validator.
-	validator := NewClusterSpecValidator()
-	writer := hardware.NewMachineCatalogueWriter(p.catalogue)
-	machineValidator := hardware.NewDefaultMachineValidator()
+	// If we've been given a CSV with additional hardware for the cluster, validate it and
+	// write it to the catalogue so it can be used for further processing.
+	if p.hardareCSVIsProvided() {
+		machineCatalogueWriter := hardware.NewMachineCatalogueWriter(p.catalogue)
 
-	// Translate all Machine instances from the p.machines source into Kubernetes object types.
-	// The PostBootstrapSetup() call invoked elsewhere in the program serializes the catalogue
-	// and submits it to the clsuter.
-	machines, err := hardware.NewCSVReaderFromFile(p.hardwareCSVFile)
+		machines, err := hardware.NewCSVReaderFromFile(p.hardwareCSVFile)
+		if err != nil {
+			return err
+		}
+
+		// TODO(chrisdoherty4) Build the selectors slice using the selectors in the Tinkerbell
+		// Enabled Management Cluster that we're upgrading.
+		var selectors []hardware.MachineSelector
+
+		machineValidator := hardware.NewDefaultMachineValidator()
+		machineValidator.Register(hardware.MatchingDisksForSelectors(selectors))
+
+		if err := hardware.TranslateAll(machines, machineCatalogueWriter, machineValidator); err != nil {
+			return err
+		}
+	}
+
+	// Retrieve all unprovisioned hardware from the existing cluster and populate the catalogue so
+	// it can be considered for the upgrade.
+	hardware, err := p.providerKubectlClient.GetUnprovisionedTinkerbellHardware(
+		ctx,
+		cluster.KubeconfigFile,
+		constants.EksaSystemNamespace,
+	)
 	if err != nil {
+		return fmt.Errorf("retrieving unprovisioned hardware: %v", err)
+	}
+	for i := range hardware {
+		if err := p.catalogue.InsertHardware(&hardware[i]); err != nil {
+			return err
+		}
+	}
+
+	// Construct a spec validator and apply assertions specific to upgrade. The validation
+	// must take place last so as to ensure the catalogue is populated with available hardware.
+	clusterSpecValidator := NewClusterSpecValidator()
+
+	// TODO(chrisdoherty4) Apply assertions specific to upgrade.
+
+	if err := clusterSpecValidator.Validate(tinkerbellClusterSpec); err != nil {
 		return err
 	}
 
-	if err := hardware.TranslateAll(machines, writer, machineValidator); err != nil {
-		return err
-	}
-
-	// Validate must happen last beacuse we depend on the catalogue entries for some checks.
-	if err := validator.Validate(tinkerbellClusterSpec); err != nil {
-		return err
-	}
-
-	// TODO: Add validations when this is supported
 	return nil
 }
 
@@ -148,4 +170,8 @@ func (p *Provider) PostClusterDeleteForUpgrade(ctx context.Context, managementCl
 		return err
 	}
 	return nil
+}
+
+func (p *Provider) hardareCSVIsProvided() bool {
+	return p.hardwareCSVFile != ""
 }


### PR DESCRIPTION
When upgrading a Tinkerbell Enabled Management Cluster we need to ensure there is sufficient hardware. We allow applying additional hardware as well as leveraging existing unprovisioned hardware during upgrade execution. This PR populates the in-memory catalogue using CSV data and existing Hardware resource data, retrieved from the cluster, where it can be validated for the desired operation (scale-up, upgrade, etc). 

A future PR will introduce the assertions given they're different dependent on what kind of upgrade activity the user is invoking. 