### PR TITLE
Set `KUBEADM_BOOTSTRAP_TOKEN_TTL` to 120m for Tinkerbell provider

### DIFF
--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -194,7 +194,8 @@ func (p *Provider) EnvMap(spec *cluster.Spec) (map[string]string, error) {
 		//
 		// Env read having set TINKERBELL_IP in the deployment manifest.
 		// https://github.com/tinkerbell/cluster-api-provider-tinkerbell/blob/main/controllers/machine.go#L192
-		"TINKERBELL_IP": "<set in eks-a tinkerbell provider>",
+		"TINKERBELL_IP":               "IGNORED",
+		"KUBEADM_BOOTSTRAP_TOKEN_TTL": "120m",
 	}, nil
 }
 


### PR DESCRIPTION
*Description of changes:*
Baremetal nodes generally take longer to provision than the VMs which sometimes cause the kubeadm join tokens to surpass their TTL and expire.

This PR sets `KUBEADM_BOOTSTRAP_TOKEN_TTL` to 120m for Tinkerbell provider to give nodes enough time to provision and join the cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

