### PR TITLE
Cert manager org update

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -372,6 +372,35 @@ spec:
                               description: The image repository, name, and tag
                               type: string
                           type: object
+                        ctl:
+                          properties:
+                            arch:
+                              description: Architectures of the asset
+                              items:
+                                type: string
+                              type: array
+                            description:
+                              type: string
+                            imageDigest:
+                              description: The SHA256 digest of the image manifest
+                              type: string
+                            name:
+                              description: The asset name
+                              type: string
+                            os:
+                              description: Operating system of the asset
+                              enum:
+                              - linux
+                              - darwin
+                              - windows
+                              type: string
+                            osName:
+                              description: Name of the OS like ubuntu, bottlerocket
+                              type: string
+                            uri:
+                              description: The image repository, name, and tag
+                              type: string
+                          type: object
                         manifest:
                           properties:
                             uri:
@@ -413,6 +442,7 @@ spec:
                       - acmesolver
                       - cainjector
                       - controller
+                      - ctl
                       - manifest
                       - webhook
                       type: object

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -540,6 +540,35 @@ spec:
                               description: The image repository, name, and tag
                               type: string
                           type: object
+                        ctl:
+                          properties:
+                            arch:
+                              description: Architectures of the asset
+                              items:
+                                type: string
+                              type: array
+                            description:
+                              type: string
+                            imageDigest:
+                              description: The SHA256 digest of the image manifest
+                              type: string
+                            name:
+                              description: The asset name
+                              type: string
+                            os:
+                              description: Operating system of the asset
+                              enum:
+                              - linux
+                              - darwin
+                              - windows
+                              type: string
+                            osName:
+                              description: Name of the OS like ubuntu, bottlerocket
+                              type: string
+                            uri:
+                              description: The image repository, name, and tag
+                              type: string
+                          type: object
                         manifest:
                           properties:
                             uri:
@@ -581,6 +610,7 @@ spec:
                       - acmesolver
                       - cainjector
                       - controller
+                      - ctl
                       - manifest
                       - webhook
                       type: object

--- a/internal/test/testdata/bundles.yaml
+++ b/internal/test/testdata/bundles.yaml
@@ -32,13 +32,13 @@ spec:
       version: v0.3.19
     certManager:
       acmesolver:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-acmesolver:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-acmesolver:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       cainjector:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-cainjector:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-cainjector:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       controller:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-controller:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-controller:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       webhook:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-webhook:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-webhook:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
     cilium:
       cilium:
         uri: public.ecr.aws/l0g8r8j6/cilium/cilium:v1.9.6
@@ -180,13 +180,13 @@ spec:
       version: v0.3.19
     certManager:
       acmesolver:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-acmesolver:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-acmesolver:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       cainjector:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-cainjector:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-cainjector:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       controller:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-controller:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-controller:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       webhook:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-webhook:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-webhook:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
     cilium:
       cilium:
         uri: public.ecr.aws/l0g8r8j6/cilium/cilium:v1.9.6
@@ -318,13 +318,13 @@ spec:
       version: v0.3.19
     certManager:
       acmesolver:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-acmesolver:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-acmesolver:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       cainjector:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-cainjector:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-cainjector:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       controller:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-controller:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-controller:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       webhook:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-webhook:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-webhook:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
     cilium:
       cilium:
         uri: public.ecr.aws/l0g8r8j6/cilium/cilium:v1.9.6
@@ -514,7 +514,7 @@ spec:
         imageDigest: sha256:711a5ebd903a62707398a5a914daab5226a3416a4def36877dca8a3937c9b2e8
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-acmesolver:v1.1.0-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-acmesolver:v1.1.0-eks-a-v0.0.0-dev-build.158
       cainjector:
         arch:
           - amd64
@@ -522,7 +522,7 @@ spec:
         imageDigest: sha256:7213acfc690ccef077c72d84d01c9b85e9e4eaa9065313681ab23ed849b4d0b7
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-cainjector:v1.1.0-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-cainjector:v1.1.0-eks-a-v0.0.0-dev-build.158
       controller:
         arch:
           - amd64
