### PR TITLE
Add validation to check if boots is already running on docker

### DIFF
--- a/pkg/executables/docker.go
+++ b/pkg/executables/docker.go
@@ -144,3 +144,18 @@ func (d *Docker) ForceRemove(ctx context.Context, name string) error {
 	}
 	return nil
 }
+
+// CheckContainerExistence checks whether a Docker container with the provided name exists
+// It returns true if a container with the name exists, false if it doesn't and an error if it encounters some other error
+func (d *Docker) CheckContainerExistence(ctx context.Context, name string) (bool, error) {
+	params := []string{"container", "inspect", name}
+
+	_, err := d.Execute(ctx, params...)
+	if err == nil {
+		return true, nil
+	} else if strings.Contains(err.Error(), "No such container") {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("checking if a docker container with name %s exists: %v", name, err)
+}

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -99,6 +99,10 @@ func (p *Provider) PostWorkloadInit(ctx context.Context, cluster *types.Cluster,
 }
 
 func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpec *cluster.Spec) error {
+	if err := p.stackInstaller.CheckLocalBootsExistence(ctx); err != nil {
+		return err
+	}
+
 	// TODO(chrisdoherty4) Extract to a defaulting construct and add associated validations to ensure
 	// there is always a user with ssh key configured.
 	if err := p.configureSshKeys(); err != nil {

--- a/pkg/providers/tinkerbell/stack/mocks/stack.go
+++ b/pkg/providers/tinkerbell/stack/mocks/stack.go
@@ -36,6 +36,21 @@ func (m *MockDocker) EXPECT() *MockDockerMockRecorder {
 	return m.recorder
 }
 
+// CheckContainerExistence mocks base method.
+func (m *MockDocker) CheckContainerExistence(ctx context.Context, name string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckContainerExistence", ctx, name)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckContainerExistence indicates an expected call of CheckContainerExistence.
+func (mr *MockDockerMockRecorder) CheckContainerExistence(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckContainerExistence", reflect.TypeOf((*MockDocker)(nil).CheckContainerExistence), ctx, name)
+}
+
 // ForceRemove mocks base method.
 func (m *MockDocker) ForceRemove(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()
@@ -127,6 +142,20 @@ func NewMockStackInstaller(ctrl *gomock.Controller) *MockStackInstaller {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStackInstaller) EXPECT() *MockStackInstallerMockRecorder {
 	return m.recorder
+}
+
+// CheckLocalBootsExistence mocks base method.
+func (m *MockStackInstaller) CheckLocalBootsExistence(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckLocalBootsExistence", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckLocalBootsExistence indicates an expected call of CheckLocalBootsExistence.
+func (mr *MockStackInstallerMockRecorder) CheckLocalBootsExistence(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckLocalBootsExistence", reflect.TypeOf((*MockStackInstaller)(nil).CheckLocalBootsExistence), ctx)
 }
 
 // Install mocks base method.

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -66,6 +66,7 @@ func TestTinkerbellProviderGenerateDeploymentFileWithExternalEtcd(t *testing.T) 
 	docker := stackmocks.NewMockDocker(mockCtrl)
 	helm := stackmocks.NewMockHelm(mockCtrl)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	stackInstaller := stackmocks.NewMockStackInstaller(mockCtrl)
 	writer := filewritermocks.NewMockFileWriter(mockCtrl)
 	cluster := &types.Cluster{Name: "test"}
 
@@ -75,6 +76,10 @@ func TestTinkerbellProviderGenerateDeploymentFileWithExternalEtcd(t *testing.T) 
 	ctx := context.Background()
 
 	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl)
+	provider.stackInstaller = stackInstaller
+
+	stackInstaller.EXPECT().CheckLocalBootsExistence(ctx)
+
 	if err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec); err != nil {
 		t.Fatalf("failed to setup and validate: %v", err)
 	}
@@ -95,6 +100,7 @@ func TestTinkerbellProviderMachineConfigsMissingUserSshKeys(t *testing.T) {
 	docker := stackmocks.NewMockDocker(mockCtrl)
 	helm := stackmocks.NewMockHelm(mockCtrl)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	stackInstaller := stackmocks.NewMockStackInstaller(mockCtrl)
 	writer := filewritermocks.NewMockFileWriter(mockCtrl)
 	keyGenerator := mocks.NewMockSSHAuthKeyGenerator(mockCtrl)
 	cluster := &types.Cluster{Name: "test"}
@@ -109,8 +115,11 @@ func TestTinkerbellProviderMachineConfigsMissingUserSshKeys(t *testing.T) {
 
 	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl)
 
-	// Hack: monkey patch the key generator directly for determinism.
+	// Hack: monkey patch the key generator and the stack installer directly for determinism.
 	provider.keyGenerator = keyGenerator
+	provider.stackInstaller = stackInstaller
+
+	stackInstaller.EXPECT().CheckLocalBootsExistence(ctx)
 
 	if err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec); err != nil {
 		t.Fatalf("failed to setup and validate: %v", err)
@@ -131,6 +140,7 @@ func TestTinkerbellProviderGenerateDeploymentFileWithStackedEtcd(t *testing.T) {
 	docker := stackmocks.NewMockDocker(mockCtrl)
 	helm := stackmocks.NewMockHelm(mockCtrl)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	stackInstaller := stackmocks.NewMockStackInstaller(mockCtrl)
 	writer := filewritermocks.NewMockFileWriter(mockCtrl)
 	cluster := &types.Cluster{Name: "test"}
 
@@ -140,6 +150,10 @@ func TestTinkerbellProviderGenerateDeploymentFileWithStackedEtcd(t *testing.T) {
 	ctx := context.Background()
 
 	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl)
+	provider.stackInstaller = stackInstaller
+
+	stackInstaller.EXPECT().CheckLocalBootsExistence(ctx)
+
 	if err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec); err != nil {
 		t.Fatalf("failed to setup and validate: %v", err)
 	}
@@ -160,6 +174,7 @@ func TestTinkerbellProviderGenerateDeploymentFileMultipleWorkerNodeGroups(t *tes
 	docker := stackmocks.NewMockDocker(mockCtrl)
 	helm := stackmocks.NewMockHelm(mockCtrl)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	stackInstaller := stackmocks.NewMockStackInstaller(mockCtrl)
 	writer := filewritermocks.NewMockFileWriter(mockCtrl)
 	cluster := &types.Cluster{Name: "test"}
 
@@ -169,6 +184,10 @@ func TestTinkerbellProviderGenerateDeploymentFileMultipleWorkerNodeGroups(t *tes
 	ctx := context.Background()
 
 	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl)
+	provider.stackInstaller = stackInstaller
+
+	stackInstaller.EXPECT().CheckLocalBootsExistence(ctx)
+
 	if err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec); err != nil {
 		t.Fatalf("failed to setup and validate: %v", err)
 	}
@@ -186,10 +205,10 @@ func TestPreCAPIInstallOnBootstrapSuccess(t *testing.T) {
 	t.Setenv(features.TinkerbellProviderEnvVar, "true")
 	clusterSpecManifest := "cluster_tinkerbell_stacked_etcd.yaml"
 	mockCtrl := gomock.NewController(t)
-	stackInstaller := stackmocks.NewMockStackInstaller(mockCtrl)
 	docker := stackmocks.NewMockDocker(mockCtrl)
 	helm := stackmocks.NewMockHelm(mockCtrl)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	stackInstaller := stackmocks.NewMockStackInstaller(mockCtrl)
 	writer := filewritermocks.NewMockFileWriter(mockCtrl)
 	cluster := &types.Cluster{Name: "test", KubeconfigFile: "test.kubeconfig"}
 	ctx := context.Background()


### PR DESCRIPTION
*Description of changes:*
This PR adds a validation to check if boots is already running as a docker container on the local machine so the cli doesn't error out later on.
The PR to remove the local boots using the `force-cleanup` option is coming as part of a follow-up PR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

