### PR TITLE
Adding validation and support for hostnames for proxy server

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -591,12 +592,13 @@ func validateProxyData(proxy string) error {
 	} else {
 		proxyHost = proxy
 	}
-	ip, port, err := net.SplitHostPort(proxyHost)
+	host, port, err := net.SplitHostPort(proxyHost)
 	if err != nil {
 		return fmt.Errorf("proxy %s is invalid, please provide a valid proxy in the format proxy_ip:port", proxy)
 	}
-	if net.ParseIP(ip) == nil {
-		return fmt.Errorf("proxy ip %s is invalid, please provide a valid proxy ip", ip)
+	_, err = net.DefaultResolver.LookupIPAddr(context.Background(), host)
+	if err != nil && net.ParseIP(host) == nil {
+		return fmt.Errorf("proxy endpoint %s is invalid, please provide a valid proxy domain name or ip", host)
 	}
 	if p, err := strconv.Atoi(port); err != nil || p < 1 || p > 65535 {
 		return fmt.Errorf("proxy port %s is invalid, please provide a valid proxy port", port)

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -594,7 +594,7 @@ func validateProxyData(proxy string) error {
 	}
 	host, port, err := net.SplitHostPort(proxyHost)
 	if err != nil {
-		return fmt.Errorf("proxy %s is invalid, please provide a valid proxy in the format proxy_ip:port", proxy)
+		return fmt.Errorf("proxy endpoint %s is invalid (%s), please provide a valid proxy address", proxy, err)
 	}
 	_, err = net.DefaultResolver.LookupIPAddr(context.Background(), host)
 	if err != nil && net.ParseIP(host) == nil {

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -513,7 +513,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			testName: "with valid proxy configuration",
+			testName: "with valid ip proxy configuration",
 			fileName: "testdata/cluster_valid_proxy.yaml",
 			wantCluster: &Cluster{
 				TypeMeta: metav1.TypeMeta{
@@ -559,6 +559,59 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 					ProxyConfiguration: &ProxyConfiguration{
 						HttpProxy:  "http://0.0.0.0:1",
 						HttpsProxy: "0.0.0.0:1",
+						NoProxy:    []string{"localhost"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			testName: "with valid domain name proxy configuration",
+			fileName: "testdata/cluster_valid_domainname_proxy.yaml",
+			wantCluster: &Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       ClusterKind,
+					APIVersion: SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: ClusterSpec{
+					KubernetesVersion: Kube119,
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						Count: 3,
+						Endpoint: &Endpoint{
+							Host: "test-ip",
+						},
+						MachineGroupRef: &Ref{
+							Kind: VSphereMachineConfigKind,
+							Name: "eksa-unit-test",
+						},
+					},
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						Name:  "md-0",
+						Count: 3,
+						MachineGroupRef: &Ref{
+							Kind: VSphereMachineConfigKind,
+							Name: "eksa-unit-test",
+						},
+					}},
+					DatacenterRef: Ref{
+						Kind: VSphereDatacenterKind,
+						Name: "eksa-unit-test",
+					},
+					ClusterNetwork: ClusterNetwork{
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
+						Pods: Pods{
+							CidrBlocks: []string{"192.168.0.0/16"},
+						},
+						Services: Services{
+							CidrBlocks: []string{"10.96.0.0/12"},
+						},
+					},
+					ProxyConfiguration: &ProxyConfiguration{
+						HttpProxy:  "http://google.com:1",
+						HttpsProxy: "google.com:1",
 						NoProxy:    []string{"localhost"},
 					},
 				},

--- a/pkg/api/v1alpha1/testdata/cluster_valid_domainname_proxy.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_valid_domainname_proxy.yaml
@@ -1,0 +1,65 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: VSphereMachineConfig
+  kubernetesVersion: "1.19"
+  workerNodeGroupConfigurations:
+    - count: 3
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: VSphereMachineConfig
+      name: "md-0"
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  proxyConfiguration:
+    httpProxy: http://google.com:1
+    httpsProxy: google.com:1
+    noProxy:
+      - localhost
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  diskGiB: 25
+  datastore: "myDatastore"
+  folder: "myFolder"
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: "ubuntu"
+  resourcePool: "myResourcePool"
+  storagePolicyName: "myStoragePolicyName"
+  template: "myTemplate"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  datacenter: "myDatacenter"
+  network: "myNetwork"
+  server: "myServer"
+  thumbprint: "myTlsThumbprint"
+  insecure: false


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR was split off from https://github.com/aws/eks-anywhere/pull/2598 to decouple two separate development efforts.

This PR expands the current implementation of the proxy server settings to support passing in domain names as well as IP addresses.

*Testing (if applicable):*
Ran TestCloudStackKubernetes121RedhatProxyConfig locally against CI Cloudstack environment with proxy server's hostname instead of static IP

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

