### PR TITLE
Change immutable field errors to type Forbidden

### DIFF
--- a/pkg/api/v1alpha1/awsiamconfig_webhook.go
+++ b/pkg/api/v1alpha1/awsiamconfig_webhook.go
@@ -78,7 +78,7 @@ func validateImmutableAWSIamFields(new, old *AWSIamConfig) field.ErrorList {
 	if !new.Spec.Equal(&old.Spec) {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "AWSIamConfig"), new, "config is immutable"),
+			field.Forbidden(field.NewPath(AWSIamConfigKind), "config is immutable"),
 		)
 	}
 

--- a/pkg/api/v1alpha1/cloudstackdatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/cloudstackdatacenterconfig_webhook.go
@@ -108,6 +108,7 @@ func isCapcV1beta1ToV1beta2Upgrade(new, old *CloudStackDatacenterConfigSpec) boo
 
 func validateImmutableFieldsCloudStackCluster(new, old *CloudStackDatacenterConfig) field.ErrorList {
 	var allErrs field.ErrorList
+	specPath := field.NewPath("spec")
 
 	// Check for CAPC v1beta1 -> CAPC v1beta2 upgrade
 	if isCapcV1beta1ToV1beta2Upgrade(&new.Spec, &old.Spec) {
@@ -124,7 +125,7 @@ func validateImmutableFieldsCloudStackCluster(new, old *CloudStackDatacenterConf
 			if !newAz.Equal(&oldAz) {
 				allErrs = append(
 					allErrs,
-					field.Invalid(field.NewPath("spec", "availabilityZone", oldAz.Name), newAz, "availabilityZone is immutable"),
+					field.Forbidden(specPath.Child("availabilityZone", oldAz.Name), "availabilityZone is immutable"),
 				)
 			}
 		}

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -113,48 +113,49 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 	}
 
 	var allErrs field.ErrorList
+	specPath := field.NewPath("spec")
 
 	if !old.ManagementClusterEqual(new) {
 		allErrs = append(
 			allErrs,
-			field.Forbidden(field.NewPath("spec", "managementCluster", new.Spec.ManagementCluster.Name), fmt.Sprintf("field is immutable %v", new.Spec.ManagementCluster)))
+			field.Forbidden(specPath.Child("managementCluster", new.Spec.ManagementCluster.Name), fmt.Sprintf("field is immutable %v", new.Spec.ManagementCluster)))
 	}
 
 	if !new.Spec.ControlPlaneConfiguration.Endpoint.Equal(old.Spec.ControlPlaneConfiguration.Endpoint) {
 		allErrs = append(
 			allErrs,
-			field.Forbidden(field.NewPath("spec", "ControlPlaneConfiguration.endpoint"), fmt.Sprintf("field is immutable %v", new.Spec.ControlPlaneConfiguration.Endpoint)))
+			field.Forbidden(specPath.Child("ControlPlaneConfiguration.endpoint"), fmt.Sprintf("field is immutable %v", new.Spec.ControlPlaneConfiguration.Endpoint)))
 	}
 
 	if !new.Spec.DatacenterRef.Equal(&old.Spec.DatacenterRef) {
 		allErrs = append(
 			allErrs,
-			field.Forbidden(field.NewPath("spec", "datacenterRef"), fmt.Sprintf("field is immutable %v", new.Spec.DatacenterRef)))
+			field.Forbidden(specPath.Child("datacenterRef"), fmt.Sprintf("field is immutable %v", new.Spec.DatacenterRef)))
 	}
 
 	if !new.Spec.ClusterNetwork.Equal(&old.Spec.ClusterNetwork) {
 		allErrs = append(
 			allErrs,
-			field.Forbidden(field.NewPath("spec", "ClusterNetwork"), fmt.Sprintf("field is immutable %v", new.Spec.ClusterNetwork)))
+			field.Forbidden(specPath.Child("ClusterNetwork"), fmt.Sprintf("field is immutable %v", new.Spec.ClusterNetwork)))
 	}
 
 	if !new.Spec.ProxyConfiguration.Equal(old.Spec.ProxyConfiguration) {
 		allErrs = append(
 			allErrs,
-			field.Forbidden(field.NewPath("spec", "ProxyConfiguration"), fmt.Sprintf("field is immutable %v", new.Spec.ProxyConfiguration)))
+			field.Forbidden(specPath.Child("ProxyConfiguration"), fmt.Sprintf("field is immutable %v", new.Spec.ProxyConfiguration)))
 	}
 
 	if new.Spec.ExternalEtcdConfiguration != nil && old.Spec.ExternalEtcdConfiguration == nil {
 		allErrs = append(
 			allErrs,
-			field.Forbidden(field.NewPath("spec.externalEtcdConfiguration"), "cannot switch from local to external etcd topology"),
+			field.Forbidden(specPath.Child("externalEtcdConfiguration"), "cannot switch from local to external etcd topology"),
 		)
 	}
 	if new.Spec.ExternalEtcdConfiguration != nil && old.Spec.ExternalEtcdConfiguration != nil {
 		if old.Spec.ExternalEtcdConfiguration.Count != new.Spec.ExternalEtcdConfiguration.Count {
 			allErrs = append(
 				allErrs,
-				field.Forbidden(field.NewPath("spec.externalEtcdConfiguration.count"), fmt.Sprintf("field is immutable %v", new.Spec.ExternalEtcdConfiguration.Count)),
+				field.Forbidden(specPath.Child("externalEtcdConfiguration.count"), fmt.Sprintf("field is immutable %v", new.Spec.ExternalEtcdConfiguration.Count)),
 			)
 		}
 	}
