### PR TITLE
Tinkerbell - OSFamily defaulted to bottlerocket

### DIFF
--- a/pkg/api/v1alpha1/tinkerbellmachineconfig.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig.go
@@ -26,7 +26,7 @@ func NewTinkerbellMachineConfigGenerate(name string, opts ...TinkerbellMachineCo
 		},
 		Spec: TinkerbellMachineConfigSpec{
 			HardwareSelector: HardwareSelector{},
-			OSFamily:         Ubuntu,
+			OSFamily:         Bottlerocket,
 			Users: []UserConfiguration{
 				{
 					Name:              "ec2-user",


### PR DESCRIPTION
*Description of changes:*
Make Bottlerocket default OS for Tinkerbell.