### PR TITLE
Enable host networking and tolerations for collector pods

### DIFF
--- a/pkg/diagnostics/collector_types.go
+++ b/pkg/diagnostics/collector_types.go
@@ -1,6 +1,7 @@
 package diagnostics
 
 import (
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -69,15 +70,10 @@ type exec struct {
 }
 
 type run struct {
-	collectorMeta   `json:",inline"`
-	Name            string            `json:"name,omitempty"`
-	Namespace       string            `json:"namespace"`
-	Image           string            `json:"image"`
-	Command         []string          `json:"command,omitempty"`
-	Args            []string          `json:"args,omitempty"`
-	Timeout         string            `json:"timeout,omitempty"`
-	ImagePullPolicy string            `json:"imagePullPolicy,omitempty"`
-	ImagePullSecret *imagePullSecrets `json:"imagePullSecret,omitempty"`
+	collectorMeta `json:",inline"`
+	Name          string      `json:"name,omitempty"`
+	Namespace     string      `json:"namespace"`
+	PodSpec       *v1.PodSpec `json:"podSpec,omitempty"`
 }
 
 type imagePullSecrets struct {

--- a/pkg/diagnostics/collectors_test.go
+++ b/pkg/diagnostics/collectors_test.go
@@ -19,7 +19,7 @@ func TestCloudStackDataCenterConfigCollectors(t *testing.T) {
 	assert.Equal(t, constants.CapcSystemNamespace, collectors[0].Logs.Namespace)
 	assert.Equal(t, fmt.Sprintf("logs/%s", constants.CapcSystemNamespace), collectors[0].Logs.Name)
 	for _, collector := range collectors[1:] {
-		assert.Equal(t, []string{"kubectl"}, collector.Run.Command)
+		assert.Equal(t, []string{"kubectl"}, collector.Run.PodSpec.Containers[0].Command)
 		assert.Equal(t, "eksa-diagnostics", collector.Run.Namespace)
 	}
 }
@@ -32,7 +32,7 @@ func TestTinkerbellDataCenterConfigCollectors(t *testing.T) {
 	assert.Equal(t, constants.CaptSystemNamespace, collectors[0].Logs.Namespace)
 	assert.Equal(t, fmt.Sprintf("logs/%s", constants.CaptSystemNamespace), collectors[0].Logs.Name)
 	for _, collector := range collectors[1:] {
-		assert.Equal(t, []string{"kubectl"}, collector.Run.Command)
+		assert.Equal(t, []string{"kubectl"}, collector.Run.PodSpec.Containers[0].Command)
 		assert.Equal(t, "eksa-diagnostics", collector.Run.Namespace)
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Leverage the `podSpec` field in the latest version of troubleshoot to be able to schedule the collector pods with host networking and tolerations. This will allow us to properly retrieve the support bundle in the workload cluster, especially for the changes described here: https://github.com/aws/eks-anywhere/pull/2431

The other option is to avoid appending these CRD collectors by checking for the existence of those resources on the cluster before actually trying to pull them. However, this is a much simpler change than doing that refactoring, so decided on going forward with this approach.

*Testing (if applicable):*
unit testing and testing generating the support bundle when networking fails to install

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