@@ -162,7 +163,7 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 	if !new.Spec.GitOpsRef.Equal(old.Spec.GitOpsRef) {
 		allErrs = append(
 			allErrs,
-			field.Forbidden(field.NewPath("spec", "GitOpsRef"), fmt.Sprintf("field is immutable %v", new.Spec.GitOpsRef)))
+			field.Forbidden(specPath.Child("GitOpsRef"), fmt.Sprintf("field is immutable %v", new.Spec.GitOpsRef)))
 	}
 
 	if !old.IsSelfManaged() {
@@ -186,7 +187,7 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 		if !oldAWSIamConfig.Equal(newAWSIamConfig) {
 			allErrs = append(
 				allErrs,
-				field.Forbidden(field.NewPath("spec", "AWS Iam Config"), fmt.Sprintf("field is immutable %v", newAWSIamConfig.Kind)))
+				field.Forbidden(specPath.Child("identityProviderRefs", AWSIamConfigKind), fmt.Sprintf("field is immutable %v", newAWSIamConfig.Kind)))
 		}
 		return allErrs
 	}
@@ -196,20 +197,20 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 	if !RefSliceEqual(new.Spec.IdentityProviderRefs, old.Spec.IdentityProviderRefs) {
 		allErrs = append(
 			allErrs,
-			field.Forbidden(field.NewPath("spec", "IdentityProviderRefs"), fmt.Sprintf("field is immutable %v", new.Spec.IdentityProviderRefs)))
+			field.Forbidden(specPath.Child("IdentityProviderRefs"), fmt.Sprintf("field is immutable %v", new.Spec.IdentityProviderRefs)))
 	}
 
 	if old.Spec.KubernetesVersion != new.Spec.KubernetesVersion {
 		allErrs = append(
 			allErrs,
-			field.Forbidden(field.NewPath("spec", "kubernetesVersion"), fmt.Sprintf("field is immutable %v", new.Spec.KubernetesVersion)),
+			field.Forbidden(specPath.Child("kubernetesVersion"), fmt.Sprintf("field is immutable %v", new.Spec.KubernetesVersion)),
 		)
 	}
 
 	if !old.Spec.ControlPlaneConfiguration.Equal(&new.Spec.ControlPlaneConfiguration) {
 		allErrs = append(
 			allErrs,
-			field.Forbidden(field.NewPath("spec", "ControlPlaneConfiguration"), fmt.Sprintf("field is immutable %v", new.Spec.ControlPlaneConfiguration)))
+			field.Forbidden(specPath.Child("ControlPlaneConfiguration"), fmt.Sprintf("field is immutable %v", new.Spec.ControlPlaneConfiguration)))
 	}
 
 	return allErrs

--- a/pkg/api/v1alpha1/fluxconfig_webhook.go
+++ b/pkg/api/v1alpha1/fluxconfig_webhook.go
@@ -90,7 +90,7 @@ func validateImmutableFluxFields(new, old *FluxConfig) field.ErrorList {
 	if !new.Spec.Equal(&old.Spec) {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", FluxConfigKind), new, "config is immutable"),
+			field.Forbidden(field.NewPath(FluxConfigKind), "config is immutable"),
 		)
 	}
 

--- a/pkg/api/v1alpha1/gitopsconfig_webhook.go
+++ b/pkg/api/v1alpha1/gitopsconfig_webhook.go
@@ -66,7 +66,7 @@ func validateImmutableGitOpsFields(new, old *GitOpsConfig) field.ErrorList {
 	if !new.Spec.Equal(&old.Spec) {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "GitOpsConfig"), new, "config is immutable"),
+			field.Forbidden(field.NewPath(GitOpsConfigKind), "config is immutable"),
 		)
 	}
 

--- a/pkg/api/v1alpha1/oidcconfig_webhook.go
+++ b/pkg/api/v1alpha1/oidcconfig_webhook.go
@@ -78,7 +78,7 @@ func validateImmutableOIDCFields(new, old *OIDCConfig) field.ErrorList {
 	if !new.Spec.Equal(&old.Spec) {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "OIDCConfig"), new, "config is immutable"),
