### PR TITLE
Cluster webhook immutable fields validation fix

### DIFF
--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -172,12 +172,14 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 		for _, identityProvider := range new.Spec.IdentityProviderRefs {
 			if identityProvider.Kind == AWSIamConfigKind {
 				newAWSIamConfig = &identityProvider
+				break
 			}
 		}
 
 		for _, identityProvider := range old.Spec.IdentityProviderRefs {
 			if identityProvider.Kind == AWSIamConfigKind {
 				oldAWSIamConfig = &identityProvider
+				break
 			}
 		}
 

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -761,6 +761,28 @@ func TestClusterValidateUpdateAWSIamNameImmutableUpdateSameName(t *testing.T) {
 	g.Expect(c.ValidateUpdate(cOld)).To(Succeed())
 }
 
+func TestClusterValidateUpdateAWSIamNameImmutableUpdateSameNameWorkloadCluster(t *testing.T) {
+	cOld := createCluster()
+	cOld.SetManagedBy("mgmt2")
+	cOld.Spec.IdentityProviderRefs = []v1alpha1.Ref{
+		{
+			Kind: v1alpha1.AWSIamConfigKind,
+			Name: "name1",
+		},
+	}
+	c := createCluster()
+	c.SetManagedBy("mgmt2")
+	c.Spec.IdentityProviderRefs = []v1alpha1.Ref{
+		{
+			Kind: v1alpha1.AWSIamConfigKind,
+			Name: "name1",
+		},
+	}
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(cOld)).To(Succeed())
+}
+
 func TestClusterValidateUpdateAWSIamNameImmutableUpdateName(t *testing.T) {
 	cOld := createCluster()
 	cOld.Spec.IdentityProviderRefs = []v1alpha1.Ref{
@@ -936,6 +958,64 @@ func TestClusterValidateUpdateOIDCNameMutableAddConfigMgmtCluster(t *testing.T) 
 
 	g := NewWithT(t)
 	g.Expect(c.ValidateUpdate(cOld)).NotTo(Succeed())
+}
+
+func TestClusterValidateUpdateSwapIdentityProviders(t *testing.T) {
+	cOld := createCluster()
+	cOld.Spec.IdentityProviderRefs = []v1alpha1.Ref{
+		{
+			Kind: v1alpha1.AWSIamConfigKind,
+			Name: "name1",
+		},
+		{
+			Kind: v1alpha1.OIDCConfigKind,
+			Name: "name1",
+		},
+	}
+	c := createCluster()
+	c.Spec.IdentityProviderRefs = []v1alpha1.Ref{
+		{
+			Kind: v1alpha1.OIDCConfigKind,
+			Name: "name1",
+		},
+		{
+			Kind: v1alpha1.AWSIamConfigKind,
+			Name: "name1",
+		},
+	}
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(cOld)).To(Succeed())
+}
+
+func TestClusterValidateUpdateSwapIdentityProvidersWorkloadCluster(t *testing.T) {
+	cOld := createCluster()
+	cOld.SetManagedBy("mgmt2")
+	cOld.Spec.IdentityProviderRefs = []v1alpha1.Ref{
+		{
+			Kind: v1alpha1.OIDCConfigKind,
+			Name: "name1",
+		},
+		{
+			Kind: v1alpha1.AWSIamConfigKind,
+			Name: "name1",
+		},
+	}
+	c := createCluster()
+	c.SetManagedBy("mgmt2")
+	c.Spec.IdentityProviderRefs = []v1alpha1.Ref{
+		{
+			Kind: v1alpha1.AWSIamConfigKind,
+			Name: "name1",
+		},
+		{
+			Kind: v1alpha1.OIDCConfigKind,
+			Name: "name1",
+		},
+	}
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(cOld)).To(Succeed())
 }
 
 func TestClusterValidateEmptyIdentityProviders(t *testing.T) {


### PR DESCRIPTION
*Issue #2830*

*Description of changes:*
Changes to fix an issue with webhook validations when Identity providers order is swapped. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

