### PR TITLE
Improve TlsValidator.HasSelfSignedCert() method (#1368)

### DIFF
--- a/pkg/crypto/validator.go
+++ b/pkg/crypto/validator.go
@@ -12,22 +12,21 @@ type DefaultTlsValidator struct{}
 
 type TlsValidator interface {
 	ValidateCert(host, port, caCertContent string) error
-	HasSelfSignedCert(host, port string) (bool, error)
+	IsSignedByUnknownAuthority(host, port string) (bool, error)
 }
 
 func NewTlsValidator() TlsValidator {
 	return &DefaultTlsValidator{}
 }
 
-// HasSelfSignedCert determines whether the url is using self-signed certs or not
-func (tv *DefaultTlsValidator) HasSelfSignedCert(host, port string) (bool, error) {
+// IsSignedByUnknownAuthority determines if the url is signed by an unknown authority.
+func (tv *DefaultTlsValidator) IsSignedByUnknownAuthority(host, port string) (bool, error) {
 	conf := &tls.Config{
 		InsecureSkipVerify: false,
 	}
 
 	_, err := tls.Dial("tcp", net.JoinHostPort(host, port), conf)
 	if err != nil {
-		// If the error is x509.UnknownAuthorityError, this means the url is using self-signed certs
 		if err.Error() == (x509.UnknownAuthorityError{}).Error() {
 			return true, nil
 		}

--- a/pkg/crypto/validator_test.go
+++ b/pkg/crypto/validator_test.go
@@ -122,7 +122,7 @@ invalidCert
 `
 )
 
-func TestHasSelfSignedCert(t *testing.T) {
+func TestIsSignedByUnknownAuthority(t *testing.T) {
 	certSvr, err := runTestServerWithCert(serverCert, serverKey)
 	if err != nil {
 		t.Fatalf("starting test server with certs: %v", err)
@@ -160,12 +160,12 @@ func TestHasSelfSignedCert(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.testName, func(t *testing.T) {
 			tv := crypto.NewTlsValidator()
-			hasCert, err := tv.HasSelfSignedCert(tc.endpoint, tc.port)
+			hasCert, err := tv.IsSignedByUnknownAuthority(tc.endpoint, tc.port)
 			if (err != nil) != tc.wantError {
-				t.Fatalf("HasSelfSignedCert() error = %v, wantError %v", err, tc.wantError)
+				t.Fatalf("IsSignedByUnknownAuthority() error = %v, wantError %v", err, tc.wantError)
 			}
 			if hasCert != tc.wantCert {
-				t.Fatalf("HasSelfSignedCert() returned %v, want %v", hasCert, tc.wantCert)
+				t.Fatalf("IsSignedByUnknownAuthority() returned %v, want %v", hasCert, tc.wantCert)
 			}
 		})
 	}

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -21,16 +21,16 @@ func ValidateCertForRegistryMirror(clusterSpec *cluster.Spec, tlsValidator TlsVa
 	}
 
 	host, port := cluster.Spec.RegistryMirrorConfiguration.Endpoint, cluster.Spec.RegistryMirrorConfiguration.Port
-	selfSigned, err := tlsValidator.HasSelfSignedCert(host, port)
+	authorityUnknown, err := tlsValidator.IsSignedByUnknownAuthority(host, port)
 	if err != nil {
 		return fmt.Errorf("validating registry mirror endpoint: %v", err)
 	}
-	if selfSigned {
+	if authorityUnknown {
 		logger.V(1).Info(fmt.Sprintf("Warning: registry mirror endpoint %s is using self-signed certs", cluster.Spec.RegistryMirrorConfiguration.Endpoint))
 	}
 
 	certContent := cluster.Spec.RegistryMirrorConfiguration.CACertContent
-	if certContent == "" && selfSigned {
+	if certContent == "" && authorityUnknown {
 		return fmt.Errorf("registry %s is using self-signed certs, please provide the certificate using caCertContent field. Or use insecureSkipVerify field to skip registry certificate verification", cluster.Spec.RegistryMirrorConfiguration.Endpoint)
 	}
 

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -54,7 +54,7 @@ func TestValidateCertForRegistryMirrorNoRegistryMirror(t *testing.T) {
 func TestValidateCertForRegistryMirrorCertInvalid(t *testing.T) {
 	tt := newTlsTest(t)
 	tt.clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.CACertContent = tt.certContent
-	tt.tlsValidator.EXPECT().HasSelfSignedCert(tt.host, tt.port).Return(false, nil)
+	tt.tlsValidator.EXPECT().IsSignedByUnknownAuthority(tt.host, tt.port).Return(false, nil)
 	tt.tlsValidator.EXPECT().ValidateCert(tt.host, tt.port, tt.certContent).Return(errors.New("invalid cert"))
 
 	tt.Expect(validations.ValidateCertForRegistryMirror(tt.clusterSpec, tt.tlsValidator)).To(
@@ -65,22 +65,22 @@ func TestValidateCertForRegistryMirrorCertInvalid(t *testing.T) {
 func TestValidateCertForRegistryMirrorCertValid(t *testing.T) {
 	tt := newTlsTest(t)
 	tt.clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.CACertContent = tt.certContent
-	tt.tlsValidator.EXPECT().HasSelfSignedCert(tt.host, tt.port).Return(false, nil)
+	tt.tlsValidator.EXPECT().IsSignedByUnknownAuthority(tt.host, tt.port).Return(false, nil)
 	tt.tlsValidator.EXPECT().ValidateCert(tt.host, tt.port, tt.certContent).Return(nil)
 
 	tt.Expect(validations.ValidateCertForRegistryMirror(tt.clusterSpec, tt.tlsValidator)).To(Succeed())
 }
 
-func TestValidateCertForRegistryMirrorNoCertNoSelfSigned(t *testing.T) {
+func TestValidateCertForRegistryMirrorNoCertIsSignedByKnownAuthority(t *testing.T) {
 	tt := newTlsTest(t)
-	tt.tlsValidator.EXPECT().HasSelfSignedCert(tt.host, tt.port).Return(false, nil)
+	tt.tlsValidator.EXPECT().IsSignedByUnknownAuthority(tt.host, tt.port).Return(false, nil)
 
 	tt.Expect(validations.ValidateCertForRegistryMirror(tt.clusterSpec, tt.tlsValidator)).To(Succeed())
 }
 
-func TestValidateCertForRegistryMirrorNoCertSelfSigned(t *testing.T) {
+func TestValidateCertForRegistryMirrorIsSignedByUnknownAuthority(t *testing.T) {
 	tt := newTlsTest(t)
-	tt.tlsValidator.EXPECT().HasSelfSignedCert(tt.host, tt.port).Return(true, nil)
+	tt.tlsValidator.EXPECT().IsSignedByUnknownAuthority(tt.host, tt.port).Return(true, nil)
 
 	tt.Expect(validations.ValidateCertForRegistryMirror(tt.clusterSpec, tt.tlsValidator)).To(
 		MatchError(ContainSubstring("registry https://host.h is using self-signed certs, please provide the certificate using caCertContent field")),

--- a/pkg/validations/mocks/tls.go
+++ b/pkg/validations/mocks/tls.go
@@ -33,19 +33,19 @@ func (m *MockTlsValidator) EXPECT() *MockTlsValidatorMockRecorder {
 	return m.recorder
 }
 
-// HasSelfSignedCert mocks base method.
-func (m *MockTlsValidator) HasSelfSignedCert(host, port string) (bool, error) {
+// IsSignedByUnknownAuthority mocks base method.
+func (m *MockTlsValidator) IsSignedByUnknownAuthority(host, port string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasSelfSignedCert", host, port)
+	ret := m.ctrl.Call(m, "IsSignedByUnknownAuthority", host, port)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// HasSelfSignedCert indicates an expected call of HasSelfSignedCert.
-func (mr *MockTlsValidatorMockRecorder) HasSelfSignedCert(host, port interface{}) *gomock.Call {
+// IsSignedByUnknownAuthority indicates an expected call of IsSignedByUnknownAuthority.
+func (mr *MockTlsValidatorMockRecorder) IsSignedByUnknownAuthority(host, port interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasSelfSignedCert", reflect.TypeOf((*MockTlsValidator)(nil).HasSelfSignedCert), host, port)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSignedByUnknownAuthority", reflect.TypeOf((*MockTlsValidator)(nil).IsSignedByUnknownAuthority), host, port)
 }
 
 // ValidateCert mocks base method.

--- a/pkg/validations/tls.go
+++ b/pkg/validations/tls.go
@@ -2,5 +2,5 @@ package validations
 
 type TlsValidator interface {
 	ValidateCert(host, port, caCertContent string) error
-	HasSelfSignedCert(host, port string) (bool, error)
+	IsSignedByUnknownAuthority(host, port string) (bool, error)
 }


### PR DESCRIPTION
*Issue #, if available:* 1368

*Description of changes:* This PR is meant to update the `TlsValidator.HasSelfSignedCert()` method so that its name matches its functionality. It was designated `good first issue` and serves as a starting point to begin contributing.

*Testing (if applicable):* Although no additional tests were added, updated mocks were generated and relevant doc strings adjusted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

