### PR TITLE
Isolated the api server collector and analyzer to vsphere cluster only

### DIFF
--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -165,11 +165,14 @@ func (a *analyzerFactory) DataCenterConfigAnalyzers(datacenter v1alpha1.Ref) []*
 }
 
 func (a *analyzerFactory) eksaVsphereAnalyzers() []*Analyze {
+	var analyzers []*Analyze
 	crds := []string{
 		fmt.Sprintf("vspheredatacenterconfigs.%s", v1alpha1.GroupVersion.Group),
 		fmt.Sprintf("vspheremachineconfigs.%s", v1alpha1.GroupVersion.Group),
 	}
-	return a.generateCrdAnalyzers(crds)
+	analyzers = append(analyzers, a.generateCrdAnalyzers(crds)...)
+	analyzers = append(analyzers, a.vsphereDiagnosticAnalyzers()...)
+	return analyzers
 }
 
 func (a *analyzerFactory) eksaCloudstackAnalyzers() []*Analyze {
@@ -211,13 +214,6 @@ func (a *analyzerFactory) EksaLogTextAnalyzers(collectors []*Collect) []*Analyze
 				analyzers = append(analyzers, analyzer...)
 			}
 		}
-		// the Run Pod collector generates logs as well but not in the default logs folder.
-		if collector.RunPod != nil {
-			rp_analyzer, rp_ok := analyzersMap[collector.RunPod.Namespaces]
-			if rp_ok {
-				analyzers = append(analyzers, rp_analyzer...)
-			}
-		}
 	}
 	return analyzers
 }
@@ -227,7 +223,6 @@ func (a *analyzerFactory) EksaLogTextAnalyzers(collectors []*Collect) []*Analyze
 func (a *analyzerFactory) namespaceLogTextAnalyzersMap() map[string][]*Analyze {
 	return map[string][]*Analyze{
 		constants.CapiKubeadmControlPlaneSystemNamespace: a.capiKubeadmControlPlaneSystemLogAnalyzers(),
-		constants.EksaDiagnosticsNamespace:               a.eksaDiagnosticsLogAnalyzers(),
 	}
 }
 
