### PR TITLE
Expose tinkerbell services on workload cluster using an lb

### DIFF
--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig.go
@@ -18,7 +18,7 @@ const TinkerbellTemplateConfigKind = "TinkerbellTemplateConfig"
 type ActionOpt func(action *[]tinkerbell.Action)
 
 // NewDefaultTinkerbellTemplateConfigCreate returns a default TinkerbellTemplateConfig with the required Tasks and Actions
-func NewDefaultTinkerbellTemplateConfigCreate(name string, versionBundle v1alpha1.VersionsBundle, disk string, osImageOverride, tinkerbellIp string, osFamily OSFamily) *TinkerbellTemplateConfig {
+func NewDefaultTinkerbellTemplateConfigCreate(name string, versionBundle v1alpha1.VersionsBundle, disk string, osImageOverride, tinkerbellLocalIp, tinkerbellLBIp string, osFamily OSFamily) *TinkerbellTemplateConfig {
 	config := &TinkerbellTemplateConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       TinkerbellTemplateConfigKind,
@@ -45,7 +45,7 @@ func NewDefaultTinkerbellTemplateConfigCreate(name string, versionBundle v1alpha
 		},
 	}
 
-	defaultActions := GetDefaultActionsFromBundle(versionBundle, disk, osImageOverride, tinkerbellIp, osFamily)
+	defaultActions := GetDefaultActionsFromBundle(versionBundle, disk, osImageOverride, tinkerbellLocalIp, tinkerbellLBIp, osFamily)
 	for _, action := range defaultActions {
 		action(&config.Spec.Template.Tasks[0].Actions)
 	}

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
@@ -11,8 +11,10 @@ import (
 
 func TestWithDefaultActionsFromBundle(t *testing.T) {
 	vBundle := givenVersionBundle()
-	tinkerbellIp := "0.0.0.0"
-	metadataString := fmt.Sprintf("\"http://%s:50061\"", tinkerbellIp)
+	tinkerbellLocalIp := "127.0.0.1"
+	tinkerbellLBIP := "1.2.3.4"
+	brMetadataString := fmt.Sprintf("\"http://%s:50061\"", tinkerbellLocalIp)
+	ubuntuMetadataString := fmt.Sprintf("\"http://%s:50061\", \"http://%s:50061\"", tinkerbellLocalIp, tinkerbellLBIP)
 
 	tests := []struct {
 		testName    string
@@ -74,7 +76,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 						"DEST_DISK": "/dev/sda2",
 						"FS_TYPE":   "ext4",
 						"DEST_PATH": "/etc/cloud/cloud.cfg.d/10_tinkerbell.cfg",
-						"CONTENTS":  fmt.Sprintf(cloudInit, metadataString),
+						"CONTENTS":  fmt.Sprintf(cloudInit, ubuntuMetadataString),
 						"UID":       "0",
 						"GID":       "0",
 						"MODE":      "0600",
@@ -162,7 +164,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 						"DEST_DISK": "/dev/nvme0n1p2",
 						"FS_TYPE":   "ext4",
 						"DEST_PATH": "/etc/cloud/cloud.cfg.d/10_tinkerbell.cfg",
-						"CONTENTS":  fmt.Sprintf(cloudInit, metadataString),
+						"CONTENTS":  fmt.Sprintf(cloudInit, ubuntuMetadataString),
 						"UID":       "0",
 						"GID":       "0",
 						"MODE":      "0600",
@@ -249,7 +251,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 						"DEST_DISK": "/dev/sda12",
 						"FS_TYPE":   "ext4",
 						"DEST_PATH": "/user-data.toml",
-						"HEGEL_URL": metadataString,
+						"HEGEL_URL": brMetadataString,
 						"UID":       "0",
 						"GID":       "0",
 						"MODE":      "0644",
@@ -321,7 +323,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 						"DEST_DISK": "/dev/nvme0n1p12",
 						"FS_TYPE":   "ext4",
 						"DEST_PATH": "/user-data.toml",
-						"HEGEL_URL": metadataString,
+						"HEGEL_URL": brMetadataString,
 						"UID":       "0",
 						"GID":       "0",
 						"MODE":      "0644",
@@ -342,7 +344,7 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			givenActions := []tinkerbell.Action{}
-			opts := GetDefaultActionsFromBundle(vBundle, tt.diskType, "", tinkerbellIp, tt.osFamily)
+			opts := GetDefaultActionsFromBundle(vBundle, tt.diskType, "", tinkerbellLocalIp, tinkerbellLBIP, tt.osFamily)
 			for _, opt := range opts {
 				opt(&givenActions)
 			}

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -46,7 +46,7 @@ func (p *Provider) PreCAPIInstallOnBootstrap(ctx context.Context, cluster *types
 
 	err := p.stackInstaller.Install(
 		ctx,
-		clusterSpec.VersionsBundle.Tinkerbell.TinkerbellStack,
+		clusterSpec.VersionsBundle.Tinkerbell,
 		p.tinkerbellIp,
 		cluster.KubeconfigFile,
 		p.datacenterConfig.Spec.HookImagesURLPath,
@@ -78,13 +78,14 @@ func (p *Provider) PostWorkloadInit(ctx context.Context, cluster *types.Cluster,
 
 	err := p.stackInstaller.Install(
 		ctx,
-		clusterSpec.VersionsBundle.Tinkerbell.TinkerbellStack,
+		clusterSpec.VersionsBundle.Tinkerbell,
 		p.templateBuilder.datacenterSpec.TinkerbellIP,
 		cluster.KubeconfigFile,
 		p.datacenterConfig.Spec.HookImagesURLPath,
 		stack.WithNamespaceCreate(true),
 		stack.WithBootsOnKubernetes(),
 		stack.WithHostPortEnabled(false),
+		stack.WithLoadBalancer(),
 	)
 	if err != nil {
 		return fmt.Errorf("installing stack on workload cluster: %v", err)

--- a/pkg/providers/tinkerbell/stack/mocks/stack.go
+++ b/pkg/providers/tinkerbell/stack/mocks/stack.go
@@ -159,9 +159,9 @@ func (mr *MockStackInstallerMockRecorder) CleanupLocalBoots(ctx, forceCleanup in
 }
 
 // Install mocks base method.
-func (m *MockStackInstaller) Install(ctx context.Context, bundle v1alpha1.TinkerbellStackBundle, tinkServerIP, kubeconfig, hookOverride string, opts ...stack.InstallOption) error {
+func (m *MockStackInstaller) Install(ctx context.Context, bundle v1alpha1.TinkerbellBundle, tinkerbellIP, kubeconfig, hookOverride string, opts ...stack.InstallOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, bundle, tinkServerIP, kubeconfig, hookOverride}
+	varargs := []interface{}{ctx, bundle, tinkerbellIP, kubeconfig, hookOverride}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -171,9 +171,9 @@ func (m *MockStackInstaller) Install(ctx context.Context, bundle v1alpha1.Tinker
 }
 
 // Install indicates an expected call of Install.
-func (mr *MockStackInstallerMockRecorder) Install(ctx, bundle, tinkServerIP, kubeconfig, hookOverride interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MockStackInstallerMockRecorder) Install(ctx, bundle, tinkerbellIP, kubeconfig, hookOverride interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, bundle, tinkServerIP, kubeconfig, hookOverride}, opts...)
+	varargs := append([]interface{}{ctx, bundle, tinkerbellIP, kubeconfig, hookOverride}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockStackInstaller)(nil).Install), varargs...)
 }
 

--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -31,6 +31,8 @@ const (
 	tinkServer     = "tinkServer"
 	rufio          = "rufio"
 	grpcPort       = "42113"
+	kubevip        = "kubevip"
+	loadBalancer   = "loadBalancer"
 )
 
 type Docker interface {
@@ -51,13 +53,14 @@ type Installer struct {
 	createNamespace bool
 	bootsOnDocker   bool
 	hostPort        bool
+	loadBalancer    bool
 }
 
 type InstallOption func(s *Installer)
 
 type StackInstaller interface {
 	CleanupLocalBoots(ctx context.Context, forceCleanup bool) error
-	Install(ctx context.Context, bundle releasev1alpha1.TinkerbellStackBundle, tinkServerIP, kubeconfig, hookOverride string, opts ...InstallOption) error
+	Install(ctx context.Context, bundle releasev1alpha1.TinkerbellBundle, tinkerbellIP, kubeconfig, hookOverride string, opts ...InstallOption) error
 	UninstallLocal(ctx context.Context) error
 }
 
@@ -89,6 +92,12 @@ func WithHostPortEnabled(enabled bool) InstallOption {
 	}
 }
 
+func WithLoadBalancer() InstallOption {
+	return func(s *Installer) {
+		s.loadBalancer = true
+	}
+}
+
 // NewInstaller returns a Tinkerbell StackInstaller which can be used to install or uninstall the Tinkerbell stack
 func NewInstaller(docker Docker, filewriter filewriter.FileWriter, helm Helm, namespace string) StackInstaller {
 	return &Installer{
@@ -100,7 +109,7 @@ func NewInstaller(docker Docker, filewriter filewriter.FileWriter, helm Helm, na
 }
 
 // Install installs the Tinkerbell stack on a target cluster using a helm chart and providing the necessary values overrides
-func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.TinkerbellStackBundle, tinkServerIP, kubeconfig, hookOverride string, opts ...InstallOption) error {
+func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.TinkerbellBundle, tinkerbellIP, kubeconfig, hookOverride string, opts ...InstallOption) error {
 	logger.V(6).Info("Installing Tinkerbell helm chart")
 
 	for _, option := range opts {
@@ -108,14 +117,14 @@ func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 	}
 
 	bootEnv := []map[string]string{}
-	for k, v := range s.getBootsEnv(bundle, tinkServerIP) {
+	for k, v := range s.getBootsEnv(bundle.TinkerbellStack, tinkerbellIP) {
 		bootEnv = append(bootEnv, map[string]string{
 			"name":  k,
 			"value": v,
 		})
 	}
 
-	osiePath, err := getURIDir(bundle.Hook.Initramfs.Amd.URI)
+	osiePath, err := getURIDir(bundle.TinkerbellStack.Hook.Initramfs.Amd.URI)
 	if err != nil {
 		return fmt.Errorf("getting directory path from hook uri: %v", err)
 	}
@@ -129,11 +138,11 @@ func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 		createNamespace: s.createNamespace,
 		tinkController: map[string]interface{}{
 			deploy: true,
-			image:  bundle.Tink.TinkController.URI,
+			image:  bundle.TinkerbellStack.Tink.TinkController.URI,
 		},
 		tinkServer: map[string]interface{}{
 			deploy: true,
-			image:  bundle.Tink.TinkServer.URI,
+			image:  bundle.TinkerbellStack.Tink.TinkServer.URI,
 			args:   []string{"--tls=false"},
 			port: map[string]bool{
 				hostPortEnabled: s.hostPort,
@@ -141,7 +150,7 @@ func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 		},
 		hegel: map[string]interface{}{
 			deploy: true,
-			image:  bundle.Hegel.Image.URI,
+			image:  bundle.TinkerbellStack.Hegel.Image.URI,
 			args:   []string{"--grpc-use-tls=false"},
 			port: map[string]bool{
 				hostPortEnabled: s.hostPort,
@@ -149,7 +158,7 @@ func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 		},
 		boots: map[string]interface{}{
 			deploy: !s.bootsOnDocker,
-			image:  bundle.Boots.Image.URI,
+			image:  bundle.TinkerbellStack.Boots.Image.URI,
 			env:    bootEnv,
 			args: []string{
 				"-dhcp-addr=0.0.0.0:67",
@@ -158,7 +167,14 @@ func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 		},
 		rufio: map[string]interface{}{
 			deploy: true,
-			image:  bundle.Rufio.Image.URI,
+			image:  bundle.TinkerbellStack.Rufio.Image.URI,
+		},
+		loadBalancer: map[string]interface{}{
+			"enabled": s.loadBalancer,
+			"ip":      tinkerbellIP,
+		},
+		kubevip: map[string]interface{}{
+			image: bundle.KubeVip,
 		},
 	}
 
@@ -174,9 +190,9 @@ func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 
 	err = s.helm.InstallChartWithValuesFile(
 		ctx,
-		bundle.TinkebellChart.Name,
-		fmt.Sprintf("oci://%s", bundle.TinkebellChart.Image()),
-		bundle.TinkebellChart.Tag(),
+		bundle.TinkerbellStack.TinkebellChart.Name,
+		fmt.Sprintf("oci://%s", bundle.TinkerbellStack.TinkebellChart.Image()),
+		bundle.TinkerbellStack.TinkebellChart.Tag(),
 		kubeconfig,
 		valuesPath,
 	)
@@ -184,7 +200,7 @@ func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 		return fmt.Errorf("installing Tinkerbell helm chart: %v", err)
 	}
 
-	return s.installBootsOnDocker(ctx, bundle, tinkServerIP, kubeconfig, hookOverride)
+	return s.installBootsOnDocker(ctx, bundle.TinkerbellStack, tinkerbellIP, kubeconfig, hookOverride)
 }
 
 func (s *Installer) installBootsOnDocker(ctx context.Context, bundle releasev1alpha1.TinkerbellStackBundle, tinkServerIP, kubeconfig, hookOverride string) error {

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -29,27 +29,32 @@ const (
 
 var helmChartURI = fmt.Sprintf("%s:%s", helmChartPath, helmChartVersion)
 
-func getTinkBundle() releasev1alpha1.TinkerbellStackBundle {
-	return releasev1alpha1.TinkerbellStackBundle{
-		Tink: releasev1alpha1.TinkBundle{
-			TinkWorker: releasev1alpha1.Image{URI: "tink-worker:latest"},
-		},
-		Boots: releasev1alpha1.TinkerbellServiceBundle{
-			Image: releasev1alpha1.Image{URI: "boots:latest"},
-		},
-		Hegel: releasev1alpha1.TinkerbellServiceBundle{
-			Image: releasev1alpha1.Image{URI: "hegel:latest"},
-		},
-		Hook: releasev1alpha1.HookBundle{
-			Initramfs: releasev1alpha1.HookArch{
-				Amd: releasev1alpha1.Archive{
-					URI: "https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/initramfs-x86-64",
+func getTinkBundle() releasev1alpha1.TinkerbellBundle {
+	return releasev1alpha1.TinkerbellBundle{
+		TinkerbellStack: releasev1alpha1.TinkerbellStackBundle{
+			Tink: releasev1alpha1.TinkBundle{
+				TinkWorker: releasev1alpha1.Image{URI: "tink-worker:latest"},
+			},
+			Boots: releasev1alpha1.TinkerbellServiceBundle{
+				Image: releasev1alpha1.Image{URI: "boots:latest"},
+			},
+			Hegel: releasev1alpha1.TinkerbellServiceBundle{
+				Image: releasev1alpha1.Image{URI: "hegel:latest"},
+			},
+			Hook: releasev1alpha1.HookBundle{
+				Initramfs: releasev1alpha1.HookArch{
+					Amd: releasev1alpha1.Archive{
+						URI: "https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/initramfs-x86-64",
+					},
 				},
 			},
+			TinkebellChart: releasev1alpha1.Image{
+				Name: helmChartName,
+				URI:  helmChartURI,
+			},
 		},
-		TinkebellChart: releasev1alpha1.Image{
-			Name: helmChartName,
-			URI:  helmChartURI,
+		KubeVip: releasev1alpha1.Image{
+			URI: "public.ecr.aws/eks-anywhere/kube-vip:latest",
 		},
 	}
 }
@@ -76,6 +81,7 @@ func TestTinkerbellStackInstallWithAllOptionsSuccess(t *testing.T) {
 		stack.WithNamespaceCreate(true),
 		stack.WithBootsOnKubernetes(),
 		stack.WithHostPortEnabled(true),
+		stack.WithLoadBalancer(),
 	); err != nil {
 		t.Fatalf("failed to install Tinkerbell stack: %v", err)
 	}

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -62,7 +62,7 @@ func (tb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spe
 		if err != nil {
 			return nil, fmt.Errorf("getting control plane disk type of the hardware selector: %v", err)
 		}
-		cpTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster.Name, *versionBundle, disk, tb.datacenterSpec.OSImageURL, tb.tinkerbellIp, tb.controlPlaneMachineSpec.OSFamily)
+		cpTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster.Name, *versionBundle, disk, tb.datacenterSpec.OSImageURL, tb.tinkerbellIp, tb.datacenterSpec.TinkerbellIP, tb.controlPlaneMachineSpec.OSFamily)
 	}
 
 	cpTemplateString, err := cpTemplateConfig.ToTemplateString()
@@ -84,7 +84,7 @@ func (tb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spe
 			if err != nil {
 				return nil, fmt.Errorf("getting control plane disk type of the hardware selector: %v", err)
 			}
-			etcdTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster.Name, *versionBundle, disk, tb.datacenterSpec.OSImageURL, tb.tinkerbellIp, tb.etcdMachineSpec.OSFamily)
+			etcdTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster.Name, *versionBundle, disk, tb.datacenterSpec.OSImageURL, tb.tinkerbellIp, tb.datacenterSpec.TinkerbellIP, tb.etcdMachineSpec.OSFamily)
 		}
 		etcdTemplateString, err = etcdTemplateConfig.ToTemplateString()
 		if err != nil {
@@ -117,7 +117,7 @@ func (tb *TemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, wo
 			if err != nil {
 				return nil, fmt.Errorf("getting worker node disk type of the hardware selector: %v", err)
 			}
-			wTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster.Name, *versionBundle, disk, tb.datacenterSpec.OSImageURL, tb.tinkerbellIp, workerNodeMachineSpec.OSFamily)
+			wTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster.Name, *versionBundle, disk, tb.datacenterSpec.OSImageURL, tb.tinkerbellIp, tb.datacenterSpec.TinkerbellIP, workerNodeMachineSpec.OSFamily)
 		}
 
 		wTemplateString, err := wTemplateConfig.ToTemplateString()

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/stack"
 	stackmocks "github.com/aws/eks-anywhere/pkg/providers/tinkerbell/stack/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
-	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 const (
@@ -226,7 +225,7 @@ func TestPreCAPIInstallOnBootstrapSuccess(t *testing.T) {
 
 	stackInstaller.EXPECT().Install(
 		ctx,
-		releasev1alpha1.TinkerbellStackBundle{},
+		clusterSpec.VersionsBundle.Tinkerbell,
 		testIP,
 		"test.kubeconfig",
 		"",
@@ -262,10 +261,11 @@ func TestPostWorkloadInitSuccess(t *testing.T) {
 
 	stackInstaller.EXPECT().Install(
 		ctx,
-		releasev1alpha1.TinkerbellStackBundle{},
+		clusterSpec.VersionsBundle.Tinkerbell,
 		testIP,
 		"test.kubeconfig",
 		"",
+		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),


### PR DESCRIPTION
*Description of changes:*
Expose tinkerbell services, hegel and tink-server, using a LoadBalancer to allow the clusters to scale up. 
A LoadBalancer is required because when the new nodes come up, they need to contact tink-server and hegel to provision, which requires these 2 services to be externally accessible.
This also required a change to the tinkerbell helm chart https://github.com/aws/eks-anywhere-build-tooling/pull/957
which will need to merge before this PR

*Testing (if applicable):*
Created baremetal clusters and verified that the tinkerbell services were exposed properly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

