### PR TITLE
Refactor post workload creation operations to generate support bundle…

### DIFF
--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -219,6 +219,11 @@ func (s *CreateWorkloadClusterTask) Run(ctx context.Context, commandContext *tas
 	}
 	commandContext.WorkloadCluster = workloadCluster
 
+	if err = commandContext.ClusterManager.RunPostCreateWorkloadCluster(ctx, commandContext.BootstrapCluster, commandContext.WorkloadCluster, commandContext.ClusterSpec); err != nil {
+		commandContext.SetError(err)
+		return &CollectDiagnosticsTask{}
+	}
+
 	logger.Info("Installing networking on workload cluster")
 	err = commandContext.ClusterManager.InstallNetworking(ctx, workloadCluster, commandContext.ClusterSpec, commandContext.Provider)
 	if err != nil {

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -2,6 +2,7 @@ package workflows_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -13,6 +14,7 @@ import (
 	writermocks "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	providermocks "github.com/aws/eks-anywhere/pkg/providers/mocks"
+	"github.com/aws/eks-anywhere/pkg/task"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/workflows"
 	"github.com/aws/eks-anywhere/pkg/workflows/interfaces/mocks"
@@ -102,7 +104,9 @@ func (c *createTestSetup) expectCreateWorkload() {
 		c.clusterManager.EXPECT().CreateWorkloadCluster(
 			c.ctx, c.bootstrapCluster, c.clusterSpec, c.provider,
 		).Return(c.workloadCluster, nil),
-
+		c.clusterManager.EXPECT().RunPostCreateWorkloadCluster(
+			c.ctx, c.bootstrapCluster, c.workloadCluster, c.clusterSpec,
+		),
 		c.clusterManager.EXPECT().InstallNetworking(
 			c.ctx, c.workloadCluster, c.clusterSpec, c.provider,
 		),
@@ -127,7 +131,9 @@ func (c *createTestSetup) expectCreateWorkloadSkipCAPI() {
 		c.clusterManager.EXPECT().CreateWorkloadCluster(
 			c.ctx, c.bootstrapCluster, c.clusterSpec, c.provider,
 		).Return(c.workloadCluster, nil),
-
+		c.clusterManager.EXPECT().RunPostCreateWorkloadCluster(
+			c.ctx, c.bootstrapCluster, c.workloadCluster, c.clusterSpec,
+		),
 		c.clusterManager.EXPECT().InstallNetworking(
 			c.ctx, c.workloadCluster, c.clusterSpec, c.provider,
 		),
@@ -308,5 +314,60 @@ func TestCreateWorkloadClusterRunSuccess(t *testing.T) {
 
 	if err := test.run(); err != nil {
 		t.Fatalf("Create.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestCreateWorkloadClusterTaskCreateWorkloadClusterFailure(t *testing.T) {
+	test := newCreateTest(t)
+	commandContext := task.CommandContext{
+		BootstrapCluster: test.bootstrapCluster,
+		ClusterSpec:      test.clusterSpec,
+		Provider:         test.provider,
+		ClusterManager:   test.clusterManager,
+	}
+
+	gomock.InOrder(
+		test.clusterManager.EXPECT().CreateWorkloadCluster(
+			test.ctx, test.bootstrapCluster, test.clusterSpec, test.provider,
+		).Return(nil, errors.New("test")),
+		test.clusterManager.EXPECT().SaveLogsManagementCluster(
+			test.ctx, test.clusterSpec, test.bootstrapCluster,
+		),
+		test.clusterManager.EXPECT().SaveLogsWorkloadCluster(
+			test.ctx, test.provider, test.clusterSpec, nil,
+		),
+	)
+	err := task.NewTaskRunner(&workflows.CreateWorkloadClusterTask{}, test.writer).RunTask(test.ctx, &commandContext)
+	if err == nil {
+		t.Fatalf("expected error from task")
+	}
+}
+
+func TestCreateWorkloadClusterTaskRunPostCreateWorkloadClusterFailure(t *testing.T) {
+	test := newCreateTest(t)
+	commandContext := task.CommandContext{
+		BootstrapCluster: test.bootstrapCluster,
+		ClusterSpec:      test.clusterSpec,
+		Provider:         test.provider,
+		ClusterManager:   test.clusterManager,
+	}
+
+	gomock.InOrder(
+		test.clusterManager.EXPECT().CreateWorkloadCluster(
+			test.ctx, test.bootstrapCluster, test.clusterSpec, test.provider,
+		).Return(test.workloadCluster, nil),
+		test.clusterManager.EXPECT().RunPostCreateWorkloadCluster(
+			test.ctx, test.bootstrapCluster, test.workloadCluster, test.clusterSpec,
+		).Return(errors.New("test")),
+		test.clusterManager.EXPECT().SaveLogsManagementCluster(
+			test.ctx, test.clusterSpec, test.bootstrapCluster,
+		),
+		test.clusterManager.EXPECT().SaveLogsWorkloadCluster(
+			test.ctx, test.provider, test.clusterSpec, test.workloadCluster,
+		),
+	)
+	err := task.NewTaskRunner(&workflows.CreateWorkloadClusterTask{}, test.writer).RunTask(test.ctx, &commandContext)
+	if err == nil {
+		t.Fatalf("expected error from task")
 	}
 }

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -18,6 +18,7 @@ type Bootstrapper interface {
 type ClusterManager interface {
 	MoveCAPI(ctx context.Context, from, to *types.Cluster, clusterName string, clusterSpec *cluster.Spec, checkers ...types.NodeReadyChecker) error
 	CreateWorkloadCluster(ctx context.Context, managementCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) (*types.Cluster, error)
+	RunPostCreateWorkloadCluster(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec) error
 	UpgradeCluster(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster, provider providers.Provider, clusterSpec *cluster.Spec) error
 	InstallCAPI(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -328,6 +328,20 @@ func (mr *MockClusterManagerMockRecorder) ResumeEKSAControllerReconcile(arg0, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeEKSAControllerReconcile", reflect.TypeOf((*MockClusterManager)(nil).ResumeEKSAControllerReconcile), arg0, arg1, arg2, arg3)
 }
 
+// RunPostCreateWorkloadCluster mocks base method.
+func (m *MockClusterManager) RunPostCreateWorkloadCluster(arg0 context.Context, arg1, arg2 *types.Cluster, arg3 *cluster.Spec) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunPostCreateWorkloadCluster", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunPostCreateWorkloadCluster indicates an expected call of RunPostCreateWorkloadCluster.
+func (mr *MockClusterManagerMockRecorder) RunPostCreateWorkloadCluster(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunPostCreateWorkloadCluster", reflect.TypeOf((*MockClusterManager)(nil).RunPostCreateWorkloadCluster), arg0, arg1, arg2, arg3)
+}
+
 // SaveLogsManagementCluster mocks base method.
 func (m *MockClusterManager) SaveLogsManagementCluster(arg0 context.Context, arg1 *cluster.Spec, arg2 *types.Cluster) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
… for workload cluster

*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/2265

*Description of changes:*
Refactor out some of the post creation methods to a separate method to be able to properly set the workload cluster context in order to be able to pull the support bundle right after workload kubeconfig is generated instead of waiting for the machines to also be fully ready.

*Testing (if applicable):*
Unit testing and e2e

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

