### PR TITLE
Continue e2e test after failure when checkpoint is enabled

### DIFF
--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -42,7 +42,6 @@ func runUpgradeFlowWithCheckpoint(test *framework.ClusterE2ETest, updateVersion 
 	test.GenerateClusterConfig()
 	test.CreateCluster()
 	test.UpgradeCluster(clusterOpts)
-	test.StopIfSucceeded()
 	test.UpgradeCluster(clusterOpts2)
 	test.ValidateCluster(updateVersion)
 	test.StopIfFailed()
@@ -498,9 +497,9 @@ func TestVSphereKubernetes121UbuntuTo122UpgradeWithCheckpoint(t *testing.T) {
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 	)
-	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
+	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)), framework.ExpectFailure(true),
 		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var(), api.WithResourcePoolForAllMachines(vsphereInvalidResourcePoolUpdateVar)), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(config.ExternalEtcdTimeoutEnv, "10m"), framework.WithEnvVar(framework.CleanupVmsVar, "false"))
-	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
+	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)), framework.ExpectFailure(false),
 		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var(), api.WithResourcePoolForAllMachines(os.Getenv(vsphereResourcePoolVar))), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupVmsVar, "true"))
 	runUpgradeFlowWithCheckpoint(
 		test,

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -82,6 +82,7 @@ type ClusterE2ETest struct {
 	ProxyConfig            *v1alpha1.ProxyConfiguration
 	AWSIamConfig           *v1alpha1.AWSIamConfig
 	eksaBinaryLocation     string
+	ExpectFailure          bool
 }
 
 type ClusterE2ETestOpt func(e *ClusterE2ETest)
@@ -149,6 +150,12 @@ func withHardware(requiredCount int, hardareType string, labels map[string]strin
 func WithNoPowerActions() ClusterE2ETestOpt {
 	return func(e *ClusterE2ETest) {
 		e.WithNoPowerActions = true
+	}
+}
+
+func ExpectFailure(expected bool) ClusterE2ETestOpt {
+	return func(e *ClusterE2ETest) {
+		e.ExpectFailure = expected
 	}
 }
 
@@ -675,6 +682,10 @@ func (e *ClusterE2ETest) Run(name string, args ...string) {
 		}
 
 		if errorMessage != "" {
+			if e.ExpectFailure {
+				e.T.Logf("This error was expected. Continuing...")
+				return
+			}
 			e.T.Fatalf("Command %s %v failed with error: %v: %s", name, args, err, errorMessage)
 		}
 
@@ -691,12 +702,6 @@ func (e *ClusterE2ETest) RunEKSA(args []string, opts ...CommandOpt) {
 		}
 	}
 	e.Run(binaryPath, args...)
-}
-
-func (e *ClusterE2ETest) StopIfSucceeded() {
-	if !e.T.Failed() {
-		e.T.FailNow()
-	}
 }
 
 func (e *ClusterE2ETest) StopIfFailed() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For checkpoint tests, the first run of `upgrade cluster` will fail. If we return the error in the framework, this will signal the e2e test to end there. So if the checkpoint feature is enabled, we won't return the error in the framework. The error will still happen in the logs as usual, but the e2e test will continue, allowing us to accurately test the checkpoint feature.

Example output after the first upgrade failure with these changes:
```
2022-08-05T17:26:04.543Z	V4	Task finished	{"task_name": "collect-cluster-diagnostics", "duration": "2m41.519058791s"}
2022-08-05T17:26:04.543Z	V4	----------------------------------
2022-08-05T17:26:04.543Z	V4	Saving checkpoint	{"file": "eksa-test-5d81cdf-checkpoint.yaml"}
2022-08-05T17:26:04.544Z	V4	Tasks completed	{"duration": "4m48.184183815s"}
2022-08-05T17:26:04.544Z	V3	Cleaning up long running container	{"name": "eksa_1659720075911723793"}
Error: failed to upgrade cluster: waiting for external etcd for workload cluster to be ready: executing wait: error: timed out waiting for the condition on clusters/eksa-test-5d81cdf

    cluster.go:646: Running shell command [ eksctl anywhere upgrade cluster -f eksa-test-5d81cdf/cluster.yaml -v 4 ]
2022-08-05T17:26:04.816Z	V4	Logger init completed	{"vlevel": 4}
2022-08-05T17:26:04.989Z	V4	Reading bundles manifest
2022-08-05T17:26:05.064Z	V2	Pulling docker image
2022-08-05T17:26:05.294Z	V3	Initializing long running container
2022-08-05T17:26:05.483Z	V4	Checkpoint feature enabled
2022-08-05T17:26:05.483Z	V4	Reading checkpoint	{"file": "eksa-test-5d81cdf/generated/eksa-test-5d81cdf-checkpoint.yaml"}
2022-08-05T17:26:05.483Z	V4	Restoring task	{"task_name": "setup-and-validate"}
2022-08-05T17:26:05.483Z	V0	docker Provider setup is valid
2022-08-05T17:26:06.948Z	V4	Restoring task	{"task_name": "update-secrets"}
2022-08-05T17:26:06.948Z	V4	Restoring task	{"task_name": "ensure-etcd-capi-components-exist"}
...
```

*Testing (if applicable):*

Tested with docker checkpoint e2e test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

