### PR TITLE
Add sow machine config immutable field validation

### DIFF
--- a/pkg/providers/snow/mocks/client.go
+++ b/pkg/providers/snow/mocks/client.go
@@ -50,6 +50,20 @@ func (mr *MockKubeUnAuthClientMockRecorder) Delete(ctx, name, namespace, kubecon
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockKubeUnAuthClient)(nil).Delete), ctx, name, namespace, kubeconfig, obj)
 }
 
+// Get mocks base method.
+func (m *MockKubeUnAuthClient) Get(ctx context.Context, name, namespace, kubeconfig string, obj runtime.Object) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", ctx, name, namespace, kubeconfig, obj)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockKubeUnAuthClientMockRecorder) Get(ctx, name, namespace, kubeconfig, obj interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockKubeUnAuthClient)(nil).Get), ctx, name, namespace, kubeconfig, obj)
+}
+
 // KubeconfigClient mocks base method.
 func (m *MockKubeUnAuthClient) KubeconfigClient(kubeconfig string) kubernetes.Client {
 	m.ctrl.T.Helper()

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -2,6 +2,7 @@ package snow_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
@@ -335,6 +336,94 @@ func TestSetupAndValidateDeleteClusterNoCertsEnv(t *testing.T) {
 	os.Unsetenv(certsFileEnvVar)
 	err := tt.provider.SetupAndValidateDeleteCluster(tt.ctx, tt.cluster)
 	tt.Expect(err).To(MatchError(ContainSubstring("'EKSA_AWS_CA_BUNDLES_FILE' is not set or is empty")))
+}
+
+func TestValidateNewSpecSuccess(t *testing.T) {
+	tt := newSnowTest(t)
+	tt.kubeUnAuthClient.EXPECT().
+		Get(
+			tt.ctx,
+			tt.clusterSpec.SnowMachineConfigs["test-cp"].Name,
+			tt.clusterSpec.SnowMachineConfigs["test-cp"].Namespace,
+			tt.cluster.KubeconfigFile,
+			&v1alpha1.SnowMachineConfig{},
+		).
+		DoAndReturn(func(_ context.Context, _, _, _ string, obj *v1alpha1.SnowMachineConfig) error {
+			tt.clusterSpec.SnowMachineConfigs["test-cp"].DeepCopyInto(obj)
+			return nil
+		})
+	tt.kubeUnAuthClient.EXPECT().
+		Get(
+			tt.ctx,
+			tt.clusterSpec.SnowMachineConfigs["test-wn"].Name,
+			tt.clusterSpec.SnowMachineConfigs["test-wn"].Namespace,
+			tt.cluster.KubeconfigFile,
+			&v1alpha1.SnowMachineConfig{},
+		).
+		DoAndReturn(func(_ context.Context, _, _, _ string, obj *v1alpha1.SnowMachineConfig) error {
+			tt.clusterSpec.SnowMachineConfigs["test-wn"].DeepCopyInto(obj)
+			return nil
+		})
+	err := tt.provider.ValidateNewSpec(tt.ctx, tt.cluster, tt.clusterSpec)
+	tt.Expect(err).To(Succeed())
+}
+
+func TestValidateNewSpecOldMachineConfigNotFound(t *testing.T) {
+	tt := newSnowTest(t)
+	tt.kubeUnAuthClient.EXPECT().
+		Get(
+			tt.ctx,
+			tt.clusterSpec.SnowMachineConfigs["test-cp"].Name,
+			tt.clusterSpec.SnowMachineConfigs["test-cp"].Namespace,
+			tt.cluster.KubeconfigFile,
+			&v1alpha1.SnowMachineConfig{},
+		).
+		Return(apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: ""}, ""))
+	tt.kubeUnAuthClient.EXPECT().
+		Get(
+			tt.ctx,
+			tt.clusterSpec.SnowMachineConfigs["test-wn"].Name,
+			tt.clusterSpec.SnowMachineConfigs["test-wn"].Namespace,
+			tt.cluster.KubeconfigFile,
+			&v1alpha1.SnowMachineConfig{},
+		).
+		Return(apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: ""}, ""))
+	err := tt.provider.ValidateNewSpec(tt.ctx, tt.cluster, tt.clusterSpec)
+	tt.Expect(err).To(Succeed())
+}
+
+func TestValidateNewSpecFetchOldMachineConfigError(t *testing.T) {
+	tt := newSnowTest(t)
+	tt.kubeUnAuthClient.EXPECT().
+		Get(
+			tt.ctx,
+			tt.clusterSpec.SnowMachineConfigs["test-cp"].Name,
+			tt.clusterSpec.SnowMachineConfigs["test-cp"].Namespace,
+			tt.cluster.KubeconfigFile,
+			&v1alpha1.SnowMachineConfig{},
+		).
+		Return(errors.New("get mc error"))
+	err := tt.provider.ValidateNewSpec(tt.ctx, tt.cluster, tt.clusterSpec)
+	tt.Expect(err).NotTo(Succeed())
+}
+
+func TestValidateNewSpecSshKeyNameChanged(t *testing.T) {
+	tt := newSnowTest(t)
+	tt.kubeUnAuthClient.EXPECT().
+		Get(
+			tt.ctx,
+			tt.clusterSpec.SnowMachineConfigs["test-cp"].Name,
+			tt.clusterSpec.SnowMachineConfigs["test-cp"].Namespace,
+			tt.cluster.KubeconfigFile,
+			&v1alpha1.SnowMachineConfig{},
+		).
+		DoAndReturn(func(_ context.Context, _, _, _ string, obj *v1alpha1.SnowMachineConfig) error {
+			tt.clusterSpec.SnowMachineConfigs["test-cp"].DeepCopyInto(obj)
+			obj.Spec.SshKeyName = "key-2"
+			return nil
+		})
+	err := tt.provider.ValidateNewSpec(tt.ctx, tt.cluster, tt.clusterSpec)
+	tt.Expect(err).To(MatchError(ContainSubstring("spec.sshKeyName is immutable")))
 }
 
 // TODO: add more tests (multi worker node groups, unstacked etcd, etc.)


### PR DESCRIPTION
*Issue #, if available:*

#1106 

*Description of changes:*

Preflight validation for snow machine config fields immutability.

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

