### PR TITLE
curatedpackages/packageclient: idiomatic go Writer

### DIFF
--- a/cmd/eksctl-anywhere/cmd/installpackages.go
+++ b/cmd/eksctl-anywhere/cmd/installpackages.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -93,7 +94,7 @@ func installPackages(ctx context.Context, args []string) error {
 
 	if ipo.showOptions {
 		configs := curatedpackages.GetConfigurationsFromBundle(p)
-		curatedpackages.DisplayConfigurationOptions(configs)
+		curatedpackages.DisplayConfigurationOptions(os.Stdout, configs)
 		return nil
 	}
 

--- a/cmd/eksctl-anywhere/cmd/listpackages.go
+++ b/cmd/eksctl-anywhere/cmd/listpackages.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -72,6 +73,6 @@ func listPackages(ctx context.Context) error {
 		deps.Kubectl,
 		curatedpackages.WithBundle(bundle),
 	)
-	packages.DisplayPackages()
+	packages.DisplayPackages(os.Stdout)
 	return nil
 }

--- a/pkg/curatedpackages/configurationclient.go
+++ b/pkg/curatedpackages/configurationclient.go
@@ -3,10 +3,9 @@ package curatedpackages
 import (
 	"bytes"
 	"fmt"
-	"os"
+	"io"
 	"strconv"
 	"strings"
-	"text/tabwriter"
 
 	"sigs.k8s.io/yaml"
 
@@ -98,13 +97,21 @@ func ParseConfigurations(configs []string) (map[string]string, error) {
 	return parsedConfigurations, nil
 }
 
-func DisplayConfigurationOptions(configs map[string]packagesv1.VersionConfiguration) {
-	w := new(tabwriter.Writer)
-	defer w.Flush()
-	w.Init(os.Stdout, minWidth, tabWidth, padding, padChar, flags)
-	fmt.Fprintf(w, "%s\t%s\t%s\t \n", "Configuration", "Required", "Default")
-	fmt.Fprintf(w, "%s\t%s\t%s\t \n", "-------------", "--------", "-------")
+// DisplayConfigurationOptions pretty-prints the given configuration values.
+func DisplayConfigurationOptions(w io.Writer, configs map[string]packagesv1.VersionConfiguration) {
+	lines := append([][]string{}, configurationHeaderLines...)
 	for key, val := range configs {
-		fmt.Fprintf(w, "%s\t%v\t%s\t \n", key, val.Required, val.Default)
+		req := fmt.Sprintf("%t", val.Required)
+		lines = append(lines, []string{key, req, val.Default})
 	}
+
+	tw := newCPTabwriter(w, nil)
+	defer tw.Flush()
+	tw.WriteTable(lines)
+}
+
+// configurationHeaderLines pretties-up the table of configuration values.
+var configurationHeaderLines = [][]string{
+	{"Configuration", "Required", "Default"},
+	{"-------------", "--------", "-------"},
 }

--- a/pkg/curatedpackages/cptabwriter.go
+++ b/pkg/curatedpackages/cptabwriter.go
@@ -1,0 +1,59 @@
+package curatedpackages
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+// cpTabwriter is a modified tabwriter for curated packages CLI duty.
+type cpTabwriter struct {
+	*tabwriter.Writer
+}
+
+// newCPTabwriter instantiates a curated packages custom tabwriter.
+//
+// If p is nil, cpTabwriterDefaultParams will be used. The caller should call
+// Flush just as they would with an unmodified tabwriter.Writer.
+func newCPTabwriter(w io.Writer, customParams *cpTabwriterParams) *cpTabwriter {
+	p := cpTabwriterDefaultParams
+	if customParams != nil {
+		p = *customParams
+	}
+	tw := tabwriter.NewWriter(w, p.minWidth, p.tabWidth, p.padding, p.padChar, p.flags)
+	return &cpTabwriter{Writer: tw}
+}
+
+// WriteTable from a 2-D slice of strings, joining every string with tabs.
+//
+// Tab characters and newlines will be added to the end of each rank.
+func (w *cpTabwriter) WriteTable(lines [][]string) (int, error) {
+	sum := 0
+	var err error
+
+	for _, line := range lines {
+		// A final "\t" is added, as tabwriter is tab-terminated, not the more
+		// common tab-separated. See https://pkg.go.dev/text/tabwriter#Writer
+		// for details. There are cases where one might not want this trailing
+		// tab, but it hasn't come up yet, and is easily worked around when
+		// the time comes.
+		sum, err = fmt.Fprintln(w, strings.Join(line, "\t")+"\t")
+		if err != nil {
+			return sum, err
+		}
+	}
+	return sum, nil
+}
+
+// cpTabwriterParams makes it easier to reuse common tabwriter parameters.
+type cpTabwriterParams struct {
+	minWidth int
+	tabWidth int
+	padding  int
+	padChar  byte
+	flags    uint
+}
+
+// cpTabwriterDefaultParams is just a convenience.
+var cpTabwriterDefaultParams = cpTabwriterParams{16, 8, 0, '\t', 0}


### PR DESCRIPTION
The DisplayPackages and DisplayConfigurationOptions functions are modified to
take an io.Writer into which they'll write. This better conforms with go
idioms, makes testing easier, and will make it easier to add CLI flags to
write to a file in the future.

In the process of doing so, a customized tabwriter is implemented to make
working with tabwriter more uniform. Helpers for instantiation and writing a
table from a 2-D slice of strings make the code easier to read, and should
make changes to the output less error prone (less fiddling with '\t' and other
spacings).

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

