### PR TITLE
Referencing branch name release-0.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ GO_TEST ?= $(GO) test
 UNIT_TEST_PACKAGE_EXCLUSION_REGEX ?=mocks$
 
 ## ensure local execution uses the 'main' branch bundle
-BRANCH_NAME?=main
+BRANCH_NAME?=release-0.10
 ifneq ($(PULL_BASE_REF),)
 	BRANCH_NAME=$(PULL_BASE_REF)
 endif


### PR DESCRIPTION
*Description of changes:*
Referencing branch name release-0.10 in the Makefile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

