### PR TITLE
adding nil check to cluster config datacenter

### DIFF
--- a/pkg/cluster/cloudstack.go
+++ b/pkg/cluster/cloudstack.go
@@ -62,7 +62,9 @@ func cloudstackEntry() *ConfigManagerEntry {
 func processCloudStackDatacenter(c *Config, objects ObjectLookup) {
 	if c.Cluster.Spec.DatacenterRef.Kind == anywherev1.CloudStackDatacenterKind {
 		datacenter := objects.GetFromRef(c.Cluster.APIVersion, c.Cluster.Spec.DatacenterRef)
-		c.CloudStackDatacenter = datacenter.(*anywherev1.CloudStackDatacenterConfig)
+		if datacenter != nil {
+			c.CloudStackDatacenter = datacenter.(*anywherev1.CloudStackDatacenterConfig)
+		}
 	}
 }
 

--- a/pkg/cluster/cloudstack_test.go
+++ b/pkg/cluster/cloudstack_test.go
@@ -1,0 +1,17 @@
+package cluster_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+)
+
+func TestParseConfigMissingCloudstackDatacenter(t *testing.T) {
+	g := NewWithT(t)
+	got, err := cluster.ParseConfigFromFile("testdata/cluster_cloudstack_missing_datacenter.yaml")
+
+	g.Expect(err).To(Not(HaveOccurred()))
+	g.Expect(got.CloudStackDatacenter).To(BeNil())
+}

--- a/pkg/cluster/docker.go
+++ b/pkg/cluster/docker.go
@@ -34,6 +34,8 @@ func dockerEntry() *ConfigManagerEntry {
 func processDockerDatacenter(c *Config, objects ObjectLookup) {
 	if c.Cluster.Spec.DatacenterRef.Kind == anywherev1.DockerDatacenterKind {
 		datacenter := objects.GetFromRef(c.Cluster.APIVersion, c.Cluster.Spec.DatacenterRef)
-		c.DockerDatacenter = datacenter.(*anywherev1.DockerDatacenterConfig)
+		if datacenter != nil {
+			c.DockerDatacenter = datacenter.(*anywherev1.DockerDatacenterConfig)
+		}
 	}
 }

--- a/pkg/cluster/docker_test.go
+++ b/pkg/cluster/docker_test.go
@@ -1,0 +1,17 @@
+package cluster_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+)
+
+func TestParseConfigMissingDockerDatacenter(t *testing.T) {
+	g := NewWithT(t)
+	got, err := cluster.ParseConfigFromFile("testdata/cluster_docker_missing_datacenter.yaml")
+
+	g.Expect(err).To(Not(HaveOccurred()))
+	g.Expect(got.DockerDatacenter).To(BeNil())
+}

