### PR TITLE
Add machine health check for snow

### DIFF
--- a/pkg/clusterapi/machine_health_check.go
+++ b/pkg/clusterapi/machine_health_check.go
@@ -1,0 +1,79 @@
+package clusterapi
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
+)
+
+const (
+	unhealthyConditionTimeout = 5 * time.Minute
+	machineHealthCheckKind    = "MachineHealthCheck"
+	maxUnhealthyControlPlane  = "100%"
+	maxUnhealthyWorker        = "40%"
+)
+
+func machineHealthCheck(clusterName string) *clusterv1.MachineHealthCheck {
+	return &clusterv1.MachineHealthCheck{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: clusterAPIVersion,
+			Kind:       machineHealthCheckKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: constants.EksaSystemNamespace,
+		},
+		Spec: clusterv1.MachineHealthCheckSpec{
+			ClusterName: clusterName,
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{},
+			},
+			UnhealthyConditions: []clusterv1.UnhealthyCondition{
+				{
+					Type:    corev1.NodeReady,
+					Status:  corev1.ConditionUnknown,
+					Timeout: metav1.Duration{Duration: unhealthyConditionTimeout},
+				},
+				{
+					Type:    corev1.NodeReady,
+					Status:  corev1.ConditionFalse,
+					Timeout: metav1.Duration{Duration: unhealthyConditionTimeout},
+				},
+			},
+		},
+	}
+}
+
+func MachineHealthCheckForControlPlane(clusterSpec *cluster.Spec) *clusterv1.MachineHealthCheck {
+	mhc := machineHealthCheck(ClusterName(clusterSpec.Cluster))
+	mhc.SetName(ControlPlaneMachineHealthCheckName(clusterSpec))
+	mhc.Spec.Selector.MatchLabels[clusterv1.MachineControlPlaneLabelName] = ""
+	maxUnhealthy := intstr.Parse(maxUnhealthyControlPlane)
+	mhc.Spec.MaxUnhealthy = &maxUnhealthy
+	return mhc
+}
+
+func MachineHealthCheckForWorkers(clusterSpec *cluster.Spec) map[string]*clusterv1.MachineHealthCheck {
+	m := make(map[string]*clusterv1.MachineHealthCheck, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	for _, workerNodeGroupConfig := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
+		mhc := machineHealthCheckForWorker(clusterSpec, workerNodeGroupConfig)
+		m[workerNodeGroupConfig.Name] = mhc
+	}
+	return m
+}
+
+func machineHealthCheckForWorker(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) *clusterv1.MachineHealthCheck {
+	mhc := machineHealthCheck(ClusterName(clusterSpec.Cluster))
+	mhc.SetName(WorkerMachineHealthCheckName(clusterSpec, workerNodeGroupConfig))
+	mhc.Spec.Selector.MatchLabels[clusterv1.MachineDeploymentLabelName] = MachineDeploymentName(clusterSpec, workerNodeGroupConfig)
+	maxUnhealthy := intstr.Parse(maxUnhealthyWorker)
+	mhc.Spec.MaxUnhealthy = &maxUnhealthy
+	return mhc
+}

