### PR TITLE
Trim leading dash in repo name

### DIFF
--- a/release/pkg/assets/images/images.go
+++ b/release/pkg/assets/images/images.go
@@ -38,10 +38,10 @@ func GetImageAssets(rc *releasetypes.ReleaseConfig, ac *assettypes.AssetConfig, 
 	sourceRepoName, releaseRepoName := repoName, repoName
 	if image.TrimEksAPrefix {
 		if rc.ReleaseEnvironment == "production" {
-			sourceRepoName = strings.TrimPrefix(repoName, "eks-anywhere")
+			sourceRepoName = strings.TrimPrefix(repoName, "eks-anywhere-")
 		}
 		if !rc.DevRelease {
-			releaseRepoName = strings.TrimPrefix(repoName, "eks-anywhere")
+			releaseRepoName = strings.TrimPrefix(repoName, "eks-anywhere-")
 		}
 	}
 


### PR DESCRIPTION
Fixes the invalid reference format error during release
```
time="2022-08-18T01:09:13Z" level=fatal msg="Invalid destination name docker://public.ecr.aws/w9m0f3l5/-cli-tools:v0.11.0-eks-a-14: invalid reference format"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

