### PR TITLE
Fixing backwards compatibility bug and adding new e2e test

### DIFF
--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
@@ -54,7 +54,7 @@ type CloudStackResourceDiskOffering struct {
 	CloudStackResourceIdentifier `json:",inline"`
 	// disk size in GB, > 0 for customized disk offering; = 0 for non-customized disk offering
 	// +optional
-	CustomSize int64 `json:"customSizeInGB"`
+	CustomSize int64 `json:"customSizeInGB,omitempty"`
 	// path the filesystem will use to mount in VM
 	MountPath string `json:"mountPath"`
 	// device name of the disk offering in VM, shows up in lsblk command

--- a/test/e2e/upgrade_from_latest_test.go
+++ b/test/e2e/upgrade_from_latest_test.go
@@ -50,7 +50,7 @@ func TestVSphereKubernetes120BottlerocketUpgradeFromLatestMinorRelease(t *testin
 	)
 }
 
-func TestCloudstackKubernetes120UpgradeFromLatestMinorRelease(t *testing.T) {
+func TestCloudStackKubernetes120UpgradeFromLatestMinorRelease(t *testing.T) {
 	provider := framework.NewCloudStack(t, framework.WithRedhat120())
 	test := framework.NewClusterE2ETest(
 		t,

--- a/test/e2e/upgrade_from_latest_test.go
+++ b/test/e2e/upgrade_from_latest_test.go
@@ -50,6 +50,23 @@ func TestVSphereKubernetes120BottlerocketUpgradeFromLatestMinorRelease(t *testin
 	)
 }
 
+func TestCloudstackKubernetes120UpgradeFromLatestMinorRelease(t *testing.T) {
+	provider := framework.NewCloudStack(t, framework.WithRedhat120())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(anywherev1.Kube120)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+	)
+	runUpgradeFromLatestReleaseFlow(
+		test,
+		anywherev1.Kube120,
+		provider.WithProviderUpgrade(),
+	)
+}
+
 func TestVSphereKubernetes121BottlerocketUpgradeFromLatestMinorRelease(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithVSphereFillers(
 		api.WithTemplateForAllMachines(""), // Use default template from bundle


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In order to ensure our users are able to smoothly upgrade between eks-a versions, we need a test running automatically in our pipeline to make sure the changes we're making preserve backwards compatibility. Identified one bug as a result of this issue where some optional field was not parseable.

*Testing (if applicable):*
Testing locally against CI environment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

