### PR TITLE
Remove kubeVersion argument to bundle reader

### DIFF
--- a/cmd/eksctl-anywhere/cmd/generatepackage.go
+++ b/cmd/eksctl-anywhere/cmd/generatepackage.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
-	"github.com/aws/eks-anywhere/pkg/version"
 )
 
 type generatePackageOptions struct {
@@ -58,11 +57,9 @@ func generatePackages(ctx context.Context, args []string) error {
 
 	b := curatedpackages.NewBundleReader(
 		kubeConfig,
-		gpOptions.kubeVersion,
 		gpOptions.source,
 		deps.Kubectl,
 		bm,
-		version.Get(),
 		deps.BundleRegistry,
 	)
 

--- a/cmd/eksctl-anywhere/cmd/installpackages.go
+++ b/cmd/eksctl-anywhere/cmd/installpackages.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
-	"github.com/aws/eks-anywhere/pkg/version"
 )
 
 type installPackageOptions struct {
@@ -69,11 +68,9 @@ func installPackages(ctx context.Context, args []string) error {
 
 	b := curatedpackages.NewBundleReader(
 		kubeConfig,
-		ipo.kubeVersion,
 		ipo.source,
 		deps.Kubectl,
 		bm,
-		version.Get(),
 		deps.BundleRegistry,
 	)
 

--- a/cmd/eksctl-anywhere/cmd/listpackages.go
+++ b/cmd/eksctl-anywhere/cmd/listpackages.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
-	"github.com/aws/eks-anywhere/pkg/version"
 )
 
 type listPackagesOption struct {
@@ -59,11 +58,9 @@ func listPackages(ctx context.Context) error {
 
 	b := curatedpackages.NewBundleReader(
 		kubeConfig,
-		lpo.kubeVersion,
 		lpo.source,
 		deps.Kubectl,
 		bm,
-		version.Get(),
 		deps.BundleRegistry,
 	)
 

--- a/cmd/eksctl-anywhere/cmd/upgradepackages.go
+++ b/cmd/eksctl-anywhere/cmd/upgradepackages.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
-	"github.com/aws/eks-anywhere/pkg/version"
 )
 
 type upgradePackageOptions struct {
@@ -49,11 +48,9 @@ func upgradePackages(ctx context.Context) error {
 
 	b := curatedpackages.NewBundleReader(
 		kubeConfig,
-		ipo.kubeVersion,
 		ipo.source,
 		deps.Kubectl,
 		nil,
-		version.Get(),
 		nil,
 	)
 	activeController, err := b.GetActiveController(ctx)

--- a/pkg/curatedpackages/bundle.go
+++ b/pkg/curatedpackages/bundle.go
@@ -11,7 +11,6 @@ import (
 	packagesv1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/logger"
-	"github.com/aws/eks-anywhere/pkg/version"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
@@ -30,21 +29,17 @@ type BundleRegistry interface {
 type BundleReader struct {
 	kubeConfig    string
 	source        BundleSource
-	kubeVersion   string
 	kubectl       KubectlRunner
 	bundleManager Manager
-	cliVersion    version.Info
 	registry      BundleRegistry
 }
 
-func NewBundleReader(kubeConfig, kubeVersion string, source BundleSource, k KubectlRunner, bm Manager, cli version.Info, reg BundleRegistry) *BundleReader {
+func NewBundleReader(kubeConfig string, source BundleSource, k KubectlRunner, bm Manager, reg BundleRegistry) *BundleReader {
 	return &BundleReader{
 		kubeConfig:    kubeConfig,
-		kubeVersion:   kubeVersion,
 		source:        source,
 		kubectl:       k,
 		bundleManager: bm,
-		cliVersion:    cli,
 		registry:      reg,
 	}
 }

--- a/pkg/curatedpackages/bundle_test.go
+++ b/pkg/curatedpackages/bundle_test.go
@@ -77,11 +77,9 @@ func TestGetLatestBundleFromClusterSucceeds(t *testing.T) {
 
 	tt.Command = curatedpackages.NewBundleReader(
 		tt.kubeConfig,
-		tt.kubeVersion,
 		curatedpackages.Cluster,
 		tt.kubectl,
 		tt.bundleManager,
-		tt.cliVersion,
 		tt.registry,
 	)
 	result, err := tt.Command.GetLatestBundle(tt.ctx)
@@ -96,11 +94,9 @@ func TestGetLatestBundleFromRegistrySucceeds(t *testing.T) {
 	tt.bundleManager.EXPECT().LatestBundle(tt.ctx, baseRef).Return(tt.packageBundle, nil)
 	tt.Command = curatedpackages.NewBundleReader(
 		tt.kubeConfig,
-		tt.kubeVersion,
 		curatedpackages.Registry,
 		tt.kubectl,
 		tt.bundleManager,
-		tt.cliVersion,
 		tt.registry,
 	)
 	result, err := tt.Command.GetLatestBundle(tt.ctx)
@@ -112,11 +108,9 @@ func TestGetLatestBundleFromUnknownSourceFails(t *testing.T) {
 	tt := newBundleTest(t)
 	tt.Command = curatedpackages.NewBundleReader(
 		tt.kubeConfig,
-		tt.kubeVersion,
 		"Unknown",
 		tt.kubectl,
 		tt.bundleManager,
-		tt.cliVersion,
 		tt.registry,
 	)
 	_, err := tt.Command.GetLatestBundle(tt.ctx)
@@ -129,11 +123,9 @@ func TestLatestBundleFromClusterUnknownBundle(t *testing.T) {
 	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, gomock.Any()).Return(bytes.Buffer{}, errors.New("error reading bundle"))
 	tt.Command = curatedpackages.NewBundleReader(
 		tt.kubeConfig,
-		tt.kubeVersion,
 		curatedpackages.Cluster,
 		tt.kubectl,
 		tt.bundleManager,
-		tt.cliVersion,
 		tt.registry,
 	)
 	_, err := tt.Command.GetLatestBundle(tt.ctx)
@@ -145,11 +137,9 @@ func TestGetLatestBundleFromRegistryWhenError(t *testing.T) {
 	tt.registry.EXPECT().GetRegistryBaseRef(tt.ctx).Return("", errors.New("registry doesn't exist"))
 	tt.Command = curatedpackages.NewBundleReader(
 		tt.kubeConfig,
-		tt.kubeVersion,
 		curatedpackages.Registry,
 		tt.kubectl,
 		tt.bundleManager,
-		tt.cliVersion,
 		tt.registry,
 	)
 	_, err := tt.Command.GetLatestBundle(tt.ctx)
@@ -161,11 +151,9 @@ func TestLatestBundleFromClusterUnknownCtrl(t *testing.T) {
 	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, gomock.Any()).Return(bytes.Buffer{}, errors.New("error fetching controller"))
 	tt.Command = curatedpackages.NewBundleReader(
 		tt.kubeConfig,
-		tt.kubeVersion,
 		curatedpackages.Cluster,
 		tt.kubectl,
 		tt.bundleManager,
-		tt.cliVersion,
 		tt.registry,
 	)
 	_, err := tt.Command.GetLatestBundle(tt.ctx)


### PR DESCRIPTION
It wasn't being used anywhere anyway.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

