### PR TITLE
Adding check before move to make sure workload clusters are ready

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -37,7 +37,7 @@ const (
 	machinesMinWait        = 30 * time.Minute
 	maxWaitPerCluster      = 15 * time.Minute
 	clusterBackoff         = 10 * time.Second
-	clustersMinWait        = 15 * time.Minute
+	clusterMinWait         = 15 * time.Minute
 	moveCAPIWait           = 15 * time.Minute
 	ctrlPlaneWaitStr       = "60m"
 	etcdWaitStr            = "60m"
@@ -58,7 +58,7 @@ type ClusterManager struct {
 	machinesMinWait    time.Duration
 	clusterMaxWait     time.Duration
 	clusterBackoff     time.Duration
-	clustersMinWait    time.Duration
+	clusterMinWait     time.Duration
 	awsIamAuth         AwsIamAuth
 }
 
@@ -137,7 +137,7 @@ func New(clusterClient ClusterClient, networking Networking, writer filewriter.F
 		machinesMinWait:    machinesMinWait,
 		clusterMaxWait:     maxWaitPerCluster,
 		clusterBackoff:     clusterBackoff,
-		clustersMinWait:    clustersMinWait,
+		clusterMinWait:     clusterMinWait,
 		awsIamAuth:         awsIamAuth,
 	}
 
@@ -841,8 +841,8 @@ func (c *ClusterManager) waitForManagedClustersReady(ctx context.Context, manage
 	}
 
 	timeout := time.Duration(totalClusters) * c.clusterMaxWait
-	if timeout <= c.clustersMinWait {
-		timeout = c.clustersMinWait
+	if timeout <= c.clusterMinWait {
+		timeout = c.clusterMinWait
 	}
 
 	r := retrier.New(timeout, retrier.WithRetryPolicy(policy))

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -878,6 +878,7 @@ func TestClusterManagerMoveCAPISuccess(t *testing.T) {
 
 	c, m := newClusterManager(t)
 	m.client.EXPECT().GetMachines(ctx, from, to.Name)
+	m.client.EXPECT().GetClusters(ctx, from).Return(nil, errors.New("error getting clusters"))
 	m.client.EXPECT().GetClusters(ctx, from).Return(clustersNotReady, nil)
 	m.client.EXPECT().GetClusters(ctx, from).Return(clustersReady, nil)
 	m.client.EXPECT().MoveManagement(ctx, from, to)

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -861,15 +861,27 @@ func TestClusterManagerMoveCAPISuccess(t *testing.T) {
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-wn"}}}
 	})
+	capiClusterName := "capi-cluster"
+	clustersNotReady := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}, Status: types.ClusterStatus{
+		Conditions: []types.Condition{{
+			Type:   "Ready",
+			Status: "False",
+		}},
+	}}}
+	clustersReady := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}, Status: types.ClusterStatus{
+		Conditions: []types.Condition{{
+			Type:   "Ready",
+			Status: "True",
+		}},
+	}}}
 	ctx := context.Background()
 
 	c, m := newClusterManager(t)
 	m.client.EXPECT().GetMachines(ctx, from, to.Name)
-	m.client.EXPECT().GetClusters(ctx, from)
+	m.client.EXPECT().GetClusters(ctx, from).Return(clustersNotReady, nil)
+	m.client.EXPECT().GetClusters(ctx, from).Return(clustersReady, nil)
 	m.client.EXPECT().MoveManagement(ctx, from, to)
-	capiClusterName := "capi-cluster"
-	clusters := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}}}
-	m.client.EXPECT().GetClusters(ctx, to).Return(clusters, nil)
+	m.client.EXPECT().GetClusters(ctx, to).Return(clustersReady, nil)
 	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "15m0s", capiClusterName)
 	m.client.EXPECT().ValidateControlPlaneNodes(ctx, to, to.Name)
 	m.client.EXPECT().CountMachineDeploymentReplicasReady(ctx, to.Name, to.KubeconfigFile)

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -865,6 +865,7 @@ func TestClusterManagerMoveCAPISuccess(t *testing.T) {
 
 	c, m := newClusterManager(t)
 	m.client.EXPECT().GetMachines(ctx, from, to.Name)
+	m.client.EXPECT().GetClusters(ctx, from)
 	m.client.EXPECT().MoveManagement(ctx, from, to)
 	capiClusterName := "capi-cluster"
 	clusters := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}}}
@@ -895,6 +896,7 @@ func TestClusterManagerMoveCAPIErrorMove(t *testing.T) {
 
 	c, m := newClusterManager(t)
 	m.client.EXPECT().GetMachines(ctx, from, from.Name)
+	m.client.EXPECT().GetClusters(ctx, from)
 	m.client.EXPECT().MoveManagement(ctx, from, to).Return(errors.New("error moving"))
 
 	if err := c.MoveCAPI(ctx, from, to, from.Name, clusterSpec); err == nil {
@@ -918,6 +920,7 @@ func TestClusterManagerMoveCAPIErrorGetClusters(t *testing.T) {
 
 	c, m := newClusterManager(t)
 	m.client.EXPECT().GetMachines(ctx, from, from.Name)
+	m.client.EXPECT().GetClusters(ctx, from)
 	m.client.EXPECT().MoveManagement(ctx, from, to)
 	m.client.EXPECT().GetClusters(ctx, to).Return(nil, errors.New("error getting clusters"))
 
@@ -945,6 +948,7 @@ func TestClusterManagerMoveCAPIErrorWaitForControlPlane(t *testing.T) {
 	capiClusterName := "capi-cluster"
 	clusters := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}}}
 	m.client.EXPECT().GetMachines(ctx, from, from.Name)
+	m.client.EXPECT().GetClusters(ctx, from)
 	m.client.EXPECT().GetClusters(ctx, to).Return(clusters, nil)
 	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "15m0s", capiClusterName).Return(errors.New("error waiting for control plane"))
 
