### PR TITLE
Derive Proxy Config From Env Vars

### DIFF
--- a/pkg/config/proxy.go
+++ b/pkg/config/proxy.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"os"
+)
+
+const (
+	HttpsProxyKey = "HTTPS_PROXY"
+	HttpProxyKey  = "HTTP_PROXY"
+	NoProxyKey    = "NO_PROXY"
+)
+
+func GetProxyConfigFromEnv() map[string]string {
+	return map[string]string{
+		HttpsProxyKey: os.Getenv(HttpsProxyKey),
+		HttpProxyKey:  os.Getenv(HttpProxyKey),
+		NoProxyKey:    os.Getenv(NoProxyKey),
+	}
+}

--- a/pkg/config/proxy_test.go
+++ b/pkg/config/proxy_test.go
@@ -1,0 +1,28 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/pkg/config"
+)
+
+func TestGetProxyConfigFromEnv(t *testing.T) {
+	wantHttpsProxy := "FOO"
+	wantHttpProxy := "BAR"
+	wantNoProxy := "localhost,anotherhost"
+	wantEnv := map[string]string{
+		config.HttpsProxyKey: wantHttpsProxy,
+		config.HttpProxyKey:  wantHttpProxy,
+		config.NoProxyKey:    wantNoProxy,
+	}
+	for k, v := range wantEnv {
+		t.Setenv(k, v)
+	}
+	env := config.GetProxyConfigFromEnv()
+
+	for k, target := range wantEnv {
+		if val := env[k]; val != target {
+			t.Fatalf("config.GetProxyConfigFromEnv %s = %s, want %s", k, val, target)
+		}
+	}
+}

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -150,6 +150,34 @@ func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
 	tt.Expect(deps.VSphereValidator).NotTo(BeNil())
 }
 
+func TestFactoryBuildWithProxyConfiguration(t *testing.T) {
+	tt := newTest(t, vsphere)
+	wantHttpsProxy := "FOO"
+	wantHttpProxy := "BAR"
+	wantNoProxy := "localhost,anotherhost"
+	env := map[string]string{
+		config.HttpsProxyKey: wantHttpsProxy,
+		config.HttpProxyKey:  wantHttpProxy,
+		config.NoProxyKey:    wantNoProxy,
+	}
+	for k, v := range env {
+		t.Setenv(k, v)
+	}
+
+	f := dependencies.NewFactory().WithProxyConfiguration()
+
+	tt.Expect(f.GetProxyConfiguration()).To(BeNil())
+
+	_, err := f.Build(context.Background())
+
+	pc := f.GetProxyConfiguration()
+	tt.Expect(err).To(BeNil())
+
+	tt.Expect(pc[config.HttpsProxyKey]).To(Equal(wantHttpsProxy))
+	tt.Expect(pc[config.HttpProxyKey]).To(Equal(wantHttpProxy))
+	tt.Expect(pc[config.NoProxyKey]).To(Equal(wantNoProxy))
+}
+
 func TestFactoryBuildWithRegistryMirror(t *testing.T) {
 	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().


### PR DESCRIPTION
 #2837

*Description of changes:*

This PR fixes a bug in our proxy configuration logic. Prior to this PR, we only derived proxy configs from cluster config files.

This meant commands such as `eksctl anywhere download images` could not be used with a proxy.

This PR allows the CLI to derive a proxy config from the following env vars:
```
HTTPS_PROXY
HTTP_PROXY
NO_PROXY
```

*Testing (if applicable):*

I tested the `eksctl anywhere download images` command manually on an ec2 instance that could only communicate to the internet via a second ec2 instance that ran a proxy service.

I'm more than happy to add unit tests, I just wanted a review on the implementation first in case I was very off base.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


