### PR TITLE
Revert "Don't include templateRef in TinkerbellMachineConfig on generate"

### DIFF
--- a/internal/pkg/api/tinkerbell.go
+++ b/internal/pkg/api/tinkerbell.go
@@ -145,7 +145,7 @@ func WithTinkerbellEtcdMachineConfig() TinkerbellFiller {
 					Name: name,
 				},
 				Spec: anywherev1.TinkerbellMachineConfigSpec{
-					TemplateRef: &anywherev1.Ref{
+					TemplateRef: anywherev1.Ref{
 						Name: clusterName,
 						Kind: anywherev1.TinkerbellTemplateConfigKind,
 					},

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig.go
@@ -82,7 +82,7 @@ func GetTinkerbellMachineConfigs(fileName string) (map[string]*TinkerbellMachine
 
 func WithTemplateRef(ref ProviderRefAccessor) TinkerbellMachineConfigGenerateOpt {
 	return func(c *TinkerbellMachineConfigGenerate) {
-		c.Spec.TemplateRef = &Ref{
+		c.Spec.TemplateRef = Ref{
 			Kind: ref.Kind(),
 			Name: ref.Name(),
 		}

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
@@ -9,7 +9,7 @@ import (
 // TinkerbellMachineConfigSpec defines the desired state of TinkerbellMachineConfig
 type TinkerbellMachineConfigSpec struct {
 	HardwareSelector HardwareSelector    `json:"hardwareSelector"`
-	TemplateRef      *Ref                `json:"templateRef,omitempty"`
+	TemplateRef      Ref                 `json:"templateRef,omitempty"`
 	OSFamily         OSFamily            `json:"osFamily"`
 	Users            []UserConfiguration `json:"users,omitempty"`
 }

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -1988,7 +1988,7 @@ func TestGetTinkerbellMachineConfig(t *testing.T) {
 		},
 		Spec: v1alpha1.TinkerbellMachineConfigSpec{
 			OSFamily: "ubuntu",
-			TemplateRef: &v1alpha1.Ref{
+			TemplateRef: v1alpha1.Ref{
 				Name: "mycluster",
 				Kind: "TinkerbellTemplateConfig",
 			},


### PR DESCRIPTION
Reverts aws/eks-anywhere#2398