### PR TITLE
Add option in helm to operate with TLS

### DIFF
--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -36,7 +36,7 @@ func NewDependenciesForPackages(ctx context.Context, opts ...PackageOpt) (*depen
 		WithExecutableBuilder().
 		WithManifestReader().
 		WithKubectl().
-		WithHelm().
+		WithHelmInsecure().
 		WithCuratedPackagesRegistry(config.registryName, config.kubeVersion, version.Get()).
 		Build(ctx)
 }

--- a/cmd/eksctl-anywhere/cmd/downloadimages.go
+++ b/cmd/eksctl-anywhere/cmd/downloadimages.go
@@ -63,7 +63,7 @@ func (c downloadImagesCommand) Run(ctx context.Context) error {
 	factory := dependencies.NewFactory()
 	deps, err := factory.
 		WithManifestReader().
-		WithHelm().
+		WithHelmInsecure().
 		Build(ctx)
 	if err != nil {
 		return err
@@ -89,7 +89,7 @@ func (c downloadImagesCommand) Run(ctx context.Context) error {
 			docker.NewOriginalRegistrySource(dockerClient),
 			docker.NewDiskDestination(dockerClient, eksaToolsImageFile),
 		),
-		ChartDownloader:    helm.NewChartRegistryDownloader(deps.Helm, downloadFolder),
+		ChartDownloader:    helm.NewChartRegistryDownloader(deps.HelmInsecure, downloadFolder),
 		Version:            version.Get(),
 		TmpDowloadFolder:   downloadFolder,
 		DstFile:            c.outputFile,

--- a/cmd/eksctl-anywhere/cmd/import_images.go
+++ b/cmd/eksctl-anywhere/cmd/import_images.go
@@ -110,7 +110,7 @@ func (c ImportImagesCommand) Call(ctx context.Context) error {
 	deps, err = factory.
 		WithRegistryMirror(c.RegistryEndpoint).
 		UseExecutableImage(bundle.DefaultEksAToolsImage().VersionedImage()).
-		WithHelm().
+		WithHelmInsecure().
 		Build(ctx)
 	if err != nil {
 		return err
@@ -126,7 +126,7 @@ func (c ImportImagesCommand) Call(ctx context.Context) error {
 			docker.NewRegistryDestination(dockerClient, c.RegistryEndpoint),
 		),
 		ChartImporter: helm.NewChartRegistryImporter(
-			deps.Helm, artifactsFolder,
+			deps.HelmInsecure, artifactsFolder,
 			c.RegistryEndpoint,
 			username,
 			password,

--- a/cmd/eksctl-anywhere/cmd/importimages.go
+++ b/cmd/eksctl-anywhere/cmd/importimages.go
@@ -72,7 +72,7 @@ func importImages(ctx context.Context, spec string) error {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
 	defer closer.CheckErr(ctx)
-	helmExecutable := executableBuilder.BuildHelmExecutable()
+	helmExecutable := executableBuilder.BuildHelmExecutable(executables.WithInsecure())
 
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration == nil || clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Endpoint == "" {
 		return fmt.Errorf("endpoint not set. It is necessary to define a valid endpoint in your spec (registryMirrorConfiguration.endpoint)")

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -71,7 +71,7 @@ func installPackageController(ctx context.Context) error {
 	helmChart := versionBundle.PackageController.HelmChart
 	imageUrl := urls.ReplaceHost(helmChart.Image(), registryEndpoint)
 	ctrlClient := curatedpackages.NewPackageControllerClient(
-		deps.Helm,
+		deps.HelmInsecure,
 		deps.Kubectl,
 		kubeConfig,
 		imageUrl,

--- a/controllers/controllers/clusters/vsphere.go
+++ b/controllers/controllers/clusters/vsphere.go
@@ -267,7 +267,7 @@ func (v *VSphereClusterReconciler) reconcileCNI(ctx context.Context, cluster *an
 
 		v.Log.Info("About to apply CNI")
 
-		helm := executables.NewHelm(executables.NewExecutable("helm"))
+		helm := executables.NewHelm(executables.NewExecutable("helm"), executables.WithInsecure())
 		cilium := cilium.NewCilium(nil, helm)
 
 		if err != nil {

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -27,8 +27,23 @@ type factoryTest struct {
 	cliConfig             config.CliConfig
 }
 
-func newTest(t *testing.T) *factoryTest {
-	clusterConfigFile := "testdata/cluster_vsphere.yaml"
+type provider string
+
+const (
+	vsphere    provider = "vsphere"
+	tinkerbell provider = "tinkerbell"
+)
+
+func newTest(t *testing.T, p provider) *factoryTest {
+	var clusterConfigFile string
+	switch p {
+	case vsphere:
+		clusterConfigFile = "testdata/cluster_vsphere.yaml"
+	case tinkerbell:
+		clusterConfigFile = "testdata/cluster_tinkerbell.yaml"
+	default:
+		t.Fatalf("Not a valid provider: %v", p)
+	}
 	// Disable tools image executable for the tests
 	if err := os.Setenv("MR_TOOLS_DISABLE", "true"); err != nil {
 		t.Fatal(err)
@@ -42,8 +57,8 @@ func newTest(t *testing.T) *factoryTest {
 	}
 }
 
-func TestFactoryBuildWithProvider(t *testing.T) {
-	tt := newTest(t)
+func TestFactoryBuildWithProvidervSphere(t *testing.T) {
+	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().
 		UseExecutableImage("image:1").
 		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
@@ -54,8 +69,22 @@ func TestFactoryBuildWithProvider(t *testing.T) {
 	tt.Expect(deps.DockerClient).To(BeNil(), "it only builds deps for vsphere")
 }
 
+func TestFactoryBuildWithProviderTinkerbell(t *testing.T) {
+	tt := newTest(t, tinkerbell)
+	deps, err := dependencies.NewFactory().
+		UseExecutableImage("image:1").
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		Build(context.Background())
+
+	tt.Expect(err).To(BeNil())
+	tt.Expect(deps.Provider).NotTo(BeNil())
+	tt.Expect(deps.HelmSecure).NotTo(BeNil())
+	tt.Expect(deps.DockerClient).NotTo(BeNil())
+	tt.Expect(deps.HelmInsecure).To(BeNil(), "should not build HelmInsecure")
+}
+
 func TestFactoryBuildWithClusterManager(t *testing.T) {
-	tt := newTest(t)
+	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().
 		UseExecutableImage("image:1").
 		WithCliConfig(&tt.cliConfig).
@@ -67,7 +96,7 @@ func TestFactoryBuildWithClusterManager(t *testing.T) {
 }
 
 func TestFactoryBuildWithClusterManagerWithoutCliConfig(t *testing.T) {
-	tt := newTest(t)
+	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().
 		UseExecutableImage("image:1").
 		WithClusterManager(tt.clusterSpec.Cluster).
@@ -78,7 +107,7 @@ func TestFactoryBuildWithClusterManagerWithoutCliConfig(t *testing.T) {
 }
 
 func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
-	tt := newTest(t)
+	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().
 		UseExecutableImage("image:1").
 		WithBootstrapper().
@@ -115,15 +144,15 @@ func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
 }
 
 func TestFactoryBuildWithRegistryMirror(t *testing.T) {
-	tt := newTest(t)
+	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().
 		UseExecutableImage("image:1").
 		WithRegistryMirror("1.2.3.4:443").
-		WithHelm().
+		WithHelmInsecure().
 		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())
-	tt.Expect(deps.Helm).NotTo(BeNil())
+	tt.Expect(deps.HelmInsecure).NotTo(BeNil())
 }
 
 func TestFactoryBuildWithPackageInstaller(t *testing.T) {
@@ -146,10 +175,10 @@ func TestFactoryBuildWithPackageInstaller(t *testing.T) {
 			},
 		},
 	}
-	tt := newTest(t)
+	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().
 		UseExecutableImage("image:1").
-		WithHelm().
+		WithHelmInsecure().
 		WithKubectl().
 		WithPackageInstaller(spec, "/test/packages.yaml").
 		Build(context.Background())
@@ -158,10 +187,10 @@ func TestFactoryBuildWithPackageInstaller(t *testing.T) {
 }
 
 func TestFactoryBuildWithCuratedPackagesCustomRegistry(t *testing.T) {
-	tt := newTest(t)
+	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().
 		UseExecutableImage("image:1").
-		WithHelm().
+		WithHelmInsecure().
 		WithCuratedPackagesRegistry("test_host:8080", "1.22", version.Info{GitVersion: "1.19"}).
 		Build(context.Background())
 
@@ -170,7 +199,7 @@ func TestFactoryBuildWithCuratedPackagesCustomRegistry(t *testing.T) {
 }
 
 func TestFactoryBuildWithCuratedPackagesDefaultRegistry(t *testing.T) {
-	tt := newTest(t)
+	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().
 		UseExecutableImage("image:1").
 		WithManifestReader().

--- a/pkg/dependencies/testdata/cluster_tinkerbell.yaml
+++ b/pkg/dependencies/testdata/cluster_tinkerbell.yaml
@@ -1,0 +1,74 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  clusterNetwork:
+    cniConfig:
+      cilium: {}
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+    endpoint:
+      host: "test-ip"
+    machineGroupRef:
+      kind: TinkerbellMachineConfig
+      name: eksa-unit-test-cp
+  datacenterRef:
+    kind: TinkerbellDatacenterConfig
+    name: eksa-unit-test
+  kubernetesVersion: "1.20"
+  managementCluster:
+    name: eksa-unit-test
+  workerNodeGroupConfigurations:
+  - count: 1
+    machineGroupRef:
+      kind: TinkerbellMachineConfig
+      name: eksa-unit-test
+    name: md-0
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellDatacenterConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  tinkerbellIP: "test-tinkerbell-ip"
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellMachineConfig
+metadata:
+  name: eksa-unit-test-cp
+spec:
+  hardwareSelector:
+    type: test-control-plane
+  osFamily: ubuntu
+  templateRef: {}
+  users:
+  - name: "mySshUsername"
+    sshAuthorizedKeys:
+    - "mySshAuthorizedKey"
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellMachineConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  hardwareSelector:
+    type: test-md
+  osFamily: ubuntu
+  templateRef: {}
+  users:
+  - name: "mySshUsername"
+    sshAuthorizedKeys:
+    - "mySshAuthorizedKey"
+
+---
+

--- a/pkg/executables/helm.go
+++ b/pkg/executables/helm.go
@@ -19,6 +19,7 @@ type Helm struct {
 	executable     Executable
 	registryMirror string
 	env            map[string]string
+	insecure       bool
 }
 
 type HelmOpt func(*Helm)
@@ -26,6 +27,12 @@ type HelmOpt func(*Helm)
 func WithRegistryMirror(mirror string) HelmOpt {
 	return func(h *Helm) {
 		h.registryMirror = mirror
+	}
+}
+
+func WithInsecure() HelmOpt {
+	return func(h *Helm) {
+		h.insecure = true
 	}
 }
 
@@ -44,6 +51,7 @@ func NewHelm(executable Executable, opts ...HelmOpt) *Helm {
 		env: map[string]string{
 			"HELM_EXPERIMENTAL_OCI": "1",
 		},
+		insecure: false,
 	}
 
 	for _, o := range opts {
@@ -59,9 +67,11 @@ func (h *Helm) Template(ctx context.Context, ociURI, version, namespace string, 
 		return nil, fmt.Errorf("failed marshalling values for helm template: %v", err)
 	}
 
-	result, err := h.executable.Command(
-		ctx, "template", h.url(ociURI), "--version", version, insecureSkipVerifyFlag, "--namespace", namespace, "--kube-version", kubeVersion, "-f", "-",
-	).WithStdIn(valuesYaml).WithEnvVars(h.env).Run()
+	params := []string{"template", h.url(ociURI), "--version", version, "--namespace", namespace, "--kube-version", kubeVersion}
+	params = h.addInsecureFlagIfProvided(params)
+	params = append(params, "-f", "-")
+
+	result, err := h.executable.Command(ctx, params...).WithStdIn(valuesYaml).WithEnvVars(h.env).Run()
 	if err != nil {
 		return nil, err
 	}
@@ -70,41 +80,53 @@ func (h *Helm) Template(ctx context.Context, ociURI, version, namespace string, 
 }
 
 func (h *Helm) PullChart(ctx context.Context, ociURI, version string) error {
-	_, err := h.executable.Command(ctx, "pull", h.url(ociURI), "--version", version, insecureSkipVerifyFlag).
+	params := []string{"pull", h.url(ociURI), "--version", version}
+	params = h.addInsecureFlagIfProvided(params)
+	_, err := h.executable.Command(ctx, params...).
 		WithEnvVars(h.env).Run()
 	return err
 }
 
 func (h *Helm) PushChart(ctx context.Context, chart, registry string) error {
 	logger.Info("Pushing", "chart", chart)
-	_, err := h.executable.Command(ctx, "push", chart, registry, insecureSkipVerifyFlag).WithEnvVars(h.env).Run()
+	params := []string{"push", chart, registry}
+	params = h.addInsecureFlagIfProvided(params)
+	_, err := h.executable.Command(ctx, params...).WithEnvVars(h.env).Run()
 	return err
 }
 
 func (h *Helm) RegistryLogin(ctx context.Context, registry, username, password string) error {
 	logger.Info("Logging in to helm registry", "registry", registry)
-	_, err := h.executable.Command(ctx, "registry", "login", registry, "--username", username, "--password", password, "--insecure").WithEnvVars(h.env).Run()
+	params := []string{"registry", "login", registry, "--username", username, "--password", password}
+	if h.insecure {
+		params = append(params, "--insecure")
+	}
+	_, err := h.executable.Command(ctx, params...).WithEnvVars(h.env).Run()
 	return err
 }
 
 func (h *Helm) SaveChart(ctx context.Context, ociURI, version, folder string) error {
-	fmt.Println(h.env)
-	_, err := h.executable.Command(ctx, "pull", h.url(ociURI), "--version", version, insecureSkipVerifyFlag, "--destination", folder).
+	params := []string{"pull", h.url(ociURI), "--version", version, "--destination", folder}
+	params = h.addInsecureFlagIfProvided(params)
+	_, err := h.executable.Command(ctx, params...).
 		WithEnvVars(h.env).Run()
 	return err
 }
 
 func (h *Helm) InstallChartFromName(ctx context.Context, ociURI, kubeConfig, name, version string) error {
-	_, err := h.executable.Command(ctx, "install", name, ociURI, "--version", version, insecureSkipVerifyFlag, "--kubeconfig", kubeConfig).
+	params := []string{"install", name, ociURI, "--version", version, "--kubeconfig", kubeConfig}
+	params = h.addInsecureFlagIfProvided(params)
+	_, err := h.executable.Command(ctx, params...).
 		WithEnvVars(h.env).Run()
 	return err
 }
 
 func (h *Helm) InstallChart(ctx context.Context, chart, ociURI, version, kubeconfigFilePath string, values []string) error {
 	valueArgs := GetHelmValueArgs(values)
-	params := []string{"install", chart, ociURI, "--version", version, insecureSkipVerifyFlag}
+	params := []string{"install", chart, ociURI, "--version", version}
 	params = append(params, valueArgs...)
 	params = append(params, "--kubeconfig", kubeconfigFilePath)
+	params = h.addInsecureFlagIfProvided(params)
 
 	logger.Info("Installing helm chart on cluster", "chart", chart, "version", version)
 	_, err := h.executable.Command(ctx, params...).WithEnvVars(h.env).Run()
@@ -112,9 +134,17 @@ func (h *Helm) InstallChart(ctx context.Context, chart, ociURI, version, kubecon
 }
 
 func (h *Helm) InstallChartWithValuesFile(ctx context.Context, chart, ociURI, version, kubeconfigFilePath, valuesFilePath string) error {
-	params := []string{"install", chart, ociURI, "--version", version, insecureSkipVerifyFlag, "--values", valuesFilePath, "--kubeconfig", kubeconfigFilePath}
+	params := []string{"install", chart, ociURI, "--version", version, "--values", valuesFilePath, "--kubeconfig", kubeconfigFilePath}
+	params = h.addInsecureFlagIfProvided(params)
 	_, err := h.executable.Command(ctx, params...).WithEnvVars(h.env).Run()
 	return err
+}
+
+func (h *Helm) addInsecureFlagIfProvided(params []string) []string {
+	if h.insecure {
+		return append(params, insecureSkipVerifyFlag)
+	}
+	return params
 }
 
 func (h *Helm) url(originalURL string) string {

--- a/pkg/executables/helm_test.go
+++ b/pkg/executables/helm_test.go
@@ -63,7 +63,16 @@ key2: values2
 func TestHelmTemplateSuccess(t *testing.T) {
 	tt := newHelmTemplateTest(t)
 	expectCommand(
-		tt.e, tt.ctx, "template", tt.ociURI, "--version", tt.version, "--insecure-skip-tls-verify", "--namespace", tt.namespace, "--kube-version", "1.22", "-f", "-",
+		tt.e, tt.ctx, "template", tt.ociURI, "--version", tt.version, "--namespace", tt.namespace, "--kube-version", "1.22", "-f", "-",
+	).withStdIn(tt.valuesYaml).withEnvVars(tt.envVars).to().Return(*bytes.NewBuffer(tt.wantTemplateContent), nil)
+
+	tt.Expect(tt.h.Template(tt.ctx, tt.ociURI, tt.version, tt.namespace, tt.values, "1.22")).To(Equal(tt.wantTemplateContent), "helm.Template() should succeed return correct template content")
+}
+
+func TestHelmTemplateSuccessWithInsecure(t *testing.T) {
+	tt := newHelmTemplateTest(t, executables.WithInsecure())
+	expectCommand(
+		tt.e, tt.ctx, "template", tt.ociURI, "--version", tt.version, "--namespace", tt.namespace, "--kube-version", "1.22", "--insecure-skip-tls-verify", "-f", "-",
 	).withStdIn(tt.valuesYaml).withEnvVars(tt.envVars).to().Return(*bytes.NewBuffer(tt.wantTemplateContent), nil)
 
 	tt.Expect(tt.h.Template(tt.ctx, tt.ociURI, tt.version, tt.namespace, tt.values, "1.22")).To(Equal(tt.wantTemplateContent), "helm.Template() should succeed return correct template content")
@@ -73,7 +82,7 @@ func TestHelmTemplateSuccessWithRegistryMirror(t *testing.T) {
 	tt := newHelmTemplateTest(t, executables.WithRegistryMirror("1.2.3.4:443"))
 	ociRegistryMirror := "oci://1.2.3.4:443/account/charts"
 	expectCommand(
-		tt.e, tt.ctx, "template", ociRegistryMirror, "--version", tt.version, "--insecure-skip-tls-verify", "--namespace", tt.namespace, "--kube-version", "1.22", "-f", "-",
+		tt.e, tt.ctx, "template", ociRegistryMirror, "--version", tt.version, "--namespace", tt.namespace, "--kube-version", "1.22", "-f", "-",
 	).withStdIn(tt.valuesYaml).withEnvVars(tt.envVars).to().Return(*bytes.NewBuffer(tt.wantTemplateContent), nil)
 
 	tt.Expect(tt.h.Template(tt.ctx, ociRegistryMirror, tt.version, tt.namespace, tt.values, "1.22")).To(Equal(tt.wantTemplateContent), "helm.Template() should succeed return correct template content")
@@ -88,7 +97,7 @@ func TestHelmTemplateSuccessWithEnv(t *testing.T) {
 		"HELM_EXPERIMENTAL_OCI": "1",
 	}
 	expectCommand(
-		tt.e, tt.ctx, "template", tt.ociURI, "--version", tt.version, "--insecure-skip-tls-verify", "--namespace", tt.namespace, "--kube-version", "1.22", "-f", "-",
+		tt.e, tt.ctx, "template", tt.ociURI, "--version", tt.version, "--namespace", tt.namespace, "--kube-version", "1.22", "-f", "-",
 	).withStdIn(tt.valuesYaml).withEnvVars(expectedEnv).to().Return(*bytes.NewBuffer(tt.wantTemplateContent), nil)
 
 	tt.Expect(tt.h.Template(tt.ctx, tt.ociURI, tt.version, tt.namespace, tt.values, "1.22")).To(Equal(tt.wantTemplateContent), "helm.Template() should succeed return correct template content")
@@ -109,7 +118,19 @@ func TestHelmSaveChartSuccess(t *testing.T) {
 	version := "1.1"
 	destinationFolder := "folder"
 	expectCommand(
-		tt.e, tt.ctx, "pull", url, "--version", version, "--insecure-skip-tls-verify", "--destination", destinationFolder,
+		tt.e, tt.ctx, "pull", url, "--version", version, "--destination", destinationFolder,
+	).withEnvVars(tt.envVars).to().Return(bytes.Buffer{}, nil)
+
+	tt.Expect(tt.h.SaveChart(tt.ctx, url, version, destinationFolder)).To(Succeed())
+}
+
+func TestHelmSaveChartSuccessWithInsecure(t *testing.T) {
+	tt := newHelmTest(t, executables.WithInsecure())
+	url := "url"
+	version := "1.1"
+	destinationFolder := "folder"
+	expectCommand(
+		tt.e, tt.ctx, "pull", url, "--version", version, "--destination", destinationFolder, "--insecure-skip-tls-verify",
 	).withEnvVars(tt.envVars).to().Return(bytes.Buffer{}, nil)
 
 	tt.Expect(tt.h.SaveChart(tt.ctx, url, version, destinationFolder)).To(Succeed())
@@ -123,7 +144,21 @@ func TestHelmInstallChartSuccess(t *testing.T) {
 	kubeconfig := "/root/.kube/config"
 	values := []string{"key1=value1"}
 	expectCommand(
-		tt.e, tt.ctx, "install", chart, url, "--version", version, "--insecure-skip-tls-verify", "--set", "key1=value1", "--kubeconfig", kubeconfig,
+		tt.e, tt.ctx, "install", chart, url, "--version", version, "--set", "key1=value1", "--kubeconfig", kubeconfig,
+	).withEnvVars(tt.envVars).to().Return(bytes.Buffer{}, nil)
+
+	tt.Expect(tt.h.InstallChart(tt.ctx, chart, url, version, kubeconfig, values)).To(Succeed())
+}
+
+func TestHelmInstallChartSuccessWithInsecure(t *testing.T) {
+	tt := newHelmTest(t, executables.WithInsecure())
+	chart := "chart"
+	url := "url"
+	version := "1.1"
+	kubeconfig := "/root/.kube/config"
+	values := []string{"key1=value1"}
+	expectCommand(
+		tt.e, tt.ctx, "install", chart, url, "--version", version, "--set", "key1=value1", "--kubeconfig", kubeconfig, "--insecure-skip-tls-verify",
 	).withEnvVars(tt.envVars).to().Return(bytes.Buffer{}, nil)
 
 	tt.Expect(tt.h.InstallChart(tt.ctx, chart, url, version, kubeconfig, values)).To(Succeed())
@@ -155,7 +190,7 @@ func TestHelmGetValueArgs(t *testing.T) {
 	}
 }
 
-func TestHelmInstallChartWithValuesFile(t *testing.T) {
+func TestHelmInstallChartWithValuesFileSuccess(t *testing.T) {
 	tt := newHelmTest(t)
 	chart := "chart"
 	url := "url"
@@ -163,7 +198,21 @@ func TestHelmInstallChartWithValuesFile(t *testing.T) {
 	kubeconfig := "/root/.kube/config"
 	valuesFileName := "values.yaml"
 	expectCommand(
-		tt.e, tt.ctx, "install", chart, url, "--version", version, "--insecure-skip-tls-verify", "--values", valuesFileName, "--kubeconfig", kubeconfig,
+		tt.e, tt.ctx, "install", chart, url, "--version", version, "--values", valuesFileName, "--kubeconfig", kubeconfig,
+	).withEnvVars(tt.envVars).to().Return(bytes.Buffer{}, nil)
+
+	tt.Expect(tt.h.InstallChartWithValuesFile(tt.ctx, chart, url, version, kubeconfig, valuesFileName)).To(Succeed())
+}
+
+func TestHelmInstallChartWithValuesFileSuccessWithInsecure(t *testing.T) {
+	tt := newHelmTest(t, executables.WithInsecure())
+	chart := "chart"
+	url := "url"
+	version := "1.1"
+	kubeconfig := "/root/.kube/config"
+	valuesFileName := "values.yaml"
+	expectCommand(
+		tt.e, tt.ctx, "install", chart, url, "--version", version, "--values", valuesFileName, "--kubeconfig", kubeconfig, "--insecure-skip-tls-verify",
 	).withEnvVars(tt.envVars).to().Return(bytes.Buffer{}, nil)
 
 	tt.Expect(tt.h.InstallChartWithValuesFile(tt.ctx, chart, url, version, kubeconfig, valuesFileName)).To(Succeed())

--- a/test/framework/executables.go
+++ b/test/framework/executables.go
@@ -53,7 +53,7 @@ func buildDocker(t *testing.T) *executables.Docker {
 
 func buildHelm(t *testing.T) *executables.Helm {
 	ctx := context.Background()
-	helm := executableBuilder(t, ctx).BuildHelmExecutable()
+	helm := executableBuilder(t, ctx).BuildHelmExecutable(executables.WithInsecure())
 
 	return helm
 }


### PR DESCRIPTION
*Description of changes:*
Currently, helm performs all actions using `--insecure-skip-tls-verify`
This PR makes this flag optional and users have to specify `WithInsecure()` option when creating Helm to add this flag to the helm calls.
Right now, all the packages that were using insecure will continue to use them. This flag is currently only being disabled for the `tinkerbell` provider.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