@@ -530,7 +530,7 @@ spec:
         imageDigest: sha256:ff95f4449c25e58405223ae7d1b6a9d8fa7528910277464d938badeec1f8d26d
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-controller:v1.1.0-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-controller:v1.1.0-eks-a-v0.0.0-dev-build.158
       webhook:
         arch:
           - amd64
@@ -538,7 +538,7 @@ spec:
         imageDigest: sha256:e6fbc2a1f498d5fc5c590e65e4c15ed0cdf6545426c0a9e3476d9f1510e2a11d
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-webhook:v1.1.0-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-webhook:v1.1.0-eks-a-v0.0.0-dev-build.158
     cilium:
       cilium:
         arch:

--- a/internal/test/testdata/bundles_template.yaml
+++ b/internal/test/testdata/bundles_template.yaml
@@ -32,13 +32,13 @@ spec:
       version: v0.3.19
     certManager:
       acmesolver:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-acmesolver:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-acmesolver:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       cainjector:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-cainjector:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-cainjector:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       controller:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-controller:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-controller:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       webhook:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-webhook:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-webhook:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
     cilium:
       cilium:
         uri: public.ecr.aws/l0g8r8j6/cilium/cilium:v1.9.6
@@ -178,13 +178,13 @@ spec:
       version: v0.3.19
     certManager:
       acmesolver:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-acmesolver:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-acmesolver:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       cainjector:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-cainjector:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-cainjector:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       controller:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-controller:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-controller:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       webhook:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-webhook:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-webhook:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
     cilium:
       cilium:
         uri: public.ecr.aws/l0g8r8j6/cilium/cilium:v1.9.6
@@ -324,13 +324,13 @@ spec:
       version: v0.3.19
     certManager:
       acmesolver:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-acmesolver:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-acmesolver:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       cainjector:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-cainjector:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-cainjector:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       controller:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-controller:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-controller:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       webhook:
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-webhook:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-webhook:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
     cilium:
       cilium:
         uri: public.ecr.aws/l0g8r8j6/cilium/cilium:v1.9.6
@@ -518,7 +518,7 @@ spec:
         imageDigest: sha256:711a5ebd903a62707398a5a914daab5226a3416a4def36877dca8a3937c9b2e8
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-acmesolver:v1.1.0-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-acmesolver:v1.1.0-eks-a-v0.0.0-dev-build.158
       cainjector:
         arch:
           - amd64
@@ -526,7 +526,7 @@ spec:
         imageDigest: sha256:7213acfc690ccef077c72d84d01c9b85e9e4eaa9065313681ab23ed849b4d0b7
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-cainjector:v1.1.0-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-cainjector:v1.1.0-eks-a-v0.0.0-dev-build.158
       controller:
         arch:
           - amd64
@@ -534,7 +534,7 @@ spec:
         imageDigest: sha256:ff95f4449c25e58405223ae7d1b6a9d8fa7528910277464d938badeec1f8d26d
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-controller:v1.1.0-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-controller:v1.1.0-eks-a-v0.0.0-dev-build.158
       webhook:
         arch:
           - amd64
