### PR TITLE
Set govc datacenter variable for e2e tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -20,6 +20,7 @@ env:
     EKSA_VSPHERE_PASSWORD: "vsphere_ci_beta_connection:vsphere_password"
     VSPHERE_SERVER: "vsphere_ci_beta_connection:vsphere_url"
     GOVC_INSECURE: "vsphere_ci_beta_connection:govc_insecure"
+    GOVC_DATACENTER: "vsphere_ci_beta_connection:vsphere_datacenter"
     T_VSPHERE_DATACENTER: "vsphere_ci_beta_connection:vsphere_datacenter"
     T_VSPHERE_DATASTORE: "vsphere_ci_beta_connection:datastore"
     T_VSPHERE_FOLDER: "vsphere_ci_beta_connection:folder"
@@ -139,7 +140,6 @@ phases:
         "amd64"
         $BRANCH_NAME
         false
-      - export GOVC_DATACENTER=${T_VSPHERE_DATACENTER}
       - >
         ./bin/test e2e cleanup vsphere
         -n ${CLUSTER_NAME_PREFIX}

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -40,6 +40,7 @@ const (
 	privateNetworkCidrVar       = "T_VSPHERE_PRIVATE_NETWORK_CIDR"
 	govcUrlVar                  = "VSPHERE_SERVER"
 	govcInsecureVar             = "GOVC_INSECURE"
+	govcDatacenterVar           = "GOVC_DATACENTER"
 )
 
 var requiredEnvVars = []string{
@@ -69,6 +70,7 @@ var requiredEnvVars = []string{
 	privateNetworkCidrVar,
 	govcUrlVar,
 	govcInsecureVar,
+	govcDatacenterVar,
 }
 
 type VSphere struct {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Tests are currently failing from #2796 due to the env var not being set for all operations. Instead of only setting it for cleanup, setting it as part of the entire list of env vars so it can cover the cleanup phase in the prebuild as well as other operations like deploy.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

