### PR TITLE
Get latest ECR tag for Tinkerbell charts

### DIFF
--- a/release/pkg/assets/config/bundle_release.go
+++ b/release/pkg/assets/config/bundle_release.go
@@ -806,6 +806,10 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 		Images: []*assettypes.Image{
 			{
 				RepoName: "tinkerbell-chart",
+				TrimVersionSignifier: true,
+				ImageTagConfiguration: assettypes.ImageTagConfiguration{
+					SourceLatestTagFromECR: true,
+				},
 			},
 		},
 		ImageRepoPrefix: "tinkerbell",


### PR DESCRIPTION
We don't push `latest` tag for Tinkerbell charts, so need to use the ECR API to get the latest tag pushed by time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

