### PR TITLE
Watch child objects with OwnerReferences

### DIFF
--- a/controllers/controllers/cluster_controller_test.go
+++ b/controllers/controllers/cluster_controller_test.go
@@ -19,6 +19,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/aws/eks-anywhere/controllers/controllers/clusters"
 	_ "github.com/aws/eks-anywhere/internal/test/envtest"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
@@ -52,10 +53,11 @@ func TestClusterReconcilerSkipManagement(t *testing.T) {
 	defaulter := vsphere.NewDefaulter(govcClient)
 
 	r := &ClusterReconciler{
-		client:    cl,
-		log:       logf.Log,
-		validator: validator,
-		defaulter: defaulter,
+		client:                  cl,
+		log:                     logf.Log,
+		validator:               validator,
+		defaulter:               defaulter,
+		buildProviderReconciler: clusters.BuildProviderReconciler,
 	}
 
 	req := reconcile.Request{
@@ -113,10 +115,11 @@ func TestClusterReconcilerSuccess(t *testing.T) {
 	defaulter := vsphere.NewDefaulter(govcClient)
 
 	r := &ClusterReconciler{
-		client:    cl,
-		log:       logf.Log,
-		validator: validator,
-		defaulter: defaulter,
+		client:                  cl,
+		log:                     logf.Log,
+		validator:               validator,
+		defaulter:               defaulter,
+		buildProviderReconciler: clusters.BuildProviderReconciler,
 	}
 
 	req := reconcile.Request{
@@ -174,10 +177,11 @@ func TestClusterReconcilerFailToSetUpMachineConfigCP(t *testing.T) {
 	defaulter := vsphere.NewDefaulter(govcClient)
 
 	r := &ClusterReconciler{
-		client:    cl,
-		log:       logf.Log,
-		validator: validator,
-		defaulter: defaulter,
+		client:                  cl,
+		log:                     logf.Log,
+		validator:               validator,
+		defaulter:               defaulter,
+		buildProviderReconciler: clusters.BuildProviderReconciler,
 	}
 
 	req := reconcile.Request{
@@ -237,10 +241,11 @@ func TestClusterReconcilerDeleteExistingCAPIClusterSuccess(t *testing.T) {
 	defaulter := vsphere.NewDefaulter(govcClient)
 
 	r := &ClusterReconciler{
-		client:    cl,
-		log:       logf.Log,
-		validator: validator,
-		defaulter: defaulter,
+		client:                  cl,
+		log:                     logf.Log,
+		validator:               validator,
+		defaulter:               defaulter,
+		buildProviderReconciler: clusters.BuildProviderReconciler,
 	}
 
 	req := reconcile.Request{

--- a/controllers/controllers/cluster_controller_test_test.go
+++ b/controllers/controllers/cluster_controller_test_test.go
@@ -1,0 +1,112 @@
+package controllers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/controllers/remote"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/eks-anywhere/controllers/controllers"
+	"github.com/aws/eks-anywhere/controllers/controllers/clusters"
+	"github.com/aws/eks-anywhere/controllers/controllers/reconciler"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/providers/vsphere"
+)
+
+func TestClusterReconcilerEnsureOwnerReferences(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	cluster := &anywherev1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: "my-namespace",
+		},
+	}
+	cluster.Spec.IdentityProviderRefs = []anywherev1.Ref{
+		{
+			Kind: anywherev1.OIDCConfigKind,
+			Name: "my-oidc",
+		},
+		{
+			Kind: anywherev1.AWSIamConfigKind,
+			Name: "my-iam",
+		},
+	}
+	cluster.SetManagedBy("my-management-cluster")
+
+	oidc := &anywherev1.OIDCConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-oidc",
+			Namespace: cluster.Namespace,
+		},
+	}
+	awsIAM := &anywherev1.AWSIamConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-iam",
+			Namespace: cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: anywherev1.GroupVersion.String(),
+					Kind:       anywherev1.ClusterKind,
+					Name:       cluster.Name,
+				},
+			},
+		},
+	}
+	objs := []runtime.Object{cluster, oidc, awsIAM}
+	cb := fake.NewClientBuilder()
+	cl := cb.WithRuntimeObjects(objs...).Build()
+
+	r := controllers.NewClusterReconciler(cl, logr.New(logf.NullLogSink{}), cl.Scheme(), nil, nil, newDummyProviderReconcilerBuilder())
+	_, err := r.Reconcile(ctx, clusterRequest(cluster))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	newOidc := &anywherev1.OIDCConfig{}
+	g.Expect(cl.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: "my-oidc"}, newOidc)).To(Succeed())
+	g.Expect(newOidc.OwnerReferences).To(HaveLen(1))
+	g.Expect(newOidc.OwnerReferences[0].Name).To(Equal(cluster.Name))
+
+	newAWSIam := &anywherev1.AWSIamConfig{}
+	g.Expect(cl.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: "my-iam"}, newAWSIam)).To(Succeed())
+	g.Expect(newAWSIam.OwnerReferences).To(HaveLen(1))
+	g.Expect(newAWSIam.OwnerReferences[0]).To(Equal(awsIAM.OwnerReferences[0]))
+}
+
+func TestClusterReconcilerSetupWithManager(t *testing.T) {
+	client := env.Client()
+	r := controllers.NewClusterReconciler(client, logf.Log, client.Scheme(), nil, nil, newDummyProviderReconcilerBuilder())
+
+	g := NewWithT(t)
+	g.Expect(r.SetupWithManager(env.Manager())).To(Succeed())
+}
+
+func newDummyProviderReconcilerBuilder() controllers.BuildProviderReconciler {
+	return func(datacenterKind string, client client.Client, log logr.Logger, validator *vsphere.Validator, defaulter *vsphere.Defaulter, tracker *remote.ClusterCacheTracker) (clusters.ProviderClusterReconciler, error) {
+		return dummyProviderReconciler{}, nil
+	}
+}
+
+type dummyProviderReconciler struct{}
+
+func (dummyProviderReconciler) Reconcile(ctx context.Context, cluster *anywherev1.Cluster) (reconciler.Result, error) {
+	return reconciler.Result{}, nil
+}
+
+func clusterRequest(cluster *anywherev1.Cluster) reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+	}
+}

