### PR TITLE
Simplify cilium templater code

### DIFF
--- a/pkg/networking/cilium/cilium.go
+++ b/pkg/networking/cilium/cilium.go
@@ -3,10 +3,8 @@ package cilium
 import (
 	"context"
 
-	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/templater"
 )
 
 const namespace = constants.KubeSystemNamespace
@@ -22,19 +20,5 @@ func NewCilium(client Client, helm Helm) *Cilium {
 }
 
 func (c *Cilium) GenerateManifest(ctx context.Context, clusterSpec *cluster.Spec, providerNamespaces []string) ([]byte, error) {
-	ciliumManifest, err := c.templater.GenerateManifest(ctx, clusterSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	if clusterSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode != v1alpha1.CiliumPolicyModeAlways {
-		return ciliumManifest, nil
-	}
-
-	networkPolicyManifest, err := c.templater.GenerateNetworkPolicyManifest(clusterSpec, providerNamespaces)
-	if err != nil {
-		return nil, err
-	}
-
-	return templater.AppendYamlResources(ciliumManifest, networkPolicyManifest), nil
+	return c.templater.GenerateManifest(ctx, clusterSpec, WithPolicyAllowedNamespaces(providerNamespaces))
 }

--- a/pkg/networking/cilium/cilium_test.go
+++ b/pkg/networking/cilium/cilium_test.go
@@ -65,21 +65,3 @@ func TestCiliumGenerateManifestSuccess(t *testing.T) {
 	_, err := tt.cilium.GenerateManifest(tt.ctx, tt.spec, []string{})
 	tt.Expect(err).To(Not(HaveOccurred()), "GenerateManifest() should succeed")
 }
-
-func TestCiliumGenerateManifestAndGenerateNetworkPolicySuccess(t *testing.T) {
-	tt := newCiliumTest(t)
-	/* templater tests already test whether templater.GenerateManifest returns expected values or not. This test ensures that cilium.GenerateManifest
-	calls the templater and does not try to load the static manifest like earlier version */
-	tt.h.EXPECT().Template(
-		tt.ctx, gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(map[string]interface{}{}), gomock.AssignableToTypeOf(""),
-	).Return(tt.ciliumValues, nil)
-
-	/* templater tests already test network policy generation based on the infra provider, gitops, mgmt/workload cluster and k8s version.
-	adding only 1 test here to ensure that for "always" mode, GenerateNetworkPolicyManifest is called and
-	the cilium manifest gets appended to manifest returned by GenerateNetworkPolicyManifest */
-	tt.spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = v1alpha12.CiliumPolicyModeAlways
-	tt.spec.Cluster.Spec.ManagementCluster.Name = "managed"
-	content, err := tt.cilium.GenerateManifest(tt.ctx, tt.spec, []string{})
-	tt.Expect(err).To(Not(HaveOccurred()), "GenerateManifest() should succeed")
-	test.AssertContentToFile(t, string(content), "testdata/manifest_network_policy.yaml")
-}

--- a/pkg/networking/cilium/testdata/manifest_network_policy.yaml
+++ b/pkg/networking/cilium/testdata/manifest_network_policy.yaml
@@ -1,4 +1,4 @@
-manifest
+manifestContent
 ---
 
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
*Description of changes:*

Reduced the templater api to just one method for manifests and added
options for the different scenarios. This reduces the complexity and
allows for better reusability, specially from the controller side.

*Testing (if applicable):*

Unit tests 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

