### PR TITLE
Updated artifacts page for image-builder

### DIFF
--- a/docs/content/en/docs/reference/artifacts.md
+++ b/docs/content/en/docs/reference/artifacts.md
@@ -6,30 +6,26 @@ description: >
   Artifacts associated with this release: OVAs and images.
 ---
 
-# Bare Metal artifacts
+EKS Anywhere supports two different node operating systems:
+
+* Bottlerocket
+* Ubuntu
+
+Bottlerocket OVAs and images are distributed by the EKS Anywhere project.
+To build your own Ubuntu-based EKS Anywhere node, see [Building Ubuntu-based node images]({{< relref "#building-ubuntu-based-node-images">}}).
+
+## Bare Metal artifacts
 
 Artifacts for EKS Anyware Bare Metal clusters are listed below.
 If you like, you can download these images and serve them locally to speed up cluster creation.
 See descriptions of the [osImageURL]({{< relref "./clusterspec/baremetal/#osimageurl" >}}) and [`hookImagesURLPath`]({{< relref "./clusterspec/baremetal/#hookimagesurlpath" >}}) fields for details.
 
-## Ubuntu OS images for Bare Metal
+### Ubuntu OS images for Bare Metal
 
-Kubernetes 1.20:
-```bash
-https://anywhere-assets.eks.amazonaws.com/releases/bundles/12/artifacts/raw/1-20/ubuntu-v1.20.15-eks-d-1-20-18-eks-a-12-amd64.gz
-```
+EKS Anywhere no long distributes Ubuntu OS images.
+However, see [Building Ubuntu-based node images]({{< relref "#building-ubuntu-based-node-images">}}) for information on how to build your own Ubuntu-based image to use with EKS Anywhere.
 
-Kubernetes 1.21:
-```bash
-https://anywhere-assets.eks.amazonaws.com/releases/bundles/12/artifacts/raw/1-21/ubuntu-v1.21.13-eks-d-1-21-16-eks-a-12-amd64.gz
-```
-
-Kubernetes 1.22:
-```bash
-https://anywhere-assets.eks.amazonaws.com/releases/bundles/12/artifacts/raw/1-22/ubuntu-v1.22.10-eks-d-1-22-9-eks-a-12-amd64.gz
-```
-
-## Bottlerocket OS images for Bare Metal
+### Bottlerocket OS images for Bare Metal
 
 Kubernetes 1.21:
 ```bash
@@ -41,7 +37,7 @@ Kubernetes 1.22:
 https://anywhere-assets.eks.amazonaws.com/releases/bundles/12/artifacts/raw/1-22/bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-12-amd64.img.gz
 ```
 
-## HookOS (kernel and initial ramdisk) for Bare Metal
+### HookOS (kernel and initial ramdisk) for Bare Metal
 
 kernel:
 ```bash
@@ -53,9 +49,9 @@ initial ramdisk:
 https://anywhere-assets.eks.amazonaws.com/releases/bundles/12/artifacts/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-x86_64
 ```
 
-# vSphere OVAs
+## vSphere OVAs
 
-## Bottlerocket OVAs
+### Bottlerocket OVAs
 
 Bottlerocket vends its VMware variant OVAs using a secure distribution tool called tuftool. Please follow instructions down below to
 download Bottlerocket OVA.
@@ -99,131 +95,171 @@ EKS-D Release
 
 1.20 - `eksdRelease:kubernetes-1-20-eks-19`
 
-## Ubuntu with Kubernetes 1.23 OVA
+### Ubuntu OVAs
+EKS Anywhere no longer distributes Ubuntu OVAs or gzip images for use with EKS Anywhere clusters.
+So building your own Ubuntu-based nodes as described in [Building Ubuntu-based node images]({{< relref "#building-ubuntu-based-node-images">}}) is the only supported way to get that functionality.
 
-* https://anywhere-assets.eks.amazonaws.com/releases/bundles/12/artifacts/ova/1-23/ubuntu-v1.23.10-eks-d-1-22-9-eks-a-12-amd64.ova
-* `os:ubuntu`
-* `eksdRelease:kubernetes-1-23-eks-4`
+## Building Ubuntu-based node images
 
