### PR TITLE
Add Bottlerocket Raw images to bundle

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -83,7 +83,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	## Copy only the bundles crd to root config kustomization folder
 	cp -f config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml ../config/crd/bases/
-	@echo "Make sure to update the test bundle with `make update-bundle-golden-files`"
+	@echo "Make sure to update the test bundle with \`make update-bundle-golden-files\`"
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/release/pkg/file_reader.go
+++ b/release/pkg/file_reader.go
@@ -122,27 +122,37 @@ func getSupportedK8sVersions(r *ReleaseConfig) ([]string, error) {
 	return supportedK8sVersions, nil
 }
 
-func getBottlerocketSupportedK8sVersions(r *ReleaseConfig) ([]string, error) {
+func getBottlerocketSupportedK8sVersionsByFormat(r *ReleaseConfig, imageFormat string) ([]string, error) {
 	// Read the eks-d latest release file to get all the releases
-	var bottlerocketOvaReleaseMap map[string]interface{}
+	var bottlerocketReleaseMap map[string]interface{}
 	var bottlerocketSupportedK8sVersions []string
-	bottlerocketReleasesFilePath := "BOTTLEROCKET_RELEASES"
+	bottlerocketReleasesFilename := "BOTTLEROCKET_RELEASES"
 	if r.BuildRepoBranchName == "release-0.9" {
-		bottlerocketReleasesFilePath = "BOTTLEROCKET_OVA_RELEASES"
+		bottlerocketReleasesFilename = "BOTTLEROCKET_OVA_RELEASES"
 	}
-	bottlerocketOvaReleaseFilePath := filepath.Join(r.BuildRepoSource, imageBuilderProjectPath, bottlerocketReleasesFilePath)
+	bottlerocketReleasesFilePath := filepath.Join(r.BuildRepoSource, imageBuilderProjectPath, bottlerocketReleasesFilename)
 
-	bottlerocketOvaReleaseFile, err := ioutil.ReadFile(bottlerocketOvaReleaseFilePath)
+	bottlerocketReleasesFileContents, err := ioutil.ReadFile(bottlerocketReleasesFilePath)
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
-	err = yaml.Unmarshal(bottlerocketOvaReleaseFile, &bottlerocketOvaReleaseMap)
+	err = yaml.Unmarshal(bottlerocketReleasesFileContents, &bottlerocketReleaseMap)
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
 
-	for channel := range bottlerocketOvaReleaseMap {
-		bottlerocketSupportedK8sVersions = append(bottlerocketSupportedK8sVersions, channel)
+	for channel := range bottlerocketReleaseMap {
+		// new format for BR releases file
+		releaseVersionByFormat := bottlerocketReleaseMap[channel].(map[string]interface{})[fmt.Sprintf("%s-release-version", imageFormat)]
+		if releaseVersionByFormat != nil {
+			bottlerocketSupportedK8sVersions = append(bottlerocketSupportedK8sVersions, channel)
+		} else if releaseVersionByFormat == nil && imageFormat == "ova" {
+			// old format for BR releases file for backward compatibility
+			releaseVersionByFormat = bottlerocketReleaseMap[channel].(map[string]interface{})["releaseVersion"]
+			if releaseVersionByFormat != nil {
+				bottlerocketSupportedK8sVersions = append(bottlerocketSupportedK8sVersions, channel)
+			}
+		}
 	}
 
 	return bottlerocketSupportedK8sVersions, nil

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -243,7 +243,7 @@ spec:
           arch:
           - amd64
           crictl: {}
-          description: Bottlerocket OVA for EKS-D 1-20-16 release
+          description: Bottlerocket Ova image for EKS-D 1-20-16 release
           etcdadm: {}
           name: bottlerocket-v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
@@ -263,7 +263,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-20-16 release
+          description: Ubuntu Ova image for EKS-D 1-20-16 release
           etcdadm:
             arch:
             - amd64
@@ -295,7 +295,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-20-16 release
+          description: Ubuntu Raw image for EKS-D 1-20-16 release
           etcdadm:
             arch:
             - amd64
@@ -965,7 +965,7 @@ spec:
           arch:
           - amd64
           crictl: {}
-          description: Bottlerocket OVA for EKS-D 1-21-14 release
+          description: Bottlerocket Ova image for EKS-D 1-21-14 release
           etcdadm: {}
           name: bottlerocket-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
@@ -985,7 +985,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-21-14 release
+          description: Ubuntu Ova image for EKS-D 1-21-14 release
           etcdadm:
             arch:
             - amd64
@@ -1003,8 +1003,17 @@ spec:
           uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-21/1-21-14/ubuntu-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
+          arch:
+          - amd64
           crictl: {}
+          description: Bottlerocket Raw image for EKS-D 1-21-14 release
           etcdadm: {}
+          name: bottlerocket-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          os: linux
+          osName: bottlerocket
+          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-21/1-21-14/bottlerocket-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-build.0-amd64.img.gz
         ubuntu:
           arch:
           - amd64
@@ -1017,7 +1026,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-21-14 release
+          description: Ubuntu Raw image for EKS-D 1-21-14 release
           etcdadm:
             arch:
             - amd64
@@ -1687,7 +1696,7 @@ spec:
           arch:
           - amd64
           crictl: {}
-          description: Bottlerocket OVA for EKS-D 1-22-7 release
+          description: Bottlerocket Ova image for EKS-D 1-22-7 release
           etcdadm: {}
           name: bottlerocket-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
@@ -1707,7 +1716,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-22-7 release
+          description: Ubuntu Ova image for EKS-D 1-22-7 release
           etcdadm:
             arch:
             - amd64
@@ -1725,8 +1734,17 @@ spec:
           uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-22/1-22-7/ubuntu-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
+          arch:
+          - amd64
           crictl: {}
+          description: Bottlerocket Raw image for EKS-D 1-22-7 release
           etcdadm: {}
+          name: bottlerocket-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          os: linux
+          osName: bottlerocket
+          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-22/1-22-7/bottlerocket-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-build.0-amd64.img.gz
         ubuntu:
           arch:
           - amd64
@@ -1739,7 +1757,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-22-7 release
+          description: Ubuntu Raw image for EKS-D 1-22-7 release
           etcdadm:
             arch:
             - amd64
@@ -2409,7 +2427,7 @@ spec:
           arch:
           - amd64
           crictl: {}
-          description: Bottlerocket OVA for EKS-D 1-23-1 release
+          description: Bottlerocket Ova image for EKS-D 1-23-1 release
           etcdadm: {}
           name: bottlerocket-v1.23.6-eks-d-1-23-1-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
@@ -2429,7 +2447,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-23-1 release
+          description: Ubuntu Ova image for EKS-D 1-23-1 release
           etcdadm:
             arch:
             - amd64
@@ -2447,8 +2465,17 @@ spec:
           uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-23/1-23-1/ubuntu-v1.23.6-eks-d-1-23-1-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
+          arch:
+          - amd64
           crictl: {}
+          description: Bottlerocket Raw image for EKS-D 1-23-1 release
           etcdadm: {}
+          name: bottlerocket-v1.23.6-eks-d-1-23-1-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          os: linux
+          osName: bottlerocket
+          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-23/1-23-1/bottlerocket-v1.23.6-eks-d-1-23-1-eks-a-v0.0.0-dev-build.0-amd64.img.gz
         ubuntu:
           arch:
           - amd64
@@ -2461,7 +2488,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-23-1 release
+          description: Ubuntu Raw image for EKS-D 1-23-1 release
           etcdadm:
             arch:
             - amd64

--- a/release/pkg/test/testdata/release-0.9-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.9-bundle-release.yaml
@@ -243,7 +243,7 @@ spec:
           arch:
           - amd64
           crictl: {}
-          description: Bottlerocket OVA for EKS-D 1-20-16 release
+          description: Bottlerocket Ova image for EKS-D 1-20-16 release
           etcdadm: {}
           name: bottlerocket-v1.20.15-eks-d-1-20-16-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
           os: linux
@@ -263,7 +263,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-20-16 release
+          description: Ubuntu Ova image for EKS-D 1-20-16 release
           etcdadm:
             arch:
             - amd64
@@ -295,7 +295,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-20-16 release
+          description: Ubuntu Raw image for EKS-D 1-20-16 release
           etcdadm:
             arch:
             - amd64
@@ -788,7 +788,7 @@ spec:
           arch:
           - amd64
           crictl: {}
-          description: Bottlerocket OVA for EKS-D 1-21-14 release
+          description: Bottlerocket Ova image for EKS-D 1-21-14 release
           etcdadm: {}
           name: bottlerocket-v1.21.12-eks-d-1-21-14-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
           os: linux
@@ -808,7 +808,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-21-14 release
+          description: Ubuntu Ova image for EKS-D 1-21-14 release
           etcdadm:
             arch:
             - amd64
@@ -840,7 +840,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-21-14 release
+          description: Ubuntu Raw image for EKS-D 1-21-14 release
           etcdadm:
             arch:
             - amd64
@@ -1333,7 +1333,7 @@ spec:
           arch:
           - amd64
           crictl: {}
-          description: Bottlerocket OVA for EKS-D 1-22-7 release
+          description: Bottlerocket Ova image for EKS-D 1-22-7 release
           etcdadm: {}
           name: bottlerocket-v1.22.9-eks-d-1-22-7-eks-a-v0.0.0-dev-release-0.9-build.0-amd64.ova
           os: linux
@@ -1353,7 +1353,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-22-7 release
+          description: Ubuntu Ova image for EKS-D 1-22-7 release
           etcdadm:
             arch:
             - amd64
@@ -1385,7 +1385,7 @@ spec:
             sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.9-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.9+build.0-linux-amd64.tar.gz
-          description: Ubuntu OVA for EKS-D 1-22-7 release
+          description: Ubuntu Raw image for EKS-D 1-22-7 release
           etcdadm:
             arch:
             - amd64


### PR DESCRIPTION
aws/eks-anywhere-build-tooling#946 added Raw image downloads for Bottlerocket. This PR adds them to the bundle manifest for use in cluster creation workflows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

