### PR TITLE
Implement backreferences from CAPI to EKSA cluster

### DIFF
--- a/controllers/controllers/utils/handlerutil/capiobjects.go
+++ b/controllers/controllers/utils/handlerutil/capiobjects.go
@@ -1,0 +1,41 @@
+package handlerutil
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+)
+
+// CAPIObjectToCluster returns a request handler that enqueues an EKS-A Cluster
+// reconcile request for CAPI objects that contain the cluster name and namespace labels
+func CAPIObjectToCluster(log logr.Logger) handler.MapFunc {
+	return func(o client.Object) []reconcile.Request {
+		labels := o.GetLabels()
+		clusterName, ok := labels[clusterapi.EKSAClusterLabelName]
+		if !ok {
+			// Object not managed by a eks-a Cluster, don't enqueue
+			log.V(6).Info("Object not managed by an eks-a Cluster, ignoring", "type", fmt.Sprintf("%T", o), "name", o.GetName())
+			return nil
+		}
+
+		clusterNamespace := labels[clusterapi.EKSAClusterLabelNamespace]
+		if clusterNamespace == "" {
+			log.Info("Object managed by an eks-a Cluster but missing cluster namespace", "type", fmt.Sprintf("%T", o), "name", o.GetName())
+			return nil
+		}
+
+		log.Info("Enqueuing Cluster request coming from CAPI object", "type", fmt.Sprintf("%T", o), "name", o.GetName(), "cluster", clusterName)
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{
+				Namespace: clusterNamespace,
+				Name:      clusterName,
+			},
+		}}
+	}
+}

--- a/controllers/controllers/utils/handlerutil/capiobjects_test.go
+++ b/controllers/controllers/utils/handlerutil/capiobjects_test.go
@@ -1,0 +1,70 @@
+package handlerutil_test
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/eks-anywhere/controllers/controllers/utils/handlerutil"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+)
+
+func TestCAPIObjectToCluster(t *testing.T) {
+	testCases := []struct {
+		testName     string
+		obj          client.Object
+		wantRequests []reconcile.Request
+	}{
+		{
+			testName:     "no eksa managed",
+			obj:          &clusterv1.Cluster{},
+			wantRequests: nil,
+		},
+		{
+			testName: " missing namespace",
+			obj: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						clusterapi.EKSAClusterLabelName: "my-cluster",
+					},
+				},
+			},
+			wantRequests: nil,
+		},
+		{
+			testName: "managed capi resource",
+			obj: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						clusterapi.EKSAClusterLabelName:      "my-cluster",
+						clusterapi.EKSAClusterLabelNamespace: "my-namespace",
+					},
+				},
+			},
+			wantRequests: []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Name:      "my-cluster",
+						Namespace: "my-namespace",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			handle := handlerutil.CAPIObjectToCluster(logr.New(logf.NullLogSink{}))
+			requests := handle(tt.obj)
+			g.Expect(requests).To(Equal(tt.wantRequests))
+		})
+	}
+}

