### PR TITLE
Adding check before move to make sure workload clusters are ready using kubectl wait

### DIFF
--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -599,6 +599,20 @@ func (mr *MockClusterClientMockRecorder) ValidateWorkerNodes(arg0, arg1, arg2 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateWorkerNodes", reflect.TypeOf((*MockClusterClient)(nil).ValidateWorkerNodes), arg0, arg1, arg2)
 }
 
+// WaitForClusterReady mocks base method.
+func (m *MockClusterClient) WaitForClusterReady(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForClusterReady", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForClusterReady indicates an expected call of WaitForClusterReady.
+func (mr *MockClusterClientMockRecorder) WaitForClusterReady(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForClusterReady", reflect.TypeOf((*MockClusterClient)(nil).WaitForClusterReady), arg0, arg1, arg2, arg3)
+}
+
 // WaitForControlPlaneNotReady mocks base method.
 func (m *MockClusterClient) WaitForControlPlaneNotReady(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -257,6 +257,10 @@ func (k *Kubectl) DeleteKubeSpecFromBytes(ctx context.Context, cluster *types.Cl
 	return nil
 }
 
+func (k *Kubectl) WaitForClusterReady(ctx context.Context, cluster *types.Cluster, timeout string, clusterName string) error {
+	return k.Wait(ctx, cluster.KubeconfigFile, timeout, "Ready", fmt.Sprintf("%s/%s", capiClustersResourceType, clusterName), constants.EksaSystemNamespace)
+}
+
 func (k *Kubectl) WaitForControlPlaneReady(ctx context.Context, cluster *types.Cluster, timeout string, newClusterName string) error {
 	return k.Wait(ctx, cluster.KubeconfigFile, timeout, "ControlPlaneReady", fmt.Sprintf("%s/%s", capiClustersResourceType, newClusterName), constants.EksaSystemNamespace)
 }

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -989,7 +989,14 @@ func TestKubectlGetClusters(t *testing.T) {
 					Metadata: types.Metadata{
 						Name: "eksa-test-capd",
 					},
-					Status: types.ClusterStatus{Phase: "Provisioned"},
+					Status: types.ClusterStatus{
+						Phase: "Provisioned",
+						Conditions: []types.Condition{
+							{Type: "Ready", Status: "True"},
+							{Type: "ControlPlaneReady", Status: "True"},
+							{Type: "InfrastructureReady", Status: "True"},
+						},
+					},
 				},
 			},
 		},
@@ -2211,4 +2218,14 @@ func TestKubectlWaitForManagedExternalEtcdNotReady(t *testing.T) {
 	).Return(bytes.Buffer{}, nil)
 
 	tt.Expect(tt.k.WaitForManagedExternalEtcdNotReady(tt.ctx, tt.cluster, "5m", "test")).To(Succeed())
+}
+
+func TestKubectlWaitForClusterReady(t *testing.T) {
+	tt := newKubectlTest(t)
+	tt.e.EXPECT().Execute(
+		tt.ctx,
+		"wait", "--timeout", "5m", "--for=condition=Ready", "clusters.cluster.x-k8s.io/test", "--kubeconfig", tt.cluster.KubeconfigFile, "-n", "eksa-system",
+	).Return(bytes.Buffer{}, nil)
+
+	tt.Expect(tt.k.WaitForClusterReady(tt.ctx, tt.cluster, "5m", "test")).To(Succeed())
 }

--- a/pkg/types/resources.go
+++ b/pkg/types/resources.go
@@ -54,7 +54,8 @@ type CAPICluster struct {
 }
 
 type ClusterStatus struct {
-	Phase string
+	Phase      string
+	Conditions Conditions
 }
 
 type Metadata struct {


### PR DESCRIPTION
*Issue #, if available:* #2665

*Description of changes:*
This PR adds a validation step prior to executing a clusterctl move to make sure the workload clusters are ready for a self-managed cluster. This PR does the same thing to https://github.com/aws/eks-anywhere/pull/2668 but it uses `kubectl wait` instead of polling

*Testing (if applicable):*
Manual testing for upgrading two 1-1-1 clusters. It waited for the workload cluster's rolling upgrade to be done before moving.

```
2022-07-07T11:05:16.877-0500    V3      Waiting for all clusters to be ready before move
2022-07-07T11:05:16.877-0500    V6      Executing command       {"cmd": "/usr/local/bin/docker exec -i eksa_1657209528309481000 kubectl get clusters.cluster.x-k8s.io -o json --kubeconfig wk-mgmt/wk-mgmt-eks-a-cluster.kubeconfig --namespace eksa-system"}
2022-07-07T11:05:17.761-0500    V6      Executing command       {"cmd": "/usr/local/bin/docker exec -i eksa_1657209528309481000 kubectl wait --timeout 60m --for=condition=Ready clusters.cluster.x-k8s.io/wk-mgmt --kubeconfig wk-mgmt/wk-mgmt-eks-a-cluster.kubeconfig -n eksa-system"}
2022-07-07T11:05:18.693-0500    V6      Executing command       {"cmd": "/usr/local/bin/docker exec -i eksa_1657209528309481000 kubectl wait --timeout 60m --for=condition=Ready clusters.cluster.x-k8s.io/wk-wl-1 --kubeconfig wk-mgmt/wk-mgmt-eks-a-cluster.kubeconfig -n eksa-system"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

