### PR TITLE
Configuration reference doc for Bare Metal

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/baremetal.md
+++ b/docs/content/en/docs/reference/clusterspec/baremetal.md
@@ -282,6 +282,7 @@ the existing nodes associated with the configuration.
 
 ### tinkerbellIP
 Optional field to identify the IP address of the Tinkerbell service.
+Other TinkerbellDatacenterConfig fields are not yet supported.
 
 ## TinkerBellMachineConfig Fields
 
@@ -296,6 +297,7 @@ See TinkerbellTemplateConfig fields below.
 The name of the user you want to configure to access your virtual machines through SSH.
 
 The default is `ec2-user`.
+Currently, only one user is supported.
 
 ### users[0].sshAuthorizedKeys (optional)
 The SSH public keys you want to configure to access your machines through SSH (as described below). Only 1 is supported at this time.
@@ -319,11 +321,11 @@ For advanced users, you can modify these fields if you have special needs to do 
 
 ### template.global_timeout
 
-NEED INFO. Set to 6000 in example (100 minutes?). Different for different OS families?
+Sets the timeout value for completing the configuration. Set to 6000 (100 minutes) by default.
 
 ### template.id
 
-NEED INFO
+Not set by default.
 
 ### template.tasks
 
@@ -333,17 +335,17 @@ The following descriptions cover the actions shown in the example template:
 ### template.tasks.actions.name.stream-image
 The `stream-image` action streams the selected image to machine you are provisioning. It identifies:
 
-* environment.COMPRESSED: NEED INFO
+* environment.COMPRESSED: When set to `true`, Tinkerbell expects `IMG_URL` to be a compressed image, which Tinkerbell will uncompress when it writes the contents to disk.
 * environment.DEST_DISK: The hard disk on which the operating system is desployed. The default is the first SCSI disk (/dev/sda), but can be changed for other disk types.
 * environment.IMG_URL: The operating system tarball (ubuntu or other) to stream to the machine you are configuring.
 * image: Container image needed to perform the steps needed by this action.
-* timeout: NEED INFO (Set to 360 (six minutes???). Is the timout to get the image???)
+* timeout: Sets the amount of time (in seconds) that Tinkerbell has to stream the image, uncompress it, and write it to disk before timing out. Consider increasing this limit from the default 360 (six minutes) to a higher limit if this action is timing out.
 
 ### template.tasks.actions.name.write-netplan
