### PR TITLE
Always clone repo for git provider

### DIFF
--- a/pkg/gitops/flux/cluster.go
+++ b/pkg/gitops/flux/cluster.go
@@ -88,8 +88,9 @@ func (fc *fluxForCluster) syncGitRepo(ctx context.Context) error {
 }
 
 func (fc *fluxForCluster) initializeProviderRepositoryIfNotExists(ctx context.Context) (*git.Repository, error) {
-	if fc.clusterSpec.FluxConfig.Spec.Github == nil {
-		return nil, nil
+	// If git provider, the repository should be pre-initialized by the user.
+	if fc.clusterSpec.FluxConfig.Spec.Git != nil {
+		return &git.Repository{}, nil
 	}
 
 	r, err := fc.gitClient.GetRepo(ctx)


### PR DESCRIPTION
*Issue #, if available:*

My last flux refactoring PR #2843 changed the `setupRepository` method in flux package. It skipped git clone step when specifying git provider, which can cause git repo add failure.

*Description of changes:*

Change the `initializeProviderRepositoryIfNotExists` to always return a non empty repo when using git provider.

*Testing (if applicable):*

Successfully create a git provider enabled docker cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

