### PR TITLE
Make some cilium constants and methods public

### DIFF
--- a/pkg/networking/cilium/client.go
+++ b/pkg/networking/cilium/client.go
@@ -11,10 +11,10 @@ import (
 )
 
 const (
-	ciliumDaemonSetName           = "cilium"
-	ciliumPreflightDaemonSetName  = "cilium-pre-flight-check"
-	ciliumDeploymentName          = "cilium-operator"
-	ciliumPreflightDeploymentName = "cilium-pre-flight-check"
+	DaemonSetName           = "cilium"
+	PreflightDaemonSetName  = "cilium-pre-flight-check"
+	DeploymentName          = "cilium-operator"
+	PreflightDeploymentName = "cilium-pre-flight-check"
 )
 
 type Client interface {
@@ -62,21 +62,21 @@ func (c *retrierClient) WaitForPreflightDaemonSet(ctx context.Context, cluster *
 }
 
 func (c *retrierClient) checkPreflightDaemonSetReady(ctx context.Context, cluster *types.Cluster) error {
-	ciliumDaemonSet, err := c.GetDaemonSet(ctx, ciliumDaemonSetName, namespace, cluster.KubeconfigFile)
+	ciliumDaemonSet, err := c.GetDaemonSet(ctx, DaemonSetName, namespace, cluster.KubeconfigFile)
 	if err != nil {
 		return err
 	}
 
-	if err := checkDaemonSetReady(ciliumDaemonSet); err != nil {
+	if err := CheckDaemonSetReady(ciliumDaemonSet); err != nil {
 		return err
 	}
 
-	preflightDaemonSet, err := c.GetDaemonSet(ctx, ciliumPreflightDaemonSetName, namespace, cluster.KubeconfigFile)
+	preflightDaemonSet, err := c.GetDaemonSet(ctx, PreflightDaemonSetName, namespace, cluster.KubeconfigFile)
 	if err != nil {
 		return err
 	}
 
-	if err := checkPreflightDaemonSetReady(ciliumDaemonSet, preflightDaemonSet); err != nil {
+	if err := CheckPreflightDaemonSetReady(ciliumDaemonSet, preflightDaemonSet); err != nil {
 		return err
 	}
 
@@ -92,12 +92,12 @@ func (c *retrierClient) WaitForPreflightDeployment(ctx context.Context, cluster 
 }
 
 func (c *retrierClient) checkPreflightDeploymentReady(ctx context.Context, cluster *types.Cluster) error {
-	preflightDeployment, err := c.GetDeployment(ctx, ciliumPreflightDeploymentName, namespace, cluster.KubeconfigFile)
+	preflightDeployment, err := c.GetDeployment(ctx, PreflightDeploymentName, namespace, cluster.KubeconfigFile)
 	if err != nil {
 		return err
 	}
 
-	if err := checkDeploymentReady(preflightDeployment); err != nil {
+	if err := CheckDeploymentReady(preflightDeployment); err != nil {
 		return err
 	}
 
@@ -115,18 +115,18 @@ func (c *retrierClient) WaitForCiliumDaemonSet(ctx context.Context, cluster *typ
 func (c *retrierClient) RolloutRestartCiliumDaemonSet(ctx context.Context, cluster *types.Cluster) error {
 	return c.Retry(
 		func() error {
-			return c.RolloutRestartDaemonSet(ctx, ciliumDaemonSetName, namespace, cluster.KubeconfigFile)
+			return c.RolloutRestartDaemonSet(ctx, DaemonSetName, namespace, cluster.KubeconfigFile)
 		},
 	)
 }
 
 func (c *retrierClient) checkCiliumDaemonSetReady(ctx context.Context, cluster *types.Cluster) error {
-	daemonSet, err := c.GetDaemonSet(ctx, ciliumDaemonSetName, namespace, cluster.KubeconfigFile)
+	daemonSet, err := c.GetDaemonSet(ctx, DaemonSetName, namespace, cluster.KubeconfigFile)
 	if err != nil {
 		return err
 	}
 
-	if err := checkDaemonSetReady(daemonSet); err != nil {
+	if err := CheckDaemonSetReady(daemonSet); err != nil {
 		return err
 	}
 
@@ -142,12 +142,12 @@ func (c *retrierClient) WaitForCiliumDeployment(ctx context.Context, cluster *ty
 }
 
 func (c *retrierClient) checkCiliumDeploymentReady(ctx context.Context, cluster *types.Cluster) error {
-	deployment, err := c.GetDeployment(ctx, ciliumDeploymentName, namespace, cluster.KubeconfigFile)
+	deployment, err := c.GetDeployment(ctx, DeploymentName, namespace, cluster.KubeconfigFile)
 	if err != nil {
 		return err
 	}
 
-	if err := checkDeploymentReady(deployment); err != nil {
+	if err := CheckDeploymentReady(deployment); err != nil {
 		return err
 	}
 

--- a/pkg/networking/cilium/ready.go
+++ b/pkg/networking/cilium/ready.go
@@ -6,7 +6,7 @@ import (
 	v1 "k8s.io/api/apps/v1"
 )
 
-func checkDaemonSetReady(daemonSet *v1.DaemonSet) error {
+func CheckDaemonSetReady(daemonSet *v1.DaemonSet) error {
 	if err := checkDaemonSetObservedGeneration(daemonSet); err != nil {
 		return err
 	}
@@ -17,7 +17,7 @@ func checkDaemonSetReady(daemonSet *v1.DaemonSet) error {
 	return nil
 }
 
-func checkPreflightDaemonSetReady(ciliumDaemonSet, preflightDaemonSet *v1.DaemonSet) error {
+func CheckPreflightDaemonSetReady(ciliumDaemonSet, preflightDaemonSet *v1.DaemonSet) error {
 	if err := checkDaemonSetObservedGeneration(ciliumDaemonSet); err != nil {
 		return err
 	}
@@ -31,7 +31,7 @@ func checkPreflightDaemonSetReady(ciliumDaemonSet, preflightDaemonSet *v1.Daemon
 	return nil
 }
 
-func checkDeploymentReady(deployment *v1.Deployment) error {
+func CheckDeploymentReady(deployment *v1.Deployment) error {
 	if err := checkDeploymentObservedGeneration(deployment); err != nil {
 		return err
 	}

--- a/pkg/networking/cilium/ready_test.go
+++ b/pkg/networking/cilium/ready_test.go
@@ -59,7 +59,7 @@ func TestCheckDaemonSetReady(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			err := checkDaemonSetReady(tt.daemonSet)
+			err := CheckDaemonSetReady(tt.daemonSet)
 			if tt.wantErr != nil {
 				g.Expect(err).To(MatchError(tt.wantErr))
 				return
@@ -170,7 +170,7 @@ func TestCheckPreflightDaemonSetReady(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			err := checkPreflightDaemonSetReady(tt.cilium, tt.preflight)
+			err := CheckPreflightDaemonSetReady(tt.cilium, tt.preflight)
 			if tt.wantErr != nil {
 				g.Expect(err).To(MatchError(tt.wantErr))
 				return
@@ -230,7 +230,7 @@ func TestCheckDeploymentReady(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			err := checkDeploymentReady(tt.deployment)
+			err := CheckDeploymentReady(tt.deployment)
 			if tt.wantErr != nil {
 				g.Expect(err).To(MatchError(tt.wantErr))
 				return


### PR DESCRIPTION
*Description of changes:*
This is necessary in order to be reused from other packages, like the
cilium reconciler.

This is part of the original cilium reconciler PR, I'm just splitting it into independent chunks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

