### PR TITLE
Revert "Don't include templateRef in TinkerbellMachineConfig on gener…

### DIFF
--- a/internal/pkg/api/tinkerbell.go
+++ b/internal/pkg/api/tinkerbell.go
@@ -145,7 +145,7 @@ func WithTinkerbellEtcdMachineConfig() TinkerbellFiller {
 					Name: name,
 				},
 				Spec: anywherev1.TinkerbellMachineConfigSpec{
-					TemplateRef: &anywherev1.Ref{
+					TemplateRef: anywherev1.Ref{
 						Name: clusterName,
 						Kind: anywherev1.TinkerbellTemplateConfigKind,
 					},

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig.go
@@ -82,7 +82,7 @@ func GetTinkerbellMachineConfigs(fileName string) (map[string]*TinkerbellMachine
 
 func WithTemplateRef(ref ProviderRefAccessor) TinkerbellMachineConfigGenerateOpt {
 	return func(c *TinkerbellMachineConfigGenerate) {
-		c.Spec.TemplateRef = &Ref{
+		c.Spec.TemplateRef = Ref{
 			Kind: ref.Kind(),
 			Name: ref.Name(),
 		}

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
@@ -9,7 +9,7 @@ import (
 // TinkerbellMachineConfigSpec defines the desired state of TinkerbellMachineConfig
 type TinkerbellMachineConfigSpec struct {
 	HardwareSelector HardwareSelector    `json:"hardwareSelector"`
-	TemplateRef      *Ref                `json:"templateRef,omitempty"`
+	TemplateRef      Ref                 `json:"templateRef,omitempty"`
 	OSFamily         OSFamily            `json:"osFamily"`
 	Users            []UserConfiguration `json:"users,omitempty"`
 }

--- a/pkg/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha1/zz_generated.deepcopy.go
@@ -1883,11 +1883,7 @@ func (in *TinkerbellMachineConfigSpec) DeepCopyInto(out *TinkerbellMachineConfig
 			(*out)[key] = val
 		}
 	}
-	if in.TemplateRef != nil {
-		in, out := &in.TemplateRef, &out.TemplateRef
-		*out = new(Ref)
-		**out = **in
-	}
+	out.TemplateRef = in.TemplateRef
 	if in.Users != nil {
 		in, out := &in.Users, &out.Users
 		*out = make([]UserConfiguration, len(*in))

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -1988,7 +1988,7 @@ func TestGetTinkerbellMachineConfig(t *testing.T) {
 		},
 		Spec: v1alpha1.TinkerbellMachineConfigSpec{
 			OSFamily: "ubuntu",
-			TemplateRef: &v1alpha1.Ref{
+			TemplateRef: v1alpha1.Ref{
 				Name: "mycluster",
 				Kind: "TinkerbellTemplateConfig",
 			},


### PR DESCRIPTION
…ate (#2398)"

This reverts commit 85f004fda894b87ac41bee9f264f0286bf621e32.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

