### PR TITLE
Snow machine config validation webhook for static validations

### DIFF
--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -5597,6 +5597,27 @@ webhooks:
     service:
       name: eksa-webhook-service
       namespace: eksa-system
+      path: /validate-anywhere-eks-amazonaws-com-v1alpha1-snowmachineconfig
+  failurePolicy: Fail
+  name: validation.snowmachineconfig.anywhere.amazonaws.com
+  rules:
+  - apiGroups:
+    - anywhere.eks.amazonaws.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - snowmachineconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: eksa-webhook-service
+      namespace: eksa-system
       path: /validate-anywhere-eks-amazonaws-com-v1alpha1-vspheredatacenterconfig
   failurePolicy: Fail
   name: validation.vspheredatacenterconfig.anywhere.amazonaws.com

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -189,6 +189,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-anywhere-eks-amazonaws-com-v1alpha1-snowmachineconfig
+  failurePolicy: Fail
+  name: validation.snowmachineconfig.anywhere.amazonaws.com
+  rules:
+  - apiGroups:
+    - anywhere.eks.amazonaws.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - snowmachineconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-anywhere-eks-amazonaws-com-v1alpha1-vspheredatacenterconfig
   failurePolicy: Fail
   name: validation.vspheredatacenterconfig.anywhere.amazonaws.com

--- a/pkg/api/v1alpha1/snowmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_webhook.go
@@ -15,6 +15,7 @@
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -37,4 +38,31 @@ var _ webhook.Defaulter = &SnowMachineConfig{}
 func (r *SnowMachineConfig) Default() {
 	snowmachineconfiglog.Info("Setting up Snow Machine Config defaults for", "name", r.Name)
 	r.SetDefaults()
+}
+
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-anywhere-eks-amazonaws-com-v1alpha1-snowmachineconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=anywhere.eks.amazonaws.com,resources=snowmachineconfigs,verbs=create;update,versions=v1alpha1,name=validation.snowmachineconfig.anywhere.amazonaws.com,admissionReviewVersions={v1,v1beta1}
+
+var _ webhook.Validator = &SnowMachineConfig{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *SnowMachineConfig) ValidateCreate() error {
+	snowmachineconfiglog.Info("validate create", "name", r.Name)
+
+	return r.Validate()
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *SnowMachineConfig) ValidateUpdate(old runtime.Object) error {
+	snowmachineconfiglog.Info("validate update", "name", r.Name)
+
+	return r.Validate()
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *SnowMachineConfig) ValidateDelete() error {
+	snowmachineconfiglog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil
 }

--- a/pkg/api/v1alpha1/snowmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_webhook_test.go
@@ -19,6 +19,57 @@ func TestSnowMachineConfigSetDefaults(t *testing.T) {
 	g.Expect(sOld.Spec.PhysicalNetworkConnector).To(Equal(v1alpha1.DefaultSnowPhysicalNetworkConnectorType))
 }
 
+func TestSnowMachineConfigValidateCreateNoAMI(t *testing.T) {
+	g := NewWithT(t)
+
+	sOld := snowMachineConfig()
+	sOld.Spec.InstanceType = v1alpha1.SbeCLarge
+	sOld.Spec.Devices = []string{"1.2.3.4"}
+
+	g.Expect(sOld.ValidateCreate()).NotTo(Succeed())
+}
+
+func TestSnowMachineConfigValidateCreate(t *testing.T) {
+	g := NewWithT(t)
+
+	sOld := snowMachineConfig()
+	sOld.Spec.AMIID = "testAMI"
+	sOld.Spec.InstanceType = v1alpha1.SbeCLarge
+	sOld.Spec.Devices = []string{"1.2.3.4"}
+
+	g.Expect(sOld.ValidateCreate()).To(Succeed())
+}
+
+func TestSnowMachineConfigValidateUpdateNoDevices(t *testing.T) {
+	g := NewWithT(t)
+
+	sOld := snowMachineConfig()
+	sNew := sOld.DeepCopy()
+	sNew.Spec.AMIID = "testAMI"
+	sNew.Spec.InstanceType = v1alpha1.SbeCLarge
+
+	g.Expect(sNew.ValidateUpdate(&sOld)).NotTo(Succeed())
+}
+
+func TestSnowMachineConfigValidateUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	sOld := snowMachineConfig()
+	sNew := sOld.DeepCopy()
+	sNew.Spec.AMIID = "testAMI"
+	sNew.Spec.InstanceType = v1alpha1.SbeCLarge
+	sNew.Spec.Devices = []string{"1.2.3.4"}
+
+	g.Expect(sNew.ValidateUpdate(&sOld)).To(Succeed())
+}
+
+// Unit test to pass the code coverage job
+func TestSnowMachineConfigValidateDelete(t *testing.T) {
+	g := NewWithT(t)
+	sOld := snowMachineConfig()
+	g.Expect(sOld.ValidateDelete()).To(Succeed())
+}
+
 func snowMachineConfig() v1alpha1.SnowMachineConfig {
 	return v1alpha1.SnowMachineConfig{
 		TypeMeta:   metav1.TypeMeta{},


### PR DESCRIPTION
*Issue #, if available:*
#2669 

*Description of changes:*

Validating the Snow Machine Config via the validating webhook.

Testing (if applicable):

- Create docker cluster with tilt and attach a snow machine config on the cluster with specific values set. Check once attached if the values are validated.
- Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

