### PR TITLE
Increase fs inotify resources for e2e tests

### DIFF
--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -25,8 +25,6 @@ const (
 	bundlesReleaseManifestFile = "local-bundle-release.yaml"
 	eksAComponentsManifestFile = "local-eksa-components.yaml"
 	testNameFile               = "e2e-test-name"
-	maxUserWatches             = 524288
-	maxUserInstances           = 512
 )
 
 type E2ESession struct {
@@ -92,10 +90,6 @@ func (e *E2ESession) setup(regex string) error {
 		return fmt.Errorf("waiting for ssm in new instance: %v", err)
 	}
 
-	err = e.updateFSInotifyResources()
-	if err != nil {
-		return err
-	}
 	err = e.createTestNameFile(regex)
 	if err != nil {
 		return err
@@ -156,17 +150,6 @@ func (e *E2ESession) setup(regex string) error {
 	}
 
 	e.testEnvVars[e2etests.ClusterNameVar] = clusterName(e.branchName, e.instanceId)
-	return nil
-}
-
-func (e *E2ESession) updateFSInotifyResources() error {
-	command := fmt.Sprintf("sudo sysctl fs.inotify.max_user_watches=%v && sudo sysctl fs.inotify.max_user_instances=%v", maxUserWatches, maxUserInstances)
-
-	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
-		return fmt.Errorf("updating fs inotify resources: %v", err)
-	}
-	logger.V(1).Info("Successfully updates the fs inotify user watches and instances")
-
 	return nil
 }
 

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -25,6 +25,8 @@ const (
 	bundlesReleaseManifestFile = "local-bundle-release.yaml"
 	eksAComponentsManifestFile = "local-eksa-components.yaml"
 	testNameFile               = "e2e-test-name"
+	maxUserWatches             = 524288
+	maxUserInstances           = 512
 )
 
 type E2ESession struct {
@@ -90,6 +92,10 @@ func (e *E2ESession) setup(regex string) error {
 		return fmt.Errorf("waiting for ssm in new instance: %v", err)
 	}
 
+	err = e.updateFSInotifyResources()
+	if err != nil {
+		return err
+	}
 	err = e.createTestNameFile(regex)
 	if err != nil {
 		return err
@@ -150,6 +156,17 @@ func (e *E2ESession) setup(regex string) error {
 	}
 
 	e.testEnvVars[e2etests.ClusterNameVar] = clusterName(e.branchName, e.instanceId)
+	return nil
+}
+
+func (e *E2ESession) updateFSInotifyResources() error {
+	command := fmt.Sprintf("sudo sysctl fs.inotify.max_user_watches=%v && sudo sysctl fs.inotify.max_user_instances=%v", maxUserWatches, maxUserInstances)
+
+	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
+		return fmt.Errorf("updating fs inotify resources: %v", err)
+	}
+	logger.V(1).Info("Successfully updates the fs inotify user watches and instances")
+
 	return nil
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The docker e2e tests are failing because of kubelet errors regarding too many open files.
It is a known issue and based on kind documentation [here](https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files), this pr fixes the issue.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

