### PR TITLE
Replace plunder-app org references with kube-vip

### DIFF
--- a/controllers/controllers/resource/testdata/cloudstackKubeadmcontrolplane.yaml
+++ b/controllers/controllers/resource/testdata/cloudstackKubeadmcontrolplane.yaml
@@ -52,7 +52,7 @@ spec:
                 value: "10"
               - name: vip_retryperiod
                 value: "2"
-              image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+              image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}

--- a/controllers/controllers/resource/testdata/vsphereKubeadmcontrolplane.yaml
+++ b/controllers/controllers/resource/testdata/vsphereKubeadmcontrolplane.yaml
@@ -52,7 +52,7 @@ spec:
                 value: "10"
               - name: vip_retryperiod
                 value: "2"
-              image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+              image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}

--- a/internal/test/testdata/bundles.yaml
+++ b/internal/test/testdata/bundles.yaml
@@ -49,7 +49,7 @@ spec:
       clusterAPIController:
         uri: public.ecr.aws/j9l9l0k3/cluster-api-provider-capc:latest
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.1748/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.0-alpha/infrastructure-components.yaml
       metadata:
@@ -135,7 +135,7 @@ spec:
       kubeProxy:
         uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-25df7d96779e2a305a22c6e3f9425c3465a77244
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
       manager:
         uri: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
       metadata:
@@ -147,7 +147,7 @@ spec:
       clusterAPIController:
         uri: public.ecr.aws/j9l9l0k3/cluster-api-provider-capc:latest
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.1748/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.0-alpha/infrastructure-components.yaml
       metadata:
@@ -273,7 +273,7 @@ spec:
       kubeProxy:
         uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-25df7d96779e2a305a22c6e3f9425c3465a77244
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
       manager:
         uri: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
       metadata:
@@ -285,7 +285,7 @@ spec:
       clusterAPIController:
         uri: public.ecr.aws/j9l9l0k3/cluster-api-provider-capc:latest
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.1748/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.0-alpha/infrastructure-components.yaml
       metadata:
@@ -335,7 +335,7 @@ spec:
       clusterAPIController:
         uri: public.ecr.aws/j9l9l0k3/cluster-api-provider-capc:latest
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.1748/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.0-alpha/infrastructure-components.yaml
       metadata:
@@ -417,7 +417,7 @@ spec:
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.952/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.1.0/infrastructure-components.yaml
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
       metadata:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.952/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.1.0/metadata.yaml
       version: v0.1.0+210860f
@@ -433,7 +433,7 @@ spec:
       kubeProxy:
         uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-25df7d96779e2a305a22c6e3f9425c3465a77244
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
       manager:
         uri: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
       metadata:
@@ -445,7 +445,7 @@ spec:
       clusterAPIController:
         uri: public.ecr.aws/j9l9l0k3/cluster-api-provider-capc:latest
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.1748/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.0-alpha/infrastructure-components.yaml
       metadata:
@@ -562,7 +562,7 @@ spec:
       clusterAPIController:
         uri: public.ecr.aws/j9l9l0k3/cluster-api-provider-capc:latest
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.1748/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.0-alpha/infrastructure-components.yaml
       metadata:
@@ -770,7 +770,7 @@ spec:
         imageDigest: sha256:cf324971db7696810effd5c6c95e34b2c115893e1fbcaeb8877355dc74768ef1
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433
       metadata:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.1641/cluster-api-provider-aws-snow/manifests/infrastructure-snow/unsure/metadata.yaml
       version: v1.0.2
@@ -782,7 +782,7 @@ spec:
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.952/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.1.0/infrastructure-components.yaml
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
       metadata:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.952/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.1.0/metadata.yaml
       version: v0.1.0+210860f
@@ -822,7 +822,7 @@ spec:
         imageDigest: sha256:204c63f246bd6eccc330be2875805cae0a1f6867ecac16c07732103429d312b7
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
       manager:
         arch:
           - amd64
