### PR TITLE
Add cilium upgrade planner

### DIFF
--- a/pkg/networking/cilium/installation.go
+++ b/pkg/networking/cilium/installation.go
@@ -1,0 +1,14 @@
+package cilium
+
+import appsv1 "k8s.io/api/apps/v1"
+
+// Installation represents the Cilium components installed in a cluster
+type Installation struct {
+	DaemonSet *appsv1.DaemonSet
+	Operator  *appsv1.Deployment
+}
+
+// Installed determines if all Cilium components are present
+func (i Installation) Installed() bool {
+	return i.DaemonSet != nil && i.Operator != nil
+}

--- a/pkg/networking/cilium/installation_test.go
+++ b/pkg/networking/cilium/installation_test.go
@@ -1,0 +1,52 @@
+package cilium_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/aws/eks-anywhere/pkg/networking/cilium"
+)
+
+func TestInstallationInstalled(t *testing.T) {
+	tests := []struct {
+		name         string
+		installation cilium.Installation
+		want         bool
+	}{
+		{
+			name: "installed",
+			installation: cilium.Installation{
+				DaemonSet: &appsv1.DaemonSet{},
+				Operator:  &appsv1.Deployment{},
+			},
+			want: true,
+		},
+		{
+			name: "ds not installed",
+			installation: cilium.Installation{
+				Operator: &appsv1.Deployment{},
+			},
+			want: false,
+		},
+		{
+			name: "operator not installed",
+			installation: cilium.Installation{
+				DaemonSet: &appsv1.DaemonSet{},
+			},
+			want: false,
+		},
+		{
+			name:         "none installed",
+			installation: cilium.Installation{},
+			want:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.installation.Installed()).To(Equal(tt.want))
+		})
+	}
+}

--- a/pkg/networking/cilium/upgrade_plan.go
+++ b/pkg/networking/cilium/upgrade_plan.go
@@ -1,0 +1,118 @@
+package cilium
+
+import (
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+)
+
+// UpgradePlan contains information about a Cilium installation upgrade
+type UpgradePlan struct {
+	DaemonSet ComponentUpgradePlan
+	Operator  ComponentUpgradePlan
+}
+
+// Needed determines if an upgrade is needed or not
+// Returns true if any of the installation components needs an upgrade
+func (c UpgradePlan) Needed() bool {
+	return c.DaemonSet.Needed() || c.Operator.Needed()
+}
+
+// Reason returns the reason why an upgrade might be needed
+// If no upgrade needed, returns empty string
+// For multiple components with needed upgrades, it composes their reasons into one
+func (c UpgradePlan) Reason() string {
+	if !c.Needed() {
+		return ""
+	}
+
+	s := make([]string, 0, 2)
+	if c.DaemonSet.UpgradeReason != "" {
+		s = append(s, c.DaemonSet.UpgradeReason)
+	}
+	if c.Operator.UpgradeReason != "" {
+		s = append(s, c.Operator.UpgradeReason)
+	}
+
+	return strings.Join(s, " - ")
+}
+
+// ComponentUpgradePlan contains upgrade information for a Cilium component
+type ComponentUpgradePlan struct {
+	UpgradeReason string
+	OldImage      string
+	NewImage      string
+}
+
+// Needed determines if an upgrade is needed or not
+func (c ComponentUpgradePlan) Needed() bool {
+	return c.UpgradeReason != ""
+}
+
+// BuildUpgradePlan generates the upgrade plan information for a cilium installation by comparing it
+// with a desired cluster Spec
+func BuildUpgradePlan(installation *Installation, clusterSpec *cluster.Spec) UpgradePlan {
+	return UpgradePlan{
+		DaemonSet: daemonSetUpgradePlan(installation.DaemonSet, clusterSpec),
+		Operator:  operatorUpgradePlan(installation.Operator, clusterSpec),
+	}
+}
+
+func daemonSetUpgradePlan(ds *appsv1.DaemonSet, clusterSpec *cluster.Spec) ComponentUpgradePlan {
+	dsImage := clusterSpec.VersionsBundle.Cilium.Cilium.VersionedImage()
+	info := ComponentUpgradePlan{
+		NewImage: dsImage,
+	}
+
+	if ds == nil {
+		info.UpgradeReason = "DaemonSet doesn't exist"
+		return info
+	}
+
+	oldDSImage := ds.Spec.Template.Spec.Containers[0].Image
+	info.OldImage = oldDSImage
+
+	containers := make([]corev1.Container, 0, len(ds.Spec.Template.Spec.Containers)+len(ds.Spec.Template.Spec.InitContainers))
+	containers = append(containers, ds.Spec.Template.Spec.Containers...)
+	containers = append(containers, ds.Spec.Template.Spec.InitContainers...)
+	for _, c := range containers {
+		if c.Image != dsImage {
+			info.OldImage = c.Image
+			info.UpgradeReason = fmt.Sprintf("DaemonSet container %s doesn't match image", c.Name)
+			return info
+		}
+	}
+
+	return info
+}
+
+func operatorUpgradePlan(operator *appsv1.Deployment, clusterSpec *cluster.Spec) ComponentUpgradePlan {
+	newImage := clusterSpec.VersionsBundle.Cilium.Operator.VersionedImage()
+	info := ComponentUpgradePlan{
+		NewImage: newImage,
+	}
+
+	if operator == nil {
+		info.UpgradeReason = "Operator deployment doesn't exist"
+		return info
+	}
+
+	if len(operator.Spec.Template.Spec.Containers) == 0 {
+		info.UpgradeReason = "Operator deployment doesn't have any containers"
+		return info
+	}
+
+	oldImage := operator.Spec.Template.Spec.Containers[0].Image
+	info.OldImage = oldImage
+
+	if oldImage != newImage {
+		info.UpgradeReason = "Operator container doesn't match the provided image"
+		return info
+	}
+
+	return info
+}

