### PR TITLE
Pause reconcile before upgrading core components

### DIFF
--- a/controllers/resource/reconciler.go
+++ b/controllers/resource/reconciler.go
@@ -13,8 +13,8 @@ import (
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/features"
+	"github.com/aws/eks-anywhere/pkg/providers/common"
 	anywhereTypes "github.com/aws/eks-anywhere/pkg/types"
 )
 
@@ -168,7 +168,7 @@ func (cor *clusterReconciler) applyTemplates(ctx context.Context, cs *anywherev1
 	for _, resource := range resources {
 		kind := resource.GetKind()
 		name := resource.GetName()
-		if cs.IsSelfManaged() && (strings.HasPrefix(name, fmt.Sprintf("%s%s", cs.Name, constants.ControlPlaneTemplatePrefix)) || strings.HasPrefix(name, fmt.Sprintf("%s%s", cs.Name, constants.EtcdTemplatePrefix))) {
+		if cs.IsSelfManaged() && (strings.HasPrefix(name, common.CPMachineTemplateBase(cs.Name)) || strings.HasPrefix(name, common.EtcdMachineTemplateBase(cs.Name))) {
 			continue
 		}
 		cor.Log.Info("applying object", "kind", kind, "name", name, "dryRun", dryRun)

--- a/controllers/resource/reconciler.go
+++ b/controllers/resource/reconciler.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -12,6 +13,7 @@ import (
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/features"
 	anywhereTypes "github.com/aws/eks-anywhere/pkg/types"
 )
@@ -159,13 +161,16 @@ func (cor *clusterReconciler) Reconcile(ctx context.Context, objectKey types.Nam
 			resources = append(resources, r...)
 		}
 	}
-	return cor.applyTemplates(ctx, resources, dryRun)
+	return cor.applyTemplates(ctx, cs, resources, dryRun)
 }
 
-func (cor *clusterReconciler) applyTemplates(ctx context.Context, resources []*unstructured.Unstructured, dryRun bool) error {
+func (cor *clusterReconciler) applyTemplates(ctx context.Context, cs *anywherev1.Cluster, resources []*unstructured.Unstructured, dryRun bool) error {
 	for _, resource := range resources {
 		kind := resource.GetKind()
 		name := resource.GetName()
+		if cs.IsSelfManaged() && (strings.HasPrefix(name, fmt.Sprintf("%s%s", cs.Name, constants.ControlPlaneTemplatePrefix)) || strings.HasPrefix(name, fmt.Sprintf("%s%s", cs.Name, constants.EtcdTemplatePrefix))) {
+			continue
+		}
 		cor.Log.Info("applying object", "kind", kind, "name", name, "dryRun", dryRun)
 		fetch, err := cor.Fetch(ctx, resource.GetName(), resource.GetNamespace(), resource.GetKind(), resource.GetAPIVersion())
 		if err == nil {

--- a/controllers/resource/testdata/cloudstackCPMachineTemplate.yaml
+++ b/controllers/resource/testdata/cloudstackCPMachineTemplate.yaml
@@ -1,0 +1,17 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: CloudStackMachineTemplate
+metadata:
+  name: test-cluster-control-plane-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      userCustomDetails:
+        foo: bar
+      offering:
+        name: large
+      template:
+        name: rhel8-1.20
+      diskOffering:
+        name: Small
+        mountPath: /data-small

--- a/controllers/resource/testdata/cloudstackEtcdMachineTemplate.yaml
+++ b/controllers/resource/testdata/cloudstackEtcdMachineTemplate.yaml
@@ -1,0 +1,17 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: CloudStackMachineTemplate
+metadata:
+  name: test-cluster-etcd-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      userCustomDetails:
+        foo: bar
+      offering:
+        name: large
+      template:
+        name: rhel8-1.20
+      diskOffering:
+        name: Small
+        mountPath: /data-small

--- a/controllers/resource/testdata/eksa-cluster-cloudstack-etcd.yaml
+++ b/controllers/resource/testdata/eksa-cluster-cloudstack-etcd.yaml
@@ -1,0 +1,72 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: test-cluster
+spec:
+  clusterNetwork:
+    cni: cilium
+    pods:
+      cidrBlocks:
+        - 172.31.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+    endpoint:
+      host: "192.168.1.71"
+    machineGroupRef:
+      kind: CloudStackMachineConfig
+      name: test-cluster
+  externalEtcdConfiguration:
+    count: 3
+    machineGroupRef:
+      name: test-cluster
+      kind: CloudStackMachineConfig
+  datacenterRef:
+    kind: CloudStackDatacenterConfig
+    name: test-cluster
+  kubernetesVersion: "1.21"
+  workerNodeGroupConfigurations:
+    - count: 3
+      machineGroupRef:
+        kind: CloudStackMachineConfig
+        name: test-cluster
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackDatacenterConfig
+metadata:
+  name: test-cluster
+spec:
+  domain: "root"
+  account: "admin"
+  zones:
+    - name: "zone1"
+      network:
+        name: GuestNet1
+    - name: "zone2"
+      network:
+        name: GuestNet2
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackMachineConfig
+metadata:
+  name: test-cluster
+spec:
+  computeOffering:
+    name: "Large Instance"
+  users:
+    - name: "cpac"
+      sshAuthorizedKeys:
+        - "ssh-rsa ssh-key-value"
+  template:
+    name: "rhel-8-kube-v1.21.5"
+  diskOffering:
+    name: "Small"
+    mountPath: "/data-small"
+    device: "/dev/vdb"
+    filesystem: "ext4"
+    label: "data_disk"
+---

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -39,7 +39,4 @@ const (
 
 	DefaultRegistry            = "public.ecr.aws"
 	CloudstackAnnotationSuffix = "cloudstack.anywhere.eks.amazonaws.com/v1alpha1"
-
-	ControlPlaneTemplatePrefix = "-control-plane-template-"
-	EtcdTemplatePrefix         = "-etcd-template-"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -39,4 +39,7 @@ const (
 
 	DefaultRegistry            = "public.ecr.aws"
 	CloudstackAnnotationSuffix = "cloudstack.anywhere.eks.amazonaws.com/v1alpha1"
+
+	ControlPlaneTemplatePrefix = "-control-plane-template-"
+	EtcdTemplatePrefix         = "-etcd-template-"
 )

--- a/pkg/providers/common/common.go
+++ b/pkg/providers/common/common.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/bootstrapper"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/crypto"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/logger"
@@ -74,12 +75,12 @@ func GenerateSSHAuthKey(writer filewriter.FileWriter) (string, error) {
 
 func CPMachineTemplateName(clusterName string, now types.NowFunc) string {
 	t := now().UnixNano() / int64(time.Millisecond)
-	return fmt.Sprintf("%s-control-plane-template-%d", clusterName, t)
+	return fmt.Sprintf("%s%s%d", clusterName, constants.ControlPlaneTemplatePrefix, t)
 }
 
 func EtcdMachineTemplateName(clusterName string, now types.NowFunc) string {
 	t := now().UnixNano() / int64(time.Millisecond)
-	return fmt.Sprintf("%s-etcd-template-%d", clusterName, t)
+	return fmt.Sprintf("%s%s%d", clusterName, constants.EtcdTemplatePrefix, t)
 }
 
 func WorkerMachineTemplateName(clusterName, workerNodeGroupName string, now types.NowFunc) string {

--- a/pkg/providers/common/common.go
+++ b/pkg/providers/common/common.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/bootstrapper"
-	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/crypto"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/logger"
@@ -73,19 +72,31 @@ func GenerateSSHAuthKey(writer filewriter.FileWriter) (string, error) {
 	return key, nil
 }
 
+func CPMachineTemplateBase(clusterName string) string {
+	return fmt.Sprintf("%s-control-plane-template", clusterName)
+}
+
+func EtcdMachineTemplateBase(clusterName string) string {
+	return fmt.Sprintf("%s-etcd-template", clusterName)
+}
+
+func WorkerMachineTemplateBase(clusterName, workerNodeGroupName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, workerNodeGroupName)
+}
+
 func CPMachineTemplateName(clusterName string, now types.NowFunc) string {
 	t := now().UnixNano() / int64(time.Millisecond)
-	return fmt.Sprintf("%s%s%d", clusterName, constants.ControlPlaneTemplatePrefix, t)
+	return fmt.Sprintf("%s-%d", CPMachineTemplateBase(clusterName), t)
 }
 
 func EtcdMachineTemplateName(clusterName string, now types.NowFunc) string {
 	t := now().UnixNano() / int64(time.Millisecond)
-	return fmt.Sprintf("%s%s%d", clusterName, constants.EtcdTemplatePrefix, t)
+	return fmt.Sprintf("%s-%d", EtcdMachineTemplateBase(clusterName), t)
 }
 
 func WorkerMachineTemplateName(clusterName, workerNodeGroupName string, now types.NowFunc) string {
 	t := now().UnixNano() / int64(time.Millisecond)
-	return fmt.Sprintf("%s-%s-%d", clusterName, workerNodeGroupName, t)
+	return fmt.Sprintf("%s-%d", WorkerMachineTemplateBase(clusterName, workerNodeGroupName), t)
 }
 
 func KubeadmConfigTemplateName(clusterName, workerNodeGroupName string, now types.NowFunc) string {

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -109,9 +109,9 @@ type deleteBootstrapClusterTask struct {
 
 type updateClusterAndGitResources struct{}
 
-type resumeEksaAndFluxReconcile struct{}
-
-type resumeFluxReconcile struct{}
+type resumeEksaAndFluxReconcile struct {
+	eksaSpecDiff bool
+}
 
 type writeClusterConfigTask struct{}
 
@@ -223,37 +223,6 @@ func (s *ensureEtcdCAPIComponentsExistTask) Restore(ctx context.Context, command
 	return &pauseEksaAndFluxReconcile{}, nil
 }
 
-func (s *pauseEksaAndFluxReconcile) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
-	logger.Info("Pausing EKS-A cluster controller reconcile")
-	err := commandContext.ClusterManager.PauseEKSAControllerReconcile(ctx, commandContext.ManagementCluster, commandContext.CurrentClusterSpec, commandContext.Provider)
-	if err != nil {
-		commandContext.SetError(err)
-		return &CollectDiagnosticsTask{}
-	}
-
-	logger.Info("Pausing Flux kustomization")
-	err = commandContext.AddonManager.PauseGitOpsKustomization(ctx, commandContext.ManagementCluster, commandContext.ClusterSpec)
-	if err != nil {
-		commandContext.SetError(err)
-		return &CollectDiagnosticsTask{}
-	}
-	return &upgradeCoreComponents{}
-}
-
-func (s *pauseEksaAndFluxReconcile) Name() string {
-	return "pause-controllers-reconcile"
-}
-
-func (s *pauseEksaAndFluxReconcile) Checkpoint() *task.CompletedTask {
-	return &task.CompletedTask{
-		Checkpoint: nil,
-	}
-}
-
-func (s *pauseEksaAndFluxReconcile) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
-	return &upgradeCoreComponents{}, nil
-}
-
 func (s *upgradeCoreComponents) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Upgrading core components")
 
@@ -359,35 +328,35 @@ func (s *upgradeNeeded) Restore(ctx context.Context, commandContext *task.Comman
 	return &createBootstrapClusterTask{}, nil
 }
 
-func (s *resumeEksaAndFluxReconcile) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
-	logger.Info("Resuming EKS-A controller reconciliation")
-	err := commandContext.ClusterManager.ResumeEKSAControllerReconcile(ctx, commandContext.ManagementCluster, commandContext.ClusterSpec, commandContext.Provider)
+func (s *pauseEksaAndFluxReconcile) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("Pausing EKS-A cluster controller reconcile")
+	err := commandContext.ClusterManager.PauseEKSAControllerReconcile(ctx, commandContext.ManagementCluster, commandContext.CurrentClusterSpec, commandContext.Provider)
 	if err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}
 	}
 
-	logger.Info("Resuming Flux kustomization")
-	err = commandContext.AddonManager.ResumeGitOpsKustomization(ctx, commandContext.ManagementCluster, commandContext.ClusterSpec)
+	logger.Info("Pausing Flux kustomization")
+	err = commandContext.AddonManager.PauseGitOpsKustomization(ctx, commandContext.ManagementCluster, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}
 	}
-	return nil
+	return &upgradeCoreComponents{}
 }
 
-func (s *resumeEksaAndFluxReconcile) Name() string {
-	return "resume-eksa-and-flux-kustomization"
+func (s *pauseEksaAndFluxReconcile) Name() string {
+	return "pause-controllers-reconcile"
 }
 
-func (s *resumeEksaAndFluxReconcile) Checkpoint() *task.CompletedTask {
+func (s *pauseEksaAndFluxReconcile) Checkpoint() *task.CompletedTask {
 	return &task.CompletedTask{
 		Checkpoint: nil,
 	}
 }
 
-func (s *resumeEksaAndFluxReconcile) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
-	return nil, nil
+func (s *pauseEksaAndFluxReconcile) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return &upgradeCoreComponents{}, nil
 }
 
 func (s *createBootstrapClusterTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
@@ -578,21 +547,9 @@ func (s *updateClusterAndGitResources) Run(ctx context.Context, commandContext *
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}
 	}
-
-	logger.Info("Resuming EKS-A controller reconciliation")
-	err = commandContext.ClusterManager.ResumeEKSAControllerReconcile(ctx, commandContext.ManagementCluster, commandContext.ClusterSpec, commandContext.Provider)
-	if err != nil {
-		commandContext.SetError(err)
-		return &CollectDiagnosticsTask{}
+	return &resumeEksaAndFluxReconcile{
+		eksaSpecDiff: true,
 	}
-
-	logger.Info("Updating Git Repo with new EKS-A cluster spec")
-	err = commandContext.AddonManager.UpdateGitEksaSpec(ctx, commandContext.ClusterSpec, datacenterConfig, machineConfigs)
-	if err != nil {
-		commandContext.SetError(err)
-		return &CollectDiagnosticsTask{}
-	}
-	return &resumeFluxReconcile{}
 }
 
 func (s *updateClusterAndGitResources) Name() string {
@@ -606,12 +563,31 @@ func (s *updateClusterAndGitResources) Checkpoint() *task.CompletedTask {
 }
 
 func (s *updateClusterAndGitResources) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
-	return &resumeFluxReconcile{}, nil
+	return &resumeEksaAndFluxReconcile{
+		eksaSpecDiff: true,
+	}, nil
 }
 
-func (s *resumeFluxReconcile) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+func (s *resumeEksaAndFluxReconcile) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	datacenterConfig := commandContext.Provider.DatacenterConfig(commandContext.ClusterSpec)
+	machineConfigs := commandContext.Provider.MachineConfigs(commandContext.ClusterSpec)
+
+	logger.Info("Resuming EKS-A controller reconciliation")
+	err := commandContext.ClusterManager.ResumeEKSAControllerReconcile(ctx, commandContext.ManagementCluster, commandContext.ClusterSpec, commandContext.Provider)
+	if err != nil {
+		commandContext.SetError(err)
+		return &CollectDiagnosticsTask{}
+	}
+
+	logger.Info("Updating Git Repo with new EKS-A cluster spec")
+	err = commandContext.AddonManager.UpdateGitEksaSpec(ctx, commandContext.ClusterSpec, datacenterConfig, machineConfigs)
+	if err != nil {
+		commandContext.SetError(err)
+		return &CollectDiagnosticsTask{}
+	}
+
 	logger.Info("Forcing reconcile Git repo with latest commit")
-	err := commandContext.AddonManager.ForceReconcileGitRepo(ctx, commandContext.ManagementCluster, commandContext.ClusterSpec)
+	err = commandContext.AddonManager.ForceReconcileGitRepo(ctx, commandContext.ManagementCluster, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}
@@ -623,20 +599,23 @@ func (s *resumeFluxReconcile) Run(ctx context.Context, commandContext *task.Comm
 		commandContext.SetError(err)
 		return &writeClusterConfigTask{}
 	}
+	if !s.eksaSpecDiff {
+		return nil
+	}
 	return &writeClusterConfigTask{}
 }
 
-func (s *resumeFluxReconcile) Name() string {
-	return "resume-flux-kustomization"
+func (s *resumeEksaAndFluxReconcile) Name() string {
+	return "resume-eksa-and-flux-kustomization"
 }
 
-func (s *resumeFluxReconcile) Checkpoint() *task.CompletedTask {
+func (s *resumeEksaAndFluxReconcile) Checkpoint() *task.CompletedTask {
 	return &task.CompletedTask{
 		Checkpoint: nil,
 	}
 }
 
-func (s *resumeFluxReconcile) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+func (s *resumeEksaAndFluxReconcile) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
 	return &writeClusterConfigTask{}, nil
 }
 

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -380,14 +380,6 @@ func (c *upgradeTestSetup) expectVerifyClusterSpecNoChanges() {
 	)
 }
 
-func (c *upgradeTestSetup) expectPauseEKSAControllerReconcileNotToBeCalled() {
-	c.clusterManager.EXPECT().PauseEKSAControllerReconcile(c.ctx, c.workloadCluster, c.newClusterSpec, c.provider).Times(0)
-}
-
-func (c *upgradeTestSetup) expectPauseGitOpsKustomizationNotToBeCalled() {
-	c.addonManager.EXPECT().PauseGitOpsKustomization(c.ctx, c.workloadCluster, c.newClusterSpec).Times(0)
-}
-
 func (c *upgradeTestSetup) expectCreateBootstrapNotToBeCalled() {
 	c.provider.EXPECT().BootstrapClusterOpts().Times(0)
 	c.bootstrapper.EXPECT().CreateBootstrapCluster(c.ctx, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).Times(0)
@@ -404,11 +396,13 @@ func TestSkipUpgradeRunSuccess(t *testing.T) {
 	test.expectPreflightValidationsToPass()
 	test.expectUpdateSecrets(test.workloadCluster)
 	test.expectEnsureEtcdCAPIComponentsExistTask(test.workloadCluster)
+	test.expectPauseEKSAControllerReconcile(test.workloadCluster)
+	test.expectPauseGitOpsKustomization(test.workloadCluster)
 	test.expectUpgradeCoreComponents(test.workloadCluster, test.workloadCluster)
 	test.expectProviderNoUpgradeNeeded(test.workloadCluster)
 	test.expectVerifyClusterSpecNoChanges()
-	test.expectPauseEKSAControllerReconcileNotToBeCalled()
-	test.expectPauseGitOpsKustomizationNotToBeCalled()
+	test.expectResumeEKSAControllerReconcile(test.workloadCluster)
+	test.expectResumeGitOpsKustomization(test.workloadCluster)
 	test.expectCreateBootstrapNotToBeCalled()
 
 	err := test.run()

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -293,13 +293,13 @@ func (c *upgradeTestSetup) expectPauseGitOpsKustomization(expectedCluster *types
 
 func (c *upgradeTestSetup) expectDatacenterConfig() {
 	gomock.InOrder(
-		c.provider.EXPECT().DatacenterConfig(c.newClusterSpec).Return(c.datacenterConfig),
+		c.provider.EXPECT().DatacenterConfig(c.newClusterSpec).Return(c.datacenterConfig).AnyTimes(),
 	)
 }
 
 func (c *upgradeTestSetup) expectMachineConfigs() {
 	gomock.InOrder(
-		c.provider.EXPECT().MachineConfigs(c.newClusterSpec).Return(c.machineConfigs),
+		c.provider.EXPECT().MachineConfigs(c.newClusterSpec).Return(c.machineConfigs).AnyTimes(),
 	)
 }
 
@@ -401,7 +401,11 @@ func TestSkipUpgradeRunSuccess(t *testing.T) {
 	test.expectUpgradeCoreComponents(test.workloadCluster, test.workloadCluster)
 	test.expectProviderNoUpgradeNeeded(test.workloadCluster)
 	test.expectVerifyClusterSpecNoChanges()
+	test.expectDatacenterConfig()
+	test.expectMachineConfigs()
 	test.expectResumeEKSAControllerReconcile(test.workloadCluster)
+	test.expectUpdateGitEksaSpec()
+	test.expectForceReconcileGitRepo(test.workloadCluster)
 	test.expectResumeGitOpsKustomization(test.workloadCluster)
 	test.expectCreateBootstrapNotToBeCalled()
 


### PR DESCRIPTION
*Issue #, if available:*
#2710 

*Description of changes:*
We are pausing reconciliation before the upgrade-core-components task to avoid premature rolling upgrades. See issue above for more details.

We also added a validation in the controller to never apply the CP and etcd templates on the management cluster through the controller.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

