### PR TITLE
Set hardware lease time to 1 month

### DIFF
--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
@@ -1,6 +1,8 @@
 package hardware
 
 import (
+	"time"
+
 	"github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -154,7 +156,8 @@ func hardwareFromMachine(m Machine) *v1alpha1.Hardware {
 							Gateway: m.Gateway,
 							Family:  4,
 						},
-						LeaseTime:   86400,
+						// set LeaseTime to 1 month while we figure out how to set static IPs
+						LeaseTime:   int64(time.Hour * 24 * 30 / time.Second),
 						Hostname:    m.Hostname,
 						NameServers: m.Nameservers,
 						UEFI:        true,


### PR DESCRIPTION
*Description of changes:*
Set hardware DHCP lease duration to 1 month temporarily while we figure out how to set static IPs on the nodes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

