### PR TITLE
Use kubernetes client-go in a few places

### DIFF
--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -42,6 +42,14 @@ func NewDependenciesForPackages(ctx context.Context, opts ...PackageOpt) (*depen
 		Build(ctx)
 }
 
+func NewLightweightDepsForPackages(ctx context.Context, opts ...PackageOpt) (*dependencies.Dependencies, error) {
+	config := New(opts...)
+	return dependencies.NewFactory().
+		WithCuratedPackagesRegistry(config.registryName, config.kubeVersion, version.Get()).
+		WithKubeRESTClient(config.kubeConfigFilename).
+		Build(ctx)
+}
+
 type PackageOpt func(*PackageConfig)
 
 type PackageConfig struct {

--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -38,6 +38,7 @@ func NewDependenciesForPackages(ctx context.Context, opts ...PackageOpt) (*depen
 		WithKubectl().
 		WithHelm(executables.WithInsecure()).
 		WithCuratedPackagesRegistry(config.registryName, config.kubeVersion, version.Get()).
+		WithKubeRESTClient(config.kubeConfigFilename).
 		Build(ctx)
 }
 
@@ -47,6 +48,8 @@ type PackageConfig struct {
 	registryName string
 	kubeVersion  string
 	mountPaths   []string
+	// kubeConfigFilename optional filename from which to load a kube config.
+	kubeConfigFilename string
 }
 
 func New(options ...PackageOpt) *PackageConfig {

--- a/cmd/eksctl-anywhere/cmd/generatepackage.go
+++ b/cmd/eksctl-anywhere/cmd/generatepackage.go
@@ -58,7 +58,7 @@ func generatePackages(ctx context.Context, args []string) error {
 	b := curatedpackages.NewBundleReader(
 		kubeConfig,
 		gpOptions.source,
-		deps.Kubectl,
+		deps.KubeRESTClient,
 		bm,
 		deps.BundleRegistry,
 	)

--- a/cmd/eksctl-anywhere/cmd/installpackages.go
+++ b/cmd/eksctl-anywhere/cmd/installpackages.go
@@ -67,7 +67,7 @@ func installPackages(ctx context.Context, args []string) error {
 	b := curatedpackages.NewBundleReader(
 		kubeConfig,
 		ipo.source,
-		deps.Kubectl,
+		deps.KubeRESTClient,
 		bm,
 		deps.BundleRegistry,
 	)

--- a/cmd/eksctl-anywhere/cmd/listpackages.go
+++ b/cmd/eksctl-anywhere/cmd/listpackages.go
@@ -49,7 +49,7 @@ var listPackagesCommand = &cobra.Command{
 
 func listPackages(ctx context.Context) error {
 	kubeConfig := kubeconfig.FromEnvironment()
-	deps, err := NewDependenciesForPackages(ctx, WithRegistryName(lpo.registry), WithKubeVersion(lpo.kubeVersion), WithMountPaths(kubeConfig))
+	deps, err := NewLightweightDepsForPackages(ctx, WithKubeVersion(lpo.kubeVersion))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/listpackages.go
+++ b/cmd/eksctl-anywhere/cmd/listpackages.go
@@ -59,7 +59,7 @@ func listPackages(ctx context.Context) error {
 	b := curatedpackages.NewBundleReader(
 		kubeConfig,
 		lpo.source,
-		deps.Kubectl,
+		deps.KubeRESTClient,
 		bm,
 		deps.BundleRegistry,
 	)

--- a/cmd/eksctl-anywhere/cmd/upgradepackages.go
+++ b/cmd/eksctl-anywhere/cmd/upgradepackages.go
@@ -45,11 +45,10 @@ func upgradePackages(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}
-
 	b := curatedpackages.NewBundleReader(
 		kubeConfig,
 		ipo.source,
-		deps.Kubectl,
+		deps.KubeRESTClient,
 		nil,
 		nil,
 	)


### PR DESCRIPTION
In general, the EKS-Anywhere project has shelled out to kubectl to interact
with the cluster's API. However, given that the EKS-A kubectl binary is run
via a docker image, it can be slow. For cluster creation/teardown, this
slowness is amortized and isn't nearly as noticeable. But for commands like
"list packages" which should be rather fast, it's very noticeable.

So we're starting to use API client libraries where it makes sense to speed up
these calls that are more interactive in nature, or where faster responses
make sense.

There will be more commits of this nature in the near future. So if you see
patterns here that you don't like, or think could be improved, now would be a
great time to bring them up for discussion. :)

As a historical note, the choice to shell out to kubectl was made because it
was planned that EKS-A would support more versions of kubernetes than the
upstream project would, and it was thought that the ability to swap out
executable versions to match the kubernetes version would be an easier or more
flexible way to manage the differences when compared with linking to / using
multiple versions of the client libraries. Whether or not that is true remains
to be seen, but that fact is being used as guidance here, in that—at least at
first—we will replace only calls that are stable and therefore less likely to
change or require multiple library versions. (Like the list and get calls
replaced here).

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