@@ -254,40 +249,6 @@ func (a *analyzerFactory) capiKubeadmControlPlaneSystemLogAnalyzers() []*Analyze
 						Pass: &singleOutcome{
 							When:    "false",
 							Message: "API server pods launched correctly",
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-// EksaDiagnosticsLogAnalyzers currently can help to analyze whether user is using a valid control plane IP to connect
-// to API server
-func (a *analyzerFactory) eksaDiagnosticsLogAnalyzers() []*Analyze {
-	runPingPod := "run-ping"
-	runPingPodLog := fmt.Sprintf("%s.log", runPingPod)
-	fullRunPingPodLogPath := path.Join(runPingPod, runPingPodLog)
-	return []*Analyze{
-		{
-			TextAnalyze: &textAnalyze{
-				analyzeMeta: analyzeMeta{
-					CheckName: fmt.Sprintf("%s:  Destination Host Unreachable. Log: %s", logAnalysisAnalyzerPrefix, fullRunPingPodLogPath),
-				},
-				FileName:     fullRunPingPodLogPath,
-				RegexPattern: `exit code: 0`,
-				Outcomes: []*outcome{
-					{
-						Fail: &singleOutcome{
-							When:    "false",
-							Message: fmt.Sprintf("The control plane endpoint host is unavailable. See %s", fullRunPingPodLogPath),
-						},
-					},
-
-					{
-						Pass: &singleOutcome{
-							When:    "true",
-							Message: "Control plane IP verified.",
 						},
 					},
 				},
@@ -359,6 +320,45 @@ func (a *analyzerFactory) crdAnalyzer(crdName string) *Analyze {
 				},
 			},
 			CustomResourceDefinitionName: crdName,
+		},
+	}
+}
+
+// vsphereDiagnosticAnalyzers will return diagnostic analyzers to analyze the condition of vSphere cluster
+func (a *analyzerFactory) vsphereDiagnosticAnalyzers() []*Analyze {
+	return a.controlPlaneIPAnalyzer()
+}
+
+// controlPlaneIPAnalyzer analyze whether a valid control plane IP is used to connect
+// to API server
+func (a *analyzerFactory) controlPlaneIPAnalyzer() []*Analyze {
+	runPingPod := "ping-host-ip"
+	runPingPodLog := fmt.Sprintf("%s.log", runPingPod)
+	fullRunPingPodLogPath := path.Join(runPingPod, runPingPodLog)
+	return []*Analyze{
+		{
+			TextAnalyze: &textAnalyze{
+				analyzeMeta: analyzeMeta{
+					CheckName: fmt.Sprintf("%s:  Destination Host Unreachable. Log: %s", logAnalysisAnalyzerPrefix, fullRunPingPodLogPath),
+				},
+				FileName:     fullRunPingPodLogPath,
+				RegexPattern: `exit code: 0`,
+				Outcomes: []*outcome{
+					{
+						Fail: &singleOutcome{
+							When:    "false",
+							Message: fmt.Sprintf("The control plane endpoint host is unavailable. See %s", fullRunPingPodLogPath),
+						},
+					},
+
+					{
+						Pass: &singleOutcome{
+							When:    "true",
+							Message: "Control plane IP verified.",
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/pkg/diagnostics/collector_types.go
+++ b/pkg/diagnostics/collector_types.go
@@ -90,7 +90,7 @@ type collectorMeta struct {
 
 type runPod struct {
 	Name             string      `json:"name,omitempty"`
-	Namespaces       string      `json:"namespace"`
+	Namespace        string      `json:"namespace"`
 	PodSpec          *v1.PodSpec `json:"podSpec,omitempty"`
 	Timeout          string      `json:"timeout,omitempty"`
 	imagePullSecrets `json:",inline"`

--- a/pkg/diagnostics/collectors_test.go
+++ b/pkg/diagnostics/collectors_test.go
@@ -4,44 +4,83 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/diagnostics"
 )
 
+func TestVsphereDataCenterConfigCollectors(t *testing.T) {
+	g := NewGomegaWithT(t)
+	spec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Cluster = &eksav1alpha1.Cluster{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{},
+			Spec: eksav1alpha1.ClusterSpec{
+				ControlPlaneConfiguration: eksav1alpha1.ControlPlaneConfiguration{
+					Endpoint: &eksav1alpha1.Endpoint{
+						Host: "1.1.1.1",
+					},
+				},
+				DatacenterRef: eksav1alpha1.Ref{
+					Kind: eksav1alpha1.VSphereDatacenterKind,
+					Name: "testRef",
+				},
+				ExternalEtcdConfiguration: &eksav1alpha1.ExternalEtcdConfiguration{
+					Count: 3,
+					MachineGroupRef: &eksav1alpha1.Ref{
+						Kind: eksav1alpha1.VSphereMachineConfigKind,
+						Name: "testRef",
+					},
+				},
+			},
+			Status: eksav1alpha1.ClusterStatus{},
+		}
+	})
+	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.VSphereDatacenterKind}
+	factory := diagnostics.NewDefaultCollectorFactory()
+	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
+	g.Expect(collectors).To(HaveLen(10), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
+	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapvSystemNamespace))
+	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CapvSystemNamespace)))
+	for _, collector := range collectors[1:7] {
+		g.Expect(collector.Run.PodSpec.Containers[0].Command).To(Equal([]string{"kubectl"}))
+		g.Expect(collector.Run.Namespace).To(Equal("eksa-diagnostics"))
+	}
+	g.Expect(collectors[8].RunPod.PodSpec.Containers[0].Name).To(Equal("check-host-port"))
+	g.Expect(collectors[9].RunPod.PodSpec.Containers[0].Name).To(Equal("ping-host-ip"))
+}
+
 func TestCloudStackDataCenterConfigCollectors(t *testing.T) {
+	g := NewGomegaWithT(t)
+	spec := test.NewClusterSpec(func(s *cluster.Spec) {})
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.CloudStackDatacenterKind}
 	factory := diagnostics.NewDefaultCollectorFactory()
-	collectors := factory.DataCenterConfigCollectors(datacenter)
-	assert.Equal(t, len(collectors), 10, "DataCenterConfigCollectors() mismatch between desired collectors and actual")
-	assert.Equal(t, constants.CapcSystemNamespace, collectors[0].Logs.Namespace)
-	assert.Equal(t, fmt.Sprintf("logs/%s", constants.CapcSystemNamespace), collectors[0].Logs.Name)
+	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
+	g.Expect(collectors).To(HaveLen(10), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
+	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapcSystemNamespace))
+	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CapcSystemNamespace)))
 	for _, collector := range collectors[1:] {
-		assert.Equal(t, []string{"kubectl"}, collector.Run.PodSpec.Containers[0].Command)
-		assert.Equal(t, "eksa-diagnostics", collector.Run.Namespace)
+		g.Expect([]string{"kubectl"}).To(Equal(collector.Run.PodSpec.Containers[0].Command))
+		g.Expect("eksa-diagnostics").To(Equal(collector.Run.Namespace))
 	}
 }
 
 func TestTinkerbellDataCenterConfigCollectors(t *testing.T) {
+	g := NewGomegaWithT(t)
+	spec := test.NewClusterSpec(func(s *cluster.Spec) {})
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.TinkerbellDatacenterKind}
 	factory := diagnostics.NewDefaultCollectorFactory()
