### PR TITLE
E2E test for re-running upgrade command

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
+	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/yaml"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/clustermanager/internal"
 	"github.com/aws/eks-anywhere/pkg/clustermarshaller"
+	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/diagnostics"
 	"github.com/aws/eks-anywhere/pkg/executables"
@@ -39,7 +41,6 @@ const (
 	moveCAPIWait           = 15 * time.Minute
 	clusterWaitStr         = "60m"
 	ctrlPlaneWaitStr       = "60m"
-	etcdWaitStr            = "60m"
 	deploymentWaitStr      = "30m"
 	ctrlPlaneInProgressStr = "1m"
 	etcdInProgressStr      = "1m"
@@ -239,7 +240,7 @@ func (c *ClusterManager) CreateWorkloadCluster(ctx context.Context, managementCl
 
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		logger.V(3).Info("Waiting for external etcd to be ready", "cluster", workloadCluster.Name)
-		err = c.clusterClient.WaitForManagedExternalEtcdReady(ctx, managementCluster, etcdWaitStr, workloadCluster.Name)
+		err = c.clusterClient.WaitForManagedExternalEtcdReady(ctx, managementCluster, config.GetExternalEtcdTimeout(), workloadCluster.Name)
 		if err != nil {
 			return nil, fmt.Errorf("waiting for external etcd for workload cluster to be ready: %v", err)
 		}
@@ -381,7 +382,14 @@ func (c *ClusterManager) UpgradeCluster(ctx context.Context, managementCluster, 
 		}
 
 		logger.V(3).Info("Waiting for external etcd to be ready after upgrade")
-		if err := c.clusterClient.WaitForManagedExternalEtcdReady(ctx, managementCluster, etcdWaitStr, newClusterSpec.Cluster.Name); err != nil {
+		etcdWait := config.GetExternalEtcdTimeout()
+		if err = c.clusterClient.WaitForManagedExternalEtcdReady(ctx, managementCluster, etcdWait, newClusterSpec.Cluster.Name); err != nil {
+			if err := c.clusterClient.RemoveAnnotationInNamespace(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", newClusterSpec.Cluster.Name),
+				etcdv1.UpgradeInProgressAnnotation,
+				managementCluster,
+				constants.EksaSystemNamespace); err != nil {
+				return fmt.Errorf("removing annotation: %v", err)
+			}
 			return fmt.Errorf("waiting for external etcd for workload cluster to be ready: %v", err)
 		}
 		externalEtcdTopology = true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@ const (
 	EksaGitKnownHostsFileEnv    = "EKSA_GIT_KNOWN_HOSTS"
 	SshKnownHostsEnv            = "SSH_KNOWN_HOSTS"
 	EksaReplicasReadyTimeoutEnv = "EKSA_REPLICAS_READY_TIMEOUT"
+	ExternalEtcdTimeoutEnv      = "EKSA_EXTERNAL_ETCD_TIMEOUT"
 )
 
 type CliConfig struct {
@@ -23,7 +24,10 @@ type CliConfig struct {
 	MaxWaitPerMachine   time.Duration
 }
 
-const DefaultMaxWaitPerMachine = 10 * time.Minute
+const (
+	DefaultMaxWaitPerMachine = 10 * time.Minute
+	DefaultEtcdWaitStr       = "60m"
+)
 
 func GetMaxWaitPerMachine() time.Duration {
 	if env, found := os.LookupEnv(EksaReplicasReadyTimeoutEnv); found {
@@ -35,4 +39,14 @@ func GetMaxWaitPerMachine() time.Duration {
 		}
 	}
 	return DefaultMaxWaitPerMachine
+}
+
+func GetExternalEtcdTimeout() string {
+	if env, found := os.LookupEnv(ExternalEtcdTimeoutEnv); found {
+		if _, err := time.ParseDuration(env); err == nil {
+			return env
+		}
+		logger.V(3).Info(fmt.Sprintf("Invalid %s value: %s Use the default timeout: %s", ExternalEtcdTimeoutEnv, env, ExternalEtcdTimeoutEnv))
+	}
+	return DefaultEtcdWaitStr
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -48,3 +48,32 @@ func TestGetMaxWaitPerMachineFromInvalidEnv(t *testing.T) {
 	maxWaitPerMachine := config.GetMaxWaitPerMachine()
 	tt.Expect(maxWaitPerMachine).To(Equal(10 * time.Minute))
 }
+
+func TestGetExternalEtcdTimeoutDefault(t *testing.T) {
+	tt := newTest(t)
+
+	externalEtcdTimeout := config.GetExternalEtcdTimeout()
+	tt.Expect(externalEtcdTimeout).To(Equal("60m"))
+}
+
+func TestGetExternalEtcdTimeoutFromValidEnv(t *testing.T) {
+	tt := newTest(t)
+
+	oldEnv := os.Getenv(config.ExternalEtcdTimeoutEnv)
+	os.Setenv(config.ExternalEtcdTimeoutEnv, "15m")
+	defer os.Setenv(config.ExternalEtcdTimeoutEnv, oldEnv)
+
+	externalEtcdTimeout := config.GetExternalEtcdTimeout()
+	tt.Expect(externalEtcdTimeout).To(Equal("15m"))
+}
+
+func TestGetExternalEtcdTimeoutFromInvalidEnv(t *testing.T) {
+	tt := newTest(t)
+
+	oldEnv := os.Getenv(config.ExternalEtcdTimeoutEnv)
+	os.Setenv(config.ExternalEtcdTimeoutEnv, "15x")
+	defer os.Setenv(config.ExternalEtcdTimeoutEnv, oldEnv)
+
+	externalEtcdTimeout := config.GetExternalEtcdTimeout()
+	tt.Expect(externalEtcdTimeout).To(Equal("60m"))
+}

--- a/pkg/providers/vsphere/mocks/client.go
+++ b/pkg/providers/vsphere/mocks/client.go
@@ -601,6 +601,20 @@ func (mr *MockProviderKubectlClientMockRecorder) LoadSecret(arg0, arg1, arg2, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadSecret", reflect.TypeOf((*MockProviderKubectlClient)(nil).LoadSecret), arg0, arg1, arg2, arg3, arg4)
 }
 
+// RemoveAnnotationInNamespace mocks base method.
+func (m *MockProviderKubectlClient) RemoveAnnotationInNamespace(arg0 context.Context, arg1, arg2, arg3 string, arg4 *types.Cluster, arg5 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveAnnotationInNamespace", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveAnnotationInNamespace indicates an expected call of RemoveAnnotationInNamespace.
+func (mr *MockProviderKubectlClientMockRecorder) RemoveAnnotationInNamespace(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAnnotationInNamespace", reflect.TypeOf((*MockProviderKubectlClient)(nil).RemoveAnnotationInNamespace), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
 // SearchVsphereDatacenterConfig mocks base method.
 func (m *MockProviderKubectlClient) SearchVsphereDatacenterConfig(arg0 context.Context, arg1, arg2, arg3 string) ([]*v1alpha1.VSphereDatacenterConfig, error) {
 	m.ctrl.T.Helper()

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -135,6 +135,7 @@ type ProviderKubectlClient interface {
 	GetEtcdadmCluster(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*etcdv1.EtcdadmCluster, error)
 	GetSecretFromNamespace(ctx context.Context, kubeconfigFile, name, namespace string) (*corev1.Secret, error)
 	UpdateAnnotation(ctx context.Context, resourceType, objectName string, annotations map[string]string, opts ...executables.KubectlOpt) error
+	RemoveAnnotationInNamespace(ctx context.Context, resourceType, objectName, key string, cluster *types.Cluster, namespace string) error
 	SearchVsphereMachineConfig(ctx context.Context, name string, kubeconfigFile string, namespace string) ([]*v1alpha1.VSphereMachineConfig, error)
 	SearchVsphereDatacenterConfig(ctx context.Context, name string, kubeconfigFile string, namespace string) ([]*v1alpha1.VSphereDatacenterConfig, error)
 	SetDaemonSetImage(ctx context.Context, kubeconfigFile, name, namespace, container, image string) error

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -692,6 +692,12 @@ func (e *ClusterE2ETest) RunEKSA(args []string, opts ...CommandOpt) {
 	e.Run(binaryPath, args...)
 }
 
+func (e *ClusterE2ETest) StopIfSucceeded() {
+	if !e.T.Failed() {
+		e.T.FailNow()
+	}
+}
+
 func (e *ClusterE2ETest) StopIfFailed() {
 	if e.T.Failed() {
 		e.T.FailNow()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a new env var `EKSA_EXTERNAL_ETCD_TIMEOUT` to configure the timeout when waiting for external etcd to be ready

The new upgrade e2e test uses an invalid resource pool on the first attempt to upgrade the cluster, we then change the resource pool field to valid option & resume upgrade, in which it should now succeed. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

