### PR TITLE
Modify description of MetalLB to avoid confusion

### DIFF
--- a/docs/content/en/docs/reference/packagespec/metallb/_index.md
+++ b/docs/content/en/docs/reference/packagespec/metallb/_index.md
@@ -5,6 +5,6 @@ weight: 20
 description: >
 ---
 
-MetalLB is a load-balancer implementation for bare metal Kubernetes clusters, using standard routing protocols.
+MetalLB is a load-balancer implementation for on-premises Kubernetes clusters, using standard routing protocols.
 
 ### Configuration options for MetalLB


### PR DESCRIPTION
Upstream's description uses the term "bare metal" which might be
confusing to EKS-A customers since we currently consider "bare metal" as
being non-virtualized environment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

