### PR TITLE
Avoid processing Snow images if the URI is empty

### DIFF
--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -102,10 +102,15 @@ func (vb *VersionsBundle) DockerImages() []Image {
 }
 
 func (vb *VersionsBundle) SnowImages() []Image {
-	return []Image{
-		vb.Snow.KubeVip,
-		vb.Snow.Manager,
+	i := make([]Image, 0, 2)
+	if vb.Snow.KubeVip.URI != "" {
+		i = append(i, vb.Snow.KubeVip)
 	}
+	if vb.Snow.Manager.URI != "" {
+		i = append(i, vb.Snow.Manager)
+	}
+
+	return i
 }
 
 func (vb *VersionsBundle) SharedImages() []Image {

--- a/release/api/v1alpha1/artifacts_test.go
+++ b/release/api/v1alpha1/artifacts_test.go
@@ -1,0 +1,88 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/release/api/v1alpha1"
+)
+
+func TestVersionsBundleSnowImages(t *testing.T) {
+	tests := []struct {
+		name           string
+		versionsBundle *v1alpha1.VersionsBundle
+		want           []v1alpha1.Image
+	}{
+		{
+			name:           "no images",
+			versionsBundle: &v1alpha1.VersionsBundle{},
+			want:           []v1alpha1.Image{},
+		},
+		{
+			name: "kubevip images",
+			versionsBundle: &v1alpha1.VersionsBundle{
+				Snow: v1alpha1.SnowBundle{
+					KubeVip: v1alpha1.Image{
+						Name: "kubevip",
+						URI:  "uri",
+					},
+				},
+			},
+			want: []v1alpha1.Image{
+				{
+					Name: "kubevip",
+					URI:  "uri",
+				},
+			},
+		},
+		{
+			name: "manager images",
+			versionsBundle: &v1alpha1.VersionsBundle{
+				Snow: v1alpha1.SnowBundle{
+					Manager: v1alpha1.Image{
+						Name: "manage",
+						URI:  "uri",
+					},
+				},
+			},
+			want: []v1alpha1.Image{
+				{
+					Name: "manage",
+					URI:  "uri",
+				},
+			},
+		},
+		{
+			name: "both images",
+			versionsBundle: &v1alpha1.VersionsBundle{
+				Snow: v1alpha1.SnowBundle{
+					KubeVip: v1alpha1.Image{
+						Name: "kubevip",
+						URI:  "uri",
+					},
+					Manager: v1alpha1.Image{
+						Name: "manage",
+						URI:  "uri",
+					},
+				},
+			},
+			want: []v1alpha1.Image{
+				{
+					Name: "kubevip",
+					URI:  "uri",
+				},
+				{
+					Name: "manage",
+					URI:  "uri",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.versionsBundle.SnowImages()).To(Equal(tt.want))
+		})
+	}
+}

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -436,7 +436,7 @@ spec:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.12-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.13-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -444,8 +444,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.12-eks-a-v0.0.0-dev-build.1
-      version: v0.1.12+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.13-eks-a-v0.0.0-dev-build.1
+      version: v0.1.13+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.5/infrastructure-components.yaml
@@ -1174,7 +1174,7 @@ spec:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.12-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.13-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1182,8 +1182,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.12-eks-a-v0.0.0-dev-build.1
-      version: v0.1.12+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.13-eks-a-v0.0.0-dev-build.1
+      version: v0.1.13+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.5/infrastructure-components.yaml
@@ -1912,7 +1912,7 @@ spec:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.12-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.13-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1920,8 +1920,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.12-eks-a-v0.0.0-dev-build.1
-      version: v0.1.12+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.13-eks-a-v0.0.0-dev-build.1
+      version: v0.1.13+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.5/infrastructure-components.yaml
@@ -2650,7 +2650,7 @@ spec:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.12-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.13-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -2658,8 +2658,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.12-eks-a-v0.0.0-dev-build.1
-      version: v0.1.12+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.13-eks-a-v0.0.0-dev-build.1
+      version: v0.1.13+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.5/infrastructure-components.yaml


### PR DESCRIPTION
*Description of changes:*

It seems like the production Bundles is being generated without the Snow
sub bundle. This includes the images for kubevip and the manager. When
running "import images", the code retrieves the list of all images from
the Bundles and it fails because these two have an empty URI. This patch
avoids adding the snow images ot the list of the URI is empty.

We should remove this once the Bundles is fixed and the Snow components
are populated.

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

