### PR TITLE
Install flux controllers during components upgrade if not exist before

### DIFF
--- a/pkg/addonmanager/addonclients/fluxaddonclient.go
+++ b/pkg/addonmanager/addonclients/fluxaddonclient.go
@@ -383,14 +383,12 @@ func (fc *fluxForCluster) commitFluxAndClusterConfigToGit(ctx context.Context) e
 		return &ConfigVersionControlFailedError{Err: err}
 	}
 
-	logger.V(3).Info("Generating eks-a cluster manifest files...")
 	err = fc.writeEksaSystemFiles()
 	if err != nil {
 		return &ConfigVersionControlFailedError{Err: err}
 	}
 
 	if fc.clusterSpec.Cluster.IsSelfManaged() {
-		logger.V(3).Info("Generating flux custom manifest files...")
 		err = fc.writeFluxSystemFiles()
 		if err != nil {
 			return &ConfigVersionControlFailedError{Err: err}
@@ -440,17 +438,22 @@ func (fc *fluxForCluster) initEksaWriter() (filewriter.FileWriter, error) {
 }
 
 func (fc *fluxForCluster) writeEksaSystemFiles() error {
+	if fc.datacenterConfig == nil && fc.machineConfigs == nil {
+		return nil
+	}
+
+	logger.V(3).Info("Generating eks-a cluster manifest files...")
 	w, err := fc.initEksaWriter()
 	if err != nil {
 		return err
 	}
 
-	logger.V(3).Info("Generating eks-a cluster config file...")
+	logger.V(4).Info("Generating eks-a cluster config file...")
 	if err := fc.generateClusterConfigFile(w); err != nil {
 		return err
 	}
 
-	logger.V(3).Info("Generating eks-a kustomization file...")
+	logger.V(4).Info("Generating eks-a kustomization file...")
 	return fc.generateEksaKustomizeFile(w)
 }
 
@@ -487,6 +490,7 @@ func (fc *fluxForCluster) initFluxWriter() (filewriter.FileWriter, error) {
 }
 
 func (fc *fluxForCluster) writeFluxSystemFiles() (err error) {
+	logger.V(3).Info("Generating flux custom manifest files...")
 	w, err := fc.initFluxWriter()
 	if err != nil {
 		return err
@@ -494,12 +498,12 @@ func (fc *fluxForCluster) writeFluxSystemFiles() (err error) {
 
 	t := templater.New(w)
 
-	logger.V(3).Info("Generating flux-system kustomization file...")
+	logger.V(4).Info("Generating flux-system kustomization file...")
 	if err = fc.generateFluxKustomizeFile(t); err != nil {
 		return err
 	}
 
-	logger.V(3).Info("Generating flux-system sync file...")
+	logger.V(4).Info("Generating flux-system sync file...")
 	if err = fc.generateFluxSyncFile(t); err != nil {
 		return err
 	}

--- a/pkg/addonmanager/addonclients/upgrader.go
+++ b/pkg/addonmanager/addonclients/upgrader.go
@@ -51,6 +51,10 @@ func FluxChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
 		logger.V(1).Info("Skipping Flux upgrades, not a self-managed cluster")
 		return nil
 	}
+	if currentSpec.Cluster.Spec.GitOpsRef == nil && newSpec.Cluster.Spec.GitOpsRef != nil {
+		logger.V(1).Info("Skipping Flux upgrades, no previous flux installed in the cluster")
+		return nil
+	}
 	if currentSpec.Cluster.Spec.GitOpsRef == nil {
 		logger.V(1).Info("Skipping Flux upgrades, GitOps not enabled")
 		return nil
@@ -68,6 +72,13 @@ func FluxChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
 				},
 			},
 		}
+	}
+	return nil
+}
+
+func (f *FluxAddonClient) Install(ctx context.Context, cluster *types.Cluster, oldSpec, newSpec *cluster.Spec) error {
+	if oldSpec.Cluster.Spec.GitOpsRef == nil && newSpec.Cluster.Spec.GitOpsRef != nil {
+		return f.InstallGitOps(ctx, cluster, newSpec, nil, nil)
 	}
 	return nil
 }

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -49,7 +49,8 @@ type AddonManager interface {
 	ForceReconcileGitRepo(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
 	Validations(ctx context.Context, clusterSpec *cluster.Spec) []validations.Validation
 	CleanupGitRepo(ctx context.Context, clusterSpec *cluster.Spec) error
-	Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec *cluster.Spec, newSpec *cluster.Spec) (*types.ChangeDiff, error)
+	Install(ctx context.Context, cluster *types.Cluster, oldSpec, newSpec *cluster.Spec) error
+	Upgrade(ctx context.Context, cluster *types.Cluster, oldSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error)
 }
 
 type Validator interface {

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -479,6 +479,20 @@ func (mr *MockAddonManagerMockRecorder) ForceReconcileGitRepo(arg0, arg1, arg2 i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceReconcileGitRepo", reflect.TypeOf((*MockAddonManager)(nil).ForceReconcileGitRepo), arg0, arg1, arg2)
 }
 
+// Install mocks base method.
+func (m *MockAddonManager) Install(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 *cluster.Spec) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Install", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Install indicates an expected call of Install.
+func (mr *MockAddonManagerMockRecorder) Install(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockAddonManager)(nil).Install), arg0, arg1, arg2, arg3)
+}
+
 // InstallGitOps mocks base method.
 func (m *MockAddonManager) InstallGitOps(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec, arg3 providers.DatacenterConfig, arg4 []providers.MachineConfig) error {
 	m.ctrl.T.Helper()

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -238,6 +238,11 @@ func (s *upgradeCoreComponents) Run(ctx context.Context, commandContext *task.Co
 	}
 	commandContext.UpgradeChangeDiff.Append(changeDiff)
 
+	if err = commandContext.AddonManager.Install(ctx, commandContext.ManagementCluster, commandContext.CurrentClusterSpec, commandContext.ClusterSpec); err != nil {
+		commandContext.SetError(err)
+		return &CollectDiagnosticsTask{}
+	}
+
 	changeDiff, err = commandContext.AddonManager.Upgrade(ctx, commandContext.ManagementCluster, commandContext.CurrentClusterSpec, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -173,6 +173,7 @@ func (c *upgradeTestSetup) expectUpgradeCoreComponents(managementCluster *types.
 	gomock.InOrder(
 		c.clusterManager.EXPECT().UpgradeNetworking(c.ctx, workloadCluster, currentSpec, c.newClusterSpec, c.provider).Return(networkingChangeDiff, nil),
 		c.capiManager.EXPECT().Upgrade(c.ctx, managementCluster, c.provider, currentSpec, c.newClusterSpec).Return(capiChangeDiff, nil),
+		c.addonManager.EXPECT().Install(c.ctx, managementCluster, currentSpec, c.newClusterSpec).Return(nil),
 		c.addonManager.EXPECT().Upgrade(c.ctx, managementCluster, currentSpec, c.newClusterSpec).Return(fluxChangeDiff, nil),
 		c.clusterManager.EXPECT().Upgrade(c.ctx, managementCluster, currentSpec, c.newClusterSpec).Return(eksaChangeDiff, nil),
 		c.eksdUpgrader.EXPECT().Upgrade(c.ctx, managementCluster, currentSpec, c.newClusterSpec).Return(eksdChangeDiff, nil),


### PR DESCRIPTION
*Issue #, if available:*

First part of #2755 

*Description of changes:*

This PR only handles the case of installing new Flux controllers in a Flux disabled cluster through upgrade command.

During components upgrade, when FluxConfig does not exist in the existing cluster, but specified in the new cluster spec, we install the flux controllers **without** adding EKS-A spec in the git repo. `UpdateGitEksaSpec` in the "updateClusterAndGitResources" step will then add the new EKS-A spec to the repo once cluster is fully upgraded. 

Logic behind this setting:
- It makes logical sense to install controllers as part of the EKS-A components during components upgrade step
- Only install the Flux controller with its controller configs during components upgrade so that none of the EKS-A resources will be reconciled by GitOps during upgrade. The EKS-A cluster controller will not interfere with CLI upgrade process.
- EKS-A spec will only be added after cluster is fully upgraded with latest spec. So that the cluster spec in Git repo will reflect the actual cluster config. If upgrade failed, the cluster spec will not be pushed. 

Also refactored addon unit tests a bit.

We will have upcoming PRs to handle
- Update Flux configs in a cluster
- Disable Flux in a cluster
- Add proper validation logic for Flux immutable fields

*Testing (if applicable):*

- Unit tests
- Manual local test to enable Flux in vsphere cluster with upgrade command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

