### PR TITLE
Fix flux suspend failed during cluster upgrade

### DIFF
--- a/pkg/gitops/flux/mocks/client.go
+++ b/pkg/gitops/flux/mocks/client.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	cluster "github.com/aws/eks-anywhere/pkg/cluster"
 	config "github.com/aws/eks-anywhere/pkg/config"
 	executables "github.com/aws/eks-anywhere/pkg/executables"
 	filewriter "github.com/aws/eks-anywhere/pkg/filewriter"
@@ -161,6 +162,21 @@ func (mr *MockKubeClientMockRecorder) DeleteSecret(arg0, arg1, arg2, arg3 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*MockKubeClient)(nil).DeleteSecret), arg0, arg1, arg2, arg3)
 }
 
+// GetEksaCluster mocks base method.
+func (m *MockKubeClient) GetEksaCluster(arg0 context.Context, arg1 *types.Cluster, arg2 string) (*v1alpha1.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEksaCluster", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*v1alpha1.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEksaCluster indicates an expected call of GetEksaCluster.
+func (mr *MockKubeClientMockRecorder) GetEksaCluster(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEksaCluster", reflect.TypeOf((*MockKubeClient)(nil).GetEksaCluster), arg0, arg1, arg2)
+}
+
 // UpdateAnnotation mocks base method.
 func (m *MockKubeClient) UpdateAnnotation(arg0 context.Context, arg1, arg2 string, arg3 map[string]string, arg4 ...executables.KubectlOpt) error {
 	m.ctrl.T.Helper()
@@ -257,6 +273,21 @@ func (m *MockGitOpsFluxClient) ForceReconcile(arg0 context.Context, arg1 *types.
 func (mr *MockGitOpsFluxClientMockRecorder) ForceReconcile(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceReconcile", reflect.TypeOf((*MockGitOpsFluxClient)(nil).ForceReconcile), arg0, arg1, arg2)
+}
+
+// GetCluster mocks base method.
+func (m *MockGitOpsFluxClient) GetCluster(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec) (*v1alpha1.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCluster", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*v1alpha1.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCluster indicates an expected call of GetCluster.
+func (mr *MockGitOpsFluxClientMockRecorder) GetCluster(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockGitOpsFluxClient)(nil).GetCluster), arg0, arg1, arg2)
 }
 
 // Reconcile mocks base method.


### PR DESCRIPTION
*Issue #, if available:*

#2755 

*Description of changes:*

When installing flux in existing cluster using upgrade command, we pause flux kustomization before components upgrade. The flux suspend step is not properly skipped since the new spec has gitops ref specified. For this case, we need to fetch the existing cluster object and check if `gitOpsRef` exist or not. If not, it means flux is not enabled in existing cluster and we skip the `SuspendKustomization` step.

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

