### PR TITLE
Don't include templateRef in TinkerbellMachineConfig on generate

### DIFF
--- a/internal/pkg/api/tinkerbell.go
+++ b/internal/pkg/api/tinkerbell.go
@@ -145,7 +145,7 @@ func WithTinkerbellEtcdMachineConfig() TinkerbellFiller {
 					Name: name,
 				},
 				Spec: anywherev1.TinkerbellMachineConfigSpec{
-					TemplateRef: anywherev1.Ref{
+					TemplateRef: &anywherev1.Ref{
 						Name: clusterName,
 						Kind: anywherev1.TinkerbellTemplateConfigKind,
 					},

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig.go
@@ -82,7 +82,7 @@ func GetTinkerbellMachineConfigs(fileName string) (map[string]*TinkerbellMachine
 
 func WithTemplateRef(ref ProviderRefAccessor) TinkerbellMachineConfigGenerateOpt {
 	return func(c *TinkerbellMachineConfigGenerate) {
-		c.Spec.TemplateRef = Ref{
+		c.Spec.TemplateRef = &Ref{
 			Kind: ref.Kind(),
 			Name: ref.Name(),
 		}

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
@@ -9,7 +9,7 @@ import (
 // TinkerbellMachineConfigSpec defines the desired state of TinkerbellMachineConfig
 type TinkerbellMachineConfigSpec struct {
 	HardwareSelector HardwareSelector    `json:"hardwareSelector"`
-	TemplateRef      Ref                 `json:"templateRef,omitempty"`
+	TemplateRef      *Ref                `json:"templateRef,omitempty"`
 	OSFamily         OSFamily            `json:"osFamily"`
 	Users            []UserConfiguration `json:"users,omitempty"`
 }

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -1862,7 +1862,7 @@ func TestGetTinkerbellMachineConfig(t *testing.T) {
 		},
 		Spec: v1alpha1.TinkerbellMachineConfigSpec{
 			OSFamily: "ubuntu",
-			TemplateRef: v1alpha1.Ref{
+			TemplateRef: &v1alpha1.Ref{
 				Name: "mycluster",
 				Kind: "TinkerbellTemplateConfig",
 			},


### PR DESCRIPTION
*Description of changes:*
Currently, the generate command prints a `TinkerbellMachineConfig` with an empty `templateRef` section. This PR makes the `templateRef` a pointer so it doesn't get placed in the generated config by default 

Before:
```yaml
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: TinkerbellMachineConfig
metadata:
  name: tdsfds-cp
spec:
  hardwareSelector: {}
  osFamily: ubuntu
  templateRef: {}
  users:
  - name: ec2-user
    sshAuthorizedKeys:
    - ssh-rsa AAAA...
```

After:
```yaml
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: TinkerbellMachineConfig
metadata:
  name: tdsfds
spec:
  hardwareSelector: {}
  osFamily: ubuntu
  users:
  - name: ec2-user
    sshAuthorizedKeys:
    - ssh-rsa AAAA...
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

