### PR TITLE
Use branch name to construct S3 URI for CLI tarball

### DIFF
--- a/release/pkg/assets_cli.go
+++ b/release/pkg/assets_cli.go
@@ -38,10 +38,11 @@ func (r *ReleaseConfig) GetEksACliArtifacts() ([]Artifact, error) {
 		var sourceS3Key string
 		var sourceS3Prefix string
 		var releaseS3Path string
-
+		sourcedFromBranch := r.CliRepoBranchName
+		latestPath := getLatestUploadDestination(sourcedFromBranch)
 		if r.DevRelease || r.ReleaseEnvironment == "development" {
 			sourceS3Key = fmt.Sprintf("eksctl-anywhere-%s-%s.tar.gz", os, arch)
-			sourceS3Prefix = fmt.Sprintf("eks-a-cli/latest/%s/%s", os, arch)
+			sourceS3Prefix = fmt.Sprintf("eks-a-cli/%s/%s/%s", latestPath, os, arch)
 		} else {
 			sourceS3Key = fmt.Sprintf("eksctl-anywhere-%s-%s-%s.tar.gz", r.ReleaseVersion, os, arch)
 			sourceS3Prefix = fmt.Sprintf("releases/eks-a/%d/artifacts/eks-a/%s/%s/%s", r.ReleaseNumber, r.ReleaseVersion, os, arch)


### PR DESCRIPTION
Instead of hardcoding the download URL for the CLI tarball to latest, we should use the branch name to determine which URL to use.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

