### PR TITLE
Load snow env vars from secret for controller

### DIFF
--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -9,7 +9,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/aws"
 	"github.com/aws/eks-anywhere/pkg/controller/clusters"
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	snowreconciler "github.com/aws/eks-anywhere/pkg/providers/snow/reconciler"
@@ -118,7 +117,7 @@ func (f *Factory) WithSnowMachineConfigReconciler() *Factory {
 		f.reconcilers.SnowMachineConfigReconciler = NewSnowMachineConfigReconciler(
 			f.manager.GetClient(),
 			f.logger,
-			aws.NewSnowAwsClientBuilder(),
+			snowreconciler.NewAwsClientBuilder(f.manager.GetClient()),
 		)
 		return nil
 	})

--- a/controllers/mocks/snow_machineconfig_controller.go
+++ b/controllers/mocks/snow_machineconfig_controller.go
@@ -35,17 +35,17 @@ func (m *MockClientBuilder) EXPECT() *MockClientBuilderMockRecorder {
 	return m.recorder
 }
 
-// BuildSnowAwsClientMap mocks base method.
-func (m *MockClientBuilder) BuildSnowAwsClientMap(ctx context.Context) (aws.Clients, error) {
+// Build mocks base method.
+func (m *MockClientBuilder) Build(ctx context.Context) (aws.Clients, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildSnowAwsClientMap", ctx)
+	ret := m.ctrl.Call(m, "Build", ctx)
 	ret0, _ := ret[0].(aws.Clients)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// BuildSnowAwsClientMap indicates an expected call of BuildSnowAwsClientMap.
-func (mr *MockClientBuilderMockRecorder) BuildSnowAwsClientMap(ctx interface{}) *gomock.Call {
+// Build indicates an expected call of Build.
+func (mr *MockClientBuilderMockRecorder) Build(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildSnowAwsClientMap", reflect.TypeOf((*MockClientBuilder)(nil).BuildSnowAwsClientMap), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockClientBuilder)(nil).Build), ctx)
 }

--- a/controllers/snow_machineconfig_controller.go
+++ b/controllers/snow_machineconfig_controller.go
@@ -16,7 +16,7 @@ import (
 )
 
 type ClientBuilder interface {
-	BuildSnowAwsClientMap(ctx context.Context) (aws.Clients, error)
+	Build(ctx context.Context) (aws.Clients, error)
 }
 
 // SnowMachineConfigReconciler reconciles a SnowMachineConfig object
@@ -80,9 +80,8 @@ func (r *SnowMachineConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 }
 
 func (r *SnowMachineConfigReconciler) reconcile(ctx context.Context, snowMachineConfig *anywherev1.SnowMachineConfig) (_ ctrl.Result, reterr error) {
-	// TODO: need to figure out how to load creds in controller
 	var allErrs []error
-	deviceClientMap, err := r.clientBuilder.BuildSnowAwsClientMap(ctx)
+	deviceClientMap, err := r.clientBuilder.Build(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/snow_machineconfig_controller_test.go
+++ b/controllers/snow_machineconfig_controller_test.go
@@ -63,7 +63,7 @@ func TestSnowMachineConfigReconcilerSuccess(t *testing.T) {
 	cl := cb.WithRuntimeObjects(objs...).Build()
 
 	clientBuilder := controllerMock.NewMockClientBuilder(ctrl)
-	clientBuilder.EXPECT().BuildSnowAwsClientMap(ctx).Return(mockClients, nil)
+	clientBuilder.EXPECT().Build(ctx).Return(mockClients, nil)
 
 	r := controllers.NewSnowMachineConfigReconciler(cl, logf.Log, clientBuilder)
 
@@ -160,7 +160,7 @@ func TestSnowMachineConfigReconcilerFailureBuildAwsClient(t *testing.T) {
 	cl := cb.WithRuntimeObjects(objs...).Build()
 
 	clientBuilder := controllerMock.NewMockClientBuilder(ctrl)
-	clientBuilder.EXPECT().BuildSnowAwsClientMap(ctx).Return(nil, errors.New("test error"))
+	clientBuilder.EXPECT().Build(ctx).Return(nil, errors.New("test error"))
 
 	r := controllers.NewSnowMachineConfigReconciler(cl, logf.Log, clientBuilder)
 
@@ -200,7 +200,7 @@ func TestSnowMachineConfigReconcilerFailureMachineDeviceIps(t *testing.T) {
 	cl := cb.WithRuntimeObjects(objs...).Build()
 
 	clientBuilder := controllerMock.NewMockClientBuilder(ctrl)
-	clientBuilder.EXPECT().BuildSnowAwsClientMap(ctx).Return(mockClients, nil)
+	clientBuilder.EXPECT().Build(ctx).Return(mockClients, nil)
 
 	r := controllers.NewSnowMachineConfigReconciler(cl, logf.Log, clientBuilder)
 
@@ -244,7 +244,7 @@ func TestSnowMachineConfigReconcilerFailureImageExists(t *testing.T) {
 	cl := cb.WithRuntimeObjects(objs...).Build()
 
 	clientBuilder := controllerMock.NewMockClientBuilder(ctrl)
-	clientBuilder.EXPECT().BuildSnowAwsClientMap(ctx).Return(mockClients, nil)
+	clientBuilder.EXPECT().Build(ctx).Return(mockClients, nil)
 
 	r := controllers.NewSnowMachineConfigReconciler(cl, logf.Log, clientBuilder)
 
@@ -284,7 +284,7 @@ func TestSnowMachineConfigReconcilerFailureKeyNameExists(t *testing.T) {
 	cl := cb.WithRuntimeObjects(objs...).Build()
 
 	clientBuilder := controllerMock.NewMockClientBuilder(ctrl)
-	clientBuilder.EXPECT().BuildSnowAwsClientMap(ctx).Return(mockClients, nil)
+	clientBuilder.EXPECT().Build(ctx).Return(mockClients, nil)
 
 	r := controllers.NewSnowMachineConfigReconciler(cl, logf.Log, clientBuilder)
 
@@ -327,7 +327,7 @@ func TestSnowMachineConfigReconcilerFailureAggregate(t *testing.T) {
 	cl := cb.WithRuntimeObjects(objs...).Build()
 
 	clientBuilder := controllerMock.NewMockClientBuilder(ctrl)
-	clientBuilder.EXPECT().BuildSnowAwsClientMap(ctx).Return(mockClients, nil)
+	clientBuilder.EXPECT().Build(ctx).Return(mockClients, nil)
 
 	r := controllers.NewSnowMachineConfigReconciler(cl, logf.Log, clientBuilder)
 

--- a/pkg/aws/snow.go
+++ b/pkg/aws/snow.go
@@ -20,7 +20,7 @@ func NewSnowAwsClientBuilder() *snowAwsClientBuilder {
 	return &snowAwsClientBuilder{}
 }
 
-func (b *snowAwsClientBuilder) BuildSnowAwsClientMap(ctx context.Context) (Clients, error) {
+func (b *snowAwsClientBuilder) Build(ctx context.Context) (Clients, error) {
 	credsFile, err := AwsCredentialsFile()
 	if err != nil {
 		return nil, fmt.Errorf("fetching aws credentials from env: %v", err)
@@ -73,7 +73,7 @@ func WithCustomCABundleFile(certsFile string) AwsConfigOpt {
 	}
 }
 
-// WithSnowEndpointAccess gatheres all the config's LoadOptions for snow,
+// WithSnowEndpointAccess gathers all the config's LoadOptions for snow,
 // which includes snowball ec2 endpoint, snow credentials for a specific profile,
 // and CA bundles for accessing the https endpoint.
 func WithSnowEndpointAccess(deviceIP string, certsFile, credsFile string) AwsConfigOpt {

--- a/pkg/aws/snow_test.go
+++ b/pkg/aws/snow_test.go
@@ -91,7 +91,7 @@ func TestBuildSnowAwsClientMap(t *testing.T) {
 			t.Setenv(aws.EksaAwsCredentialsFileKey, tt.credsFilePath)
 			t.Setenv(aws.EksaAwsCABundlesFileKey, tt.certsFilePath)
 
-			_, err := clientBuilder.BuildSnowAwsClientMap(ctx)
+			_, err := clientBuilder.Build(ctx)
 			if tt.wantErr == "" {
 				g.Expect(err).To(Succeed())
 			} else {

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -489,7 +489,7 @@ func (f *Factory) WithAwsSnow() *Factory {
 		}
 
 		builder := aws.NewSnowAwsClientBuilder()
-		deviceClientMap, err := builder.BuildSnowAwsClientMap(ctx)
+		deviceClientMap, err := builder.Build(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/providers/snow/reconciler/clientbuilder.go
+++ b/pkg/providers/snow/reconciler/clientbuilder.go
@@ -1,0 +1,97 @@
+package reconciler
+
+import (
+	"bytes"
+	"context"
+	"net"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	awscredentials "github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/pkg/errors"
+	"gopkg.in/ini.v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/eks-anywhere/pkg/aws"
+)
+
+type AwsClientBuilder struct {
+	client client.Client
+}
+
+func NewAwsClientBuilder(client client.Client) *AwsClientBuilder {
+	return &AwsClientBuilder{
+		client: client,
+	}
+}
+
+func (b *AwsClientBuilder) Build(ctx context.Context) (aws.Clients, error) {
+	credentials, certificates, err := getSnowCredentials(ctx, b.client)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting snow credentials")
+	}
+
+	return createAwsClients(ctx, credentials, certificates)
+}
+
+type credentialConfiguration struct {
+	AccessKey string `ini:"aws_access_key_id"`
+	SecretKey string `ini:"aws_secret_access_key"`
+	Region    string `ini:"region"`
+}
+
+func createAwsClients(ctx context.Context, credentials []byte, certificates []byte) (aws.Clients, error) {
+	var deviceIps []string
+	credsCfg, err := ini.Load(credentials)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading values from credentials")
+	}
+	for _, ip := range credsCfg.SectionStrings() {
+		if net.ParseIP(ip) != nil {
+			deviceIps = append(deviceIps, ip)
+		}
+	}
+
+	deviceClientMap := make(aws.Clients, len(deviceIps))
+	for _, ip := range deviceIps {
+		ipCfg, err := parseIpConfiguration(credsCfg, ip)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parsing configuration for %v", ip)
+		}
+		clientCfg, err := awsconfig.LoadDefaultConfig(ctx,
+			awsconfig.WithCustomCABundle(bytes.NewReader(certificates)),
+			awsconfig.WithRegion(ipCfg.Region),
+			awsconfig.WithCredentialsProvider(awscredentials.StaticCredentialsProvider{
+				Value: awstypes.Credentials{
+					AccessKeyID:     ipCfg.AccessKey,
+					SecretAccessKey: ipCfg.SecretKey,
+				},
+			}),
+			awsconfig.WithEndpointResolverWithOptions(aws.SnowEndpointResolver(ip)),
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "setting up aws client")
+		}
+		deviceClientMap[ip] = aws.NewClient(ctx, clientCfg)
+	}
+
+	return deviceClientMap, nil
+}
+
+func parseIpConfiguration(credsCfg *ini.File, ip string) (*credentialConfiguration, error) {
+	var config credentialConfiguration
+	err := credsCfg.Section(ip).StrictMapTo(&config)
+	if err != nil {
+		return nil, err
+	}
+	if len(config.AccessKey) == 0 {
+		return nil, errors.New("unable to set aws_access_key_id")
+	}
+	if len(config.SecretKey) == 0 {
+		return nil, errors.New("unable to set aws_secret_access_key")
+	}
+	if len(config.Region) == 0 {
+		return nil, errors.New("unable to set region")
+	}
+	return &config, nil
+}

--- a/pkg/providers/snow/reconciler/clientbuilder_test.go
+++ b/pkg/providers/snow/reconciler/clientbuilder_test.go
@@ -1,0 +1,153 @@
+package reconciler_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/providers/snow/reconciler"
+)
+
+const caBundle = `-----BEGIN CERTIFICATE-----
+MIIDXjCCAkagAwIBAgIIb5m0RljJCMEwDQYJKoZIhvcNAQENBQAwODE2MDQGA1UE
+AwwtSklELTIwNjg0MzQyMDAwMi0xOTItMTY4LTEtMjM1LTIyLTAxLTA2LTIyLTA0
+MB4XDTIxMDExMTIyMDc1OFoXDTI1MTIxNjIyMDc1OFowODE2MDQGA1UEAwwtSklE
+LTIwNjg0MzQyMDAwMi0xOTItMTY4LTEtMjM1LTIyLTAxLTA2LTIyLTA0MIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmOTQDBfBtPcVDFg/a59dk+rYrPRU
+f5zl7JgFAEw1n82SkbNm4srwloj8pCuD1nJAlN+3LKoiby9jU8ZqoQKqppJaK1QK
+dv27JYNlWorG9r6KrFkiETn2cxuAwcRBvq4UF76WdNr7zFjI108byPp9Pd0mxKiQ
+6WVaxcKX9AEcarB/GfidHO95Aay6tiBU1SQvBJro3L1/UFu5STSpZai9zx+VkWTJ
+D0JXh7eLF4yL0N1oU0hX2CGDxDz4VlJmBOvbnRuwsOruRMtUFRUy59cPzr//4fjd
+4S7AYbeOVPwEP7q19NZ6+P7E71jTq1rz8RhAnW/JcbTKS0KqgBUPz0U4qQIDAQAB
+o2wwajAMBgNVHRMEBTADAQH/MB0GA1UdDgQWBBQTaZzL2goqq7/MbJEfNRuzbwih
+kTA7BgNVHREENDAyhjBJRDpKSUQtMjA2ODQzNDIwMDAyLTE5Mi0xNjgtMS0yMzUt
+MjItMDEtMDYtMjItMDQwDQYJKoZIhvcNAQENBQADggEBAEzel+UsphUx49EVAyWB
+PzSzoE7X62fg/b4gU7ifFHpWpYpAPsbapz9/Tywc4TGRItfctXYZsjchJKiutGU2
+zX4rt1NSHkx72iMl3obQ2jQmTD8f9LyCqya+QM4CA74kk6v2ng1EiwMYvQlTvWY4
+FEWv21yNRs2yiRuHWjRYH4TF54cCoDQGpFpsOFi0L4V/yo1XuimSLx2vvKZ0lCNt
+KxC1oCgCxxNkOa/6iLk6qVANoX5KIVsataVhvGK+9mwWn8+dnMFneMiWd/jvi+dh
+eywldVELBWRKELDdBc9Xb4i5BETF6dUlmvpWgpOXXO3uJlIRGZCVFLsgQ511oMxM
+rEA=
+-----END CERTIFICATE-----
+`
+
+const validCredentials = `[1.2.3.4]
+aws_access_key_id = ABCDEFGHIJKLMNOPQR2T
+aws_secret_access_key = AfSD7sYz/TBZtzkReBl6PuuISzJ2WtNkeePw+nNzJ
+region = snow
+
+[1.2.3.5]
+aws_access_key_id = ABCDEFGHIJKLMNOPQR2T
+aws_secret_access_key = AfSD7sYz/TBZtzkReBl6PuuISzJ2WtNkeePw+nNzJ
+region = snow
+`
+
+const invalidCredentialsIniFormat = `1.2.3.5
+aws_access_key_id = ABCDEFGHIJKLMNOPQR2T
+aws_secret_access_key = AfSD7sYz/TBZtzkReBl6PuuISzJ2WtNkeePw+nNzJ
+region = snow
+`
+
+const invalidCredentialsMissingAccessKey = `[1.2.3.5]
+aws_secret_access_key = AfSD7sYz/TBZtzkReBl6PuuISzJ2WtNkeePw+nNzJ
+region = snow
+`
+
+const invalidCredentialsMissingSecretKey = `[1.2.3.5]
+aws_access_key_id = ABCDEFGHIJKLMNOPQR2T
+region = snow
+`
+
+const invalidCredentialsMissingRegion = `[1.2.3.5]
+aws_access_key_id = ABCDEFGHIJKLMNOPQR2T
+aws_secret_access_key = AfSD7sYz/TBZtzkReBl6PuuISzJ2WtNkeePw+nNzJ
+`
+
+func TestBuildSnowAwsClientMap(t *testing.T) {
+	tests := []struct {
+		name          string
+		secretContent string
+		secret        *corev1.Secret
+		wantErr       string
+	}{
+		{
+			name:    "valid",
+			secret:  testSecret(validCredentials),
+			wantErr: "",
+		},
+		{
+			name:    "invalid ini format",
+			secret:  testSecret(invalidCredentialsIniFormat),
+			wantErr: "loading values from credentials: key-value delimiter not found: 1.2.3.5",
+		},
+		{
+			name:    "missing access key",
+			secret:  testSecret(invalidCredentialsMissingAccessKey),
+			wantErr: "parsing configuration for 1.2.3.5: unable to set aws_access_key_id",
+		},
+		{
+			name:    "missing secret key",
+			secret:  testSecret(invalidCredentialsMissingSecretKey),
+			wantErr: "parsing configuration for 1.2.3.5: unable to set aws_secret_access_key",
+		},
+		{
+			name:    "missing region",
+			secret:  testSecret(invalidCredentialsMissingRegion),
+			wantErr: "parsing configuration for 1.2.3.5: unable to set region",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+
+			objs := []runtime.Object{tt.secret}
+
+			cb := fake.NewClientBuilder()
+			cl := cb.WithRuntimeObjects(objs...).Build()
+			clientBuilder := reconciler.NewAwsClientBuilder(cl)
+
+			_, err := clientBuilder.Build(ctx)
+			if tt.wantErr == "" {
+				g.Expect(err).To(Succeed())
+			} else {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			}
+		})
+	}
+}
+
+func TestBuildSnowAwsClientMapNonexistentSecret(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	cb := fake.NewClientBuilder()
+	cl := cb.Build()
+	clientBuilder := reconciler.NewAwsClientBuilder(cl)
+
+	_, err := clientBuilder.Build(ctx)
+	g.Expect(err).To(MatchError(ContainSubstring("getting snow credentials: secrets \"capas-manager-bootstrap-credentials\" not found")))
+}
+
+func testSecret(creds string) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.CapasSystemNamespace,
+			Name:      reconciler.BoostrapSecretName,
+		},
+		Data: map[string][]byte{
+			"credentials": []byte(creds),
+			"ca-bundle":   []byte(caBundle),
+		},
+	}
+}

--- a/pkg/providers/snow/reconciler/credentials.go
+++ b/pkg/providers/snow/reconciler/credentials.go
@@ -1,0 +1,25 @@
+package reconciler
+
+import (
+	"context"
+
+	apiv1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
+)
+
+const BoostrapSecretName = "capas-manager-bootstrap-credentials"
+
+func getSnowCredentials(ctx context.Context, cli client.Client) (credentials, caBundle []byte, err error) {
+	secret := &apiv1.Secret{}
+	secretKey := client.ObjectKey{
+		Namespace: constants.CapasSystemNamespace,
+		Name:      BoostrapSecretName,
+	}
+	if err = cli.Get(ctx, secretKey, secret); err != nil {
+		return nil, nil, err
+	}
+
+	return secret.Data["credentials"], secret.Data["ca-bundle"], nil
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding ability to read credentials from the credentials secret provided by the capas provider in order to construct the aws client maps.

*Testing (if applicable):*
unit testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

