### PR TITLE
Update tinkerbell stack to use the latest tinkerbell helm chart

### DIFF
--- a/pkg/executables/helm.go
+++ b/pkg/executables/helm.go
@@ -133,8 +133,10 @@ func (h *Helm) InstallChart(ctx context.Context, chart, ociURI, version, kubecon
 	return err
 }
 
+// InstallChartWithValuesFile installs a helm chart with the provided values file and waits for the chart deployment to be ready
+// The default timeout for the chart to reach ready state is 5m
 func (h *Helm) InstallChartWithValuesFile(ctx context.Context, chart, ociURI, version, kubeconfigFilePath, valuesFilePath string) error {
-	params := []string{"install", chart, ociURI, "--version", version, "--values", valuesFilePath, "--kubeconfig", kubeconfigFilePath}
+	params := []string{"install", chart, ociURI, "--version", version, "--values", valuesFilePath, "--kubeconfig", kubeconfigFilePath, "--wait"}
 	params = h.addInsecureFlagIfProvided(params)
 	_, err := h.executable.Command(ctx, params...).WithEnvVars(h.env).Run()
 	return err

--- a/pkg/executables/helm_test.go
+++ b/pkg/executables/helm_test.go
@@ -198,7 +198,7 @@ func TestHelmInstallChartWithValuesFileSuccess(t *testing.T) {
 	kubeconfig := "/root/.kube/config"
 	valuesFileName := "values.yaml"
 	expectCommand(
-		tt.e, tt.ctx, "install", chart, url, "--version", version, "--values", valuesFileName, "--kubeconfig", kubeconfig,
+		tt.e, tt.ctx, "install", chart, url, "--version", version, "--values", valuesFileName, "--kubeconfig", kubeconfig, "--wait",
 	).withEnvVars(tt.envVars).to().Return(bytes.Buffer{}, nil)
 
 	tt.Expect(tt.h.InstallChartWithValuesFile(tt.ctx, chart, url, version, kubeconfig, valuesFileName)).To(Succeed())
@@ -212,7 +212,7 @@ func TestHelmInstallChartWithValuesFileSuccessWithInsecure(t *testing.T) {
 	kubeconfig := "/root/.kube/config"
 	valuesFileName := "values.yaml"
 	expectCommand(
-		tt.e, tt.ctx, "install", chart, url, "--version", version, "--values", valuesFileName, "--kubeconfig", kubeconfig, "--insecure-skip-tls-verify",
+		tt.e, tt.ctx, "install", chart, url, "--version", version, "--values", valuesFileName, "--kubeconfig", kubeconfig, "--wait", "--insecure-skip-tls-verify",
 	).withEnvVars(tt.envVars).to().Return(bytes.Buffer{}, nil)
 
 	tt.Expect(tt.h.InstallChartWithValuesFile(tt.ctx, chart, url, version, kubeconfig, valuesFileName)).To(Succeed())

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -63,7 +63,7 @@ func TestTinkerbellStackInstallWithAllOptionsSuccess(t *testing.T) {
 	cluster := &types.Cluster{Name: "test"}
 	ctx := context.Background()
 
-	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace)
+	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace, "192.168.0.0/16")
 
 	writer.EXPECT().Write(overridesFileName, gomock.Any()).Return(overridesFileName, nil)
 
@@ -91,7 +91,7 @@ func TestTinkerbellStackInstallHookOverrideSuccess(t *testing.T) {
 	cluster := &types.Cluster{Name: "test"}
 	ctx := context.Background()
 
-	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace)
+	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace, "192.168.0.0/16")
 
 	writer.EXPECT().Write(overridesFileName, gomock.Any()).Return(overridesFileName, nil)
 
@@ -117,7 +117,7 @@ func TestTinkerbellStackInstallWithBootsOnDockerSuccess(t *testing.T) {
 	writer := filewritermocks.NewMockFileWriter(mockCtrl)
 	cluster := &types.Cluster{Name: "test"}
 	ctx := context.Background()
-	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace)
+	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace, "192.168.0.0/16")
 
 	writer.EXPECT().Write(overridesFileName, gomock.Any()).Return(overridesFileName, nil)
 	helm.EXPECT().InstallChartWithValuesFile(ctx, helmChartName, fmt.Sprintf("oci://%s", helmChartPath), helmChartVersion, cluster.KubeconfigFile, overridesFileName)
