### PR TITLE
Improve error when hardware CSV has missing required columns

### DIFF
--- a/pkg/providers/tinkerbell/hardware/machine.go
+++ b/pkg/providers/tinkerbell/hardware/machine.go
@@ -23,9 +23,9 @@ type Machine struct {
 	// Labels to be applied to the Hardware resource.
 	Labels Labels `csv:"labels"`
 
-	BMCIPAddress string `csv:"bmc_ip"`
-	BMCUsername  string `csv:"bmc_username"`
-	BMCPassword  string `csv:"bmc_password"`
+	BMCIPAddress string `csv:"bmc_ip, omitempty"`
+	BMCUsername  string `csv:"bmc_username, omitempty"`
+	BMCPassword  string `csv:"bmc_password, omitempty"`
 }
 
 // HasBMC determines if m has a BMC configuration. A BMC configuration is present if any of the BMC fields


### PR DESCRIPTION
Previously users would receive an error about missing data when an entire column is missing. This improves the error to explicitly call out a missing column.