@@ -846,7 +846,7 @@ spec:
       clusterAPIController:
         uri: public.ecr.aws/j9l9l0k3/cluster-api-provider-capc:latest
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.1748/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.0-alpha/infrastructure-components.yaml
       metadata:

--- a/internal/test/testdata/bundles_template.yaml
+++ b/internal/test/testdata/bundles_template.yaml
@@ -49,7 +49,7 @@ spec:
       clusterAPIController:
         uri: public.ecr.aws/j9l9l0k3/cluster-api-provider-capc:latest
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.1748/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.0-alpha/infrastructure-components.yaml
       metadata:
@@ -135,7 +135,7 @@ spec:
       kubeProxy:
         uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-25df7d96779e2a305a22c6e3f9425c3465a77244
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
       manager:
         uri: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
       metadata:
@@ -195,7 +195,7 @@ spec:
       clusterAPIController:
         uri: public.ecr.aws/j9l9l0k3/cluster-api-provider-capc:latest
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.1748/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.0-alpha/infrastructure-components.yaml
       metadata:
@@ -281,7 +281,7 @@ spec:
       kubeProxy:
         uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-25df7d96779e2a305a22c6e3f9425c3465a77244
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
       manager:
         uri: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
       metadata:
@@ -341,7 +341,7 @@ spec:
       clusterAPIController:
         uri: public.ecr.aws/j9l9l0k3/cluster-api-provider-capc:latest
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.1748/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.0-alpha/infrastructure-components.yaml
       metadata:
@@ -423,7 +423,7 @@ spec:
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.952/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.1.0/infrastructure-components.yaml
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
       metadata:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.952/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.1.0/metadata.yaml
       version: v0.1.0+210860f
@@ -439,7 +439,7 @@ spec:
       kubeProxy:
         uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-25df7d96779e2a305a22c6e3f9425c3465a77244
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
       manager:
         uri: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774
       metadata:
@@ -566,7 +566,7 @@ spec:
       clusterAPIController:
         uri: public.ecr.aws/j9l9l0k3/cluster-api-provider-capc:latest
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.1748/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.0-alpha/infrastructure-components.yaml
       metadata:
@@ -772,7 +772,7 @@ spec:
       components:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.952/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.1.0/infrastructure-components.yaml
       kubeVip:
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
       metadata:
         uri: https://dev-release-prod-pdx.s3.amazonaws.com/artifacts/v0.0.0-dev-build.952/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.1.0/metadata.yaml
       version: v0.1.0+210860f
