### PR TITLE
Add retry to deploy key add

### DIFF
--- a/internal/test/e2e/fluxGit.go
+++ b/internal/test/e2e/fluxGit.go
@@ -3,17 +3,17 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"log"
-	"os"
-	"regexp"
-	"time"
-
 	"github.com/aws/eks-anywhere/internal/pkg/ssm"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/git"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/retrier"
 	e2etests "github.com/aws/eks-anywhere/test/framework"
+	"log"
+	"os"
+	"regexp"
+	"time"
 )
 
 type s3Files struct {
@@ -141,9 +141,6 @@ func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*g
 		return nil, fmt.Errorf("creating repository in Github for test: %v", err)
 	}
 
-	// Wait for eventual consistency in the GitHub API when creating a repository before adding a deploy key
-	time.Sleep(time.Second * 5)
-
 	pk, pub, err := e.generateKeyPairForGitTest()
 	if err != nil {
 		return nil, fmt.Errorf("generating key pair for git tests: %v", err)
@@ -158,9 +155,16 @@ func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*g
 		ReadOnly:   false,
 	}
 
-	err = g.AddDeployKeyToRepo(ctx, ko)
+	//Newly generated repositories may take some time to show up in the GitHub API; retry a few times to get around this
+	err = retrier.Retry(6, time.Second*10, func() error {
+		err = g.AddDeployKeyToRepo(ctx, ko)
+		if err != nil {
+			return fmt.Errorf("couldn't add deploy key to repo: %v", err)
+		}
+		return nil
+	})
 	if err != nil {
-		return r, fmt.Errorf("couldn't add deploy key to repo: %v", err)
+		return r, err
 	}
 
 	// Generate a PEM file from the private key and write it instance at the user-provided path

--- a/internal/test/e2e/fluxGit.go
+++ b/internal/test/e2e/fluxGit.go
@@ -3,6 +3,11 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"time"
+
 	"github.com/aws/eks-anywhere/internal/pkg/ssm"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
@@ -10,10 +15,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/retrier"
 	e2etests "github.com/aws/eks-anywhere/test/framework"
-	"log"
-	"os"
-	"regexp"
-	"time"
 )
 
 type s3Files struct {
@@ -155,7 +156,7 @@ func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*g
 		ReadOnly:   false,
 	}
 
-	//Newly generated repositories may take some time to show up in the GitHub API; retry a few times to get around this
+	// Newly generated repositories may take some time to show up in the GitHub API; retry a few times to get around this
 	err = retrier.Retry(6, time.Second*10, func() error {
 		err = g.AddDeployKeyToRepo(ctx, ko)
 		if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The creation and addition of deploy keys to newly created test repositories works in the test framework when run locally. 

When run in the large e2e test runs all tests using this functionality return a 404 when attempting to add the key.

In an effort to continue to debug and solve this, I'm adding a retrier to the deploy key addition; I am wondering if we're continuing to run into issues with the github API for our account since we're creating 30+ repos in the same moments as the tests spin up and set up Git tests and Github tests launch.

This may not be the solution but will tell us more about this problem.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

