### PR TITLE
Change secret creation failure messaging

### DIFF
--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -69,11 +69,11 @@ func (pc *PackageControllerClient) InstallController(ctx context.Context) error 
 	}
 
 	if err = pc.ApplySecret(ctx); err != nil {
-		logger.Info("warning: no aws key/license provided, package controller will be installed but curated packages might not be installed")
+		logger.Info("Warning: No AWS key/license provided. Please be aware this will prevent the package controller from installing curated packages.")
 	}
 
 	if err = pc.CreateCronJob(ctx); err != nil {
-		logger.Info("warning: not able to trigger cron job, package controller will be installed but curated packages might not be installed")
+		logger.Info("Warning: not able to trigger cron job, please be aware this will prevent the package controller from installing curated packages.")
 	}
 	return nil
 }

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -69,11 +69,11 @@ func (pc *PackageControllerClient) InstallController(ctx context.Context) error 
 	}
 
 	if err = pc.ApplySecret(ctx); err != nil {
-		logger.Info("Warning: not able to create secret. Package installation might fail.", "error", err)
+		logger.Info("warning: no aws key/license provided, package controller will be installed but curated packages might not be installed")
 	}
 
 	if err = pc.CreateCronJob(ctx); err != nil {
-		logger.Info("Warning: not able to trigger cron job. Package installation might fail.", "error", err)
+		logger.Info("warning: not able to trigger cron job, package controller will be installed but curated packages might not be installed")
 	}
 	return nil
 }


### PR DESCRIPTION
*Description of changes:*
Remove noisy messaging during secret creation failure and cron job failure.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

