### PR TITLE
Resolving eks-a controller spec discrepancy

### DIFF
--- a/controllers/resource/fetcher.go
+++ b/controllers/resource/fetcher.go
@@ -596,10 +596,10 @@ func MapClusterToCloudStackDatacenterConfigSpec(csCluster *cloudstackv1.CloudSta
 			CredentialsRef: fd.ACSEndpoint.Name,
 			Zone: anywherev1.CloudStackZone{
 				Name: fd.Zone.Name,
-				Id: fd.Zone.ID,
+				Id:   fd.Zone.ID,
 				Network: anywherev1.CloudStackResourceIdentifier{
 					Name: fd.Zone.Network.Name,
-					Id: fd.Zone.Network.ID,
+					Id:   fd.Zone.Network.ID,
 				},
 			},
 			Domain:  fd.Domain,

--- a/controllers/resource/fetcher.go
+++ b/controllers/resource/fetcher.go
@@ -596,8 +596,10 @@ func MapClusterToCloudStackDatacenterConfigSpec(csCluster *cloudstackv1.CloudSta
 			CredentialsRef: fd.ACSEndpoint.Name,
 			Zone: anywherev1.CloudStackZone{
 				Name: fd.Zone.Name,
+				Id: fd.Zone.ID,
 				Network: anywherev1.CloudStackResourceIdentifier{
 					Name: fd.Zone.Network.Name,
+					Id: fd.Zone.Network.ID,
 				},
 			},
 			Domain:  fd.Domain,

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -580,7 +580,6 @@ func (p *cloudstackProvider) needsNewKubeadmConfigTemplate(workerNodeGroupConfig
 // CAPC resources in fetcher.go with those already on the cluster when deciding whether or not to generate and apply
 // new CloudStackMachineTemplates
 func AnyImmutableFieldChanged(oldCsdc, newCsdc *v1alpha1.CloudStackDatacenterConfig, oldCsmc, newCsmc *v1alpha1.CloudStackMachineConfig) bool {
-	fmt.Printf("Comparing old csdc spec (%s) and new csdc spec (%s)", oldCsdc.Spec, newCsdc.Spec)
 	if len(newCsdc.Spec.AvailabilityZones) != len(oldCsdc.Spec.AvailabilityZones) {
 		return true
 	}

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -580,20 +580,20 @@ func (p *cloudstackProvider) needsNewKubeadmConfigTemplate(workerNodeGroupConfig
 // CAPC resources in fetcher.go with those already on the cluster when deciding whether or not to generate and apply
 // new CloudStackMachineTemplates
 func AnyImmutableFieldChanged(oldCsdc, newCsdc *v1alpha1.CloudStackDatacenterConfig, oldCsmc, newCsmc *v1alpha1.CloudStackMachineConfig) bool {
-	if len(newCsdc.Spec.AvailabilityZones) != len(oldCsdc.Spec.AvailabilityZones) {
+	if len(oldCsdc.Spec.AvailabilityZones) != len(newCsdc.Spec.AvailabilityZones) {
 		return true
 	}
-	oAzsMap := map[string]v1alpha1.CloudStackAvailabilityZone{}
-	for _, oAz := range oldCsdc.Spec.AvailabilityZones {
-		oAzsMap[oAz.Name] = oAz
+	oldAzsMap := map[string]v1alpha1.CloudStackAvailabilityZone{}
+	for _, oldAz := range oldCsdc.Spec.AvailabilityZones {
+		oldAzsMap[oldAz.Name] = oldAz
 	}
-	for _, sAz := range newCsdc.Spec.AvailabilityZones {
-		oAz, found := oAzsMap[sAz.Name]
-		if !found || !(sAz.Zone.Equal(&oAz.Zone) &&
-			sAz.Name == oAz.Name &&
-			sAz.CredentialsRef == oAz.CredentialsRef &&
-			sAz.Account == oAz.Account &&
-			sAz.Domain == oAz.Domain) {
+	for _, newAz := range newCsdc.Spec.AvailabilityZones {
+		oldAz, found := oldAzsMap[newAz.Name]
+		if !found || !(oldAz.Zone.Equal(&newAz.Zone) &&
+			oldAz.Name == newAz.Name &&
+			oldAz.CredentialsRef == newAz.CredentialsRef &&
+			oldAz.Account == newAz.Account &&
+			oldAz.Domain == newAz.Domain) {
 
 			return true
 		}

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -1730,6 +1730,21 @@ func TestAnyImmutableFieldChangedFewerZones(t *testing.T) {
 	assert.True(t, AnyImmutableFieldChanged(dcConfig, newDcConfig, nil, nil), "Should have an immutable field changed")
 }
 
+func TestAnyImmutableFieldMissingApiEndpointFromCloudStackCluster(t *testing.T) {
+	// We currently can't retrieve ManagementApiEndpoint for an AZ from the CloudStackCluster resource, so a difference there should be ignored
+	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
+	cc := givenClusterConfig(t, testClusterConfigMainFilename)
+	fillClusterSpecWithClusterConfig(clusterSpec, cc)
+	dcConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
+	machineConfigsMap := givenMachineConfigs(t, testClusterConfigMainFilename)
+
+	newDcConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
+	newDcConfig.Spec.AvailabilityZones[0].ManagementApiEndpoint = ""
+	newMachineConfigsMap := givenMachineConfigs(t, testClusterConfigMainFilename)
+
+	assert.False(t, AnyImmutableFieldChanged(dcConfig, newDcConfig, machineConfigsMap["test"], newMachineConfigsMap["test"]), "Should not have any immutable fields changes")
+}
+
 func TestInstallCustomProviderComponentsKubeVipEnabled(t *testing.T) {
 	ctx := context.Background()
 	mockCtrl := gomock.NewController(t)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
in the e2e tests, we observed two issues:
1. Many errors in the EKS-A controller log like `cloudstackmachinetemplate not found`
2. Replacement of worker nodes because

After setting up the debugger, the issue was isolated to the moment the EKS-A controller was paused, and we were able to analyze that comparison between the CSDC generated from the CloudStackCluster and the CSDC in the cluster would not be apples-to-apples, and would be missing the ManagementAPIEndpoint attribute

*Testing (if applicable):*
Unit testing, and e2e testing behavior is improved. No more errors in EKS-A controller logs, and no more recycling of worker machines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

