### PR TITLE
cleanup tinkerbell test environment between test runs

### DIFF
--- a/internal/test/e2e/tinkerbell.go
+++ b/internal/test/e2e/tinkerbell.go
@@ -71,6 +71,7 @@ func (e *E2ESession) setupTinkerbellEnv(testRegex string) error {
 	}
 
 	e.testEnvVars[tinkerbellInventoryCsvFilePathEnvVar] = inventoryFilePath
+	e.testEnvVars[e2etests.TinkerbellCIEnvironment] = "true"
 
 	return nil
 }

--- a/test/framework/tinkerbell.go
+++ b/test/framework/tinkerbell.go
@@ -19,6 +19,7 @@ const (
 	tinkerbellImageUbuntu123EnvVar          = "T_TINKERBELL_IMAGE_UBUNTU_1_23"
 	tinkerbellInventoryCsvFilePathEnvVar    = "T_TINKERBELL_INVENTORY_CSV"
 	tinkerbellSSHAuthorizedKey              = "T_TINKERBELL_SSH_AUTHORIZED_KEY"
+	TinkerbellCIEnvironment                 = "T_TINKERBELL_CI_ENVIRONMENT"
 )
 
 var requiredTinkerbellEnvVars = []string{


### PR DESCRIPTION
During CI multiple Tinkerbell tests run from the same test runner. If one of the tests fail, the subsequent tests also fail since kind cluster and boots container from previous test are still running and cause issue. This cleans up kind and docker environment after each tinkerbell test that runs during CI build.