### PR TITLE
Support backward compatibility cloudstack datacenter config

### DIFF
--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -444,10 +444,10 @@ func (p *cloudstackProvider) validateSecretsUnchanged(ctx context.Context, clust
 }
 
 func secretDifferentFromProfile(secret *corev1.Secret, profile decoder.CloudStackProfileConfig) bool {
-	return string(secret.Data["uri"]) != profile.ManagementUrl ||
-		string(secret.Data["apikey"]) != profile.ApiKey ||
-		string(secret.Data["secretkey"]) != profile.SecretKey ||
-		string(secret.Data["verifyssl"]) != profile.VerifySsl
+	return string(secret.Data["api-url"]) != profile.ManagementUrl ||
+		string(secret.Data["api-key"]) != profile.ApiKey ||
+		string(secret.Data["secret-key"]) != profile.SecretKey ||
+		string(secret.Data["verify-ssl"]) != profile.VerifySsl
 }
 
 func (p *cloudstackProvider) validateClusterSpec(ctx context.Context, clusterSpec *cluster.Spec) (err error) {

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -54,10 +54,10 @@ var expectedSecret = &v1.Secret{
 		Name:      "global",
 	},
 	Data: map[string][]byte{
-		"uri":       []byte("http://127.16.0.1:8080/client/api"),
-		"apikey":    []byte("test-key1"),
-		"secretkey": []byte("test-secret1"),
-		"verifyssl": []byte("false"),
+		"api-url":    []byte("http://127.16.0.1:8080/client/api"),
+		"api-key":    []byte("test-key1"),
+		"secret-key": []byte("test-secret1"),
+		"verify-ssl": []byte("false"),
 	},
 }
 
