### PR TITLE
Add instructions for running packages on workload clusters

### DIFF
--- a/docs/content/en/docs/getting-started/production-environment/vsphere-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/vsphere-getstarted.md
@@ -202,6 +202,11 @@ Follow these steps if you want to use your initial cluster to create and manage 
 
    As noted earlier, adding the `--kubeconfig` option tells `eksctl` to use the management cluster identified by that kubeconfig file to create a different workload cluster.
 
+   {{% alert title="Note" color="primary" %}}
+
+   Curated packages installation at workload cluster creation is currently not supported. Refer to [install curated packages](#install-curated-packages) section for how to install curated packages after cluster creation.
+   {{% /alert %}}
+
 1. Check the workload cluster:
 
    You can now use the workload cluster as you would any Kubernetes cluster.
@@ -218,6 +223,21 @@ Follow these steps if you want to use your initial cluster to create and manage 
 1. Add more workload clusters:
 
    To add more workload clusters, go through the same steps for creating the initial workload, copying the config file to a new name (such as `eksa-w02-cluster.yaml`), modifying resource names, and running the create cluster command again.
+
+1. ###### Install curated packages:
+
+   [cert-manager](https://cert-manager.io/) installation is required before installing curated packages on workload clusters. You can install cert-manager using the command below, then complete the curated packages installation by following instructions [here]({{< relref "../../tasks/packages" >}}).
+
+   ```bash
+   helm repo add jetstack https://charts.jetstack.io
+   helm repo update
+   helm install \
+      cert-manager jetstack/cert-manager \
+      --namespace cert-manager \
+      --create-namespace \
+      --version v1.8.0 \
+      --set installCRDs=true
+   ```
 
 ## Next steps:
 * See the [Cluster management]({{< relref "../../tasks/cluster" >}}) section for more information on common operational tasks like scaling and deleting the cluster.

--- a/docs/content/en/docs/getting-started/production-environment/vsphere-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/vsphere-getstarted.md
@@ -203,8 +203,7 @@ Follow these steps if you want to use your initial cluster to create and manage 
    As noted earlier, adding the `--kubeconfig` option tells `eksctl` to use the management cluster identified by that kubeconfig file to create a different workload cluster.
 
    {{% alert title="Note" color="primary" %}}
-
-   Curated packages installation at workload cluster creation is currently not supported. Refer to [install curated packages](#install-curated-packages) section for how to install curated packages after cluster creation.
+   Curated packages installation at workload cluster creation is currently not supported. Refer to instructions [here]({{< relref "../../tasks/packages" >}}) for how to install curated packages after cluster creation.
    {{% /alert %}}
 
 1. Check the workload cluster:
@@ -223,21 +222,6 @@ Follow these steps if you want to use your initial cluster to create and manage 
 1. Add more workload clusters:
 
    To add more workload clusters, go through the same steps for creating the initial workload, copying the config file to a new name (such as `eksa-w02-cluster.yaml`), modifying resource names, and running the create cluster command again.
-
-1. ###### Install curated packages:
-
-   [cert-manager](https://cert-manager.io/) installation is required before installing curated packages on workload clusters. You can install cert-manager using the command below, then complete the curated packages installation by following instructions [here]({{< relref "../../tasks/packages" >}}).
-
-   ```bash
-   helm repo add jetstack https://charts.jetstack.io
-   helm repo update
-   helm install \
-      cert-manager jetstack/cert-manager \
-      --namespace cert-manager \
-      --create-namespace \
-      --version v1.8.0 \
-      --set installCRDs=true
-   ```
 
 ## Next steps:
 * See the [Cluster management]({{< relref "../../tasks/cluster" >}}) section for more information on common operational tasks like scaling and deleting the cluster.

--- a/docs/content/en/docs/tasks/packages/_index.md
+++ b/docs/content/en/docs/tasks/packages/_index.md
@@ -23,7 +23,7 @@ Skip the following installation steps if the returned result is not empty.
     ```bash
     eksctl anywhere version
     ```
-* Make sure cert-manager is up and running in the cluster. Note cert-manager is not installed on workload clusters by default. If cert-manager is not installed, you can manually install cert-manager with Helm 3.8+ and follow the instructions below to finish the package controller installation.
+* Make sure cert-manager is up and running in the cluster. Note cert-manager is not installed on workload clusters by default. If cert-manager is not installed, you can manually install cert-manager and follow the instructions below to finish the package controller installation.
 
 {{% /alert %}}
 

--- a/docs/content/en/docs/tasks/packages/_index.md
+++ b/docs/content/en/docs/tasks/packages/_index.md
@@ -23,7 +23,17 @@ Skip the following installation steps if the returned result is not empty.
     ```bash
     eksctl anywhere version
     ```
-* Make sure cert-manager is up and running in the cluster.
+* Make sure cert-manager is up and running in the cluster. Note cert-manager is not installed on workload clusters by default. If cert-manager is not installed, you can install cert-manager using following commands:
+  ```bash
+   helm repo add jetstack https://charts.jetstack.io
+   helm repo update
+   helm install \
+      cert-manager jetstack/cert-manager \
+      --namespace cert-manager \
+      --create-namespace \
+      --version v1.8.0 \
+      --set installCRDs=true
+   ```
 
 {{% /alert %}}
 

--- a/docs/content/en/docs/tasks/packages/_index.md
+++ b/docs/content/en/docs/tasks/packages/_index.md
@@ -23,17 +23,7 @@ Skip the following installation steps if the returned result is not empty.
     ```bash
     eksctl anywhere version
     ```
-* Make sure cert-manager is up and running in the cluster. Note cert-manager is not installed on workload clusters by default. If cert-manager is not installed, you can install cert-manager using following commands:
-  ```bash
-   helm repo add jetstack https://charts.jetstack.io
-   helm repo update
-   helm install \
-      cert-manager jetstack/cert-manager \
-      --namespace cert-manager \
-      --create-namespace \
-      --version v1.8.0 \
-      --set installCRDs=true
-   ```
+* Make sure cert-manager is up and running in the cluster. Note cert-manager is not installed on workload clusters by default. If cert-manager is not installed, you can manually install cert-manager with Helm 3.8+ and follow the instructions below to finish the package controller installation.
 
 {{% /alert %}}
 


### PR DESCRIPTION
The instruction for running curated packages for initial v.s. separate workload clusters are different. Therefore I'm adding some clarification on how to do so for workload clusters.

*Issue #, if available:* N/A

*Description of changes:* Two doc files.

*Testing (if applicable):* Built locally and made sure there were no format issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

