### PR TITLE
Remove default tink user

### DIFF
--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
@@ -32,12 +32,6 @@ primary = true
   Ec2:
     metadata_urls: [%s]
     strict_id: false
-system_info:
-  default_user:
-    name: tink
-    groups: [wheel, adm]
-    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-    shell: /bin/bash
 manage_etc_hosts: localhost
 warnings:
   dsid_missing_source: off


### PR DESCRIPTION
*Description of changes:*
The default template currently creates a default user `tink` on ubuntu. This is not needed for anything so this PR removes this default user.

*Testing (if applicable):*
Ran a create and verified the cluster creation still works with this default user removed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