--- a/controllers/controllers/main_test.go
+++ b/controllers/controllers/main_test.go
@@ -1,0 +1,14 @@
+package controllers_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/aws/eks-anywhere/internal/test/envtest"
+)
+
+var env *envtest.Environment
+
+func TestMain(m *testing.M) {
+	os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+}

--- a/controllers/controllers/utils/handlerutil/childobjects.go
+++ b/controllers/controllers/utils/handlerutil/childobjects.go
@@ -1,0 +1,38 @@
+package handlerutil
+
+import (
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+func ChildObjectToClusters(log logr.Logger) handler.MapFunc {
+	return func(o client.Object) []reconcile.Request {
+		requests := []reconcile.Request{}
+		for _, owner := range o.GetOwnerReferences() {
+			if owner.Kind == anywherev1.ClusterKind {
+				requests = append(requests, reconcileRequestForOwnerRef(o, owner))
+			}
+		}
+
+		if len(requests) == 0 {
+			log.V(6).Info("Object doesn't contain references to a Cluster", "kind", o.GetObjectKind(), "name", o.GetName())
+		}
+
+		return requests
+	}
+}
+
+func reconcileRequestForOwnerRef(o client.Object, owner metav1.OwnerReference) reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      owner.Name,
+			Namespace: o.GetNamespace(),
+		},
+	}
+}

