### PR TITLE
kubectl wait retry

### DIFF
--- a/pkg/executables/export_test.go
+++ b/pkg/executables/export_test.go
@@ -1,0 +1,12 @@
+package executables
+
+import (
+	"context"
+	"time"
+)
+
+var KubectlWaitRetryPolicy = kubectlWaitRetryPolicy
+
+func CallKubectlPrivateWait(k *Kubectl, ctx context.Context, kubeconfig string, timeoutTime time.Time, forCondition string, property string, namespace string) error {
+	return k.wait(ctx, kubeconfig, timeoutTime, forCondition, property, namespace)
+}

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -13,9 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/eks-anywhere/pkg/retrier" //nolint:gci
-	// ^ gci complains Expected 'e', Found '"'
-
 	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
 	tinkv1alpha1 "github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
@@ -36,6 +33,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/retrier"
 	"github.com/aws/eks-anywhere/pkg/types"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -7,12 +7,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/aws/eks-anywhere/pkg/retrier"
 	"math"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/aws/eks-anywhere/pkg/retrier" //nolint:gci
+	// ^ gci complains Expected 'e', Found '"'
 
 	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
@@ -41,7 +43,7 @@ import (
 const (
 	kubectlPath        = "kubectl"
 	timeoutPrecision   = 2
-	minimumWaitTimeout = 10 ^ -timeoutPrecision // Smallest timeout value given the precision
+	minimumWaitTimeout = 0.01 // Smallest express-able timeout value given the precision
 )
 
 var (

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -42,7 +42,6 @@ const (
 	kubectlPath        = "kubectl"
 	timeoutPrecision   = 2
 	minimumWaitTimeout = 10 ^ -timeoutPrecision // Smallest timeout value given the precision
-	waitBackoffFactor  = 1.5
 )
 
 var (

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -386,7 +386,7 @@ func kubectlWaitRetryPolicy(totalRetries int, err error) (retry bool, wait time.
 func (k *Kubectl) wait(ctx context.Context, kubeconfig string, timeoutTime time.Time, forCondition string, property string, namespace string) error {
 	secondsRemainingUntilTimeout := time.Until(timeoutTime).Seconds()
 	if secondsRemainingUntilTimeout <= minimumWaitTimeout {
-		return fmt.Errorf("error: timed out waiting for the condition on %v", property)
+		return fmt.Errorf("error: timed out waiting for condition %v on %v", forCondition, property)
 	}
 	kubectlTimeoutString := fmt.Sprintf("%.*fs", timeoutPrecision, secondsRemainingUntilTimeout)
 

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
@@ -304,6 +305,51 @@ func TestKubectlWaitBadTimeout(t *testing.T) {
 	timeout = "1y"
 	if err := k.Wait(ctx, kubeconfig, timeout, forCondition, property, namespace); err == nil {
 		t.Errorf("Kubectl.Wait() error = nil, want duration parse error")
+	}
+
+	timeout = "-1s"
+	if err := k.Wait(ctx, kubeconfig, timeout, forCondition, property, namespace); err == nil {
+		t.Errorf("Kubectl.Wait() error = nil, want duration parse error")
+	}
+}
+
+func TestKubectlWaitRetryPolicy(t *testing.T) {
+	connectionRefusedError := fmt.Errorf("The connection to the server 127.0.0.1:56789 was refused")
+	ioTimeoutError := fmt.Errorf("Unable to connect to the server 127.0.0.1:56789, i/o timeout\n")
+	miscellaneousError := fmt.Errorf("Some other random miscellaneous error")
+
+	_, wait := executables.KubectlWaitRetryPolicy(1, connectionRefusedError)
+	if wait != 10*time.Second {
+		t.Errorf("kubectlWaitRetryPolicy didn't correctly calculate first retry wait for connection refused")
+	}
+
+	_, wait = executables.KubectlWaitRetryPolicy(-1, connectionRefusedError)
+	if wait != 10*time.Second {
+		t.Errorf("kubectlWaitRetryPolicy didn't correctly protect for total retries < 0")
+	}
+
+	_, wait = executables.KubectlWaitRetryPolicy(2, connectionRefusedError)
+	if wait != 15*time.Second {
+		t.Errorf("kubectlWaitRetryPolicy didn't correctly protect for second retry wait")
+	}
+
+	_, wait = executables.KubectlWaitRetryPolicy(1, ioTimeoutError)
+	if wait != 10*time.Second {
+		t.Errorf("kubectlWaitRetryPolicy didn't correctly calculate first retry wait for ioTimeout")
+	}
+
+	retry, _ := executables.KubectlWaitRetryPolicy(1, miscellaneousError)
+	if retry != false {
+		t.Errorf("kubectlWaitRetryPolicy didn't not-retry on non-network error")
+	}
+}
+
+func TestWaitForTimeout(t *testing.T) {
+	k := executables.Kubectl{}
+	timeoutTime := time.Now()
+	err := executables.CallKubectlPrivateWait(&k, nil, "", timeoutTime, "", "property", "")
+	if err == nil || err.Error() != "error: timed out waiting for the condition on property" {
+		t.Errorf("kubectl private wait didn't timeout")
 	}
 }
 

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -283,10 +283,27 @@ func TestKubectlWaitSuccess(t *testing.T) {
 	var timeout, kubeconfig, forCondition, property, namespace string
 
 	k, ctx, _, e := newKubectl(t)
-	expectedParam := []string{"wait", "--timeout", timeout, "--for=condition=" + forCondition, property, "--kubeconfig", kubeconfig, "-n", namespace}
+
+	// KubeCtl wait does not tolerate blank timeout values.
+	// It also converts timeouts provided to seconds before actually invoking kubectl wait.
+	timeout = "1m"
+	expectedTimeout := "60.00s"
+
+	expectedParam := []string{"wait", "--timeout", expectedTimeout, "--for=condition=" + forCondition, property, "--kubeconfig", kubeconfig, "-n", namespace}
 	e.EXPECT().Execute(ctx, gomock.Eq(expectedParam)).Return(bytes.Buffer{}, nil)
 	if err := k.Wait(ctx, kubeconfig, timeout, forCondition, property, namespace); err != nil {
 		t.Errorf("Kubectl.Wait() error = %v, want nil", err)
+	}
+}
+
+func TestKubectlWaitBadTimeout(t *testing.T) {
+	var timeout, kubeconfig, forCondition, property, namespace string
+
+	k, ctx, _, _ := newKubectl(t)
+
+	timeout = "1y"
+	if err := k.Wait(ctx, kubeconfig, timeout, forCondition, property, namespace); err == nil {
+		t.Errorf("Kubectl.Wait() error = nil, want duration parse error")
 	}
 }
 
@@ -354,7 +371,11 @@ func TestKubectlWaitError(t *testing.T) {
 	var timeout, kubeconfig, forCondition, property, namespace string
 
 	k, ctx, _, e := newKubectl(t)
-	expectedParam := []string{"wait", "--timeout", timeout, "--for=condition=" + forCondition, property, "--kubeconfig", kubeconfig, "-n", namespace}
+
+	timeout = "1m"
+	expectedTimeout := "60.00s"
+
+	expectedParam := []string{"wait", "--timeout", expectedTimeout, "--for=condition=" + forCondition, property, "--kubeconfig", kubeconfig, "-n", namespace}
 	e.EXPECT().Execute(ctx, gomock.Eq(expectedParam)).Return(bytes.Buffer{}, errors.New("error from execute"))
 	if err := k.Wait(ctx, kubeconfig, timeout, forCondition, property, namespace); err == nil {
 		t.Errorf("Kubectl.Wait() error = nil, want not nil")
@@ -2287,20 +2308,27 @@ func TestKubectlDelete(t *testing.T) {
 
 func TestKubectlWaitForManagedExternalEtcdNotReady(t *testing.T) {
 	tt := newKubectlTest(t)
+	timeout := "5m"
+	expectedTimeout := "300.00s"
+
 	tt.e.EXPECT().Execute(
 		tt.ctx,
-		"wait", "--timeout", "5m", "--for=condition=ManagedEtcdReady=false", "clusters.cluster.x-k8s.io/test", "--kubeconfig", tt.cluster.KubeconfigFile, "-n", "eksa-system",
+		"wait", "--timeout", expectedTimeout, "--for=condition=ManagedEtcdReady=false", "clusters.cluster.x-k8s.io/test", "--kubeconfig", tt.cluster.KubeconfigFile, "-n", "eksa-system",
 	).Return(bytes.Buffer{}, nil)
 
-	tt.Expect(tt.k.WaitForManagedExternalEtcdNotReady(tt.ctx, tt.cluster, "5m", "test")).To(Succeed())
+	tt.Expect(tt.k.WaitForManagedExternalEtcdNotReady(tt.ctx, tt.cluster, timeout, "test")).To(Succeed())
 }
 
 func TestKubectlWaitForClusterReady(t *testing.T) {
 	tt := newKubectlTest(t)
+
+	timeout := "5m"
+	expectedTimeout := "300.00s"
+
 	tt.e.EXPECT().Execute(
 		tt.ctx,
-		"wait", "--timeout", "5m", "--for=condition=Ready", "clusters.cluster.x-k8s.io/test", "--kubeconfig", tt.cluster.KubeconfigFile, "-n", "eksa-system",
+		"wait", "--timeout", expectedTimeout, "--for=condition=Ready", "clusters.cluster.x-k8s.io/test", "--kubeconfig", tt.cluster.KubeconfigFile, "-n", "eksa-system",
 	).Return(bytes.Buffer{}, nil)
 
-	tt.Expect(tt.k.WaitForClusterReady(tt.ctx, tt.cluster, "5m", "test")).To(Succeed())
+	tt.Expect(tt.k.WaitForClusterReady(tt.ctx, tt.cluster, timeout, "test")).To(Succeed())
 }

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -347,8 +347,8 @@ func TestKubectlWaitRetryPolicy(t *testing.T) {
 func TestWaitForTimeout(t *testing.T) {
 	k := executables.Kubectl{}
 	timeoutTime := time.Now()
-	err := executables.CallKubectlPrivateWait(&k, nil, "", timeoutTime, "", "property", "")
-	if err == nil || err.Error() != "error: timed out waiting for the condition on property" {
+	err := executables.CallKubectlPrivateWait(&k, nil, "", timeoutTime, "myCondition", "myProperty", "")
+	if err == nil || err.Error() != "error: timed out waiting for condition myCondition on myProperty" {
 		t.Errorf("kubectl private wait didn't timeout")
 	}
 }

--- a/pkg/retrier/retrier.go
+++ b/pkg/retrier/retrier.go
@@ -63,6 +63,10 @@ func WithRetryPolicy(policy RetryPolicy) RetrierOpt {
 // Retry runs the fn function until it either successful completes (not error),
 // the set timeout reached or the retry policy aborts the execution
 func (r *Retrier) Retry(fn func() error) error {
+	// While it seems aberrant to call a method with a nil receiver, several unit tests actually do.  With a previous
+	// version of this module (which didn't attempt to dereference the receiver until after the wrapped function failed)
+	// these passed.  Changes below, to log the receiver struct's key params changed that breaking the unit tests.
+	// The below conditional block restores the original behavior, enabling these tests to again pass.
 	if r == nil {
 		return fn()
 	}

--- a/pkg/retrier/retrier.go
+++ b/pkg/retrier/retrier.go
@@ -63,6 +63,10 @@ func WithRetryPolicy(policy RetryPolicy) RetrierOpt {
 // Retry runs the fn function until it either successful completes (not error),
 // the set timeout reached or the retry policy aborts the execution
 func (r *Retrier) Retry(fn func() error) error {
+	if r == nil {
+		return fn()
+	}
+
 	start := time.Now()
 	retries := 0
 	var err error

--- a/pkg/retrier/retrier_test.go
+++ b/pkg/retrier/retrier_test.go
@@ -171,3 +171,17 @@ func TestNewWithRetryPolicyFinishByPolicy(t *testing.T) {
 		t.Fatalf("Wrong number of retries, got %d, want %d", gotRetries, wantRetries)
 	}
 }
+
+func TestRetrierWithNilReceiver(t *testing.T) {
+	var retrier *retrier.Retrier = nil // This seems improbable, but happens in some other unit tests.
+
+	expectedError := errors.New("my expected error")
+	retryable := func() error {
+		return expectedError
+	}
+
+	err := retrier.Retry(retryable)
+	if err == nil || err.Error() != expectedError.Error() {
+		t.Errorf("Retrier didn't correctly handle nil receiver")
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Wrap kubectl wait calls in a retrier.  
Minor fixes to retrier.

*Testing (if applicable):*
New unit tests to confirm retry logic on kubectl wait.
All existing unit tests and docker e2e test pass.
Manual testing with toxiproxy-induced network outages to bootstrap cluster to confirm some fine points of work that are difficult/slow to unit test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

