### PR TITLE
Include documentation on Ubuntu cgroups v2

### DIFF
--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -16,7 +16,7 @@ This will let you create a cluster in multiple providers for local development o
 ### Administrative machine prerequisites
 
 - Docker 20.x.x
-- Mac OS 10.15 / Ubuntu 20.04.2 LTS (newer Ubuntu versions with cgroup v2 enabled are not supported)
+- Mac OS 10.15 / Ubuntu 20.04.2 LTS (See Note on newer Ubuntu versions)
 - 4 CPU cores
 - 16GB memory
 - 30GB free disk space
@@ -24,6 +24,7 @@ This will let you create a cluster in multiple providers for local development o
 
    {{% alert title="Note" color="primary" %}}
    * If you are using Ubuntu use the [Docker CE](https://docs.docker.com/engine/install/ubuntu/) installation instructions to install Docker and not the Snap installation.
+   * If you are using Ubuntu 21.10 or 22.04 you will need to switch from _cgroups v2_ to _cgroups v1_. For details, see [Troubleshooting Guide]({{< relref "../../tasks/troubleshoot/troubleshooting.md#cgroups-v2-is-not-supported-in-ubuntu-2110-and-2204" >}}).
    * If you are using Docker Desktop, you need to know that:
        * For EKS Anywhere Bare Metal, Docker Desktop is not supported
        * For EKS Anywhere vSphere, if you are using Mac OS Docker Desktop 4.4.2 or newer `"deprecatedCgroupv1": true` must be set in `~/Library/Group\ Containers/group.com.docker/settings.json`.

--- a/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
+++ b/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
@@ -61,6 +61,32 @@ Ensure you are running Docker Desktop 4.4.2 or newer and have set `"deprecatedCg
 "1"
 ```
 
+### cgroups v2 is not supported in Ubuntu 21.10+ and 22.04
+```
+ERROR: failed to create cluster: could not find a log line that matches "Reached target .*Multi-User System.*|detected cgroup v1"
+```
+It is recommended to use Ubuntu 20.04 for the Administrative Machine. This is because the EKS Anywhere Bootstrap cluster requires _cgroups v1_. Since Ubuntu 21.10 _cgroups v2_ is enabled by default. You can use Ubuntu 21.10 and 22.04 for the Administrative machine if you configure Ubuntu to use _cgroups v1_ instead.
+
+To verify cgroups version
+```
+% docker info | grep Cgroup
+ Cgroup Driver: cgroupfs
+ Cgroup Version: 2
+```
+To use _cgroups v1_ you need to _sudo_ and edit _/etc/default/grub_ to set _GRUB_CMDLINE_LINUX_ to "systemd.unified_cgroup_hierarchy=0" and reboot.
+```
+%sudo <editor> /etc/default/group
+GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=0"
+
+sudo reboot now
+```
+Then verify you are using _cgroups v1_.
+```
+% docker info | grep Cgroup
+ Cgroup Driver: cgroupfs
+ Cgroup Version: 1
+```
+
 ### ECR access denied
 
 ```


### PR DESCRIPTION
The EKS Anywhere docs currently state that only Ubuntu 20.04.2 is
supported as the administration machine due to Ubuntu 21 and 22 using
cgroups v2. This commit explains how to configure Ubuntu 21 and 22 to
use cgroups v1 if the administration machine is using the latest Ubuntu
versions.

This has been tested using `make serve` from the docs path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

