### PR TITLE
Update vSphere prereq docs to highlight network access

### DIFF
--- a/docs/content/en/docs/reference/vsphere/domains.md
+++ b/docs/content/en/docs/reference/vsphere/domains.md
@@ -1,4 +1,5 @@
 
+* vCenter endpoint (must be accessible to EKS Anywhere clusters)
 * public.ecr.aws
 * anywhere-assets.eks.amazonaws.com (to download the EKS Anywhere binaries, manifests and OVAs)
 * distro.eks.amazonaws.com (to download EKS Distro binaries and manifests)

--- a/docs/content/en/docs/reference/vsphere/vsphere-prereq.md
+++ b/docs/content/en/docs/reference/vsphere/vsphere-prereq.md
@@ -16,7 +16,7 @@ To prepare a VMware vSphere environment to run EKS Anywhere, you need the follow
 * A vSphere 7+ environment running vCenter
 * Capacity to deploy 6-10 VMs
 * [DHCP service]({{< relref "./vsphere-dhcp/" >}}) running in vSphere environment in the primary VM network for your workload cluster
-* One network in vSphere to use for the cluster. This network must have inbound access into vCenter
+* One network in vSphere to use for the cluster. EKS Anywhere clusters need access to vCenter through the network to enable self-managing and storage capabilities.
 * An [OVA]({{< relref "./vsphere-ovas/" >}}) imported into vSphere and converted into a template for the workload VMs
 * User credentials to create VMs and attach networks, etc
 * One IP address routable from cluster but excluded from DHCP offering. 


### PR DESCRIPTION
*Description of changes:*
Added wording to [vSphere prerequisite docs](https://anywhere.eks.amazonaws.com/docs/reference/vsphere/vsphere-prereq/) to emphasize the need to have the vCenter endpoint be accessible to EKS-A clusters.
