### PR TITLE
Fixing panic on ImmutableFieldChanges comparison

### DIFF
--- a/pkg/api/v1alpha1/cloudstackdatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/cloudstackdatacenterconfig_webhook.go
@@ -121,28 +121,10 @@ func validateImmutableFieldsCloudStackCluster(new, old *CloudStackDatacenterConf
 	for _, oldAz := range old.Spec.AvailabilityZones {
 		if newAz, ok := newAzMap[oldAz.Name]; ok {
 			atLeastOneAzOverlap = true
-			if newAz.ManagementApiEndpoint != oldAz.ManagementApiEndpoint {
+			if !newAz.Equal(&oldAz) {
 				allErrs = append(
 					allErrs,
-					field.Invalid(field.NewPath("spec", "availabilityZone", oldAz.Name, "managementApiEndpoint"), newAz.ManagementApiEndpoint, "field is immutable"),
-				)
-			}
-			if newAz.Domain != oldAz.Domain {
-				allErrs = append(
-					allErrs,
-					field.Invalid(field.NewPath("spec", "availabilityZone", oldAz.Name, "domain"), newAz.Domain, "field is immutable"),
-				)
-			}
-			if newAz.Account != oldAz.Account {
-				allErrs = append(
-					allErrs,
-					field.Invalid(field.NewPath("spec", "availabilityZone", oldAz.Name, "account"), newAz.Account, "field is immutable"),
-				)
-			}
-			if !newAz.Zone.Equal(&oldAz.Zone) {
-				allErrs = append(
-					allErrs,
-					field.Invalid(field.NewPath("spec", "availabilityZone", oldAz.Name, "zone"), newAz.Zone, "field is immutable"),
+					field.Invalid(field.NewPath("spec", "availabilityZone", oldAz.Name), newAz, "availabilityZone is immutable"),
 				)
 			}
 		}

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -577,19 +577,8 @@ func (p *cloudstackProvider) needsNewKubeadmConfigTemplate(workerNodeGroupConfig
 }
 
 func AnyImmutableFieldChanged(oldCsdc, newCsdc *v1alpha1.CloudStackDatacenterConfig, oldCsmc, newCsmc *v1alpha1.CloudStackMachineConfig) bool {
-	if len(oldCsdc.Spec.AvailabilityZones) != len(newCsdc.Spec.AvailabilityZones) {
+	if !oldCsdc.Spec.Equal(&newCsdc.Spec) {
 		return true
-	}
-	newAzs := make(map[string]v1alpha1.CloudStackAvailabilityZone, len(newCsdc.Spec.AvailabilityZones))
-	for _, az := range newCsdc.Spec.AvailabilityZones {
-		newAzs[az.Name] = az
-	}
-	for _, oldAz := range oldCsdc.Spec.AvailabilityZones {
-		if newAz, ok := newAzs[oldAz.Name]; ok {
-			if !oldAz.Equal(&newAz) {
-				return true
-			}
-		}
 	}
 	if oldCsmc.Spec.Template != newCsmc.Spec.Template {
 		return true

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -577,9 +577,18 @@ func (p *cloudstackProvider) needsNewKubeadmConfigTemplate(workerNodeGroupConfig
 }
 
 func AnyImmutableFieldChanged(oldCsdc, newCsdc *v1alpha1.CloudStackDatacenterConfig, oldCsmc, newCsmc *v1alpha1.CloudStackMachineConfig) bool {
-	for index, zone := range oldCsdc.Spec.AvailabilityZones {
-		if !zone.Equal(&newCsdc.Spec.AvailabilityZones[index]) {
-			return true
+	if len(oldCsdc.Spec.AvailabilityZones) != len(newCsdc.Spec.AvailabilityZones) {
+		return true
+	}
+	newAzs := make(map[string]v1alpha1.CloudStackAvailabilityZone, len(newCsdc.Spec.AvailabilityZones))
+	for _, az := range newCsdc.Spec.AvailabilityZones {
+		newAzs[az.Name] = az
+	}
+	for _, oldAz := range oldCsdc.Spec.AvailabilityZones {
+		if newAz, ok := newAzs[oldAz.Name]; ok {
+			if !oldAz.Equal(&newAz) {
+				return true
+			}
 		}
 	}
 	if oldCsmc.Spec.Template != newCsmc.Spec.Template {

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -1710,6 +1710,26 @@ func TestAnyImmutableFieldChangedSymlinksChange(t *testing.T) {
 	assert.True(t, AnyImmutableFieldChanged(dcConfig, newDcConfig, machineConfigsMap["test"], newMachineConfigsMap["test"]), "Should not have any immutable fields changes")
 }
 
+func TestAnyImmutableFieldChangedDomain(t *testing.T) {
+	dcConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
+
+	newDcConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
+	newDcConfig.Spec.AvailabilityZones[0].Domain = "shinyNewDomain"
+
+	assert.True(t, AnyImmutableFieldChanged(dcConfig, newDcConfig, nil, nil), "Should have an immutable field changed")
+}
+
+func TestAnyImmutableFieldChangedFewerZones(t *testing.T) {
+	dcConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
+	secondAz := dcConfig.Spec.AvailabilityZones[0].DeepCopy()
+	secondAz.Name = "shinyNewAz"
+	dcConfig.Spec.AvailabilityZones = append(dcConfig.Spec.AvailabilityZones, *secondAz)
+
+	newDcConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
+
+	assert.True(t, AnyImmutableFieldChanged(dcConfig, newDcConfig, nil, nil), "Should have an immutable field changed")
+}
+
 func TestInstallCustomProviderComponentsKubeVipEnabled(t *testing.T) {
 	ctx := context.Background()
 	mockCtrl := gomock.NewController(t)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
From manual testing, we uncovered a possible panic when removing AvailabilityZones. Since this discovery, making the logic safer and adding unit tests

*Testing (if applicable):*
Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

