### PR TITLE
Added bare metal info to cluster scaling docs

### DIFF
--- a/docs/content/en/docs/tasks/cluster/cluster-scale.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-scale.md
@@ -4,7 +4,7 @@ linkTitle: "Scale cluster"
 weight: 20
 date: 2017-01-05
 description: >
-  How to scale your cluster.
+  How to scale your cluster
 ---
 
 When you are scaling your EKS Anywhere cluster, consider the number of nodes you need for your control plane and for your data plane.
@@ -12,6 +12,20 @@ Each plane can be scaled horizontally (add more nodes) or vertically (provide no
 In each case you can scale the cluster manually, semi-automatically, or automatically.
 
 See the [Kubernetes Components](https://kubernetes.io/docs/concepts/overview/components/) documentation to learn the differences between the control plane and the data plane (worker nodes).
+
+### Scaling nodes on Bare Metal clusters
+Before you can scale up nodes on a Bare Metal cluster, you must have already defined the machines in a [hardware CSV file]({{< relref "../../reference/baremetal/bare-preparation/#prepare-hardware-inventory" >}}) and supplied it to Tinkerbell.
+
+Then, to scale a worker node group:
+
+```bash
+kubectl scale machinedeployments -n eksa-system <workerNodeGroupName> --replicas <num replicas>
+```
+To scale control plane nodes:
+
+```bash
+kubectl scale kubeadmcontrolplane -n eksa-system <controlPlaneName> --replicas <num replicas>
+```
 
 ### Manual cluster scaling
 

--- a/docs/content/en/docs/tasks/cluster/cluster-scale/_index.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-scale/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Scale cluster"
+linkTitle: "Scale cluster"
+weight: 10
+description: >
+  How to scale your cluster
+---

--- a/docs/content/en/docs/tasks/cluster/cluster-scale/baremetal-scale.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-scale/baremetal-scale.md
@@ -7,13 +7,41 @@ description: >
   How to scale your Bare Metal cluster
 ---
 
-Before you can scale up nodes on a Bare Metal cluster, you must have already defined the machines in a [hardware CSV file]({{< relref "../../../reference/baremetal/bare-preparation#prepare-hardware-inventory" >}}) and supplied it to Tinkerbell.
+### Scaling nodes on Bare Metal clusters
+Before you can scale up nodes on a Bare Metal cluster, you must ensure you have enough available hardware for the scale up operation to function.
+For scale down operation, you can skip directly to the scale commands.
+To check if you have enough available hardware for scale up, you can use the `kubectl` command below to check if there are hardware with the selector labels corresponding to the controlplane/worker node group and without the `ownerName` label. 
 
-Then, to scale a worker node group:
+```bash
+kubectl get hardware -n eksa-system --show-labels
+```
+
+For example, if you want to scale a worker node group with selector label `type=worker-group-1`, then you must have an additional hardware object in your cluster with the label `type=worker-group-1` that doesn't have the `ownerName` label. 
+
+In the command shown below, `eksa-worker2` matches the selector label and it doesn't have the `ownerName` label. Thus, it can be used to scale up `worker-group-1` by 1.
+
+```bash
+kubectl get hardware -n eksa-system --show-labels 
+NAME                STATE       LABELS
+eksa-controlplane               type=controlplane,v1alpha1.tinkerbell.org/ownerName=abhnvp-control-plane-template-1656427179688-9rm5f,v1alpha1.tinkerbell.org/ownerNamespace=eksa-system
+eksa-worker1                    type=worker-group-1,v1alpha1.tinkerbell.org/ownerName=abhnvp-md-0-1656427179689-9fqnx,v1alpha1.tinkerbell.org/ownerNamespace=eksa-system
+eksa-worker2                    type=worker-group-1
+```
+
+If you don't have any available hardware that match this requirement in the cluster, you can [setup a new hardware CSV]({{< relref "../../../reference/baremetal/bare-preparation/#prepare-hardware-inventory" >}}) and then run the following command to push the additional hardware to your cluster
+
+```bash
+eksctl generate hardware -z <hardware.csv> | kubectl apply -f -
+```
+
+Once you verify you have the additional hardware available, you are ready to scale your cluster.
+
+To scale a worker node group:
 
 ```bash
 kubectl scale machinedeployments -n eksa-system <workerNodeGroupName> --replicas <num replicas>
 ```
+
 To scale control plane nodes:
 
 ```bash

--- a/docs/content/en/docs/tasks/cluster/cluster-scale/baremetal-scale.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-scale/baremetal-scale.md
@@ -1,0 +1,21 @@
+---
+title: "Scale Bare Metal cluster"
+linkTitle: "Scale Bare Metal cluster"
+weight: 20
+date: 2017-01-05
+description: >
+  How to scale your Bare Metal cluster
+---
+
+Before you can scale up nodes on a Bare Metal cluster, you must have already defined the machines in a [hardware CSV file]({{< relref "../../../reference/baremetal/bare-preparation#prepare-hardware-inventory" >}}) and supplied it to Tinkerbell.
+
+Then, to scale a worker node group:
+
+```bash
+kubectl scale machinedeployments -n eksa-system <workerNodeGroupName> --replicas <num replicas>
+```
+To scale control plane nodes:
+
+```bash
+kubectl scale kubeadmcontrolplane -n eksa-system <controlPlaneName> --replicas <num replicas>
+```

--- a/docs/content/en/docs/tasks/cluster/cluster-scale/vsphere-scale.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-scale/vsphere-scale.md
@@ -13,20 +13,6 @@ In each case you can scale the cluster manually, semi-automatically, or automati
 
 See the [Kubernetes Components](https://kubernetes.io/docs/concepts/overview/components/) documentation to learn the differences between the control plane and the data plane (worker nodes).
 
-### Scaling nodes on Bare Metal clusters
-Before you can scale up nodes on a Bare Metal cluster, you must have already defined the machines in a [hardware CSV file]({{< relref "../../../reference/baremetal/bare-preparation#prepare-hardware-inventory" >}}) and supplied it to Tinkerbell.
-
-Then, to scale a worker node group:
-
-```bash
-kubectl scale machinedeployments -n eksa-system <workerNodeGroupName> --replicas <num replicas>
-```
-To scale control plane nodes:
-
-```bash
-kubectl scale kubeadmcontrolplane -n eksa-system <controlPlaneName> --replicas <num replicas>
-```
-
 ### Manual cluster scaling
 
 Horizontally scaling the cluster is done by increasing the number for the control plane or worker node groups under the Cluster specification.

--- a/docs/content/en/docs/tasks/cluster/cluster-scale/vsphere-scale.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-scale/vsphere-scale.md
@@ -1,20 +1,20 @@
 ---
-title: "Scale cluster"
-linkTitle: "Scale cluster"
+title: "Scale vSphere cluster"
+linkTitle: "Scale vSphere cluster"
 weight: 20
 date: 2017-01-05
 description: >
-  How to scale your cluster
+  How to scale your vSphere cluster
 ---
 
-When you are scaling your EKS Anywhere cluster, consider the number of nodes you need for your control plane and for your data plane.
+When you are scaling your vSphere EKS Anywhere cluster, consider the number of nodes you need for your control plane and for your data plane.
 Each plane can be scaled horizontally (add more nodes) or vertically (provide nodes with more resources).
 In each case you can scale the cluster manually, semi-automatically, or automatically.
 
 See the [Kubernetes Components](https://kubernetes.io/docs/concepts/overview/components/) documentation to learn the differences between the control plane and the data plane (worker nodes).
 
 ### Scaling nodes on Bare Metal clusters
-Before you can scale up nodes on a Bare Metal cluster, you must have already defined the machines in a [hardware CSV file]({{< relref "../../reference/baremetal/bare-preparation/#prepare-hardware-inventory" >}}) and supplied it to Tinkerbell.
+Before you can scale up nodes on a Bare Metal cluster, you must have already defined the machines in a [hardware CSV file]({{< relref "../../../reference/baremetal/bare-preparation#prepare-hardware-inventory" >}}) and supplied it to Tinkerbell.
 
 Then, to scale a worker node group:
 
@@ -78,7 +78,7 @@ In a semi-automatic mode you change your cluster spec and then have automation m
 
 You can do this by storing your cluster config manifest in git and then having a CI/CD system deploy your changes.
 Or you can use a GitOps controller to apply the changes.
-To read more about making changes with the integrated Flux GitOps controller you can read how to [Manage a cluster with GitOps]({{< relref "./cluster-flux" >}}).
+To read more about making changes with the integrated Flux GitOps controller you can read how to [Manage a cluster with GitOps]({{< relref "../cluster-flux" >}}).
 
 ### Automatic scaling
 


### PR DESCRIPTION
*Description of changes:*
Added a new section on scaling worker and control plane nodes for EKS Anywhere bare metal clusters to the cluster scaling task docs. I'm not sure of the implication of bare metal on the other sections of that doc, so further research is needed.