### PR TITLE
enable option to override govc envmap that gets passed to container

### DIFF
--- a/internal/pkg/vsphere/deploy.go
+++ b/internal/pkg/vsphere/deploy.go
@@ -30,7 +30,7 @@ type NetworkMapping struct {
 	Network string `json:"Network"`
 }
 
-func DeployTemplate(library, templateName, vmName, deployFolder, datacenter, datastore, resourcePool string, opts OVFDeployOptions) error {
+func DeployTemplate(envMap map[string]string, library, templateName, vmName, deployFolder, datacenter, datastore, resourcePool string, opts OVFDeployOptions) error {
 	context := context.Background()
 	executableBuilder, close, err := executables.NewExecutableBuilder(context, executables.DefaultEksaImage())
 	if err != nil {
@@ -39,7 +39,7 @@ func DeployTemplate(library, templateName, vmName, deployFolder, datacenter, dat
 
 	defer close.CheckErr(context)
 	tmpWriter, _ := filewriter.NewWriter(vmName)
-	govc := executableBuilder.BuildGovcExecutable(tmpWriter)
+	govc := executableBuilder.BuildGovcExecutable(tmpWriter, executables.WithGovcEnvMap(envMap))
 	defer govc.Close(context)
 
 	deployOptions, err := json.Marshal(opts)

--- a/pkg/executables/builder.go
+++ b/pkg/executables/builder.go
@@ -37,8 +37,8 @@ func (b *ExecutableBuilder) BuildKubectlExecutable() *Kubectl {
 	return NewKubectl(b.buildExecutable(kubectlPath))
 }
 
-func (b *ExecutableBuilder) BuildGovcExecutable(writer filewriter.FileWriter) *Govc {
-	return NewGovc(b.buildExecutable(govcPath), writer)
+func (b *ExecutableBuilder) BuildGovcExecutable(writer filewriter.FileWriter, opts ...GovcOpt) *Govc {
+	return NewGovc(b.buildExecutable(govcPath), writer, opts...)
 }
 
 func (b *ExecutableBuilder) BuildCmkExecutable(writer filewriter.FileWriter, execConfig decoder.CloudStackExecConfig) *Cmk {


### PR DESCRIPTION
This is required to support targeting 2 different vpshere from the same machine using govc executable int the bundle. With this change we now have option to pass custom env map directly to container env rather than it always picking the envs from the cli environment.