### PR TITLE
[Provider Tinkerbell] Explicitly set `PUBLIC_IP` and `PUBLIC_SYSLOG_IP` on Boots container

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -216,6 +216,8 @@ func (s *Installer) installBootsOnDocker(ctx context.Context, bundle releasev1al
 	flags := []string{
 		"-v", fmt.Sprintf("%s:/kubeconfig", kubeconfig),
 		"--network", "host",
+		"-e", fmt.Sprintf("PUBLIC_IP=%s", tinkServerIP),
+		"-e", fmt.Sprintf("PUBLIC_SYSLOG_IP=%s", tinkServerIP),
 	}
 
 	for name, value := range s.getBootsEnv(bundle, tinkServerIP) {

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -134,6 +134,8 @@ func TestTinkerbellStackInstallWithBootsOnDockerSuccess(t *testing.T) {
 		"-e", gomock.Any(),
 		"-e", gomock.Any(),
 		"-e", gomock.Any(),
+		"-e", gomock.Any(),
+		"-e", gomock.Any(),
 	)
 
 	err := s.Install(ctx, getTinkBundle(), testIP, cluster.KubeconfigFile, "", stack.WithBootsOnDocker())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This allows the use case where the Boots container in the Bootstrap cluster is run on a machine with multiple interfaces and/or IP addresses and the user needs to specify the IP to use in DHCP packets.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

