### PR TITLE
add additional logging for debugging failing gitflux tests

### DIFF
--- a/internal/test/e2e/fluxGit.go
+++ b/internal/test/e2e/fluxGit.go
@@ -147,6 +147,7 @@ func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*g
 		return nil, fmt.Errorf("generating key pair for git tests: %v", err)
 	}
 
+	logger.Info("Create Deploy Key Configuration for Git Flux tests", "owner", owner, "repo", repo)
 	// Add the newly generated public key to the newly created repository as a deploy key
 	ko := git.AddDeployKeyOpts{
 		Owner:      owner,
@@ -157,7 +158,7 @@ func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*g
 	}
 
 	// Newly generated repositories may take some time to show up in the GitHub API; retry a few times to get around this
-	err = retrier.Retry(6, time.Second*10, func() error {
+	err = retrier.Retry(10, time.Second*10, func() error {
 		err = g.AddDeployKeyToRepo(ctx, ko)
 		if err != nil {
 			return fmt.Errorf("couldn't add deploy key to repo: %v", err)

--- a/pkg/git/gogithub/gogithub.go
+++ b/pkg/git/gogithub/gogithub.go
@@ -83,7 +83,11 @@ func (ggc *githubClient) DeleteRepo(ctx context.Context, owner, repo string) (*g
 }
 
 func (ggc *githubClient) AddDeployKeyToRepo(ctx context.Context, owner, repo string, key *goGithub.Key) error {
-	_, _, err := ggc.client.Repositories.CreateKey(ctx, owner, repo, key)
+	_, resp, err := ggc.client.Repositories.CreateKey(ctx, owner, repo, key)
+	if err != nil {
+		logger.Info("createKey response", "resp", resp)
+		return fmt.Errorf("adding deploy key to repo: %v", err)
+	}
 	return err
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
additional logging to assist in debuging GitFlux test failures

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

