### PR TITLE
Use force ownership in controller serverside apply

### DIFF
--- a/pkg/controller/serverside/reconcile.go
+++ b/pkg/controller/serverside/reconcile.go
@@ -32,7 +32,7 @@ func ReconcileObjects(ctx context.Context, c client.Client, objs []client.Object
 
 func ReconcileObject(ctx context.Context, c client.Client, obj client.Object) error {
 	// Server side apply
-	err := c.Patch(ctx, obj, client.Apply, &client.PatchOptions{FieldManager: fieldManager})
+	err := c.Patch(ctx, obj, client.Apply, client.FieldOwner(fieldManager), client.ForceOwnership)
 	if err != nil {
 		return errors.Wrapf(err, "failed to reconcile object %s, %s/%s", obj.GetObjectKind().GroupVersionKind(), obj.GetNamespace(), obj.GetName())
 	}


### PR DESCRIPTION
*Description of changes:*
This is recommended practice for most controllers. It ensures they
recover ownership of any field they need to control in case an external
entity updates them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