@@ -812,7 +812,7 @@ spec:
         imageDigest: sha256:204c63f246bd6eccc330be2875805cae0a1f6867ecac16c07732103429d312b7
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
       manager:
         arch:
           - amd64

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -793,7 +793,7 @@ func TestGetInfrastructureBundleSuccess(t *testing.T) {
 						URI: "public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.1.0",
 					},
 					KubeVip: releasev1alpha1.Image{
-						URI: "public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774",
+						URI: "public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774",
 					},
 					Metadata: releasev1alpha1.Manifest{
 						URI: "Metadata.yaml",

--- a/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
@@ -142,7 +142,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
@@ -155,7 +155,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -155,7 +155,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
@@ -154,7 +154,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
@@ -143,7 +143,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/cloudstack/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_minimal_cp.yaml
@@ -137,7 +137,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/cloudstack/testdata/expected_results_minimal_proxy_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_minimal_proxy_cp.yaml
@@ -137,7 +137,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
@@ -141,7 +141,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -141,7 +141,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -150,10 +150,10 @@ func wantKubeadmControlPlane() *controlplanev1.KubeadmControlPlane {
 					},
 				},
 				PreKubeadmCommands: []string{
-					"/etc/eks/bootstrap.sh public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433 1.2.3.4",
+					"/etc/eks/bootstrap.sh public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433 1.2.3.4",
 				},
 				PostKubeadmCommands: []string{
-					"/etc/eks/bootstrap-after.sh public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433 1.2.3.4",
+					"/etc/eks/bootstrap-after.sh public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433 1.2.3.4",
 				},
 				Files: []bootstrapv1.File{},
 			},

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -138,7 +138,7 @@ func givenClusterSpec() *cluster.Spec {
 					KubeVip: releasev1alpha1.Image{
 						Name:        "kube-vip",
 						OS:          "linux",
-						URI:         "public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433",
+						URI:         "public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433",
 						ImageDigest: "sha256:cf324971db7696810effd5c6c95e34b2c115893e1fbcaeb8877355dc74768ef1",
 						Description: "Container image for kube-vip image",
 						Arch:        []string{"amd64"},
@@ -522,7 +522,7 @@ func TestUpgradeNeededBundle(t *testing.T) {
 				KubeVip: releasev1alpha1.Image{
 					Name:        "kube-vip-diff",
 					OS:          "linux-diff",
-					URI:         "public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433-diff",
+					URI:         "public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433-diff",
 					ImageDigest: "sha256:cf324971db7696810effd5c6c95e34b2c115893e1fbcaeb8877355dc74768ef1",
 					Description: "Container image for kube-vip image-diff",
 					Arch:        []string{"amd64-diff"},
@@ -545,7 +545,7 @@ func TestUpgradeNeededBundle(t *testing.T) {
 				KubeVip: releasev1alpha1.Image{
 					Name:        "kube-vip",
 					OS:          "linux",
-					URI:         "public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433",
+					URI:         "public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433",
 					ImageDigest: "sha256:diff",
 					Description: "Container image for kube-vip image",
 					Arch:        []string{"amd64"},
@@ -568,7 +568,7 @@ func TestUpgradeNeededBundle(t *testing.T) {
 				KubeVip: releasev1alpha1.Image{
 					Name:        "kube-vip",
 					OS:          "linux",
-					URI:         "public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433",
+					URI:         "public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433",
 					ImageDigest: "sha256:cf324971db7696810effd5c6c95e34b2c115893e1fbcaeb8877355dc74768ef1",
 					Description: "Container image for kube-vip image",
 					Arch:        []string{"amd64"},

--- a/pkg/providers/snow/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_cp.yaml
@@ -98,10 +98,10 @@ spec:
       proxy: {}
       registryMirror: {}
     postKubeadmCommands:
-    - /etc/eks/bootstrap-after.sh public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433
+    - /etc/eks/bootstrap-after.sh public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433
       1.2.3.4
     preKubeadmCommands:
-    - /etc/eks/bootstrap.sh public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433
+    - /etc/eks/bootstrap.sh public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433
       1.2.3.4
   machineTemplate:
     infrastructureRef:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
@@ -90,7 +90,7 @@ spec:
                 value: "2"
               - name: address
                 value: 1.2.3.4
-              image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
+              image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_full_oidc.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_full_oidc.yaml
@@ -99,7 +99,7 @@ spec:
                 value: "2"
               - name: address
                 value: 1.2.3.4
-              image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
+              image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_oidc.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_oidc.yaml
@@ -94,7 +94,7 @@ spec:
                 value: "2"
               - name: address
                 value: 1.2.3.4
-              image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
+              image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_labels.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_labels.yaml
@@ -92,7 +92,7 @@ spec:
                 value: "2"
               - name: address
                 value: 1.2.3.4
-              image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
+              image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_taints.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_taints.yaml
@@ -110,7 +110,7 @@ spec:
                 value: "2"
               - name: address
                 value: 1.2.3.4
-              image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
+              image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
@@ -90,7 +90,7 @@ spec:
                 value: "2"
               - name: address
                 value: 1.2.3.4
-              image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
+              image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
@@ -90,7 +90,7 @@ spec:
                 value: "2"
               - name: address
                 value: 1.2.3.4
-              image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
+              image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
@@ -178,7 +178,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
@@ -173,7 +173,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -191,7 +191,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
@@ -152,7 +152,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
@@ -155,7 +155,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
@@ -152,7 +152,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -152,7 +152,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
@@ -152,7 +152,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
@@ -152,7 +152,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
@@ -152,7 +152,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -152,7 +152,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
@@ -152,7 +152,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -152,7 +152,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
@@ -147,7 +147,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
@@ -150,7 +150,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -152,7 +152,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -152,7 +152,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -153,7 +153,7 @@ spec:
               value: "2"
             - name: address
               value: 1.2.3.4
-            image: public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -2434,7 +2434,7 @@ func TestGetInfrastructureBundleSuccess(t *testing.T) {
 						URI: "public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774",
 					},
 					KubeVip: releasev1alpha1.Image{
-						URI: "public.ecr.aws/l0g8r8j6/plunder-app/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774",
+						URI: "public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774",
 					},
 					Driver: releasev1alpha1.Image{
 						URI: "public.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-7c2690c880c6521afdd9ffa8d90443a11c6b817b",

--- a/release/pkg/assets_kube_vip.go
+++ b/release/pkg/assets_kube_vip.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const kubeVipProjectPath = "projects/plunder-app/kube-vip"
+const kubeVipProjectPath = "projects/kube-vip/kube-vip"
 
 // GetKubeVipAssets returns the eks a artifacts for kube-vip
 func (r *ReleaseConfig) GetKubeVipAssets() ([]Artifact, error) {
@@ -30,7 +30,7 @@ func (r *ReleaseConfig) GetKubeVipAssets() ([]Artifact, error) {
 	}
 
 	name := "kube-vip"
-	repoName := fmt.Sprintf("plunder-app/%s", name)
+	repoName := fmt.Sprintf("kube-vip/%s", name)
 	tagOptions := map[string]string{
 		"gitTag":      gitTag,
 		"projectPath": kubeVipProjectPath,

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -159,7 +159,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc3/metadata.yaml
       version: v0.4.5-rc3+abcdef1
@@ -464,7 +464,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -496,7 +496,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
       tinkerbellStack:
@@ -725,7 +725,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -896,7 +896,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc3/metadata.yaml
       version: v0.4.5-rc3+abcdef1
@@ -1210,7 +1210,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -1242,7 +1242,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
       tinkerbellStack:
@@ -1471,7 +1471,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -1642,7 +1642,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc3/metadata.yaml
       version: v0.4.5-rc3+abcdef1
@@ -1956,7 +1956,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -1988,7 +1988,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
       tinkerbellStack:
@@ -2217,7 +2217,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -2388,7 +2388,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc3/metadata.yaml
       version: v0.4.5-rc3+abcdef1
@@ -2702,7 +2702,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -2734,7 +2734,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
       tinkerbellStack:
@@ -2963,7 +2963,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64

--- a/release/pkg/test/testdata/release-0.10-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.10-bundle-release.yaml
@@ -159,7 +159,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc3/metadata.yaml
       version: v0.4.5-rc3+abcdef1
@@ -480,7 +480,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
       tinkerbellStack:
@@ -709,7 +709,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
       manager:
         arch:
         - amd64
@@ -880,7 +880,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc3/metadata.yaml
       version: v0.4.5-rc3+abcdef1
@@ -1210,7 +1210,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
       tinkerbellStack:
@@ -1439,7 +1439,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
       manager:
         arch:
         - amd64
@@ -1610,7 +1610,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc3/metadata.yaml
       version: v0.4.5-rc3+abcdef1
@@ -1940,7 +1940,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
       tinkerbellStack:
@@ -2169,7 +2169,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
       manager:
         arch:
         - amd64
@@ -2340,7 +2340,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc3/metadata.yaml
       version: v0.4.5-rc3+abcdef1
@@ -2670,7 +2670,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
       tinkerbellStack:
@@ -2899,7 +2899,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/plunder-app/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
       manager:
         arch:
         - amd64


### PR DESCRIPTION
Replace plunder-app org references with kube-vip, continuation of aws/eks-anywhere-build-tooling#1000.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

