### PR TITLE
Correct bare metal hardware validations on create

### DIFF
--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"encoding/json"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -20,6 +22,14 @@ type HardwareSelector map[string]string
 // IsEmpty returns true if s has no key-value pairs.
 func (s HardwareSelector) IsEmpty() bool {
 	return len(s) == 0
+}
+
+func (s HardwareSelector) ToString() (string, error) {
+	encoded, err := json.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
 }
 
 func (c *TinkerbellMachineConfig) PauseReconcile() {

--- a/pkg/providers/tinkerbell/assert_test.go
+++ b/pkg/providers/tinkerbell/assert_test.go
@@ -150,7 +150,7 @@ func TestNewIPNotInUseAssertion_InUseFails(t *testing.T) {
 	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }
 
-func TestNewCreateMinimumHardwareAvailableAssertion_SufficientSucceeds(t *testing.T) {
+func TestMinimumHardwareAvailableAssertionForCreate_SufficientSucceeds(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
@@ -180,11 +180,11 @@ func TestNewCreateMinimumHardwareAvailableAssertion_SufficientSucceeds(t *testin
 		},
 	})).To(gomega.Succeed())
 
-	assertion := tinkerbell.NewCreateMinimumHardwareAvailableAssertion(catalogue)
+	assertion := tinkerbell.MinimumHardwareAvailableAssertionForCreate(catalogue)
 	g.Expect(assertion(clusterSpec)).To(gomega.Succeed())
 }
 
-func TestNewCreateMinimumHardwareAvailableAssertion_SufficientSucceedsWithoutExternalEtcd(t *testing.T) {
+func TestMinimumHardwareAvailableAssertionForCreate_SufficientSucceedsWithoutExternalEtcd(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
@@ -208,11 +208,11 @@ func TestNewCreateMinimumHardwareAvailableAssertion_SufficientSucceedsWithoutExt
 		},
 	})).To(gomega.Succeed())
 
-	assertion := tinkerbell.NewCreateMinimumHardwareAvailableAssertion(catalogue)
+	assertion := tinkerbell.MinimumHardwareAvailableAssertionForCreate(catalogue)
 	g.Expect(assertion(clusterSpec)).To(gomega.Succeed())
 }
 
