### PR TITLE
Introduce existing cluster spec parameter to SetupAndValidateUpgrade

### DIFF
--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -409,7 +409,7 @@ func (p *cloudstackProvider) SetupAndValidateCreateCluster(ctx context.Context, 
 	return nil
 }
 
-func (p *cloudstackProvider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
+func (p *cloudstackProvider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *types.Cluster, _, clusterSpec *cluster.Spec) error {
 	if err := p.validateEnv(ctx); err != nil {
 		return fmt.Errorf("validating environment variables: %v", err)
 	}

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -282,7 +282,7 @@ func TestProviderSetupAndValidateUpgradeClusterFailureOnInvalidUrl(t *testing.T)
 	}
 
 	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, cloudStackCloudConfigWithInvalidUrl)
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	tt.Expect(err).NotTo(BeNil())
 }
 
@@ -340,7 +340,7 @@ func TestProviderSetupAndValidateUpgradeClusterFailureOnInvalidClusterSpec(t *te
 	cmk := givenWildcardCmk(mockCtrl)
 	provider := newProviderWithKubectl(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, kubectl, cmk)
 
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	tt.Expect(err).NotTo(BeNil())
 }
 
@@ -1349,7 +1349,7 @@ func TestSetupAndValidateUpgradeCluster(t *testing.T) {
 	tctx.SaveContext()
 
 	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	if err != nil {
 		t.Fatalf("unexpected failure %v", err)
 	}
@@ -1371,7 +1371,7 @@ func TestSetupAndValidateUpgradeClusterCPSshNotExists(t *testing.T) {
 
 	cluster := &types.Cluster{}
 	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	if err != nil {
 		t.Fatalf("unexpected failure %v", err)
 	}
@@ -1394,7 +1394,7 @@ func TestSetupAndValidateUpgradeClusterWorkerSshNotExists(t *testing.T) {
 	cluster := &types.Cluster{}
 	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
 
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	if err != nil {
 		t.Fatalf("unexpected failure %v", err)
 	}
@@ -1417,7 +1417,7 @@ func TestSetupAndValidateUpgradeClusterEtcdSshNotExists(t *testing.T) {
 	cluster := &types.Cluster{}
 	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
 
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	if err != nil {
 		t.Fatalf("unexpected failure %v", err)
 	}
@@ -1435,7 +1435,7 @@ func TestSetupAndValidateForUpgradeSSHAuthorizedKeyInvalidCP(t *testing.T) {
 	tctx.SaveContext()
 
 	cluster := &types.Cluster{}
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	thenErrorExpected(t, "setting up SSH keys: ssh: no key found", err)
 }
 
@@ -1451,7 +1451,7 @@ func TestSetupAndValidateForUpgradeSSHAuthorizedKeyInvalidWorker(t *testing.T) {
 	tctx.SaveContext()
 
 	cluster := &types.Cluster{}
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	thenErrorExpected(t, "setting up SSH keys: ssh: no key found", err)
 }
 
@@ -1467,7 +1467,7 @@ func TestSetupAndValidateForUpgradeSSHAuthorizedKeyInvalidEtcd(t *testing.T) {
 	tctx.SaveContext()
 
 	cluster := &types.Cluster{}
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	thenErrorExpected(t, "setting up SSH keys: ssh: no key found", err)
 }
 

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -125,7 +125,7 @@ func (p *provider) SetupAndValidateDeleteCluster(ctx context.Context, _ *types.C
 	return nil
 }
 
-func (p *provider) SetupAndValidateUpgradeCluster(ctx context.Context, _ *types.Cluster, _ *cluster.Spec) error {
+func (p *provider) SetupAndValidateUpgradeCluster(ctx context.Context, _ *types.Cluster, _, _ *cluster.Spec) error {
 	return nil
 }
 

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -383,17 +383,17 @@ func (mr *MockProviderMockRecorder) SetupAndValidateDeleteCluster(arg0, arg1 int
 }
 
 // SetupAndValidateUpgradeCluster mocks base method.
-func (m *MockProvider) SetupAndValidateUpgradeCluster(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec) error {
+func (m *MockProvider) SetupAndValidateUpgradeCluster(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 *cluster.Spec) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetupAndValidateUpgradeCluster", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetupAndValidateUpgradeCluster", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetupAndValidateUpgradeCluster indicates an expected call of SetupAndValidateUpgradeCluster.
-func (mr *MockProviderMockRecorder) SetupAndValidateUpgradeCluster(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockProviderMockRecorder) SetupAndValidateUpgradeCluster(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupAndValidateUpgradeCluster", reflect.TypeOf((*MockProvider)(nil).SetupAndValidateUpgradeCluster), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupAndValidateUpgradeCluster", reflect.TypeOf((*MockProvider)(nil).SetupAndValidateUpgradeCluster), arg0, arg1, arg2, arg3)
 }
 
 // UpdateKubeConfig mocks base method.

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -13,7 +13,7 @@ type Provider interface {
 	Name() string
 	SetupAndValidateCreateCluster(ctx context.Context, clusterSpec *cluster.Spec) error
 	SetupAndValidateDeleteCluster(ctx context.Context, cluster *types.Cluster) error
-	SetupAndValidateUpgradeCluster(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
+	SetupAndValidateUpgradeCluster(ctx context.Context, cluster *types.Cluster, current, desired *cluster.Spec) error
 	UpdateSecrets(ctx context.Context, cluster *types.Cluster) error
 	GenerateCAPISpecForCreate(ctx context.Context, managementCluster *types.Cluster, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error)
 	GenerateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currrentSpec, newClusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error)

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -81,7 +81,7 @@ func (p *SnowProvider) SetupAndValidateCreateCluster(ctx context.Context, cluste
 	return nil
 }
 
-func (p *SnowProvider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
+func (p *SnowProvider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *types.Cluster, _, clusterSpec *cluster.Spec) error {
 	if err := p.setupBootstrapCreds(); err != nil {
 		return fmt.Errorf("setting up credentials: %v", err)
 	}

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -294,7 +294,7 @@ func TestSetupAndValidateUpgradeClusterSuccess(t *testing.T) {
 	setupContext(t)
 	tt.aws.EXPECT().EC2ImageExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
 	tt.aws.EXPECT().EC2KeyNameExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
-	err := tt.provider.SetupAndValidateUpgradeCluster(tt.ctx, tt.cluster, tt.clusterSpec)
+	err := tt.provider.SetupAndValidateUpgradeCluster(tt.ctx, tt.cluster, tt.clusterSpec, tt.clusterSpec)
 	tt.Expect(err).To(Succeed())
 }
 
@@ -302,7 +302,7 @@ func TestSetupAndValidateUpgradeClusterNoCredsEnv(t *testing.T) {
 	tt := newSnowTest(t)
 	setupContext(t)
 	os.Unsetenv(credsFileEnvVar)
-	err := tt.provider.SetupAndValidateUpgradeCluster(tt.ctx, tt.cluster, tt.clusterSpec)
+	err := tt.provider.SetupAndValidateUpgradeCluster(tt.ctx, tt.cluster, nil, tt.clusterSpec)
 	tt.Expect(err).To(MatchError(ContainSubstring("'EKSA_AWS_CREDENTIALS_FILE' is not set or is empty")))
 }
 
@@ -310,7 +310,7 @@ func TestSetupAndValidateUpgradeClusterNoCertsEnv(t *testing.T) {
 	tt := newSnowTest(t)
 	setupContext(t)
 	os.Unsetenv(certsFileEnvVar)
-	err := tt.provider.SetupAndValidateUpgradeCluster(tt.ctx, tt.cluster, tt.clusterSpec)
+	err := tt.provider.SetupAndValidateUpgradeCluster(tt.ctx, tt.cluster, nil, tt.clusterSpec)
 	tt.Expect(err).To(MatchError(ContainSubstring("'EKSA_AWS_CA_BUNDLES_FILE' is not set or is empty")))
 }
 

--- a/pkg/providers/tinkerbell/assert_test.go
+++ b/pkg/providers/tinkerbell/assert_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestAssertMachineConfigsValid_ValidSucceds(t *testing.T) {
 	g := gomega.NewWithT(t)
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 	g.Expect(tinkerbell.AssertMachineConfigsValid(clusterSpec)).To(gomega.Succeed())
 }
 
@@ -40,7 +40,7 @@ func TestAssertMachineConfigsValid_InvalidFails(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
-			spec := NewDefaultValidClusterSpecBuilder().Build()
+			spec := DefaultClusterSpec()
 			mutate(spec)
 			g.Expect(tinkerbell.AssertMachineConfigsValid(spec)).ToNot(gomega.Succeed())
 		})
@@ -49,7 +49,7 @@ func TestAssertMachineConfigsValid_InvalidFails(t *testing.T) {
 
 func TestAssertDatacenterConfigValid_ValidSucceeds(t *testing.T) {
 	g := gomega.NewWithT(t)
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 	g.Expect(tinkerbell.AssertDatacenterConfigValid(clusterSpec)).To(gomega.Succeed())
 }
 
@@ -68,7 +68,7 @@ func TestAssertDatacenterConfigValid_InvalidFails(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			cluster := NewDefaultValidClusterSpecBuilder().Build()
+			cluster := DefaultClusterSpec()
 			mutate(cluster)
 			g.Expect(tinkerbell.AssertDatacenterConfigValid(cluster)).ToNot(gomega.Succeed())
 		})
@@ -77,7 +77,7 @@ func TestAssertDatacenterConfigValid_InvalidFails(t *testing.T) {
 
 func TestAssertMachineConfigNamespaceMatchesDatacenterConfig_Same(t *testing.T) {
 	g := gomega.NewWithT(t)
-	builder := NewDefaultValidClusterSpecBuilder()
+	builder := DefaultClusterSpecBuilder()
 	clusterSpec := builder.Build()
 	err := tinkerbell.AssertMachineConfigNamespaceMatchesDatacenterConfig(clusterSpec)
 	g.Expect(err).To(gomega.Succeed())
@@ -85,7 +85,7 @@ func TestAssertMachineConfigNamespaceMatchesDatacenterConfig_Same(t *testing.T) 
 
 func TestAssertMachineConfigNamespaceMatchesDatacenterConfig_Different(t *testing.T) {
 	g := gomega.NewWithT(t)
-	builder := NewDefaultValidClusterSpecBuilder()
+	builder := DefaultClusterSpecBuilder()
 	clusterSpec := builder.Build()
 
 	// Invalidate the namespace check.
@@ -97,13 +97,13 @@ func TestAssertMachineConfigNamespaceMatchesDatacenterConfig_Different(t *testin
 
 func TestAssertEtcdMachineRefExists_Exists(t *testing.T) {
 	g := gomega.NewWithT(t)
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 	g.Expect(tinkerbell.AssertEtcdMachineRefExists(clusterSpec)).To(gomega.Succeed())
 }
 
 func TestAssertEtcdMachineRefExists_Missing(t *testing.T) {
 	g := gomega.NewWithT(t)
-	builder := NewDefaultValidClusterSpecBuilder()
+	builder := DefaultClusterSpecBuilder()
 	clusterSpec := builder.Build()
 	delete(clusterSpec.MachineConfigs, builder.ExternalEtcdMachineName)
 	g.Expect(tinkerbell.AssertEtcdMachineRefExists(clusterSpec)).ToNot(gomega.Succeed())
@@ -111,13 +111,13 @@ func TestAssertEtcdMachineRefExists_Missing(t *testing.T) {
 
 func TestAssertWorkerNodeGroupMachineRefsExists_Exists(t *testing.T) {
 	g := gomega.NewWithT(t)
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 	g.Expect(tinkerbell.AssertWorkerNodeGroupMachineRefsExists(clusterSpec)).To(gomega.Succeed())
 }
 
 func TestAssertWorkerNodeGroupMachineRefsExists_Missing(t *testing.T) {
 	g := gomega.NewWithT(t)
-	builder := NewDefaultValidClusterSpecBuilder()
+	builder := DefaultClusterSpecBuilder()
 	clusterSpec := builder.Build()
 	delete(clusterSpec.MachineConfigs, builder.WorkerNodeGroupMachineName)
 	g.Expect(tinkerbell.AssertWorkerNodeGroupMachineRefsExists(clusterSpec)).ToNot(gomega.Succeed())
@@ -125,7 +125,7 @@ func TestAssertWorkerNodeGroupMachineRefsExists_Missing(t *testing.T) {
 
 func TestAssertEtcdMachineRefExists_ExternalEtcdUnspecified(t *testing.T) {
 	g := gomega.NewWithT(t)
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
 	g.Expect(tinkerbell.AssertEtcdMachineRefExists(clusterSpec)).To(gomega.Succeed())
 }
@@ -140,7 +140,7 @@ func TestNewIPNotInUseAssertion_NotInUseSucceeds(t *testing.T) {
 		Times(5).
 		Return(nil, errors.New("failed to connect"))
 
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 
 	assertion := tinkerbell.NewIPNotInUseAssertion(netClient)
 	g.Expect(assertion(clusterSpec)).To(gomega.Succeed())
@@ -158,16 +158,16 @@ func TestNewIPNotInUseAssertion_InUseFails(t *testing.T) {
 		DialTimeout(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(client, nil)
 
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 
 	assertion := tinkerbell.NewIPNotInUseAssertion(netClient)
 	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }
 
-func TestMinimumHardwareAvailableAssertionForCreate_SufficientSucceeds(t *testing.T) {
+func TestMinimumHardwareForCreate_SufficientSucceeds(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 
 	catalogue := hardware.NewCatalogue()
 
@@ -194,14 +194,14 @@ func TestMinimumHardwareAvailableAssertionForCreate_SufficientSucceeds(t *testin
 		},
 	})).To(gomega.Succeed())
 
-	assertion := tinkerbell.MinimumHardwareAvailableAssertionForCreate(catalogue)
+	assertion := tinkerbell.MinimumHardwareForCreate(catalogue)
 	g.Expect(assertion(clusterSpec)).To(gomega.Succeed())
 }
 
-func TestMinimumHardwareAvailableAssertionForCreate_SufficientSucceedsWithoutExternalEtcd(t *testing.T) {
+func TestMinimumHardwareForCreate_SufficientSucceedsWithoutExternalEtcd(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
 
 	catalogue := hardware.NewCatalogue()
@@ -222,14 +222,14 @@ func TestMinimumHardwareAvailableAssertionForCreate_SufficientSucceedsWithoutExt
 		},
 	})).To(gomega.Succeed())
 
-	assertion := tinkerbell.MinimumHardwareAvailableAssertionForCreate(catalogue)
+	assertion := tinkerbell.MinimumHardwareForCreate(catalogue)
 	g.Expect(assertion(clusterSpec)).To(gomega.Succeed())
 }
 
-func TestMinimumHardwareAvailableAssertionForCreate_NoControlPlaneSelectorMatchesAnything(t *testing.T) {
+func TestMinimumHardwareForCreate_NoControlPlaneSelectorMatchesAnything(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 	clusterSpec.ControlPlaneMachineConfig().Spec.HardwareSelector = eksav1alpha1.HardwareSelector{}
 	clusterSpec.WorkerNodeGroupConfigurations()[0].Count = 0
 	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
@@ -239,14 +239,14 @@ func TestMinimumHardwareAvailableAssertionForCreate_NoControlPlaneSelectorMatche
 	// Add something to match the control plane selector.
 	g.Expect(catalogue.InsertHardware(&v1alpha1.Hardware{})).To(gomega.Succeed())
 
-	assertion := tinkerbell.MinimumHardwareAvailableAssertionForCreate(catalogue)
+	assertion := tinkerbell.MinimumHardwareForCreate(catalogue)
 	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }
 
-func TestMinimumHardwareAvailableAssertionForCreate_NoExternalEtcdSelectorMatchesAnything(t *testing.T) {
+func TestMinimumHardwareForCreate_NoExternalEtcdSelectorMatchesAnything(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 	clusterSpec.ControlPlaneConfiguration().Count = 0
 	clusterSpec.WorkerNodeGroupConfigurations()[0].Count = 0
 	clusterSpec.ExternalEtcdMachineConfig().Spec.HardwareSelector = eksav1alpha1.HardwareSelector{}
@@ -256,14 +256,14 @@ func TestMinimumHardwareAvailableAssertionForCreate_NoExternalEtcdSelectorMatche
 	// Add something to match the control plane selector.
 	g.Expect(catalogue.InsertHardware(&v1alpha1.Hardware{})).To(gomega.Succeed())
 
-	assertion := tinkerbell.MinimumHardwareAvailableAssertionForCreate(catalogue)
+	assertion := tinkerbell.MinimumHardwareForCreate(catalogue)
 	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }
 
-func TestMinimumHardwareAvailableAssertionForCreate_NoWorkerNodeGroupSelectorMatchesAnything(t *testing.T) {
+func TestMinimumHardwareForCreate_NoWorkerNodeGroupSelectorMatchesAnything(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 	clusterSpec.ControlPlaneConfiguration().Count = 0
 	nodeGroup := clusterSpec.WorkerNodeGroupMachineConfig(clusterSpec.WorkerNodeGroupConfigurations()[0])
 	nodeGroup.Spec.HardwareSelector = eksav1alpha1.HardwareSelector{}
@@ -274,35 +274,35 @@ func TestMinimumHardwareAvailableAssertionForCreate_NoWorkerNodeGroupSelectorMat
 	// Add something to match the control plane selector.
 	g.Expect(catalogue.InsertHardware(&v1alpha1.Hardware{})).To(gomega.Succeed())
 
-	assertion := tinkerbell.MinimumHardwareAvailableAssertionForCreate(catalogue)
+	assertion := tinkerbell.MinimumHardwareForCreate(catalogue)
 	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }
 
-func TestMinimumHardwareAvailableAssertionForCreate_InsufficientFails(t *testing.T) {
+func TestMinimumHardwareForCreate_InsufficientFails(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	catalogue := hardware.NewCatalogue()
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 
-	assertion := tinkerbell.MinimumHardwareAvailableAssertionForCreate(catalogue)
+	assertion := tinkerbell.MinimumHardwareForCreate(catalogue)
 	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }
 
-func TestMinimumHardwareAvailableAssertionForCreate_InsufficientFailsWithoutExternalEtcd(t *testing.T) {
+func TestMinimumHardwareForCreate_InsufficientFailsWithoutExternalEtcd(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	catalogue := hardware.NewCatalogue()
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
 
-	assertion := tinkerbell.MinimumHardwareAvailableAssertionForCreate(catalogue)
+	assertion := tinkerbell.MinimumHardwareForCreate(catalogue)
 	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }
 
 func TestHardwareSatisfiesOnlyOneSelectorAssertion_MeetsOnlyOneSelector(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
 
 	catalogue := hardware.NewCatalogue()
@@ -319,7 +319,7 @@ func TestHardwareSatisfiesOnlyOneSelectorAssertion_MeetsOnlyOneSelector(t *testi
 func TestHardwareSatisfiesOnlyOneSelectorAssertion_MeetsMultipleSelectorFails(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 
 	// Ensure we have distinct labels for selectors so we can populate the same key on the
 	// test hardware.
@@ -345,7 +345,7 @@ func TestHardwareSatisfiesOnlyOneSelectorAssertion_MeetsMultipleSelectorFails(t 
 func TestHardwareSatisfiesOnlyOneSelectorAssertion_NoLabelsMeetsNothing(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec := DefaultClusterSpec()
 
 	catalogue := hardware.NewCatalogue()
 	g.Expect(catalogue.InsertHardware(&v1alpha1.Hardware{})).To(gomega.Succeed())
@@ -360,4 +360,203 @@ func mergeHardwareSelectors(m1, m2 map[string]string) map[string]string {
 		m1[name] = value
 	}
 	return m1
+}
+
+func TestMinimumHardwareForUpgrade(t *testing.T) {
+	for name, d := range map[string]struct {
+		specs     func() (current, desired *tinkerbell.ClusterSpec)
+		catalogue func(current, desired *tinkerbell.ClusterSpec) *hardware.Catalogue
+		result    gomega.OmegaMatcher
+	}{
+		"KubernetesVersion": {
+			specs: func() (current, desired *tinkerbell.ClusterSpec) {
+				current, desired = DefaultClusterSpec(), DefaultClusterSpec()
+				desired.Cluster.Spec.KubernetesVersion = "1.22"
+				current.Cluster.Spec.ExternalEtcdConfiguration = nil
+				return current, desired
+			},
+			catalogue: versionUpgradeCatalogue,
+			result:    gomega.Succeed(),
+		},
+		"ScaleControlPlane": {
+			specs: func() (current, desired *tinkerbell.ClusterSpec) {
+				current, desired = DefaultClusterSpec(), DefaultClusterSpec()
+				desired.Cluster.Spec.ControlPlaneConfiguration.Count = 2
+				return current, desired
+			},
+			catalogue: scaleUpgradeCatalogue,
+			result:    gomega.Succeed(),
+		},
+		"ScaleChangeWorkerNodeGroup": {
+			specs: func() (current, desired *tinkerbell.ClusterSpec) {
+				current, desired = DefaultClusterSpec(), DefaultClusterSpec()
+				desired.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 2
+				return current, desired
+			},
+			catalogue: scaleUpgradeCatalogue,
+			result:    gomega.Succeed(),
+		},
+		"ScaleDeleteWorkerNodeGroup": {
+			specs: func() (current, desired *tinkerbell.ClusterSpec) {
+				current, desired = DefaultClusterSpec(), DefaultClusterSpec()
+				desired.Cluster.Spec.WorkerNodeGroupConfigurations = desired.Cluster.Spec.WorkerNodeGroupConfigurations[:1]
+				return current, desired
+			},
+			catalogue: scaleUpgradeCatalogue,
+			result:    gomega.Succeed(),
+		},
+		"ScaleAddWorkerNodeGroup": {
+			specs: func() (current, desired *tinkerbell.ClusterSpec) {
+				current, desired = DefaultClusterSpec(), DefaultClusterSpec()
+
+				firstGroup := desired.Cluster.Spec.WorkerNodeGroupConfigurations[0]
+				desired.Cluster.Spec.WorkerNodeGroupConfigurations = append(
+					desired.Cluster.Spec.WorkerNodeGroupConfigurations,
+					eksav1alpha1.WorkerNodeGroupConfiguration{
+						MachineGroupRef: firstGroup.MachineGroupRef,
+						Count:           1,
+					},
+				)
+				return current, desired
+			},
+			catalogue: scaleUpgradeCatalogue,
+			result:    gomega.Succeed(),
+		},
+		"ScaleMultiple": {
+			specs: func() (current, desired *tinkerbell.ClusterSpec) {
+				current, desired = DefaultClusterSpec(), DefaultClusterSpec()
+				desired.Cluster.Spec.ControlPlaneConfiguration.Count = 2
+				desired.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 2
+				desired.Cluster.Spec.WorkerNodeGroupConfigurations[1].Count = 2
+				return current, desired
+			},
+			catalogue: scaleUpgradeCatalogue,
+			result:    gomega.Succeed(),
+		},
+		"NoAction": {
+			specs: func() (current, desired *tinkerbell.ClusterSpec) {
+				return DefaultClusterSpec(), DefaultClusterSpec()
+			},
+			catalogue: emptyCatalogue,
+			result:    gomega.Succeed(),
+		},
+		"VersionAndScaledControlPlane": {
+			specs: func() (current, desired *tinkerbell.ClusterSpec) {
+				current, desired = DefaultClusterSpec(), DefaultClusterSpec()
+				desired.Cluster.Spec.KubernetesVersion = "1.22"
+				desired.Cluster.Spec.ControlPlaneConfiguration.Count = 2
+				return current, desired
+			},
+			catalogue: emptyCatalogue,
+			result:    gomega.HaveOccurred(),
+		},
+		"VersionAndScaledWorkerNodeGroup": {
+			specs: func() (current, desired *tinkerbell.ClusterSpec) {
+				current, desired = DefaultClusterSpec(), DefaultClusterSpec()
+				desired.Cluster.Spec.KubernetesVersion = "1.22"
+				desired.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 2
+				return current, desired
+			},
+			catalogue: emptyCatalogue,
+			result:    gomega.HaveOccurred(),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			current, desired := d.specs()
+			catalogue := d.catalogue(current, desired)
+			assertion := tinkerbell.MinimumHardwareForUpgrade(current, catalogue)
+			g.Expect(assertion(desired)).To(d.result)
+		})
+	}
+}
+
+func versionUpgradeCatalogue(current, desired *tinkerbell.ClusterSpec) *hardware.Catalogue {
+	catalogue := hardware.NewCatalogue()
+
+	err := catalogue.InsertHardware(&v1alpha1.Hardware{
+		ObjectMeta: v1.ObjectMeta{
+			Labels: map[string]string(current.ControlPlaneMachineConfig().Spec.HardwareSelector),
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	for _, group := range current.WorkerNodeGroupConfigurations() {
+		selector := current.WorkerNodeGroupMachineConfig(group).Spec.HardwareSelector
+		err := catalogue.InsertHardware(&v1alpha1.Hardware{
+			ObjectMeta: v1.ObjectMeta{
+				Labels: map[string]string(selector),
+			},
+		})
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return catalogue
+}
+
+func emptyCatalogue(current, desired *tinkerbell.ClusterSpec) *hardware.Catalogue {
+	return hardware.NewCatalogue()
+}
+
+func scaleUpgradeCatalogue(current, desired *tinkerbell.ClusterSpec) *hardware.Catalogue {
+	catalogue := hardware.NewCatalogue()
+
+	controlPlaneDiff := desired.ControlPlaneConfiguration().Count - current.ControlPlaneConfiguration().Count
+	if controlPlaneDiff > 0 {
+		for i := 0; i < controlPlaneDiff; i++ {
+			err := catalogue.InsertHardware(&v1alpha1.Hardware{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string(desired.ControlPlaneMachineConfig().Spec.HardwareSelector),
+				},
+			})
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	currentGroups := buildNodeGroupMap(current.WorkerNodeGroupConfigurations())
+
+	for _, desiredGroup := range desired.WorkerNodeGroupConfigurations() {
+		// Default to the desired group count.
+		diff := desiredGroup.Count
+
+		// If there's a corresponding current worker node group diff the two.
+		currentGroup, exists := currentGroups[desiredGroup.Name]
+		if exists {
+			diff = desiredGroup.Count - currentGroup.Count
+		}
+
+		if diff > 0 {
+			selector := desired.WorkerNodeGroupMachineConfig(desiredGroup).Spec.HardwareSelector
+			for i := 0; i < diff; i++ {
+				err := catalogue.InsertHardware(&v1alpha1.Hardware{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string(selector),
+					},
+				})
+				if err != nil {
+					panic(err)
+				}
+			}
+		}
+	}
+
+	return catalogue
+}
+
+// buildNodeGroupMap builds a map of node group name to node group config.
+func buildNodeGroupMap(s []eksav1alpha1.WorkerNodeGroupConfiguration) map[string]eksav1alpha1.WorkerNodeGroupConfiguration {
+	groups := map[string]eksav1alpha1.WorkerNodeGroupConfiguration{}
+	for _, nodeGroup := range s {
+		groups[nodeGroup.Name] = nodeGroup
+	}
+	return groups
+}
+
+func removeExternalEtcd(spec *tinkerbell.ClusterSpec) {
 }

--- a/pkg/providers/tinkerbell/assert_test.go
+++ b/pkg/providers/tinkerbell/assert_test.go
@@ -465,7 +465,7 @@ func TestMinimumHardwareForUpgrade(t *testing.T) {
 			g := gomega.NewWithT(t)
 			current, desired := d.specs()
 			catalogue := d.catalogue(current, desired)
-			assertion := tinkerbell.MinimumHardwareForUpgrade(current, catalogue)
+			assertion := tinkerbell.MinimumHardwareForUpgrade(current.Spec, catalogue)
 			g.Expect(assertion(desired)).To(d.result)
 		})
 	}
@@ -556,7 +556,4 @@ func buildNodeGroupMap(s []eksav1alpha1.WorkerNodeGroupConfiguration) map[string
 		groups[nodeGroup.Name] = nodeGroup
 	}
 	return groups
-}
-
-func removeExternalEtcd(spec *tinkerbell.ClusterSpec) {
 }

--- a/pkg/providers/tinkerbell/cluster_test.go
+++ b/pkg/providers/tinkerbell/cluster_test.go
@@ -18,7 +18,7 @@ func TestClusterSpecValidator_AssertionsWithoutError(t *testing.T) {
 		validator.Register(assertion.ClusterSpecAsseritonFunc())
 	}
 
-	g.Expect(validator.Validate(NewDefaultValidClusterSpecBuilder().Build())).To(gomega.Succeed())
+	g.Expect(validator.Validate(DefaultClusterSpecBuilder().Build())).To(gomega.Succeed())
 	for _, assertion := range assertions {
 		g.Expect(assertion.Called).To(gomega.BeTrue())
 	}
@@ -34,7 +34,7 @@ func TestClusterSpecValidator_AssertionsWithError(t *testing.T) {
 		validator.Register(assertion.ClusterSpecAsseritonFunc())
 	}
 
-	g.Expect(validator.Validate(NewDefaultValidClusterSpecBuilder().Build())).ToNot(gomega.Succeed())
+	g.Expect(validator.Validate(DefaultClusterSpecBuilder().Build())).ToNot(gomega.Succeed())
 	g.Expect(assertions[0].Called).To(gomega.BeTrue())
 	g.Expect(assertions[1].Called).To(gomega.BeFalse())
 	g.Expect(assertions[1].Called).To(gomega.BeFalse())

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -122,7 +122,7 @@ func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpe
 	// TODO(chrisdoherty4) Look to inject the validator. Possibly look to use a builder for
 	// constructing the validations rather than injecting flags into the provider.
 	clusterSpecValidator := NewClusterSpecValidator(
-		MinimumHardwareAvailableAssertionForCreate(p.catalogue),
+		MinimumHardwareForCreate(p.catalogue),
 		HardwareSatisfiesOnlyOneSelectorAssertion(p.catalogue),
 	)
 

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -118,7 +118,8 @@ func (p *Provider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *
 	// must take place last so as to ensure the catalogue is populated with available hardware.
 	clusterSpecValidator := NewClusterSpecValidator()
 
-	// TODO(chrisdoherty4) Apply assertions specific to upgrade.
+	// TODO(chrisdoherty4) Retrieve the current cluster spec and inject here.
+	clusterSpecValidator.Register(MinimumHardwareForUpgrade(tinkerbellClusterSpec, p.catalogue))
 
 	if err := clusterSpecValidator.Validate(tinkerbellClusterSpec); err != nil {
 		return err

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -436,7 +436,7 @@ func (p *vsphereProvider) SetupAndValidateCreateCluster(ctx context.Context, clu
 	return nil
 }
 
-func (p *vsphereProvider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
+func (p *vsphereProvider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *types.Cluster, _, clusterSpec *cluster.Spec) error {
 	if err := SetupEnvVars(p.datacenterConfig); err != nil {
 		return fmt.Errorf("failed setup and validations: %v", err)
 	}

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -1339,7 +1339,7 @@ func TestSetupAndValidateUpgradeCluster(t *testing.T) {
 	defer tctx.RestoreContext()
 
 	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	if err != nil {
 		t.Fatalf("unexpected failure %v", err)
 	}
@@ -1355,7 +1355,7 @@ func TestSetupAndValidateUpgradeClusterNoUsername(t *testing.T) {
 	os.Unsetenv(EksavSphereUsernameKey)
 
 	cluster := &types.Cluster{}
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 
 	thenErrorExpected(t, "failed setup and validations: EKSA_VSPHERE_USERNAME is not set or is empty", err)
 }
@@ -1370,7 +1370,7 @@ func TestSetupAndValidateUpgradeClusterNoPassword(t *testing.T) {
 	os.Unsetenv(EksavSpherePasswordKey)
 
 	cluster := &types.Cluster{}
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 
 	thenErrorExpected(t, "failed setup and validations: EKSA_VSPHERE_PASSWORD is not set or is empty", err)
 }
@@ -1391,7 +1391,7 @@ func TestSetupAndValidateUpgradeClusterCPSshNotExists(t *testing.T) {
 
 	cluster := &types.Cluster{}
 	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	if err != nil {
 		t.Fatalf("unexpected failure %v", err)
 	}
@@ -1414,7 +1414,7 @@ func TestSetupAndValidateUpgradeClusterWorkerSshNotExists(t *testing.T) {
 	cluster := &types.Cluster{}
 	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
 
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	if err != nil {
 		t.Fatalf("unexpected failure %v", err)
 	}
@@ -1437,7 +1437,7 @@ func TestSetupAndValidateUpgradeClusterEtcdSshNotExists(t *testing.T) {
 	cluster := &types.Cluster{}
 	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
 
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	if err != nil {
 		t.Fatalf("unexpected failure %v", err)
 	}
@@ -1903,7 +1903,7 @@ func TestSetupAndValidateForUpgradeSSHAuthorizedKeyInvalidCP(t *testing.T) {
 	tctx.SaveContext()
 
 	cluster := &types.Cluster{}
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	thenErrorExpected(t, "failed setup and validations: ssh: no key found", err)
 }
 
@@ -1919,7 +1919,7 @@ func TestSetupAndValidateForUpgradeSSHAuthorizedKeyInvalidWorker(t *testing.T) {
 	tctx.SaveContext()
 
 	cluster := &types.Cluster{}
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	thenErrorExpected(t, "failed setup and validations: ssh: no key found", err)
 }
 
@@ -1935,7 +1935,7 @@ func TestSetupAndValidateForUpgradeSSHAuthorizedKeyInvalidEtcd(t *testing.T) {
 	tctx.SaveContext()
 
 	cluster := &types.Cluster{}
-	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec)
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, nil, clusterSpec)
 	thenErrorExpected(t, "failed setup and validations: ssh: no key found", err)
 }
 

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -114,8 +114,9 @@ func newUpgradeManagedClusterTest(t *testing.T) *upgradeTestSetup {
 	return tt
 }
 
-func (c *upgradeTestSetup) expectSetup() {
-	c.provider.EXPECT().SetupAndValidateUpgradeCluster(c.ctx, gomock.Any(), c.newClusterSpec)
+func (c *upgradeTestSetup) expectSetup(expectedCluster *types.Cluster) {
+	c.provider.EXPECT().SetupAndValidateUpgradeCluster(c.ctx, gomock.Any(), nil, c.newClusterSpec)
+	c.clusterManager.EXPECT().GetCurrentClusterSpec(c.ctx, expectedCluster, c.newClusterSpec.Cluster.Name).Return(c.currentClusterSpec, nil)
 	c.provider.EXPECT().Name()
 }
 
@@ -384,7 +385,7 @@ func (c *upgradeTestSetup) expectPreflightValidationsToPass() {
 
 func TestSkipUpgradeRunSuccess(t *testing.T) {
 	test := newUpgradeSelfManagedClusterTest(t)
-	test.expectSetup()
+	test.expectSetup(test.managementCluster)
 	test.expectPreflightValidationsToPass()
 	test.expectUpdateSecrets(test.workloadCluster)
 	test.expectEnsureEtcdCAPIComponentsExistTask(test.workloadCluster)
@@ -403,7 +404,7 @@ func TestSkipUpgradeRunSuccess(t *testing.T) {
 
 func TestUpgradeRunSuccess(t *testing.T) {
 	test := newUpgradeSelfManagedClusterTest(t)
-	test.expectSetup()
+	test.expectSetup(test.workloadCluster)
 	test.expectPreflightValidationsToPass()
 	test.expectUpdateSecrets(test.workloadCluster)
 	test.expectEnsureEtcdCAPIComponentsExistTask(test.workloadCluster)
@@ -435,7 +436,7 @@ func TestUpgradeRunSuccess(t *testing.T) {
 
 func TestUpgradeRunProviderNeedsUpgradeSuccess(t *testing.T) {
 	test := newUpgradeSelfManagedClusterTest(t)
-	test.expectSetup()
+	test.expectSetup(test.workloadCluster)
 	test.expectPreflightValidationsToPass()
 	test.expectUpdateSecrets(test.workloadCluster)
 	test.expectEnsureEtcdCAPIComponentsExistTask(test.workloadCluster)
@@ -466,7 +467,7 @@ func TestUpgradeRunProviderNeedsUpgradeSuccess(t *testing.T) {
 
 func TestUpgradeRunFailedUpgrade(t *testing.T) {
 	test := newUpgradeSelfManagedClusterTest(t)
-	test.expectSetup()
+	test.expectSetup(test.workloadCluster)
 	test.expectPreflightValidationsToPass()
 	test.expectUpdateSecrets(test.workloadCluster)
 	test.expectEnsureEtcdCAPIComponentsExistTask(test.workloadCluster)
@@ -489,7 +490,7 @@ func TestUpgradeRunFailedUpgrade(t *testing.T) {
 
 func TestUpgradeWorkloadRunSuccess(t *testing.T) {
 	test := newUpgradeManagedClusterTest(t)
-	test.expectSetup()
+	test.expectSetup(test.managementCluster)
 	test.expectPreflightValidationsToPass()
 	test.expectUpdateSecrets(test.managementCluster)
 	test.expectEnsureEtcdCAPIComponentsExistTask(test.managementCluster)


### PR DESCRIPTION
Depends on https://github.com/aws/eks-anywhere/pull/2707

In Tinkerbell we need access to both the desired and current cluster specifications. The upgrade workflow is one place currently responsible for pulling the current spec from the existing cluster so I've used the same logic to keep it in one place but for validation. 