### PR TITLE
Use helm chart from bundle in Tinkerbell

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -28,11 +28,6 @@ const (
 	tinkServer     = "tinkServer"
 	rufio          = "rufio"
 	grpcPort       = "42113"
-
-	// TODO: remove this once the chart is added to bundle
-	helmChartOci     = "oci://public.ecr.aws/i7k6m1j7/tinkerbell/tinkerbell-chart"
-	helmChartName    = "tinkerbell-chart"
-	helmChartVersion = "0.1.0"
 )
 
 type Docker interface {
@@ -149,7 +144,15 @@ func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 		return fmt.Errorf("writing values override for Tinkerbell Installer helm chart: %s", err)
 	}
 
-	if err := s.helm.InstallChartWithValuesFile(ctx, helmChartName, helmChartOci, helmChartVersion, kubeconfig, valuesPath); err != nil {
+	err = s.helm.InstallChartWithValuesFile(
+		ctx,
+		bundle.TinkebellChart.Name,
+		fmt.Sprintf("oci://%s", bundle.TinkebellChart.Image()),
+		bundle.TinkebellChart.Tag(),
+		kubeconfig,
+		valuesPath,
+	)
+	if err != nil {
 		return fmt.Errorf("installing Tinkerbell helm chart: %v", err)
 	}
 

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -23,11 +23,12 @@ const (
 	boots             = "boots"
 	testIP            = "1.2.3.4"
 
-	// TODO: remove this once the chart is added to bundle
-	helmChartOci     = "oci://public.ecr.aws/i7k6m1j7/tinkerbell/tinkerbell-chart"
+	helmChartPath    = "public.ecr.aws/eks-anywhere/tinkerbell/tinkerbell-chart"
 	helmChartName    = "tinkerbell-chart"
 	helmChartVersion = "0.1.0"
 )
+
+var helmChartURI = fmt.Sprintf("%s:%s", helmChartPath, helmChartVersion)
 
 func getTinkBundle() releasev1alpha1.TinkerbellStackBundle {
 	return releasev1alpha1.TinkerbellStackBundle{
@@ -47,6 +48,10 @@ func getTinkBundle() releasev1alpha1.TinkerbellStackBundle {
 				},
 			},
 		},
+		TinkebellChart: releasev1alpha1.Image{
+			Name: helmChartName,
+			URI:  helmChartURI,
+		},
 	}
 }
 
@@ -63,7 +68,7 @@ func TestTinkerbellStackInstallWithAllOptionsSuccess(t *testing.T) {
 
 	writer.EXPECT().Write(overridesFileName, gomock.Any()).Return(overridesFileName, nil)
 
-	helm.EXPECT().InstallChartWithValuesFile(ctx, helmChartName, helmChartOci, helmChartVersion, cluster.KubeconfigFile, overridesFileName)
+	helm.EXPECT().InstallChartWithValuesFile(ctx, helmChartName, fmt.Sprintf("oci://%s", helmChartPath), helmChartVersion, cluster.KubeconfigFile, overridesFileName)
 
 	if err := s.Install(ctx,
 		getTinkBundle(),
@@ -87,7 +92,7 @@ func TestTinkerbellStackInstallWithBootsOnDockerSuccess(t *testing.T) {
 	s := stack.NewInstaller(docker, writer, helm)
 
 	writer.EXPECT().Write(overridesFileName, gomock.Any()).Return(overridesFileName, nil)
-	helm.EXPECT().InstallChartWithValuesFile(ctx, helmChartName, helmChartOci, helmChartVersion, cluster.KubeconfigFile, overridesFileName)
+	helm.EXPECT().InstallChartWithValuesFile(ctx, helmChartName, fmt.Sprintf("oci://%s", helmChartPath), helmChartVersion, cluster.KubeconfigFile, overridesFileName)
 	docker.EXPECT().Run(ctx, "boots:latest",
 		boots,
 		[]string{"-kubeconfig", "/kubeconfig", "-dhcp-addr", "0.0.0.0:67", "-osie-path-override", "https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook"},


### PR DESCRIPTION
*Description of changes:*
Use tinkerbell helm chart from bundle instead of using a hardcoded one

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

