### PR TITLE
Add preflight for k8s v1.20 on baremetal

### DIFF
--- a/pkg/providers/tinkerbell/assert.go
+++ b/pkg/providers/tinkerbell/assert.go
@@ -1,6 +1,7 @@
 package tinkerbell
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -67,6 +68,15 @@ func AssertWorkerNodeGroupMachineRefsExists(spec *ClusterSpec) error {
 		if err := validateMachineRefExists(groupRef, spec.MachineConfigs); err != nil {
 			return fmt.Errorf("worker node group configuration machine group ref: %v", err)
 		}
+	}
+
+	return nil
+}
+
+// AssertK8SVersionNot120 ensures Kubernetes version is not set to v1.20
+func AssertK8SVersionNot120(spec *ClusterSpec) error {
+	if spec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube120 {
+		return errors.New("kubernetes version v1.20 is not supported for Bare Metal")
 	}
 
 	return nil

--- a/pkg/providers/tinkerbell/assert_test.go
+++ b/pkg/providers/tinkerbell/assert_test.go
@@ -115,6 +115,20 @@ func TestAssertWorkerNodeGroupMachineRefsExists_Exists(t *testing.T) {
 	g.Expect(tinkerbell.AssertWorkerNodeGroupMachineRefsExists(clusterSpec)).To(gomega.Succeed())
 }
 
+func TestAssertK8SVersionNot120_Success(t *testing.T) {
+	g := gomega.NewWithT(t)
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec.Cluster.Spec.KubernetesVersion = eksav1alpha1.Kube123
+	g.Expect(tinkerbell.AssertK8SVersionNot120(clusterSpec)).Error().ShouldNot(gomega.HaveOccurred())
+}
+
+func TestAssertK8SVersionNot120_Error(t *testing.T) {
+	g := gomega.NewWithT(t)
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec.Cluster.Spec.KubernetesVersion = eksav1alpha1.Kube120
+	g.Expect(tinkerbell.AssertK8SVersionNot120(clusterSpec)).Error().Should(gomega.HaveOccurred())
+}
+
 func TestAssertWorkerNodeGroupMachineRefsExists_Missing(t *testing.T) {
 	g := gomega.NewWithT(t)
 	builder := NewDefaultValidClusterSpecBuilder()

--- a/pkg/providers/tinkerbell/cluster.go
+++ b/pkg/providers/tinkerbell/cluster.go
@@ -100,6 +100,7 @@ func NewClusterSpecValidator(assertions ...ClusterSpecAssertion) *ClusterSpecVal
 	// Register mandatory assertions. If an assertion becomes optional dependent on context move it
 	// to a New* func and register it dynamically. See assert.go for examples.
 	v.Register(
+		AssertK8SVersionNot120,
 		AssertDatacenterConfigValid,
 		AssertControlPlaneMachineRefExists,
 		AssertEtcdMachineRefExists,


### PR DESCRIPTION
*Description of changes:*
Add a preflight for k8s v1.20 for bare metal deployment so it fails early

*Testing (if applicable):*
Tried to create a v1.20 bare metal cluster and verified that it fails preflight
```
❌ Validation failed	{"validation": "tinkerbell Provider setup is valid", "error": "kubernetes version v1.20 is not supported for Bare Metal", "remediation": ""}

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