-## Ubuntu with Kubernetes 1.22 OVA
+The `image-builder` CLI lets you build your own Ubuntu-based vSphere OVAs or Bare Metal gzip images to use in EKS Anywhere clusters.
+When you run `image-builder` it will pull in all components needed to create images to use for nodes in an EKS Anywhere cluster, including the lastest Ubuntu, Kubernetes, and EKS Distro security updates, bug fixes, and patches.
+With this tool, when you build an image you get to choose:
 
-* https://anywhere-assets.eks.amazonaws.com/releases/bundles/12/artifacts/ova/1-22/ubuntu-v1.22.10-eks-d-1-22-9-eks-a-12-amd64.ova
-* `os:ubuntu`
-* `eksdRelease:kubernetes-1-22-eks-9`
+* Operating system type (for example, ubuntu)
+* Provider (vsphere or baremetal)
+* Release channel for EKS Distro (generally aligning with Kubernetes releases)
+* vSphere only: configuration file providing information needed to access your vSphere setup
 
-## Ubuntu with Kubernetes 1.21 OVA
+Because `image-builder` creates images in the same way that the EKS Anywhere project does for their own testing, images built with that tool are supported.
+The following procedure describes how to use `image-builder` to build images for EKS Anywhere on a vSphere or Bare Metal provider.
 
-* https://anywhere-assets.eks.amazonaws.com/releases/bundles/12/artifacts/ova/1-21/ubuntu-v1.21.13-eks-d-1-21-16-eks-a-12-amd64.ova
-* `os:ubuntu`
-* `eksdRelease:kubernetes-1-21-eks-16`
+### Prerequisites
 
-## Ubuntu with Kubernetes 1.20 OVA
+To use `image-builder` you must meet the following prerequisites:
 
-* https://anywhere-assets.eks.amazonaws.com/releases/bundles/12/artifacts/ova/1-20/ubuntu-v1.20.15-eks-d-1-20-18-eks-a-12-amd64.ova
-* `os:ubuntu`
-* `eksdRelease:kubernetes-1-20-eks-18`
+* Run on Ubuntu 22.04 or later 
+* Machine requirements:
+  * AMD 64-bit architecture
+  * 50 GB disk space
+  * 2 vCPUs
+  * 8 GB RAM
+  * Bare Metal only: Run on a bare metal machine with virtualization enabled
+* Network access to:
+  * vCenter endpoint
+  * public.ecr.aws (to download container images from EKS Anywhere)
+  * anywhere-assets.eks.amazonaws.com (to download the EKS Anywhere binaries, manifests and OVAs)
+  * distro.eks.amazonaws.com (to download EKS Distro binaries and manifests)
+  * d2glxqk2uabbnd.cloudfront.net (for EKS Anywhere and EKS Distro ECR container images)
+* vSphere only:
+  * Required vSphere user permissions:
+    * Inventory:
+      * Create new
+    * Configuration:
+      * Change configuration
+      * Add new disk
+      * Add or remove device
+      * Change memory
+      * Change settings
+      * Set annotation
+    * Interaction:
+      * Power on
+      * Power off
+      * Console interaction
+      * Configure CD media
+      * Device connection
+    * Snapshot management:
+      * Create snapshot
+    * Provisioning
+      * Mark as template
+    * Resource Pool
+      * Assign vm to resource pool
+    * Datastore
+      * Allocate space
+      * Browse data
+      * Low level file operations
+    * Network
+      * Assign network to vm
+### Optional Proxy configuration
+You can use a proxy server to route outbound requests to the internet. To configure `image-builder` tool to use a proxy server, export these proxy environment variables:
+  ```
+  export HTTP_PROXY=<HTTP proxy URL e.g. http://proxy.corp.com:80>
+  export HTTPS_PROXY=<HTTPS proxy URL e.g. http://proxy.corp.com:443>
+  export NO_PROXY=<No proxy>
+  ```
 
