### PR TITLE
Document Proxy Env Vars

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/optional/proxy.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/proxy.md
@@ -22,6 +22,26 @@ spec:
       noProxy:
       - list of no proxy endpoints
 ```
+
+### Configuring Docker daemon
+EKS Anywhere will proxy for you given the above configuration file.
+However, to successfully use EKS Anywhere you will also need to ensure your Docker daemon is configured to use the proxy.
+
+This generally means updating your daemon to launch with the HTTPS_PROXY, HTTP_PROXY, and NO_PROXY environment variables.
+
+For an example of how to do this with systemd, please see Docker's documentation [here](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy).
+
+### Configuring EKS Anywhere proxy without config file
+For commands using a cluster config file, EKS Anywhere will derive its proxy config from the cluster configuration file.
+
+However, for commands that do not utilize a cluster config file, you can set the following environment variables:
+```bash
+export HTTPS_PROXY=https-proxy-ip:port
+export HTTP_PROXY=http-proxy-ip:port
+export NO_PROXY=no-proxy-domain.com,another-domain.com,localhost
+```
+
+
 ## Proxy Configuration Spec Details
 ### __proxyConfiguration__ (required)
 * __Description__: top level key; required to use proxy.


### PR DESCRIPTION
*Issue #, if available:*
Follows https://github.com/aws/eks-anywhere/pull/2849

*Description of changes:*
This change documents support for using EKS-Anywhere behind a Proxy via environment variables.

Previously, only commands using a cluster config file could use a proxy.

Now, you can use a proxy for any command by setting the documented environment variables.

Additionally, I added documentation that to successfully use a proxy you will need to update your docker daemon's configuration as described in docker's own documentation.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->