### PR TITLE
Add missing BMC headers test

### DIFF
--- a/pkg/providers/tinkerbell/hardware/csv_test.go
+++ b/pkg/providers/tinkerbell/hardware/csv_test.go
@@ -86,6 +86,32 @@ func TestNewCSVReaderWithIOReaderError(t *testing.T) {
 	g.Expect(err.Error()).To(gomega.ContainSubstring(expect.Error()))
 }
 
+func TestCSVReaderWithoutBMCHeaders(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	reader, err := hardware.NewCSVReaderFromFile("./testdata/hardware_no_bmc_headers.csv")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	machine, err := reader.Read()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	g.Expect(machine).To(gomega.Equal(
+		hardware.Machine{
+			Labels:       map[string]string{"type": "cp"},
+			Nameservers:  []string{"1.1.1.1"},
+			Gateway:      "10.10.10.1",
+			Netmask:      "255.255.255.0",
+			IPAddress:    "10.10.10.10",
+			MACAddress:   "00:00:00:00:00:01",
+			Hostname:     "worker1",
+			Disk:         "/dev/sda",
+			BMCIPAddress: "",
+			BMCUsername:  "",
+			BMCPassword:  "",
+		},
+	))
+}
+
 // BufferedCSV is an in-memory CSV that satisfies io.Reader and io.Writer.
 type BufferedCSV struct {
 	*bytes.Buffer

--- a/pkg/providers/tinkerbell/hardware/testdata/hardware_no_bmc_headers.csv
+++ b/pkg/providers/tinkerbell/hardware/testdata/hardware_no_bmc_headers.csv
@@ -1,0 +1,2 @@
+hostname,mac,ip_address,netmask,gateway,nameservers,labels,disk
+worker1,00:00:00:00:00:01,10.10.10.10,255.255.255.0,10.10.10.1,1.1.1.1,type=cp,/dev/sda

--- a/pkg/providers/tinkerbell/hardware/yaml_test.go
+++ b/pkg/providers/tinkerbell/hardware/yaml_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestTinkerbellManifestYAMLWrites(t *testing.T) {
-	t.Skip("Machine to type conversion functions currently unimplemented hence the test fails.")
 	g := gomega.NewWithT(t)
 
 	var buf bytes.Buffer


### PR DESCRIPTION
When reading hardware some users don't wish to specify any BMC
information for any hardware. This renders the BMC columns in the
hardware CSV redundant. This test ensures users can specify a CSV
without any BMC columns simplifying their CSV.