### PR TITLE
Fix tinkerbell disk extractor

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -306,7 +306,7 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 			}
 			logger.V(4).Info("Tinkerbell IP", "tinkerbell-ip", tinkerbellIp)
 
-			f.dependencies.Provider = tinkerbell.NewProvider(
+			provider, err := tinkerbell.NewProvider(
 				datacenterConfig,
 				machineConfigs,
 				clusterConfig,
@@ -320,6 +320,11 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 				force,
 				skipIpCheck,
 			)
+			if err != nil {
+				return err
+			}
+
+			f.dependencies.Provider = provider
 
 		case v1alpha1.DockerDatacenterKind:
 			datacenterConfig, err := v1alpha1.GetDockerDatacenterConfig(clusterConfigFile)

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware_test.go
@@ -132,32 +132,82 @@ func TestDiskExtractorWithValidHardwareSelectors(t *testing.T) {
 	machine := NewValidMachine()
 
 	hardwareSelector := eksav1alpha1.HardwareSelector{"type": "cp"}
-	diskExtractor.RegisterHardwareSelector(hardwareSelector)
+	g.Expect(diskExtractor.Register(hardwareSelector)).To(gomega.Succeed())
 
 	err := diskExtractor.Write(machine)
-
 	g.Expect(err).To(gomega.Succeed())
 
 	disk, err := diskExtractor.GetDisk(hardwareSelector)
-
 	g.Expect(err).To(gomega.Succeed())
 	g.Expect(disk).To(gomega.Equal(machine.Disk))
 }
 
-func TestDiskExtractorWithInvalidHardwareSelectors(t *testing.T) {
+func TestDiskExtractor_MachineHasMultipleLabels(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	diskExtractor := hardware.NewDiskExtractor()
+	machine := NewValidMachine()
+	machine.Labels = map[string]string{
+		"type": "cp",
+		"foo":  "foo",
+		"bar":  "bar",
+	}
+
+	hardwareSelector := eksav1alpha1.HardwareSelector{"type": "cp"}
+	g.Expect(diskExtractor.Register(hardwareSelector)).To(gomega.Succeed())
+
+	err := diskExtractor.Write(machine)
+	g.Expect(err).To(gomega.Succeed())
+
+	disk, err := diskExtractor.GetDisk(hardwareSelector)
+	g.Expect(err).To(gomega.Succeed())
+	g.Expect(disk).To(gomega.Equal(machine.Disk))
+}
+
+func TestDiskExtractor_MultipleSelectors(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	extractor := hardware.NewDiskExtractor()
+
+	machine1 := NewValidMachine()
+	machine1.Disk = "/dev/foo"
+	machine1.Labels = map[string]string{"foo": "foo"}
+	selector1 := eksav1alpha1.HardwareSelector{"foo": "foo"}
+	g.Expect(extractor.Register(selector1)).To(gomega.Succeed())
+
+	machine2 := NewValidMachine()
+	machine2.Disk = "/dev/bar"
+	machine2.Labels = map[string]string{"bar": "bar"}
+	selector2 := eksav1alpha1.HardwareSelector{"bar": "bar"}
+	g.Expect(extractor.Register(selector2)).To(gomega.Succeed())
+
+	err := extractor.Write(machine1)
+	g.Expect(err).To(gomega.Succeed())
+
+	err = extractor.Write(machine2)
+	g.Expect(err).To(gomega.Succeed())
+
+	disk, err := extractor.GetDisk(selector1)
+	g.Expect(err).To(gomega.Succeed())
+	g.Expect(disk).To(gomega.Equal(machine1.Disk))
+
+	disk, err = extractor.GetDisk(selector2)
+	g.Expect(err).To(gomega.Succeed())
+	g.Expect(disk).To(gomega.Equal(machine2.Disk))
+}
+
+func TestDiskExtractorNoDiskFound(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	diskExtractor := hardware.NewDiskExtractor()
 	machine := NewValidMachine()
 
 	hardwareSelector := eksav1alpha1.HardwareSelector{"type": "cp1"}
-	diskExtractor.RegisterHardwareSelector(hardwareSelector)
+	g.Expect(diskExtractor.Register(hardwareSelector)).To(gomega.Succeed())
 
 	err := diskExtractor.Write(machine)
-
 	g.Expect(err).To(gomega.Succeed())
 
 	_, err = diskExtractor.GetDisk(hardwareSelector)
-
-	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err).To(gomega.MatchError(hardware.ErrDiskNotFound{}))
 }

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -46,7 +46,7 @@ func givenMachineConfigs(t *testing.T, fileName string) map[string]*v1alpha1.Tin
 
 func newProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineConfigs map[string]*v1alpha1.TinkerbellMachineConfig, clusterConfig *v1alpha1.Cluster, writer filewriter.FileWriter, docker stack.Docker, helm stack.Helm, kubectl ProviderKubectlClient, forceCleanup bool) *Provider {
 	hardwareFile := "./testdata/hardware.csv"
-	return NewProvider(
+	provider, err := NewProvider(
 		datacenterConfig,
 		machineConfigs,
 		clusterConfig,
@@ -60,6 +60,11 @@ func newProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineC
 		forceCleanup,
 		false,
 	)
+	if err != nil {
+		panic(err)
+	}
+
+	return provider
 }
 
 func TestTinkerbellProviderGenerateDeploymentFileWithExternalEtcd(t *testing.T) {


### PR DESCRIPTION
The disk extractor is used to extract disks from hardware so it can be
used to populate tinkerbell actions. The matching algorithm prevented
matches on hardware with labels other than those specified on the
selector which is inconsistent with how other code matches machines to
selectors.

The change uses the same matching function as all other parts of the
code base.
