### PR TITLE
Pull hook from the bundle

### DIFF
--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
@@ -152,7 +152,7 @@ func hardwareFromMachine(m Machine) *v1alpha1.Hardware {
 							Gateway: m.Gateway,
 							Family:  4,
 						},
-						LeaseTime:   2630000,
+						LeaseTime:   86400,
 						Hostname:    m.Hostname,
 						NameServers: m.Nameservers,
 						UEFI:        true,

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
@@ -152,7 +152,7 @@ func hardwareFromMachine(m Machine) *v1alpha1.Hardware {
 							Gateway: m.Gateway,
 							Family:  4,
 						},
-						LeaseTime:   86400,
+						LeaseTime:   2630000,
 						Hostname:    m.Hostname,
 						NameServers: m.Nameservers,
 						UEFI:        true,

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -40,6 +40,13 @@ func getTinkBundle() releasev1alpha1.TinkerbellStackBundle {
 		Hegel: releasev1alpha1.TinkerbellServiceBundle{
 			Image: releasev1alpha1.Image{URI: "hegel:latest"},
 		},
+		Hook: releasev1alpha1.HookBundle{
+			Initramfs: releasev1alpha1.HookArch{
+				Amd: releasev1alpha1.Archive{
+					URI: "https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/initramfs-x86-64",
+				},
+			},
+		},
 	}
 }
 
@@ -83,10 +90,9 @@ func TestTinkerbellStackInstallWithBootsOnDockerSuccess(t *testing.T) {
 	helm.EXPECT().InstallChartWithValuesFile(ctx, helmChartName, helmChartOci, helmChartVersion, cluster.KubeconfigFile, overridesFileName)
 	docker.EXPECT().Run(ctx, "boots:latest",
 		boots,
-		[]string{"-kubeconfig", "/kubeconfig", "-dhcp-addr", "0.0.0.0:67"},
+		[]string{"-kubeconfig", "/kubeconfig", "-dhcp-addr", "0.0.0.0:67", "-osie-path-override", "https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook"},
 		"-v", gomock.Any(),
 		"--network", "host",
-		"-e", gomock.Any(),
 		"-e", gomock.Any(),
 		"-e", gomock.Any(),
 		"-e", gomock.Any(),


### PR DESCRIPTION
*Description of changes:*
This PR updates the cli to pull the Hook images from the URIs listed in the bundle instead of being hardcoded.
It also bumps up the lease duration for IPs handed out by boots to 1 month

*Testing (if applicable):*
Created the cluster with the hook from bundle

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