-	collectors := factory.DataCenterConfigCollectors(datacenter)
-	assert.Equal(t, len(collectors), 13, "DataCenterConfigCollectors() mismatch between desired collectors and actual")
-	assert.Equal(t, constants.CaptSystemNamespace, collectors[0].Logs.Namespace)
-	assert.Equal(t, fmt.Sprintf("logs/%s", constants.CaptSystemNamespace), collectors[0].Logs.Name)
+	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
+	g.Expect(collectors).To(HaveLen(13), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
+	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CaptSystemNamespace))
+	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CaptSystemNamespace)))
 	for _, collector := range collectors[1:] {
-		assert.Equal(t, []string{"kubectl"}, collector.Run.PodSpec.Containers[0].Command)
-		assert.Equal(t, "eksa-diagnostics", collector.Run.Namespace)
+		g.Expect([]string{"kubectl"}).To(Equal(collector.Run.PodSpec.Containers[0].Command))
+		g.Expect("eksa-diagnostics").To(Equal(collector.Run.Namespace))
 	}
-}
-
-func TestAPIServerCollectors(t *testing.T) {
-	controlPlaneIP := "1.1.1.1"
-	factory := diagnostics.NewDefaultCollectorFactory()
-	collectors := factory.APIServerCollectors(controlPlaneIP)
-	assert.Equal(t, len(collectors), 2, "APIServerCollector() should return two collectors:hostPortCollector and pingHostCollector ")
-	assert.Equal(t, collectors[0].RunPod.Name, "run-ip", "First of APIserverCollectors should be type of runPod named run-ip")
-	assert.Equal(t, collectors[1].RunPod.Name, "run-ping", "Second of APIserverCollectors should be type of runPod named run-ping")
 }

