### PR TITLE
Automated cherry pick of #2486: Avoid processing Snow images if the URI is empty

### DIFF
--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -102,10 +102,15 @@ func (vb *VersionsBundle) DockerImages() []Image {
 }
 
 func (vb *VersionsBundle) SnowImages() []Image {
-	return []Image{
-		vb.Snow.KubeVip,
-		vb.Snow.Manager,
+	i := make([]Image, 0, 2)
+	if vb.Snow.KubeVip.URI != "" {
+		i = append(i, vb.Snow.KubeVip)
 	}
+	if vb.Snow.Manager.URI != "" {
+		i = append(i, vb.Snow.Manager)
+	}
+
+	return i
 }
 
 func (vb *VersionsBundle) SharedImages() []Image {

--- a/release/api/v1alpha1/artifacts_test.go
+++ b/release/api/v1alpha1/artifacts_test.go
@@ -1,0 +1,88 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/release/api/v1alpha1"
+)
+
+func TestVersionsBundleSnowImages(t *testing.T) {
+	tests := []struct {
+		name           string
+		versionsBundle *v1alpha1.VersionsBundle
+		want           []v1alpha1.Image
+	}{
+		{
+			name:           "no images",
+			versionsBundle: &v1alpha1.VersionsBundle{},
+			want:           []v1alpha1.Image{},
+		},
+		{
+			name: "kubevip images",
+			versionsBundle: &v1alpha1.VersionsBundle{
+				Snow: v1alpha1.SnowBundle{
+					KubeVip: v1alpha1.Image{
+						Name: "kubevip",
+						URI:  "uri",
+					},
+				},
+			},
+			want: []v1alpha1.Image{
+				{
+					Name: "kubevip",
+					URI:  "uri",
+				},
+			},
+		},
+		{
+			name: "manager images",
+			versionsBundle: &v1alpha1.VersionsBundle{
+				Snow: v1alpha1.SnowBundle{
+					Manager: v1alpha1.Image{
+						Name: "manage",
+						URI:  "uri",
+					},
+				},
+			},
+			want: []v1alpha1.Image{
+				{
+					Name: "manage",
+					URI:  "uri",
+				},
+			},
+		},
+		{
+			name: "both images",
+			versionsBundle: &v1alpha1.VersionsBundle{
+				Snow: v1alpha1.SnowBundle{
+					KubeVip: v1alpha1.Image{
+						Name: "kubevip",
+						URI:  "uri",
+					},
+					Manager: v1alpha1.Image{
+						Name: "manage",
+						URI:  "uri",
+					},
+				},
+			},
+			want: []v1alpha1.Image{
+				{
+					Name: "kubevip",
+					URI:  "uri",
+				},
+				{
+					Name: "manage",
+					URI:  "uri",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.versionsBundle.SnowImages()).To(Equal(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #2486 on release-0.9.

#2486: Avoid processing Snow images if the URI is empty

For details on the cherry pick process, see the [cherry pick requests](https://github.com/aws/eks-anywhere-build-tooling/tree/main/docs/development/cherry-picks.md) page.

```release-note

```