### PR TITLE
Add mutating webhook for awsiamconfig

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_snowmachineconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_snowmachineconfigs.yaml
@@ -99,6 +99,15 @@ spec:
             type: object
           status:
             description: SnowMachineConfigStatus defines the observed state of SnowMachineConfig
+            properties:
+              failureMessage:
+                description: FailureMessage indicates that there is a fatal problem
+                  reconciling the state, and will be set to a descriptive error message.
+                type: string
+              specValid:
+                description: SpecValid is set to true if vspheredatacenterconfig is
+                  validated.
+                type: boolean
             type: object
         type: object
     served: true

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -13,6 +13,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-anywhere-eks-amazonaws-com-v1alpha1-awsiamconfig
+  failurePolicy: Fail
+  name: mutation.awsiamconfig.anywhere.amazonaws.com
+  rules:
+  - apiGroups:
+    - anywhere.eks.amazonaws.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsiamconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-anywhere-eks-amazonaws-com-v1alpha1-cluster
   failurePolicy: Fail
   name: mutation.cluster.anywhere.amazonaws.com

--- a/pkg/api/v1alpha1/awsiamconfig.go
+++ b/pkg/api/v1alpha1/awsiamconfig.go
@@ -10,6 +10,8 @@ const (
 	AWSIamConfigKind = "AWSIamConfig"
 	eksConfigMap     = "EKSConfigMap"
 	mountedFile      = "MountedFile"
+
+	DefaultAWSIamConfigPartition = "aws"
 )
 
 func GetAndValidateAWSIamConfig(fileName string, refName string, clusterConfig *Cluster) (*AWSIamConfig, error) {
@@ -125,7 +127,7 @@ func validateAWSIamNamespace(config *AWSIamConfig, clusterConfig *Cluster) error
 
 func setDefaultAWSIamPartition(config *AWSIamConfig) {
 	if config.Spec.Partition == "" {
-		config.Spec.Partition = "aws"
+		config.Spec.Partition = DefaultAWSIamConfigPartition
 		logger.V(1).Info("AWSIamConfig Partition is empty. Using default partition 'aws'")
 	}
 }

--- a/pkg/api/v1alpha1/awsiamconfig_webhook.go
+++ b/pkg/api/v1alpha1/awsiamconfig_webhook.go
@@ -20,6 +20,16 @@ func (r *AWSIamConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
+//+kubebuilder:webhook:path=/mutate-anywhere-eks-amazonaws-com-v1alpha1-awsiamconfig,mutating=true,failurePolicy=fail,sideEffects=None,groups=anywhere.eks.amazonaws.com,resources=awsiamconfigs,verbs=create;update,versions=v1alpha1,name=mutation.awsiamconfig.anywhere.amazonaws.com,admissionReviewVersions={v1,v1beta1}
+
+var _ webhook.Defaulter = &AWSIamConfig{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *AWSIamConfig) Default() {
+	awsiamconfiglog.Info("Setting up AWSIamConfig defaults for", "name", r.Name)
+	r.SetDefaults()
+}
+
 // change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-anywhere-eks-amazonaws-com-v1alpha1-awsiamconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=anywhere.eks.amazonaws.com,resources=awsiamconfigs,verbs=create;update,versions=v1alpha1,name=validation.awsiamconfig.anywhere.amazonaws.com,admissionReviewVersions={v1,v1beta1}
 

--- a/pkg/api/v1alpha1/awsiamconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/awsiamconfig_webhook_test.go
@@ -66,6 +66,15 @@ func TestValidateUpdateAWSIamConfigFailCausedByMutableFieldChange(t *testing.T) 
 	g.Expect(aiNew.ValidateUpdate(&aiOld)).To(MatchError(ContainSubstring("MapRoles Username is required")))
 }
 
+func TestAWSIamConfigSetDefaults(t *testing.T) {
+	g := NewWithT(t)
+
+	sOld := awsIamConfig()
+	sOld.Default()
+
+	g.Expect(sOld.Spec.Partition).To(Equal(v1alpha1.DefaultAWSIamConfigPartition))
+}
+
 func awsIamConfig() v1alpha1.AWSIamConfig {
 	return v1alpha1.AWSIamConfig{
 		TypeMeta:   metav1.TypeMeta{},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 1) Add mutating webhook for awsiamconfig 2) make generate-manifests 

*Testing (if applicable):* 

1. Unit Test

2. Tilt Up
 ```
1.6594634882760844e+09	INFO	awsiamconfig-resource	Setting up AWSIamConfig defaults for	{"name": "eksa-unit-test"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

