### PR TITLE
Fix upgrade with checkpoint e2e test

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -2,8 +2,8 @@ version: 0.2
 
 env:
   variables:
-    INTEGRATION_TEST_MAX_EC2_COUNT: 160
-    INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT: 160
+    INTEGRATION_TEST_MAX_EC2_COUNT: 165
+    INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT: 165
     T_CLOUDSTACK_CIDR: "10.11.255.0/24"
     SKIPPED_TESTS: "TestTinkerbellKubernetes121ExternalEtcdSimpleFlow,TestTinkerbellKubernetes123SimpleFlow,TestVSphereKubernetes122BottlerocketAutoimport,TestCloudStackKubernetes120OIDC,TestCloudStackKubernetes121OIDC,TestCloudStackKubernetes121RedhatRegistryMirrorAndCert,TestSnowKubernetes121SimpleFlow,TestSnowKubernetes122SimpleFlow,TestSnowKubernetes123SimpleFlow,TestSnowKubernetes121OIDC,TestSnowKubernetes121UbuntuProxyConfig,TestSnowKubernetes123UbuntuRemoveWorkerNodeGroups,TestSnowKubernetes123LabelsUbuntu,TestSnowKubernetes123TaintsUbuntu,TestSnowKubernetes121To122UbuntuUpgrade,TestSnowKubernetes122To123UbuntuMultipleFieldsUpgrade"
     CLOUDSTACK_PROVIDER: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,7 +46,7 @@ func GetExternalEtcdTimeout() string {
 		if _, err := time.ParseDuration(env); err == nil {
 			return env
 		}
-		logger.V(3).Info(fmt.Sprintf("Invalid %s value: %s Use the default timeout: %s", ExternalEtcdTimeoutEnv, env, ExternalEtcdTimeoutEnv))
+		logger.V(3).Info(fmt.Sprintf("Invalid %s value: %s Use the default timeout: %s", ExternalEtcdTimeoutEnv, env, DefaultEtcdWaitStr))
 	}
 	return DefaultEtcdWaitStr
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -531,9 +531,9 @@ func TestVSphereKubernetes121UbuntuTo122UpgradeWithCheckpoint(t *testing.T) {
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 	)
 	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var(), api.WithResourcePoolForAllMachines(vsphereInvalidResourcePoolUpdateVar)), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(config.ExternalEtcdTimeoutEnv, "10m"))
+		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var(), api.WithResourcePoolForAllMachines(vsphereInvalidResourcePoolUpdateVar)), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(config.ExternalEtcdTimeoutEnv, "10m"), framework.WithEnvVar(framework.CleanupVmsVar, "false"))
 	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var(), api.WithResourcePoolForAllMachines(os.Getenv(vsphereResourcePoolVar))), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"))
+		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var(), api.WithResourcePoolForAllMachines(os.Getenv(vsphereResourcePoolVar))), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupVmsVar, "true"))
 	runUpgradeFlowWithCheckpoint(
 		test,
 		v1alpha1.Kube122,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
E2E test for checkpoint feature cleaned up VMs too early. This should fix that issue.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

