### PR TITLE
Docker desktop not supported for bare metal

### DIFF
--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -24,7 +24,9 @@ This will let you create a cluster in multiple providers for local development o
 
    {{% alert title="Note" color="primary" %}}
    * If you are using Ubuntu use the [Docker CE](https://docs.docker.com/engine/install/ubuntu/) installation instructions to install Docker and not the Snap installation.
-   * If you are using Mac OS Docker Desktop 4.4.2 or newer `"deprecatedCgroupv1": true` must be set in `~/Library/Group\ Containers/group.com.docker/settings.json`.
+   * If you are using Mac OS Docker Desktop, you need to know that:
+       * For EKS Anywhere Bare Metal, Docker Desktop is not supported
+       * For EKS Anywhere vSphere, if you are using Docker Desktop 4.4.2 or newer `"deprecatedCgroupv1": true` must be set in `~/Library/Group\ Containers/group.com.docker/settings.json`.
    * Currently newer versions of Ubuntu (21.10) and other linux distributions with cgroup v2 enabled are not supported.
    {{% /alert %}}
 

--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -24,9 +24,9 @@ This will let you create a cluster in multiple providers for local development o
 
    {{% alert title="Note" color="primary" %}}
    * If you are using Ubuntu use the [Docker CE](https://docs.docker.com/engine/install/ubuntu/) installation instructions to install Docker and not the Snap installation.
-   * If you are using Mac OS Docker Desktop, you need to know that:
+   * If you are using Docker Desktop, you need to know that:
        * For EKS Anywhere Bare Metal, Docker Desktop is not supported
-       * For EKS Anywhere vSphere, if you are using Docker Desktop 4.4.2 or newer `"deprecatedCgroupv1": true` must be set in `~/Library/Group\ Containers/group.com.docker/settings.json`.
+       * For EKS Anywhere vSphere, if you are using Mac OS Docker Desktop 4.4.2 or newer `"deprecatedCgroupv1": true` must be set in `~/Library/Group\ Containers/group.com.docker/settings.json`.
    * Currently newer versions of Ubuntu (21.10) and other linux distributions with cgroup v2 enabled are not supported.
    {{% /alert %}}
 


### PR DESCRIPTION
*Description of changes:*
This PR adds a note to the [install guide](https://anywhere.eks.amazonaws.com/docs/getting-started/install/) that Docker Desktop is not supported for EKS-A Bare Metal.