@@ -970,6 +974,7 @@ func TestClusterManagerMoveCAPIErrorGetMachines(t *testing.T) {
 	c, m := newClusterManager(t, clustermanager.WithWaitForMachines(0, 10*time.Microsecond, 20*time.Microsecond))
 	m.client.EXPECT().GetMachines(ctx, from, from.Name)
 	m.client.EXPECT().MoveManagement(ctx, from, to)
+	m.client.EXPECT().GetClusters(ctx, from)
 	m.client.EXPECT().GetClusters(ctx, to)
 	m.client.EXPECT().ValidateControlPlaneNodes(ctx, to, to.Name)
 	m.client.EXPECT().CountMachineDeploymentReplicasReady(ctx, to.Name, to.KubeconfigFile)

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -989,7 +989,23 @@ func TestKubectlGetClusters(t *testing.T) {
 					Metadata: types.Metadata{
 						Name: "eksa-test-capd",
 					},
-					Status: types.ClusterStatus{Phase: "Provisioned"},
+					Status: types.ClusterStatus{
+						Phase: "Provisioned",
+						Conditions: []types.Condition{
+							{
+								Type: "Ready",
+								Status: "True",
+							},
+							{
+								Type: "ControlPlaneReady",
+								Status: "True",
+							},
+							{
+								Type: "InfrastructureReady",
+								Status: "True",
+							},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -993,15 +993,15 @@ func TestKubectlGetClusters(t *testing.T) {
 						Phase: "Provisioned",
 						Conditions: []types.Condition{
 							{
-								Type: "Ready",
+								Type:   "Ready",
 								Status: "True",
 							},
 							{
-								Type: "ControlPlaneReady",
+								Type:   "ControlPlaneReady",
 								Status: "True",
 							},
 							{
-								Type: "InfrastructureReady",
+								Type:   "InfrastructureReady",
 								Status: "True",
 							},
 						},

--- a/pkg/types/resources.go
+++ b/pkg/types/resources.go
@@ -54,7 +54,7 @@ type CAPICluster struct {
 }
 
 type ClusterStatus struct {
-	Phase string
+	Phase      string
 	Conditions Conditions
 }
 

--- a/pkg/types/resources.go
+++ b/pkg/types/resources.go
@@ -55,6 +55,7 @@ type CAPICluster struct {
 
 type ClusterStatus struct {
 	Phase string
+	Conditions Conditions
 }
 
 type Metadata struct {
@@ -73,6 +74,8 @@ type NowFunc func() time.Time
 
 type NodeReadyChecker func(status MachineStatus) bool
 
+type ClusterReadyChecker func(status ClusterStatus) bool
+
 func WithNodeRef() NodeReadyChecker {
 	return func(status MachineStatus) bool {
 		return status.NodeRef != nil
@@ -83,6 +86,17 @@ func WithNodeHealthy() NodeReadyChecker {
 	return func(status MachineStatus) bool {
 		for _, c := range status.Conditions {
 			if c.Type == "NodeHealthy" {
+				return c.Status == "True"
+			}
+		}
+		return false
+	}
+}
+
+func WithClusterReady() ClusterReadyChecker {
+	return func(status ClusterStatus) bool {
+		for _, c := range status.Conditions {
+			if c.Type == "Ready" {
 				return c.Status == "True"
 			}
 		}

--- a/pkg/types/resources_test.go
+++ b/pkg/types/resources_test.go
@@ -3,6 +3,8 @@ package types_test
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 
@@ -76,6 +78,51 @@ func TestHasAnyLabel(t *testing.T) {
 			if got := m.HasAnyLabel(tt.wantLabels); got != tt.hasAnyLabel {
 				t.Errorf("machine.HasAnyLabel() = %v, want %v", got, tt.hasAnyLabel)
 			}
+		})
+	}
+}
+
+func TestWithClusterReady(t *testing.T) {
+	tt := NewWithT(t)
+	tests := []struct {
+		testName string
+		status   types.ClusterStatus
+		expected bool
+	}{
+		{
+			testName: "no conditions",
+			status:   types.ClusterStatus{},
+			expected: false,
+		},
+		{
+			testName: "no Ready type",
+			status: types.ClusterStatus{Conditions: []types.Condition{{
+				Type:   "Runnung",
+				Status: "True",
+			}}},
+			expected: false,
+		},
+		{
+			testName: "Ready is False",
+			status: types.ClusterStatus{Conditions: []types.Condition{{
+				Type:   "Ready",
+				Status: "False",
+			}}},
+			expected: false,
+		},
+		{
+			testName: "Ready is True",
+			status: types.ClusterStatus{Conditions: []types.Condition{{
+				Type:   "Ready",
+				Status: "True",
+			}}},
+			expected: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			checker := types.WithClusterReady()
+			tt.Expect(checker(test.status)).To(Equal(test.expected))
 		})
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/2665

*Description of changes:*
This PR adds a validation step prior to executing a clusterctl move to make sure the workload clusters are ready for a self-managed cluster. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

