### PR TITLE
Adding tinkerbell provider to help

### DIFF
--- a/cmd/eksctl-anywhere/cmd/generateclusterconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generateclusterconfig.go
@@ -50,7 +50,7 @@ func preRunGenerateClusterConfig(cmd *cobra.Command, args []string) {
 
 func init() {
 	generateCmd.AddCommand(generateClusterConfigCmd)
-	generateClusterConfigCmd.Flags().StringP("provider", "p", "", "Provider to use (vsphere or docker)")
+	generateClusterConfigCmd.Flags().StringP("provider", "p", "", "Provider to use (vsphere or tinkerbell or docker)")
 	err := generateClusterConfigCmd.MarkFlagRequired("provider")
 	if err != nil {
 		log.Fatalf("marking flag as required: %v", err)


### PR DESCRIPTION
*Description of changes:*
Adding Tinkerbell to help

*Testing:*
```code
./bin/eksctl-anywhere generate clusterconfig -h 

This command is used to generate a cluster config yaml for the create cluster command

Usage:
  anywhere generate clusterconfig <cluster-name> (max 80 chars) [flags]

Flags:
  -h, --help              help for clusterconfig
  -p, --provider string   Provider to use (vsphere or tinkerbell or docker)

Global Flags:
  -v, --verbosity int   Set the log level verbosity
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

