### PR TITLE
Add datacenter to govc env vars

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -139,6 +139,7 @@ phases:
         "amd64"
         $BRANCH_NAME
         false
+      - export GOVC_DATACENTER=${T_VSPHERE_DATACENTER}
       - >
         ./bin/test e2e cleanup vsphere
         -n ${CLUSTER_NAME_PREFIX}
@@ -151,6 +152,7 @@ phases:
       - export EKSA_VSPHERE_USERNAME=${TEST_RUNNER_GOVC_USERNAME}
       - export EKSA_VSPHERE_PASSWORD=${TEST_RUNNER_GOVC_PASSWORD}
       - export VSPHERE_SERVER=${TEST_RUNNER_GOVC_URL}
+      - export GOVC_DATACENTER=${TEST_RUNNER_GOVC_DATACENTER}
       - export NODE_PREFIX=eksa-e2e-$CODEBUILD_BUILD_ID
       - >
         if [[ ${#NODE_PREFIX} -gt 80 ]] ; then

--- a/internal/test/e2e/testRunner.go
+++ b/internal/test/e2e/testRunner.go
@@ -26,6 +26,7 @@ const (
 	govcPasswordKey            string = "GOVC_PASSWORD"
 	govcURLKey                 string = "GOVC_URL"
 	govcInsecure               string = "GOVC_INSECURE"
+	govcDatacenterKey          string = "GOVC_DATACENTER"
 	ssmActivationCodeKey       string = "ssm_activation_code"
 	ssmActivationIdKey         string = "ssm_activation_id"
 	ssmActivationRegionKey     string = "ssm_activation_region"
@@ -133,6 +134,11 @@ func (v *VSphereTestRunner) setEnvironment() (map[string]string, error) {
 		return nil, fmt.Errorf("unable to set %s: %v", govcURLKey, err)
 	}
 	envMap[govcInsecure] = strconv.FormatBool(v.Insecure)
+
+	if err := os.Setenv(govcDatacenterKey, v.Datacenter); err != nil {
+		return nil, fmt.Errorf("unable to set %v: %v", govcDatacenterKey, err)
+	}
+	envMap[govcDatacenterKey] = v.Datacenter
 
 	v.envMap = envMap
 	return envMap, nil

--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -30,6 +30,7 @@ const (
 	govcPasswordKey      = "GOVC_PASSWORD"
 	govcURLKey           = "GOVC_URL"
 	govcInsecure         = "GOVC_INSECURE"
+	govcDatacenterKey    = "GOVC_DATACENTER"
 	govcTlsHostsFile     = "govc_known_hosts"
 	govcTlsKnownHostsKey = "GOVC_TLS_KNOWN_HOSTS"
 	vSphereUsernameKey   = "EKSA_VSPHERE_USERNAME"
@@ -39,7 +40,7 @@ const (
 	DeployOptsFile       = "deploy-opts.json"
 )
 
-var requiredEnvs = []string{govcUsernameKey, govcPasswordKey, govcURLKey, govcInsecure}
+var requiredEnvs = []string{govcUsernameKey, govcPasswordKey, govcURLKey, govcInsecure, govcDatacenterKey}
 
 type networkMapping struct {
 	Name    string `json:"Name,omitempty"`
@@ -532,6 +533,9 @@ func (g *Govc) validateAndSetupCreds() (map[string]string, error) {
 		}
 	} else if govcURL, ok := os.LookupEnv(govcURLKey); !ok || len(govcURL) <= 0 {
 		return nil, fmt.Errorf("%s is not set or is empty: %t", govcURLKey, ok)
+	}
+	if govcDatacenter, ok := os.LookupEnv(govcDatacenterKey); !ok || len(govcDatacenter) <= 0 {
+		return nil, fmt.Errorf("%s is not set or is empty: %t", govcDatacenterKey, ok)
 	}
 	envMap, err := g.getEnvMap()
 	if err != nil {

--- a/pkg/providers/vsphere/envars.go
+++ b/pkg/providers/vsphere/envars.go
@@ -43,5 +43,8 @@ func SetupEnvVars(datacenterConfig *anywherev1.VSphereDatacenterConfig) error {
 	if err := os.Setenv(govcInsecure, strconv.FormatBool(datacenterConfig.Spec.Insecure)); err != nil {
 		return fmt.Errorf("unable to set %s: %v", govcInsecure, err)
 	}
+	if err := os.Setenv(govcDatacenterKey, datacenterConfig.Spec.Datacenter); err != nil {
+		return fmt.Errorf("unable to set %s: %v", govcDatacenterKey, err)
+	}
 	return nil
 }

--- a/pkg/providers/vsphere/envars_test.go
+++ b/pkg/providers/vsphere/envars_test.go
@@ -1,0 +1,21 @@
+package vsphere_test
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/providers/vsphere"
+)
+
+func TestSetupEnvVarsErrorDatacenter(t *testing.T) {
+	config := &v1alpha1.VSphereDatacenterConfig{
+		Spec: v1alpha1.VSphereDatacenterConfigSpec{
+			Server:     "test",
+			Insecure:   false,
+			Datacenter: string([]byte{0}),
+		},
+	}
+	if err := vsphere.SetupEnvVars(config); err == nil {
+		t.Fatal("SetupEnvVars() err = nil, want err not nil")
+	}
+}

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -50,6 +50,7 @@ const (
 	vSphereUsernameKey        = "VSPHERE_USERNAME"
 	vSpherePasswordKey        = "VSPHERE_PASSWORD"
 	vSphereServerKey          = "VSPHERE_SERVER"
+	govcDatacenterKey         = "GOVC_DATACENTER"
 	govcInsecure              = "GOVC_INSECURE"
 	expClusterResourceSetKey  = "EXP_CLUSTER_RESOURCE_SET"
 	defaultTemplateLibrary    = "eks-a-templates"


### PR DESCRIPTION
*Issue #, if available:*
#2614 

*Description of changes:*
Specify the datacenter as an env var to avoid having govc infer based on the datacenters it is able to retrieve.

*Testing (if applicable):*
unit test and e2e

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