--- a/pkg/diagnostics/interfaces.go
+++ b/pkg/diagnostics/interfaces.go
@@ -31,7 +31,7 @@ type DiagnosticBundle interface {
 	CollectAndAnalyze(ctx context.Context, sinceTimeValue *time.Time) error
 	WithDefaultAnalyzers() *EksaDiagnosticBundle
 	WithDefaultCollectors() *EksaDiagnosticBundle
-	WithDatacenterConfig(config v1alpha1.Ref) *EksaDiagnosticBundle
+	WithDatacenterConfig(config v1alpha1.Ref, spec *cluster.Spec) *EksaDiagnosticBundle
 	WithOidcConfig(config *v1alpha1.OIDCConfig) *EksaDiagnosticBundle
 	WithExternalEtcd(config *v1alpha1.ExternalEtcdConfiguration) *EksaDiagnosticBundle
 	WithGitOpsConfig(config *v1alpha1.GitOpsConfig) *EksaDiagnosticBundle
@@ -55,6 +55,5 @@ type CollectorFactory interface {
 	DefaultCollectors() []*Collect
 	ManagementClusterCollectors() []*Collect
 	EksaHostCollectors(configs []providers.MachineConfig) []*Collect
-	DataCenterConfigCollectors(datacenter v1alpha1.Ref) []*Collect
-	APIServerCollectors(controlPlaneIP string) []*Collect
+	DataCenterConfigCollectors(datacenter v1alpha1.Ref, spec *cluster.Spec) []*Collect
 }

--- a/pkg/diagnostics/interfaces/mocks/diagnostics.go
+++ b/pkg/diagnostics/interfaces/mocks/diagnostics.go
@@ -232,17 +232,17 @@ func (mr *MockDiagnosticBundleMockRecorder) PrintBundleConfig() *gomock.Call {
 }
 
 // WithDatacenterConfig mocks base method.
-func (m *MockDiagnosticBundle) WithDatacenterConfig(config v1alpha1.Ref) *diagnostics.EksaDiagnosticBundle {
+func (m *MockDiagnosticBundle) WithDatacenterConfig(config v1alpha1.Ref, spec *cluster.Spec) *diagnostics.EksaDiagnosticBundle {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WithDatacenterConfig", config)
+	ret := m.ctrl.Call(m, "WithDatacenterConfig", config, spec)
 	ret0, _ := ret[0].(*diagnostics.EksaDiagnosticBundle)
 	return ret0
 }
 
 // WithDatacenterConfig indicates an expected call of WithDatacenterConfig.
-func (mr *MockDiagnosticBundleMockRecorder) WithDatacenterConfig(config interface{}) *gomock.Call {
+func (mr *MockDiagnosticBundleMockRecorder) WithDatacenterConfig(config, spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithDatacenterConfig", reflect.TypeOf((*MockDiagnosticBundle)(nil).WithDatacenterConfig), config)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithDatacenterConfig", reflect.TypeOf((*MockDiagnosticBundle)(nil).WithDatacenterConfig), config, spec)
 }
 
 // WithDefaultAnalyzers mocks base method.
@@ -530,32 +530,18 @@ func (m *MockCollectorFactory) EXPECT() *MockCollectorFactoryMockRecorder {
 	return m.recorder
 }
 
-// APIServerCollectors mocks base method.
-func (m *MockCollectorFactory) APIServerCollectors(controlPlaneIP string) []*diagnostics.Collect {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIServerCollectors", controlPlaneIP)
-	ret0, _ := ret[0].([]*diagnostics.Collect)
-	return ret0
-}
-
-// APIServerCollectors indicates an expected call of APIServerCollectors.
-func (mr *MockCollectorFactoryMockRecorder) APIServerCollectors(controlPlaneIP interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerCollectors", reflect.TypeOf((*MockCollectorFactory)(nil).APIServerCollectors), controlPlaneIP)
-}
-
 // DataCenterConfigCollectors mocks base method.
-func (m *MockCollectorFactory) DataCenterConfigCollectors(datacenter v1alpha1.Ref) []*diagnostics.Collect {
+func (m *MockCollectorFactory) DataCenterConfigCollectors(datacenter v1alpha1.Ref, spec *cluster.Spec) []*diagnostics.Collect {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DataCenterConfigCollectors", datacenter)
+	ret := m.ctrl.Call(m, "DataCenterConfigCollectors", datacenter, spec)
 	ret0, _ := ret[0].([]*diagnostics.Collect)
 	return ret0
 }
 
 // DataCenterConfigCollectors indicates an expected call of DataCenterConfigCollectors.
-func (mr *MockCollectorFactoryMockRecorder) DataCenterConfigCollectors(datacenter interface{}) *gomock.Call {
+func (mr *MockCollectorFactoryMockRecorder) DataCenterConfigCollectors(datacenter, spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataCenterConfigCollectors", reflect.TypeOf((*MockCollectorFactory)(nil).DataCenterConfigCollectors), datacenter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataCenterConfigCollectors", reflect.TypeOf((*MockCollectorFactory)(nil).DataCenterConfigCollectors), datacenter, spec)
 }
 
 // DefaultCollectors mocks base method.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Move the the api server collector to be one of collectors of vSphere provider. This collector will only work when need to generate support bundle for the vSphere cluster. It won't bother the process of creating/getting support bundle for docker cluster. Same change on control plane analyzer. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

