### PR TITLE
Remove Bottlerocket default console settings and update documentation

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/baremetal.md
+++ b/docs/content/en/docs/reference/clusterspec/baremetal.md
@@ -379,6 +379,23 @@ spec:
 
 ### Bottlerocket TinkerbellTemplateConfig example
 
+Pay special attention to the `BOOTCONFIG_CONTENTS` environment section below if you wish to set up console redirection for the kernel and systemd.
+If you are only using a direct attached monitor as your primary display device, no additional configuration is needed here.
+However, if you need all boot output to be shown via a server’s serial console for example, extra configuration should be provided inside `BOOTCONFIG_CONTENTS`.
+
+An empty `kernel {}` key is provided below in the example; inside this key is where you will specify your console devices.
+You may specify multiple comma delimited console devices in quotes to a console key as such: `console = "tty0", "ttyS0,115200n8"`.
+The order of the devices is significant; systemd will output to the last device specified.
+The console key belongs inside the kernel key like so:
+```
+kernel {
+    console = "tty0", "ttyS0,115200n8"
+}
+```
+
+The above example will send all kernel output to both consoles, and systemd output to `ttyS0`.
+Additional information about serial console setup can be found in the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html).
+
 ```yaml
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
@@ -400,10 +417,12 @@ spec:
         name: stream-image
         timeout: 360
       - environment:
+          # An example console declaration that will send all kernel output to both consoles, and systemd output to ttyS0.
+          # kernel {
+          #     console = "tty0", "ttyS0,115200n8"
+          # }
           BOOTCONFIG_CONTENTS: |
-            kernel {
-                console = "tty0", "ttyS0,115200n8"
-            }
+            kernel {}
           DEST_DISK: /dev/sda12
           DEST_PATH: /bootconfig.data
           DIRMODE: "0700"

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
@@ -24,10 +24,7 @@ dhcp4 = true
 # the file
 primary = true
 `
-	bottlerocketBootconfig = `kernel {
-  console = "tty0", "ttyS0,115200n8"
-}
-`
+	bottlerocketBootconfig = `kernel {}`
 
 	cloudInit = `datasource:
   Ec2:


### PR DESCRIPTION
*Issue #, if available:*
N/A
Related to Bottlerocket issue: https://github.com/bottlerocket-os/bottlerocket/issues/2291

*Description of changes:*
```
    docs: Add additional information about Bottlerocket console settings
    
    This change adds additional information regarding console setup to the
    Bottlerocket section of "Advanced Bare Metal cluster configuration".  It
    removes the default console settings from the spec itself and provides a
    bit more information and references about how you could set up consoles
    on your Bottlerocket host.
    
    For additional context and reference, see the Bottlerocket issue:
    https://github.com/bottlerocket-os/bottlerocket/issues/2291
```
```
    tinkerbell template defaults: Remove Bottlerocket console settings
    
    With the current default settings, Bottlerocket nodes are launched (and
    no overrides are present), and are passed the console settings
    `console=tty0 console=ttyS0,115200n8`.  These settings configure the
    console output for the kernel, and by extension systemd.  Given the
    current defaults, the kernel will output to both `tty0` and `ttyS0`, and
    bind `/dev/console` to the last device in line which is `ttyS0` (a
    serial console).  systemd sends all of its output to `/dev/console`,
    meaning that if `ttyS0` doesn't exist on a users system, they will never
    see output and therefore have an extremely difficult time debugging a
    system that doesn't join the cluster.
    
    Given the fact that real hardware is so varied there isn't really a good
    default value to provide here.  This change removes the default settings
    altogether.  In the absence of console configuration, the kernel is
    smart enough to output to the first device capable of acting as a
    console, often this is a local VGA device, etc.  The kernel will bind
    `/dev/console` to said device, meaning systemd will also send its output
    there.  For the common case of a user wanting to directly connect a
    monitor as the primary display device, they will see all boot output on
    the monitor.  The user experience here is much better, while also
    continuing to allow for more advanced configuration.
    
    For additional information and context:
    https://github.com/bottlerocket-os/bottlerocket/issues/2291
    https://elixir.bootlin.com/linux/v5.10.102/source/Documentation/admin-guide/serial-console.rst#L47
```


*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