--- a/pkg/cluster/snow.go
+++ b/pkg/cluster/snow.go
@@ -61,7 +61,9 @@ func snowEntry() *ConfigManagerEntry {
 func processSnowDatacenter(c *Config, objects ObjectLookup) {
 	if c.Cluster.Spec.DatacenterRef.Kind == anywherev1.SnowDatacenterKind {
 		datacenter := objects.GetFromRef(c.Cluster.APIVersion, c.Cluster.Spec.DatacenterRef)
-		c.SnowDatacenter = datacenter.(*anywherev1.SnowDatacenterConfig)
+		if datacenter != nil {
+			c.SnowDatacenter = datacenter.(*anywherev1.SnowDatacenterConfig)
+		}
 	}
 }
 

--- a/pkg/cluster/snow_test.go
+++ b/pkg/cluster/snow_test.go
@@ -213,3 +213,11 @@ func TestDefaultConfigClientBuilderSnowCluster(t *testing.T) {
 	g.Expect(config.SnowMachineConfigs["machine-1"]).To(Equal(machineControlPlane))
 	g.Expect(config.SnowMachineConfigs["machine-2"]).To(Equal(machineWorker))
 }
+
+func TestParseConfigMissingSnowDatacenter(t *testing.T) {
+	g := NewWithT(t)
+	got, err := cluster.ParseConfigFromFile("testdata/cluster_snow_missing_datacenter.yaml")
+
+	g.Expect(err).To(Not(HaveOccurred()))
+	g.Expect(got.DockerDatacenter).To(BeNil())
+}

--- a/pkg/cluster/testdata/cluster_cloudstack_missing_datacenter.yaml
+++ b/pkg/cluster/testdata/cluster_cloudstack_missing_datacenter.yaml
@@ -1,0 +1,63 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  clusterNetwork:
+    cni: cilium
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      kind: CloudStackMachineConfig
+      name: eksa-unit-test
+  datacenterRef:
+    kind: CloudStackDatacenterConfig
+    name: eksa-unit-test
+  kubernetesVersion: "1.20"
+  workerNodeGroupConfigurations:
+    - count: 3
+      machineGroupRef:
+        kind: CloudStackMachineConfig
+        name: eksa-unit-test
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackDatacenterConfig
+metadata:
+  name: eksa-unit-test2
+spec:
+  account: "admin"
+  domain: "domain1"
+  zones:
+    - name: "zone1"
+      network:
+        name: "net1"
+  managementApiEndpoint: "https://127.0.0.1:8080/client/api"
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackMachineConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  computeOffering:
+    name: "m4-large"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+  template:
+    name: "centos7-k8s-120"
+  userCustomDetails:
+    foo: bar
+  affinity: pro
+---
+

--- a/pkg/cluster/testdata/cluster_docker_missing_datacenter.yaml
+++ b/pkg/cluster/testdata/cluster_docker_missing_datacenter.yaml
@@ -1,0 +1,35 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  clusterNetwork:
+    cniConfig:
+      cilium: {}
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+  datacenterRef:
+    kind: DockerDatacenterConfig
+    name: eksa-unit-test
+  externalEtcdConfiguration:
+    count: 1
+  kubernetesVersion: "1.22"
+  managementCluster:
+    name: dev-cluster
+  workerNodeGroupConfigurations:
+  - count: 1
+    name: md-0
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: DockerDatacenterConfig
+metadata:
+  name: eksa-unit-test2
+spec: {}
+---

--- a/pkg/cluster/testdata/cluster_snow_missing_datacenter.yaml
+++ b/pkg/cluster/testdata/cluster_snow_missing_datacenter.yaml
@@ -1,0 +1,57 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+    endpoint:
+      host: "myHostIp"
+    machineGroupRef:
+      kind: SnowMachineConfig
+      name: eksa-unit-test-cp
+  datacenterRef:
+    kind: SnowDatacenterConfig
+    name: eksa-unit-test
+  kubernetesVersion: "1.21"
+  workerNodeGroupConfigurations:
+    - name: workers-1
+      count: 1
+      machineGroupRef:
+        kind: SnowMachineConfig
+        name: eksa-unit-test
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: SnowDatacenterConfig
+metadata:
+  name: eksa-unit-test2
+spec: {}
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: SnowMachineConfig
+metadata:
+  name: eksa-unit-test-cp
+spec:
+  amiID: eks-d-v1-21-ami
+  instanceType: sbe-c.large
+  sshKeyName: default
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: SnowMachineConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  amiID: eks-d-v1-21-ami
+  instanceType: sbe-c.xlarge
+  sshKeyName: default
+---

--- a/pkg/cluster/testdata/cluster_vsphere_missing_datacenter.yaml
+++ b/pkg/cluster/testdata/cluster_vsphere_missing_datacenter.yaml
@@ -1,0 +1,70 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+    endpoint:
+      host: "myHostIp"
+    machineGroupRef:
+      kind: VSphereMachineConfig
+      name: eksa-unit-test-cp
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: eksa-unit-test2
+  kubernetesVersion: "1.19"
+  workerNodeGroupConfigurations:
+    - name: workers-1
+      count: 1
+      machineGroupRef:
+        kind: VSphereMachineConfig
+        name: eksa-unit-test
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  datacenter: "myDatacenter"
+  network: "myNetwork"
+  server: "myServer"
+  insecure: false
+  thumbprint: "myTlsThumbprint"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test-cp
+spec:
+  diskGiB: 25
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: ubuntu
+  users:
+    - name: mySshUsername
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  diskGiB: 25
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: ubuntu
+  users:
+    - name: mySshUsername
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---

--- a/pkg/cluster/vsphere.go
+++ b/pkg/cluster/vsphere.go
@@ -62,7 +62,9 @@ func vsphereEntry() *ConfigManagerEntry {
 func processVSphereDatacenter(c *Config, objects ObjectLookup) {
 	if c.Cluster.Spec.DatacenterRef.Kind == anywherev1.VSphereDatacenterKind {
 		datacenter := objects.GetFromRef(c.Cluster.APIVersion, c.Cluster.Spec.DatacenterRef)
-		c.VSphereDatacenter = datacenter.(*anywherev1.VSphereDatacenterConfig)
+		if datacenter != nil {
+			c.VSphereDatacenter = datacenter.(*anywherev1.VSphereDatacenterConfig)
+		}
 	}
 }
 

--- a/pkg/cluster/vsphere_test.go
+++ b/pkg/cluster/vsphere_test.go
@@ -1,0 +1,18 @@
+package cluster_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+)
+
+func TestParseConfigMissingVSphereDatacenter(t *testing.T) {
+	g := NewWithT(t)
+	got, err := cluster.ParseConfigFromFile("testdata/cluster_vsphere_missing_datacenter.yaml")
+
+	g.Expect(err).To(Not(HaveOccurred()))
+
+	g.Expect(got.VSphereDatacenter).To(BeNil())
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Objects.GetFromRef() can return a nil value that cannot be cast to a provider datacenter datatype.
Added nil check to prevent casting in provider processors.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

