### PR TITLE
Change default kubernetes version to 1.23

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -223,7 +223,7 @@ func GetAndValidateClusterConfig(fileName string) (*Cluster, error) {
 
 // GetClusterDefaultKubernetesVersion returns the default kubernetes version for a Cluster
 func GetClusterDefaultKubernetesVersion() KubernetesVersion {
-	return Kube122
+	return Kube123
 }
 
 // ValidateClusterConfigContent validates a Cluster object without modifying it

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -2321,3 +2321,8 @@ func TestClusterProxyConfiguration(t *testing.T) {
 		})
 	}
 }
+
+func TestGetClusterDefaultKubernetesVersion(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(GetClusterDefaultKubernetesVersion()).To(Equal(Kube123))
+}


### PR DESCRIPTION
*Issue #, if available:*
#2159 

*Description of changes:*
- Change default kubernetes version to 1.23

*Testing (if applicable):*
- make

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