-## Building your own Ubuntu OVA for vSphere
-The EKS Anywhere project OVA building process leverages upstream [image-builder repository.](https://github.com/kubernetes-sigs/image-builder)
-If you want to build an OVA with a custom Ubuntu base image to use for an EKS Anywhere cluster, please follow the instructions below.
+### Build vSphere OVA node images
 
-Having access to a vSphere environment and docker running locally are prerequisites for building your own images.
+1. Install packages and prepare environment:
+   ```
+   sudo apt update -y
+   sudo apt install jq unzip make ansible -y
+   sudo snap install yq
+   ```
+1. Get `image-builder`:
+   ```bash
+   cd /tmp
+   sudo wget https://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f.s3.us-west-2.amazonaws.com/projects/aws/image-builder/latest/image-builder-linux-amd64-0.1.0.tar.gz
+   sudo tar xvf image-builder-linux-amd64-0.1.0.tar.gz
+   sudo cp image-builder /usr/local/bin
+   ```
+1. Create a content library on vSphere:
+   ```
+   govc library.create "<library name>"
+   ```
+1. Create a vsphere configuration file (for example, `vsphere-connection.json`):
+   ```json
+   {
+     "cluster":"<vsphere cluster used for image building>",
+     "convert_to_template":"false",
+     "create_snapshot":"<creates a snapshot on base OVA after building if set to true>",
+     "datacenter":"<vsphere datacenter used for image building>",
+     "datastore":"<datastore used to store template/for image building>",
+     "folder":"<folder on vsphere to create temporary vm>",
+     "insecure_connection":"true",
+     "linked_clone":"false",
+     "network":"<vsphere network used for image building>",
+     "password":"<vcenter username>",
+     "resource_pool":"<resource pool used for image building vm>",
+     "username":"<vcenter username>",
+     "vcenter_server":"<vcenter fqdn>",
+     "vsphere_library_name": "<vsphere content library name>"
+   }
+   ```
 
-### Required vSphere Permissions
-#### Virtual machine
-Inventory:
-* Create new
+1. Run `image-builder` with the following options:
 
-Configuration:
-* Change configuration
-* Add new disk
-* Add or remove device
-* Change memory
-* Change settings
-* Set annotation
+   * `--os`: Currently only `ubuntu` is supported.
+   * `--hypervisor`: For vSphere use `vsphere`
+   * `--release-channel`: Supported EKS Distro releases include 1-20, 1-21, 1-22, and 1-23.
+   * `--vsphere-config`: vSphere configuration file (`vsphere-connection.json` in this example)
 
-Interaction:
-* Power on
-* Power off
-* Console interaction
-* Configure CD media
-* Device connection
+   ```bash
+   image-builder build --os ubuntu --hypervisor vsphere --release-channel 1-23 --vsphere-config vsphere-connection.json
+   ```
+### Build Bare Metal node images
+1. Install packages and prepare environment:
+   ```
+   sudo apt update -y
+   sudo apt install jq make qemu-kvm libvirt-daemon-system libvirt-clients virtinst cpu-checker libguestfs-tools libosinfo-bin unzip ansible -y
+   sudo snap install yq
+   sudo usermod -a -G kvm ubuntu
+   sudo chmod 666 /dev/kvm
+   sudo chown root:kvm /dev/kvm
+   ```
+1. Get `image-builder`:
+    ```bash
+    cd /tmp
+    sudo wget https://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f.s3.us-west-2.amazonaws.com/projects/aws/image-builder/latest/image-builder-linux-amd64-0.1.0.tar.gz
+    sudo tar xvf image-builder-linux-amd64-0.1.0.tar.gz
+    sudo cp image-builder /usr/local/bin
+    ```
+1. Run `image-builder` with the following options:
 
-Snapshot management:
-* Create snapshot
+    * `--os`: Currently only `ubuntu` is supported.
+    * `--hypervisor`: For Bare Metal use `baremetal`
+    * `--release-channel`: Supported EKS Distro releases include 1-20, 1-21, 1-22, and 1-23.
 
-Provisioning
-* Mark as template
+   ```bash
+   image-builder build --os ubuntu --hypervisor baremetal --release-channel 1-23
+   ```
+1. To consume the resulting gzip Ubuntu-based image, serve the image from an accessible Web server. For example, add the image to a server called `my-web-server`:
+   ```
+   my-web-server
+   ├── hook
+   │   ├── initramfs-x86_64
+   │   └── vmlinuz-x86_64
+   └── my-ubuntu-v1.22.10-eks-d-1-22-8-eks-a-11-amd64.gz
+   ```
 
-#### Resource Pool
-* Assign vm to resource pool
+1. Then create the [Bare metal configuration]({{< relref "./clusterspec/baremetal/" >}}) file, setting the `osImageURL` field to the location of the image. For example:
 
-#### Datastore
-* Allocate space
-* Browse data
-* Low level file operations
+   ```
+   osImageURL: "http://my-web-server/my-ubuntu-v1.22.10-eks-d-1-22-8-eks-a-11-amd64.gz"
+   ```
 
-#### Network
-* Assign network to vm
-
-### Steps to build an OVA
-1. Spin up a builder-base docker container and exec into it. Please use the most recent tag for the image on its repository [here](https://gallery.ecr.aws/eks-distro-build-tooling/builder-base)
-```
-docker exec -it public.ecr.aws/eks-distro-build-tooling/builder-base:latest bash
-```
-2. Clone the [eks-anywhere-build-tooling repo.](https://github.com/aws/eks-anywhere-build-tooling)
-```
-git clone https://github.com/aws/eks-anywhere-build-tooling.git
-```
-3. Navigate to the image-builder directory.
-```
-cd eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder
-```
-4. Get the vSphere connection details and create a json file named `vsphere.json` with the following template.
-```
-{
-    "cluster": "<vSphere cluster name>",
-    "datacenter": "<datacenter name on vSphere>",
-    "datastore": "<datastore to be used on vSphere>",
-    "folder": "<folder path to use for building ova>",
-    "network": "<dhcp enabled network name>",
-    "resource_pool": "<vSphere resource pool to use>",
-    "vcenter_server": "<vSphere server URL>",
-    "username": "<vSphere username>",
-    "password": "<vSphere password>",
-    "template": "",
-    "insecure_connection": "false",
-    "linked_clone": "false",
-    "convert_to_template": "false",
-    "create_snapshot": "true"
-}
-
-```
-4. Export the vSphere connection data file, escaping all the quotes
-```
-export VSPHERE_CONNECTION_DATA=\"$(cat vsphere.json | jq -c . | sed 's/"/\\"/g')\"
-```
-5. Download the most recent release bundle manifest and get the latest URLs for `etcdadm` and `crictl` for the intended Kubernetes version.
-```
-wget https://anywhere-assets.eks.amazonaws.com/bundle-release.yaml
-```
-7. Export the CRICTL_URL and ETCADM_HTTP_SOURCE environment variables with the URLs from previous step.
-```
-export CRICTL_URL=<crictl url>
-export ETCDADM_HTTP_SOURCE=<etcdadm url>
-```
-7. Create a library on vSphere for image-builder.
-```
-govc library.create "CodeBuild"
-```
-8. Update the Ubuntu configuration file with the new custom ISO URL and its checksum at
-`image-builder/images/capi/packer/ova/ubuntu-2004.json`
-9. Setup image-builder and run the OVA build for the Kubernetes version.
-```
-RELEASE_BRANCH=1-23 make release-ova-ubuntu-2004
-```
-
-# Images
+   See descriptions of [osImageURL]({{< relref "./clusterspec/baremetal/#osimageurl" >}}) for further information.
+ 
+## Images
 
 The various images for EKS Anywhere can be found [in the EKS Anywhere ECR repository](https://gallery.ecr.aws/eks-anywhere/).
 The various images for EKS Distro can be found [in the EKS Distro ECR repository](https://gallery.ecr.aws/eks-distro/).

--- a/docs/content/en/docs/reference/artifacts.md
+++ b/docs/content/en/docs/reference/artifacts.md
@@ -230,8 +230,8 @@ You can use a proxy server to route outbound requests to the internet. To config
 1. Get `image-builder`:
     ```bash
     cd /tmp
-    sudo wget https://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f.s3.us-west-2.amazonaws.com/projects/aws/image-builder/latest/image-builder-linux-amd64-0.1.0.tar.gz
-    sudo tar xvf image-builder-linux-amd64-0.1.0.tar.gz
+    sudo wget <location-of-image-builder-tarball>
+    sudo tar xvf image-builder*.tar.gz
     sudo cp image-builder /usr/local/bin
     ```
 1. Run `image-builder` with the following options:

--- a/docs/content/en/docs/reference/artifacts.md
+++ b/docs/content/en/docs/reference/artifacts.md
@@ -125,7 +125,7 @@ To use `image-builder` you must meet the following prerequisites:
   * 8 GB RAM
   * Bare Metal only: Run on a bare metal machine with virtualization enabled
 * Network access to:
-  * vCenter endpoint
+  * vCenter endpoint (vSphere only)
   * public.ecr.aws (to download container images from EKS Anywhere)
   * anywhere-assets.eks.amazonaws.com (to download the EKS Anywhere binaries, manifests and OVAs)
   * distro.eks.amazonaws.com (to download EKS Distro binaries and manifests)
@@ -178,8 +178,8 @@ You can use a proxy server to route outbound requests to the internet. To config
 1. Get `image-builder`:
    ```bash
    cd /tmp
-   sudo wget https://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f.s3.us-west-2.amazonaws.com/projects/aws/image-builder/latest/image-builder-linux-amd64-0.1.0.tar.gz
-   sudo tar xvf image-builder-linux-amd64-0.1.0.tar.gz
+   sudo wget <location-of-image-builder-tarball>
+   sudo tar xvf image-builder*.tar.gz
    sudo cp image-builder /usr/local/bin
    ```
 1. Create a content library on vSphere:
@@ -250,7 +250,6 @@ You can use a proxy server to route outbound requests to the internet. To config
    │   └── vmlinuz-x86_64
    └── my-ubuntu-v1.22.10-eks-d-1-22-8-eks-a-11-amd64.gz
    ```
-
 1. Then create the [Bare metal configuration]({{< relref "./clusterspec/baremetal/" >}}) file, setting the `osImageURL` field to the location of the image. For example:
 
    ```

--- a/docs/content/en/docs/reference/artifacts.md
+++ b/docs/content/en/docs/reference/artifacts.md
@@ -159,13 +159,6 @@ To use `image-builder` you must meet the following prerequisites:
       * Low level file operations
     * Network
       * Assign network to vm
-### Optional Proxy configuration
-You can use a proxy server to route outbound requests to the internet. To configure `image-builder` tool to use a proxy server, export these proxy environment variables:
-  ```
-  export HTTP_PROXY=<HTTP proxy URL e.g. http://proxy.corp.com:80>
-  export HTTPS_PROXY=<HTTPS proxy URL e.g. http://proxy.corp.com:443>
-  export NO_PROXY=<No proxy>
-  ```
 
 ### Optional Proxy configuration
 You can use a proxy server to route outbound requests to the internet. To configure `image-builder` tool to use a proxy server, export these proxy environment variables:

--- a/docs/content/en/docs/reference/artifacts.md
+++ b/docs/content/en/docs/reference/artifacts.md
@@ -96,8 +96,8 @@ EKS-D Release
 1.20 - `eksdRelease:kubernetes-1-20-eks-19`
 
 ### Ubuntu OVAs
-EKS Anywhere no longer distributes Ubuntu OVAs or gzip images for use with EKS Anywhere clusters.
-So building your own Ubuntu-based nodes as described in [Building Ubuntu-based node images]({{< relref "#building-ubuntu-based-node-images">}}) is the only supported way to get that functionality.
+EKS Anywhere no longer distributes Ubuntu OVAs for use with EKS Anywhere clusters.
+Building your own Ubuntu-based nodes as described in [Building Ubuntu-based node images]({{< relref "#building-ubuntu-based-node-images">}}) is the only supported way to get that functionality.
 
 ## Building Ubuntu-based node images
 

--- a/docs/content/en/docs/reference/artifacts.md
+++ b/docs/content/en/docs/reference/artifacts.md
@@ -167,6 +167,14 @@ You can use a proxy server to route outbound requests to the internet. To config
   export NO_PROXY=<No proxy>
   ```
 
+### Optional Proxy configuration
+You can use a proxy server to route outbound requests to the internet. To configure `image-builder` tool to use a proxy server, export these proxy environment variables:
+  ```
+  export HTTP_PROXY=<HTTP proxy URL e.g. http://proxy.corp.com:80>
+  export HTTPS_PROXY=<HTTPS proxy URL e.g. http://proxy.corp.com:443>
+  export NO_PROXY=<No proxy>
+  ```
+
 ### Build vSphere OVA node images
 
 1. Install packages and prepare environment:
@@ -250,6 +258,7 @@ You can use a proxy server to route outbound requests to the internet. To config
    │   └── vmlinuz-x86_64
    └── my-ubuntu-v1.22.10-eks-d-1-22-8-eks-a-11-amd64.gz
    ```
+
 1. Then create the [Bare metal configuration]({{< relref "./clusterspec/baremetal/" >}}) file, setting the `osImageURL` field to the location of the image. For example:
 
    ```


### PR DESCRIPTION
*Description of changes:*
This PR updates the artifacts.md page to tell users that:
- EKS Anywhere no longer distributes Ubuntu images and
- They can use image-builder to create their own Ubuntu-based node images

