### PR TITLE
Fix snow upgrade

### DIFF
--- a/pkg/clients/kubernetes/scheme.go
+++ b/pkg/clients/kubernetes/scheme.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -16,6 +17,7 @@ var schemeAdders = []schemeAdder{
 	controlplanev1.AddToScheme,
 	anywherev1.AddToScheme,
 	snowv1.AddToScheme,
+	bootstrapv1.AddToScheme,
 }
 
 func addToScheme(scheme *runtime.Scheme, schemeAdder ...schemeAdder) error {

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -135,8 +135,8 @@ func (p *SnowProvider) GenerateCAPISpecForCreate(ctx context.Context, cluster *t
 	return p.generateCAPISpec(ctx, cluster, clusterSpec)
 }
 
-func (p *SnowProvider) GenerateCAPISpecForUpgrade(ctx context.Context, _, managementCluster *types.Cluster, _ *cluster.Spec, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
-	return p.generateCAPISpec(ctx, managementCluster, clusterSpec)
+func (p *SnowProvider) GenerateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, _ *types.Cluster, _ *cluster.Spec, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
+	return p.generateCAPISpec(ctx, bootstrapCluster, clusterSpec)
 }
 
 func (p *SnowProvider) GenerateStorageClass() []byte {

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -430,7 +430,7 @@ func TestGenerateCAPISpecForUpgrade(t *testing.T) {
 			return nil
 		})
 
-	gotCp, gotMd, err := tt.provider.GenerateCAPISpecForUpgrade(tt.ctx, nil, tt.cluster, nil, tt.clusterSpec)
+	gotCp, gotMd, err := tt.provider.GenerateCAPISpecForUpgrade(tt.ctx, tt.cluster, nil, nil, tt.clusterSpec)
 	tt.Expect(err).To(Succeed())
 	test.AssertContentToFile(t, string(gotCp), "testdata/expected_results_main_cp.yaml")
 	test.AssertContentToFile(t, string(gotMd), "testdata/expected_results_main_md.yaml")


### PR DESCRIPTION
*Issue #, if available:*

Found this bug while testing label upgrade in snow provider. The kubeconfig used for upgrade to fetch existing CAPI object in the cluster should be bootstrap cluster (where CAPI resources live) instead of workload cluster.

*Description of changes:*

*Testing (if applicable):*

- Unit tests
- e2e label upgrade passed w new kubeadmconfigtemplate generated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

