### PR TITLE
fix vsphere env var race conditions during e2e tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
@@ -13,9 +13,7 @@ env:
   secrets-manager:
     EKSA_VSPHERE_USERNAME: "vsphere_ci_beta_connection:vsphere_username"
     EKSA_VSPHERE_PASSWORD: "vsphere_ci_beta_connection:vsphere_password"
-    GOVC_URL: "vsphere_ci_beta_connection:vsphere_url"
-    GOVC_USERNAME: "vsphere_ci_beta_connection:vsphere_username"
-    GOVC_PASSWORD: "vsphere_ci_beta_connection:vsphere_password"
+    VSPHERE_SERVER: "vsphere_ci_beta_connection:vsphere_url"
     GOVC_INSECURE: "vsphere_ci_beta_connection:govc_insecure"
     T_VSPHERE_DATACENTER: "vsphere_ci_beta_connection:vsphere_datacenter"
     T_VSPHERE_DATASTORE: "vsphere_ci_beta_connection:datastore"

--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -18,9 +18,7 @@ env:
   secrets-manager:
     EKSA_VSPHERE_USERNAME: "vsphere_ci_beta_connection:vsphere_username"
     EKSA_VSPHERE_PASSWORD: "vsphere_ci_beta_connection:vsphere_password"
-    GOVC_URL: "vsphere_ci_beta_connection:vsphere_url"
-    GOVC_USERNAME: "vsphere_ci_beta_connection:vsphere_username"
-    GOVC_PASSWORD: "vsphere_ci_beta_connection:vsphere_password"
+    VSPHERE_SERVER: "vsphere_ci_beta_connection:vsphere_url"
     GOVC_INSECURE: "vsphere_ci_beta_connection:govc_insecure"
     T_VSPHERE_DATACENTER: "vsphere_ci_beta_connection:vsphere_datacenter"
     T_VSPHERE_DATASTORE: "vsphere_ci_beta_connection:datastore"

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -38,7 +38,7 @@ const (
 	VsphereClusterIPPoolEnvVar  = "T_VSPHERE_CLUSTER_IP_POOL"
 	cidrVar                     = "T_VSPHERE_CIDR"
 	privateNetworkCidrVar       = "T_VSPHERE_PRIVATE_NETWORK_CIDR"
-	govcUrlVar                  = "GOVC_URL"
+	govcUrlVar                  = "VSPHERE_SERVER"
 	govcInsecureVar             = "GOVC_INSECURE"
 )
 


### PR DESCRIPTION
This is to account for govc envvars being needed by test runners and vsphere tests. To account for this we name them differently on code build box and override to govc vars at time of vm creation

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