--- a/pkg/clusterapi/machine_health_check_test.go
+++ b/pkg/clusterapi/machine_health_check_test.go
@@ -1,0 +1,96 @@
+package clusterapi_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	"github.com/aws/eks-anywhere/pkg/constants"
+)
+
+func TestMachineHealthCheckForControlPlane(t *testing.T) {
+	tt := newApiBuilerTest(t)
+	maxUnhealthy := intstr.Parse("100%")
+	want := &clusterv1.MachineHealthCheck{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "cluster.x-k8s.io/v1beta1",
+			Kind:       "MachineHealthCheck",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-kcp-unhealthy",
+			Namespace: constants.EksaSystemNamespace,
+		},
+		Spec: clusterv1.MachineHealthCheckSpec{
+			ClusterName: "test-cluster",
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"cluster.x-k8s.io/control-plane": "",
+				},
+			},
+			MaxUnhealthy: &maxUnhealthy,
+			UnhealthyConditions: []clusterv1.UnhealthyCondition{
+				{
+					Type:    corev1.NodeReady,
+					Status:  corev1.ConditionUnknown,
+					Timeout: metav1.Duration{Duration: 5 * time.Minute},
+				},
+				{
+					Type:    corev1.NodeReady,
+					Status:  corev1.ConditionFalse,
+					Timeout: metav1.Duration{Duration: 5 * time.Minute},
+				},
+			},
+		},
+	}
+	got := clusterapi.MachineHealthCheckForControlPlane(tt.clusterSpec)
+	tt.Expect(got).To(Equal(want))
+}
+
+func TestMachineHealthCheckForWorkers(t *testing.T) {
+	tt := newApiBuilerTest(t)
+	tt.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{*tt.workerNodeGroupConfig}
+	maxUnhealthy := intstr.Parse("40%")
+	want := map[string]*clusterv1.MachineHealthCheck{
+		"wng-1": {
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "cluster.x-k8s.io/v1beta1",
+				Kind:       "MachineHealthCheck",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster-wng-1-worker-unhealthy",
+				Namespace: constants.EksaSystemNamespace,
+			},
+			Spec: clusterv1.MachineHealthCheckSpec{
+				ClusterName: "test-cluster",
+				Selector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"cluster.x-k8s.io/deployment-name": "test-cluster-wng-1",
+					},
+				},
+				MaxUnhealthy: &maxUnhealthy,
+				UnhealthyConditions: []clusterv1.UnhealthyCondition{
+					{
+						Type:    corev1.NodeReady,
+						Status:  corev1.ConditionUnknown,
+						Timeout: metav1.Duration{Duration: 5 * time.Minute},
+					},
+					{
+						Type:    corev1.NodeReady,
+						Status:  corev1.ConditionFalse,
+						Timeout: metav1.Duration{Duration: 5 * time.Minute},
+					},
+				},
+			},
+		},
+	}
+
+	got := clusterapi.MachineHealthCheckForWorkers(tt.clusterSpec)
+	tt.Expect(got).To(Equal(want))
+}

--- a/pkg/clusterapi/name.go
+++ b/pkg/clusterapi/name.go
@@ -58,3 +58,11 @@ func ControlPlaneMachineTemplateName(clusterSpec *cluster.Spec) string {
 func WorkerMachineTemplateName(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) string {
 	return DefaultObjectName(fmt.Sprintf("%s-%s", clusterSpec.Cluster.Name, workerNodeGroupConfig.Name))
 }
+
+func ControlPlaneMachineHealthCheckName(clusterSpec *cluster.Spec) string {
+	return fmt.Sprintf("%s-kcp-unhealthy", KubeadmControlPlaneName(clusterSpec))
+}
+
+func WorkerMachineHealthCheckName(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) string {
+	return fmt.Sprintf("%s-worker-unhealthy", MachineDeploymentName(clusterSpec, workerNodeGroupConfig))
+}

--- a/pkg/clusterapi/name_test.go
+++ b/pkg/clusterapi/name_test.go
@@ -173,3 +173,39 @@ func TestWorkerMachineTemplateName(t *testing.T) {
 		})
 	}
 }
+
+func TestControlPlaneMachineHealthCheckName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "cp",
+			want: "test-cluster-kcp-unhealthy",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newApiBuilerTest(t)
+			g.Expect(clusterapi.ControlPlaneMachineHealthCheckName(g.clusterSpec)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestWorkerMachineHealthCheckName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "wng 1",
+			want: "test-cluster-wng-1-worker-unhealthy",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newApiBuilerTest(t)
+			g.Expect(clusterapi.WorkerMachineHealthCheckName(g.clusterSpec, *g.workerNodeGroupConfig)).To(Equal(tt.want))
+		})
+	}
+}

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -579,8 +579,8 @@ func (c *ClusterManager) InstallStorageClass(ctx context.Context, cluster *types
 	return nil
 }
 
