### PR TITLE
Add nil check to clusterConfig processors

### DIFF
--- a/pkg/cluster/cloudstack.go
+++ b/pkg/cluster/cloudstack.go
@@ -62,6 +62,9 @@ func cloudstackEntry() *ConfigManagerEntry {
 func processCloudStackDatacenter(c *Config, objects ObjectLookup) {
 	if c.Cluster.Spec.DatacenterRef.Kind == anywherev1.CloudStackDatacenterKind {
 		datacenter := objects.GetFromRef(c.Cluster.APIVersion, c.Cluster.Spec.DatacenterRef)
+		if datacenter == nil {
+			return
+		}
 		c.CloudStackDatacenter = datacenter.(*anywherev1.CloudStackDatacenterConfig)
 	}
 }

--- a/pkg/cluster/docker.go
+++ b/pkg/cluster/docker.go
@@ -34,6 +34,9 @@ func dockerEntry() *ConfigManagerEntry {
 func processDockerDatacenter(c *Config, objects ObjectLookup) {
 	if c.Cluster.Spec.DatacenterRef.Kind == anywherev1.DockerDatacenterKind {
 		datacenter := objects.GetFromRef(c.Cluster.APIVersion, c.Cluster.Spec.DatacenterRef)
+		if datacenter == nil {
+			return
+		}
 		c.DockerDatacenter = datacenter.(*anywherev1.DockerDatacenterConfig)
 	}
 }

--- a/pkg/cluster/snow.go
+++ b/pkg/cluster/snow.go
@@ -61,6 +61,9 @@ func snowEntry() *ConfigManagerEntry {
 func processSnowDatacenter(c *Config, objects ObjectLookup) {
 	if c.Cluster.Spec.DatacenterRef.Kind == anywherev1.SnowDatacenterKind {
 		datacenter := objects.GetFromRef(c.Cluster.APIVersion, c.Cluster.Spec.DatacenterRef)
+		if datacenter == nil {
+			return
+		}
 		c.SnowDatacenter = datacenter.(*anywherev1.SnowDatacenterConfig)
 	}
 }

--- a/pkg/cluster/vsphere.go
+++ b/pkg/cluster/vsphere.go
@@ -62,6 +62,9 @@ func vsphereEntry() *ConfigManagerEntry {
 func processVSphereDatacenter(c *Config, objects ObjectLookup) {
 	if c.Cluster.Spec.DatacenterRef.Kind == anywherev1.VSphereDatacenterKind {
 		datacenter := objects.GetFromRef(c.Cluster.APIVersion, c.Cluster.Spec.DatacenterRef)
+		if datacenter == nil {
+			return
+		}
 		c.VSphereDatacenter = datacenter.(*anywherev1.VSphereDatacenterConfig)
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

Objects.GetFromRef() can return a nil value that cannot be cast to a provider datacenter datatype.

*Description of changes:*
Added nil check to prevent casting in provider processors.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

