### PR TITLE
Avoid ":" in github repository names for E2E tests

### DIFF
--- a/internal/test/e2e/fluxGit.go
+++ b/internal/test/e2e/fluxGit.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/eks-anywhere/internal/pkg/ssm"
@@ -46,7 +47,7 @@ func (e *E2ESession) setupFluxGitEnv(testRegex string) error {
 		}
 	}
 
-	repo, err := e.setupGithubRepo(e.jobId, e.testEnvVars)
+	repo, err := e.setupGithubRepo()
 	if err != nil {
 		return fmt.Errorf("setting up github repo for test: %v", err)
 	}
@@ -112,9 +113,10 @@ func (e *E2ESession) setUpSshAgent(privateKeyFile string) error {
 	return nil
 }
 
-func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*git.Repository, error) {
+func (e *E2ESession) setupGithubRepo() (*git.Repository, error) {
 	logger.V(1).Info("setting up Github repo for test")
-	owner := envVars[e2etests.GithubUserVar]
+	owner := e.testEnvVars[e2etests.GithubUserVar]
+	repo := strings.ReplaceAll(e.jobId, ":", "-") // Github API urls get funky if you use ":" in the repo name
 
 	c := &v1alpha1.GithubProviderConfig{
 		Owner:      owner,
@@ -123,7 +125,7 @@ func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*g
 	}
 
 	ctx := context.Background()
-	g, err := e.TestGithubClient(ctx, envVars[e2etests.GithubTokenVar], c.Owner, c.Repository, c.Personal)
+	g, err := e.TestGithubClient(ctx, e.testEnvVars[e2etests.GithubTokenVar], c.Owner, c.Repository, c.Personal)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create Github client for test setup: %v", err)
 	}
@@ -171,7 +173,7 @@ func (e *E2ESession) setupGithubRepo(repo string, envVars map[string]string) (*g
 
 	// Generate a PEM file from the private key and write it instance at the user-provided path
 	pkFile := fileFromBytes{
-		dstPath:    envVars[config.EksaGitPrivateKeyTokenEnv],
+		dstPath:    e.testEnvVars[config.EksaGitPrivateKeyTokenEnv],
 		permission: 600,
 		content:    pk,
 	}


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

