### PR TITLE
Fixing upload_artifacts failure in docker prow e2e test

### DIFF
--- a/scripts/e2e_test_docker.sh
+++ b/scripts/e2e_test_docker.sh
@@ -83,6 +83,7 @@ $BIN_FOLDER/test e2e run \
 # Faking cross-platform versioned folders for dry-run
 mkdir -p $BIN_FOLDER/linux/amd64
 cp $BIN_FOLDER/eksctl-anywhere $BIN_FOLDER/linux/amd64/eksctl-anywhere
+export BRANCH_NAME="main"
 
 $REPO_ROOT/cmd/integration_test/build/script/upload_artifacts.sh \
     "s3://artifacts-bucket" \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes the issue we've observed in the eks-anywhere-e2e-presubmit test like [here](https://prow.eks.amazonaws.com/view/s3/prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp/pr-logs/pull/aws_eks-anywhere/2412/eks-anywhere-e2e-presubmit/1539610872614227968) where BRANCH_NAME wasn't being set. The test run and then it fails to upload artifacts with error

```
/home/prow/go/src/github.com/aws/eks-anywhere/cmd/integration_test/build/script/upload_artifacts.sh: line 21: BRANCH_NAME: unbound variable
2022-06-22 15:27:06+00:00 2022-06-22T15:18:18.368Z	V0	✅ Validate certificate for registry mirror
make: *** [docker-e2e-test] Error 1
```

This change is only for main, and we may want to make a similar one in our release branch to set the proper branch name. I'm not sure if we can use git to dynamically get the branch name instead of hardcoding it

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

