### PR TITLE
Add CertManagerExits logic for PackageController Installation

### DIFF
--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -79,8 +79,7 @@ func installPackageController(ctx context.Context) error {
 		helmChart.Tag(),
 	)
 
-	err = curatedpackages.VerifyCertManagerExists(ctx, deps.Kubectl, kubeConfig)
-	if err != nil {
+	if err = curatedpackages.VerifyCertManagerExists(ctx, deps.Kubectl, kubeConfig); err != nil {
 		return err
 	}
 

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 
 	"github.com/spf13/cobra"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/utils/urls"
@@ -78,6 +80,16 @@ func installPackageController(ctx context.Context) error {
 		helmChart.Name,
 		helmChart.Tag(),
 	)
+
+	// If cert-manager does not exist, instruct users to follow instructions in
+	// PrintCertManagerDoesNotExistMsg to install packages manually.
+	// Note although we passed in a namespace parameter in the kubectl command, the GetResource command will be
+	// performed in all namespaces since CRDs are not bounded by namespaces.
+	certManagerExists, _ := deps.Kubectl.GetResource(ctx, "crd", "certificates.cert-manager.io", kubeConfig, constants.CertManagerNamespace)
+	if !certManagerExists {
+		curatedpackages.PrintCertManagerDoesNotExistMsg()
+		return errors.New("cert-manager is not present in the cluster")
+	}
 
 	if err = ctrlClient.ValidateControllerDoesNotExist(ctx); err != nil {
 		return err

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -26,6 +26,7 @@ const (
 	EtcdadmControllerProviderName           = "bootstrap-etcdadm-controller"
 	DefaultHttpsPort                        = "443"
 	DefaultWorkerNodeGroupName              = "md-0"
+	UserMsgSeparator                        = "-"
 
 	VSphereProviderName    = "vsphere"
 	DockerProviderName     = "docker"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -26,7 +26,6 @@ const (
 	EtcdadmControllerProviderName           = "bootstrap-etcdadm-controller"
 	DefaultHttpsPort                        = "443"
 	DefaultWorkerNodeGroupName              = "md-0"
-	UserMsgSeparator                        = "-"
 
 	VSphereProviderName    = "vsphere"
 	DockerProviderName     = "docker"

--- a/pkg/curatedpackages/curatedpackages.go
+++ b/pkg/curatedpackages/curatedpackages.go
@@ -32,6 +32,8 @@ https://anywhere.eks.amazonaws.com/docs/tasks/packages/ for how to resolve this 
 	width = 112
 )
 
+var userMsgSeparator = strings.Repeat("-", width)
+
 func CreateBundleManager(kubeVersion string) bundle.Manager {
 	major, minor, err := parseKubeVersion(kubeVersion)
 	if err != nil {
@@ -75,9 +77,9 @@ func PrintLicense() {
 	//the AWS Service Terms are extended to provide customers access to these features free of charge.
 	//These features will be subject to a service charge and fee structure at ”General Availability“ of the features.
 	//----------------------------------------------------------------------------------------------------------------
-	fmt.Println(strings.Repeat("-", width))
+	fmt.Println(userMsgSeparator)
 	fmt.Println(license)
-	fmt.Println(strings.Repeat("-", width))
+	fmt.Println(userMsgSeparator)
 }
 
 func PrintCertManagerDoesNotExistMsg() {
@@ -88,9 +90,9 @@ func PrintCertManagerDoesNotExistMsg() {
 	//by an action to install Curated packages at a workload cluster. Refer to
 	//https://anywhere.eks.amazonaws.com/docs/tasks/packages/ for how to resolve this issue.
 	//----------------------------------------------------------------------------------------------------------------
-	fmt.Println(strings.Repeat("-", width))
+	fmt.Println(userMsgSeparator)
 	fmt.Println(certManagerDoesNotExistMsg)
-	fmt.Println(strings.Repeat("-", width))
+	fmt.Println(userMsgSeparator)
 }
 
 func VerifyCertManagerExists(ctx context.Context, kubectl KubectlRunner, kubeConfig string) error {

--- a/pkg/curatedpackages/curatedpackages.go
+++ b/pkg/curatedpackages/curatedpackages.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/eks-anywhere-packages/pkg/bundle"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
@@ -24,6 +25,9 @@ const (
 (including Section 2 (Betas and Previews)) of the same. During the EKS Anywhere Curated Packages Public Preview,
 the AWS Service Terms are extended to provide customers access to these features free of charge.
 These features will be subject to a service charge and fee structure at ”General Availability“ of the features.`
+	certManagerDoesNotExistMsg = `Curated packages cannot be installed as cert-manager is not present in the cluster. This is most likely caused
+by an action to install Curated packages at a workload cluster. Refer to
+https://anywhere.eks.amazonaws.com/docs/tasks/packages/ for how to resolve this issue.`
 	width = 112
 )
 
@@ -70,9 +74,22 @@ func PrintLicense() {
 	//the AWS Service Terms are extended to provide customers access to these features free of charge.
 	//These features will be subject to a service charge and fee structure at ”General Availability“ of the features.
 	//----------------------------------------------------------------------------------------------------------------
-	fmt.Println(strings.Repeat("-", width))
+	fmt.Println(strings.Repeat(constants.UserMsgSeparator, width))
 	fmt.Println(license)
-	fmt.Println(strings.Repeat("-", width))
+	fmt.Println(strings.Repeat(constants.UserMsgSeparator, width))
+}
+
+func PrintCertManagerDoesNotExistMsg() {
+	// Currently, use the width of the longest line to repeat the dashes
+	// Sample Output
+	//----------------------------------------------------------------------------------------------------------------
+	//Curated packages cannot be installed as cert-manager is not present in the cluster. This is most likely caused
+	//by an action to install Curated packages at a workload cluster. Refer to
+	//https://anywhere.eks.amazonaws.com/docs/tasks/packages/ for how to resolve this issue.
+	//----------------------------------------------------------------------------------------------------------------
+	fmt.Println(strings.Repeat(constants.UserMsgSeparator, width))
+	fmt.Println(certManagerDoesNotExistMsg)
+	fmt.Println(strings.Repeat(constants.UserMsgSeparator, width))
 }
 
 func Pull(ctx context.Context, art string) ([]byte, error) {

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -2,8 +2,10 @@ package curatedpackages
 
 import (
 	"context"
+	"errors"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/utils/urls"
@@ -22,6 +24,7 @@ type Installer struct {
 	spec              *cluster.Spec
 	packageClient     PackageHandler
 	packagesLocation  string
+	kubectl           KubectlRunner
 }
 
 func NewInstaller(installer ChartInstaller, runner KubectlRunner, spec *cluster.Spec, packagesLocation string) *Installer {
@@ -36,6 +39,7 @@ func NewInstaller(installer ChartInstaller, runner KubectlRunner, spec *cluster.
 		packagesLocation:  packagesLocation,
 		packageController: pcc,
 		packageClient:     pc,
+		kubectl:           runner,
 	}
 }
 
@@ -49,6 +53,18 @@ func newPackageController(installer ChartInstaller, runner KubectlRunner, spec *
 
 func (pi *Installer) InstallCuratedPackages(ctx context.Context) error {
 	PrintLicense()
+
+	// If cert-manager does not exist, instruct users to follow instructions in
+	// PrintCertManagerDoesNotExistMsg to install packages manually.
+	// Note although we passed in a namespace parameter in the kubectl command, the GetResource command will be
+	// performed in all namespaces since CRDs are not bounded by namespaces.
+	kubeConfig := kubeconfig.FromClusterName(pi.spec.Cluster.Name)
+	certManagerExists, _ := pi.kubectl.GetResource(ctx, "crd", "certificates.cert-manager.io", kubeConfig, constants.CertManagerNamespace)
+	if !certManagerExists {
+		PrintCertManagerDoesNotExistMsg()
+		return errors.New("cert-manager is not present in the cluster")
+	}
+
 	err := pi.installPackagesController(ctx)
 	if err != nil {
 		logger.MarkFail("Error when installing curated packages on workload cluster; please install through eksctl anywhere install packagecontroller command", "error", err)

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -2,10 +2,8 @@ package curatedpackages
 
 import (
 	"context"
-	"errors"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/utils/urls"
@@ -54,18 +52,14 @@ func newPackageController(installer ChartInstaller, runner KubectlRunner, spec *
 func (pi *Installer) InstallCuratedPackages(ctx context.Context) error {
 	PrintLicense()
 
-	// If cert-manager does not exist, instruct users to follow instructions in
-	// PrintCertManagerDoesNotExistMsg to install packages manually.
-	// Note although we passed in a namespace parameter in the kubectl command, the GetResource command will be
-	// performed in all namespaces since CRDs are not bounded by namespaces.
 	kubeConfig := kubeconfig.FromClusterName(pi.spec.Cluster.Name)
-	certManagerExists, _ := pi.kubectl.GetResource(ctx, "crd", "certificates.cert-manager.io", kubeConfig, constants.CertManagerNamespace)
-	if !certManagerExists {
-		PrintCertManagerDoesNotExistMsg()
-		return errors.New("cert-manager is not present in the cluster")
+
+	err := VerifyCertManagerExists(ctx, pi.kubectl, kubeConfig)
+	if err != nil {
+		return err
 	}
 
-	err := pi.installPackagesController(ctx)
+	err = pi.installPackagesController(ctx)
 	if err != nil {
 		logger.MarkFail("Error when installing curated packages on workload cluster; please install through eksctl anywhere install packagecontroller command", "error", err)
 		return err


### PR DESCRIPTION
The existence of cert-manager is required to ensure proper operation of the PackageController. We modify the cluster creation workflow and imperative package installation command to add in the CertManagerExits logic, and guide users to handle the case where cert-manager is not present in the cluster.

*Issue #, if available:* https://github.com/aws/eks-anywhere-packages/issues/278

*Description of changes:* Modified the cluster creation workflow and imperative package installation command to add in the CertManagerExits logic

*Testing (if applicable):* Tested in cluster creation workflow and imperative package installation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

