### PR TITLE
proper handling of dotted notations so helm can recognize and overrid…

### DIFF
--- a/pkg/curatedpackages/configurationclient.go
+++ b/pkg/curatedpackages/configurationclient.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
 	packagesv1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"
+	"sigs.k8s.io/yaml"
 )
 
 func GetConfigurationsFromBundle(bundlePackage *packagesv1.BundlePackage) map[string]packagesv1.VersionConfiguration {
@@ -35,14 +37,40 @@ func UpdateConfigurations(originalConfigs map[string]packagesv1.VersionConfigura
 	return nil
 }
 
-func GenerateAllValidConfigurations(configs map[string]packagesv1.VersionConfiguration) string {
-	b := new(bytes.Buffer)
+func GenerateAllValidConfigurations(configs map[string]packagesv1.VersionConfiguration) (string, error) {
+	data := map[string]interface{}{}
 	for key, val := range configs {
 		if val.Default != "" || val.Required {
-			fmt.Fprintf(b, "%s: \"%s\"\n", key, val.Default)
+			keySegments := strings.Split(key, ".")
+			parse(data, keySegments, 0, val.Default)
 		}
 	}
-	return b.String()
+	out, err := yaml.Marshal(data)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshall object %v", data)
+	}
+	return string(out), nil
+}
+
+func parse(data map[string]interface{}, keySegments []string, index int, val string) {
+	if index >= len(keySegments) {
+		return
+	}
+	key := keySegments[index]
+	inner := map[string]interface{}{}
+	if _, ok := data[key]; ok {
+		inner = data[key].(map[string]interface{})
+	}
+	parse(inner, keySegments, index + 1, val)
+	if len(inner) == 0 {
+		if bVal, err := strconv.ParseBool(val); err == nil {
+			data[key] = bVal
+		} else {
+			data[key] = val
+		}
+	} else {
+		data[key] = inner
+	}
 }
 
 func GenerateDefaultConfigurations(configs map[string]packagesv1.VersionConfiguration) string {

--- a/pkg/curatedpackages/configurationclient.go
+++ b/pkg/curatedpackages/configurationclient.go
@@ -48,7 +48,7 @@ func GenerateAllValidConfigurations(configs map[string]packagesv1.VersionConfigu
 	}
 	out, err := yaml.Marshal(data)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshall object %v", data)
+		return "", fmt.Errorf("failed to marshal configurations %v", data)
 	}
 	return string(out), nil
 }

--- a/pkg/curatedpackages/configurationclient.go
+++ b/pkg/curatedpackages/configurationclient.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	packagesv1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 	"sigs.k8s.io/yaml"
+
+	packagesv1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 )
 
 func GetConfigurationsFromBundle(bundlePackage *packagesv1.BundlePackage) map[string]packagesv1.VersionConfiguration {
@@ -61,7 +62,7 @@ func parse(data map[string]interface{}, keySegments []string, index int, val str
 	if _, ok := data[key]; ok {
 		inner = data[key].(map[string]interface{})
 	}
-	parse(inner, keySegments, index + 1, val)
+	parse(inner, keySegments, index+1, val)
 	if len(inner) == 0 {
 		if bVal, err := strconv.ParseBool(val); err == nil {
 			data[key] = bVal

--- a/pkg/curatedpackages/configurationclient_test.go
+++ b/pkg/curatedpackages/configurationclient_test.go
@@ -38,13 +38,13 @@ func newConfigurationTest(t *testing.T) *configurationTest {
 							Required: false,
 						},
 						{
-							Name:    "expose.tls.enabled",
-							Default: "false",
+							Name:     "expose.tls.enabled",
+							Default:  "false",
 							Required: false,
 						},
 						{
-							Name:    "expose.tls.auto.commonName",
-							Default: "localhost",
+							Name:     "expose.tls.auto.commonName",
+							Default:  "localhost",
 							Required: false,
 						},
 					},

--- a/pkg/curatedpackages/configurationclient_test.go
+++ b/pkg/curatedpackages/configurationclient_test.go
@@ -37,6 +37,11 @@ func newConfigurationTest(t *testing.T) *configurationTest {
 							Default:  "",
 							Required: false,
 						},
+						{
+							Name:    "expose.tls.enabled",
+							Default: "false",
+							Required: false,
+						},
 					},
 				},
 			},
