### PR TITLE
Add kubernetes.Client controller implementation

### DIFF
--- a/controllers/controllers/clients/kubernetes.go
+++ b/controllers/controllers/clients/kubernetes.go
@@ -1,0 +1,26 @@
+package clients
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+)
+
+// Kubeclient implements kubernetes.Client interface using a
+// client.Client as the underlying implementation
+type KubeClient struct {
+	client client.Client
+}
+
+func NewKubeClient(client client.Client) *KubeClient {
+	return &KubeClient{
+		client: client,
+	}
+}
+
+// Get retrieves an obj for the given name and namespace from the Kubernetes Cluster.
+func (c *KubeClient) Get(ctx context.Context, name, namespace string, obj kubernetes.Object) error {
+	return c.client.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj)
+}

--- a/controllers/controllers/clients/kubernetes_test.go
+++ b/controllers/controllers/clients/kubernetes_test.go
@@ -1,0 +1,47 @@
+package clients_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aws/eks-anywhere/controllers/controllers/clients"
+	_ "github.com/aws/eks-anywhere/internal/test/envtest"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+func TestKubeClientGet(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	cluster := &anywherev1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: "default",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       anywherev1.ClusterKind,
+			APIVersion: anywherev1.GroupVersion.String(),
+		},
+	}
+	cb := fake.NewClientBuilder()
+	cl := cb.WithRuntimeObjects(cluster).Build()
+
+	client := clients.NewKubeClient(cl)
+	receiveCluster := &anywherev1.Cluster{}
+	g.Expect(client.Get(ctx, "my-cluster", "default", receiveCluster)).To(Succeed())
+	g.Expect(receiveCluster).To(Equal(cluster))
+}
+
+func TestKubeClientGetNotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	cb := fake.NewClientBuilder()
+	cl := cb.WithRuntimeObjects().Build()
+
+	client := clients.NewKubeClient(cl)
+	receiveCluster := &anywherev1.Cluster{}
+	g.Expect(client.Get(ctx, "my-cluster", "default", receiveCluster)).Error()
+}

--- a/pkg/clients/kubernetes/kubeconfig.go
+++ b/pkg/clients/kubernetes/kubeconfig.go
@@ -3,12 +3,14 @@ package kubernetes
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Client interface {
-	Get(ctx context.Context, name, namespace string, obj runtime.Object) error
+	Get(ctx context.Context, name, namespace string, obj Object) error
 }
+
+type Object client.Object
 
 // KubeconfigClient is an authenticated kubernetes API client
 // it authenticates using the credentials of a kubeconfig file
@@ -25,7 +27,7 @@ func NewKubeconfigClient(client *UnAuthClient, kubeconfig string) *KubeconfigCli
 }
 
 // Get performs a GET call to the kube API server
-// and unmarshalls the response into the provdied Object
-func (c *KubeconfigClient) Get(ctx context.Context, name, namespace string, obj runtime.Object) error {
+// and unmarshalls the response into the provided Object
+func (c *KubeconfigClient) Get(ctx context.Context, name, namespace string, obj Object) error {
 	return c.client.Get(ctx, name, namespace, c.kubeconfig, obj)
 }

--- a/pkg/clients/kubernetes/mocks/kubeconfig.go
+++ b/pkg/clients/kubernetes/mocks/kubeconfig.go
@@ -8,8 +8,8 @@ import (
 	context "context"
 	reflect "reflect"
 
+	kubernetes "github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	gomock "github.com/golang/mock/gomock"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
 // MockClient is a mock of Client interface.
@@ -36,7 +36,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Get mocks base method.
-func (m *MockClient) Get(ctx context.Context, name, namespace string, obj runtime.Object) error {
+func (m *MockClient) Get(ctx context.Context, name, namespace string, obj kubernetes.Object) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", ctx, name, namespace, obj)
 	ret0, _ := ret[0].(error)

--- a/pkg/cluster/client_builder.go
+++ b/pkg/cluster/client_builder.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime"
-
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 )
 
 // Client is a kubernetes API client
 type Client interface {
-	Get(ctx context.Context, name, namespace string, obj runtime.Object) error
+	Get(ctx context.Context, name, namespace string, obj kubernetes.Object) error
 }
 
 // ConfigClientProcessor updates a Config retrieving objects from

--- a/pkg/cluster/mocks/client_builder.go
+++ b/pkg/cluster/mocks/client_builder.go
@@ -8,8 +8,8 @@ import (
 	context "context"
 	reflect "reflect"
 
+	kubernetes "github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	gomock "github.com/golang/mock/gomock"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
 // MockClient is a mock of Client interface.
@@ -36,7 +36,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Get mocks base method.
-func (m *MockClient) Get(ctx context.Context, name, namespace string, obj runtime.Object) error {
+func (m *MockClient) Get(ctx context.Context, name, namespace string, obj kubernetes.Object) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", ctx, name, namespace, obj)
 	ret0, _ := ret[0].(error)

--- a/pkg/clusterapi/fetch.go
+++ b/pkg/clusterapi/fetch.go
@@ -4,18 +4,18 @@ import (
 	"context"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 )
 
 // KubeClient is a kubernetes API client
 type KubeClient interface {
-	Get(ctx context.Context, name, namespace string, obj runtime.Object) error
+	Get(ctx context.Context, name, namespace string, obj kubernetes.Object) error
 }
 
 func MachineDeploymentInCluster(ctx context.Context, kubeclient KubeClient, clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) (*clusterv1.MachineDeployment, error) {

--- a/pkg/clusterapi/mocks/fetch.go
+++ b/pkg/clusterapi/mocks/fetch.go
@@ -8,8 +8,8 @@ import (
 	context "context"
 	reflect "reflect"
 
+	kubernetes "github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	gomock "github.com/golang/mock/gomock"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
 // MockKubeClient is a mock of KubeClient interface.
@@ -36,7 +36,7 @@ func (m *MockKubeClient) EXPECT() *MockKubeClientMockRecorder {
 }
 
 // Get mocks base method.
-func (m *MockKubeClient) Get(ctx context.Context, name, namespace string, obj runtime.Object) error {
+func (m *MockKubeClient) Get(ctx context.Context, name, namespace string, obj kubernetes.Object) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", ctx, name, namespace, obj)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
*Issue #, if available:* part of #1090

*Description of changes:*

The controller runtime client implementation takes client.Client as an
input, which is a superset of runtime.Object. To make things easier, we
just make that a requirement in our kube client interface. To avoid
polluting our interface with something defined in controller runtime,
we just create a our own kubernetes.Object interface.

*Testing (if applicable):*
Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