-The `write-netplan` action writes network configuration information to the machine. It identifies:
+The `write-netplan` action writes Ubuntu network configuration information to the machine (see [Netplan](https://netplan.io/)) for details. It identifies:
 
-* environment.CONTENTS.network.version: NEED INFO. CNI version, cilium version??? 
-* environment.CONTENTS.network.renderer: NEED INFO  What is "networkd"????
+* environment.CONTENTS.network.version: Identifies the network version.
+* environment.CONTENTS.network.renderer: Defines the service to manage networking. By default, the `networkd` systemd service is used.
 * environment.CONTENTS.network.ethernets: Network interface to external network (eno1, by default) and whether or not to use dhcp4 (true, by default).
 * environment.DEST_DISK: Destination block storage device partition where the operating system is copied. By default, /dev/sda2 is used (sda1 is the UEFI partition). 
 * environment.DEST_PATH: File where the networking configuration is written (/etc/netplan/config.yaml, by default).
@@ -356,26 +358,26 @@ The `write-netplan` action writes network configuration information to the machi
 * timeout:
 
 ### template.tasks.actions.add-tink-cloud-init-config
-The `add-tink-cloud-init-config` action configures cloud-init features to further configure the operating system. It identifies:
+The `add-tink-cloud-init-config` action configures cloud-init features to further configure the operating system. See [cloud-init Documentation](https://cloudinit.readthedocs.io/en/latest/) for details. It identifies:
 
-* environment.CONTENTS.datasource: NEED INFO. Ec2.metadata_urls: [] Ec2.strict_id: false
+* environment.CONTENTS.datasource: Identifies Ec2 (Ec2.metadata_urls) as the data source and sets `Ec2.strict_id: false` to prevent could init from producing warnings about this datasource.
 * environment.CONTENTS.system_info: Creates the `tink` user and gives it administrative group privileges (wheel, adm) and passwordless sudo privileges, and set the default shell (/bin/bash).
-* environment.CONTENTS.manage_etc_hosts NEED INFO.  Set to localhost.
-* environment.CONTENTS.warnings: NEED INFO. Sets dsid_missing_source: off
-* environment.DEST_DISK: Destination block storage device partition where the operating system is located (/dev/sda2, by default).
-* environment.DEST_PATH: Location of the cloud-init configuration file on disk (/etc/cloud/cloud.cfg.d/10_tinkerbell.cfg, by default)
+* environment.CONTENTS.manage_etc_hosts: Updates the system's `/etc/hosts` file with the hostname. Set to `localhost` by default.
+* environment.CONTENTS.warnings: Sets dsid_missing_source to `off`.
+* environment.DEST_DISK: Destination block storage device partition where the operating system is located (`/dev/sda2`, by default).
+* environment.DEST_PATH: Location of the cloud-init configuration file on disk (`/etc/cloud/cloud.cfg.d/10_tinkerbell.cfg`, by default)
 * environment.DIRMODE: Linux directory permissions bits to use when creating directories (0700, by default)
 * environment.FS_TYPE: Type of filesystem on the partition (ext4, by default).
 * environment.GID: The Linux group ID to set on file. Set to 0 (root group) by default.
 * environment.MODE: The Linux permission bits to set on file (0600, by default).
 * environment.UID: The Linux user ID to set on file. Set to 0 (root user) by default.
 * image: Container image used to perform the steps needed by this action.
-* timeout: NEED INFO. Set to 90, by default
+* timeout: Time needed to complete the action. Set to 90, by default
 
 ### template.tasks.actions.add-tink-cloud-init-ds-config
 The `add-tink-cloud-init-ds-config` action configures cloud-init data store features. This identifies the location of your metadata source once the machine is up and running. It identifies:
 
-* environment.CONTENTS.datasource: NEED INFO. Set to Ec2.
+* environment.CONTENTS.datasource: Sets the datasource. Uses Ec2, by default.
 * environment.DEST_DISK: Destination block storage device partition where the operating system is located (/dev/sda2, by default).
 * environment.DEST_PATH: Location of the data store identity configuration file on disk (/etc/cloud/ds-identify.cfg, by default) 
 * environment.DIRMODE: Linux directory permissions bits to use when creating directories (0700, by default)
@@ -384,7 +386,7 @@ The `add-tink-cloud-init-ds-config` action configures cloud-init data store feat
 * environment.MODE: The Linux permission bits to set on file (0600, by default).
 * environment.UID: The Linux user ID to set on file. Set to 0 (root user) by default.
 * image: Container image used to perform the steps needed by this action.
-* timeout: NEED INFO. Set to 90, by default
+* timeout: Time needed to complete the action. Set to 90, by default
 
 ### template.tasks.actions.kexec-image
 The `kexec-image` action performs provisioning activities on the machine, then allows kexec to pivot the kernel to use the system installed on disk. This action identifies:
@@ -392,12 +394,11 @@ The `kexec-image` action performs provisioning activities on the machine, then a
 * environment.BLOCK_DEVICE: Disk partition on which the operating system is installed (/dev/sda2, by default)
 * environment.FS_TYPE: Type of filesystem on the partition (ext4, by default).
 * image: Container image used to perform the steps needed by this action.
-* pid: NEED INFO. Set to host.
-* timeout: NEED INFO. Set to 90.
+* pid: Process ID. Set to host, by default.
+* timeout: Time needed to complete the action. Set to 90.
 * volumes: Identifies mount points that need to be remounted to point to locations in the installed system.
 
 If your hardware requires a full reboot, you can change the kexec-image setting as follows:
-
 
 ```
 actions:

--- a/docs/content/en/docs/reference/clusterspec/baremetal.md
+++ b/docs/content/en/docs/reference/clusterspec/baremetal.md
@@ -198,7 +198,7 @@ The following fields identify information needed to configure the nodes in each 
 ### hardwareSelector
 Use fields under `hardwareSelector` to add key/value pair labels to match particular machines that you identified in the CSV file where you defined the machines in your cluster.
 Choose any label name you like.
-For example, if you had added the label `node=cp-machine` to all the machines listed in your CSV file, the following `hardwareSelector` field would cause those machines to be added to the control plane:
+For example, if you had added the label `node=cp-machine` to the machines listed in your CSV file that you want to be control plane nodes, the following `hardwareSelector` field would cause those machines to be added to the control plane:
 ```bash
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1

--- a/docs/content/en/docs/reference/clusterspec/baremetal.md
+++ b/docs/content/en/docs/reference/clusterspec/baremetal.md
@@ -103,11 +103,11 @@ CNI plugin to be installed in the cluster. The only supported value at the momen
 
 ### clusterNetwork.pods.cidrBlocks[0] (required)
 Subnet used by pods in CIDR notation. Please note that only 1 custom pods CIDR block specification is permitted.
-This CIDR block should not conflict with the network subnet range selected for the machines.
+This CIDR block should not conflict with the `clusterNetwork.services.cidrBlocks` and network subnet range selected for the machines.
 
 ### clusterNetwork.services.cidrBlocks[0] (required)
 Subnet used by services in CIDR notation. Please note that only 1 custom services CIDR block specification is permitted.
-This CIDR block should not conflict with the network subnet range selected for the machines.
+This CIDR block should not conflict with the `clusterNetwork.pods.cidrBlocks` and network subnet range selected for the machines.
 
 ### clusterNetwork.dns.resolvConf.path (optional)
 Path to the file with a custom DNS resolver configuration.
@@ -116,17 +116,18 @@ Path to the file with a custom DNS resolver configuration.
 Specific control plane configuration for your Kubernetes cluster.
 
 ### controlPlaneConfiguration.count (required)
-Number of control plane nodes
+Number of control plane nodes.
+This number needs to be odd to maintain ETCD quorum.
 
 ### controlPlaneConfiguration.endpoint.host (required)
 A unique IP you want to use for the control plane in your EKS Anywhere cluster. Choose an IP in your network
 range that does not conflict with other machines.
 
-### controlPlaneConfiguration.machineGroupRef (required)
-Refers to the Kubernetes object with Tinkerbell-specific configuration for your nodes. See `TinkerbellMachineConfig Fields` below.
-
 >**_NOTE:_** This IP should be outside the network DHCP range as it is a floating IP that gets assigned to one of
 the control plane nodes for kube-apiserver loadbalancing. 
+
+### controlPlaneConfiguration.machineGroupRef (required)
+Refers to the Kubernetes object with Tinkerbell-specific configuration for your nodes. See `TinkerbellMachineConfig Fields` below.
 
 ### controlPlaneConfiguration.taints
 A list of taints to apply to the control plane nodes of the cluster.
@@ -187,7 +188,7 @@ the existing nodes associated with the configuration.
 ## TinkerbellDatacenterConfig Fields
 
 ### tinkerbellIP
-Optional field to identify the IP address of the Tinkerbell service.
+Required field to identify the IP address of the Tinkerbell service.
 Other TinkerbellDatacenterConfig fields are not yet supported.
 See [Artifacts]({{< relref "../artifacts/" >}}) for details.
 
@@ -220,10 +221,12 @@ spec:
     node: "cp-machine"
 ```
 ### osFamily (required)
-Operating system on the machine. For example, `bottlerocker` or `ubuntu`.
-### templateRef
+Operating system on the machine. For example, `bottlerocket` or `ubuntu`.
+### templateRef (optional)
 Identifies the template that defines the actions that will be applied to the TinkerbellMachineConfig.
 See TinkerbellTemplateConfig fields below.
+EKS Anywhere will generate default templates based on `osFamily` during the `create` command.
+You can override this default template by providing your own template here.
 
 ### users
 The name of the user you want to configure to access your virtual machines through SSH.

--- a/docs/content/en/docs/reference/clusterspec/baremetal.md
+++ b/docs/content/en/docs/reference/clusterspec/baremetal.md
@@ -79,6 +79,7 @@ kind: TinkerbellMachineConfig
 metadata:
   name: my-cluster-name
 spec:
+  hardwareSelector: {}
   osFamily: ubuntu
   templateRef:
     kind: TinkerbellTemplateConfig
@@ -189,19 +190,27 @@ the existing nodes associated with the configuration.
 Optional field to identify the IP address of the Tinkerbell service.
 Other TinkerbellDatacenterConfig fields are not yet supported.
 
-## TinkerBellMachineConfig Fields
-
-### osFamily (required)
-Operating system on the machine. For example, `ubuntu`.
-
+## TinkerbellMachineConfig Fields
+In the example, there are `TinkerbellMachineConfig` sections for control plane (`my-cluster-name-cp`) and worker (`my-cluster-name`) machine groups.
+The following fields identify information needed to configure the nodes in each of those groups.
+>**_NOTE:_** Currently, you can only have one machine group for all machines in the control plane and one for all machines in the worker group.
+>
 ### hardwareSelector
-
-
-
-
-
-
-
+Use fields under `hardwareSelector` to add key/value pair labels to match particular machines that you identified in the CSV file where you defined the machines in your cluster.
+Choose any label name you like.
+For example, if you had added the label `node=cp-machine` to all the machines listed in your CSV file, the following `hardwareSelector` field would cause those machines to be added to the control plane:
+```bash
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellMachineConfig
+metadata:
+  name: my-cluster-name-cp
+spec:
+  hardwareSelector:
+    node: "cp-machine"
+```
+### osFamily (required)
+Operating system on the machine. For example, `bottlerocker` or `ubuntu`.
 ### templateRef
 Identifies the template that defines the actions that will be applied to the TinkerbellMachineConfig.
 See TinkerbellTemplateConfig fields below.
@@ -414,6 +423,9 @@ spec:
 The values in the `TinkerbellTemplateConfig` fields are created from the contents of the CSV file used to generate a configuration.
 The template contains actions that are performed on a Bare Metal machine when it first boots up to be provisioned.
 For advanced users, you can add these fields to your cluster configuration file if you have special needs to do so.
+
+While there are a fields that apply to all provisioned operating systems, actions are specific to each operating system.
+Examples below describe actions for Ubuntu and Bottlerocket operating systems.
 
 ### template.global_timeout
 

--- a/docs/content/en/docs/reference/clusterspec/baremetal.md
+++ b/docs/content/en/docs/reference/clusterspec/baremetal.md
@@ -34,7 +34,7 @@ spec:
   controlPlaneConfiguration:              
     count: 1
     endpoint:
-      host: "193.17.0.50"
+      host: "<Control Plane Endpoint IP>"
     machineGroupRef:
       kind: TinkerbellMachineConfig
       name: my-cluster-name-cp
@@ -57,9 +57,7 @@ kind: TinkerbellDatacenterConfig
 metadata:
   name: my-cluster-name
 spec:
-  tinkerbellIP: "193.17.0.50"
-  osImageURL: "http://10.80.30.20:8080/ubuntu-...gz"    # Optional
-  hookImagesURLPath: "http://10.80.30.20:8080"          # Optional
+  tinkerbellIP: "<Tinkerbell IP>"
 
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
@@ -536,43 +534,43 @@ actions:
 ## Bottlerocket-specific actions
 
 ### template.tasks.actions.write-bootconfig (Bottlerocket)
-The write-bootconfig action identifies the location on the machine to put content needed to boot the system from disk????
+The write-bootconfig action identifies the location on the machine to put content needed to boot the system from disk.
 
-* environment.BOOTCONFIG_CONTENTS.kernel: Add kernel parameters that are passed to the kernel when the system boots???
-* environment.DEST_DISK: Identifies the block storage device that holds the boot partition???
+* environment.BOOTCONFIG_CONTENTS.kernel: Add kernel parameters that are passed to the kernel when the system boots.
+* environment.DEST_DISK: Identifies the block storage device that holds the boot partition.
 * environment.DEST_PATH: Identifies the file holding boot configuration data (`/bootconfig.data` in this example).
-* environment.DIRMODE: The Linux permissions assigned to the boot directory???
-* environment.FS_TYPE: The filesystem type associated with the boot partition???
-* environment.GID: The group ID associated with files and directories created on the boot partition???. GID 0 is the root group.
-* environment.MODE: The Linux permissions assigned to files in the boot partition???
-* environment.UID: The user ID associated with files and directories created on the boot partition???. UID 0 is the root user.
+* environment.DIRMODE: The Linux permissions assigned to the boot directory.
+* environment.FS_TYPE: The filesystem type associated with the boot partition.
+* environment.GID: The group ID associated with files and directories created on the boot partition.
+* environment.MODE: The Linux permissions assigned to files in the boot partition.
+* environment.UID: The user ID associated with files and directories created on the boot partition. UID 0 is the root user.
 * image: Container image used to perform the steps needed by this action.
 * timeout: Time needed to complete the action, in seconds.
 
 ### template.tasks.actions.write-netconfig (Bottlerocket)
-The write-netconfig action configures networking for the system???
+The write-netconfig action configures networking for the system.
 
 * environment.CONTENTS: Add network values, including: `version = 1` (version number), `[eno1]` (external network interface), `dhcp4 = true` (turns on dhcp4), and `primary = true` (identifies this interface as the primary interface used by kubelet).
-* environment.DEST_DISK: Identifies the block storage device that holds the network configuration information ???
+* environment.DEST_DISK: Identifies the block storage device that holds the network configuration information.
 * environment.DEST_PATH: Identifies the file holding network configuration data (`/net.toml` in this example).
-* environment.DIRMODE: The Linux permissions assigned to the directory holding network configuration settings???
-* environment.FS_TYPE: The filesystem type associated with the partition holding network configuration settings???
-* environment.GID: The group ID associated with files and directories created on the partition???. GID 0 is the root group.
-* environment.MODE: The Linux permissions assigned to files in the partition???
-* environment.UID: The user ID associated with files and directories created on the partition???. UID 0 is the root user.
+* environment.DIRMODE: The Linux permissions assigned to the directory holding network configuration settings.
+* environment.FS_TYPE: The filesystem type associated with the partition holding network configuration settings.
+* environment.GID: The group ID associated with files and directories created on the partition. GID 0 is the root group.
+* environment.MODE: The Linux permissions assigned to files in the partition.
+* environment.UID: The user ID associated with files and directories created on the partition. UID 0 is the root user.
 * image: Container image used to perform the steps needed by this action.
 
 ### template.tasks.actions.write-user-data (Bottlerocket)
 The write-user-data action configures the Tinkerbell Hegel service, which provides the metadata store for Tinkerbell.
 
 * environment.HEGEL_URL: The IP address and port number of the Tinkerbell [Hegel](https://docs.tinkerbell.org/services/hegel/) service.
-* environment.DEST_DISK: Identifies the block storage device that holds the network configuration information ???
+* environment.DEST_DISK: Identifies the block storage device that holds the network configuration information.
 * environment.DEST_PATH: Identifies the file holding network configuration data (`/net.toml` in this example).
-* environment.DIRMODE: The Linux permissions assigned to the directory holding network configuration settings???
-* environment.FS_TYPE: The filesystem type associated with the partition holding network configuration settings???
-* environment.GID: The group ID associated with files and directories created on the partition???. GID 0 is the root group.
-* environment.MODE: The Linux permissions assigned to files in the partition???
-* environment.UID: The user ID associated with files and directories created on the partition???. UID 0 is the root user.
+* environment.DIRMODE: The Linux permissions assigned to the directory holding network configuration settings.
+* environment.FS_TYPE: The filesystem type associated with the partition holding network configuration settings.
+* environment.GID: The group ID associated with files and directories created on the partition. GID 0 is the root group.
+* environment.MODE: The Linux permissions assigned to files in the partition.
+* environment.UID: The user ID associated with files and directories created on the partition. UID 0 is the root user.
 * image: Container image used to perform the steps needed by this action.
 * timeout: Time needed to complete the action, in seconds.
 
@@ -581,7 +579,7 @@ The reboot action defines how the system restarts to bring up the installed syst
 
 * image: Container image used to perform the steps needed by this action.
 * timeout: Time needed to complete the action, in seconds.
-* volumes: The volume (directory) to mount into the container from the installed system.??????
+* volumes: The volume (directory) to mount into the container from the installed system.
 ### version
 
 Matches the current version of the Tinkerbell template.

--- a/docs/content/en/docs/reference/clusterspec/baremetal.md
+++ b/docs/content/en/docs/reference/clusterspec/baremetal.md
@@ -260,6 +260,12 @@ They can also add their own [Tinkerbell actions](https://docs.tinkerbell.org/act
 The following shows two `TinkerbellTemplateConfig` examples that you can add to your cluster configuration file to override the values that EKS Anywhere sets: one for Ubuntu and one for Bottlerocket.
 Most actions used differ for different operating systems.
 
+>**_NOTE:_** For the `stream-image` action, `DEST_DISK` points to the device representing the entire hard disk (for example, `/dev/sda`). 
+For UEFI-enabled images, such as Ubuntu, write actions use `DEST_DISK` to point to the second partition (for example, `/dev/sda2`), with the first being the EFI partition.
+For the Bottlerocket image, which has 12 partitions, `DEST_DISK` is partition 12 (for example, `/dev/sda12`).
+Device names will be different for different disk types.
+>
+
 ### Ubuntu TinkerbellTemplateConfig example
 
 ```
@@ -474,7 +480,7 @@ The `write-netplan` action writes Ubuntu network configuration information to th
 * environment.CONTENTS.network.version: Identifies the network version.
 * environment.CONTENTS.network.renderer: Defines the service to manage networking. By default, the `networkd` systemd service is used.
 * environment.CONTENTS.network.ethernets: Network interface to external network (eno1, by default) and whether or not to use dhcp4 (true, by default).
-* environment.DEST_DISK: Destination block storage device partition where the operating system is copied. By default, /dev/sda2 is used (sda1 is the UEFI partition). 
+* environment.DEST_DISK: Destination block storage device partition where the operating system is copied. By default, /dev/sda2 is used (sda1 is the EFI partition). 
 * environment.DEST_PATH: File where the networking configuration is written (/etc/netplan/config.yaml, by default).
 * environment.DIRMODE: Linux directory permissions bits to use when creating directories (0755, by default)
 * environment.FS_TYPE: Type of filesystem on the partition (ext4, by default).

--- a/docs/content/en/docs/reference/clusterspec/baremetal.md
+++ b/docs/content/en/docs/reference/clusterspec/baremetal.md
@@ -12,13 +12,401 @@ The following additional optional configuration can also be included:
 * [CNI]({{< relref "optional/cni.md" >}})
 * [multus]({{< relref "optional/multus.md" >}})
 
+To generate your own cluster configuration, follow instructions from [Create production cluster]({{< relref "../../getting-started/production-environment/" >}}) and modify it using descriptions below.
 
 ```yaml
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: my-cluster-name
+spec:
+  clusterNetwork:
+    cniConfig:
+      cilium: {}
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+  controlPlaneConfiguration:              
+    count: 1
+    endpoint:
+      host: "193.17.0.50"
+    machineGroupRef:
+      kind: TinkerbellMachineConfig
+      name: my-cluster-name-cp
+  datacenterRef:
+    kind: TinkerbellDatacenterConfig
+    name: my-cluster-name
+  kubernetesVersion: "1.22"
+  managementCluster:
+    name: my-cluster-name
+  workerNodeGroupConfigurations:
+  - count: 1
+    machineGroupRef:
+      kind: TinkerbellMachineConfig
+      name: my-cluster-name
+    name: md-0
 
-ADD GENERIC BARE METAL TEMPLATE
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellDatacenterConfig
+metadata:
+  name: my-cluster-name
+spec:
+  tinkerbellCertURL: ""
+  tinkerbellGRPCAuth: ""
+  tinkerbellHegelURL: ""
+  tinkerbellIP: "193.17.0.50"
+  tinkerbellPBnJGRPCAuth: ""
 
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellMachineConfig
+metadata:
+  name: my-cluster-name-cp
+spec:
+  osFamily: ubuntu
+  templateRef:
+    kind: TinkerbellTemplateConfig
+    name: my-cluster-name
+  users:
+  - name: ec2-user
+    sshAuthorizedKeys:
+    - ssh-rsa AAAAB3NzaC1yc2... jwjones@833efcab1482.home.example.com
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellMachineConfig
+metadata:
+  name: my-cluster-name
+spec:
+  osFamily: ubuntu
+  templateRef:
+    kind: TinkerbellTemplateConfig
+    name: my-cluster-name
+  users:
+  - name: ec2-user
+    sshAuthorizedKeys:
+    - ssh-rsa AAAAB3NzaC1yc2... jwjones@833efcab1482.home.example.com
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellTemplateConfig
+metadata:
+  name: my-cluster-name
+spec:
+  template:
+    global_timeout: 6000
+    id: ""
+    name: my-cluster-name
+    tasks:
+    - actions:
+      - environment:
+          COMPRESSED: "true"
+          DEST_DISK: /dev/sda
+          IMG_URL: https://.../ubuntu-v1.22.9-eks-d...
+        image: public.ecr.aws/.../image2disk:6c0f0d437bde2c...
+        name: stream-image
+        timeout: 360
+      - environment:
+          CONTENTS: |
+            network:
+              version: 2
+              renderer: networkd
+              ethernets:
+                  eno1:
+                      dhcp4: true
+          DEST_DISK: /dev/sda2
+          DEST_PATH: /etc/netplan/config.yaml
+          DIRMODE: "0755"
+          FS_TYPE: ext4
+          GID: "0"
+          MODE: "0644"
+          UID: "0"
+        image: public.ecr.aws/.../writefile:6c0f0d437bde2c...
+        name: write-netplan
+        timeout: 90
+      - environment:
+          CONTENTS: |
+            datasource:
+              Ec2:
+                metadata_urls: []
+                strict_id: false
+            system_info:
+              default_user:
+                name: tink
+                groups: [wheel, adm]
+                sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+                shell: /bin/bash
+            manage_etc_hosts: localhost
+            warnings:
+              dsid_missing_source: off
+          DEST_DISK: /dev/sda2
+          DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
+          DIRMODE: "0700"
+          FS_TYPE: ext4
+          GID: "0"
+          MODE: "0600"
+          UID: "0"
+        image: public.ecr.aws/.../writefile:6c0f0d437bde2c...
+        name: add-tink-cloud-init-config
+        timeout: 90
+      - environment:
+          CONTENTS: |
+            datasource: Ec2
+          DEST_DISK: /dev/sda2
+          DEST_PATH: /etc/cloud/ds-identify.cfg
+          DIRMODE: "0700"
+          FS_TYPE: ext4
+          GID: "0"
+          MODE: "0600"
+          UID: "0"
+        image: public.ecr.aws/.../writefile:6c0f0d437bde2c...
+        name: add-tink-cloud-init-ds-config
+        timeout: 90
+      - environment:
+          BLOCK_DEVICE: /dev/sda2
+          FS_TYPE: ext4
+        image: public.ecr.aws/.../kexec:6c0f0d437bde2c...
+        name: kexec-image
+        pid: host
+        timeout: 90
+      name: my-cluster-name
+      volumes:
+      - /dev:/dev
+      - /dev/console:/dev/console
+      - /lib/firmware:/lib/firmware:ro
+      worker: '{{.device_1}}'
+    version: "0.1"
+
+---
 ```
 
 ## Cluster Fields
 
-ADD DESCRIPTIONS OF FIELDS
+### name (required)
+Name of your cluster (`my-cluster-name` in this example).
+
+### clusterNetwork (required)
+Specific network configuration for your Kubernetes cluster.
+
+### clusterNetwork.cniConfig (required)
+CNI plugin to be installed in the cluster. The only supported value at the moment is `cilium`.
+
+### clusterNetwork.pods.cidrBlocks[0] (required)
+Subnet used by pods in CIDR notation. Please note that only 1 custom pods CIDR block specification is permitted.
+This CIDR block should not conflict with the network subnet range selected for the machines.
+
+### clusterNetwork.services.cidrBlocks[0] (required)
+Subnet used by services in CIDR notation. Please note that only 1 custom services CIDR block specification is permitted.
+This CIDR block should not conflict with the network subnet range selected for the machines.
+
+### clusterNetwork.dns.resolvConf.path (optional)
+Path to the file with a custom DNS resolver configuration.
+
+### controlPlaneConfiguration (required)
+Specific control plane configuration for your Kubernetes cluster.
+
+### controlPlaneConfiguration.count (required)
+Number of control plane nodes
+
+### controlPlaneConfiguration.endpoint.host (required)
+A unique IP you want to use for the control plane in your EKS Anywhere cluster. Choose an IP in your network
+range that does not conflict with other machines.
+
+### controlPlaneConfiguration.machineGroupRef (required)
+Refers to the Kubernetes object with Tinkerbell-specific configuration for your nodes. See `TinkerbellMachineConfig Fields` below.
+
+>**_NOTE:_** This IP should be outside the network DHCP range as it is a floating IP that gets assigned to one of
+the control plane nodes for kube-apiserver loadbalancing. 
+
+### controlPlaneConfiguration.taints
+A list of taints to apply to the control plane nodes of the cluster.
+
+Replaces the default control plane taint, `node-role.kubernetes.io/master`. The default control plane components will tolerate the provided taints.
+
+Modifying the taints associated with the control plane configuration will cause new nodes to be rolled-out, replacing the existing nodes.
+
+>**_NOTE:_** The taints provided will be used instead of the default control plane taint `node-role.kubernetes.io/master`.
+Any pods that you run on the control plane nodes must tolerate the taints you provide in the control plane configuration.
+> 
+
+### controlPlaneConfiguration.labels
+A list of labels to apply to the control plane nodes of the cluster. This is in addition to the labels that
+EKS Anywhere will add by default.
+
+Modifying the labels associated with the control plane configuration will cause new nodes to be rolled out, replacing
+the existing nodes.
+
+### datacenterRef
+Refers to the Kubernetes object with Tinkerbell-specific configuration. See `TinkerbellDatacenterConfig Fields` below.
+
+### kubernetesVersion (required)
+The Kubernetes version you want to use for your cluster. Supported values: `1.22`, `1.21`, `1.20`
+
+### managementCluster
+Identifies the name of the management cluster.
+If this is a standalone cluster or if it were serving as the management cluster for other workload clusters, this will be the same as the cluster name.
+Bare Metal EKS Anywhere clusters do not yet support the creation of separate workload clusters.
+
+### workerNodeGroupConfigurations (required)
+This takes in a list of node groups that you can define for your workers.
+You may define one or more worker node groups.
+
+### workerNodeGroupConfigurations.count (required)
+Number of worker nodes
+
+### workerNodeGroupConfigurations.machineGroupRef (required)
+Refers to the Kubernetes object with Tinkerbell-specific configuration for your nodes. See `TinkerbellMachineConfig Fields` below.
+
+### workerNodeGroupConfigurations.name (required)
+Name of the worker node group (default: md-0)
+
+### workerNodeGroupConfigurations.taints
+A list of taints to apply to the nodes in the worker node group.
+
+Modifying the taints associated with a worker node group configuration will cause new nodes to be rolled-out, replacing the existing nodes associated with the configuration.
+
+At least one node group must not have `NoSchedule` or `NoExecute` taints applied to it.
+
+### workerNodeGroupConfigurations.labels
+A list of labels to apply to the nodes in the worker node group. This is in addition to the labels that
+EKS Anywhere will add by default.
+
+Modifying the labels associated with a worker node group configuration will cause new nodes to be rolled out, replacing
+the existing nodes associated with the configuration.
+
+## TinkerbellDatacenterConfig Fields
+
+### tinkerbellIP
+Optional field to identify the IP address of the Tinkerbell service.
+
+## TinkerBellMachineConfig Fields
+
+### osFamily (required)
+Operating system on the machine. For example, `ubuntu`.
+
+### templateRef
+Identifies the template that defines the actions that will be applied to the TinkerbellMachineConfig.
+See TinkerbellTemplateConfig fields below.
+
+### users
+The name of the user you want to configure to access your virtual machines through SSH.
+
+The default is `ec2-user`.
+
+### users[0].sshAuthorizedKeys (optional)
+The SSH public keys you want to configure to access your machines through SSH (as described below). Only 1 is supported at this time.
+
+### users[0].sshAuthorizedKeys[0] (optional)
+This is the SSH public key that will be placed in `authorized_keys` on all EKS Anywhere cluster machines so you can SSH into
+them. The user will be what is defined under name above. For example:
+
+```
+ssh -i <private-key-file> <user>@<machine-IP>
+```
+
+The default is generating a key in your `$(pwd)/<cluster-name>` folder when not specifying a value
+
+
+## TinkerbellTemplateConfig Fields
+
+The values in the `TinkerbellTemplateConfig` fields are created from the contents of the CSV file used to generate this configuration.
+The template contains actions that are performed on a Bare Metal machine when it first boots up to be provisioned.
+For advanced users, you can modify these fields if you have special needs to do so.
+
+### template.global_timeout
+
+NEED INFO. Set to 6000 in example (100 minutes?). Different for different OS families?
+
+### template.id
+
+NEED INFO
+
+### template.tasks
+
+Within the TinkerbellTemplateConfig `template` under `tasks` is a set of actions.
+The following descriptions cover the actions shown in the example template:
+
+### template.tasks.actions.name.stream-image
+The `stream-image` action streams the selected image to machine you are provisioning. It identifies:
+
+* environment.COMPRESSED: NEED INFO
+* environment.DEST_DISK: The hard disk on which the operating system is desployed. The default is the first SCSI disk (/dev/sda), but can be changed for other disk types.
+* environment.IMG_URL: The operating system tarball (ubuntu or other) to stream to the machine you are configuring.
+* image: Container image needed to perform the steps needed by this action.
+* timeout: NEED INFO (Set to 360 (six minutes???). Is the timout to get the image???)
+
+### template.tasks.actions.name.write-netplan
+The `write-netplan` action writes network configuration information to the machine. It identifies:
+
+* environment.CONTENTS.network.version: NEED INFO. CNI version, cilium version??? 
+* environment.CONTENTS.network.renderer: NEED INFO  What is "networkd"????
+* environment.CONTENTS.network.ethernets: Network interface to external network (eno1, by default) and whether or not to use dhcp4 (true, by default).
+* environment.DEST_DISK: Destination block storage device partition where the operating system is copied. By default, /dev/sda2 is used (sda1 is the UEFI partition). 
+* environment.DEST_PATH: File where the networking configuration is written (/etc/netplan/config.yaml, by default).
+* environment.DIRMODE: Linux directory permissions bits to use when creating directories (0755, by default)
+* environment.FS_TYPE: Type of filesystem on the partition (ext4, by default).
+* environment.GID: The Linux group ID to set on file. Set to 0 (root group) by default.
+* environment.MODE: The Linux permission bits to set on file (0644, by default).
+* environment.UID: The Linux user ID to set on file. Set to 0 (root user) by default.
+* image: Container image used to perform the steps needed by this action.
+* timeout:
+
+### template.tasks.actions.add-tink-cloud-init-config
+The `add-tink-cloud-init-config` action configures cloud-init features to further configure the operating system. It identifies:
+
+* environment.CONTENTS.datasource: NEED INFO. Ec2.metadata_urls: [] Ec2.strict_id: false
+* environment.CONTENTS.system_info: Creates the `tink` user and gives it administrative group privileges (wheel, adm) and passwordless sudo privileges, and set the default shell (/bin/bash).
+* environment.CONTENTS.manage_etc_hosts NEED INFO.  Set to localhost.
+* environment.CONTENTS.warnings: NEED INFO. Sets dsid_missing_source: off
+* environment.DEST_DISK: Destination block storage device partition where the operating system is located (/dev/sda2, by default).
+* environment.DEST_PATH: Location of the cloud-init configuration file on disk (/etc/cloud/cloud.cfg.d/10_tinkerbell.cfg, by default)
+* environment.DIRMODE: Linux directory permissions bits to use when creating directories (0700, by default)
+* environment.FS_TYPE: Type of filesystem on the partition (ext4, by default).
+* environment.GID: The Linux group ID to set on file. Set to 0 (root group) by default.
+* environment.MODE: The Linux permission bits to set on file (0600, by default).
+* environment.UID: The Linux user ID to set on file. Set to 0 (root user) by default.
+* image: Container image used to perform the steps needed by this action.
+* timeout: NEED INFO. Set to 90, by default
+
+### template.tasks.actions.add-tink-cloud-init-ds-config
+The `add-tink-cloud-init-ds-config` action configures cloud-init data store features. This identifies the location of your metadata source once the machine is up and running. It identifies:
+
+* environment.CONTENTS.datasource: NEED INFO. Set to Ec2.
+* environment.DEST_DISK: Destination block storage device partition where the operating system is located (/dev/sda2, by default).
+* environment.DEST_PATH: Location of the data store identity configuration file on disk (/etc/cloud/ds-identify.cfg, by default) 
+* environment.DIRMODE: Linux directory permissions bits to use when creating directories (0700, by default)
+* environment.FS_TYPE: Type of filesystem on the partition (ext4, by default).
+* environment.GID: The Linux group ID to set on file. Set to 0 (root group) by default.
+* environment.MODE: The Linux permission bits to set on file (0600, by default).
+* environment.UID: The Linux user ID to set on file. Set to 0 (root user) by default.
+* image: Container image used to perform the steps needed by this action.
+* timeout: NEED INFO. Set to 90, by default
+
+### template.tasks.actions.kexec-image
+The `kexec-image` action performs provisioning activities on the machine, then allows kexec to pivot the kernel to use the system installed on disk. This action identifies:
+
+* environment.BLOCK_DEVICE: Disk partition on which the operating system is installed (/dev/sda2, by default)
+* environment.FS_TYPE: Type of filesystem on the partition (ext4, by default).
+* image: Container image used to perform the steps needed by this action.
+* pid: NEED INFO. Set to host.
+* timeout: NEED INFO. Set to 90.
+* volumes: Identifies mount points that need to be remounted to point to locations in the installed system.
+
+If your hardware requires a full reboot, you can change the kexec-image setting as follows:
+
+
+```
+actions:
+- name: "reboot"
+  image: public.ecr.aws/l0g8r8j6/tinkerbell/hub/reboot-action:latest
+  timeout: 90
+  volumes:
+  - /worker:/worker
+```
+
+* version
+     "0.1"

--- a/docs/content/en/docs/reference/clusterspec/baremetal.md
+++ b/docs/content/en/docs/reference/clusterspec/baremetal.md
@@ -58,6 +58,8 @@ metadata:
   name: my-cluster-name
 spec:
   tinkerbellIP: "193.17.0.50"
+  osImageURL: "http://10.80.30.20:8080/ubuntu-...gz"    # Optional
+  hookImagesURLPath: "http://10.80.30.20:8080"          # Optional
 
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
@@ -189,6 +191,16 @@ the existing nodes associated with the configuration.
 ### tinkerbellIP
 Optional field to identify the IP address of the Tinkerbell service.
 Other TinkerbellDatacenterConfig fields are not yet supported.
+See [Artifacts]({{< relref "../artifacts/" >}}) for details.
+
+### osImageURL
+Optional field to replace the default operating system image.
+This field is useful if you want to provide a customized operating system image or simply host the standard image locally.
+See [Artifacts]({{< relref "../artifacts/" >}}) for details.
+
+### hookImagesURLPath
+Optional field to replace the HookOS image.
+This field is useful if you want to provide a customized HookOS image or simply host the standard image locally.
 
 ## TinkerbellMachineConfig Fields
 In the example, there are `TinkerbellMachineConfig` sections for control plane (`my-cluster-name-cp`) and worker (`my-cluster-name`) machine groups.


### PR DESCRIPTION
*Description of changes:*
This PR creates the Bare metal configuration reference page, used to build bare metal EKS-A clusters.