--- a/controllers/controllers/utils/handlerutil/childobjects_test.go
+++ b/controllers/controllers/utils/handlerutil/childobjects_test.go
@@ -1,0 +1,86 @@
+package handlerutil_test
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/eks-anywhere/controllers/controllers/utils/handlerutil"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+func TestChildObjectToClusters(t *testing.T) {
+	testCases := []struct {
+		testName     string
+		obj          client.Object
+		wantRequests []reconcile.Request
+	}{
+		{
+			testName: "two clusters",
+			obj: &anywherev1.OIDCConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-oidc",
+					Namespace: "my-namespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: anywherev1.GroupVersion.String(),
+							Kind:       anywherev1.ClusterKind,
+							Name:       "my-cluster",
+						},
+						{
+							APIVersion: anywherev1.GroupVersion.String(),
+							Kind:       anywherev1.ClusterKind,
+							Name:       "my-other-cluster",
+						},
+					},
+				},
+			},
+			wantRequests: []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Name:      "my-cluster",
+						Namespace: "my-namespace",
+					},
+				},
+				{
+					NamespacedName: types.NamespacedName{
+						Name:      "my-other-cluster",
+						Namespace: "my-namespace",
+					},
+				},
+			},
+		},
+		{
+			testName: "no-clusters",
+			obj: &anywherev1.OIDCConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-oidc",
+					Namespace: "my-namespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: anywherev1.GroupVersion.String(),
+							Kind:       "OtherObj",
+							Name:       "my-obj",
+						},
+					},
+				},
+			},
+			wantRequests: []reconcile.Request{},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			handle := handlerutil.ChildObjectToClusters(logr.New(logf.NullLogSink{}))
+			requests := handle(tt.obj)
+			g.Expect(requests).To(Equal(tt.wantRequests))
+		})
+	}
+}

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/aws/eks-anywhere/controllers/controllers"
+	"github.com/aws/eks-anywhere/controllers/controllers/clusters"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/features"
@@ -138,6 +139,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 			mgr.GetScheme(),
 			deps.Govc,
 			tracker,
+			clusters.BuildProviderReconciler,
 		)).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", anywherev1.ClusterKind)
 			os.Exit(1)

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -106,7 +106,7 @@ func newEnvironment(ctx context.Context) (*Environment, error) {
 		CRDDirectoryPaths:     crdDirectoryPaths,
 		ErrorIfCRDPathMissing: true,
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
-			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+			Paths: []string{filepath.Join(root, "config", "webhook")},
 		},
 	}
 
@@ -165,6 +165,11 @@ func (e *Environment) Client() client.Client {
 // APIReader returns a non cached reader client
 func (e *Environment) APIReader() client.Reader {
 	return e.apiReader
+}
+
+// Manager returns a Manager for the test environment
+func (e *Environment) Manager() manager.Manager {
+	return e.manager
 }
 
 func (e *Environment) CreateNamespaceForTest(ctx context.Context, t *testing.T) string {

--- a/pkg/cluster/config_test.go
+++ b/pkg/cluster/config_test.go
@@ -1,0 +1,43 @@
+package cluster_test
+
+import (
+	"reflect"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+)
+
+func TestConfigChildObjects(t *testing.T) {
+	g := NewWithT(t)
+	config := &cluster.Config{
+		Cluster:              &anywherev1.Cluster{},
+		SnowDatacenter:       &anywherev1.SnowDatacenterConfig{},
+		CloudStackDatacenter: &anywherev1.CloudStackDatacenterConfig{},
+		VSphereDatacenter:    &anywherev1.VSphereDatacenterConfig{},
+		SnowMachineConfigs: map[string]*anywherev1.SnowMachineConfig{
+			"machine1": {}, "machine2": {},
+		},
+		VSphereMachineConfigs: map[string]*anywherev1.VSphereMachineConfig{
+			"machine1": {}, "machine2": {},
+		},
+		CloudStackMachineConfigs: map[string]*anywherev1.CloudStackMachineConfig{
+			"machine1": {}, "machine2": {},
+		},
+		OIDCConfigs: map[string]*anywherev1.OIDCConfig{
+			"machine1": {},
+		},
+		AWSIAMConfigs: map[string]*anywherev1.AWSIamConfig{
+			"config1": {},
+		},
+		FluxConfig: &anywherev1.FluxConfig{},
+	}
+
+	objs := config.ChildObjects()
+	g.Expect(objs).To(HaveLen(12))
+	for _, o := range objs {
+		g.Expect(reflect.ValueOf(o).IsNil()).To(BeFalse())
+	}
+}


### PR DESCRIPTION
*Issue #, if available:* part of #1090

*Description of changes:*

On every reconciliation loop, check if the cluster child objects contain
an owner reference linked to that cluster. If they don't, add it and
update them.

When watching child objects, use their OwnerReferences to enqueue
reconcile requests for Clusters.

*Testing (if applicable):*
Unit and integration tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

