### PR TITLE
Remove snowmachine devices non empty validation

### DIFF
--- a/pkg/api/v1alpha1/snowmachineconfig.go
+++ b/pkg/api/v1alpha1/snowmachineconfig.go
@@ -56,9 +56,12 @@ func validateSnowMachineConfig(config *SnowMachineConfig) error {
 		return fmt.Errorf("SnowMachineConfig InstanceType %s is not supported, please use one of the following: %s, %s, %s, %s ", config.Spec.InstanceType, SbeCLarge, SbeCXLarge, SbeC2XLarge, SbeC4XLarge)
 	}
 
-	if len(config.Spec.Devices) == 0 {
-		return errors.New("SnowMachineConfig Devices must contain at least one device IP")
-	}
+	// TODO: temporarily remove this validation since `devices` is a newly added, required field.
+	// This validation runs in snowmachineconfig webhook and ValidateUpdate fails when upgrading from older eks-a version
+	// without the `devices` field. We will add this validation back once users update their clusters to latest version.
+	// if len(config.Spec.Devices) == 0 {
+	// 	return errors.New("SnowMachineConfig Devices must contain at least one device IP")
+	// }
 	return nil
 }
 

--- a/pkg/api/v1alpha1/snowmachineconfig_test.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_test.go
@@ -113,16 +113,6 @@ func TestSnowValidate(t *testing.T) {
 			},
 			wantErr: "InstanceType invalid-instance-type is not supported",
 		},
-		{
-			name: "empty devices",
-			obj: &SnowMachineConfig{
-				Spec: SnowMachineConfigSpec{
-					AMIID:        "ami-1",
-					InstanceType: DefaultSnowInstanceType,
-				},
-			},
-			wantErr: "Devices must contain at least one device IP",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/api/v1alpha1/snowmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_webhook_test.go
@@ -40,17 +40,6 @@ func TestSnowMachineConfigValidateCreate(t *testing.T) {
 	g.Expect(sOld.ValidateCreate()).To(Succeed())
 }
 
-func TestSnowMachineConfigValidateUpdateNoDevices(t *testing.T) {
-	g := NewWithT(t)
-
-	sOld := snowMachineConfig()
-	sNew := sOld.DeepCopy()
-	sNew.Spec.AMIID = "testAMI"
-	sNew.Spec.InstanceType = v1alpha1.SbeCLarge
-
-	g.Expect(sNew.ValidateUpdate(&sOld)).NotTo(Succeed())
-}
-
 func TestSnowMachineConfigValidateUpdate(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Temporarily remove the device non empty validation since it is a newly added, required field.
This validation runs in snowmachineconfig webhook and ValidateUpdate fails when upgrading from older eks-a version without the `devices` field. We will add this validation back once users update their clusters to latest version.

*Testing (if applicable):*

unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

