### PR TITLE
Add Tinkerbell taints and labels test

### DIFF
--- a/internal/pkg/api/tinkerbell.go
+++ b/internal/pkg/api/tinkerbell.go
@@ -175,3 +175,24 @@ func WithTinkerbellEtcdMachineConfig() TinkerbellFiller {
 		return nil
 	}
 }
+
+func WithCustomTinkerbellMachineConfig(selector string) TinkerbellFiller {
+	return func(config TinkerbellConfig) error {
+		if _, ok := config.machineConfigs[selector]; !ok {
+			m := &anywherev1.TinkerbellMachineConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       anywherev1.TinkerbellMachineConfigKind,
+					APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: selector,
+				},
+				Spec: anywherev1.TinkerbellMachineConfigSpec{
+					HardwareSelector: map[string]string{HardwareLabelTypeKeyName: selector},
+				},
+			}
+			config.machineConfigs[selector] = m
+		}
+		return nil
+	}
+}

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -1,0 +1,52 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/test/framework"
+)
+
+const (
+	ubuntu          = "ubuntu"
+	nodeGroupLabel1 = "md-0"
+	nodeGroupLabel2 = "md-1"
+)
+
+func TestTinkerbellKubernetes122UbuntuWorkerNodeGroupsTaintsAndLabels(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewTinkerbell(
+			t,
+			framework.WithUbuntu122Tinkerbell(),
+			framework.WithCustomTinkerbellMachineConfig(nodeGroupLabel1),
+			framework.WithCustomTinkerbellMachineConfig(nodeGroupLabel2),
+		),
+		framework.WithClusterFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube122),
+			api.WithControlPlaneLabel(cpKey1, cpVal1),
+			api.WithControlPlaneTaints([]corev1.Taint{framework.NoScheduleTaint()}),
+			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+			api.WithWorkerNodeGroup(worker0, api.WithMachineGroupRef(nodeGroupLabel1, "TinkerbellMachineConfig"), api.WithTaint(framework.PreferNoScheduleTaint()), api.WithLabel(key1, val1), api.WithCount(1)),
+			api.WithWorkerNodeGroup(worker1, api.WithMachineGroupRef(nodeGroupLabel2, "TinkerbellMachineConfig"), api.WithLabel(key2, val2), api.WithCount(1)),
+		),
+		framework.WithControlPlaneHardware(1),
+		framework.WithCustomLabelHardware(1, nodeGroupLabel1),
+		framework.WithCustomLabelHardware(1, nodeGroupLabel2),
+	)
+
+	test.GenerateClusterConfig()
+	test.GenerateHardwareConfig()
+	test.PowerOffHardware()
+	test.CreateCluster()
+	test.ValidateWorkerNodes(framework.ValidateWorkerNodeTaints, framework.ValidateWorkerNodeLabels)
+	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneTaints, framework.ValidateControlPlaneLabels)
+	test.DeleteCluster()
+	test.ValidateHardwareDecommissioned()
+}

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -147,6 +147,10 @@ func WithWorkerHardware(requiredCount int) ClusterE2ETestOpt {
 	return withHardware(requiredCount, api.Worker, map[string]string{api.HardwareLabelTypeKeyName: api.Worker})
 }
 
+func WithCustomLabelHardware(requiredCount int, label string) ClusterE2ETestOpt {
+	return withHardware(requiredCount, api.Worker, map[string]string{api.HardwareLabelTypeKeyName: label})
+}
+
 func WithExternalEtcdHardware(requiredCount int) ClusterE2ETestOpt {
 	return withHardware(requiredCount, api.ExternalEtcd, map[string]string{api.HardwareLabelTypeKeyName: api.ExternalEtcd})
 }

--- a/test/framework/tinkerbell.go
+++ b/test/framework/tinkerbell.go
@@ -161,3 +161,9 @@ func WithTinkerbellExternalEtcdTopology(count int) TinkerbellOpt {
 		t.clusterFillers = append(t.clusterFillers, api.WithExternalEtcdTopology(count), api.WithExternalEtcdMachineRef(anywherev1.TinkerbellMachineConfigKind))
 	}
 }
+
+func WithCustomTinkerbellMachineConfig(selector string) TinkerbellOpt {
+	return func(t *Tinkerbell) {
+		t.fillers = append([]api.TinkerbellFiller{api.WithCustomTinkerbellMachineConfig(selector)}, t.fillers...)
+	}
+}


### PR DESCRIPTION
*Description of changes:*
Add e2e test for worker node groups with taints and labels for tinkerbell provider on Ubuntu 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

