### PR TITLE
Update fetcher to map cloudstack cluster for capc v1beta2

### DIFF
--- a/controllers/resource/fetcher_test.go
+++ b/controllers/resource/fetcher_test.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	cloudstackv1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta1"
+	cloudstackv1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta2"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
@@ -187,31 +187,35 @@ func TestMapClusterToCloudStackDatacenterConfigSpec(t *testing.T) {
 			args: args{
 				csCluster: &cloudstackv1.CloudStackCluster{
 					Spec: cloudstackv1.CloudStackClusterSpec{
-						Zones: []cloudstackv1.Zone{
+						FailureDomains: []cloudstackv1.CloudStackFailureDomainSpec{
 							{
-								Name: "zone",
-								Network: cloudstackv1.Network{
-									Name: "network",
+								Zone: cloudstackv1.CloudStackZoneSpec{
+									Name: "zone",
+									Network: cloudstackv1.Network{
+										Name: "network",
+									},
 								},
+								Account: "account",
+								Domain:  "domain",
 							},
 						},
-						Account: "account",
-						Domain:  "domain",
 					},
 				},
 			},
 			want: &anywherev1.CloudStackDatacenterConfig{
 				Spec: anywherev1.CloudStackDatacenterConfigSpec{
-					Zones: []anywherev1.CloudStackZone{
+					AvailabilityZones: []anywherev1.CloudStackAvailabilityZone{
 						{
-							Name: "zone",
-							Network: anywherev1.CloudStackResourceIdentifier{
-								Name: "network",
+							Zone: anywherev1.CloudStackZone{
+								Name: "zone",
+								Network: anywherev1.CloudStackResourceIdentifier{
+									Name: "network",
+								},
 							},
+							Account: "account",
+							Domain:  "domain",
 						},
 					},
-					Account: "account",
-					Domain:  "domain",
 				},
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	k8s.io/client-go v0.23.4
 	oras.land/oras-go v1.1.0
 	sigs.k8s.io/cluster-api v1.1.3
-	sigs.k8s.io/cluster-api-provider-cloudstack v0.4.5-rc3
+	sigs.k8s.io/cluster-api-provider-cloudstack v0.5.0
 	sigs.k8s.io/cluster-api-provider-vsphere v1.0.1
 	sigs.k8s.io/cluster-api/test v1.0.0
 	sigs.k8s.io/controller-runtime v0.11.1
@@ -185,4 +185,6 @@ replace (
 
 	// need the modifications eksa made to the capi api structs
 	sigs.k8s.io/cluster-api => github.com/mrajashree/cluster-api v1.1.3-custom
+	// need the unreleased version (v1beta2) of API from CAPC. remove once a new capc is released with v1beta2 API
+	sigs.k8s.io/cluster-api-provider-cloudstack => github.com/rejoshed/cluster-api-provider-cloudstack v0.4.5-rc3.0.20220716163849-c554f7451de3
 )

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,7 @@ github.com/aws/aws-sdk-go-v2/service/sso v1.11.3 h1:frW4ikGcxfAEDfmQqWgMLp+F1n4n
 github.com/aws/aws-sdk-go-v2/service/sso v1.11.3/go.mod h1:7UQ/e69kU7LDPtY40OyoHYgRmgfGM4mgsLYtcObdveU=
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.3 h1:cJGRyzCSVwZC7zZZ1xbx9m32UnrKydRYhOvcD1NYP9Q=
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.3/go.mod h1:bfBj0iVmsUyUg4weDB4NxktD9rDGeKSVWnjTnwbx9b8=
+github.com/aws/cluster-api-provider-cloudstack v0.4.4/go.mod h1:fafGBTlbWJKQz5EuGV36U0smcZ4BYPZ0bxCyz1nLdgg=
 github.com/aws/eks-anywhere-packages v0.1.11 h1:CC8tdEEWrcmzJxKgpMuK6SHFNeHVyZXSi4GFXOioJXQ=
 github.com/aws/eks-anywhere-packages v0.1.11/go.mod h1:g4HXRg4xMgofXwDrlOtMYVkKEQQC3JXgduQTkDfPf6U=
 github.com/aws/eks-distro-build-tooling/release v0.0.0-20211103003257-a7e2379eae5e h1:GB6Cn9yKEt31mDF7RrVWyM9WoppNkGYth8zBPIJGJ+w=
@@ -1487,6 +1488,8 @@ github.com/rakyll/statik v0.1.6/go.mod h1:OEi9wJV/fMUAGx1eNjq75DKDsJVuEv1U0oYdX6
 github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/rejoshed/cluster-api-provider-cloudstack v0.4.5-rc3.0.20220716163849-c554f7451de3 h1:2qtcxIZ/5Z1WbeoPeBzlqCCIdwWzeKsJdrt2NsGGrWg=
+github.com/rejoshed/cluster-api-provider-cloudstack v0.4.5-rc3.0.20220716163849-c554f7451de3/go.mod h1:qJ9cAquiVi7/uwAwlKiQLMVrfskkXF5orz68Shltsh0=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -1541,6 +1544,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/smallfish/simpleyaml v0.1.0 h1:5uAZdLAiHxS9cmzkOxg7lH0dILXKTD7uRZbAhyHmyU0=
+github.com/smallfish/simpleyaml v0.1.0/go.mod h1:gU3WdNn44dQVAbVHD2SrSqKKCvmzFApWD2UURhgEj1M=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
@@ -2693,8 +2698,6 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyz
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.25/go.mod h1:Mlj9PNLmG9bZ6BHFwFKDo5afkpWyUISkb9Me0GnK66I=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.27/go.mod h1:tq2nT0Kx7W+/f2JVE+zxYtUhdjuELJkVpNz+x/QN5R4=
-sigs.k8s.io/cluster-api-provider-cloudstack v0.4.5-rc3 h1:Ge3aNWoBTfhgUgweecZaMVT24xNx/Y+WeN9OP4exJwA=
-sigs.k8s.io/cluster-api-provider-cloudstack v0.4.5-rc3/go.mod h1:pw63Cikv2KHwjS9VFwlJn2rqf2/bcTnycaX10K7Ti0k=
 sigs.k8s.io/cluster-api-provider-vsphere v1.0.1 h1:qs7zSFkAL9tU8tHob7bmrEWfKsOU5JaskpeSIYrhQCc=
 sigs.k8s.io/cluster-api-provider-vsphere v1.0.1/go.mod h1:Z6MDQcZjX5DUcEFStotBptj2fMR4vgCVPAnw6inIY20=
 sigs.k8s.io/cluster-api/test v1.0.0 h1:PeWOLXtDGYMmzXwGX+NtH7Xxx6BtS83DT7vKzITY5X0=


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/aws/eks-anywhere/issues/2406

*Description of changes:*
Updated the mapper function from CloudStackCluster to CloudStackDataCenterConfig for v1beta2 API

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