@@ -60,7 +65,7 @@ func TestGetConfigurationsFromBundleSuccess(t *testing.T) {
 	tt := newConfigurationTest(t)
 	configs := curatedpackages.GetConfigurationsFromBundle(tt.validbp)
 
-	tt.Expect(len(configs)).To(Equal(3))
+	tt.Expect(len(configs)).To(Equal(4))
 }
 
 func TestGetConfigurationsFromBundleFail(t *testing.T) {
@@ -107,7 +112,8 @@ func TestGenerateAllValidConfigurationsSuccess(t *testing.T) {
 	output, err := curatedpackages.GenerateAllValidConfigurations(configs)
 	tt.Expect(err).To(BeNil())
 
-	expectedOutput := fmt.Sprintf("%s: %s\n",
+	expectedOutput := fmt.Sprintf("%s:\n  %s:\n    %s: %s\n%s: %s\n",
+		"expose", "tls", "enabled", "false",
 		"sourceRegistry", "localhost:8080")
 
 	tt.Expect(output).To(Equal(expectedOutput))

--- a/pkg/curatedpackages/configurationclient_test.go
+++ b/pkg/curatedpackages/configurationclient_test.go
@@ -42,6 +42,11 @@ func newConfigurationTest(t *testing.T) *configurationTest {
 							Default: "false",
 							Required: false,
 						},
+						{
+							Name:    "expose.tls.auto.commonName",
+							Default: "localhost",
+							Required: false,
+						},
 					},
 				},
 			},
@@ -65,7 +70,7 @@ func TestGetConfigurationsFromBundleSuccess(t *testing.T) {
 	tt := newConfigurationTest(t)
 	configs := curatedpackages.GetConfigurationsFromBundle(tt.validbp)
 
-	tt.Expect(len(configs)).To(Equal(4))
+	tt.Expect(len(configs)).To(Equal(5))
 }
 
 func TestGetConfigurationsFromBundleFail(t *testing.T) {
@@ -112,9 +117,11 @@ func TestGenerateAllValidConfigurationsSuccess(t *testing.T) {
 	output, err := curatedpackages.GenerateAllValidConfigurations(configs)
 	tt.Expect(err).To(BeNil())
 
-	expectedOutput := fmt.Sprintf("%s:\n  %s:\n    %s: %s\n%s: %s\n",
-		"expose", "tls", "enabled", "false",
-		"sourceRegistry", "localhost:8080")
+	expectedOutput := fmt.Sprintf(
+		"%s:\n  %s:\n    %s:\n      %s: %s\n    %s: %s\n%s: %s\n",
+		"expose", "tls", "auto", "commonName", "localhost", "enabled", "false",
+		"sourceRegistry", "localhost:8080",
+	)
 
 	tt.Expect(output).To(Equal(expectedOutput))
 }

--- a/pkg/curatedpackages/configurationclient_test.go
+++ b/pkg/curatedpackages/configurationclient_test.go
@@ -104,8 +104,10 @@ func TestGenerateAllValidConfigurationsSuccess(t *testing.T) {
 	tt := newConfigurationTest(t)
 	configs := curatedpackages.GetConfigurationsFromBundle(tt.validbp)
 
-	output := curatedpackages.GenerateAllValidConfigurations(configs)
-	expectedOutput := fmt.Sprintf("%s: \"%s\"\n",
+	output, err := curatedpackages.GenerateAllValidConfigurations(configs)
+	tt.Expect(err).To(BeNil())
+
+	expectedOutput := fmt.Sprintf("%s: %s\n",
 		"sourceRegistry", "localhost:8080")
 
 	tt.Expect(output).To(Equal(expectedOutput))

--- a/pkg/curatedpackages/packageclient.go
+++ b/pkg/curatedpackages/packageclient.go
@@ -146,8 +146,8 @@ func (pc *PackageClient) getInstallConfigurations(bp *packagesv1.BundlePackage) 
 		return "", err
 	}
 
-	configString := GenerateAllValidConfigurations(configs)
-	return configString, nil
+	configString, err := GenerateAllValidConfigurations(configs)
+	return configString, err
 }
 
 func (pc *PackageClient) getGenerateConfigurations(bp *packagesv1.BundlePackage) string {


### PR DESCRIPTION
…e the values in charts accordingly

*Issue #, if available:*
Currently, dotted notations are not parsed and taken as a flat key, which Helm can't recognize. The details are documented here (https://github.com/aws/eks-anywhere-packages/issues/299).

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

