### PR TITLE
Fix bug of textAnalyzer

### DIFF
--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -225,7 +225,7 @@ func (a *analyzerFactory) namespaceLogTextAnalyzersMap() map[string][]*Analyze {
 
 func (a *analyzerFactory) capiKubeadmControlPlaneSystemLogAnalyzers() []*Analyze {
 	capiCpManagerPod := "capi-kubeadm-control-plane-controller-manager-*"
-	capiCpManagerContainerLogFile := path.Join(capiCpManagerPod, "manager.log")
+	capiCpManagerContainerLogFile := capiCpManagerPod + ".log"
 	fullManagerPodLogPath := path.Join(logpath(constants.CapiKubeadmControlPlaneSystemNamespace), capiCpManagerContainerLogFile)
 	return []*Analyze{
 		{
@@ -233,9 +233,8 @@ func (a *analyzerFactory) capiKubeadmControlPlaneSystemLogAnalyzers() []*Analyze
 				analyzeMeta: analyzeMeta{
 					CheckName: fmt.Sprintf("%s: API server pod missing. Log: %s", logAnalysisAnalyzerPrefix, fullManagerPodLogPath),
 				},
-				CollectorName: constants.CapiKubeadmControlPlaneSystemNamespace,
-				FileName:      capiCpManagerContainerLogFile,
-				RegexPattern:  `machine (.*?) reports APIServerPodHealthy condition is false \(Error, Pod kube-apiserver-(.*?) is missing\)`,
+				FileName:     fullManagerPodLogPath,
+				RegexPattern: `machine (.*?) reports APIServerPodHealthy condition is false \(Error, Pod kube-apiserver-(.*?) is missing\)`,
 				Outcomes: []*outcome{
 					{
 						Fail: &singleOutcome{

--- a/pkg/diagnostics/analyzers_test.go
+++ b/pkg/diagnostics/analyzers_test.go
@@ -26,3 +26,15 @@ func getDeploymentStatusAnalyzer(analyzers []*diagnostics.Analyze, name string) 
 
 	return nil
 }
+
+func TestEksaLogTextAnalyzers(t *testing.T) {
+	collectorFactory := diagnostics.NewDefaultCollectorFactory()
+	collectors := collectorFactory.ManagementClusterCollectors()
+	analyzerFactory := diagnostics.NewAnalyzerFactory()
+	expectAnalzyers := analyzerFactory.EksaLogTextAnalyzers(collectors)
+	for _, analyzer := range expectAnalzyers {
+		if analyzer == nil {
+			t.Errorf("EksaLogTextAnalyzers failed: return a nil analyzer")
+		}
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*
capi Kubeadm Control Plane System Log Analyzers cannot locate the log file due to the wrong file path. Output of the analyzer showed `message: No matching files`.

*Description of changes:*
Fix the bug by giving the analyzer the full manager pod log path and removing the collector name which should not be partial of it.

*Testing (if applicable):*
- run `make` to complie binaries
- then run `./bin/eksctl-anywhere generate support-bundle -f myCluster.yaml`
- the output of that analyzer shows "message: API server pods launched correctly" instead of "No matching files". 
- Details show below: 
`- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: API server pods launched correctly
  title: 'log analysis:: API server pod missing. Log: logs/capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-controller-manager-*.log'
`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