@@ -146,7 +146,7 @@ func TestTinkerbellStackUninstallLocalSucess(t *testing.T) {
 	helm := mocks.NewMockHelm(mockCtrl)
 	writer := filewritermocks.NewMockFileWriter(mockCtrl)
 	ctx := context.Background()
-	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace)
+	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace, "192.168.0.0/16")
 
 	docker.EXPECT().ForceRemove(ctx, boots)
 
@@ -162,7 +162,7 @@ func TestTinkerbellStackUninstallLocalFailure(t *testing.T) {
 	helm := mocks.NewMockHelm(mockCtrl)
 	writer := filewritermocks.NewMockFileWriter(mockCtrl)
 	ctx := context.Background()
-	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace)
+	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace, "192.168.0.0/16")
 
 	dockerError := "docker error"
 	expectedError := fmt.Sprintf("removing local boots container: %s", dockerError)
@@ -178,7 +178,7 @@ func TestTinkerbellStackCheckLocalBootsExistenceDoesNotExist(t *testing.T) {
 	helm := mocks.NewMockHelm(mockCtrl)
 	writer := filewritermocks.NewMockFileWriter(mockCtrl)
 	ctx := context.Background()
-	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace)
+	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace, "192.168.0.0/16")
 
 	docker.EXPECT().CheckContainerExistence(ctx, "boots").Return(true, nil)
 	docker.EXPECT().ForceRemove(ctx, "boots")
@@ -193,7 +193,7 @@ func TestTinkerbellStackCheckLocalBootsExistenceDoesExist(t *testing.T) {
 	helm := mocks.NewMockHelm(mockCtrl)
 	writer := filewritermocks.NewMockFileWriter(mockCtrl)
 	ctx := context.Background()
-	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace)
+	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace, "192.168.0.0/16")
 	expectedErrorMsg := "boots container already exists, delete the container manually or re-run the command with --force-cleanup"
 
 	docker.EXPECT().CheckContainerExistence(ctx, "boots").Return(true, nil)
@@ -208,7 +208,7 @@ func TestTinkerbellStackCheckLocalBootsExistenceDockerError(t *testing.T) {
 	helm := mocks.NewMockHelm(mockCtrl)
 	writer := filewritermocks.NewMockFileWriter(mockCtrl)
 	ctx := context.Background()
-	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace)
+	s := stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace, "192.168.0.0/16")
 
 	docker.EXPECT().CheckContainerExistence(ctx, "boots").Return(false, nil)
 

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -138,7 +138,7 @@ func NewProvider(
 		clusterConfig:         clusterConfig,
 		datacenterConfig:      datacenterConfig,
 		machineConfigs:        machineConfigs,
-		stackInstaller:        stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace),
+		stackInstaller:        stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace, clusterConfig.Spec.ClusterNetwork.Pods.CidrBlocks[0]),
 		providerKubectlClient: providerKubectlClient,
 		templateBuilder: &TemplateBuilder{
 			datacenterSpec:              &datacenterConfig.Spec,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/2772

*Description of changes:*
Update tinkerbell stack to use the updated tinkerbell helm chart with envoy and LoadBalancerClass here https://github.com/aws/eks-anywhere-build-tooling/pull/1091
Also, add a `--wait` to the helm install command so helm waits for deployments to be ready before moving forward

*Testing (if applicable):*
Created a new bare-metal cluster with the updated tinkerbell chart

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

