### PR TITLE
Separating clusterConfig validation from creation

### DIFF
--- a/cmd/eksctl-anywhere/cmd/checkimages.go
+++ b/cmd/eksctl-anywhere/cmd/checkimages.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/aws/eks-anywhere/cmd/eksctl-anywhere/cmd/internal/commands/artifacts"
-	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/version"
@@ -57,7 +56,7 @@ func checkImages(context context.Context, spec string) error {
 		return err
 	}
 
-	clusterSpec, err := cluster.NewSpecFromClusterConfig(spec, version.Get())
+	clusterSpec, err := readAndValidateClusterSpec(spec, version.Get())
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 
-	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
@@ -12,7 +11,7 @@ import (
 )
 
 func getImages(spec string) ([]v1alpha1.Image, error) {
-	clusterSpec, err := cluster.NewSpecFromClusterConfig(spec, version.Get())
+	clusterSpec, err := readAndValidateClusterSpec(spec, version.Get())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/diagnostics"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
@@ -88,7 +87,7 @@ func (gsbo *generateSupportBundleOptions) generateBundleConfig(ctx context.Conte
 		return factory.DiagnosticBundleDefault(), nil
 	}
 
-	clusterSpec, err := cluster.NewSpecFromClusterConfig(f, version.Get())
+	clusterSpec, err := readAndValidateClusterSpec(f, version.Get())
 	if err != nil {
 		return nil, fmt.Errorf("unable to get cluster config from file: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/importimages.go
+++ b/cmd/eksctl-anywhere/cmd/importimages.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/logger"
@@ -59,7 +58,7 @@ func importImages(ctx context.Context, spec string) error {
 	if registryUsername == "" || registryPassword == "" {
 		return fmt.Errorf("username or password not set. Provide REGISTRY_USERNAME and REGISTRY_PASSWORD for importing helm charts (e.g. cilium)")
 	}
-	clusterSpec, err := cluster.NewSpecFromClusterConfig(spec, version.Get())
+	clusterSpec, err := readAndValidateClusterSpec(spec, version.Get())
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
@@ -52,7 +51,7 @@ func runInstallPackageController(cmd *cobra.Command, args []string) error {
 func installPackageController(ctx context.Context) error {
 	kubeConfig := kubeconfig.FromEnvironment()
 
-	clusterSpec, err := cluster.NewSpecFromClusterConfig(ico.fileName, version.Get())
+	clusterSpec, err := readAndValidateClusterSpec(ico.fileName, version.Get())
 	if err != nil {
 		return fmt.Errorf("the cluster config file provided is invalid: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/listovas.go
+++ b/cmd/eksctl-anywhere/cmd/listovas.go
@@ -12,7 +12,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/version"
 )
 
@@ -52,7 +51,7 @@ var listOvasCmd = &cobra.Command{
 }
 
 func listOvas(context context.Context, spec string) error {
-	clusterSpec, err := cluster.NewSpecFromClusterConfig(spec, version.Get())
+	clusterSpec, err := readAndValidateClusterSpec(spec, version.Get())
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -23,6 +23,18 @@ func (c clusterOptions) mountDirs() []string {
 	return dirs
 }
 
+func readAndValidateClusterSpec(clusterConfigPath string, cliVersion version.Info, opts ...cluster.SpecOpt) (*cluster.Spec, error) {
+	clusterSpec, err := cluster.NewSpecFromClusterConfig(clusterConfigPath, cliVersion, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err = cluster.ValidateConfig(clusterSpec.Config); err != nil {
+		return nil, err
+	}
+
+	return clusterSpec, nil
+}
+
 func newClusterSpec(options clusterOptions) (*cluster.Spec, error) {
 	var specOpts []cluster.SpecOpt
 	if options.bundlesOverride != "" {
@@ -36,7 +48,7 @@ func newClusterSpec(options clusterOptions) (*cluster.Spec, error) {
 		specOpts = append(specOpts, cluster.WithManagementCluster(managementCluster))
 	}
 
-	clusterSpec, err := cluster.NewSpecFromClusterConfig(options.fileName, version.Get(), specOpts...)
+	clusterSpec, err := readAndValidateClusterSpec(options.fileName, version.Get(), specOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get cluster config from file: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/diagnostics"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
@@ -85,7 +84,7 @@ func preRunSupportBundle(cmd *cobra.Command, args []string) error {
 }
 
 func (csbo *createSupportBundleOptions) createBundle(ctx context.Context, since, sinceTime, bundleConfig string) error {
-	clusterSpec, err := cluster.NewSpecFromClusterConfig(csbo.fileName, version.Get())
+	clusterSpec, err := readAndValidateClusterSpec(csbo.fileName, version.Get())
 	if err != nil {
 		return fmt.Errorf("unable to get cluster config from file: %v", err)
 	}

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -190,9 +190,6 @@ func NewSpecFromClusterConfig(clusterConfigPath string, cliVersion version.Info,
 	if err = configManager.SetDefaults(clusterConfig); err != nil {
 		return nil, err
 	}
-	if err = ValidateConfig(clusterConfig); err != nil {
-		return nil, err
-	}
 
 	versionsBundle, err := GetVersionsBundle(clusterConfig.Cluster, bundlesManifest)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Splitting cluster config validation out from clusterSpec creation

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