@@ -401,7 +401,7 @@ func TestProviderSetupAndValidateUpgradeClusterFailureOnSecretChanged(t *testing
 	cmk := givenWildcardCmk(mockCtrl)
 	provider := newProviderWithKubectl(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, kubectl, cmk)
 	modifiedSecret := expectedSecret.DeepCopy()
-	modifiedSecret.Data["apikey"] = []byte("updated-api-key")
+	modifiedSecret.Data["api-key"] = []byte("updated-api-key")
 	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.Name).Return(clusterSpec.Cluster, nil)
 	kubectl.EXPECT().GetSecretFromNamespace(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(modifiedSecret, nil)
 

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -557,8 +557,9 @@ func TestBootstrapClusterOpts(t *testing.T) {
 	clusterSpecManifest := "cluster_minimal_proxy.yaml"
 	provider := givenProvider(t)
 	provider.clusterConfig = givenClusterConfig(t, clusterSpecManifest)
+	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
 
-	bootstrapClusterOps, err := provider.BootstrapClusterOpts()
+	bootstrapClusterOps, err := provider.BootstrapClusterOpts(clusterSpec)
 	if err != nil {
 		t.Fatalf("failed BootstrapClusterOpts: %v", err)
 	}

--- a/pkg/providers/common/common.go
+++ b/pkg/providers/common/common.go
@@ -30,18 +30,19 @@ func GetAuditPolicy() string {
 	return auditPolicy
 }
 
-func BootstrapClusterOpts(serverEndpoint string, clusterConfig *v1alpha1.Cluster) ([]bootstrapper.BootstrapClusterOption, error) {
+func BootstrapClusterOpts(clusterConfig *v1alpha1.Cluster, serverEndpoints ...string) ([]bootstrapper.BootstrapClusterOption, error) {
 	env := map[string]string{}
 	if clusterConfig.Spec.ProxyConfiguration != nil {
-		noProxy := fmt.Sprintf("%s,%s", clusterConfig.Spec.ControlPlaneConfiguration.Endpoint.Host, serverEndpoint)
+		noProxyes := append([]string{}, serverEndpoints...)
+		noProxyes = append(noProxyes, clusterConfig.Spec.ControlPlaneConfiguration.Endpoint.Host)
 		for _, s := range clusterConfig.Spec.ProxyConfiguration.NoProxy {
 			if s != "" {
-				noProxy += "," + s
+				noProxyes = append(noProxyes, s)
 			}
 		}
 		env["HTTP_PROXY"] = clusterConfig.Spec.ProxyConfiguration.HttpProxy
 		env["HTTPS_PROXY"] = clusterConfig.Spec.ProxyConfiguration.HttpsProxy
-		env["NO_PROXY"] = noProxy
+		env["NO_PROXY"] = strings.Join(noProxyes, ",")
 	}
 	return []bootstrapper.BootstrapClusterOption{bootstrapper.WithEnv(env)}, nil
 }

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -72,7 +72,7 @@ func NewProvider(providerConfig *v1alpha1.DockerDatacenterConfig, docker Provide
 	}
 }
 
-func (p *provider) BootstrapClusterOpts() ([]bootstrapper.BootstrapClusterOption, error) {
+func (p *provider) BootstrapClusterOpts(_ *cluster.Spec) ([]bootstrapper.BootstrapClusterOption, error) {
 	return []bootstrapper.BootstrapClusterOption{bootstrapper.WithExtraDockerMounts()}, nil
 }
 

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -40,18 +40,18 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 }
 
 // BootstrapClusterOpts mocks base method.
-func (m *MockProvider) BootstrapClusterOpts() ([]bootstrapper.BootstrapClusterOption, error) {
+func (m *MockProvider) BootstrapClusterOpts(arg0 *cluster.Spec) ([]bootstrapper.BootstrapClusterOption, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BootstrapClusterOpts")
+	ret := m.ctrl.Call(m, "BootstrapClusterOpts", arg0)
 	ret0, _ := ret[0].([]bootstrapper.BootstrapClusterOption)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BootstrapClusterOpts indicates an expected call of BootstrapClusterOpts.
-func (mr *MockProviderMockRecorder) BootstrapClusterOpts() *gomock.Call {
+func (mr *MockProviderMockRecorder) BootstrapClusterOpts(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BootstrapClusterOpts", reflect.TypeOf((*MockProvider)(nil).BootstrapClusterOpts))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BootstrapClusterOpts", reflect.TypeOf((*MockProvider)(nil).BootstrapClusterOpts), arg0)
 }
 
 // ChangeDiff mocks base method.

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -24,7 +24,7 @@ type Provider interface {
 	PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error
 	// PostWorkloadInit is called after the workload cluster is created and initialized with a CNI. This allows us to do provider specific configuration on the workload cluster.
 	PostWorkloadInit(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
-	BootstrapClusterOpts() ([]bootstrapper.BootstrapClusterOption, error)
+	BootstrapClusterOpts(clusterSpec *cluster.Spec) ([]bootstrapper.BootstrapClusterOption, error)
 	UpdateKubeConfig(content *[]byte, clusterName string) error
 	Version(clusterSpec *cluster.Spec) string
 	EnvMap(clusterSpec *cluster.Spec) (map[string]string, error)

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -160,7 +160,7 @@ func (p *SnowProvider) PostWorkloadInit(ctx context.Context, cluster *types.Clus
 	return nil
 }
 
-func (p *SnowProvider) BootstrapClusterOpts() ([]bootstrapper.BootstrapClusterOption, error) {
+func (p *SnowProvider) BootstrapClusterOpts(_ *cluster.Spec) ([]bootstrapper.BootstrapClusterOption, error) {
 	return nil, nil
 }
 

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 
-func (p *Provider) BootstrapClusterOpts() ([]bootstrapper.BootstrapClusterOption, error) {
+func (p *Provider) BootstrapClusterOpts(_ *cluster.Spec) ([]bootstrapper.BootstrapClusterOption, error) {
 	var opts []bootstrapper.BootstrapClusterOption
 
 	if p.clusterConfig.Spec.ProxyConfiguration != nil {

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -229,8 +229,8 @@ func (p *vsphereProvider) machineConfigsSpecChanged(ctx context.Context, cc *v1a
 	return false, nil
 }
 
-func (p *vsphereProvider) BootstrapClusterOpts() ([]bootstrapper.BootstrapClusterOption, error) {
-	return common.BootstrapClusterOpts(p.datacenterConfig.Spec.Server, p.clusterConfig)
+func (p *vsphereProvider) BootstrapClusterOpts(_ *cluster.Spec) ([]bootstrapper.BootstrapClusterOption, error) {
+	return common.BootstrapClusterOpts(p.clusterConfig, p.datacenterConfig.Spec.Server)
 }
 
 func (p *vsphereProvider) Name() string {

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -1055,8 +1055,9 @@ func TestUpdateKubeConfig(t *testing.T) {
 
 func TestBootstrapClusterOpts(t *testing.T) {
 	provider := givenProvider(t)
+	clusterSpec := givenEmptyClusterSpec()
 
-	bootstrapClusterOps, err := provider.BootstrapClusterOpts()
+	bootstrapClusterOps, err := provider.BootstrapClusterOpts(clusterSpec)
 	if err != nil {
 		t.Fatalf("failed BootstrapClusterOpts: %v", err)
 	}

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -103,7 +103,7 @@ func (s *CreateBootStrapClusterTask) Run(ctx context.Context, commandContext *ta
 	}
 	logger.Info("Creating new bootstrap cluster")
 
-	bootstrapOptions, err := commandContext.Provider.BootstrapClusterOpts()
+	bootstrapOptions, err := commandContext.Provider.BootstrapClusterOpts(commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
 		return nil

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -86,7 +86,7 @@ func (c *createTestSetup) expectCreateBootstrap() {
 	}
 
 	gomock.InOrder(
-		c.provider.EXPECT().BootstrapClusterOpts().Return(opts, nil),
+		c.provider.EXPECT().BootstrapClusterOpts(gomock.Any()).Return(opts, nil),
 		// Checking for not nil because in go you can't compare closures
 		c.bootstrapper.EXPECT().CreateBootstrapCluster(
 			c.ctx, c.clusterSpec, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()),

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -86,7 +86,7 @@ func (c *createTestSetup) expectCreateBootstrap() {
 	}
 
 	gomock.InOrder(
-		c.provider.EXPECT().BootstrapClusterOpts(gomock.Any()).Return(opts, nil),
+		c.provider.EXPECT().BootstrapClusterOpts(c.clusterSpec).Return(opts, nil),
 		// Checking for not nil because in go you can't compare closures
 		c.bootstrapper.EXPECT().CreateBootstrapCluster(
 			c.ctx, c.clusterSpec, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()),

--- a/pkg/workflows/delete.go
+++ b/pkg/workflows/delete.go
@@ -97,7 +97,7 @@ func (s *createManagementCluster) Run(ctx context.Context, commandContext *task.
 		return &deleteWorkloadCluster{}
 	}
 	logger.Info("Creating management cluster")
-	bootstrapOptions, err := commandContext.Provider.BootstrapClusterOpts()
+	bootstrapOptions, err := commandContext.Provider.BootstrapClusterOpts(commandContext.ClusterSpec)
 	if err != nil {
 		logger.Error(err, "Error getting management options from provider")
 		commandContext.SetError(err)

--- a/pkg/workflows/delete_test.go
+++ b/pkg/workflows/delete_test.go
@@ -61,7 +61,7 @@ func (c *deleteTestSetup) expectCreateBootstrap() {
 	}
 
 	gomock.InOrder(
-		c.provider.EXPECT().BootstrapClusterOpts(gomock.Any()).Return(opts, nil),
+		c.provider.EXPECT().BootstrapClusterOpts(c.clusterSpec).Return(opts, nil),
 		c.bootstrapper.EXPECT().CreateBootstrapCluster(
 			c.ctx, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()),
 		).Return(c.bootstrapCluster, nil),
@@ -76,7 +76,7 @@ func (c *deleteTestSetup) expectNotToCreateBootstrap() {
 		bootstrapper.WithDefaultCNIDisabled(), bootstrapper.WithExtraDockerMounts(),
 	}
 
-	c.provider.EXPECT().BootstrapClusterOpts(gomock.Any()).Return(opts, nil).Times(0)
+	c.provider.EXPECT().BootstrapClusterOpts(c.clusterSpec).Return(opts, nil).Times(0)
 	c.bootstrapper.EXPECT().CreateBootstrapCluster(
 		c.ctx, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()),
 	).Return(c.bootstrapCluster, nil).Times(0)

--- a/pkg/workflows/delete_test.go
+++ b/pkg/workflows/delete_test.go
@@ -61,7 +61,7 @@ func (c *deleteTestSetup) expectCreateBootstrap() {
 	}
 
 	gomock.InOrder(
-		c.provider.EXPECT().BootstrapClusterOpts().Return(opts, nil),
+		c.provider.EXPECT().BootstrapClusterOpts(gomock.Any()).Return(opts, nil),
 		c.bootstrapper.EXPECT().CreateBootstrapCluster(
 			c.ctx, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()),
 		).Return(c.bootstrapCluster, nil),
@@ -76,7 +76,7 @@ func (c *deleteTestSetup) expectNotToCreateBootstrap() {
 		bootstrapper.WithDefaultCNIDisabled(), bootstrapper.WithExtraDockerMounts(),
 	}
 
-	c.provider.EXPECT().BootstrapClusterOpts().Return(opts, nil).Times(0)
+	c.provider.EXPECT().BootstrapClusterOpts(gomock.Any()).Return(opts, nil).Times(0)
 	c.bootstrapper.EXPECT().CreateBootstrapCluster(
 		c.ctx, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()),
 	).Return(c.bootstrapCluster, nil).Times(0)

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -361,7 +361,7 @@ func (s *createBootstrapClusterTask) Run(ctx context.Context, commandContext *ta
 		return &upgradeWorkloadClusterTask{}
 	}
 	logger.Info("Creating bootstrap cluster")
-	bootstrapOptions, err := commandContext.Provider.BootstrapClusterOpts()
+	bootstrapOptions, err := commandContext.Provider.BootstrapClusterOpts(commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
 		return nil

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -186,7 +186,7 @@ func (c *upgradeTestSetup) expectCreateBootstrap() {
 	}
 
 	gomock.InOrder(
-		c.provider.EXPECT().BootstrapClusterOpts(gomock.Any()).Return(opts, nil),
+		c.provider.EXPECT().BootstrapClusterOpts(c.newClusterSpec).Return(opts, nil),
 		c.bootstrapper.EXPECT().CreateBootstrapCluster(
 			c.ctx, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()),
 		).Return(c.bootstrapCluster, nil),
@@ -198,7 +198,7 @@ func (c *upgradeTestSetup) expectCreateBootstrap() {
 }
 
 func (c *upgradeTestSetup) expectNotToCreateBootstrap() {
-	c.provider.EXPECT().BootstrapClusterOpts(gomock.Any()).Times(0)
+	c.provider.EXPECT().BootstrapClusterOpts(c.newClusterSpec).Times(0)
 	c.bootstrapper.EXPECT().CreateBootstrapCluster(
 		c.ctx, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()),
 	).Times(0)
@@ -389,7 +389,7 @@ func (c *upgradeTestSetup) expectPauseGitOpsKustomizationNotToBeCalled() {
 }
 
 func (c *upgradeTestSetup) expectCreateBootstrapNotToBeCalled() {
-	c.provider.EXPECT().BootstrapClusterOpts(gomock.Any()).Times(0)
+	c.provider.EXPECT().BootstrapClusterOpts(c.newClusterSpec).Times(0)
 	c.bootstrapper.EXPECT().CreateBootstrapCluster(c.ctx, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).Times(0)
 	c.clusterManager.EXPECT().InstallCAPI(c.ctx, gomock.Not(gomock.Nil()), c.bootstrapCluster, c.provider).Times(0)
 }

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -186,7 +186,7 @@ func (c *upgradeTestSetup) expectCreateBootstrap() {
 	}
 
 	gomock.InOrder(
-		c.provider.EXPECT().BootstrapClusterOpts().Return(opts, nil),
+		c.provider.EXPECT().BootstrapClusterOpts(gomock.Any()).Return(opts, nil),
 		c.bootstrapper.EXPECT().CreateBootstrapCluster(
 			c.ctx, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()),
 		).Return(c.bootstrapCluster, nil),
@@ -198,7 +198,7 @@ func (c *upgradeTestSetup) expectCreateBootstrap() {
 }
 
 func (c *upgradeTestSetup) expectNotToCreateBootstrap() {
-	c.provider.EXPECT().BootstrapClusterOpts().Times(0)
+	c.provider.EXPECT().BootstrapClusterOpts(gomock.Any()).Times(0)
 	c.bootstrapper.EXPECT().CreateBootstrapCluster(
 		c.ctx, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()),
 	).Times(0)
@@ -389,7 +389,7 @@ func (c *upgradeTestSetup) expectPauseGitOpsKustomizationNotToBeCalled() {
 }
 
 func (c *upgradeTestSetup) expectCreateBootstrapNotToBeCalled() {
-	c.provider.EXPECT().BootstrapClusterOpts().Times(0)
+	c.provider.EXPECT().BootstrapClusterOpts(gomock.Any()).Times(0)
 	c.bootstrapper.EXPECT().CreateBootstrapCluster(c.ctx, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil())).Times(0)
 	c.clusterManager.EXPECT().InstallCAPI(c.ctx, gomock.Not(gomock.Nil()), c.bootstrapCluster, c.provider).Times(0)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cloudstack provider has datacenter config but it contains the original values before transforming using Defaulters. This PR uses the passed-in clusterSpec instead of the stored datacenter config when preflight checking and template generation.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

