### PR TITLE
Add missing 'anywhere'

### DIFF
--- a/docs/content/en/docs/tasks/cluster/cluster-scale/baremetal-scale.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-scale/baremetal-scale.md
@@ -31,7 +31,7 @@ eksa-worker2                    type=worker-group-1
 If you don't have any available hardware that match this requirement in the cluster, you can [setup a new hardware CSV]({{< relref "../../../reference/baremetal/bare-preparation/#prepare-hardware-inventory" >}}) and then run the following command to push the additional hardware to your cluster
 
 ```bash
-eksctl generate hardware -z <hardware.csv> | kubectl apply -f -
+eksctl anywhere generate hardware -z <hardware.csv> | kubectl apply -f -
 ```
 
 Once you verify you have the additional hardware available, you are ready to scale your cluster.


### PR DESCRIPTION
eksctl generate hardware is missing the 'anywhere' subcommand.

*Issue #, if available:*

*Description of changes:*
I'm simply adding the missing 'anywhere' subcommand

*Testing (if applicable):*
Tested locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