-func TestNewCreateMinimumHardwareAvailableAssertion_NoControlPlaneSelectorMatchesAnything(t *testing.T) {
+func TestMinimumHardwareAvailableAssertionForCreate_NoControlPlaneSelectorMatchesAnything(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
@@ -225,11 +225,11 @@ func TestNewCreateMinimumHardwareAvailableAssertion_NoControlPlaneSelectorMatche
 	// Add something to match the control plane selector.
 	g.Expect(catalogue.InsertHardware(&v1alpha1.Hardware{})).To(gomega.Succeed())
 
-	assertion := tinkerbell.NewCreateMinimumHardwareAvailableAssertion(catalogue)
-	g.Expect(assertion(clusterSpec)).To(gomega.Succeed())
+	assertion := tinkerbell.MinimumHardwareAvailableAssertionForCreate(catalogue)
+	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }
 
-func TestNewCreateMinimumHardwareAvailableAssertion_NoExternalEtcdSelectorMatchesAnything(t *testing.T) {
+func TestMinimumHardwareAvailableAssertionForCreate_NoExternalEtcdSelectorMatchesAnything(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
@@ -242,11 +242,11 @@ func TestNewCreateMinimumHardwareAvailableAssertion_NoExternalEtcdSelectorMatche
 	// Add something to match the control plane selector.
 	g.Expect(catalogue.InsertHardware(&v1alpha1.Hardware{})).To(gomega.Succeed())
 
-	assertion := tinkerbell.NewCreateMinimumHardwareAvailableAssertion(catalogue)
-	g.Expect(assertion(clusterSpec)).To(gomega.Succeed())
+	assertion := tinkerbell.MinimumHardwareAvailableAssertionForCreate(catalogue)
+	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }
 
-func TestNewCreateMinimumHardwareAvailableAssertion_NoWorkerNodeGroupSelectorMatchesAnything(t *testing.T) {
+func TestMinimumHardwareAvailableAssertionForCreate_NoWorkerNodeGroupSelectorMatchesAnything(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
@@ -260,40 +260,27 @@ func TestNewCreateMinimumHardwareAvailableAssertion_NoWorkerNodeGroupSelectorMat
 	// Add something to match the control plane selector.
 	g.Expect(catalogue.InsertHardware(&v1alpha1.Hardware{})).To(gomega.Succeed())
 
-	assertion := tinkerbell.NewCreateMinimumHardwareAvailableAssertion(catalogue)
-	g.Expect(assertion(clusterSpec)).To(gomega.Succeed())
+	assertion := tinkerbell.MinimumHardwareAvailableAssertionForCreate(catalogue)
+	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }
 
-func TestNewCreateMinimumHardwareAvailableAssertion_InsufficientFails(t *testing.T) {
+func TestMinimumHardwareAvailableAssertionForCreate_InsufficientFails(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	catalogue := hardware.NewCatalogue()
 	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
 
-	assertion := tinkerbell.NewCreateMinimumHardwareAvailableAssertion(catalogue)
+	assertion := tinkerbell.MinimumHardwareAvailableAssertionForCreate(catalogue)
 	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }
 
-func TestNewCreateMinimumHardwareAvailableAssertion_InsufficientFailsWithoutExternalEtcd(t *testing.T) {
+func TestMinimumHardwareAvailableAssertionForCreate_InsufficientFailsWithoutExternalEtcd(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	catalogue := hardware.NewCatalogue()
 	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
 	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
 
-	assertion := tinkerbell.NewCreateMinimumHardwareAvailableAssertion(catalogue)
-	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
-}
-
-func TestNewCreateMinimumHardwareAvailableAssertion_TotalCountsNotMet(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	catalogue := hardware.NewCatalogue()
-	g.Expect(catalogue.InsertHardware(&v1alpha1.Hardware{})).To(gomega.Succeed())
-	clusterSpecBuilder := NewDefaultValidClusterSpecBuilder()
-	clusterSpecBuilder.WithoutHardwareSelectors()
-	clusterSpec := clusterSpecBuilder.Build()
-
-	assertion := tinkerbell.NewCreateMinimumHardwareAvailableAssertion(catalogue)
+	assertion := tinkerbell.MinimumHardwareAvailableAssertionForCreate(catalogue)
 	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -115,6 +115,7 @@ func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpe
 	// constructing the validations rather than injecting flags into the provider.
 	clusterSpecValidator := NewClusterSpecValidator(
 		MinimumHardwareAvailableAssertionForCreate(p.catalogue),
+		HardwareSatisfiesOnlyOneSelectorAssertion(p.catalogue),
 	)
 
 	if !p.skipIpCheck {

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -114,7 +114,7 @@ func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpe
 	// TODO(chrisdoherty4) Look to inject the validator. Possibly look to use a builder for
 	// constructing the validations rather than injecting flags into the provider.
 	clusterSpecValidator := NewClusterSpecValidator(
-		NewCreateMinimumHardwareAvailableAssertion(p.catalogue),
+		MinimumHardwareAvailableAssertionForCreate(p.catalogue),
 	)
 
 	if !p.skipIpCheck {

--- a/pkg/providers/tinkerbell/validate.go
+++ b/pkg/providers/tinkerbell/validate.go
@@ -94,103 +94,58 @@ func validateIPUnused(client networkutils.NetClient, ip string) error {
 
 // minimumHardwareRequirement defines the minimum requirement for a hardware selector.
 type minimumHardwareRequirement struct {
-	// Name is a string that indicates what the minimum requirement is for.
-	Name string
 	// MinCount is the minimum number of hardware required to satisfy the requirement
 	MinCount int
 	// Selector defines what labels should be present on Hardware to consider it eligable for
 	// this requirement.
 	Selector v1alpha1.HardwareSelector
+	// count is used internally by validation to sum the actual available hardware.
+	count int
 }
 
 // minimumHardwareRequirements is a collection of minimumHardwareRequirement instances.
-type minimumHardwareRequirements []minimumHardwareRequirement
+type minimumHardwareRequirements map[string]*minimumHardwareRequirement
 
 // Add a minimumHardwareRequirement to r.
-func (r *minimumHardwareRequirements) New(name string, min int, selector v1alpha1.HardwareSelector) {
-	*r = append(*r, minimumHardwareRequirement{
-		Name:     name,
+func (r *minimumHardwareRequirements) Add(selector v1alpha1.HardwareSelector, min int) error {
+	name, err := selector.ToString()
+	if err != nil {
+		return err
+	}
+
+	(*r)[name] = &minimumHardwareRequirement{
 		MinCount: min,
 		Selector: selector,
-	})
+	}
+
+	return nil
 }
 
 // ValidateminimumHardwareRequirements validates all requirements can be satisfied using hardware
 // registered with catalogue.
 func validateMinimumHardwareRequirements(requirements minimumHardwareRequirements, catalogue *hardware.Catalogue) error {
-	requirementCounts := constructMinimumHardwareRequirementCounts(requirements)
-
 	// Count all hardware that meets the selector requirements for each requirement.
 	// This does not consider whether or not a piece of hardware is selectable by multiple
 	// selectors. That requires a different validation ideally run before this one.
 	for _, h := range catalogue.AllHardware() {
-		for i, r := range requirementCounts {
+		for _, r := range requirements {
 			if hardware.LabelsMatchSelector(r.Selector, h.Labels) {
-				requirementCounts[i].Count++
+				r.count++
 			}
 		}
 	}
 
 	// Validate counts of hardware meet the minimum required count.
-	for _, r := range requirementCounts {
-		if r.Count < r.MinCount {
+	for name, r := range requirements {
+		if r.count < r.MinCount {
 			return fmt.Errorf(
-				"minimum hardware count for '%v' not met (selector=%v): have %v, require %v",
-				r.Name,
-				r.Selector,
-				r.Count,
+				"minimum hardware count not met for selector '%v': have %v, require %v",
+				name,
+				r.count,
 				r.MinCount,
 			)
 		}
 	}
 
 	return nil
-}
-
-// minimumHardwareRequirementCounts is a helper construct for summing the total hardware found
-// when validating minimum hardware requirements.
-type minimumHardwareRequirementCount struct {
-	minimumHardwareRequirement
-	Count int
-}
-
-func constructMinimumHardwareRequirementCounts(requirements []minimumHardwareRequirement) []minimumHardwareRequirementCount {
-	var counts []minimumHardwareRequirementCount
-	for _, r := range requirements {
-		counts = append(counts, minimumHardwareRequirementCount{
-			minimumHardwareRequirement: r,
-		})
-	}
-	return counts
-}
-
-// validateTotalHardwareRequestedAvailable performs a simple check that sums the total requested
-// hardware and ensures at least that much is registered in the catalogue. It does not take
-// into consideration hardware groupings defined by selectors.
-func validateTotalHardwareRequestedAvailable(cluster v1alpha1.ClusterSpec, catalogue *hardware.Catalogue) error {
-	requestedNodesCount := cluster.ControlPlaneConfiguration.Count
-	requestedNodesCount += sumWorkerNodeCounts(cluster.WorkerNodeGroupConfigurations)
-
-	// Optional external etcd configuration.
-	if cluster.ExternalEtcdConfiguration != nil {
-		requestedNodesCount += cluster.ExternalEtcdConfiguration.Count
-	}
-
-	if catalogue.TotalHardware() < requestedNodesCount {
-		return fmt.Errorf(
-			"have %v tinkerbell hardware; cluster spec requires >= %v hardware",
-			catalogue.TotalHardware(),
-			requestedNodesCount,
-		)
-	}
-
-	return nil
-}
-
-func sumWorkerNodeCounts(nodes []v1alpha1.WorkerNodeGroupConfiguration) int {
-	var requestedNodesCount int
-	for _, workerSpec := range nodes {
-		requestedNodesCount += workerSpec.Count
-	}
-	return requestedNodesCount
 }


### PR DESCRIPTION
We found an issue in CAPT where even the most basic of cases can result in clusters not being provisioned. It stems from the fact `TinkerbellMachines` are reconciled in a non-deterministic order and any hardware selectable by more than 1 selector could cause another selector to be left without hardware. 

This change introduces a new constraint that ensures hardware is mapped to a single selector preventing any subsets or intersections between selectors and hardware. In doing so, we ensure deterministic reconciliation in CAPT avoiding accidental selection of hardware required by other selectors.

Additionally, it replaces a total hardware required constraint with one that accounts for selectors being the same across MachineConfigs. This ensures we have sufficient hardware to meet the demands of the cluster.