### PR TITLE
add option to override the local tinkerbell IP in the bootstrap cluster

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -29,10 +29,11 @@ import (
 
 type createClusterOptions struct {
 	clusterOptions
-	forceClean      bool
-	skipIpCheck     bool
-	hardwareCSVPath string
-	installPackages string
+	forceClean            bool
+	skipIpCheck           bool
+	hardwareCSVPath       string
+	tinkerbellBootstrapIP string
+	installPackages       string
 }
 
 var cc = &createClusterOptions{}
@@ -56,6 +57,7 @@ func init() {
 		"",
 		TinkerbellHardwareCSVFlagDescription,
 	)
+	createClusterCmd.Flags().StringVar(&cc.tinkerbellBootstrapIP, "tinkerbell-bootstrap-ip", "", "Override the local tinkerbell IP in the bootstrap cluster")
 	createClusterCmd.Flags().BoolVar(&cc.forceClean, "force-cleanup", false, "Force deletion of previously created bootstrap cluster")
 	createClusterCmd.Flags().BoolVar(&cc.skipIpCheck, "skip-ip-check", false, "Skip check for whether cluster control plane ip is in use")
 	createClusterCmd.Flags().StringVar(&cc.bundlesOverride, "bundles-override", "", "Override default Bundles manifest (not recommended)")
@@ -145,7 +147,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		WithBootstrapper().
 		WithCliConfig(cliConfig).
 		WithClusterManager(clusterSpec.Cluster).
-		WithProvider(cc.fileName, clusterSpec.Cluster, cc.skipIpCheck, cc.hardwareCSVPath, cc.forceClean).
+		WithProvider(cc.fileName, clusterSpec.Cluster, cc.skipIpCheck, cc.hardwareCSVPath, cc.forceClean, cc.tinkerbellBootstrapIP).
 		WithFluxAddonClient(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().
 		WithEksdInstaller().

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -20,9 +20,10 @@ import (
 
 type deleteClusterOptions struct {
 	clusterOptions
-	wConfig          string
-	forceCleanup     bool
-	hardwareFileName string
+	wConfig               string
+	forceCleanup          bool
+	hardwareFileName      string
+	tinkerbellBootstrapIP string
 }
 
 var dc = &deleteClusterOptions{}
@@ -104,7 +105,7 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 		WithBootstrapper().
 		WithCliConfig(cliConfig).
 		WithClusterManager(clusterSpec.Cluster).
-		WithProvider(dc.fileName, clusterSpec.Cluster, cc.skipIpCheck, dc.hardwareFileName, false).
+		WithProvider(dc.fileName, clusterSpec.Cluster, cc.skipIpCheck, dc.hardwareFileName, false, dc.tinkerbellBootstrapIP).
 		WithFluxAddonClient(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().
 		Build(ctx)

--- a/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
@@ -19,8 +19,9 @@ import (
 )
 
 type generateSupportBundleOptions struct {
-	fileName         string
-	hardwareFileName string
+	fileName              string
+	hardwareFileName      string
+	tinkerbellBootstrapIP string
 }
 
 var gsbo = &generateSupportBundleOptions{}
@@ -93,7 +94,7 @@ func (gsbo *generateSupportBundleOptions) generateBundleConfig(ctx context.Conte
 	}
 
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).
-		WithProvider(f, clusterSpec.Cluster, cc.skipIpCheck, gsbo.hardwareFileName, false).
+		WithProvider(f, clusterSpec.Cluster, cc.skipIpCheck, gsbo.hardwareFileName, false, gsbo.tinkerbellBootstrapIP).
 		WithDiagnosticBundleFactory().
 		Build(ctx)
 	if err != nil {

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -19,12 +19,13 @@ import (
 )
 
 type createSupportBundleOptions struct {
-	fileName         string
-	wConfig          string
-	since            string
-	sinceTime        string
-	bundleConfig     string
-	hardwareFileName string
+	fileName              string
+	wConfig               string
+	since                 string
+	sinceTime             string
+	bundleConfig          string
+	hardwareFileName      string
+	tinkerbellBootstrapIP string
 }
 
 var csbo = &createSupportBundleOptions{}
@@ -90,7 +91,7 @@ func (csbo *createSupportBundleOptions) createBundle(ctx context.Context, since,
 	}
 
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).
-		WithProvider(csbo.fileName, clusterSpec.Cluster, cc.skipIpCheck, csbo.hardwareFileName, false).
+		WithProvider(csbo.fileName, clusterSpec.Cluster, cc.skipIpCheck, csbo.hardwareFileName, false, csbo.tinkerbellBootstrapIP).
 		WithDiagnosticBundleFactory().
 		Build(ctx)
 	if err != nil {

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -20,9 +20,10 @@ import (
 
 type upgradeClusterOptions struct {
 	clusterOptions
-	wConfig         string
-	forceClean      bool
-	hardwareCSVPath string
+	wConfig               string
+	forceClean            bool
+	hardwareCSVPath       string
+	tinkerbellBootstrapIP string
 }
 
 var uc = &upgradeClusterOptions{}
@@ -116,7 +117,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(cmd *cobra.Command) error {
 		WithBootstrapper().
 		WithCliConfig(cliConfig).
 		WithClusterManager(clusterSpec.Cluster).
-		WithProvider(uc.fileName, clusterSpec.Cluster, cc.skipIpCheck, uc.hardwareCSVPath, uc.forceClean).
+		WithProvider(uc.fileName, clusterSpec.Cluster, cc.skipIpCheck, uc.hardwareCSVPath, uc.forceClean, uc.tinkerbellBootstrapIP).
 		WithFluxAddonClient(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().
 		WithCAPIManager().

--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -78,7 +78,7 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 
 	deps, err := dependencies.ForSpec(ctx, newClusterSpec).
 		WithClusterManager(newClusterSpec.Cluster).
-		WithProvider(uc.fileName, newClusterSpec.Cluster, false, uc.hardwareCSVPath, uc.forceClean).
+		WithProvider(uc.fileName, newClusterSpec.Cluster, false, uc.hardwareCSVPath, uc.forceClean, uc.tinkerbellBootstrapIP).
 		WithFluxAddonClient(newClusterSpec.Cluster, newClusterSpec.FluxConfig, nil).
 		WithCAPIManager().
 		Build(ctx)

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/files"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	gitfactory "github.com/aws/eks-anywhere/pkg/git/factory"
+	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/networking/cilium"
 	"github.com/aws/eks-anywhere/pkg/networking/kindnetd"
@@ -207,7 +208,7 @@ func (f *Factory) WithExecutableBuilder() *Factory {
 	return f
 }
 
-func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1.Cluster, skipIpCheck bool, hardwareCSVPath string, force bool) *Factory {
+func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1.Cluster, skipIpCheck bool, hardwareCSVPath string, force bool, tinkerbellBootstrapIp string) *Factory {
 	switch clusterConfig.Spec.DatacenterRef.Kind {
 	case v1alpha1.VSphereDatacenterKind:
 		f.WithKubectl().WithGovc().WithWriter().WithCAPIClusterResourceSetManager()
@@ -290,10 +291,16 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 				return fmt.Errorf("unable to get machine config from file %s: %v", clusterConfigFile, err)
 			}
 
-			tinkerbellIp, err := networkutils.GetLocalIP()
-			if err != nil {
-				return fmt.Errorf("unable to get local IP of the machine %v", err)
+			tinkerbellIp := tinkerbellBootstrapIp
+			if tinkerbellIp == "" {
+				logger.V(4).Info("Inferring local Tinkerbell Bootstrap IP from environment")
+				localIp, err := networkutils.GetLocalIP()
+				if err != nil {
+					return err
+				}
+				tinkerbellIp = localIp.String()
 			}
+			logger.V(4).Info("Tinkerbell IP", "tinkerbell-ip", tinkerbellIp)
 
 			f.dependencies.Provider = tinkerbell.NewProvider(
 				datacenterConfig,
@@ -304,7 +311,7 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 				f.dependencies.DockerClient,
 				f.dependencies.Helm,
 				f.dependencies.Kubectl,
-				tinkerbellIp.String(),
+				tinkerbellIp,
 				time.Now,
 				force,
 				skipIpCheck,

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -15,11 +15,12 @@ import (
 
 type factoryTest struct {
 	*WithT
-	clusterConfigFile  string
-	clusterSpec        *cluster.Spec
-	ctx                context.Context
-	hardwareConfigFile string
-	cliConfig          config.CliConfig
+	clusterConfigFile     string
+	clusterSpec           *cluster.Spec
+	ctx                   context.Context
+	hardwareConfigFile    string
+	tinkerbellBootstrapIP string
+	cliConfig             config.CliConfig
 }
 
 func newTest(t *testing.T) *factoryTest {
@@ -41,7 +42,7 @@ func TestFactoryBuildWithProvider(t *testing.T) {
 	tt := newTest(t)
 	deps, err := dependencies.NewFactory().
 		UseExecutableImage("image:1").
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
 		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())
@@ -79,7 +80,7 @@ func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
 		WithBootstrapper().
 		WithCliConfig(&tt.cliConfig).
 		WithClusterManager(tt.clusterSpec.Cluster).
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
 		WithFluxAddonClient(tt.clusterSpec.Cluster, tt.clusterSpec.FluxConfig, nil).
 		WithWriter().
 		WithEksdInstaller().

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -51,6 +51,7 @@ type Provider struct {
 	catalogue       *hardware.Catalogue
 	diskExtractor   hardware.DiskExtractor
 	tinkerbellIp    string
+
 	// TODO(chrisdoheryt4) Temporarily depend on the netclient until the validator can be injected.
 	// This is already a dependency, just uncached, because we require it during the initializing
 	// constructor call for constructing the validator in-line.


### PR DESCRIPTION
Add option to override the local tinkerbell bootstrap ip.

This is needed for cases where tink needs to run on a different interface than the default interface ip that we infer.

Equinix requested this for their workflow. Also, testing using dhcp relay over vpn required this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

