### PR TITLE
Set boots lease duration to max

### DIFF
--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
@@ -2,7 +2,7 @@ package hardware
 
 import (
 	"fmt"
-	"time"
+	"math"
 
 	tinkv1alpha1 "github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -205,8 +205,10 @@ func hardwareFromMachine(m Machine) *tinkv1alpha1.Hardware {
 							Gateway: m.Gateway,
 							Family:  4,
 						},
-						// set LeaseTime to 1 month while we figure out how to set static IPs
-						LeaseTime:   int64(time.Hour * 24 * 30 / time.Second),
+						// set LeaseTime to the max value so it effectively hands out max duration leases (~136 years)
+						// This value gets ignored for Ubuntu because we set static IPs for it
+						// It's only temporarily needed for Bottlerocket until Bottlerocket supports static IPs
+						LeaseTime:   int64(math.Pow(2, 32) - 2),
 						Hostname:    m.Hostname,
 						NameServers: m.Nameservers,
 						UEFI:        true,


### PR DESCRIPTION
*Description of changes:*
Set boots dhcp lease duration to the max allowed value.
This value only applies for BottleRocket nodes as the IPs are set statically on Ubuntu nodes.
This is a temporary solution until BottleRocket support static IPs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

