### PR TITLE
Make gitOpsRef mutable in upgrade preflight check

### DIFF
--- a/pkg/validations/upgradevalidations/immutableFields.go
+++ b/pkg/validations/upgradevalidations/immutableFields.go
@@ -126,13 +126,13 @@ func ValidateGitOpsImmutableFields(ctx context.Context, k validations.KubectlCli
 		if prevGitOps.Spec.Flux.Github.Personal != clusterSpec.GitOpsConfig.Spec.Flux.Github.Personal {
 			return errors.New("gitOps spec.flux.github.personal is immutable")
 		}
-		if clusterSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace != "" && prevGitOps.Spec.Flux.Github.FluxSystemNamespace != clusterSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace {
+		if prevGitOps.Spec.Flux.Github.FluxSystemNamespace != clusterSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace {
 			return errors.New("gitOps spec.flux.github.fluxSystemNamespace is immutable")
 		}
-		if clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch != "" && prevGitOps.Spec.Flux.Github.Branch != clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch {
+		if prevGitOps.Spec.Flux.Github.Branch != clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch {
 			return errors.New("gitOps spec.flux.github.branch is immutable")
 		}
-		if clusterSpec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath != "" && prevGitOps.Spec.Flux.Github.ClusterConfigPath != clusterSpec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath {
+		if prevGitOps.Spec.Flux.Github.ClusterConfigPath != clusterSpec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath {
 			return errors.New("gitOps spec.flux.github.clusterConfigPath is immutable")
 		}
 

--- a/pkg/validations/upgradevalidations/immutableFields.go
+++ b/pkg/validations/upgradevalidations/immutableFields.go
@@ -2,6 +2,7 @@ package upgradevalidations
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -34,78 +35,8 @@ func ValidateImmutableFields(ctx context.Context, k validations.KubectlClient, c
 		return fmt.Errorf("spec.dataCenterRef.name is immutable")
 	}
 
-	if !nSpec.GitOpsRef.Equal(oSpec.GitOpsRef) {
-		return fmt.Errorf("spec.gitOpsRef is immutable")
-	}
-
-	if nSpec.GitOpsRef != nil {
-		if nSpec.GitOpsRef.Kind == v1alpha1.GitOpsConfigKind {
-			prevGitOps, err := k.GetEksaGitOpsConfig(ctx, nSpec.GitOpsRef.Name, cluster.KubeconfigFile, spec.Cluster.Namespace)
-			if err != nil {
-				return err
-			}
-
-			if prevGitOps.Spec.Flux.Github.Owner != spec.GitOpsConfig.Spec.Flux.Github.Owner {
-				return fmt.Errorf("gitOps spec.flux.github.owner is immutable")
-			}
-			if prevGitOps.Spec.Flux.Github.Repository != spec.GitOpsConfig.Spec.Flux.Github.Repository {
-				return fmt.Errorf("gitOps spec.flux.github.repository is immutable")
-			}
-			if prevGitOps.Spec.Flux.Github.Personal != spec.GitOpsConfig.Spec.Flux.Github.Personal {
-				return fmt.Errorf("gitOps spec.flux.github.personal is immutable")
-			}
-			if spec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace != "" && prevGitOps.Spec.Flux.Github.FluxSystemNamespace != spec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace {
-				return fmt.Errorf("gitOps spec.flux.github.fluxSystemNamespace is immutable")
-			}
-			if spec.GitOpsConfig.Spec.Flux.Github.Branch != "" && prevGitOps.Spec.Flux.Github.Branch != spec.GitOpsConfig.Spec.Flux.Github.Branch {
-				return fmt.Errorf("gitOps spec.flux.github.branch is immutable")
-			}
-			if spec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath != "" && prevGitOps.Spec.Flux.Github.ClusterConfigPath != spec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath {
-				return fmt.Errorf("gitOps spec.flux.github.clusterConfigPath is immutable")
-			}
-		}
-
-		if nSpec.GitOpsRef.Kind == v1alpha1.FluxConfigKind {
-			prevGitOps, err := k.GetEksaFluxConfig(ctx, nSpec.GitOpsRef.Name, cluster.KubeconfigFile, spec.Cluster.Namespace)
-			if err != nil {
-				return err
-			}
-
-			if prevGitOps.Spec.Git != nil {
-				if prevGitOps.Spec.Git.RepositoryUrl != spec.FluxConfig.Spec.Git.RepositoryUrl {
-					return fmt.Errorf("fluxConfig spec.fluxConfig.spec.git.repositoryUrl is immutable")
-				}
-				if prevGitOps.Spec.Git.SshKeyAlgorithm != spec.FluxConfig.Spec.Git.SshKeyAlgorithm {
-					return fmt.Errorf("fluxConfig spec.fluxConfig.spec.git.sshKeyAlgorithm is immutable")
-				}
-			}
-
-			if prevGitOps.Spec.Github != nil {
-				if prevGitOps.Spec.Github.Repository != spec.FluxConfig.Spec.Github.Repository {
-					return fmt.Errorf("fluxConfig spec.github.repository is immutable")
-				}
-
-				if prevGitOps.Spec.Github.Owner != spec.FluxConfig.Spec.Github.Owner {
-					return fmt.Errorf("fluxConfig spec.github.owner is immutable")
-				}
-
-				if prevGitOps.Spec.Github.Personal != spec.FluxConfig.Spec.Github.Personal {
-					return fmt.Errorf("fluxConfig spec.github.personal is immutable")
-				}
-			}
-
-			if prevGitOps.Spec.Branch != spec.FluxConfig.Spec.Branch {
-				return fmt.Errorf("fluxConfig spec.branch is immutable")
-			}
-
-			if prevGitOps.Spec.ClusterConfigPath != spec.FluxConfig.Spec.ClusterConfigPath {
-				return fmt.Errorf("fluxConfig spec.clusterConfigPath is immutable")
-			}
-
-			if prevGitOps.Spec.SystemNamespace != spec.FluxConfig.Spec.SystemNamespace {
-				return fmt.Errorf("fluxConfig spec.systemNamespace is immutable")
-			}
-		}
+	if err := ValidateGitOpsImmutableFields(ctx, k, cluster, spec, prevSpec); err != nil {
+		return err
 	}
 
 	if !nSpec.ControlPlaneConfiguration.Endpoint.Equal(oSpec.ControlPlaneConfiguration.Endpoint) {
@@ -168,4 +99,84 @@ func ValidateImmutableFields(ctx context.Context, k validations.KubectlClient, c
 	}
 
 	return provider.ValidateNewSpec(ctx, cluster, spec)
+}
+
+func ValidateGitOpsImmutableFields(ctx context.Context, k validations.KubectlClient, cluster *types.Cluster, clusterSpec *cluster.Spec, oldCluster *v1alpha1.Cluster) error {
+	if oldCluster.Spec.GitOpsRef == nil {
+		return nil
+	}
+
+	if !clusterSpec.Cluster.Spec.GitOpsRef.Equal(oldCluster.Spec.GitOpsRef) {
+		return errors.New("once cluster.spec.gitOpsRef is set, it is immutable")
+	}
+
+	switch clusterSpec.Cluster.Spec.GitOpsRef.Kind {
+	case v1alpha1.GitOpsConfigKind:
+		prevGitOps, err := k.GetEksaGitOpsConfig(ctx, clusterSpec.Cluster.Spec.GitOpsRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace)
+		if err != nil {
+			return err
+		}
+
+		if prevGitOps.Spec.Flux.Github.Owner != clusterSpec.GitOpsConfig.Spec.Flux.Github.Owner {
+			return errors.New("gitOps spec.flux.github.owner is immutable")
+		}
+		if prevGitOps.Spec.Flux.Github.Repository != clusterSpec.GitOpsConfig.Spec.Flux.Github.Repository {
+			return errors.New("gitOps spec.flux.github.repository is immutable")
+		}
+		if prevGitOps.Spec.Flux.Github.Personal != clusterSpec.GitOpsConfig.Spec.Flux.Github.Personal {
+			return errors.New("gitOps spec.flux.github.personal is immutable")
+		}
+		if clusterSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace != "" && prevGitOps.Spec.Flux.Github.FluxSystemNamespace != clusterSpec.GitOpsConfig.Spec.Flux.Github.FluxSystemNamespace {
+			return errors.New("gitOps spec.flux.github.fluxSystemNamespace is immutable")
+		}
+		if clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch != "" && prevGitOps.Spec.Flux.Github.Branch != clusterSpec.GitOpsConfig.Spec.Flux.Github.Branch {
+			return errors.New("gitOps spec.flux.github.branch is immutable")
+		}
+		if clusterSpec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath != "" && prevGitOps.Spec.Flux.Github.ClusterConfigPath != clusterSpec.GitOpsConfig.Spec.Flux.Github.ClusterConfigPath {
+			return errors.New("gitOps spec.flux.github.clusterConfigPath is immutable")
+		}
+
+	case v1alpha1.FluxConfigKind:
+		prevGitOps, err := k.GetEksaFluxConfig(ctx, clusterSpec.Cluster.Spec.GitOpsRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace)
+		if err != nil {
+			return err
+		}
+
+		if prevGitOps.Spec.Git != nil {
+			if prevGitOps.Spec.Git.RepositoryUrl != clusterSpec.FluxConfig.Spec.Git.RepositoryUrl {
+				return errors.New("fluxConfig spec.fluxConfig.spec.git.repositoryUrl is immutable")
+			}
+			if prevGitOps.Spec.Git.SshKeyAlgorithm != clusterSpec.FluxConfig.Spec.Git.SshKeyAlgorithm {
+				return errors.New("fluxConfig spec.fluxConfig.spec.git.sshKeyAlgorithm is immutable")
+			}
+		}
+
+		if prevGitOps.Spec.Github != nil {
+			if prevGitOps.Spec.Github.Repository != clusterSpec.FluxConfig.Spec.Github.Repository {
+				return errors.New("fluxConfig spec.github.repository is immutable")
+			}
+
+			if prevGitOps.Spec.Github.Owner != clusterSpec.FluxConfig.Spec.Github.Owner {
+				return errors.New("fluxConfig spec.github.owner is immutable")
+			}
+
+			if prevGitOps.Spec.Github.Personal != clusterSpec.FluxConfig.Spec.Github.Personal {
+				return errors.New("fluxConfig spec.github.personal is immutable")
+			}
+		}
+
+		if prevGitOps.Spec.Branch != clusterSpec.FluxConfig.Spec.Branch {
+			return errors.New("fluxConfig spec.branch is immutable")
+		}
+
+		if prevGitOps.Spec.ClusterConfigPath != clusterSpec.FluxConfig.Spec.ClusterConfigPath {
+			return errors.New("fluxConfig spec.clusterConfigPath is immutable")
+		}
+
+		if prevGitOps.Spec.SystemNamespace != clusterSpec.FluxConfig.Spec.SystemNamespace {
+			return errors.New("fluxConfig spec.systemNamespace is immutable")
+		}
+	}
+
+	return nil
 }

--- a/pkg/validations/upgradevalidations/immutableFields_test.go
+++ b/pkg/validations/upgradevalidations/immutableFields_test.go
@@ -1,0 +1,244 @@
+package upgradevalidations_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/validations/mocks"
+	"github.com/aws/eks-anywhere/pkg/validations/upgradevalidations"
+)
+
+func TestValidateGitOpsImmutableFieldsRef(t *testing.T) {
+	tests := []struct {
+		name           string
+		oldRef, newRef *v1alpha1.Ref
+		wantErr        string
+	}{
+		{
+			name:   "old gitRef nil, new gitRef not nil",
+			oldRef: nil,
+			newRef: &v1alpha1.Ref{
+				Kind: "GitOpsConfig",
+				Name: "gitops-new",
+			},
+			wantErr: "",
+		},
+		{
+			name: "old gitRef not nil, new gitRef nil",
+			oldRef: &v1alpha1.Ref{
+				Kind: "GitOpsConfig",
+				Name: "gitops-old",
+			},
+			newRef:  nil,
+			wantErr: "once cluster.spec.gitOpsRef is set, it is immutable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(tt *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+			clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Name = testclustername
+				s.Cluster.Spec.GitOpsRef = tc.newRef
+			})
+			cluster := &types.Cluster{
+				KubeconfigFile: "kubeconfig",
+			}
+
+			oldCluster := &v1alpha1.Cluster{
+				Spec: v1alpha1.ClusterSpec{
+					GitOpsRef: tc.oldRef,
+				},
+			}
+
+			err := upgradevalidations.ValidateGitOpsImmutableFields(ctx, nil, cluster, clusterSpec, oldCluster)
+			if tc.wantErr == "" {
+				g.Expect(err).To(Succeed())
+			} else {
+				g.Expect(err).To(MatchError(ContainSubstring(tc.wantErr)))
+			}
+		})
+	}
+}
+
+type gitOpsTest struct {
+	*WithT
+	ctx context.Context
+	k   *mocks.MockKubectlClient
+	c   *types.Cluster
+	o   *v1alpha1.Cluster
+	s   *cluster.Spec
+}
+
+func newGitClientTest(t *testing.T) *gitOpsTest {
+	ctrl := gomock.NewController(t)
+	return &gitOpsTest{
+		WithT: NewWithT(t),
+		ctx:   context.Background(),
+		k:     mocks.NewMockKubectlClient(ctrl),
+		c: &types.Cluster{
+			KubeconfigFile: "kubeconfig",
+		},
+		o: &v1alpha1.Cluster{
+			Spec: v1alpha1.ClusterSpec{
+				GitOpsRef: &v1alpha1.Ref{
+					Name: "test",
+					Kind: "GitOpsConfig",
+				},
+			},
+		},
+		s: test.NewClusterSpec(func(s *cluster.Spec) {
+			s.Cluster.Name = testclustername
+			s.Cluster.Spec.GitOpsRef = &v1alpha1.Ref{
+				Name: "test",
+				Kind: "GitOpsConfig",
+			}
+		}),
+	}
+}
+
+func TestValidateGitOpsImmutableFieldsGetEksaGitOpsConfigError(t *testing.T) {
+	g := newGitClientTest(t)
+	g.k.EXPECT().GetEksaGitOpsConfig(g.ctx, g.s.Cluster.Spec.GitOpsRef.Name, "kubeconfig", "").Return(nil, errors.New("error in get gitops config"))
+	g.Expect(upgradevalidations.ValidateGitOpsImmutableFields(g.ctx, g.k, g.c, g.s, g.o)).To(MatchError(ContainSubstring("error in get gitops config")))
+}
+
+func TestValidateGitOpsImmutableFieldsGetEksaFluxConfigError(t *testing.T) {
+	g := newGitClientTest(t)
+	g.o.Spec.GitOpsRef.Kind = "FluxConfig"
+	g.s.Cluster.Spec.GitOpsRef.Kind = "FluxConfig"
+	g.k.EXPECT().GetEksaFluxConfig(g.ctx, g.s.Cluster.Spec.GitOpsRef.Name, "kubeconfig", "").Return(nil, errors.New("error in get flux config"))
+	g.Expect(upgradevalidations.ValidateGitOpsImmutableFields(g.ctx, g.k, g.c, g.s, g.o)).To(MatchError(ContainSubstring("error in get flux config")))
+}
+
+func TestValidateGitOpsImmutableFieldsFluxConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		new, old *v1alpha1.FluxConfig
+		wantErr  string
+	}{
+		{
+			name: "github repo diff",
+			new: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					Github: &v1alpha1.GithubProviderConfig{
+						Repository: "a",
+					},
+				},
+			},
+			old: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					Github: &v1alpha1.GithubProviderConfig{
+						Repository: "b",
+					},
+				},
+			},
+			wantErr: "fluxConfig spec.github.repository is immutable",
+		},
+		{
+			name: "github owner diff",
+			new: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					Github: &v1alpha1.GithubProviderConfig{
+						Owner: "a",
+					},
+				},
+			},
+			old: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					Github: &v1alpha1.GithubProviderConfig{
+						Owner: "b",
+					},
+				},
+			},
+			wantErr: "fluxConfig spec.github.owner is immutable",
+		},
+		{
+			name: "github personal diff",
+			new: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					Github: &v1alpha1.GithubProviderConfig{
+						Personal: true,
+					},
+				},
+			},
+			old: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					Github: &v1alpha1.GithubProviderConfig{
+						Personal: false,
+					},
+				},
+			},
+			wantErr: "fluxConfig spec.github.personal is immutable",
+		},
+		{
+			name: "branch diff",
+			new: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					Branch: "a",
+				},
+			},
+			old: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					Branch: "b",
+				},
+			},
+			wantErr: "fluxConfig spec.branch is immutable",
+		},
+		{
+			name: "clusterConfigPath diff",
+			new: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					ClusterConfigPath: "a",
+				},
+			},
+			old: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					ClusterConfigPath: "b",
+				},
+			},
+			wantErr: "fluxConfig spec.clusterConfigPath is immutable",
+		},
+		{
+			name: "systemNamespace diff",
+			new: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					SystemNamespace: "a",
+				},
+			},
+			old: &v1alpha1.FluxConfig{
+				Spec: v1alpha1.FluxConfigSpec{
+					SystemNamespace: "b",
+				},
+			},
+			wantErr: "fluxConfig spec.systemNamespace is immutable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(tt *testing.T) {
+			g := newGitClientTest(t)
+			g.o.Spec.GitOpsRef.Kind = "FluxConfig"
+			g.s.Cluster.Spec.GitOpsRef.Kind = "FluxConfig"
+			g.s.FluxConfig = tc.new
+
+			g.k.EXPECT().GetEksaFluxConfig(g.ctx, g.s.Cluster.Spec.GitOpsRef.Name, "kubeconfig", "").Return(tc.old, nil)
+
+			err := upgradevalidations.ValidateGitOpsImmutableFields(g.ctx, g.k, g.c, g.s, g.o)
+			if tc.wantErr == "" {
+				g.Expect(err).To(Succeed())
+			} else {
+				g.Expect(err).To(MatchError(ContainSubstring(tc.wantErr)))
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

#2755 

*Description of changes:*

Enable flux upgrade in preflight flux immutability validation:
- old gitOpsRef nil, new gitOpsRef not nil -- validation succeeds, as we support installing flux in existing cluster
- old gitOpsRef not nil, new gitOpsRef nil -- validation fails, as we don't support removing flux in existing cluster rn
- both old and new gitOpsRef nil -- validation succeeds
- both old and new gitOpsRef not nil -- compare objects and fail if diff

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

