### PR TITLE
Reject cluster operations with external etcd for bare metal

### DIFF
--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -93,6 +93,10 @@ func (p *Provider) PostWorkloadInit(ctx context.Context, cluster *types.Cluster,
 }
 
 func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpec *cluster.Spec) error {
+	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
+		return ErrExternalEtcdUnsupported
+	}
+
 	if err := p.stackInstaller.CleanupLocalBoots(ctx, p.forceCleanup); err != nil {
 		return err
 	}

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_multiple_node_groups.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_multiple_node_groups.yaml
@@ -22,11 +22,6 @@ spec:
   datacenterRef:
     kind: TinkerbellDatacenterConfig
     name: test
-  externalEtcdConfiguration:
-    count: 1
-    machineGroupRef:
-      name: test-etcd
-      kind: TinkerbellMachineConfig
   kubernetesVersion: "1.21"
   managementCluster:
     name: test

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
@@ -22,10 +22,6 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: TinkerbellCluster
     name: test
-  managedExternalEtcdRef:
-    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
-    kind: EtcdadmCluster
-    name: test-etcd
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -37,11 +33,9 @@ spec:
     clusterConfiguration:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
-        external:
-          endpoints: []
-          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
-          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
-          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
+        local:
+          imageRepository: public.ecr.aws/eks-distro/etcd-io
+          imageTag: v3.4.16-eks-1-21-4
       dns:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.3-eks-1-21-4
@@ -127,148 +121,6 @@ spec:
       name: test-control-plane-template-1234567890000
   replicas: 1
   version: v1.21.2-eks-1-21-4
----
-kind: EtcdadmCluster
-apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
-metadata:
-  name: test-etcd
-  namespace: eksa-system
-spec:
-  replicas: 1
-  etcdadmConfigSpec:
-    etcdadmBuiltin: true
-    format: cloud-config
-    cloudInitConfig:
-      version: 3.4.16
-      installDir: "/usr/bin"
-    preEtcdadmCommands:
-      - hostname "{{ ds.meta_data.hostname }}"
-      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
-      - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
-    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-    users:
-      - name: tink-user
-        sshAuthorizedKeys:
-          - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
-        sudo: ALL=(ALL) NOPASSWD:ALL
-  infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: TinkerbellMachineTemplate
-    name: test-etcd-template-1234567890000
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: TinkerbellMachineTemplate
-metadata:
-  name: test-etcd-template-1234567890000
-  namespace: eksa-system
-spec:
-  template:
-    spec:
-      hardwareAffinity:
-        required:
-        - labelSelector:
-            matchLabels: 
-              type: etcd
-      templateOverride: |
-        global_timeout: 6000
-        id: ""
-        name: tink-test
-        tasks:
-        - actions:
-          - environment:
-              COMPRESSED: "true"
-              DEST_DISK: /dev/sda
-              IMG_URL: ""
-            image: image2disk:v1.0.0
-            name: stream-image
-            timeout: 360
-          - environment:
-              BLOCK_DEVICE: /dev/sda2
-              CHROOT: "y"
-              CMD_LINE: apt -y update && apt -y install openssl
-              DEFAULT_INTERPRETER: /bin/sh -c
-              FS_TYPE: ext4
-            image: cexec:v1.0.0
-            name: install-openssl
-            timeout: 90
-          - environment:
-              CONTENTS: |
-                network:
-                  version: 2
-                  renderer: networkd
-                  ethernets:
-                      eno1:
-                          dhcp4: true
-                      eno2:
-                          dhcp4: true
-                      eno3:
-                          dhcp4: true
-                      eno4:
-                          dhcp4: true
-              DEST_DISK: /dev/sda2
-              DEST_PATH: /etc/netplan/config.yaml
-              DIRMODE: "0755"
-              FS_TYPE: ext4
-              GID: "0"
-              MODE: "0644"
-              UID: "0"
-            image: writefile:v1.0.0
-            name: write-netplan
-            timeout: 90
-          - environment:
-              CONTENTS: |
-                datasource:
-                  Ec2:
-                    metadata_urls: []
-                    strict_id: false
-                system_info:
-                  default_user:
-                    name: tink
-                    groups: [wheel, adm]
-                    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-                    shell: /bin/bash
-                manage_etc_hosts: localhost
-                warnings:
-                  dsid_missing_source: off
-              DEST_DISK: /dev/sda2
-              DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
-              DIRMODE: "0700"
-              FS_TYPE: ext4
-              GID: "0"
-              MODE: "0600"
-            image: writefile:v1.0.0
-            name: add-tink-cloud-init-config
-            timeout: 90
-          - environment:
-              CONTENTS: |
-                datasource: Ec2
-              DEST_DISK: /dev/sda2
-              DEST_PATH: /etc/cloud/ds-identify.cfg
-              DIRMODE: "0700"
-              FS_TYPE: ext4
-              GID: "0"
-              MODE: "0600"
-              UID: "0"
-            image: writefile:v1.0.0
-            name: add-tink-cloud-init-ds-config
-            timeout: 90
-          - environment:
-              BLOCK_DEVICE: /dev/sda2
-              FS_TYPE: ext4
-            image: kexec:v1.0.0
-            name: kexec-image
-            pid: host
-            timeout: 90
-          name: tink-test
-          volumes:
-          - /dev:/dev
-          - /dev/console:/dev/console
-          - /lib/firmware:/lib/firmware:ro
-          worker: '{{.device_1}}'
-        version: "0.1"
-        
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -2,6 +2,7 @@ package tinkerbell
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -30,6 +31,10 @@ const (
 	maxRetries    = 30
 	backOffPeriod = 5 * time.Second
 )
+
+// ErrExternalEtcdUnsupported is returned from create or update when the user attempts to create
+// or upgrade a cluster with an external etcd configuration.
+var ErrExternalEtcdUnsupported = errors.New("external etcd configuration is unsupported")
 
 var (
 	eksaTinkerbellDatacenterResourceType = fmt.Sprintf("tinkerbelldatacenterconfigs.%s", v1alpha1.GroupVersion.Group)

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -63,6 +63,7 @@ func newProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineC
 }
 
 func TestTinkerbellProviderGenerateDeploymentFileWithExternalEtcd(t *testing.T) {
+	t.Skip("External etcd unsupported for GA")
 	clusterSpecManifest := "cluster_tinkerbell_external_etcd.yaml"
 	mockCtrl := gomock.NewController(t)
 	docker := stackmocks.NewMockDocker(mockCtrl)

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -66,6 +66,10 @@ func AnyImmutableFieldChanged(oldVdc, newVdc *v1alpha1.TinkerbellDatacenterConfi
 func (p *Provider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	logger.Info("Warning: The tinkerbell infrastructure provider is still in development and should not be used in production")
 
+	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
+		return ErrExternalEtcdUnsupported
+	}
+
 	if err := p.configureSshKeys(); err != nil {
 		return err
 	}


### PR DESCRIPTION
For GA, bare metal doesn't support external etcd. This change explicitly rejects invocations that use an external etcd config.