### PR TITLE
Wait adaptive duration per unready replicas between retries

### DIFF
--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -479,7 +479,7 @@ func TestClusterManagerUpgradeSelfManagedClusterSuccess(t *testing.T) {
 	tt.mocks.provider.EXPECT().MachineDeploymentsToDelete(wCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy()).Return([]string{})
 	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, wCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, wCluster.Name).Return(nil)
-	tt.mocks.client.EXPECT().ValidateWorkerNodes(tt.ctx, wCluster.Name, mCluster.KubeconfigFile).Return(nil)
+	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, wCluster.Name, mCluster.KubeconfigFile).Return(0, 0, nil)
 	tt.mocks.provider.EXPECT().GetDeployments()
 	tt.mocks.writer.EXPECT().Write(clusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
 	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
@@ -515,7 +515,7 @@ func TestClusterManagerUpgradeWorkloadClusterSuccess(t *testing.T) {
 	tt.mocks.provider.EXPECT().MachineDeploymentsToDelete(mCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy()).Return([]string{})
 	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, mCluster.Name).Return(nil)
-	tt.mocks.client.EXPECT().ValidateWorkerNodes(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Return(nil)
+	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Return(0, 0, nil)
 	tt.mocks.provider.EXPECT().GetDeployments()
 	tt.mocks.writer.EXPECT().Write(mgmtClusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
 	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, mCluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
@@ -551,7 +551,85 @@ func TestClusterManagerUpgradeCloudStackWorkloadClusterSuccess(t *testing.T) {
 	tt.mocks.provider.EXPECT().MachineDeploymentsToDelete(mCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy()).Return([]string{})
 	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, mCluster.Name).Return(nil)
-	tt.mocks.client.EXPECT().ValidateWorkerNodes(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Return(nil)
+	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Return(0, 0, nil)
+	tt.mocks.provider.EXPECT().GetDeployments()
+	tt.mocks.writer.EXPECT().Write(mgmtClusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
+	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, mCluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
+	tt.mocks.networking.EXPECT().RunPostControlPlaneUpgradeSetup(tt.ctx, wCluster).Return(nil)
+
+	if err := tt.clusterManager.UpgradeCluster(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.mocks.provider); err != nil {
+		t.Errorf("ClusterManager.UpgradeCluster() error = %v, wantErr nil", err)
+	}
+}
+
+func TestClusterManagerUpgradeWorkloadClusterWaitForMDReadyErrorOnce(t *testing.T) {
+	mgmtClusterName := "cluster-name"
+	workClusterName := "cluster-name-w"
+
+	mCluster := &types.Cluster{
+		Name:               mgmtClusterName,
+		ExistingManagement: true,
+	}
+	wCluster := &types.Cluster{
+		Name: workClusterName,
+	}
+
+	tt := newSpecChangedTest(t)
+	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, mCluster, mgmtClusterName).Return(tt.oldClusterConfig, nil)
+	tt.mocks.client.EXPECT().GetBundles(tt.ctx, mCluster.KubeconfigFile, mCluster.Name, "").Return(test.Bundles(t), nil)
+	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
+	tt.mocks.provider.EXPECT().GenerateCAPISpecForUpgrade(tt.ctx, mCluster, mCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy())
+	tt.mocks.client.EXPECT().ApplyKubeSpecFromBytesWithNamespace(tt.ctx, mCluster, test.OfType("[]uint8"), constants.EksaSystemNamespace).Times(2)
+	tt.mocks.provider.EXPECT().RunPostControlPlaneUpgrade(tt.ctx, tt.clusterSpec, tt.clusterSpec, wCluster, mCluster)
+	tt.mocks.client.EXPECT().WaitForControlPlaneReady(tt.ctx, mCluster, "60m", mgmtClusterName).MaxTimes(2)
+	tt.mocks.client.EXPECT().WaitForControlPlaneNotReady(tt.ctx, mCluster, "1m", mgmtClusterName)
+	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
+	tt.mocks.provider.EXPECT().MachineDeploymentsToDelete(mCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy()).Return([]string{})
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
+	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, mCluster.Name).Return(nil)
+	// Fail once
+	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Times(1).Return(0, 0, errors.New("error counting MD replicas"))
+	// Return 1 and 1 for ready and total replicas
+	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Times(1).Return(1, 1, nil)
+	tt.mocks.provider.EXPECT().GetDeployments()
+	tt.mocks.writer.EXPECT().Write(mgmtClusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
+	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, mCluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
+	tt.mocks.networking.EXPECT().RunPostControlPlaneUpgradeSetup(tt.ctx, wCluster).Return(nil)
+
+	if err := tt.clusterManager.UpgradeCluster(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.mocks.provider); err != nil {
+		t.Errorf("ClusterManager.UpgradeCluster() error = %v, wantErr nil", err)
+	}
+}
+
+func TestClusterManagerUpgradeWorkloadClusterWaitForMDReadyUnreadyOnce(t *testing.T) {
+	mgmtClusterName := "cluster-name"
+	workClusterName := "cluster-name-w"
+
+	mCluster := &types.Cluster{
+		Name:               mgmtClusterName,
+		ExistingManagement: true,
+	}
+	wCluster := &types.Cluster{
+		Name: workClusterName,
+	}
+
+	tt := newSpecChangedTest(t)
+	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, mCluster, mgmtClusterName).Return(tt.oldClusterConfig, nil)
+	tt.mocks.client.EXPECT().GetBundles(tt.ctx, mCluster.KubeconfigFile, mCluster.Name, "").Return(test.Bundles(t), nil)
+	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
+	tt.mocks.provider.EXPECT().GenerateCAPISpecForUpgrade(tt.ctx, mCluster, mCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy())
+	tt.mocks.client.EXPECT().ApplyKubeSpecFromBytesWithNamespace(tt.ctx, mCluster, test.OfType("[]uint8"), constants.EksaSystemNamespace).Times(2)
+	tt.mocks.provider.EXPECT().RunPostControlPlaneUpgrade(tt.ctx, tt.clusterSpec, tt.clusterSpec, wCluster, mCluster)
+	tt.mocks.client.EXPECT().WaitForControlPlaneReady(tt.ctx, mCluster, "60m", mgmtClusterName).MaxTimes(2)
+	tt.mocks.client.EXPECT().WaitForControlPlaneNotReady(tt.ctx, mCluster, "1m", mgmtClusterName)
+	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
+	tt.mocks.provider.EXPECT().MachineDeploymentsToDelete(mCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy()).Return([]string{})
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
+	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, mCluster.Name).Return(nil)
+	// Return 0 and 1 for ready and total replicas once
+	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Times(1).Return(0, 1, nil)
+	// Return 1 and 1 for ready and total replicas
+	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Times(1).Return(1, 1, nil)
 	tt.mocks.provider.EXPECT().GetDeployments()
 	tt.mocks.writer.EXPECT().Write(mgmtClusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
 	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, mCluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
@@ -660,7 +738,7 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForCAPITimeout(t *testing.T) {
 	tt.mocks.provider.EXPECT().MachineDeploymentsToDelete(wCluster, tt.clusterSpec, tt.clusterSpec.DeepCopy()).Return([]string{})
 	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, wCluster, "30m", "Available", gomock.Any(), gomock.Any()).Return(errors.New("time out"))
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, wCluster.Name).Return(nil)
-	tt.mocks.client.EXPECT().ValidateWorkerNodes(tt.ctx, wCluster.Name, mCluster.KubeconfigFile).Return(nil)
+	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, wCluster.Name, mCluster.KubeconfigFile).Return(0, 0, nil)
 	tt.mocks.writer.EXPECT().Write(clusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
 	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
 	tt.mocks.networking.EXPECT().RunPostControlPlaneUpgradeSetup(tt.ctx, wCluster).Return(nil)
@@ -692,7 +770,7 @@ func TestClusterManagerMoveCAPISuccess(t *testing.T) {
 	m.client.EXPECT().GetClusters(ctx, to).Return(clusters, nil)
 	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "15m0s", capiClusterName)
 	m.client.EXPECT().ValidateControlPlaneNodes(ctx, to, to.Name)
-	m.client.EXPECT().ValidateWorkerNodes(ctx, to.Name, to.KubeconfigFile)
+	m.client.EXPECT().CountMachineDeploymentReplicasReady(ctx, to.Name, to.KubeconfigFile)
 	m.client.EXPECT().GetMachines(ctx, to, to.Name)
 
 	if err := c.MoveCAPI(ctx, from, to, to.Name, clusterSpec); err != nil {
@@ -793,7 +871,7 @@ func TestClusterManagerMoveCAPIErrorGetMachines(t *testing.T) {
 	m.client.EXPECT().MoveManagement(ctx, from, to)
 	m.client.EXPECT().GetClusters(ctx, to)
 	m.client.EXPECT().ValidateControlPlaneNodes(ctx, to, to.Name)
-	m.client.EXPECT().ValidateWorkerNodes(ctx, to.Name, to.KubeconfigFile)
+	m.client.EXPECT().CountMachineDeploymentReplicasReady(ctx, to.Name, to.KubeconfigFile)
 	m.client.EXPECT().GetMachines(ctx, to, from.Name).Return(nil, errors.New("error getting machines")).AnyTimes()
 
 	if err := c.MoveCAPI(ctx, from, to, from.Name, clusterSpec); err == nil {

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -85,6 +85,22 @@ func (mr *MockClusterClientMockRecorder) ApplyKubeSpecFromBytesWithNamespace(arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyKubeSpecFromBytesWithNamespace", reflect.TypeOf((*MockClusterClient)(nil).ApplyKubeSpecFromBytesWithNamespace), arg0, arg1, arg2, arg3)
 }
 
+// CountMachineDeploymentReplicasReady mocks base method.
+func (m *MockClusterClient) CountMachineDeploymentReplicasReady(arg0 context.Context, arg1, arg2 string) (int, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountMachineDeploymentReplicasReady", arg0, arg1, arg2)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CountMachineDeploymentReplicasReady indicates an expected call of CountMachineDeploymentReplicasReady.
+func (mr *MockClusterClientMockRecorder) CountMachineDeploymentReplicasReady(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountMachineDeploymentReplicasReady", reflect.TypeOf((*MockClusterClient)(nil).CountMachineDeploymentReplicasReady), arg0, arg1, arg2)
+}
+
 // CreateNamespace mocks base method.
 func (m *MockClusterClient) CreateNamespace(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/executables/testdata/kubectl_machine_deployments_provisioned.json
+++ b/pkg/executables/testdata/kubectl_machine_deployments_provisioned.json
@@ -1,0 +1,376 @@
+{
+    "apiVersion": "v1",
+    "items": [
+            {
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
+            "kind": "MachineDeployment",
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cluster.x-k8s.io/v1alpha3\",\"kind\":\"MachineDeployment\",\"metadata\":{\"annotations\":{},\"name\":\"test0-md-0\",\"namespace\":\"default\"},\"spec\":{\"clusterName\":\"test0\",\"replicas\":1,\"selector\":{\"matchLabels\":null},\"template\":{\"spec\":{\"bootstrap\":{\"configRef\":{\"apiVersion\":\"bootstrap.cluster.x-k8s.io/v1alpha3\",\"kind\":\"KubeadmConfigTemplate\",\"name\":\"test0-md-0\",\"namespace\":\"default\"}},\"clusterName\":\"test0\",\"infrastructureRef\":{\"apiVersion\":\"infrastructure.cluster.x-k8s.io/v1alpha3\",\"kind\":\"DockerMachineTemplate\",\"name\":\"test0-md-0\",\"namespace\":\"default\"},\"version\":\"v1.19.8-eks-1-19-4\"}}}}\n",
+                    "machinedeployment.clusters.x-k8s.io/revision": "1"
+                },
+                "creationTimestamp": "2021-07-01T14:50:15Z",
+                "generation": 1,
+                "labels": {
+                    "cluster.x-k8s.io/cluster-name": "test0"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {},
+                                    "f:machinedeployment.clusters.x-k8s.io/revision": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:cluster.x-k8s.io/cluster-name": {}
+                                },
+                                "f:ownerReferences": {}
+                            },
+                            "f:spec": {
+                                ".": {},
+                                "f:clusterName": {},
+                                "f:minReadySeconds": {},
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    ".": {},
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:cluster.x-k8s.io/cluster-name": {},
+                                        "f:cluster.x-k8s.io/deployment-name": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    ".": {},
+                                    "f:rollingUpdate": {
+                                        ".": {},
+                                        "f:maxSurge": {},
+                                        "f:maxUnavailable": {}
+                                    },
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    ".": {},
+                                    "f:metadata": {
+                                        ".": {},
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:cluster.x-k8s.io/cluster-name": {},
+                                            "f:cluster.x-k8s.io/deployment-name": {}
+                                        }
+                                    },
+                                    "f:spec": {
+                                        ".": {},
+                                        "f:bootstrap": {
+                                            ".": {},
+                                            "f:configRef": {
+                                                ".": {},
+                                                "f:apiVersion": {},
+                                                "f:kind": {},
+                                                "f:name": {},
+                                                "f:namespace": {}
+                                            }
+                                        },
+                                        "f:clusterName": {},
+                                        "f:infrastructureRef": {
+                                            ".": {},
+                                            "f:apiVersion": {},
+                                            "f:kind": {},
+                                            "f:name": {},
+                                            "f:namespace": {}
+                                        },
+                                        "f:version": {}
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "clusterctl",
+                        "operation": "Update",
+                        "time": "2021-07-01T14:50:15Z"
+                    },
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:status": {
+                                ".": {},
+                                "f:availableReplicas": {},
+                                "f:observedGeneration": {},
+                                "f:phase": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:selector": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "time": "2021-07-01T14:50:17Z"
+                    }
+                ],
+                "name": "test0-md-0",
+                "namespace": "default",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "kind": "Cluster",
+                        "name": "test0",
+                        "uid": "9607241e-c3a5-40c7-8f51-268231e615c1"
+                    }
+                ],
+                "resourceVersion": "3226",
+                "selfLink": "/apis/cluster.x-k8s.io/v1alpha3/namespaces/default/machinedeployments/test0-md-0",
+                "uid": "324c8511-f947-45f8-b586-c015e5711d69"
+            },
+            "spec": {
+                "clusterName": "test0",
+                "minReadySeconds": 0,
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 1,
+                "selector": {
+                    "matchLabels": {
+                        "cluster.x-k8s.io/cluster-name": "test0",
+                        "cluster.x-k8s.io/deployment-name": "test0-md-0"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 1,
+                        "maxUnavailable": 0
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "cluster.x-k8s.io/cluster-name": "test0",
+                            "cluster.x-k8s.io/deployment-name": "test0-md-0"
+                        }
+                    },
+                    "spec": {
+                        "bootstrap": {
+                            "configRef": {
+                                "apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+                                "kind": "KubeadmConfigTemplate",
+                                "name": "test0-md-0",
+                                "namespace": "default"
+                            }
+                        },
+                        "clusterName": "test0",
+                        "infrastructureRef": {
+                            "apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+                            "kind": "DockerMachineTemplate",
+                            "name": "test0-md-0",
+                            "namespace": "default"
+                        },
+                        "version": "v1.19.8-eks-1-19-4"
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "observedGeneration": 1,
+                "phase": "Running",
+                "readyReplicas": 1,
+                "replicas": 2,
+                "selector": "cluster.x-k8s.io/cluster-name=test0,cluster.x-k8s.io/deployment-name=test0-md-0",
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
+            "kind": "MachineDeployment",
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cluster.x-k8s.io/v1alpha3\",\"kind\":\"MachineDeployment\",\"metadata\":{\"annotations\":{},\"name\":\"test1-md-0\",\"namespace\":\"default\"},\"spec\":{\"clusterName\":\"test1\",\"replicas\":1,\"selector\":{\"matchLabels\":null},\"template\":{\"spec\":{\"bootstrap\":{\"configRef\":{\"apiVersion\":\"bootstrap.cluster.x-k8s.io/v1alpha3\",\"kind\":\"KubeadmConfigTemplate\",\"name\":\"test1-md-0\",\"namespace\":\"default\"}},\"clusterName\":\"test1\",\"infrastructureRef\":{\"apiVersion\":\"infrastructure.cluster.x-k8s.io/v1alpha3\",\"kind\":\"DockerMachineTemplate\",\"name\":\"test1-md-0\",\"namespace\":\"default\"},\"version\":\"v1.19.8-eks-1-19-4\"}}}}\n",
+                    "machinedeployment.clusters.x-k8s.io/revision": "1"
+                },
+                "creationTimestamp": "2021-07-01T14:50:15Z",
+                "generation": 1,
+                "labels": {
+                    "cluster.x-k8s.io/cluster-name": "test1"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {},
+                                    "f:machinedeployment.clusters.x-k8s.io/revision": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:cluster.x-k8s.io/cluster-name": {}
+                                },
+                                "f:ownerReferences": {}
+                            },
+                            "f:spec": {
+                                ".": {},
+                                "f:clusterName": {},
+                                "f:minReadySeconds": {},
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    ".": {},
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:cluster.x-k8s.io/cluster-name": {},
+                                        "f:cluster.x-k8s.io/deployment-name": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    ".": {},
+                                    "f:rollingUpdate": {
+                                        ".": {},
+                                        "f:maxSurge": {},
+                                        "f:maxUnavailable": {}
+                                    },
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    ".": {},
+                                    "f:metadata": {
+                                        ".": {},
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:cluster.x-k8s.io/cluster-name": {},
+                                            "f:cluster.x-k8s.io/deployment-name": {}
+                                        }
+                                    },
+                                    "f:spec": {
+                                        ".": {},
+                                        "f:bootstrap": {
+                                            ".": {},
+                                            "f:configRef": {
+                                                ".": {},
+                                                "f:apiVersion": {},
+                                                "f:kind": {},
+                                                "f:name": {},
+                                                "f:namespace": {}
+                                            }
+                                        },
+                                        "f:clusterName": {},
+                                        "f:infrastructureRef": {
+                                            ".": {},
+                                            "f:apiVersion": {},
+                                            "f:kind": {},
+                                            "f:name": {},
+                                            "f:namespace": {}
+                                        },
+                                        "f:version": {}
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "clusterctl",
+                        "operation": "Update",
+                        "time": "2021-07-01T14:50:15Z"
+                    },
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:status": {
+                                ".": {},
+                                "f:availableReplicas": {},
+                                "f:observedGeneration": {},
+                                "f:phase": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:selector": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "time": "2021-07-01T14:50:17Z"
+                    }
+                ],
+                "name": "test1-md-0",
+                "namespace": "default",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "kind": "Cluster",
+                        "name": "test1",
+                        "uid": "9607241e-c3a5-40c7-8f51-268231e615c1"
+                    }
+                ],
+                "resourceVersion": "3226",
+                "selfLink": "/apis/cluster.x-k8s.io/v1alpha3/namespaces/default/machinedeployments/test1-md-0",
+                "uid": "324c8511-f947-45f8-b586-c015e5711d69"
+            },
+            "spec": {
+                "clusterName": "test1",
+                "minReadySeconds": 0,
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 1,
+                "selector": {
+                    "matchLabels": {
+                        "cluster.x-k8s.io/cluster-name": "test1",
+                        "cluster.x-k8s.io/deployment-name": "test1-md-0"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 1,
+                        "maxUnavailable": 0
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "cluster.x-k8s.io/cluster-name": "test1",
+                            "cluster.x-k8s.io/deployment-name": "test1-md-0"
+                        }
+                    },
+                    "spec": {
+                        "bootstrap": {
+                            "configRef": {
+                                "apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+                                "kind": "KubeadmConfigTemplate",
+                                "name": "test1-md-0",
+                                "namespace": "default"
+                            }
+                        },
+                        "clusterName": "test1",
+                        "infrastructureRef": {
+                            "apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+                            "kind": "DockerMachineTemplate",
+                            "name": "test1-md-0",
+                            "namespace": "default"
+                        },
+                        "version": "v1.19.8-eks-1-19-4"
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "observedGeneration": 1,
+                "phase": "Provisioned",
+                "readyReplicas": 1,
+                "replicas": 1,
+                "selector": "cluster.x-k8s.io/cluster-name=test1,cluster.x-k8s.io/deployment-name=test1-md-0",
+                "updatedReplicas": 1
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}

--- a/pkg/executables/testdata/kubectl_machine_deployments_unavailable.json
+++ b/pkg/executables/testdata/kubectl_machine_deployments_unavailable.json
@@ -1,0 +1,377 @@
+{
+    "apiVersion": "v1",
+    "items": [
+            {
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
+            "kind": "MachineDeployment",
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cluster.x-k8s.io/v1alpha3\",\"kind\":\"MachineDeployment\",\"metadata\":{\"annotations\":{},\"name\":\"test0-md-0\",\"namespace\":\"default\"},\"spec\":{\"clusterName\":\"test0\",\"replicas\":1,\"selector\":{\"matchLabels\":null},\"template\":{\"spec\":{\"bootstrap\":{\"configRef\":{\"apiVersion\":\"bootstrap.cluster.x-k8s.io/v1alpha3\",\"kind\":\"KubeadmConfigTemplate\",\"name\":\"test0-md-0\",\"namespace\":\"default\"}},\"clusterName\":\"test0\",\"infrastructureRef\":{\"apiVersion\":\"infrastructure.cluster.x-k8s.io/v1alpha3\",\"kind\":\"DockerMachineTemplate\",\"name\":\"test0-md-0\",\"namespace\":\"default\"},\"version\":\"v1.19.8-eks-1-19-4\"}}}}\n",
+                    "machinedeployment.clusters.x-k8s.io/revision": "1"
+                },
+                "creationTimestamp": "2021-07-01T14:50:15Z",
+                "generation": 1,
+                "labels": {
+                    "cluster.x-k8s.io/cluster-name": "test0"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {},
+                                    "f:machinedeployment.clusters.x-k8s.io/revision": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:cluster.x-k8s.io/cluster-name": {}
+                                },
+                                "f:ownerReferences": {}
+                            },
+                            "f:spec": {
+                                ".": {},
+                                "f:clusterName": {},
+                                "f:minReadySeconds": {},
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    ".": {},
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:cluster.x-k8s.io/cluster-name": {},
+                                        "f:cluster.x-k8s.io/deployment-name": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    ".": {},
+                                    "f:rollingUpdate": {
+                                        ".": {},
+                                        "f:maxSurge": {},
+                                        "f:maxUnavailable": {}
+                                    },
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    ".": {},
+                                    "f:metadata": {
+                                        ".": {},
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:cluster.x-k8s.io/cluster-name": {},
+                                            "f:cluster.x-k8s.io/deployment-name": {}
+                                        }
+                                    },
+                                    "f:spec": {
+                                        ".": {},
+                                        "f:bootstrap": {
+                                            ".": {},
+                                            "f:configRef": {
+                                                ".": {},
+                                                "f:apiVersion": {},
+                                                "f:kind": {},
+                                                "f:name": {},
+                                                "f:namespace": {}
+                                            }
+                                        },
+                                        "f:clusterName": {},
+                                        "f:infrastructureRef": {
+                                            ".": {},
+                                            "f:apiVersion": {},
+                                            "f:kind": {},
+                                            "f:name": {},
+                                            "f:namespace": {}
+                                        },
+                                        "f:version": {}
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "clusterctl",
+                        "operation": "Update",
+                        "time": "2021-07-01T14:50:15Z"
+                    },
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:status": {
+                                ".": {},
+                                "f:availableReplicas": {},
+                                "f:observedGeneration": {},
+                                "f:phase": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:selector": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "time": "2021-07-01T14:50:17Z"
+                    }
+                ],
+                "name": "test0-md-0",
+                "namespace": "default",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "kind": "Cluster",
+                        "name": "test0",
+                        "uid": "9607241e-c3a5-40c7-8f51-268231e615c1"
+                    }
+                ],
+                "resourceVersion": "3226",
+                "selfLink": "/apis/cluster.x-k8s.io/v1alpha3/namespaces/default/machinedeployments/test0-md-0",
+                "uid": "324c8511-f947-45f8-b586-c015e5711d69"
+            },
+            "spec": {
+                "clusterName": "test0",
+                "minReadySeconds": 0,
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 1,
+                "selector": {
+                    "matchLabels": {
+                        "cluster.x-k8s.io/cluster-name": "test0",
+                        "cluster.x-k8s.io/deployment-name": "test0-md-0"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 1,
+                        "maxUnavailable": 0
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "cluster.x-k8s.io/cluster-name": "test0",
+                            "cluster.x-k8s.io/deployment-name": "test0-md-0"
+                        }
+                    },
+                    "spec": {
+                        "bootstrap": {
+                            "configRef": {
+                                "apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+                                "kind": "KubeadmConfigTemplate",
+                                "name": "test0-md-0",
+                                "namespace": "default"
+                            }
+                        },
+                        "clusterName": "test0",
+                        "infrastructureRef": {
+                            "apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+                            "kind": "DockerMachineTemplate",
+                            "name": "test0-md-0",
+                            "namespace": "default"
+                        },
+                        "version": "v1.19.8-eks-1-19-4"
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "observedGeneration": 1,
+                "phase": "Running",
+                "readyReplicas": 1,
+                "replicas": 2,
+                "selector": "cluster.x-k8s.io/cluster-name=test0,cluster.x-k8s.io/deployment-name=test0-md-0",
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
+            "kind": "MachineDeployment",
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cluster.x-k8s.io/v1alpha3\",\"kind\":\"MachineDeployment\",\"metadata\":{\"annotations\":{},\"name\":\"test1-md-0\",\"namespace\":\"default\"},\"spec\":{\"clusterName\":\"test1\",\"replicas\":1,\"selector\":{\"matchLabels\":null},\"template\":{\"spec\":{\"bootstrap\":{\"configRef\":{\"apiVersion\":\"bootstrap.cluster.x-k8s.io/v1alpha3\",\"kind\":\"KubeadmConfigTemplate\",\"name\":\"test1-md-0\",\"namespace\":\"default\"}},\"clusterName\":\"test1\",\"infrastructureRef\":{\"apiVersion\":\"infrastructure.cluster.x-k8s.io/v1alpha3\",\"kind\":\"DockerMachineTemplate\",\"name\":\"test1-md-0\",\"namespace\":\"default\"},\"version\":\"v1.19.8-eks-1-19-4\"}}}}\n",
+                    "machinedeployment.clusters.x-k8s.io/revision": "1"
+                },
+                "creationTimestamp": "2021-07-01T14:50:15Z",
+                "generation": 1,
+                "labels": {
+                    "cluster.x-k8s.io/cluster-name": "test1"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {},
+                                    "f:machinedeployment.clusters.x-k8s.io/revision": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:cluster.x-k8s.io/cluster-name": {}
+                                },
+                                "f:ownerReferences": {}
+                            },
+                            "f:spec": {
+                                ".": {},
+                                "f:clusterName": {},
+                                "f:minReadySeconds": {},
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    ".": {},
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:cluster.x-k8s.io/cluster-name": {},
+                                        "f:cluster.x-k8s.io/deployment-name": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    ".": {},
+                                    "f:rollingUpdate": {
+                                        ".": {},
+                                        "f:maxSurge": {},
+                                        "f:maxUnavailable": {}
+                                    },
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    ".": {},
+                                    "f:metadata": {
+                                        ".": {},
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:cluster.x-k8s.io/cluster-name": {},
+                                            "f:cluster.x-k8s.io/deployment-name": {}
+                                        }
+                                    },
+                                    "f:spec": {
+                                        ".": {},
+                                        "f:bootstrap": {
+                                            ".": {},
+                                            "f:configRef": {
+                                                ".": {},
+                                                "f:apiVersion": {},
+                                                "f:kind": {},
+                                                "f:name": {},
+                                                "f:namespace": {}
+                                            }
+                                        },
+                                        "f:clusterName": {},
+                                        "f:infrastructureRef": {
+                                            ".": {},
+                                            "f:apiVersion": {},
+                                            "f:kind": {},
+                                            "f:name": {},
+                                            "f:namespace": {}
+                                        },
+                                        "f:version": {}
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "clusterctl",
+                        "operation": "Update",
+                        "time": "2021-07-01T14:50:15Z"
+                    },
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:status": {
+                                ".": {},
+                                "f:availableReplicas": {},
+                                "f:observedGeneration": {},
+                                "f:phase": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:selector": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "time": "2021-07-01T14:50:17Z"
+                    }
+                ],
+                "name": "test1-md-0",
+                "namespace": "default",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "kind": "Cluster",
+                        "name": "test1",
+                        "uid": "9607241e-c3a5-40c7-8f51-268231e615c1"
+                    }
+                ],
+                "resourceVersion": "3226",
+                "selfLink": "/apis/cluster.x-k8s.io/v1alpha3/namespaces/default/machinedeployments/test1-md-0",
+                "uid": "324c8511-f947-45f8-b586-c015e5711d69"
+            },
+            "spec": {
+                "clusterName": "test1",
+                "minReadySeconds": 0,
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 1,
+                "selector": {
+                    "matchLabels": {
+                        "cluster.x-k8s.io/cluster-name": "test1",
+                        "cluster.x-k8s.io/deployment-name": "test1-md-0"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 1,
+                        "maxUnavailable": 0
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "cluster.x-k8s.io/cluster-name": "test1",
+                            "cluster.x-k8s.io/deployment-name": "test1-md-0"
+                        }
+                    },
+                    "spec": {
+                        "bootstrap": {
+                            "configRef": {
+                                "apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+                                "kind": "KubeadmConfigTemplate",
+                                "name": "test1-md-0",
+                                "namespace": "default"
+                            }
+                        },
+                        "clusterName": "test1",
+                        "infrastructureRef": {
+                            "apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+                            "kind": "DockerMachineTemplate",
+                            "name": "test1-md-0",
+                            "namespace": "default"
+                        },
+                        "version": "v1.19.8-eks-1-19-4"
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "observedGeneration": 1,
+                "phase": "Running",
+                "readyReplicas": 0,
+                "replicas": 1,
+                "selector": "cluster.x-k8s.io/cluster-name=test1,cluster.x-k8s.io/deployment-name=test1-md-0",
+                "updatedReplicas": 1,
+                "UnavailableReplicas": 1
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}

--- a/pkg/executables/testdata/kubectl_machine_deployments_unready.json
+++ b/pkg/executables/testdata/kubectl_machine_deployments_unready.json
@@ -1,0 +1,376 @@
+{
+    "apiVersion": "v1",
+    "items": [
+            {
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
+            "kind": "MachineDeployment",
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cluster.x-k8s.io/v1alpha3\",\"kind\":\"MachineDeployment\",\"metadata\":{\"annotations\":{},\"name\":\"test0-md-0\",\"namespace\":\"default\"},\"spec\":{\"clusterName\":\"test0\",\"replicas\":1,\"selector\":{\"matchLabels\":null},\"template\":{\"spec\":{\"bootstrap\":{\"configRef\":{\"apiVersion\":\"bootstrap.cluster.x-k8s.io/v1alpha3\",\"kind\":\"KubeadmConfigTemplate\",\"name\":\"test0-md-0\",\"namespace\":\"default\"}},\"clusterName\":\"test0\",\"infrastructureRef\":{\"apiVersion\":\"infrastructure.cluster.x-k8s.io/v1alpha3\",\"kind\":\"DockerMachineTemplate\",\"name\":\"test0-md-0\",\"namespace\":\"default\"},\"version\":\"v1.19.8-eks-1-19-4\"}}}}\n",
+                    "machinedeployment.clusters.x-k8s.io/revision": "1"
+                },
+                "creationTimestamp": "2021-07-01T14:50:15Z",
+                "generation": 1,
+                "labels": {
+                    "cluster.x-k8s.io/cluster-name": "test0"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {},
+                                    "f:machinedeployment.clusters.x-k8s.io/revision": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:cluster.x-k8s.io/cluster-name": {}
+                                },
+                                "f:ownerReferences": {}
+                            },
+                            "f:spec": {
+                                ".": {},
+                                "f:clusterName": {},
+                                "f:minReadySeconds": {},
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    ".": {},
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:cluster.x-k8s.io/cluster-name": {},
+                                        "f:cluster.x-k8s.io/deployment-name": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    ".": {},
+                                    "f:rollingUpdate": {
+                                        ".": {},
+                                        "f:maxSurge": {},
+                                        "f:maxUnavailable": {}
+                                    },
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    ".": {},
+                                    "f:metadata": {
+                                        ".": {},
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:cluster.x-k8s.io/cluster-name": {},
+                                            "f:cluster.x-k8s.io/deployment-name": {}
+                                        }
+                                    },
+                                    "f:spec": {
+                                        ".": {},
+                                        "f:bootstrap": {
+                                            ".": {},
+                                            "f:configRef": {
+                                                ".": {},
+                                                "f:apiVersion": {},
+                                                "f:kind": {},
+                                                "f:name": {},
+                                                "f:namespace": {}
+                                            }
+                                        },
+                                        "f:clusterName": {},
+                                        "f:infrastructureRef": {
+                                            ".": {},
+                                            "f:apiVersion": {},
+                                            "f:kind": {},
+                                            "f:name": {},
+                                            "f:namespace": {}
+                                        },
+                                        "f:version": {}
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "clusterctl",
+                        "operation": "Update",
+                        "time": "2021-07-01T14:50:15Z"
+                    },
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:status": {
+                                ".": {},
+                                "f:availableReplicas": {},
+                                "f:observedGeneration": {},
+                                "f:phase": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:selector": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "time": "2021-07-01T14:50:17Z"
+                    }
+                ],
+                "name": "test0-md-0",
+                "namespace": "default",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "kind": "Cluster",
+                        "name": "test0",
+                        "uid": "9607241e-c3a5-40c7-8f51-268231e615c1"
+                    }
+                ],
+                "resourceVersion": "3226",
+                "selfLink": "/apis/cluster.x-k8s.io/v1alpha3/namespaces/default/machinedeployments/test0-md-0",
+                "uid": "324c8511-f947-45f8-b586-c015e5711d69"
+            },
+            "spec": {
+                "clusterName": "test0",
+                "minReadySeconds": 0,
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 1,
+                "selector": {
+                    "matchLabels": {
+                        "cluster.x-k8s.io/cluster-name": "test0",
+                        "cluster.x-k8s.io/deployment-name": "test0-md-0"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 1,
+                        "maxUnavailable": 0
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "cluster.x-k8s.io/cluster-name": "test0",
+                            "cluster.x-k8s.io/deployment-name": "test0-md-0"
+                        }
+                    },
+                    "spec": {
+                        "bootstrap": {
+                            "configRef": {
+                                "apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+                                "kind": "KubeadmConfigTemplate",
+                                "name": "test0-md-0",
+                                "namespace": "default"
+                            }
+                        },
+                        "clusterName": "test0",
+                        "infrastructureRef": {
+                            "apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+                            "kind": "DockerMachineTemplate",
+                            "name": "test0-md-0",
+                            "namespace": "default"
+                        },
+                        "version": "v1.19.8-eks-1-19-4"
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "observedGeneration": 1,
+                "phase": "Running",
+                "readyReplicas": 1,
+                "replicas": 2,
+                "selector": "cluster.x-k8s.io/cluster-name=test0,cluster.x-k8s.io/deployment-name=test0-md-0",
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
+            "kind": "MachineDeployment",
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cluster.x-k8s.io/v1alpha3\",\"kind\":\"MachineDeployment\",\"metadata\":{\"annotations\":{},\"name\":\"test1-md-0\",\"namespace\":\"default\"},\"spec\":{\"clusterName\":\"test1\",\"replicas\":1,\"selector\":{\"matchLabels\":null},\"template\":{\"spec\":{\"bootstrap\":{\"configRef\":{\"apiVersion\":\"bootstrap.cluster.x-k8s.io/v1alpha3\",\"kind\":\"KubeadmConfigTemplate\",\"name\":\"test1-md-0\",\"namespace\":\"default\"}},\"clusterName\":\"test1\",\"infrastructureRef\":{\"apiVersion\":\"infrastructure.cluster.x-k8s.io/v1alpha3\",\"kind\":\"DockerMachineTemplate\",\"name\":\"test1-md-0\",\"namespace\":\"default\"},\"version\":\"v1.19.8-eks-1-19-4\"}}}}\n",
+                    "machinedeployment.clusters.x-k8s.io/revision": "1"
+                },
+                "creationTimestamp": "2021-07-01T14:50:15Z",
+                "generation": 1,
+                "labels": {
+                    "cluster.x-k8s.io/cluster-name": "test1"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {},
+                                    "f:machinedeployment.clusters.x-k8s.io/revision": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:cluster.x-k8s.io/cluster-name": {}
+                                },
+                                "f:ownerReferences": {}
+                            },
+                            "f:spec": {
+                                ".": {},
+                                "f:clusterName": {},
+                                "f:minReadySeconds": {},
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    ".": {},
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:cluster.x-k8s.io/cluster-name": {},
+                                        "f:cluster.x-k8s.io/deployment-name": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    ".": {},
+                                    "f:rollingUpdate": {
+                                        ".": {},
+                                        "f:maxSurge": {},
+                                        "f:maxUnavailable": {}
+                                    },
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    ".": {},
+                                    "f:metadata": {
+                                        ".": {},
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:cluster.x-k8s.io/cluster-name": {},
+                                            "f:cluster.x-k8s.io/deployment-name": {}
+                                        }
+                                    },
+                                    "f:spec": {
+                                        ".": {},
+                                        "f:bootstrap": {
+                                            ".": {},
+                                            "f:configRef": {
+                                                ".": {},
+                                                "f:apiVersion": {},
+                                                "f:kind": {},
+                                                "f:name": {},
+                                                "f:namespace": {}
+                                            }
+                                        },
+                                        "f:clusterName": {},
+                                        "f:infrastructureRef": {
+                                            ".": {},
+                                            "f:apiVersion": {},
+                                            "f:kind": {},
+                                            "f:name": {},
+                                            "f:namespace": {}
+                                        },
+                                        "f:version": {}
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "clusterctl",
+                        "operation": "Update",
+                        "time": "2021-07-01T14:50:15Z"
+                    },
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:status": {
+                                ".": {},
+                                "f:availableReplicas": {},
+                                "f:observedGeneration": {},
+                                "f:phase": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:selector": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "time": "2021-07-01T14:50:17Z"
+                    }
+                ],
+                "name": "test1-md-0",
+                "namespace": "default",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "cluster.x-k8s.io/v1alpha3",
+                        "kind": "Cluster",
+                        "name": "test1",
+                        "uid": "9607241e-c3a5-40c7-8f51-268231e615c1"
+                    }
+                ],
+                "resourceVersion": "3226",
+                "selfLink": "/apis/cluster.x-k8s.io/v1alpha3/namespaces/default/machinedeployments/test1-md-0",
+                "uid": "324c8511-f947-45f8-b586-c015e5711d69"
+            },
+            "spec": {
+                "clusterName": "test1",
+                "minReadySeconds": 0,
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 1,
+                "selector": {
+                    "matchLabels": {
+                        "cluster.x-k8s.io/cluster-name": "test1",
+                        "cluster.x-k8s.io/deployment-name": "test1-md-0"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 1,
+                        "maxUnavailable": 0
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "cluster.x-k8s.io/cluster-name": "test1",
+                            "cluster.x-k8s.io/deployment-name": "test1-md-0"
+                        }
+                    },
+                    "spec": {
+                        "bootstrap": {
+                            "configRef": {
+                                "apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+                                "kind": "KubeadmConfigTemplate",
+                                "name": "test1-md-0",
+                                "namespace": "default"
+                            }
+                        },
+                        "clusterName": "test1",
+                        "infrastructureRef": {
+                            "apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+                            "kind": "DockerMachineTemplate",
+                            "name": "test1-md-0",
+                            "namespace": "default"
+                        },
+                        "version": "v1.19.8-eks-1-19-4"
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "observedGeneration": 1,
+                "phase": "Running",
+                "readyReplicas": 1,
+                "replicas": 1,
+                "selector": "cluster.x-k8s.io/cluster-name=test1,cluster.x-k8s.io/deployment-name=test1-md-0",
+                "updatedReplicas": 1
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently it waits zero seconds between retries when waiting for all machine deployment replicas are ready. This PR introduces a wait time adaptive to unready replicas between retries. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

