### PR TITLE
Quick sleep in git setup

### DIFF
--- a/internal/test/e2e/fluxGit.go
+++ b/internal/test/e2e/fluxGit.go
@@ -141,6 +141,7 @@ func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*g
 		return nil, fmt.Errorf("creating repository in Github for test: %v", err)
 	}
 
+	// Wait for eventual consistency in the GitHub API when creating a repository
 	time.Sleep(time.Second * 5)
 
 	pk, pub, err := e.generateKeyPairForGitTest()

--- a/internal/test/e2e/fluxGit.go
+++ b/internal/test/e2e/fluxGit.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"regexp"
+	"time"
 
 	"github.com/aws/eks-anywhere/internal/pkg/ssm"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -139,6 +140,8 @@ func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*g
 	if err != nil {
 		return nil, fmt.Errorf("creating repository in Github for test: %v", err)
 	}
+
+	time.Sleep(time.Second * 5)
 
 	pk, pub, err := e.generateKeyPairForGitTest()
 	if err != nil {

--- a/internal/test/e2e/fluxGit.go
+++ b/internal/test/e2e/fluxGit.go
@@ -141,7 +141,7 @@ func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*g
 		return nil, fmt.Errorf("creating repository in Github for test: %v", err)
 	}
 
-	// Wait for eventual consistency in the GitHub API when creating a repository
+	// Wait for eventual consistency in the GitHub API when creating a repository before adding a deploy key
 	time.Sleep(time.Second * 5)
 
 	pk, pub, err := e.generateKeyPairForGitTest()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
getting 404s when attempting to add a deploy key to the newly created repositories in the Github tests; I ran into this on my local one time out of dozens of tests; I'm wondering if this is related to eventual consistency int he GitHub API, want to try a sleep to see if it influences the problem.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

