### PR TITLE
Add tooling to delete kube objects defined in yaml

### DIFF
--- a/pkg/controller/clientutil/delete.go
+++ b/pkg/controller/clientutil/delete.go
@@ -1,0 +1,35 @@
+package clientutil
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func DeleteYaml(ctx context.Context, c client.Client, yaml []byte) error {
+	objs, err := YamlToClientObjects(yaml)
+	if err != nil {
+		return err
+	}
+
+	return deleteObjects(ctx, c, objs)
+}
+
+func deleteObjects(ctx context.Context, c client.Client, objs []client.Object) error {
+	for _, o := range objs {
+		if err := deleteObject(ctx, c, o); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteObject(ctx context.Context, c client.Client, obj client.Object) error {
+	if err := c.Delete(ctx, obj); err != nil {
+		return errors.Wrapf(err, "deleting object %s, %s/%s", obj.GetObjectKind().GroupVersionKind(), obj.GetNamespace(), obj.GetName())
+	}
+
+	return nil
+}

--- a/pkg/controller/clientutil/delete_test.go
+++ b/pkg/controller/clientutil/delete_test.go
@@ -1,0 +1,130 @@
+package clientutil_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
+)
+
+func TestDeleteYamlSuccess(t *testing.T) {
+	tests := []struct {
+		name        string
+		initialObjs []client.Object
+		yaml        []byte
+	}{
+		{
+			name: "delete single object",
+			initialObjs: []client.Object{
+				cluster("cluster-1"),
+			},
+			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-1
+  namespace: default
+spec:
+  controlPlaneEndpoint:
+    host: 1.1.1.1
+    port: 8080`),
+		},
+		{
+			name: "delete multiple objects",
+			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-1
+  namespace: default
+spec:
+  paused: true
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-2
+  namespace: default
+spec:
+  paused: true`),
+			initialObjs: []client.Object{
+				cluster("cluster-1"),
+				cluster("cluster-2"),
+			},
+		},
+	}
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			c := fake.NewClientBuilder().WithObjects(tt.initialObjs...).Build()
+
+			g.Expect(clientutil.DeleteYaml(ctx, c, tt.yaml)).To(Succeed(), "Failed to delete with DeleteYaml()")
+
+			for _, o := range tt.initialObjs {
+				key := client.ObjectKey{
+					Namespace: "default",
+					Name:      o.GetName(),
+				}
+
+				cluster := &clusterapiv1.Cluster{}
+				err := c.Get(ctx, key, cluster)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "Object should have been deleted")
+			}
+		})
+	}
+}
+
+func cluster(name string) *clusterapiv1.Cluster {
+	c := &clusterapiv1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Cluster",
+			APIVersion: clusterapiv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+	}
+
+	return c
+}
+
+func TestDeleteYamlError(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    []byte
+		wantErr string
+	}{
+		{
+			name:    "invalid yaml",
+			yaml:    []byte(`x`),
+			wantErr: "error unmarshaling JSON",
+		},
+		{
+			name: "error deleting",
+			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-1
+  namespace: default
+spec:
+  paused: true`),
+			wantErr: "deleting object cluster.x-k8s.io/v1beta1, Kind=Cluster, default/cluster-1",
+		},
+	}
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			c := fake.NewClientBuilder().Build()
+
+			g.Expect(clientutil.DeleteYaml(ctx, c, tt.yaml)).To(MatchError(ContainSubstring(tt.wantErr)))
+		})
+	}
+}


### PR DESCRIPTION
*Description of changes:*
Intended to be used from controllers with `client.Client`

*Testing (if applicable):*
Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

