### PR TITLE
Enable hostPort for tink services only on bootstrap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tinkerbell/rufio v0.0.0-20220606134123-599b7401b5cc
 	github.com/tinkerbell/tink v0.6.1-0.20220509141453-30fe9e015575
+	go.uber.org/multierr v1.7.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
@@ -134,7 +135,6 @@ require (
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -50,6 +50,7 @@ func (p *Provider) PreCAPIInstallOnBootstrap(ctx context.Context, cluster *types
 		cluster.KubeconfigFile,
 		stack.WithNamespaceCreate(false),
 		stack.WithBootsOnDocker(),
+		stack.WithHostPortEnabled(true),
 	)
 	if err != nil {
 		return fmt.Errorf("install Tinkerbell stack on bootstrap cluster: %v", err)
@@ -80,6 +81,7 @@ func (p *Provider) PostWorkloadInit(ctx context.Context, cluster *types.Cluster,
 		cluster.KubeconfigFile,
 		stack.WithNamespaceCreate(true),
 		stack.WithBootsOnKubernetes(),
+		stack.WithHostPortEnabled(false),
 	)
 	if err != nil {
 		return fmt.Errorf("installing stack on workload cluster: %v", err)

--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -19,9 +19,11 @@ const (
 	createNamespace   = "createNamespace"
 	deploy            = "deploy"
 	env               = "env"
+	hostPortEnabled   = "hostPortEnabled"
 	image             = "image"
 	namespace         = "namespace"
 	overridesFileName = "tinkerbell-chart-overrides.yaml"
+	port              = "port"
 
 	boots          = "boots"
 	hegel          = "hegel"
@@ -48,6 +50,7 @@ type Installer struct {
 	namespace       string
 	createNamespace bool
 	bootsOnDocker   bool
+	hostPort        bool
 }
 
 type InstallOption func(s *Installer)
@@ -76,6 +79,13 @@ func WithBootsOnDocker() InstallOption {
 func WithBootsOnKubernetes() InstallOption {
 	return func(s *Installer) {
 		s.bootsOnDocker = false
+	}
+}
+
+// WithHostPortEnabled is an InstallOption that allows you to enable/disable host port for Tinkerbell deployments
+func WithHostPortEnabled(enabled bool) InstallOption {
+	return func(s *Installer) {
+		s.hostPort = enabled
 	}
 }
 
@@ -121,11 +131,17 @@ func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 			deploy: true,
 			image:  bundle.Tink.TinkServer.URI,
 			args:   []string{"--tls=false"},
+			port: map[string]bool{
+				hostPortEnabled: s.hostPort,
+			},
 		},
 		hegel: map[string]interface{}{
 			deploy: true,
 			image:  bundle.Hegel.Image.URI,
 			args:   []string{"--grpc-use-tls=false"},
+			port: map[string]bool{
+				hostPortEnabled: s.hostPort,
+			},
 		},
 		boots: map[string]interface{}{
 			deploy: !s.bootsOnDocker,

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -74,6 +74,7 @@ func TestTinkerbellStackInstallWithAllOptionsSuccess(t *testing.T) {
 		cluster.KubeconfigFile,
 		stack.WithNamespaceCreate(true),
 		stack.WithBootsOnKubernetes(),
+		stack.WithHostPortEnabled(true),
 	); err != nil {
 		t.Fatalf("failed to install Tinkerbell stack: %v", err)
 	}

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -226,8 +226,9 @@ func TestPreCAPIInstallOnBootstrapSuccess(t *testing.T) {
 	stackInstaller.EXPECT().Install(
 		ctx,
 		releasev1alpha1.TinkerbellStackBundle{},
-		gomock.Any(),
+		testIP,
 		"test.kubeconfig",
+		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
 	)
@@ -260,8 +261,9 @@ func TestPostWorkloadInitSuccess(t *testing.T) {
 	stackInstaller.EXPECT().Install(
 		ctx,
 		releasev1alpha1.TinkerbellStackBundle{},
-		gomock.Any(),
+		testIP,
 		"test.kubeconfig",
+		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
 	)


### PR DESCRIPTION
*Description of changes:*
`hostPort` is needed for `hegel` and `tink-server` on local Kind cluster but it's not needed when the Tinkerbell stack on the workload cluster. This PR enables `hostPort` for tink services only for bootstrap phase.
These are the helm chart values that are used to control hostPort for deployments https://github.com/aws/eks-anywhere-build-tooling/blob/main/projects/tinkerbell/tinkerbell-chart/chart/values.yaml#L32-L34

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

