### PR TITLE
Tinkerbell - changed stream image action timeout to 600

### DIFF
--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
@@ -90,7 +90,7 @@ func withStreamImageAction(b v1alpha1.VersionsBundle, disk string, osFamily OSFa
 		*a = append(*a, tinkerbell.Action{
 			Name:    "stream-image",
 			Image:   b.Tinkerbell.TinkerbellStack.Actions.ImageToDisk.URI,
-			Timeout: 360,
+			Timeout: 600,
 			Environment: map[string]string{
 				"DEST_DISK":  disk,
 				"IMG_URL":    imageUrl,

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
@@ -28,7 +28,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 				{
 					Name:    "stream-image",
 					Image:   "public.ecr.aws/eks-anywhere/image2disk:latest",
-					Timeout: 360,
+					Timeout: 600,
 					Environment: map[string]string{
 						"IMG_URL":    "http://tinkerbell-example:8080/ubuntu-2004-kube-v1.21.5.gz",
 						"DEST_DISK":  "/dev/sda",
@@ -116,7 +116,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 				{
 					Name:    "stream-image",
 					Image:   "public.ecr.aws/eks-anywhere/image2disk:latest",
-					Timeout: 360,
+					Timeout: 600,
 					Environment: map[string]string{
 						"IMG_URL":    "http://tinkerbell-example:8080/ubuntu-2004-kube-v1.21.5.gz",
 						"DEST_DISK":  "/dev/nvme0n1",
@@ -201,7 +201,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 				{
 					Name:    "stream-image",
 					Image:   "public.ecr.aws/eks-anywhere/image2disk:latest",
-					Timeout: 360,
+					Timeout: 600,
 					Environment: map[string]string{
 						"IMG_URL":    "http://tinkerbell-example:8080/bottlerocket-2004-kube-v1.21.5.gz",
 						"DEST_DISK":  "/dev/sda",
@@ -273,7 +273,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 				{
 					Name:    "stream-image",
 					Image:   "public.ecr.aws/eks-anywhere/image2disk:latest",
-					Timeout: 360,
+					Timeout: 600,
 					Environment: map[string]string{
 						"IMG_URL":    "http://tinkerbell-example:8080/bottlerocket-2004-kube-v1.21.5.gz",
 						"DEST_DISK":  "/dev/nvme0n1",


### PR DESCRIPTION
*Description of changes:*
Increased stream-image action timeout to 600 from 360 to avoid timing out during machine provisioning. 