### PR TITLE
Enabling Tinkerbell e2e tests on main branch

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -286,7 +286,7 @@ func splitTests(testsList []string, conf ParallelRunConf) ([]instanceRunConf, er
 		}
 	}
 
-	if strings.EqualFold(conf.BranchName, "release-0.10") {
+	if strings.EqualFold(conf.BranchName, "main") {
 		runConfs, err = splitTinkerbellTests(awsSession, testsList, conf, testRunnerConfig, runConfs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to split Tinkerbell tests: %v", err)


### PR DESCRIPTION
*Description of changes:*
Re-enabling tinkerbell e2e tests on main branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

