### PR TITLE
Fix kube-vip image for lb

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -174,7 +174,7 @@ func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 			"ip":      tinkerbellIP,
 		},
 		kubevip: map[string]interface{}{
-			image: bundle.KubeVip,
+			image: bundle.KubeVip.URI,
 		},
 	}
 


### PR DESCRIPTION
*Description of changes:*
Fix kube-vip image URI in tinkerbell helm chart

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

