### PR TITLE
Skeleton for methods to rerun CLI commands

### DIFF
--- a/pkg/task/mocks/task.go
+++ b/pkg/task/mocks/task.go
@@ -35,6 +35,20 @@ func (m *MockTask) EXPECT() *MockTaskMockRecorder {
 	return m.recorder
 }
 
+// Checkpoint mocks base method.
+func (m *MockTask) Checkpoint() *task.CompletedTask {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Checkpoint")
+	ret0, _ := ret[0].(*task.CompletedTask)
+	return ret0
+}
+
+// Checkpoint indicates an expected call of Checkpoint.
+func (mr *MockTaskMockRecorder) Checkpoint() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Checkpoint", reflect.TypeOf((*MockTask)(nil).Checkpoint))
+}
+
 // Name mocks base method.
 func (m *MockTask) Name() string {
 	m.ctrl.T.Helper()
@@ -47,6 +61,21 @@ func (m *MockTask) Name() string {
 func (mr *MockTaskMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockTask)(nil).Name))
+}
+
+// Restore mocks base method.
+func (m *MockTask) Restore(arg0 context.Context, arg1 *task.CommandContext, arg2 *task.CompletedTask) (task.Task, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Restore", arg0, arg1, arg2)
+	ret0, _ := ret[0].(task.Task)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Restore indicates an expected call of Restore.
+func (mr *MockTaskMockRecorder) Restore(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Restore", reflect.TypeOf((*MockTask)(nil).Restore), arg0, arg1, arg2)
 }
 
 // Run mocks base method.

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -16,6 +16,8 @@ import (
 type Task interface {
 	Run(ctx context.Context, commandContext *CommandContext) Task
 	Name() string
+	Checkpoint() *CompletedTask
+	Restore(ctx context.Context, commandContext *CommandContext, completedTask *CompletedTask) (Task, error)
 }
 
 // Command context maintains the mutable and shared entities
@@ -100,7 +102,8 @@ func (pp *Profiler) logProfileSummary(taskName string) {
 
 // Manages Task execution
 type taskRunner struct {
-	task Task
+	task   Task
+	writer filewriter.FileWriter
 }
 
 // executes Task
@@ -127,8 +130,19 @@ func taskRunnerFinalBlock(startTime time.Time) {
 	logger.V(4).Info("Tasks completed", "duration", time.Since(startTime))
 }
 
-func NewTaskRunner(task Task) *taskRunner {
+func NewTaskRunner(task Task, writer filewriter.FileWriter) *taskRunner {
 	return &taskRunner{
-		task: task,
+		task:   task,
+		writer: writer,
 	}
+}
+
+type TaskCheckpoint interface{}
+
+type CheckpointInfo struct {
+	CompletedTasks map[string]*CompletedTask `json:"completedTasks"`
+}
+
+type CompletedTask struct {
+	Checkpoint TaskCheckpoint `json:"checkpoint"`
 }

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 
+	writermocks "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
 	"github.com/aws/eks-anywhere/pkg/task"
 	mocktasks "github.com/aws/eks-anywhere/pkg/task/mocks"
 )
@@ -43,7 +44,7 @@ func TestTaskRunnerRunTask(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner := task.NewTaskRunner(tt.fields.tasks[0])
+			runner := task.NewTaskRunner(tt.fields.tasks[0], writermocks.NewMockFileWriter(ctrl))
 			if err := runner.RunTask(ctx, cmdContext); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -62,7 +62,7 @@ func (c *Create) Run(ctx context.Context, clusterSpec *cluster.Spec, validator i
 		commandContext.BootstrapCluster = clusterSpec.ManagementCluster
 	}
 
-	err := task.NewTaskRunner(&SetAndValidateTask{}).RunTask(ctx, commandContext)
+	err := task.NewTaskRunner(&SetAndValidateTask{}, c.writer).RunTask(ctx, commandContext)
 	if err != nil {
 		return err
 	}
@@ -150,6 +150,14 @@ func (s *CreateBootStrapClusterTask) Name() string {
 	return "bootstrap-cluster-init"
 }
 
+func (s *CreateBootStrapClusterTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *CreateBootStrapClusterTask) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
 // SetAndValidateTask implementation
 
 func (s *SetAndValidateTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
@@ -191,6 +199,14 @@ func (s *SetAndValidateTask) providerValidation(ctx context.Context, commandCont
 
 func (s *SetAndValidateTask) Name() string {
 	return "setup-validate"
+}
+
+func (s *SetAndValidateTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *SetAndValidateTask) Checkpoint() *task.CompletedTask {
+	return nil
 }
 
 // CreateWorkloadClusterTask implementation
@@ -256,6 +272,14 @@ func (s *CreateWorkloadClusterTask) Name() string {
 	return "workload-cluster-init"
 }
 
+func (s *CreateWorkloadClusterTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *CreateWorkloadClusterTask) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
 // InstallResourcesOnManagement implementation
 func (s *InstallResourcesOnManagementTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	if commandContext.BootstrapCluster.ExistingManagement {
@@ -272,6 +296,14 @@ func (s *InstallResourcesOnManagementTask) Run(ctx context.Context, commandConte
 
 func (s *InstallResourcesOnManagementTask) Name() string {
 	return "install-resources-on-management-cluster"
+}
+
+func (s *InstallResourcesOnManagementTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *InstallResourcesOnManagementTask) Checkpoint() *task.CompletedTask {
+	return nil
 }
 
 // MoveClusterManagementTask implementation
@@ -292,6 +324,14 @@ func (s *MoveClusterManagementTask) Run(ctx context.Context, commandContext *tas
 
 func (s *MoveClusterManagementTask) Name() string {
 	return "capi-management-move"
+}
+
+func (s *MoveClusterManagementTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *MoveClusterManagementTask) Checkpoint() *task.CompletedTask {
+	return nil
 }
 
 // InstallEksaComponentsTask implementation
@@ -346,6 +386,14 @@ func (s *InstallEksaComponentsTask) Name() string {
 	return "eksa-components-install"
 }
 
+func (s *InstallEksaComponentsTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *InstallEksaComponentsTask) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
 // InstallAddonManagerTask implementation
 
 func (s *InstallAddonManagerTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
@@ -363,6 +411,14 @@ func (s *InstallAddonManagerTask) Name() string {
 	return "addon-manager-install"
 }
 
+func (s *InstallAddonManagerTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *InstallAddonManagerTask) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
 func (s *WriteClusterConfigTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Writing cluster config file")
 	err := clustermarshaller.WriteClusterConfig(commandContext.ClusterSpec, commandContext.Provider.DatacenterConfig(commandContext.ClusterSpec), commandContext.Provider.MachineConfigs(commandContext.ClusterSpec), commandContext.Writer)
@@ -375,6 +431,14 @@ func (s *WriteClusterConfigTask) Run(ctx context.Context, commandContext *task.C
 
 func (s *WriteClusterConfigTask) Name() string {
 	return "write-cluster-config"
+}
+
+func (s *WriteClusterConfigTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *WriteClusterConfigTask) Checkpoint() *task.CompletedTask {
+	return nil
 }
 
 // DeleteBootstrapClusterTask implementation

--- a/pkg/workflows/delete.go
+++ b/pkg/workflows/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/task"
@@ -16,6 +17,7 @@ type Delete struct {
 	provider       providers.Provider
 	clusterManager interfaces.ClusterManager
 	addonManager   interfaces.AddonManager
+	writer         filewriter.FileWriter
 }
 
 func NewDelete(bootstrapper interfaces.Bootstrapper, provider providers.Provider,
@@ -51,7 +53,7 @@ func (c *Delete) Run(ctx context.Context, workloadCluster *types.Cluster, cluste
 		commandContext.BootstrapCluster = clusterSpec.ManagementCluster
 	}
 
-	return task.NewTaskRunner(&setupAndValidate{}).RunTask(ctx, commandContext)
+	return task.NewTaskRunner(&setupAndValidate{}, c.writer).RunTask(ctx, commandContext)
 }
 
 type setupAndValidate struct{}
@@ -80,6 +82,14 @@ func (s *setupAndValidate) Run(ctx context.Context, commandContext *task.Command
 
 func (s *setupAndValidate) Name() string {
 	return "setup-and-validate"
+}
+
+func (s *setupAndValidate) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *setupAndValidate) Checkpoint() *task.CompletedTask {
+	return nil
 }
 
 func (s *createManagementCluster) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
@@ -114,6 +124,14 @@ func (s *createManagementCluster) Name() string {
 	return "management-cluster-init"
 }
 
+func (s *createManagementCluster) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *createManagementCluster) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
 func (s *installCAPI) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Installing cluster-api providers on management cluster")
 	err := commandContext.ClusterManager.InstallCAPI(ctx, commandContext.ClusterSpec, commandContext.BootstrapCluster, commandContext.Provider)
@@ -128,6 +146,14 @@ func (s *installCAPI) Name() string {
 	return "install-capi"
 }
 
+func (s *installCAPI) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *installCAPI) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
 func (s *moveClusterManagement) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Moving cluster management from workload cluster")
 	err := commandContext.ClusterManager.MoveCAPI(ctx, commandContext.WorkloadCluster, commandContext.BootstrapCluster, commandContext.WorkloadCluster.Name, commandContext.ClusterSpec, types.WithNodeRef())
@@ -140,6 +166,14 @@ func (s *moveClusterManagement) Run(ctx context.Context, commandContext *task.Co
 
 func (s *moveClusterManagement) Name() string {
 	return "cluster-management-move"
+}
+
+func (s *moveClusterManagement) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *moveClusterManagement) Checkpoint() *task.CompletedTask {
+	return nil
 }
 
 func (s *deleteWorkloadCluster) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
@@ -157,6 +191,14 @@ func (s *deleteWorkloadCluster) Name() string {
 	return "delete-workload-cluster"
 }
 
+func (s *deleteWorkloadCluster) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *deleteWorkloadCluster) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
 func (s *cleanupGitRepo) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Clean up Git Repo")
 	err := commandContext.AddonManager.CleanupGitRepo(ctx, commandContext.ClusterSpec)
@@ -170,6 +212,14 @@ func (s *cleanupGitRepo) Run(ctx context.Context, commandContext *task.CommandCo
 
 func (s *cleanupGitRepo) Name() string {
 	return "clean-up-git-repo"
+}
+
+func (s *cleanupGitRepo) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *cleanupGitRepo) Checkpoint() *task.CompletedTask {
+	return nil
 }
 
 func (s *deleteManagementCluster) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
@@ -192,4 +242,12 @@ func (s *deleteManagementCluster) Run(ctx context.Context, commandContext *task.
 
 func (s *deleteManagementCluster) Name() string {
 	return "kind-cluster-delete"
+}
+
+func (s *deleteManagementCluster) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *deleteManagementCluster) Checkpoint() *task.CompletedTask {
+	return nil
 }

--- a/pkg/workflows/diagnostics.go
+++ b/pkg/workflows/diagnostics.go
@@ -29,6 +29,14 @@ func (s *CollectDiagnosticsTask) Name() string {
 	return "collect-cluster-diagnostics"
 }
 
+func (s *CollectDiagnosticsTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return s.Run(ctx, commandContext), nil
+}
+
+func (s *CollectDiagnosticsTask) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
 // CollectWorkloadClusterDiagnosticsTask implementation
 
 func (s *CollectWorkloadClusterDiagnosticsTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
@@ -51,4 +59,12 @@ func (s *CollectMgmtClusterDiagnosticsTask) Run(ctx context.Context, commandCont
 
 func (s *CollectMgmtClusterDiagnosticsTask) Name() string {
 	return "collect-management-cluster-diagnostics"
+}
+
+func (s *CollectMgmtClusterDiagnosticsTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *CollectMgmtClusterDiagnosticsTask) Checkpoint() *task.CompletedTask {
+	return nil
 }

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -70,7 +70,7 @@ func (c *Upgrade) Run(ctx context.Context, clusterSpec *cluster.Spec, management
 		UpgradeChangeDiff: c.upgradeChangeDiff,
 	}
 
-	return task.NewTaskRunner(&setupAndValidateTasks{}).RunTask(ctx, commandContext)
+	return task.NewTaskRunner(&setupAndValidateTasks{}, c.writer).RunTask(ctx, commandContext)
 }
 
 type setupAndValidateTasks struct{}
@@ -144,6 +144,14 @@ func (s *setupAndValidateTasks) Name() string {
 	return "setup-and-validate"
 }
 
+func (s *setupAndValidateTasks) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return &updateSecrets{}, nil
+}
+
+func (s *setupAndValidateTasks) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
 func (s *updateSecrets) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	err := commandContext.Provider.UpdateSecrets(ctx, commandContext.ManagementCluster)
 	if err != nil {
@@ -155,6 +163,14 @@ func (s *updateSecrets) Run(ctx context.Context, commandContext *task.CommandCon
 
 func (s *updateSecrets) Name() string {
 	return "update-secrets"
+}
+
+func (s *updateSecrets) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+func (s *updateSecrets) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return &ensureEtcdCAPIComponentsExistTask{}, nil
 }
 
 func (s *ensureEtcdCAPIComponentsExistTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
@@ -174,6 +190,14 @@ func (s *ensureEtcdCAPIComponentsExistTask) Run(ctx context.Context, commandCont
 
 func (s *ensureEtcdCAPIComponentsExistTask) Name() string {
 	return "ensure-etcd-capi-components-exist"
+}
+
+func (s *ensureEtcdCAPIComponentsExistTask) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+func (s *ensureEtcdCAPIComponentsExistTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return &upgradeCoreComponents{}, nil
 }
 
 func (s *upgradeCoreComponents) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
@@ -227,6 +251,14 @@ func (s *upgradeCoreComponents) Name() string {
 	return "upgrade-core-components"
 }
 
+func (s *upgradeCoreComponents) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+func (s *upgradeCoreComponents) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return &upgradeNeeded{}, nil
+}
+
 func (s *upgradeNeeded) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	newSpec := commandContext.ClusterSpec
 
@@ -255,6 +287,14 @@ func (s *upgradeNeeded) Name() string {
 	return "upgrade-needed"
 }
 
+func (s *upgradeNeeded) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+func (s *upgradeNeeded) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return &pauseEksaAndFluxReconcile{}, nil
+}
+
 func (s *pauseEksaAndFluxReconcile) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Pausing EKS-A cluster controller reconcile")
 	err := commandContext.ClusterManager.PauseEKSAControllerReconcile(ctx, commandContext.ManagementCluster, commandContext.CurrentClusterSpec, commandContext.Provider)
@@ -274,6 +314,14 @@ func (s *pauseEksaAndFluxReconcile) Run(ctx context.Context, commandContext *tas
 
 func (s *pauseEksaAndFluxReconcile) Name() string {
 	return "pause-controllers-reconcile"
+}
+
+func (s *pauseEksaAndFluxReconcile) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+func (s *pauseEksaAndFluxReconcile) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return &createBootstrapClusterTask{}, nil
 }
 
 func (s *createBootstrapClusterTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
@@ -313,6 +361,17 @@ func (s *createBootstrapClusterTask) Name() string {
 	return "bootstrap-cluster-init"
 }
 
+func (s *createBootstrapClusterTask) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+func (s *createBootstrapClusterTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	if commandContext.ManagementCluster != nil && commandContext.ManagementCluster.ExistingManagement {
+		return &upgradeWorkloadClusterTask{}, nil
+	}
+	return &installCAPITask{}, nil
+}
+
 func (s *installCAPITask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Installing cluster-api providers on bootstrap cluster")
 	err := commandContext.ClusterManager.InstallCAPI(ctx, commandContext.ClusterSpec, commandContext.BootstrapCluster, commandContext.Provider)
@@ -325,6 +384,14 @@ func (s *installCAPITask) Run(ctx context.Context, commandContext *task.CommandC
 
 func (s *installCAPITask) Name() string {
 	return "install-capi"
+}
+
+func (s *installCAPITask) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+func (s *installCAPITask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return &moveManagementToBootstrapTask{}, nil
 }
 
 func (s *moveManagementToBootstrapTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
@@ -340,6 +407,14 @@ func (s *moveManagementToBootstrapTask) Run(ctx context.Context, commandContext 
 
 func (s *moveManagementToBootstrapTask) Name() string {
 	return "capi-management-move-to-bootstrap"
+}
+
+func (s *moveManagementToBootstrapTask) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+func (s *moveManagementToBootstrapTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return &upgradeWorkloadClusterTask{}, nil
 }
 
 func (s *upgradeWorkloadClusterTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
@@ -372,6 +447,14 @@ func (s *upgradeWorkloadClusterTask) Name() string {
 	return "upgrade-workload-cluster"
 }
 
+func (s *upgradeWorkloadClusterTask) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+func (s *upgradeWorkloadClusterTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return &moveManagementToWorkloadTask{}, nil
+}
+
 func (s *moveManagementToWorkloadTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	if commandContext.ManagementCluster.ExistingManagement {
 		return &updateClusterAndGitResources{}
@@ -393,6 +476,14 @@ func (s *moveManagementToWorkloadTaskAndExit) Run(ctx context.Context, commandCo
 
 func (s *moveManagementToWorkloadTask) Name() string {
 	return "capi-management-move-to-workload"
+}
+
+func (s *moveManagementToWorkloadTask) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+func (s *moveManagementToWorkloadTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return &updateClusterAndGitResources{}, nil
 }
 
 func (s *updateClusterAndGitResources) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
@@ -430,6 +521,14 @@ func (s *updateClusterAndGitResources) Name() string {
 	return "update-resources"
 }
 
+func (s *updateClusterAndGitResources) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+func (s *updateClusterAndGitResources) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return &resumeFluxReconcile{}, nil
+}
+
 func (s *resumeFluxReconcile) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Forcing reconcile Git repo with latest commit")
 	err := commandContext.AddonManager.ForceReconcileGitRepo(ctx, commandContext.ManagementCluster, commandContext.ClusterSpec)
@@ -451,6 +550,14 @@ func (s *resumeFluxReconcile) Name() string {
 	return "resume-flux-kustomization"
 }
 
+func (s *resumeFluxReconcile) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+func (s *resumeFluxReconcile) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return &writeClusterConfigTask{}, nil
+}
+
 func (s *writeClusterConfigTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Writing cluster config file")
 	err := clustermarshaller.WriteClusterConfig(commandContext.ClusterSpec, commandContext.Provider.DatacenterConfig(commandContext.ClusterSpec), commandContext.Provider.MachineConfigs(commandContext.ClusterSpec), commandContext.Writer)
@@ -462,6 +569,14 @@ func (s *writeClusterConfigTask) Run(ctx context.Context, commandContext *task.C
 
 func (s *writeClusterConfigTask) Name() string {
 	return "write-cluster-config"
+}
+
+func (s *writeClusterConfigTask) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+func (s *writeClusterConfigTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return &deleteBootstrapClusterTask{}, nil
 }
 
 func (s *deleteBootstrapClusterTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a skeleton for the methods needed to rerun CLI commands. The `Restore()` method will restore the necessary information from the completed tasks & return the next task. The `Checkpoint()` method will return the information needed to save to the checkpoint file for that task. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