+			field.Forbidden(field.NewPath(OIDCConfigKind), "config is immutable"),
 		)
 	}
 

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_webhook.go
@@ -89,39 +89,40 @@ func (r *VSphereDatacenterConfig) ValidateUpdate(old runtime.Object) error {
 
 func validateImmutableFieldsVSphereCluster(new, old *VSphereDatacenterConfig) field.ErrorList {
 	var allErrs field.ErrorList
+	specPath := field.NewPath("spec")
 
 	if old.Spec.Server != new.Spec.Server {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "server"), new.Spec.Server, "field is immutable"),
+			field.Forbidden(specPath.Child("server"), "field is immutable"),
 		)
 	}
 
 	if old.Spec.Datacenter != new.Spec.Datacenter {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "datacenter"), new.Spec.Datacenter, "field is immutable"),
+			field.Forbidden(specPath.Child("datacenter"), "field is immutable"),
 		)
 	}
 
 	if old.Spec.Network != new.Spec.Network {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "network"), new.Spec.Network, "field is immutable"),
+			field.Forbidden(specPath.Child("network"), "field is immutable"),
 		)
 	}
 
 	if old.Spec.Insecure != new.Spec.Insecure {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "insecure"), new.Spec.Insecure, "field is immutable"),
+			field.Forbidden(specPath.Child("insecure"), "field is immutable"),
 		)
 	}
 
 	if old.Spec.Thumbprint != new.Spec.Thumbprint {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "thumbprint"), new.Spec.Thumbprint, "field is immutable"),
+			field.Forbidden(specPath.Child("thumbprint"), "field is immutable"),
 		)
 	}
 

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
@@ -62,18 +62,19 @@ func validateImmutableFieldsVSphereMachineConfig(new, old *VSphereMachineConfig)
 	}
 
 	var allErrs field.ErrorList
+	specPath := field.NewPath("spec")
 
 	if old.Spec.OSFamily != new.Spec.OSFamily {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "osFamily"), new.Spec.OSFamily, "field is immutable"),
+			field.Forbidden(specPath.Child("osFamily"), "field is immutable"),
 		)
 	}
 
 	if old.Spec.StoragePolicyName != new.Spec.StoragePolicyName {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "storagepolicyname"), new.Spec.StoragePolicyName, "field is immutable"),
+			field.Forbidden(specPath.Child("storagePolicyName"), "field is immutable"),
 		)
 	}
 
@@ -92,56 +93,56 @@ func validateImmutableFieldsVSphereMachineConfig(new, old *VSphereMachineConfig)
 	if !reflect.DeepEqual(old.Spec.Users, new.Spec.Users) {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "users"), new.Spec.Users, "field is immutable"),
+			field.Forbidden(specPath.Child("users"), "field is immutable"),
 		)
 	}
 
 	if old.Spec.Template != new.Spec.Template {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "template"), new.Spec.Template, "field is immutable"),
+			field.Forbidden(specPath.Child("template"), "field is immutable"),
 		)
 	}
 
 	if old.Spec.Datastore != new.Spec.Datastore {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "datastore"), new.Spec.Datastore, "field is immutable"),
+			field.Forbidden(specPath.Child("datastore"), "field is immutable"),
 		)
 	}
 
 	if old.Spec.Folder != new.Spec.Folder {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "folder"), new.Spec.Folder, "field is immutable"),
+			field.Forbidden(specPath.Child("folder"), "field is immutable"),
 		)
 	}
 
 	if old.Spec.ResourcePool != new.Spec.ResourcePool {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "resourcePool"), new.Spec.ResourcePool, "field is immutable"),
+			field.Forbidden(specPath.Child("resourcePool"), "field is immutable"),
 		)
 	}
 
 	if old.Spec.MemoryMiB != new.Spec.MemoryMiB {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "memoryMiB"), new.Spec.MemoryMiB, "field is immutable"),
+			field.Forbidden(specPath.Child("memoryMiB"), "field is immutable"),
 		)
 	}
 
 	if old.Spec.NumCPUs != new.Spec.NumCPUs {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "numCPUs"), new.Spec.NumCPUs, "field is immutable"),
+			field.Forbidden(specPath.Child("numCPUs"), "field is immutable"),
 		)
 	}
 
 	if old.Spec.DiskGiB != new.Spec.DiskGiB {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "diskGiB"), new.Spec.DiskGiB, "field is immutable"),
+			field.Forbidden(specPath.Child("diskGiB"), "field is immutable"),
 		)
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change immutable field errors to type Forbidden instead of Invalid so as to follow CAPI.
Reference: https://github.com/kubernetes-sigs/cluster-api/blob/main/api/v1beta1/machinehealthcheck_webhook.go#L135

*Testing (if applicable):*
- Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

