### PR TITLE
Add CertManagerExits logic for PackageController Installation

### DIFF
--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -37,6 +37,7 @@ func NewDependenciesForPackages(ctx context.Context, opts ...PackageOpt) (*depen
 		WithManifestReader().
 		WithKubectl().
 		WithHelmInsecure().
+		WithCertManagerClient(kubeconfig.FromEnvironment()).
 		WithCuratedPackagesRegistry(config.registryName, config.kubeVersion, version.Get()).
 		Build(ctx)
 }

--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -151,7 +151,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		WithFluxAddonClient(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().
 		WithEksdInstaller().
-		WithPackageInstaller(clusterSpec, cc.installPackages).
+		WithPackageInstaller(clusterSpec, cc.installPackages, kubeconfigPath).
 		Build(ctx)
 	if err != nil {
 		return err

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -60,6 +60,22 @@ func installPackageController(ctx context.Context) error {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
 
+	// If cert-manager does not exist, instruct users to follow instructions in
+	// PrintCertManagerDoesNotExistMsg to install packages manually.
+	certManagerClient := curatedpackages.NewCertManagerClient(
+		deps.Kubectl,
+		kubeConfig,
+	)
+
+	certManagerExists, err := certManagerClient.CertManagerExists(ctx)
+	if err != nil {
+		return err
+	}
+	if !certManagerExists {
+		curatedpackages.PrintCertManagerDoesNotExistMsg()
+		return nil
+	}
+
 	versionBundle, err := curatedpackages.GetVersionBundle(deps.ManifestReader, version.Get().GitVersion, clusterSpec)
 	if err != nil {
 		return err

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -60,14 +60,7 @@ func installPackageController(ctx context.Context) error {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
 
-	// If cert-manager does not exist, instruct users to follow instructions in
-	// PrintCertManagerDoesNotExistMsg to install packages manually.
-	certManagerClient := curatedpackages.NewCertManagerClient(
-		deps.Kubectl,
-		kubeConfig,
-	)
-
-	certManagerExists, err := certManagerClient.CertManagerExists(ctx)
+	certManagerExists, err := deps.CertManagerClient.CertManagerExists(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 
@@ -60,13 +61,11 @@ func installPackageController(ctx context.Context) error {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
 
-	certManagerExists, err := deps.CertManagerClient.CertManagerExists(ctx)
-	if err != nil {
-		return err
-	}
-	if !certManagerExists {
+	// If cert-manager does not exist, instruct users to follow instructions in
+	// PrintCertManagerDoesNotExistMsg to install packages manually.
+	if !deps.CertManagerClient.CertManagerExists(ctx) {
 		curatedpackages.PrintCertManagerDoesNotExistMsg()
-		return nil
+		return errors.New("cert-manager is not present in the cluster")
 	}
 
 	versionBundle, err := curatedpackages.GetVersionBundle(deps.ManifestReader, version.Get().GitVersion, clusterSpec)

--- a/pkg/curatedpackages/certmanagerclient.go
+++ b/pkg/curatedpackages/certmanagerclient.go
@@ -2,6 +2,8 @@ package curatedpackages
 
 import (
 	"context"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
 )
 
 type CertManagerClient struct {
@@ -20,7 +22,7 @@ func NewCertManagerClient(kubectl KubectlRunner, kubeConfig string) *CertManager
 func (cmc *CertManagerClient) CertManagerExists(ctx context.Context) (bool, error) {
 	// Note although we passed in a namespace parameter in the kubectl command, the GetResource command will be
 	// performed in all namespaces since CRDs are not bounded by namespaces.
-	found, err := cmc.kubectl.GetResource(ctx, "crd", "certificates.cert-manager.io", cmc.kubeConfig, "cert-manager")
+	found, err := cmc.kubectl.GetResource(ctx, "crd", "certificates.cert-manager.io", cmc.kubeConfig, constants.CertManagerNamespace)
 
 	return found, err
 }

--- a/pkg/curatedpackages/certmanagerclient.go
+++ b/pkg/curatedpackages/certmanagerclient.go
@@ -19,10 +19,10 @@ func NewCertManagerClient(kubectl KubectlRunner, kubeConfig string) *CertManager
 }
 
 // CertManagerExists checks if cert-manager exists in any namespace in the cluster.
-func (cmc *CertManagerClient) CertManagerExists(ctx context.Context) (bool, error) {
+func (cmc *CertManagerClient) CertManagerExists(ctx context.Context) bool {
 	// Note although we passed in a namespace parameter in the kubectl command, the GetResource command will be
 	// performed in all namespaces since CRDs are not bounded by namespaces.
-	found, err := cmc.kubectl.GetResource(ctx, "crd", "certificates.cert-manager.io", cmc.kubeConfig, constants.CertManagerNamespace)
+	found, _ := cmc.kubectl.GetResource(ctx, "crd", "certificates.cert-manager.io", cmc.kubeConfig, constants.CertManagerNamespace)
 
-	return found, err
+	return found
 }

--- a/pkg/curatedpackages/certmanagerclient.go
+++ b/pkg/curatedpackages/certmanagerclient.go
@@ -1,0 +1,26 @@
+package curatedpackages
+
+import (
+	"context"
+)
+
+type CertManagerClient struct {
+	kubeConfig string
+	kubectl    KubectlRunner
+}
+
+func NewCertManagerClient(kubectl KubectlRunner, kubeConfig string) *CertManagerClient {
+	return &CertManagerClient{
+		kubeConfig: kubeConfig,
+		kubectl:    kubectl,
+	}
+}
+
+// CertManagerExists checks if cert-manager exists in any namespace in the cluster.
+func (cmc *CertManagerClient) CertManagerExists(ctx context.Context) (bool, error) {
+	// Note although we passed in a namespace parameter in the kubectl command, the GetResource command will be
+	// performed in all namespaces since CRDs are not bounded by namespaces.
+	found, err := cmc.kubectl.GetResource(ctx, "crd", "certificates.cert-manager.io", cmc.kubeConfig, "cert-manager")
+
+	return found, err
+}

--- a/pkg/curatedpackages/curatedpackages.go
+++ b/pkg/curatedpackages/curatedpackages.go
@@ -24,6 +24,9 @@ const (
 (including Section 2 (Betas and Previews)) of the same. During the EKS Anywhere Curated Packages Public Preview,
 the AWS Service Terms are extended to provide customers access to these features free of charge.
 These features will be subject to a service charge and fee structure at ”General Availability“ of the features.`
+	certManagerDoesNotExistMsg = `Curated packages cannot be installed as cert-manager is not present in the cluster. This is most likely caused
+by an action to install Curated packages at a workload cluster. Refer to
+https: //anywhere.eks.amazonaws.com/docs/tasks/packages/ for how to resolve this issue.`
 	width = 112
 )
 
@@ -72,6 +75,19 @@ func PrintLicense() {
 	//----------------------------------------------------------------------------------------------------------------
 	fmt.Println(strings.Repeat("-", width))
 	fmt.Println(license)
+	fmt.Println(strings.Repeat("-", width))
+}
+
+func PrintCertManagerDoesNotExistMsg() {
+	// Currently, use the width of the longest line to repeat the dashes
+	// Sample Output
+	//----------------------------------------------------------------------------------------------------------------
+	//Curated packages cannot be installed as cert-manager is not present in the cluster. This is most likely caused
+	//by an action to install Curated packages at a workload cluster. Refer to
+	//https: //anywhere.eks.amazonaws.com/docs/tasks/packages/ for how to resolve this issue.
+	//----------------------------------------------------------------------------------------------------------------
+	fmt.Println(strings.Repeat("-", width))
+	fmt.Println(certManagerDoesNotExistMsg)
 	fmt.Println(strings.Repeat("-", width))
 }
 

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -19,7 +19,7 @@ type PackageHandler interface {
 }
 
 type CertManager interface {
-	CertManagerExists(ctx context.Context) (bool, error)
+	CertManagerExists(ctx context.Context) bool
 }
 
 type Installer struct {
@@ -59,16 +59,12 @@ func (pi *Installer) InstallCuratedPackages(ctx context.Context) error {
 
 	// If cert-manager does not exist, instruct users to follow instructions in
 	// PrintCertManagerDoesNotExistMsg to install packages manually.
-	certManagerExists, err := pi.certManager.CertManagerExists(ctx)
-	if err != nil {
-		return err
-	}
-	if !certManagerExists {
+	if !pi.certManager.CertManagerExists(ctx) {
 		PrintCertManagerDoesNotExistMsg()
 		return errors.New("Error when installing curated packages on workload cluster; cert manager doesn't exist")
 	}
 
-	err = pi.installPackagesController(ctx)
+	err := pi.installPackagesController(ctx)
 	if err != nil {
 		logger.MarkFail("Error when installing curated packages on workload cluster; please install through eksctl anywhere install packagecontroller command", "error", err)
 		return err

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -30,7 +30,6 @@ type Installer struct {
 }
 
 func NewInstaller(installer ChartInstaller, runner KubectlRunner, spec *cluster.Spec, packagesLocation string) *Installer {
-
 	pcc := newPackageController(installer, runner, spec)
 
 	pc := NewPackageClient(

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -30,14 +30,12 @@ type Installer struct {
 	certManager       CertManager
 }
 
-func NewInstaller(installer ChartInstaller, runner KubectlRunner, spec *cluster.Spec, packagesLocation string) *Installer {
+func NewInstaller(installer ChartInstaller, runner KubectlRunner, spec *cluster.Spec, packagesLocation string, cm *CertManagerClient) *Installer {
 	pcc := newPackageController(installer, runner, spec)
 
 	pc := NewPackageClient(
 		runner,
 	)
-
-	cm := newCertManager(runner, spec)
 
 	return &Installer{
 		spec:              spec,
@@ -54,12 +52,6 @@ func newPackageController(installer ChartInstaller, runner KubectlRunner, spec *
 	chart := spec.VersionsBundle.PackageController.HelmChart
 	imageUrl := urls.ReplaceHost(chart.Image(), spec.Cluster.RegistryMirror())
 	return NewPackageControllerClient(installer, runner, kubeConfig, imageUrl, chart.Name, chart.Tag())
-}
-
-func newCertManager(runner KubectlRunner, spec *cluster.Spec) *CertManagerClient {
-	kubeConfig := kubeconfig.FromClusterName(spec.Cluster.Name)
-
-	return NewCertManagerClient(runner, kubeConfig)
 }
 
 func (pi *Installer) InstallCuratedPackages(ctx context.Context) error {

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -2,6 +2,7 @@ package curatedpackages
 
 import (
 	"context"
+	"errors"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
@@ -72,7 +73,7 @@ func (pi *Installer) InstallCuratedPackages(ctx context.Context) error {
 	}
 	if !certManagerExits {
 		PrintCertManagerDoesNotExistMsg()
-		return nil
+		return errors.New("Error when installing curated packages on workload cluster; cert manager doesn't exist")
 	}
 
 	err = pi.installPackagesController(ctx)

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -67,11 +67,11 @@ func (pi *Installer) InstallCuratedPackages(ctx context.Context) error {
 
 	// If cert-manager does not exist, instruct users to follow instructions in
 	// PrintCertManagerDoesNotExistMsg to install packages manually.
-	certManagerExits, err := pi.certManager.CertManagerExists(ctx)
+	certManagerExists, err := pi.certManager.CertManagerExists(ctx)
 	if err != nil {
 		return err
 	}
-	if !certManagerExits {
+	if !certManagerExists {
 		PrintCertManagerDoesNotExistMsg()
 		return errors.New("Error when installing curated packages on workload cluster; cert manager doesn't exist")
 	}

--- a/pkg/curatedpackages/packageinstaller_test.go
+++ b/pkg/curatedpackages/packageinstaller_test.go
@@ -81,6 +81,16 @@ func TestPackageInstallerSuccess(t *testing.T) {
 	tt.Expect(err).To(BeNil())
 }
 
+func TestPackageInstallerFailWhenCertManagerFails(t *testing.T) {
+	tt := newPackageInstallerTest(t)
+
+	kubeConfigPath := kubeconfig.FromClusterName(tt.spec.Cluster.Name)
+	tt.kubectlRunner.EXPECT().GetResource(tt.ctx, "crd", "certificates.cert-manager.io", kubeConfigPath, "cert-manager").Return(false, nil)
+
+	err := tt.command.InstallCuratedPackages(tt.ctx)
+	tt.Expect(err).NotTo(BeNil())
+}
+
 func TestPackageInstallerFailWhenControllerFails(t *testing.T) {
 	tt := newPackageInstallerTest(t)
 

--- a/pkg/curatedpackages/packageinstaller_test.go
+++ b/pkg/curatedpackages/packageinstaller_test.go
@@ -74,6 +74,7 @@ func TestPackageInstallerSuccess(t *testing.T) {
 	sourceRegistry := fmt.Sprintf("sourceRegistry=%s", registry)
 	values := []string{sourceRegistry}
 	tt.kubectlRunner.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, nil)
+	tt.kubectlRunner.EXPECT().GetResource(tt.ctx, "crd", "certificates.cert-manager.io", kubeConfigPath, "cert-manager").Return(true, nil)
 	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, helmChart.Name, "oci://"+helmChart.Image(), helmChart.Tag(), kubeConfigPath, values).Return(nil)
 
 	err := tt.command.InstallCuratedPackages(tt.ctx)
@@ -88,6 +89,7 @@ func TestPackageInstallerFailWhenControllerFails(t *testing.T) {
 	registry := curatedpackages.GetRegistry(helmChart.URI)
 	sourceRegistry := fmt.Sprintf("sourceRegistry=%s", registry)
 	values := []string{sourceRegistry}
+	tt.kubectlRunner.EXPECT().GetResource(tt.ctx, "crd", "certificates.cert-manager.io", kubeConfigPath, "cert-manager").Return(true, nil)
 	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, helmChart.Name, "oci://"+helmChart.Image(), helmChart.Tag(), kubeConfigPath, values).Return(errors.New("controller installation failed"))
 
 	err := tt.command.InstallCuratedPackages(tt.ctx)
@@ -104,6 +106,7 @@ func TestPackageInstallerFailWhenPackageFails(t *testing.T) {
 	sourceRegistry := fmt.Sprintf("sourceRegistry=%s", registry)
 	values := []string{sourceRegistry}
 	tt.kubectlRunner.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, errors.New("path doesn't exist"))
+	tt.kubectlRunner.EXPECT().GetResource(tt.ctx, "crd", "certificates.cert-manager.io", kubeConfigPath, "cert-manager").Return(true, nil)
 	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, helmChart.Name, "oci://"+helmChart.Image(), helmChart.Tag(), kubeConfigPath, values).Return(nil)
 
 	err := tt.command.InstallCuratedPackages(tt.ctx)

--- a/pkg/curatedpackages/packageinstaller_test.go
+++ b/pkg/curatedpackages/packageinstaller_test.go
@@ -34,6 +34,7 @@ func newPackageInstallerTest(t *testing.T) *packageInstallerTest {
 	k := mocks.NewMockKubectlRunner(ctrl)
 	c := mocks.NewMockChartInstaller(ctrl)
 	packagesPath := "/test/package.yaml"
+
 	spec := &cluster.Spec{
 		Config: &cluster.Config{
 			Cluster: &anywherev1.Cluster{
@@ -53,6 +54,7 @@ func newPackageInstallerTest(t *testing.T) *packageInstallerTest {
 			},
 		},
 	}
+	kubeConfigPath := kubeconfig.FromClusterName(spec.Cluster.Name)
 	return &packageInstallerTest{
 		WithT:          NewWithT(t),
 		ctx:            context.Background(),
@@ -60,7 +62,7 @@ func newPackageInstallerTest(t *testing.T) *packageInstallerTest {
 		kubectlRunner:  k,
 		spec:           spec,
 		packagePath:    packagesPath,
-		command:        curatedpackages.NewInstaller(c, k, spec, packagesPath),
+		command:        curatedpackages.NewInstaller(c, k, spec, packagesPath, curatedpackages.NewCertManagerClient(k, kubeConfigPath)),
 	}
 }
 

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -187,7 +187,7 @@ func TestFactoryBuildWithPackageInstaller(t *testing.T) {
 		WithLocalExecutables().
 		WithHelmInsecure().
 		WithKubectl().
-		WithPackageInstaller(spec, "/test/packages.yaml").
+		WithPackageInstaller(spec, "/test/packages.yaml", spec.Cluster.Name).
 		Build(context.Background())
 	tt.Expect(err).To(BeNil())
 	tt.Expect(deps.PackageInstaller).NotTo(BeNil())


### PR DESCRIPTION
The existence of cert-manager is required to ensure proper operation of the PackageController. We modify the cluster creation workflow and imperative package installation command to add in the CertManagerExits logic, and guide users to handle the case where cert-manager is not present in the cluster.

*Issue #, if available:* https://github.com/aws/eks-anywhere-packages/issues/278

*Description of changes:* Modified the cluster creation workflow and imperative package installation command to add in the CertManagerExits logic

*Testing (if applicable):* Tested in cluster creation workflow and imperative package installation 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

