### PR TITLE
Increase timeout on default tinkerbell template's stream-image action

### DIFF
--- a/pkg/api/v1alpha1/testdata/cluster_1_21_valid_multiple_tinkerbell_templates.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_1_21_valid_multiple_tinkerbell_templates.yaml
@@ -94,7 +94,7 @@ spec:
               IMG_URL: ""
             image: image2disk:v1.0.0
             name: stream-image
-            timeout: 360
+            timeout: 600
         name: tink-test-1
         volumes:
           - /dev:/dev
@@ -121,7 +121,7 @@ spec:
               IMG_URL: ""
             image: image2disk:v1.0.0
             name: stream-image
-            timeout: 360
+            timeout: 600
         name: tink-test-2
         volumes:
           - /dev:/dev

--- a/pkg/api/v1alpha1/testdata/cluster_1_21_valid_tinkerbell.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_1_21_valid_tinkerbell.yaml
@@ -78,7 +78,7 @@ spec:
               IMG_URL: ""
             image: image2disk:v1.0.0
             name: stream-image
-            timeout: 360
+            timeout: 600
         name: tink-test
         volumes:
           - /dev:/dev

--- a/pkg/api/v1alpha1/testdata/cluster_invalid_kinds_tinkerbell.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_invalid_kinds_tinkerbell.yaml
@@ -78,5 +78,5 @@ spec:
           IMG_URL: ""
         image: image2disk:v1.0.0
         name: stream-image
-        timeout: 360
+        timeout: 600
     version: "0.1"

--- a/pkg/api/v1alpha1/testdata/not_parseable_cluster_tinkerbell.yaml
+++ b/pkg/api/v1alpha1/testdata/not_parseable_cluster_tinkerbell.yaml
@@ -80,7 +80,7 @@ spec:
           IMG_URL: ""
         image: image2disk:v1.0.0
         name: stream-image
-        timeout: 360
+        timeout: 600
         idont: "belonghere"
     version: "0.1"
     idont: "belonghere"

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
@@ -77,7 +77,7 @@ func withStreamImageAction(b v1alpha1.VersionsBundle, disk string, osFamily OSFa
 		*a = append(*a, tinkerbell.Action{
 			Name:    "stream-image",
 			Image:   b.Tinkerbell.TinkerbellStack.Actions.ImageToDisk.URI,
-			Timeout: 360,
+			Timeout: 600,
 			Environment: map[string]string{
 				"DEST_DISK":  disk,
 				"IMG_URL":    imageUrl,

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
@@ -28,7 +28,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 				{
 					Name:    "stream-image",
 					Image:   "public.ecr.aws/eks-anywhere/image2disk:latest",
-					Timeout: 360,
+					Timeout: 600,
 					Environment: map[string]string{
 						"IMG_URL":    "http://tinkerbell-example:8080/ubuntu-2004-kube-v1.21.5.gz",
 						"DEST_DISK":  "/dev/sda",
@@ -116,7 +116,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 				{
 					Name:    "stream-image",
 					Image:   "public.ecr.aws/eks-anywhere/image2disk:latest",
-					Timeout: 360,
+					Timeout: 600,
 					Environment: map[string]string{
 						"IMG_URL":    "http://tinkerbell-example:8080/ubuntu-2004-kube-v1.21.5.gz",
 						"DEST_DISK":  "/dev/nvme",
@@ -204,7 +204,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 				{
 					Name:    "stream-image",
 					Image:   "public.ecr.aws/eks-anywhere/image2disk:latest",
-					Timeout: 360,
+					Timeout: 600,
 					Environment: map[string]string{
 						"IMG_URL":    "http://tinkerbell-example:8080/bottlerocket-2004-kube-v1.21.5.gz",
 						"DEST_DISK":  "/dev/sda",
@@ -276,7 +276,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 				{
 					Name:    "stream-image",
 					Image:   "public.ecr.aws/eks-anywhere/image2disk:latest",
-					Timeout: 360,
+					Timeout: 600,
 					Environment: map[string]string{
 						"IMG_URL":    "http://tinkerbell-example:8080/bottlerocket-2004-kube-v1.21.5.gz",
 						"DEST_DISK":  "/dev/nvme",

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_test.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_test.go
@@ -59,7 +59,7 @@ func TestGetTinkerbellTemplateConfig(t *testing.T) {
 										{
 											Name:    "stream-image",
 											Image:   "image2disk:v1.0.0",
-											Timeout: 360,
+											Timeout: 600,
 											Environment: map[string]string{
 												"IMG_URL":    "",
 												"DEST_DISK":  "/dev/sda",
@@ -106,7 +106,7 @@ func TestGetTinkerbellTemplateConfig(t *testing.T) {
 										{
 											Name:    "stream-image",
 											Image:   "image2disk:v1.0.0",
-											Timeout: 360,
+											Timeout: 600,
 											Environment: map[string]string{
 												"IMG_URL":    "",
 												"DEST_DISK":  "/dev/sda",
@@ -146,7 +146,7 @@ func TestGetTinkerbellTemplateConfig(t *testing.T) {
 										{
 											Name:    "stream-image",
 											Image:   "image2disk:v1.0.0",
-											Timeout: 360,
+											Timeout: 600,
 											Environment: map[string]string{
 												"IMG_URL":    "",
 												"DEST_DISK":  "/dev/sda",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