@@ -542,7 +542,7 @@ spec:
         imageDigest: sha256:e6fbc2a1f498d5fc5c590e65e4c15ed0cdf6545426c0a9e3476d9f1510e2a11d
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/l0g8r8j6/jetstack/cert-manager-webhook:v1.1.0-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-webhook:v1.1.0-eks-a-v0.0.0-dev-build.158
     cilium:
       cilium:
         arch:

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -412,16 +412,16 @@ var versionBundle = &cluster.VersionsBundle{
 		},
 		CertManager: v1alpha1.CertManagerBundle{
 			Acmesolver: v1alpha1.Image{
-				URI: "public.ecr.aws/l0g8r8j6/jetstack/cert-manager-acmesolver:v1.1.0",
+				URI: "public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-acmesolver:v1.1.0",
 			},
 			Cainjector: v1alpha1.Image{
-				URI: "public.ecr.aws/l0g8r8j6/jetstack/cert-manager-cainjector:v1.1.0",
+				URI: "public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-cainjector:v1.1.0",
 			},
 			Controller: v1alpha1.Image{
-				URI: "public.ecr.aws/l0g8r8j6/jetstack/cert-manager-controller:v1.1.0",
+				URI: "public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-controller:v1.1.0",
 			},
 			Webhook: v1alpha1.Image{
-				URI: "public.ecr.aws/l0g8r8j6/jetstack/cert-manager-webhook:v1.1.0",
+				URI: "public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-webhook:v1.1.0",
 			},
 			Manifest: v1alpha1.Manifest{
 				URI: "testdata/fake_manifest.yaml",

--- a/pkg/executables/testdata/clusterctl_expected.yaml
+++ b/pkg/executables/testdata/clusterctl_expected.yaml
@@ -47,13 +47,13 @@ providers:
 overridesFolder: {{.dir}}/cluster-name/generated/overrides
 images:
   cert-manager/cert-manager-cainjector:
-    repository: public.ecr.aws/l0g8r8j6/jetstack
+    repository: public.ecr.aws/l0g8r8j6/cert-manager
     tag: v1.1.0
   cert-manager/cert-manager-controller:
-    repository: public.ecr.aws/l0g8r8j6/jetstack
+    repository: public.ecr.aws/l0g8r8j6/cert-manager
     tag: v1.1.0
   cert-manager/cert-manager-webhook:
-    repository: public.ecr.aws/l0g8r8j6/jetstack
+    repository: public.ecr.aws/l0g8r8j6/cert-manager
     tag: v1.1.0
   cluster-api/cluster-api-controller:
     repository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api

--- a/release/api/v1alpha1/bundle_types.go
+++ b/release/api/v1alpha1/bundle_types.go
@@ -144,6 +144,7 @@ type CertManagerBundle struct {
 	Acmesolver Image    `json:"acmesolver"`
 	Cainjector Image    `json:"cainjector"`
 	Controller Image    `json:"controller"`
+	Ctl        Image    `json:"ctl"`
 	Webhook    Image    `json:"webhook"`
 	Manifest   Manifest `json:"manifest"`
 }

--- a/release/api/v1alpha1/zz_generated.deepcopy.go
+++ b/release/api/v1alpha1/zz_generated.deepcopy.go
@@ -235,6 +235,7 @@ func (in *CertManagerBundle) DeepCopyInto(out *CertManagerBundle) {
 	in.Acmesolver.DeepCopyInto(&out.Acmesolver)
 	in.Cainjector.DeepCopyInto(&out.Cainjector)
 	in.Controller.DeepCopyInto(&out.Controller)
+	in.Ctl.DeepCopyInto(&out.Ctl)
 	in.Webhook.DeepCopyInto(&out.Webhook)
 	out.Manifest = in.Manifest
 }

--- a/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -372,6 +372,35 @@ spec:
                               description: The image repository, name, and tag
                               type: string
                           type: object
+                        ctl:
+                          properties:
+                            arch:
+                              description: Architectures of the asset
+                              items:
+                                type: string
+                              type: array
+                            description:
+                              type: string
+                            imageDigest:
+                              description: The SHA256 digest of the image manifest
+                              type: string
+                            name:
+                              description: The asset name
+                              type: string
+                            os:
+                              description: Operating system of the asset
+                              enum:
+                              - linux
+                              - darwin
+                              - windows
+                              type: string
+                            osName:
+                              description: Name of the OS like ubuntu, bottlerocket
+                              type: string
+                            uri:
+                              description: The image repository, name, and tag
+                              type: string
+                          type: object
                         manifest:
                           properties:
                             uri:
@@ -413,6 +442,7 @@ spec:
                       - acmesolver
                       - cainjector
                       - controller
+                      - ctl
                       - manifest
                       - webhook
                       type: object

--- a/release/pkg/assets_certmanager.go
+++ b/release/pkg/assets_certmanager.go
@@ -23,7 +23,7 @@ import (
 	anywherev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
-const certManagerProjectPath = "projects/jetstack/cert-manager"
+const certManagerProjectPath = "projects/cert-manager/cert-manager"
 
 // GetCertManagerAssets returns the eks-a artifacts for certmanager
 func (r *ReleaseConfig) GetCertManagerAssets() ([]Artifact, error) {
@@ -36,12 +36,13 @@ func (r *ReleaseConfig) GetCertManagerAssets() ([]Artifact, error) {
 		"cert-manager-acmesolver",
 		"cert-manager-cainjector",
 		"cert-manager-controller",
+		"cert-manager-ctl",
 		"cert-manager-webhook",
 	}
 
 	artifacts := []Artifact{}
 	for _, image := range certImages {
-		repoName := fmt.Sprintf("jetstack/%s", image)
+		repoName := fmt.Sprintf("cert-manager/%s", image)
 		tagOptions := map[string]string{
 			"gitTag":      gitTag,
 			"projectPath": certManagerProjectPath,
@@ -179,6 +180,7 @@ func (r *ReleaseConfig) GetCertManagerBundle(imageDigests map[string]string) (an
 		Acmesolver: bundleImageArtifacts["cert-manager-acmesolver"],
 		Cainjector: bundleImageArtifacts["cert-manager-cainjector"],
 		Controller: bundleImageArtifacts["cert-manager-controller"],
+		Ctl:        bundleImageArtifacts["cert-manager-ctl"],
 		Webhook:    bundleImageArtifacts["cert-manager-webhook"],
 		Manifest:   bundleManifestArtifacts["cert-manager.yaml"],
 	}

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -302,7 +302,7 @@ func (r *ReleaseConfig) GenerateBundleArtifactsTable() (map[string][]Artifact, e
 			return nil, errors.Wrapf(err, "Error converting branch minor version to integer")
 		}
 	}
-	
+
 	// TODO: change logic when we update major version to 1
 	if r.BuildRepoBranchName == "main" || branchMinorVersion > 9 {
 		eksAArtifactsFuncs["cluster-api-provider-tinkerbell"] = r.GetCaptAssets

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -80,7 +80,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-acmesolver:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.7.2-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -88,7 +88,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-cainjector:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.7.2-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -96,10 +96,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-controller:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.7.2-eks-a-v0.0.0-dev-build.1
+      ctl:
+        arch:
+        - amd64
+        description: Container image for cert-manager-ctl image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-ctl
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.7.2-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.5.3/cert-manager.yaml
-      version: v1.5.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.7.2/cert-manager.yaml
+      version: v1.7.2+abcdef1
       webhook:
         arch:
         - amd64
@@ -107,7 +115,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-webhook:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.7.2-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -809,7 +817,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-acmesolver:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.7.2-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -817,7 +825,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-cainjector:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.7.2-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -825,10 +833,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-controller:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.7.2-eks-a-v0.0.0-dev-build.1
+      ctl:
+        arch:
+        - amd64
+        description: Container image for cert-manager-ctl image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-ctl
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.7.2-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.5.3/cert-manager.yaml
-      version: v1.5.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.7.2/cert-manager.yaml
+      version: v1.7.2+abcdef1
       webhook:
         arch:
         - amd64
@@ -836,7 +852,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-webhook:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.7.2-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -1547,7 +1563,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-acmesolver:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.7.2-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -1555,7 +1571,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-cainjector:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.7.2-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -1563,10 +1579,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-controller:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.7.2-eks-a-v0.0.0-dev-build.1
+      ctl:
+        arch:
+        - amd64
+        description: Container image for cert-manager-ctl image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-ctl
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.7.2-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.5.3/cert-manager.yaml
-      version: v1.5.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.7.2/cert-manager.yaml
+      version: v1.7.2+abcdef1
       webhook:
         arch:
         - amd64
@@ -1574,7 +1598,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-webhook:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.7.2-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -2285,7 +2309,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-acmesolver:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.7.2-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -2293,7 +2317,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-cainjector:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.7.2-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -2301,10 +2325,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-controller:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.7.2-eks-a-v0.0.0-dev-build.1
+      ctl:
+        arch:
+        - amd64
+        description: Container image for cert-manager-ctl image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-ctl
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.7.2-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.5.3/cert-manager.yaml
-      version: v1.5.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.7.2/cert-manager.yaml
+      version: v1.7.2+abcdef1
       webhook:
         arch:
         - amd64
@@ -2312,7 +2344,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-webhook:v1.5.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.7.2-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:

--- a/release/pkg/test/testdata/release-0.10-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.10-bundle-release.yaml
@@ -444,7 +444,7 @@ spec:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.11-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
       packageController:
         arch:
         - amd64
@@ -452,8 +452,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.11-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.1.11+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
+      version: v0.1.13+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -1174,7 +1174,7 @@ spec:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.11-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
       packageController:
         arch:
         - amd64
@@ -1182,8 +1182,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.11-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.1.11+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
+      version: v0.1.13+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -1904,7 +1904,7 @@ spec:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.11-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
       packageController:
         arch:
         - amd64
@@ -1912,8 +1912,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.11-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.1.11+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
+      version: v0.1.13+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -2634,7 +2634,7 @@ spec:
         description: 'Helm chart: eks-anywhere-packages-helm'
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.11-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
       packageController:
         arch:
         - amd64
@@ -2642,8 +2642,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.11-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.1.11+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
+      version: v0.1.13+abcdef1
     snow:
       components: {}
       kubeVip: {}

--- a/release/pkg/test/testdata/release-0.10-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.10-bundle-release.yaml
@@ -80,7 +80,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-acmesolver:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
       cainjector:
         arch:
         - amd64
@@ -88,7 +88,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-cainjector:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
       controller:
         arch:
         - amd64
@@ -96,10 +96,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-controller:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+      ctl:
+        arch:
+        - amd64
+        description: Container image for cert-manager-ctl image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-ctl
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cert-manager/manifests/v1.5.3/cert-manager.yaml
-      version: v1.5.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cert-manager/manifests/v1.7.2/cert-manager.yaml
+      version: v1.7.2+abcdef1
       webhook:
         arch:
         - amd64
@@ -107,7 +115,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-webhook:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
     cilium:
       cilium:
         arch:
@@ -793,7 +801,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-acmesolver:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
       cainjector:
         arch:
         - amd64
@@ -801,7 +809,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-cainjector:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
       controller:
         arch:
         - amd64
@@ -809,10 +817,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-controller:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+      ctl:
+        arch:
+        - amd64
+        description: Container image for cert-manager-ctl image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-ctl
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cert-manager/manifests/v1.5.3/cert-manager.yaml
-      version: v1.5.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cert-manager/manifests/v1.7.2/cert-manager.yaml
+      version: v1.7.2+abcdef1
       webhook:
         arch:
         - amd64
@@ -820,7 +836,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-webhook:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
     cilium:
       cilium:
         arch:
@@ -1515,7 +1531,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-acmesolver:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
       cainjector:
         arch:
         - amd64
@@ -1523,7 +1539,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-cainjector:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
       controller:
         arch:
         - amd64
@@ -1531,10 +1547,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-controller:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+      ctl:
+        arch:
+        - amd64
+        description: Container image for cert-manager-ctl image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-ctl
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cert-manager/manifests/v1.5.3/cert-manager.yaml
-      version: v1.5.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cert-manager/manifests/v1.7.2/cert-manager.yaml
+      version: v1.7.2+abcdef1
       webhook:
         arch:
         - amd64
@@ -1542,7 +1566,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-webhook:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
     cilium:
       cilium:
         arch:
@@ -2237,7 +2261,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-acmesolver:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
       cainjector:
         arch:
         - amd64
@@ -2245,7 +2269,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-cainjector:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
       controller:
         arch:
         - amd64
@@ -2253,10 +2277,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-controller:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+      ctl:
+        arch:
+        - amd64
+        description: Container image for cert-manager-ctl image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-ctl
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cert-manager/manifests/v1.5.3/cert-manager.yaml
-      version: v1.5.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cert-manager/manifests/v1.7.2/cert-manager.yaml
+      version: v1.7.2+abcdef1
       webhook:
         arch:
         - amd64
@@ -2264,7 +2296,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/jetstack/cert-manager-webhook:v1.5.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
     cilium:
       cilium:
         arch:


### PR DESCRIPTION
*Description of changes:*
Updating cert manager org from `jetstack` to `cert-manager`. 
Also updated unit tests and bundle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

