### PR TITLE
SNS trigger file

### DIFF
--- a/release/triggers/snsAnnounce.json
+++ b/release/triggers/snsAnnounce.json
@@ -1,0 +1,4 @@
+{
+  "Subject": "Update me on release branch after cutting a release",
+  "Message": "Update me on release branch after cutting a release. Changes made to this file on main branch will not trigger SNS"
+}


### PR DESCRIPTION
*Description of changes:*
Adding a dummy sns trigger file. This file should be modified to house the proper announcement after cutting the release on the release branch. Any updates to this file on main branch will not trigger an sns announcement.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

