### PR TITLE
Enable LBClass feature gate for baremetal v1.21 cluster

### DIFF
--- a/pkg/clusterapi/extraargs.go
+++ b/pkg/clusterapi/extraargs.go
@@ -43,6 +43,17 @@ func AwsIamAuthExtraArgs(awsiam *v1alpha1.AWSIamConfig) ExtraArgs {
 	return args
 }
 
+// FeatureGatesExtraArgs takes a list of features with the value and returns it in the proper format
+// Example FeatureGatesExtraArgs("ServiceLoadBalancerClass=true")
+func FeatureGatesExtraArgs(features ...string) ExtraArgs {
+	if len(features) == 0 {
+		return nil
+	}
+	return ExtraArgs{
+		"feature-gates": strings.Join(features[:], ","),
+	}
+}
+
 func PodIAMAuthExtraArgs(podIAMConfig *v1alpha1.PodIAMConfig) ExtraArgs {
 	if podIAMConfig == nil {
 		return nil

--- a/pkg/clusterapi/extraargs_test.go
+++ b/pkg/clusterapi/extraargs_test.go
@@ -473,3 +473,39 @@ func TestNodeCIDRMaskExtraArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestFeatureGatesExtraArgs(t *testing.T) {
+	tests := []struct {
+		testName string
+		features []string
+		want     clusterapi.ExtraArgs
+	}{
+		{
+			testName: "no feature gates",
+			features: []string{},
+			want:     nil,
+		},
+		{
+			testName: "single feature gate",
+			features: []string{"feature1=true"},
+			want: clusterapi.ExtraArgs{
+				"feature-gates": "feature1=true",
+			},
+		},
+		{
+			testName: "multiple feature gates",
+			features: []string{"feature1=true", "feature2=false", "feature3=true"},
+			want: clusterapi.ExtraArgs{
+				"feature-gates": "feature1=true,feature2=false,feature3=true",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			if got := clusterapi.FeatureGatesExtraArgs(tt.features...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FeatureGatesExtraArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -361,6 +361,12 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, controlPlaneMachineSpec, etcd
 
 	apiServerExtraArgs := clusterapi.OIDCToExtraArgs(clusterSpec.OIDCConfig).
 		Append(clusterapi.AwsIamAuthExtraArgs(clusterSpec.AWSIamConfig))
+
+	// LoadBalancerClass is feature gated in K8S v1.21 and needs to be enabled manually
+	if clusterSpec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube121 {
+		apiServerExtraArgs.Append(clusterapi.FeatureGatesExtraArgs("ServiceLoadBalancerClass=true"))
+	}
+
 	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
 		Append(clusterapi.ResolvConfExtraArgs(clusterSpec.Cluster.Spec.ClusterNetwork.DNS.ResolvConf)).
 		Append(clusterapi.ControlPlaneNodeLabelsExtraArgs(clusterSpec.Cluster.Spec.ControlPlaneConfiguration))

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_awsiam.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_awsiam.yaml
@@ -42,6 +42,7 @@ spec:
       apiServer:
         extraArgs:
           authentication-token-webhook-config-file: /etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml
+          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
           - hostPath: /var/lib/kubeadm/aws-iam-authenticator/
             mountPath: /etc/kubernetes/aws-iam-authenticator/

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
@@ -39,6 +39,9 @@ spec:
       dns:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.3-eks-1-21-4
+      apiServer:
+        extraArgs:
+          feature-gates: ServiceLoadBalancerClass=true
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_full_oidc.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_full_oidc.yaml
@@ -41,6 +41,7 @@ spec:
         imageTag: v1.8.3-eks-1-21-4
       apiServer:
         extraArgs:
+          feature-gates: ServiceLoadBalancerClass=true
           oidc-client-id: my-client-id
           oidc-groups-claim: claim1
           oidc-groups-prefix: prefix-for-groups

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_oidc.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_oidc.yaml
@@ -41,6 +41,7 @@ spec:
         imageTag: v1.8.3-eks-1-21-4
       apiServer:
         extraArgs:
+          feature-gates: ServiceLoadBalancerClass=true
           oidc-client-id: my-client-id
           oidc-issuer-url: https://mydomain.com/issuer
     initConfiguration:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_labels.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_labels.yaml
@@ -39,6 +39,9 @@ spec:
       dns:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.3-eks-1-21-4
+      apiServer:
+        extraArgs:
+          feature-gates: ServiceLoadBalancerClass=true
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_taints.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_taints.yaml
@@ -39,6 +39,9 @@ spec:
       dns:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.3-eks-1-21-4
+      apiServer:
+        extraArgs:
+          feature-gates: ServiceLoadBalancerClass=true
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
@@ -39,6 +39,9 @@ spec:
       dns:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.3-eks-1-21-4
+      apiServer:
+        extraArgs:
+          feature-gates: ServiceLoadBalancerClass=true
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
@@ -39,6 +39,9 @@ spec:
       dns:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.3-eks-1-21-4
+      apiServer:
+        extraArgs:
+          feature-gates: ServiceLoadBalancerClass=true
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:


### PR DESCRIPTION
*Description of changes:*
Enable LBClass feature gate for baremetal v1.21 cluster

*Testing (if applicable):*
Created a baremetal v1.21 cluster and verified the changes
```
k get pod -n kube-system kube-apiserver-eksa-da04 -oyaml | grep gate
    - --feature-gates=ServiceLoadBalancerClass=true
```
https://v1-21.docs.kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#:~:text=field%20on%20Services.-,ServiceLoadBalancerClass,-%3A%20Enables%20the%20loadBalancerClass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