-func (c *ClusterManager) InstallMachineHealthChecks(ctx context.Context, workloadCluster *types.Cluster, provider providers.Provider) error {
-	mhc, err := provider.GenerateMHC()
+func (c *ClusterManager) InstallMachineHealthChecks(ctx context.Context, clusterSpec *cluster.Spec, workloadCluster *types.Cluster, provider providers.Provider) error {
+	mhc, err := provider.GenerateMHC(clusterSpec)
 	if err != nil {
 		return err
 	}

--- a/pkg/executables/builder.go
+++ b/pkg/executables/builder.go
@@ -17,6 +17,7 @@ type ExecutableBuilder interface {
 	Init(ctx context.Context) (Closer, error)
 	Build(binaryPath string) Executable
 }
+
 type ExecutablesBuilder struct {
 	executableBuilder ExecutableBuilder
 }

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -1021,7 +1021,7 @@ func (p *cloudstackProvider) machineConfigsSpecChanged(ctx context.Context, cc *
 	return false, nil
 }
 
-func (p *cloudstackProvider) GenerateMHC() ([]byte, error) {
+func (p *cloudstackProvider) GenerateMHC(_ *cluster.Spec) ([]byte, error) {
 	data := map[string]string{
 		"clusterName":         p.clusterConfig.Name,
 		"eksaSystemNamespace": constants.EksaSystemNamespace,

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -989,7 +989,7 @@ spec:
       timeout: 300s
 `, constants.EksaSystemNamespace)
 
-	mch, err := provider.GenerateMHC()
+	mch, err := provider.GenerateMHC(nil)
 	assert.NoError(t, err, "Expected successful execution of GenerateMHC() but got an error", "error", err)
 	assert.Equal(t, string(mch), mhcTemplate, "generated MachineHealthCheck is different from the expected one")
 }

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -424,7 +424,7 @@ func (p *provider) GenerateStorageClass() []byte {
 	return nil
 }
 
-func (p *provider) GenerateMHC() ([]byte, error) {
+func (p *provider) GenerateMHC(_ *cluster.Spec) ([]byte, error) {
 	return []byte{}, nil
 }
 

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -158,18 +158,18 @@ func (mr *MockProviderMockRecorder) GenerateCAPISpecForUpgrade(arg0, arg1, arg2,
 }
 
 // GenerateMHC mocks base method.
-func (m *MockProvider) GenerateMHC() ([]byte, error) {
+func (m *MockProvider) GenerateMHC(arg0 *cluster.Spec) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateMHC")
+	ret := m.ctrl.Call(m, "GenerateMHC", arg0)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GenerateMHC indicates an expected call of GenerateMHC.
-func (mr *MockProviderMockRecorder) GenerateMHC() *gomock.Call {
+func (mr *MockProviderMockRecorder) GenerateMHC(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateMHC", reflect.TypeOf((*MockProvider)(nil).GenerateMHC))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateMHC", reflect.TypeOf((*MockProvider)(nil).GenerateMHC), arg0)
 }
 
 // GenerateStorageClass mocks base method.

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -35,7 +35,7 @@ type Provider interface {
 	MachineResourceType() string
 	MachineConfigs(clusterSpec *cluster.Spec) []MachineConfig
 	ValidateNewSpec(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
-	GenerateMHC() ([]byte, error)
+	GenerateMHC(clusterSpec *cluster.Spec) ([]byte, error)
 	ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff
 	RunPostControlPlaneUpgrade(ctx context.Context, oldClusterSpec *cluster.Spec, clusterSpec *cluster.Spec, workloadCluster *types.Cluster, managementCluster *types.Cluster) error
 	UpgradeNeeded(ctx context.Context, newSpec, currentSpec *cluster.Spec, cluster *types.Cluster) (bool, error)

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -21,8 +21,7 @@ const (
 )
 
 func CAPICluster(clusterSpec *cluster.Spec, snowCluster *snowv1.AWSSnowCluster, kubeadmControlPlane *controlplanev1.KubeadmControlPlane) *clusterv1.Cluster {
-	cluster := clusterapi.Cluster(clusterSpec, snowCluster, kubeadmControlPlane)
-	return cluster
+	return clusterapi.Cluster(clusterSpec, snowCluster, kubeadmControlPlane)
 }
 
 func KubeadmControlPlane(clusterSpec *cluster.Spec, snowMachineTemplate *snowv1.AWSSnowMachineTemplate) (*controlplanev1.KubeadmControlPlane, error) {
@@ -92,8 +91,7 @@ func kubeadmConfigTemplate(clusterSpec *cluster.Spec, workerNodeGroupConfig v1al
 }
 
 func machineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration, kubeadmConfigTemplate *bootstrapv1.KubeadmConfigTemplate, snowMachineTemplate *snowv1.AWSSnowMachineTemplate) clusterv1.MachineDeployment {
-	md := clusterapi.MachineDeployment(clusterSpec, workerNodeGroupConfig, kubeadmConfigTemplate, snowMachineTemplate)
-	return md
+	return clusterapi.MachineDeployment(clusterSpec, workerNodeGroupConfig, kubeadmConfigTemplate, snowMachineTemplate)
 }
 
 func MachineDeployments(clusterSpec *cluster.Spec, kubeadmConfigTemplates map[string]*bootstrapv1.KubeadmConfigTemplate, machineTemplates map[string]*snowv1.AWSSnowMachineTemplate) map[string]*clusterv1.MachineDeployment {

--- a/pkg/providers/snow/objects.go
+++ b/pkg/providers/snow/objects.go
@@ -172,3 +172,13 @@ func recreateKubeadmConfigTemplateNeeded(new, old *bootstrapv1.KubeadmConfigTemp
 	}
 	return !equality.Semantic.DeepDerivative(new.Spec, old.Spec)
 }
+
+// MachineHealthCheckObjects creates MachineHealthCheck resources for control plane and all the worker node groups.
+func MachineHealthCheckObjects(clusterSpec *cluster.Spec) []runtime.Object {
+	mhcWorkers := clusterapi.MachineHealthCheckForWorkers(clusterSpec)
+	o := make([]runtime.Object, 0, len(mhcWorkers)+1)
+	for _, item := range mhcWorkers {
+		o = append(o, item)
+	}
+	return append(o, clusterapi.MachineHealthCheckForControlPlane(clusterSpec))
+}

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -225,8 +225,8 @@ func (p *SnowProvider) ValidateNewSpec(ctx context.Context, cluster *types.Clust
 	return nil
 }
 
-func (p *SnowProvider) GenerateMHC() ([]byte, error) {
-	return nil, nil
+func (p *SnowProvider) GenerateMHC(clusterSpec *cluster.Spec) ([]byte, error) {
+	return templater.ObjectsToYaml(MachineHealthCheckObjects(clusterSpec)...)
 }
 
 func (p *SnowProvider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -482,6 +482,13 @@ func TestMachineConfigs(t *testing.T) {
 	tt.Expect(len(want)).To(Equal(2))
 }
 
+func TestGenerateMHC(t *testing.T) {
+	tt := newSnowTest(t)
+	got, err := tt.provider.GenerateMHC(tt.clusterSpec)
+	tt.Expect(err).To(Succeed())
+	test.AssertContentToFile(t, string(got), "testdata/expected_results_machine_health_check.yaml")
+}
+
 func TestDeleteResources(t *testing.T) {
 	tt := newSnowTest(t)
 	tt.kubeUnAuthClient.EXPECT().Delete(

--- a/pkg/providers/snow/testdata/expected_results_machine_health_check.yaml
+++ b/pkg/providers/snow/testdata/expected_results_machine_health_check.yaml
@@ -1,0 +1,50 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  creationTimestamp: null
+  name: snow-test-md-0-worker-unhealthy
+  namespace: eksa-system
+spec:
+  clusterName: snow-test
+  maxUnhealthy: 40%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/deployment-name: snow-test-md-0
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 5m0s
+    type: Ready
+  - status: "False"
+    timeout: 5m0s
+    type: Ready
+status:
+  currentHealthy: 0
+  expectedMachines: 0
+  remediationsAllowed: 0
+
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  creationTimestamp: null
+  name: snow-test-kcp-unhealthy
+  namespace: eksa-system
+spec:
+  clusterName: snow-test
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 5m0s
+    type: Ready
+  - status: "False"
+    timeout: 5m0s
+    type: Ready
+status:
+  currentHealthy: 0
+  expectedMachines: 0
+  remediationsAllowed: 0
+
+---

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -324,7 +324,7 @@ func (p *Provider) GenerateStorageClass() []byte {
 	return nil
 }
 
-func (p *Provider) GenerateMHC() ([]byte, error) {
+func (p *Provider) GenerateMHC(_ *cluster.Spec) ([]byte, error) {
 	data := map[string]string{
 		"clusterName":         p.clusterConfig.Name,
 		"eksaSystemNamespace": constants.EksaSystemNamespace,

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1073,7 +1073,7 @@ func (p *vsphereProvider) GenerateStorageClass() []byte {
 	return defaultStorageClass
 }
 
-func (p *vsphereProvider) GenerateMHC() ([]byte, error) {
+func (p *vsphereProvider) GenerateMHC(_ *cluster.Spec) ([]byte, error) {
 	data := map[string]string{
 		"clusterName":         p.clusterConfig.Name,
 		"eksaSystemNamespace": constants.EksaSystemNamespace,

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -2748,7 +2748,7 @@ spec:
       timeout: 300s
 `, constants.EksaSystemNamespace)
 
-	mch, err := provider.GenerateMHC()
+	mch, err := provider.GenerateMHC(nil)
 	assert.NoError(t, err, "Expected successful execution of GenerateMHC() but got an error", "error", err)
 	assert.Equal(t, string(mch), mhcTemplate, "generated MachineHealthCheck is different from the expected one")
 }

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -263,7 +263,7 @@ func (s *CreateWorkloadClusterTask) Run(ctx context.Context, commandContext *tas
 	}
 
 	logger.V(4).Info("Installing machine health checks on bootstrap cluster")
-	err = commandContext.ClusterManager.InstallMachineHealthChecks(ctx, commandContext.BootstrapCluster, commandContext.Provider)
+	err = commandContext.ClusterManager.InstallMachineHealthChecks(ctx, commandContext.ClusterSpec, commandContext.BootstrapCluster, commandContext.Provider)
 	if err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -232,7 +232,7 @@ func (c *createTestSetup) expectNotDeleteBootstrap() {
 func (c *createTestSetup) expectInstallMHC() {
 	gomock.InOrder(
 		c.clusterManager.EXPECT().InstallMachineHealthChecks(
-			c.ctx, c.bootstrapCluster, c.provider,
+			c.ctx, c.clusterSpec, c.bootstrapCluster, c.provider,
 		),
 	)
 }

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -33,7 +33,7 @@ type ClusterManager interface {
 	PauseEKSAControllerReconcile(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	ResumeEKSAControllerReconcile(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	EKSAClusterSpecChanged(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) (bool, error)
-	InstallMachineHealthChecks(ctx context.Context, workloadCluster *types.Cluster, provider providers.Provider) error
+	InstallMachineHealthChecks(ctx context.Context, clusterSpec *cluster.Spec, workloadCluster *types.Cluster, provider providers.Provider) error
 	GetCurrentClusterSpec(ctx context.Context, cluster *types.Cluster, clusterName string) (*cluster.Spec, error)
 	Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error)
 	InstallAwsIamAuth(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec) error

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -240,17 +240,17 @@ func (mr *MockClusterManagerMockRecorder) InstallCustomComponents(arg0, arg1, ar
 }
 
 // InstallMachineHealthChecks mocks base method.
-func (m *MockClusterManager) InstallMachineHealthChecks(arg0 context.Context, arg1 *types.Cluster, arg2 providers.Provider) error {
+func (m *MockClusterManager) InstallMachineHealthChecks(arg0 context.Context, arg1 *cluster.Spec, arg2 *types.Cluster, arg3 providers.Provider) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallMachineHealthChecks", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "InstallMachineHealthChecks", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallMachineHealthChecks indicates an expected call of InstallMachineHealthChecks.
-func (mr *MockClusterManagerMockRecorder) InstallMachineHealthChecks(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClusterManagerMockRecorder) InstallMachineHealthChecks(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMachineHealthChecks", reflect.TypeOf((*MockClusterManager)(nil).InstallMachineHealthChecks), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMachineHealthChecks", reflect.TypeOf((*MockClusterManager)(nil).InstallMachineHealthChecks), arg0, arg1, arg2, arg3)
 }
 
 // InstallNetworking mocks base method.


### PR DESCRIPTION
*Issue #, if available:*

#1105 

*Description of changes:*

Add machine health check in api builder, for both control plane and worker machines. Currently it's only used in Snow provider.

While adding this feature to snow, I realize all the other providers only have machine health check for single worker node group. We should add multiple worker node group support for vsphere, cloudstack, docker, and tinkerbell machine health check. Created issue #2722 

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