--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -10,7 +10,7 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
-	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 )
@@ -21,6 +21,8 @@ const (
 	etcdadmClusterKind        = "EtcdadmCluster"
 	kubeadmConfigTemplateKind = "KubeadmConfigTemplate"
 	machineDeploymentKind     = "MachineDeployment"
+	EKSAClusterLabelName      = "cluster.anywhere.eks.amazonaws.com/cluster-name"
+	EKSAClusterLabelNamespace = "cluster.anywhere.eks.amazonaws.com/cluster-namespace"
 )
 
 var (
@@ -39,8 +41,42 @@ func InfrastructureAPIVersion() string {
 	return fmt.Sprintf("infrastructure.%s/%s", clusterv1.GroupVersion.Group, clusterv1.GroupVersion.Version)
 }
 
-func clusterLabels(clusterName string) map[string]string {
-	return map[string]string{clusterv1.ClusterLabelName: clusterName}
+func eksaClusterLabels(clusterSpec *cluster.Spec) map[string]string {
+	return map[string]string{
+		EKSAClusterLabelName:      clusterSpec.Cluster.Name,
+		EKSAClusterLabelNamespace: clusterSpec.Cluster.Namespace,
+	}
+}
+
+func capiClusterLabel(clusterSpec *cluster.Spec) map[string]string {
+	return map[string]string{
+		clusterv1.ClusterLabelName: ClusterName(clusterSpec.Cluster),
+	}
+}
+
+func capiObjectLabels(clusterSpec *cluster.Spec) map[string]string {
+	return mergeLabels(eksaClusterLabels(clusterSpec), capiClusterLabel(clusterSpec))
+}
+
+func mergeLabels(labels ...map[string]string) map[string]string {
+	size := 0
+	for _, l := range labels {
+		size += len(l)
+	}
+
+	merged := make(map[string]string, size)
+	for _, l := range labels {
+		for k, v := range l {
+			merged[k] = v
+		}
+	}
+
+	return merged
+}
+
+// ClusterName generates the CAPI cluster name for an EKSA Cluster
+func ClusterName(cluster *anywherev1.Cluster) string {
+	return cluster.Name
 }
 
 func Cluster(clusterSpec *cluster.Spec, infrastructureObject, controlPlaneObject APIObject) *clusterv1.Cluster {
@@ -53,7 +89,7 @@ func Cluster(clusterSpec *cluster.Spec, infrastructureObject, controlPlaneObject
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterName,
 			Namespace: constants.EksaSystemNamespace,
-			Labels:    clusterLabels(clusterName),
+			Labels:    capiObjectLabels(clusterSpec),
 		},
 		Spec: clusterv1.ClusterSpec{
 			ClusterNetwork: &clusterv1.ClusterNetwork{
@@ -171,7 +207,7 @@ func KubeadmControlPlane(clusterSpec *cluster.Spec, infrastructureObject APIObje
 	return kcp, nil
 }
 
-func KubeadmConfigTemplate(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) (*bootstrapv1.KubeadmConfigTemplate, error) {
+func KubeadmConfigTemplate(clusterSpec *cluster.Spec, workerNodeGroupConfig anywherev1.WorkerNodeGroupConfiguration) (*bootstrapv1.KubeadmConfigTemplate, error) {
 	kct := &bootstrapv1.KubeadmConfigTemplate{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: bootstrapAPIVersion,
@@ -211,7 +247,7 @@ func KubeadmConfigTemplate(clusterSpec *cluster.Spec, workerNodeGroupConfig v1al
 	return kct, nil
 }
 
-func MachineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration, bootstrapObject, infrastructureObject APIObject) clusterv1.MachineDeployment {
+func MachineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig anywherev1.WorkerNodeGroupConfiguration, bootstrapObject, infrastructureObject APIObject) clusterv1.MachineDeployment {
 	clusterName := clusterSpec.Cluster.GetName()
 	replicas := int32(workerNodeGroupConfig.Count)
 	version := clusterSpec.VersionsBundle.KubeDistro.Kubernetes.Tag
@@ -224,7 +260,7 @@ func MachineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      MachineDeploymentName(clusterSpec, workerNodeGroupConfig),
 			Namespace: constants.EksaSystemNamespace,
-			Labels:    clusterLabels(clusterName),
+			Labels:    capiObjectLabels(clusterSpec),
 		},
 		Spec: clusterv1.MachineDeploymentSpec{
 			ClusterName: clusterName,
@@ -233,7 +269,7 @@ func MachineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1
 			},
 			Template: clusterv1.MachineTemplateSpec{
 				ObjectMeta: clusterv1.ObjectMeta{
-					Labels: clusterLabels(clusterName),
+					Labels: capiClusterLabel(clusterSpec),
 				},
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -40,7 +40,9 @@ func wantCAPICluster() *clusterv1.Cluster {
 			Name:      "snow-test",
 			Namespace: "eksa-system",
 			Labels: map[string]string{
-				"cluster.x-k8s.io/cluster-name": "snow-test",
+				"cluster.x-k8s.io/cluster-name":                        "snow-test",
+				"cluster.anywhere.eks.amazonaws.com/cluster-name":      "snow-test",
+				"cluster.anywhere.eks.amazonaws.com/cluster-namespace": "test-namespace",
 			},
 		},
 		Spec: clusterv1.ClusterSpec{
@@ -391,7 +393,9 @@ func wantMachineDeployment() *clusterv1.MachineDeployment {
 			Name:      "snow-test-md-0",
 			Namespace: "eksa-system",
 			Labels: map[string]string{
-				"cluster.x-k8s.io/cluster-name": "snow-test",
+				"cluster.x-k8s.io/cluster-name":                        "snow-test",
+				"cluster.anywhere.eks.amazonaws.com/cluster-name":      "snow-test",
+				"cluster.anywhere.eks.amazonaws.com/cluster-namespace": "test-namespace",
 			},
 		},
 		Spec: clusterv1.MachineDeploymentSpec{

--- a/pkg/providers/snow/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_cp.yaml
@@ -3,6 +3,8 @@ kind: Cluster
 metadata:
   creationTimestamp: null
   labels:
+    cluster.anywhere.eks.amazonaws.com/cluster-name: snow-test
+    cluster.anywhere.eks.amazonaws.com/cluster-namespace: test-namespace
     cluster.x-k8s.io/cluster-name: snow-test
   name: snow-test
   namespace: eksa-system

--- a/pkg/providers/snow/testdata/expected_results_main_md.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_md.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   creationTimestamp: null
   labels:
+    cluster.anywhere.eks.amazonaws.com/cluster-name: snow-test
+    cluster.anywhere.eks.amazonaws.com/cluster-namespace: test-namespace
     cluster.x-k8s.io/cluster-name: snow-test
   name: snow-test-md-0
   namespace: eksa-system


### PR DESCRIPTION
*Issue #, if available:* part of #1090

*Description of changes:*

Using labels in CAPI objects to reference the parent eksa Cluster by its
name and namespace.

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

