### PR TITLE
Fix snow upgrade bugs encountered during upgrade from beta

### DIFF
--- a/pkg/clusterapi/name.go
+++ b/pkg/clusterapi/name.go
@@ -7,10 +7,16 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
 var nameRegex = regexp.MustCompile(`(.*?)(-)(\d+)$`)
 
+// IncrementName takes an object name and increments the suffix number by one.
+// This method is used for updating objects (e.g. machinetemplate, kubeadmconfigtemplate) that are either immutable
+// or require recreation to trigger machine rollout. The original object name should follow the name convention of
+// alphanumeric followed by dash digits, e.g. abc-1, md-0, kct-2. An error will be raised if the original name does not follow
+// this pattern.
 func IncrementName(name string) (string, error) {
 	match := nameRegex.FindStringSubmatch(name)
 	if match == nil {
@@ -23,6 +29,19 @@ func IncrementName(name string) (string, error) {
 	}
 
 	return ObjectName(match[1], n+1), nil
+}
+
+// IncrementNameWithFallbackDefault calls the IncrementName and fallbacks to use the default name if IncrementName
+// returns an error. This method is used to accommodate for any objects with name breaking changes from a previous version.
+// For example, in beta capi snowmachinetemplate is named after the eks-a snowmachineconfig name, without the '-1' suffix.
+// We set the object name to the default new machinetemplate name after detecting the invalid old name.
+func IncrementNameWithFallbackDefault(name, defaultName string) string {
+	n, err := IncrementName(name)
+	if err != nil {
+		logger.V(3).Info("Unable to increment object name (might due to changes of name format), fallback to the default name", "error", err.Error())
+		return defaultName
+	}
+	return n
 }
 
 func ObjectName(baseName string, version int) string {

--- a/pkg/clusterapi/name.go
+++ b/pkg/clusterapi/name.go
@@ -38,7 +38,7 @@ func IncrementName(name string) (string, error) {
 func IncrementNameWithFallbackDefault(name, defaultName string) string {
 	n, err := IncrementName(name)
 	if err != nil {
-		logger.V(3).Info("Unable to increment object name (might due to changes of name format), fallback to the default name", "error", err.Error())
+		logger.V(4).Info("Unable to increment object name (might due to changes of name format), fallback to the default name", "error", err.Error())
 		return defaultName
 	}
 	return n

--- a/pkg/clusterapi/name_test.go
+++ b/pkg/clusterapi/name_test.go
@@ -42,6 +42,35 @@ func TestIncrementName(t *testing.T) {
 	}
 }
 
+func TestIncrementNameWithFallbackDefault(t *testing.T) {
+	tests := []struct {
+		name        string
+		oldName     string
+		defaultName string
+		want        string
+	}{
+		{
+			name:        "valid",
+			oldName:     "cluster-1",
+			defaultName: "default",
+			want:        "cluster-2",
+		},
+		{
+			name:        "invalid format",
+			oldName:     "cluster-1a",
+			defaultName: "default",
+			want:        "default",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := clusterapi.IncrementNameWithFallbackDefault(tt.oldName, tt.defaultName)
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
 func TestObjectName(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -13,6 +13,7 @@ const (
 	CapvSystemNamespace                     = "capv-system"
 	CaptSystemNamespace                     = "capt-system"
 	CapaSystemNamespace                     = "capa-system"
+	CapasSystemNamespace                    = "capas-system"
 	CertManagerNamespace                    = "cert-manager"
 	DefaultNamespace                        = "default"
 	EtcdAdmBootstrapProviderSystemNamespace = "etcdadm-bootstrap-provider-system"

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -300,6 +300,7 @@ var providerNamespaces = map[string]string{
 	constants.DockerProviderName:     constants.CapdSystemNamespace,
 	constants.CloudStackProviderName: constants.CapcSystemNamespace,
 	constants.AWSProviderName:        constants.CapaSystemNamespace,
+	constants.SnowProviderName:       constants.CapasSystemNamespace,
 	etcdadmBootstrapProviderName:     constants.EtcdAdmBootstrapProviderSystemNamespace,
 	etcdadmControllerProviderName:    constants.EtcdAdmControllerSystemNamespace,
 	kubeadmBootstrapProviderName:     constants.CapiKubeadmBootstrapSystemNamespace,

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -184,7 +184,7 @@ func (p *SnowProvider) EnvMap(clusterSpec *cluster.Spec) (map[string]string, err
 
 func (p *SnowProvider) GetDeployments() map[string][]string {
 	return map[string][]string{
-		"capas-system": {"capas-controller-manager"},
+		constants.CapasSystemNamespace: {"capas-controller-manager"},
 	}
 }
 

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -231,7 +231,15 @@ func (p *SnowProvider) GenerateMHC(clusterSpec *cluster.Spec) ([]byte, error) {
 }
 
 func (p *SnowProvider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	return nil
+	if currentSpec.VersionsBundle.Snow.Version == newSpec.VersionsBundle.Snow.Version {
+		return nil
+	}
+
+	return &types.ComponentChangeDiff{
+		ComponentName: constants.SnowProviderName,
+		NewVersion:    newSpec.VersionsBundle.Snow.Version,
+		OldVersion:    currentSpec.VersionsBundle.Snow.Version,
+	}
 }
 
 func (p *SnowProvider) RunPostControlPlaneUpgrade(ctx context.Context, oldClusterSpec *cluster.Spec, clusterSpec *cluster.Spec, workloadCluster *types.Cluster, managementCluster *types.Cluster) error {

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -739,3 +739,25 @@ func TestUpgradeNeededMachineConfigs(t *testing.T) {
 		})
 	}
 }
+
+func TestChangeDiffNoChange(t *testing.T) {
+	g := NewWithT(t)
+	provider := givenProvider(t)
+	clusterSpec := givenEmptyClusterSpec()
+	g.Expect(provider.ChangeDiff(clusterSpec, clusterSpec)).To(BeNil())
+}
+
+func TestChangeDiffWithChange(t *testing.T) {
+	g := NewWithT(t)
+	provider := givenProvider(t)
+	clusterSpec := givenEmptyClusterSpec()
+	newClusterSpec := clusterSpec.DeepCopy()
+	clusterSpec.VersionsBundle.Snow.Version = "v1.0.2"
+	newClusterSpec.VersionsBundle.Snow.Version = "v1.0.3"
+	want := &types.ComponentChangeDiff{
+		ComponentName: "snow",
+		NewVersion:    "v1.0.3",
+		OldVersion:    "v1.0.2",
+	}
+	g.Expect(provider.ChangeDiff(clusterSpec, newClusterSpec)).To(Equal(want))
+}


### PR DESCRIPTION
*Issue #, if available:*

#1106 

*Description of changes:*

- Support snow upgrade from beta with different CAPI objects naming format
- Add ChangeDiff to upgrade CAPAS provider during components upgrade

*Testing (if applicable):*

- Unit tests
- Manually upgrade snow cluster from beta to latest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

