### PR TITLE
Add logic to build cluster.Spec from cluster

### DIFF
--- a/pkg/cluster/fetch.go
+++ b/pkg/cluster/fetch.go
@@ -22,6 +22,9 @@ type EksdReleaseFetch func(ctx context.Context, name, namespace string) (*eksdv1
 
 type OIDCFetch func(ctx context.Context, name, namespace string) (*v1alpha1.OIDCConfig, error)
 
+// BuildSpec constructs a cluster.Spec for a eks-a cluster by retrieving all
+// necessary objects using fetch methods
+// This is deprecated in favour of BuildSpec
 func BuildSpecForCluster(ctx context.Context, cluster *v1alpha1.Cluster, bundlesFetch BundlesFetch, eksdReleaseFetch EksdReleaseFetch, gitOpsFetch GitOpsFetch, fluxConfigFetch FluxConfigFetch, oidcFetch OIDCFetch) (*Spec, error) {
 	bundles, err := GetBundlesForCluster(ctx, cluster, bundlesFetch)
 	if err != nil {
@@ -59,7 +62,16 @@ func BuildSpecForCluster(ctx context.Context, cluster *v1alpha1.Cluster, bundles
 }
 
 func GetBundlesForCluster(ctx context.Context, cluster *v1alpha1.Cluster, fetch BundlesFetch) (*v1alpha1release.Bundles, error) {
-	var name, namespace string
+	name, namespace := bundlesNamespacedKey(cluster)
+	bundles, err := fetch(ctx, name, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("fetching Bundles for cluster: %v", err)
+	}
+
+	return bundles, nil
+}
+
+func bundlesNamespacedKey(cluster *v1alpha1.Cluster) (name, namespace string) {
 	if cluster.Spec.BundlesRef != nil {
 		name = cluster.Spec.BundlesRef.Name
 		namespace = cluster.Spec.BundlesRef.Namespace
@@ -71,12 +83,7 @@ func GetBundlesForCluster(ctx context.Context, cluster *v1alpha1.Cluster, fetch 
 		namespace = cluster.Namespace
 	}
 
-	bundles, err := fetch(ctx, name, namespace)
-	if err != nil {
-		return nil, fmt.Errorf("failed fetching Bundles for cluster: %v", err)
-	}
-
-	return bundles, nil
+	return name, namespace
 }
 
 func GetFluxConfigForCluster(ctx context.Context, cluster *v1alpha1.Cluster, fetch FluxConfigFetch) (*v1alpha1.FluxConfig, error) {
@@ -118,12 +125,16 @@ func GetEksdReleaseForCluster(ctx context.Context, cluster *v1alpha1.Cluster, bu
 }
 
 func GetVersionsBundle(clusterConfig *v1alpha1.Cluster, bundles *v1alpha1release.Bundles) (*v1alpha1release.VersionsBundle, error) {
+	return getVersionsBundleForKubernetesVersion(clusterConfig.Spec.KubernetesVersion, bundles)
+}
+
+func getVersionsBundleForKubernetesVersion(kubernetesVersion v1alpha1.KubernetesVersion, bundles *v1alpha1release.Bundles) (*v1alpha1release.VersionsBundle, error) {
 	for _, versionsBundle := range bundles.Spec.VersionsBundles {
-		if versionsBundle.KubeVersion == string(clusterConfig.Spec.KubernetesVersion) {
+		if versionsBundle.KubeVersion == string(kubernetesVersion) {
 			return &versionsBundle, nil
 		}
 	}
-	return nil, fmt.Errorf("kubernetes version %s is not supported by bundles manifest %d", clusterConfig.Spec.KubernetesVersion, bundles.Spec.Number)
+	return nil, fmt.Errorf("kubernetes version %s is not supported by bundles manifest %d", kubernetesVersion, bundles.Spec.Number)
 }
 
 func GetOIDCForCluster(ctx context.Context, cluster *v1alpha1.Cluster, fetch OIDCFetch) (*v1alpha1.OIDCConfig, error) {
@@ -141,4 +152,39 @@ func GetOIDCForCluster(ctx context.Context, cluster *v1alpha1.Cluster, fetch OID
 		}
 	}
 	return nil, nil
+}
+
+// BuildSpec constructs a cluster.Spec for a eks-a cluster by retrieving all
+// necessary objects from the cluster using a kubernetes client
+func BuildSpec(ctx context.Context, client Client, cluster *v1alpha1.Cluster) (*Spec, error) {
+	configBuilder := NewDefaultConfigClientBuilder()
+	config, err := configBuilder.Build(ctx, client, cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	bundlesName, bundlesNamespace := bundlesNamespacedKey(cluster)
+	bundles := &v1alpha1release.Bundles{}
+	if err = client.Get(ctx, bundlesName, bundlesNamespace, bundles); err != nil {
+		return nil, err
+	}
+
+	versionsBundle, err := GetVersionsBundle(cluster, bundles)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ideally we would use the same namespace as the Bundles, but Bundles can be in any namespace and
+	// the eksd release is always in eksa-system
+	eksdRelease := &eksdv1alpha1.Release{}
+	if err = client.Get(ctx, versionsBundle.EksD.Name, constants.EksaSystemNamespace, eksdRelease); err != nil {
+		return nil, err
+	}
+
+	spec := NewSpec()
+	if err := spec.init(config, bundles, versionsBundle, eksdRelease); err != nil {
+		return nil, err
+	}
+
+	return spec, nil
 }

--- a/pkg/cluster/fetch_test.go
+++ b/pkg/cluster/fetch_test.go
@@ -2,43 +2,48 @@ package cluster_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	eksdv1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	v1alpha1release "github.com/aws/eks-anywhere/release/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster/mocks"
+	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 func TestGetBundlesForCluster(t *testing.T) {
 	testCases := []struct {
 		testName                string
-		cluster                 *v1alpha1.Cluster
+		cluster                 *anywherev1.Cluster
 		wantName, wantNamespace string
 	}{
 		{
 			testName: "no bundles ref",
-			cluster: &v1alpha1.Cluster{
+			cluster: &anywherev1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "eksa-cluster",
 					Namespace: "eksa",
 				},
-				Spec: v1alpha1.ClusterSpec{},
+				Spec: anywherev1.ClusterSpec{},
 			},
 			wantName:      "eksa-cluster",
 			wantNamespace: "eksa",
 		},
 		{
 			testName: "bundles ref",
-			cluster: &v1alpha1.Cluster{
+			cluster: &anywherev1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "eksa-cluster",
 					Namespace: "eksa",
 				},
-				Spec: v1alpha1.ClusterSpec{
-					BundlesRef: &v1alpha1.BundlesRef{
+				Spec: anywherev1.ClusterSpec{
+					BundlesRef: &anywherev1.BundlesRef{
 						Name:       "bundles-1",
 						Namespace:  "eksa-system",
 						APIVersion: "anywhere.eks.amazonaws.com/v1alpha1",
@@ -52,8 +57,8 @@ func TestGetBundlesForCluster(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
 			g := NewWithT(t)
-			wantBundles := &v1alpha1release.Bundles{}
-			mockFetch := func(ctx context.Context, name, namespace string) (*v1alpha1release.Bundles, error) {
+			wantBundles := &releasev1.Bundles{}
+			mockFetch := func(ctx context.Context, name, namespace string) (*releasev1.Bundles, error) {
 				g.Expect(name).To(Equal(tt.wantName))
 				g.Expect(namespace).To(Equal(tt.wantNamespace))
 
@@ -69,17 +74,17 @@ func TestGetBundlesForCluster(t *testing.T) {
 
 func TestGetFluxConfigForClusterIsNil(t *testing.T) {
 	g := NewWithT(t)
-	c := &v1alpha1.Cluster{
+	c := &anywherev1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "eksa-cluster",
 			Namespace: "eksa",
 		},
-		Spec: v1alpha1.ClusterSpec{
+		Spec: anywherev1.ClusterSpec{
 			GitOpsRef: nil,
 		},
 	}
-	var wantFlux *v1alpha1.FluxConfig
-	mockFetch := func(ctx context.Context, name, namespace string) (*v1alpha1.FluxConfig, error) {
+	var wantFlux *anywherev1.FluxConfig
+	mockFetch := func(ctx context.Context, name, namespace string) (*anywherev1.FluxConfig, error) {
 		g.Expect(name).To(Equal(c.Name))
 		g.Expect(namespace).To(Equal(c.Namespace))
 
@@ -93,25 +98,25 @@ func TestGetFluxConfigForClusterIsNil(t *testing.T) {
 
 func TestGetFluxConfigForCluster(t *testing.T) {
 	g := NewWithT(t)
-	c := &v1alpha1.Cluster{
+	c := &anywherev1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "eksa-cluster",
 			Namespace: "eksa",
 		},
-		Spec: v1alpha1.ClusterSpec{
-			GitOpsRef: &v1alpha1.Ref{
-				Kind: v1alpha1.FluxConfigKind,
+		Spec: anywherev1.ClusterSpec{
+			GitOpsRef: &anywherev1.Ref{
+				Kind: anywherev1.FluxConfigKind,
 				Name: "eksa-cluster",
 			},
 		},
 	}
-	wantFlux := &v1alpha1.FluxConfig{
+	wantFlux := &anywherev1.FluxConfig{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{},
-		Spec:       v1alpha1.FluxConfigSpec{},
-		Status:     v1alpha1.FluxConfigStatus{},
+		Spec:       anywherev1.FluxConfigSpec{},
+		Status:     anywherev1.FluxConfigStatus{},
 	}
-	mockFetch := func(ctx context.Context, name, namespace string) (*v1alpha1.FluxConfig, error) {
+	mockFetch := func(ctx context.Context, name, namespace string) (*anywherev1.FluxConfig, error) {
 		g.Expect(name).To(Equal(c.Name))
 		g.Expect(namespace).To(Equal(c.Namespace))
 
@@ -121,4 +126,269 @@ func TestGetFluxConfigForCluster(t *testing.T) {
 	gotFlux, err := cluster.GetFluxConfigForCluster(context.Background(), c, mockFetch)
 	g.Expect(err).To(BeNil())
 	g.Expect(gotFlux).To(Equal(wantFlux))
+}
+
+type buildSpecTest struct {
+	*WithT
+	ctx         context.Context
+	ctrl        *gomock.Controller
+	client      *mocks.MockClient
+	cluster     *anywherev1.Cluster
+	bundles     *releasev1.Bundles
+	eksdRelease *eksdv1.Release
+	kubeDistro  *cluster.KubeDistro
+}
+
+func newBuildSpecTest(t *testing.T) *buildSpecTest {
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockClient(ctrl)
+	cluster := &anywherev1.Cluster{
+		Spec: anywherev1.ClusterSpec{
+			BundlesRef: &anywherev1.BundlesRef{
+				Name:      "bundles-1",
+				Namespace: "my-namespace",
+			},
+			KubernetesVersion: anywherev1.Kube123,
+		},
+	}
+	bundles := &releasev1.Bundles{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bundles-1",
+		},
+		Spec: releasev1.BundlesSpec{
+			VersionsBundles: []releasev1.VersionsBundle{
+				{
+					KubeVersion: "1.23",
+					EksD: releasev1.EksDRelease{
+						Name: "eksd-123",
+					},
+				},
+			},
+		},
+	}
+	eksdRelease, kubeDistro := wantKubeDistroForEksdRelease()
+
+	return &buildSpecTest{
+		WithT:       NewWithT(t),
+		ctx:         context.Background(),
+		ctrl:        ctrl,
+		client:      client,
+		cluster:     cluster,
+		bundles:     bundles,
+		eksdRelease: eksdRelease,
+		kubeDistro:  kubeDistro,
+	}
+}
+
+func (tt *buildSpecTest) expectGetBundles() {
+	tt.client.EXPECT().Get(tt.ctx, "bundles-1", "my-namespace", &releasev1.Bundles{}).DoAndReturn(
+		func(ctx context.Context, name, namespace string, obj runtime.Object) error {
+			o := obj.(*releasev1.Bundles)
+			o.ObjectMeta = tt.bundles.ObjectMeta
+			o.Spec = tt.bundles.Spec
+			return nil
+		},
+	)
+}
+
+func (tt *buildSpecTest) expectGetEksd() {
+	tt.client.EXPECT().Get(tt.ctx, "eksd-123", "eksa-system", &eksdv1.Release{}).DoAndReturn(
+		func(ctx context.Context, name, namespace string, obj runtime.Object) error {
+			o := obj.(*eksdv1.Release)
+			o.ObjectMeta = tt.eksdRelease.ObjectMeta
+			o.Status = tt.eksdRelease.Status
+			return nil
+		},
+	)
+}
+
+func TestBuildSpec(t *testing.T) {
+	tt := newBuildSpecTest(t)
+	tt.expectGetBundles()
+	tt.expectGetEksd()
+
+	wantSpec := &cluster.Spec{
+		Config: &cluster.Config{
+			Cluster:       tt.cluster,
+			OIDCConfigs:   map[string]*anywherev1.OIDCConfig{},
+			AWSIAMConfigs: map[string]*anywherev1.AWSIamConfig{},
+		},
+		VersionsBundle: &cluster.VersionsBundle{
+			VersionsBundle: &tt.bundles.Spec.VersionsBundles[0],
+			KubeDistro:     tt.kubeDistro,
+		},
+		Bundles: tt.bundles,
+	}
+
+	spec, err := cluster.BuildSpec(tt.ctx, tt.client, tt.cluster)
+	tt.Expect(err).NotTo(HaveOccurred())
+	tt.Expect(spec.Config).To(Equal(wantSpec.Config))
+	tt.Expect(spec.AWSIamConfig).To(Equal(wantSpec.AWSIamConfig))
+	tt.Expect(spec.OIDCConfig).To(Equal(wantSpec.OIDCConfig))
+	tt.Expect(spec.Bundles).To(Equal(wantSpec.Bundles))
+	tt.Expect(spec.VersionsBundle).To(Equal(wantSpec.VersionsBundle))
+}
+
+func TestBuildSpecGetBundlesError(t *testing.T) {
+	tt := newBuildSpecTest(t)
+	tt.client.EXPECT().Get(tt.ctx, "bundles-1", "my-namespace", &releasev1.Bundles{}).Return(errors.New("client error"))
+
+	_, err := cluster.BuildSpec(tt.ctx, tt.client, tt.cluster)
+	tt.Expect(err).To(MatchError(ContainSubstring("client error")))
+}
+
+func TestBuildSpecGetEksdError(t *testing.T) {
+	tt := newBuildSpecTest(t)
+	tt.expectGetBundles()
+	tt.client.EXPECT().Get(tt.ctx, "eksd-123", "eksa-system", &eksdv1.Release{}).Return(errors.New("client error"))
+
+	_, err := cluster.BuildSpec(tt.ctx, tt.client, tt.cluster)
+	tt.Expect(err).To(MatchError(ContainSubstring("client error")))
+}
+
+func TestBuildSpecBuildConfigError(t *testing.T) {
+	tt := newBuildSpecTest(t)
+	tt.cluster.Namespace = "default"
+	tt.cluster.Spec.GitOpsRef = &anywherev1.Ref{
+		Name: "my-flux",
+		Kind: anywherev1.FluxConfigKind,
+	}
+	tt.client.EXPECT().Get(tt.ctx, "my-flux", "default", &anywherev1.FluxConfig{}).Return(errors.New("client error"))
+
+	_, err := cluster.BuildSpec(tt.ctx, tt.client, tt.cluster)
+	tt.Expect(err).To(MatchError(ContainSubstring("client error")))
+}
+
+func TestBuildSpecUnsupportedKubernetesVersionError(t *testing.T) {
+	tt := newBuildSpecTest(t)
+	tt.bundles.Spec.VersionsBundles = []releasev1.VersionsBundle{}
+	tt.bundles.Spec.Number = 2
+	tt.expectGetBundles()
+
+	_, err := cluster.BuildSpec(tt.ctx, tt.client, tt.cluster)
+	tt.Expect(err).To(MatchError(ContainSubstring("kubernetes version 1.23 is not supported by bundles manifest 2")))
+}
+
+func TestBuildSpecInitError(t *testing.T) {
+	tt := newBuildSpecTest(t)
+	tt.eksdRelease.Status.Components = []eksdv1.Component{}
+	tt.expectGetBundles()
+	tt.expectGetEksd()
+
+	_, err := cluster.BuildSpec(tt.ctx, tt.client, tt.cluster)
+	tt.Expect(err).To(MatchError(ContainSubstring("is no present in eksd release")))
+}
+
+func wantKubeDistroForEksdRelease() (*eksdv1.Release, *cluster.KubeDistro) {
+	eksdRelease := &eksdv1.Release{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "eksd-123",
+		},
+		Status: eksdv1.ReleaseStatus{
+			Components: []eksdv1.Component{
+				{
+					Name:   "etcd",
+					GitTag: "v3.4.14",
+				},
+				{
+					Name: "comp-1",
+					Assets: []eksdv1.Asset{
+						{
+							Name: "external-provisioner-image",
+							Image: &eksdv1.AssetImage{
+								URI: "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1",
+							},
+						},
+						{
+							Name: "node-driver-registrar-image",
+							Image: &eksdv1.AssetImage{
+								URI: "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0",
+							},
+						},
+						{
+							Name: "livenessprobe-image",
+							Image: &eksdv1.AssetImage{
+								URI: "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0",
+							},
+						},
+						{
+							Name: "external-attacher-image",
+							Image: &eksdv1.AssetImage{
+								URI: "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v3.1.0",
+							},
+						},
+						{
+							Name: "pause-image",
+							Image: &eksdv1.AssetImage{
+								URI: "public.ecr.aws/eks-distro/kubernetes/pause:v1.19.8",
+							},
+						},
+						{
+							Name: "coredns-image",
+							Image: &eksdv1.AssetImage{
+								URI: "public.ecr.aws/eks-distro/coredns/coredns:v1.8.0",
+							},
+						},
+						{
+							Name: "etcd-image",
+							Image: &eksdv1.AssetImage{
+								URI: "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.14",
+							},
+						},
+						{
+							Name: "aws-iam-authenticator-image",
+							Image: &eksdv1.AssetImage{
+								URI: "public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.5.2",
+							},
+						},
+						{
+							Name: "kube-apiserver-image",
+							Image: &eksdv1.AssetImage{
+								URI: "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.19.8",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	kubeDistro := &cluster.KubeDistro{
+		Kubernetes: cluster.VersionedRepository{
+			Repository: "public.ecr.aws/eks-distro/kubernetes",
+			Tag:        "v1.19.8",
+		},
+		CoreDNS: cluster.VersionedRepository{
+			Repository: "public.ecr.aws/eks-distro/coredns",
+			Tag:        "v1.8.0",
+		},
+		Etcd: cluster.VersionedRepository{
+			Repository: "public.ecr.aws/eks-distro/etcd-io",
+			Tag:        "v3.4.14",
+		},
+		NodeDriverRegistrar: releasev1.Image{
+			URI: "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0",
+		},
+		LivenessProbe: releasev1.Image{
+			URI: "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0",
+		},
+		ExternalAttacher: releasev1.Image{
+			URI: "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v3.1.0",
+		},
+		ExternalProvisioner: releasev1.Image{
+			URI: "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1",
+		},
+		Pause: releasev1.Image{
+			URI: "public.ecr.aws/eks-distro/kubernetes/pause:v1.19.8",
+		},
+		EtcdImage: releasev1.Image{
+			URI: "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.14",
+		},
+		AwsIamAuthImage: releasev1.Image{
+			URI: "public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.5.2",
+		},
+		EtcdVersion: "3.4.14",
+	}
+
+	return eksdRelease, kubeDistro
 }

--- a/pkg/cluster/spec_test.go
+++ b/pkg/cluster/spec_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1/thirdparty/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/version"
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -128,6 +129,59 @@ func TestNewSpecValid(t *testing.T) {
 		t.Fatalf("NewSpec() error = %v, want err nil", err)
 	}
 
+	validateSpecFromSimpleBundle(t, gotSpec)
+}
+
+func TestNewSpecFromClusterConfigTinkerbellValid(t *testing.T) {
+	g := NewWithT(t)
+	v := version.Info{GitVersion: "v0.0.1"}
+	wantConfigs := map[string]*anywherev1.TinkerbellTemplateConfig{
+		"tink-test": {
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "TinkerbellTemplateConfig",
+				APIVersion: "anywhere.eks.amazonaws.com/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "tink-test",
+			},
+			Spec: anywherev1.TinkerbellTemplateConfigSpec{
+				Template: tinkerbell.Workflow{
+					Version:       "0.1",
+					Name:          "tink-test",
+					GlobalTimeout: 6000,
+					Tasks: []tinkerbell.Task{
+						{
+							Name:       "tink-test",
+							WorkerAddr: "{{.device_1}}",
+							Volumes: []string{
+								"/dev:/dev",
+								"/dev/console:/dev/console",
+								"/lib/firmware:/lib/firmware:ro",
+							},
+							Actions: []tinkerbell.Action{
+								{
+									Name:    "stream-image",
+									Image:   "image2disk:v1.0.0",
+									Timeout: 360,
+									Environment: map[string]string{
+										"IMG_URL":    "",
+										"DEST_DISK":  "/dev/sda",
+										"COMPRESSED": "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	gotSpec, err := cluster.NewSpecFromClusterConfig("testdata/cluster_tinkerbell_1_19.yaml", v,
+		cluster.WithReleasesManifest("testdata/simple_release.yaml"),
+	)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(gotSpec.TinkerbellTemplateConfigs).To(Equal(wantConfigs))
 	validateSpecFromSimpleBundle(t, gotSpec)
 }
 
@@ -282,4 +336,47 @@ func TestBundlesRefDefaulter(t *testing.T) {
 			g.Expect(tt.config).To(Equal(tt.want))
 		})
 	}
+}
+
+func TestBuildSpecFromBundles(t *testing.T) {
+	g := NewWithT(t)
+	clus := &anywherev1.Cluster{
+		Spec: anywherev1.ClusterSpec{
+			KubernetesVersion: anywherev1.Kube123,
+		},
+	}
+
+	bundles := &v1alpha1.Bundles{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bundles-1",
+		},
+		Spec: v1alpha1.BundlesSpec{
+			VersionsBundles: []v1alpha1.VersionsBundle{
+				{
+					KubeVersion: "1.23",
+				},
+			},
+		},
+	}
+
+	eksdRelease, wantKubeDistro := wantKubeDistroForEksdRelease()
+
+	wantSpec := &cluster.Spec{
+		Config: &cluster.Config{
+			Cluster: clus,
+		},
+		VersionsBundle: &cluster.VersionsBundle{
+			VersionsBundle: &bundles.Spec.VersionsBundles[0],
+			KubeDistro:     wantKubeDistro,
+		},
+		Bundles: bundles,
+	}
+
+	spec, err := cluster.BuildSpecFromBundles(clus, bundles, cluster.WithEksdRelease(eksdRelease))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(spec.Config).To(Equal(wantSpec.Config))
+	g.Expect(spec.AWSIamConfig).To(Equal(wantSpec.AWSIamConfig))
+	g.Expect(spec.OIDCConfig).To(Equal(wantSpec.OIDCConfig))
+	g.Expect(spec.Bundles).To(Equal(wantSpec.Bundles))
+	g.Expect(spec.VersionsBundle).To(Equal(wantSpec.VersionsBundle))
 }

--- a/pkg/cluster/testdata/cluster_tinkerbell_1_19.yaml
+++ b/pkg/cluster/testdata/cluster_tinkerbell_1_19.yaml
@@ -1,0 +1,88 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  clusterNetwork:
+    cni: cilium
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+    endpoint:
+      host: 1.2.3.4
+    machineGroupRef:
+      name: test-cp
+      kind: TinkerbellMachineConfig
+  datacenterRef:
+    kind: TinkerbellDatacenterConfig
+    name: test
+  externalEtcdConfiguration:
+    count: 1
+    machineGroupRef:
+      name: test-cp
+      kind: TinkerbellMachineConfig
+  kubernetesVersion: "1.19"
+  managementCluster:
+    name: test
+  workerNodeGroupConfigurations:
+    - count: 1
+      machineGroupRef:
+        name: test-md
+        kind: TinkerbellMachineConfig
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellDatacenterConfig
+metadata:
+  name: test
+spec:
+  tinkerbellIP: "1.2.3.4"
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellMachineConfig
+metadata:
+  name: test-cp
+  namespace: test-namespace
+spec:
+  osFamily: ubuntu
+  templateRef:
+    kind: TinkerbellTemplateConfig
+    name: tink-test
+  users:
+    - name: tink-user
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3"
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellTemplateConfig
+metadata:
+  name: tink-test
+spec:
+  template:
+    global_timeout: 6000
+    id: ""
+    name: tink-test
+    tasks:
+      - actions:
+          - environment:
+              COMPRESSED: "true"
+              DEST_DISK: /dev/sda
+              IMG_URL: ""
+            image: image2disk:v1.0.0
+            name: stream-image
+            timeout: 360
+        name: tink-test
+        volumes:
+          - /dev:/dev
+          - /dev/console:/dev/console
+          - /lib/firmware:/lib/firmware:ro
+        worker: "{{.device_1}}"
+    version: "0.1"


### PR DESCRIPTION
*Issue #, if available:* part of https://github.com/aws/eks-anywhere/issues/1090 and https://github.com/aws/eks-anywhere/issues/1109

*Description of changes:*

Builds (fully) a `cluster.Spec` using a kubernetes client:
* Builds the `cluster.Config` with the default builder
* Retrieves Bundles and the eksd release from the cluster
* Some data massaging to complete the Spec

Please, look at comments in PR for more localized explanations.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

