### PR TITLE
Increase support bundle pod logs collection 'since' time to 3 hours.

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -695,8 +695,8 @@ func (c *ClusterManager) SaveLogsWorkloadCluster(ctx context.Context, provider p
 
 func collectDiagnosticBundle(ctx context.Context, bundle diagnostics.DiagnosticBundle) error {
 	var sinceTimeValue *time.Time
-	oneHour := "1h"
-	sinceTimeValue, err := diagnostics.ParseTimeFromDuration(oneHour)
+	threeHours := "3h"
+	sinceTimeValue, err := diagnostics.ParseTimeFromDuration(threeHours)
 	if err != nil {
 		logger.V(5).Info("Error parsing time options for support bundle generation", "error", err)
 		return nil

--- a/pkg/diagnostics/diagnostic_bundle.go
+++ b/pkg/diagnostics/diagnostic_bundle.go
@@ -370,7 +370,9 @@ func ParseTimeOptions(since string, sinceTime string) (*time.Time, error) {
 	var sinceTimeValue time.Time
 	var err error
 	if sinceTime == "" && since == "" {
-		return &sinceTimeValue, nil
+		return &sinceTimeValue, nil // returning an uninitialized (zero) Time value here results in a
+		// sinceTimeValue of "0001-01-01 00:00:00 +0000 UTC"
+		// so all pod logs will be collected from the very beginning
 	} else if sinceTime != "" && since != "" {
 		return nil, fmt.Errorf("at most one of `sinceTime` or `since` could be specified")
 	} else if sinceTime != "" {


### PR DESCRIPTION
Issue:
In certain failure cases, the logs for tinkerbell infrastructure pods
were empty. This was because the support bundle log collection duration
was set to one hour. For certain timeout scenarios in bare metal world,
the failure and hence the support bundle collection could take more an
hour since start of cluster creation. Tinkerbell infrastructure pods are
mostly inactive once provisioning finishes or fails, and may not be
actively logging resulting in empty hourly logs for these pods.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

