### PR TITLE
Update gci linter config to new format

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,12 @@ linters:
     - gci
 linters-settings:
   gci:
-    local-prefixes: github.com/aws/eks-anywhere
+    sections:
+      - standard
+      - default
+      - prefix(github.com/aws/eks-anywhere)
+    custom-order: true
+    skip-generated: false
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0


### PR DESCRIPTION
*Description of changes:*
Current config format is deprecated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