--- a/pkg/networking/cilium/upgrade_plan_test.go
+++ b/pkg/networking/cilium/upgrade_plan_test.go
@@ -1,0 +1,376 @@
+package cilium_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/networking/cilium"
+)
+
+func TestBuildUpgradePlan(t *testing.T) {
+	tests := []struct {
+		name         string
+		installation *cilium.Installation
+		clusterSpec  *cluster.Spec
+		want         cilium.UpgradePlan
+	}{
+		{
+			name: "no upgrade needed",
+			installation: &cilium.Installation{
+				DaemonSet: daemonSet("cilium:v1.0.0"),
+				Operator:  deployment("cilium-operator:v1.0.0"),
+			},
+			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+			}),
+			want: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{
+					OldImage: "cilium:v1.0.0",
+					NewImage: "cilium:v1.0.0",
+				},
+				Operator: cilium.ComponentUpgradePlan{
+					OldImage: "cilium-operator:v1.0.0",
+					NewImage: "cilium-operator:v1.0.0",
+				},
+			},
+		},
+		{
+			name: "daemon set not installed",
+			installation: &cilium.Installation{
+				Operator: deployment("cilium-operator:v1.0.0"),
+			},
+			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+			}),
+			want: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{
+					UpgradeReason: "DaemonSet doesn't exist",
+					NewImage:      "cilium:v1.0.0",
+				},
+				Operator: cilium.ComponentUpgradePlan{
+					OldImage: "cilium-operator:v1.0.0",
+					NewImage: "cilium-operator:v1.0.0",
+				},
+			},
+		},
+		{
+			name: "daemon container old version",
+			installation: &cilium.Installation{
+				DaemonSet: daemonSet("cilium:v1.0.0"),
+				Operator:  deployment("cilium-operator:v1.0.0"),
+			},
+			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.1"
+				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+			}),
+			want: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{
+					UpgradeReason: "DaemonSet container agent doesn't match image",
+					OldImage:      "cilium:v1.0.0",
+					NewImage:      "cilium:v1.0.1",
+				},
+				Operator: cilium.ComponentUpgradePlan{
+					OldImage: "cilium-operator:v1.0.0",
+					NewImage: "cilium-operator:v1.0.0",
+				},
+			},
+		},
+		{
+			name: "daemon init container old version",
+			installation: &cilium.Installation{
+				DaemonSet: daemonSet("cilium:v1.0.1", func(ds *appsv1.DaemonSet) {
+					ds.Spec.Template.Spec.InitContainers = []corev1.Container{
+						{
+							Name:  "init",
+							Image: "cilium:v1.0.0",
+						},
+					}
+				}),
+				Operator: deployment("cilium-operator:v1.0.0"),
+			},
+			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.1"
+				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+			}),
+			want: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{
+					UpgradeReason: "DaemonSet container init doesn't match image",
+					OldImage:      "cilium:v1.0.0",
+					NewImage:      "cilium:v1.0.1",
+				},
+				Operator: cilium.ComponentUpgradePlan{
+					OldImage: "cilium-operator:v1.0.0",
+					NewImage: "cilium-operator:v1.0.0",
+				},
+			},
+		},
+		{
+			name: "operator is not present",
+			installation: &cilium.Installation{
+				DaemonSet: daemonSet("cilium:v1.0.0"),
+			},
+			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+			}),
+			want: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{
+					OldImage: "cilium:v1.0.0",
+					NewImage: "cilium:v1.0.0",
+				},
+				Operator: cilium.ComponentUpgradePlan{
+					UpgradeReason: "Operator deployment doesn't exist",
+					NewImage:      "cilium-operator:v1.0.0",
+				},
+			},
+		},
+		{
+			name: "operator 0 containers",
+			installation: &cilium.Installation{
+				DaemonSet: daemonSet("cilium:v1.0.0"),
+				Operator: deployment("cilium-operator:v1.0.0", func(d *appsv1.Deployment) {
+					d.Spec.Template.Spec.Containers = nil
+				}),
+			},
+			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.1"
+			}),
+			want: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{
+					OldImage: "cilium:v1.0.0",
+					NewImage: "cilium:v1.0.0",
+				},
+				Operator: cilium.ComponentUpgradePlan{
+					UpgradeReason: "Operator deployment doesn't have any containers",
+					NewImage:      "cilium-operator:v1.0.1",
+				},
+			},
+		},
+		{
+			name: "operator container old version",
+			installation: &cilium.Installation{
+				DaemonSet: daemonSet("cilium:v1.0.0"),
+				Operator:  deployment("cilium-operator:v1.0.0"),
+			},
+			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.1"
+			}),
+			want: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{
+					OldImage: "cilium:v1.0.0",
+					NewImage: "cilium:v1.0.0",
+				},
+				Operator: cilium.ComponentUpgradePlan{
+					UpgradeReason: "Operator container doesn't match the provided image",
+					OldImage:      "cilium-operator:v1.0.0",
+					NewImage:      "cilium-operator:v1.0.1",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(
+				cilium.BuildUpgradePlan(tt.installation, tt.clusterSpec),
+			).To(Equal(tt.want))
+		})
+	}
+}
+
+type deploymentOpt func(*appsv1.Deployment)
+
+func deployment(image string, opts ...deploymentOpt) *appsv1.Deployment {
+	d := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Image: image,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	return d
+}
+
+type dsOpt func(*appsv1.DaemonSet)
+
+func daemonSet(image string, opts ...dsOpt) *appsv1.DaemonSet {
+	d := &appsv1.DaemonSet{
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "agent",
+							Image: image,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	return d
+}
+
+func TestComponentUpgradePlanNeeded(t *testing.T) {
+	tests := []struct {
+		name string
+		info cilium.ComponentUpgradePlan
+		want bool
+	}{
+		{
+			name: "not needed",
+			info: cilium.ComponentUpgradePlan{
+				UpgradeReason: "",
+			},
+			want: false,
+		},
+		{
+			name: "needed",
+			info: cilium.ComponentUpgradePlan{
+				UpgradeReason: "missing ds",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.info.Needed()).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestUpgradePlanNeeded(t *testing.T) {
+	tests := []struct {
+		name string
+		info cilium.UpgradePlan
+		want bool
+	}{
+		{
+			name: "not needed",
+			info: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{},
+				Operator:  cilium.ComponentUpgradePlan{},
+			},
+			want: false,
+		},
+		{
+			name: "ds needed",
+			info: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{
+					UpgradeReason: "ds old version",
+				},
+				Operator: cilium.ComponentUpgradePlan{},
+			},
+			want: true,
+		},
+		{
+			name: "operator needed",
+			info: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{},
+				Operator: cilium.ComponentUpgradePlan{
+					UpgradeReason: "operator old version",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "both needed",
+			info: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{
+					UpgradeReason: "ds old version",
+				},
+				Operator: cilium.ComponentUpgradePlan{
+					UpgradeReason: "operator old version",
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.info.Needed()).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestUpgradePlanReason(t *testing.T) {
+	tests := []struct {
+		name string
+		info cilium.UpgradePlan
+		want string
+	}{
+		{
+			name: "not needed",
+			info: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{},
+				Operator:  cilium.ComponentUpgradePlan{},
+			},
+			want: "",
+		},
+		{
+			name: "ds needed",
+			info: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{
+					UpgradeReason: "ds old version",
+				},
+				Operator: cilium.ComponentUpgradePlan{},
+			},
+			want: "ds old version",
+		},
+		{
+			name: "operator needed",
+			info: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{},
+				Operator: cilium.ComponentUpgradePlan{
+					UpgradeReason: "operator old version",
+				},
+			},
+			want: "operator old version",
+		},
+		{
+			name: "both needed",
+			info: cilium.UpgradePlan{
+				DaemonSet: cilium.ComponentUpgradePlan{
+					UpgradeReason: "ds old version",
+				},
+				Operator: cilium.ComponentUpgradePlan{
+					UpgradeReason: "operator old version",
+				},
+			},
+			want: "ds old version - operator old version",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.info.Reason()).To(Equal(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
*Description of changes:*
In combination with the cilium installation, this allows to represent
the currently installed Cilium components and make an upgrade plan based
on the desired state defined in a cluster Spec.

*Testing (if applicable):*
Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

