### PR TITLE
Use Println instead of Print for kubectl output

### DIFF
--- a/pkg/curatedpackages/packageclient.go
+++ b/pkg/curatedpackages/packageclient.go
@@ -127,7 +127,7 @@ func (pc *PackageClient) InstallPackage(ctx context.Context, bp *packagesv1.Bund
 	if err != nil {
 		return err
 	}
-	fmt.Print(&stdOut)
+	fmt.Println(&stdOut)
 	return nil
 }
 


### PR DESCRIPTION
*Description of changes:*
This messes up with the terminal output and the go test output when the
printed text doesn't end with a break line.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

