### PR TITLE
Remove Ubuntu artifacts from release process

### DIFF
--- a/release/pkg/assets/config/bundle_release.go
+++ b/release/pkg/assets/config/bundle_release.go
@@ -597,20 +597,8 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 		Archives: []*assettypes.Archive{
 			{
 				Name:                "eks-distro",
-				OSName:              "ubuntu",
-				Format:              "ova",
-				ArchiveS3PathGetter: archives.EksDistroArtifactPathGetter,
-			},
-			{
-				Name:                "eks-distro",
 				OSName:              "bottlerocket",
 				Format:              "ova",
-				ArchiveS3PathGetter: archives.EksDistroArtifactPathGetter,
-			},
-			{
-				Name:                "eks-distro",
-				OSName:              "ubuntu",
-				Format:              "raw",
 				ArchiveS3PathGetter: archives.EksDistroArtifactPathGetter,
 			},
 			{

--- a/release/pkg/operations/bundle_release_test.go
+++ b/release/pkg/operations/bundle_release_test.go
@@ -77,14 +77,13 @@ func TestGenerateBundleManifest(t *testing.T) {
 			cliMinVersion:       "v0.7.2",
 			cliMaxVersion:       "v0.7.2",
 		},
-		// TODO: uncomment this in the next release
-		// {
-		// 	testName:            "Dev-release from release-0.10",
-		// 	buildRepoBranchName: "release-0.10",
-		// 	cliRepoBranchName:   "release-0.10",
-		// 	cliMinVersion:       "v0.10.0",
-		// 	cliMaxVersion:       "v0.10.0",
-		// },
+		{
+			testName:            "Dev-release from release-0.11",
+			buildRepoBranchName: "release-0.11",
+			cliRepoBranchName:   "release-0.11",
+			cliMinVersion:       "v0.11.0",
+			cliMaxVersion:       "v0.11.0",
+		},
 	}
 
 	for _, tt := range testCases {

--- a/release/pkg/test/testdata/release-0.11-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.11-bundle-release.yaml
@@ -4,15 +4,15 @@ metadata:
   creationTimestamp: "1970-01-01T00:00:00Z"
   name: bundles-1
 spec:
-  cliMaxVersion: v0.10.0
-  cliMinVersion: v0.10.0
+  cliMaxVersion: v0.11.0
+  cliMinVersion: v0.11.0
   number: 1
   versionsBundles:
   - aws:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
       controller:
         arch:
         - amd64
@@ -21,7 +21,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-aws-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -30,13 +30,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
       version: v0.6.4+abcdef1
     bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.1.3/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -45,7 +45,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -54,10 +54,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     bottlerocketAdmin:
       admin:
         arch:
@@ -76,7 +76,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-18-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-19-eks-a-v0.0.0-dev-release-0.11-build.1
     certManager:
       acmesolver:
         arch:
@@ -86,7 +86,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       cainjector:
         arch:
         - amd64
@@ -95,7 +95,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       controller:
         arch:
         - amd64
@@ -104,7 +104,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       ctl:
         arch:
         - amd64
@@ -113,10 +113,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cert-manager/manifests/v1.7.2/cert-manager.yaml
-      version: v1.7.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cert-manager/manifests/v1.8.2/cert-manager.yaml
+      version: v1.8.2+abcdef1
       webhook:
         arch:
         - amd64
@@ -125,7 +125,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
     cilium:
       cilium:
         arch:
@@ -141,7 +141,7 @@ spec:
         name: cilium-chart
         uri: public.ecr.aws/isovalent/cilium:1.10.11-eksa.2
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cilium/manifests/cilium/v1.10.11-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cilium/manifests/cilium/v1.10.11-eksa.2/cilium.yaml
       operator:
         arch:
         - amd64
@@ -160,9 +160,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.5-rc5-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.7-rc2-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.7-rc2/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -171,7 +171,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVip:
         arch:
         - amd64
@@ -180,13 +180,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc5/metadata.yaml
-      version: v0.4.5-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.7-rc2/metadata.yaml
+      version: v0.4.7-rc2+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/cluster-api/v1.1.3/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
       controller:
         arch:
         - amd64
@@ -195,7 +195,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -204,13 +204,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/cluster-api/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/control-plane-kubeadm/v1.1.3/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -219,7 +219,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -228,15 +228,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/control-plane-kubeadm/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -245,7 +245,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       manager:
         arch:
         - amd64
@@ -254,14 +254,41 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     eksD:
       channel: 1-20
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+      crictl:
+        arch:
+        - amd64
+        description: cri-tools tarball for linux/amd64
+        name: cri-tools-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+      etcdadm:
+        arch:
+        - amd64
+        description: etcdadm tarball for linux/amd64
+        name: etcdadm-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
+      imagebuilder:
+        arch:
+        - amd64
+        description: image-builder tarball for linux/amd64
+        name: image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.0/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -270,83 +297,23 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-18-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-19-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVersion: v1.20.15
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-18.yaml
-      name: kubernetes-1-20-eks-18
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-19.yaml
+      name: kubernetes-1-20-eks-19
       ova:
         bottlerocket:
           arch:
           - amd64
-          crictl: {}
-          description: Bottlerocket Ova image for EKS-D 1-20-18 release
-          etcdadm: {}
-          name: bottlerocket-v1.20.15-eks-d-1-20-18-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-20-19 release
+          name: bottlerocket-v1.20.15-eks-d-1-20-19-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/ova/1-20/1-20-18/bottlerocket-v1.20.15-eks-d-1-20-18-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
-        ubuntu:
-          arch:
-          - amd64
-          crictl:
-            arch:
-            - amd64
-            description: cri-tools tarball for linux/amd64
-            name: cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          description: Ubuntu Ova image for EKS-D 1-20-18 release
-          etcdadm:
-            arch:
-            - amd64
-            description: etcdadm tarball for linux/amd64
-            name: etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.20.15-eks-d-1-20-18-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
-          os: linux
-          osName: ubuntu
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/ova/1-20/1-20-18/ubuntu-v1.20.15-eks-d-1-20-18-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-20/1-20-19/bottlerocket-v1.20.15-eks-d-1-20-19-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
       raw:
-        bottlerocket:
-          crictl: {}
-          etcdadm: {}
-        ubuntu:
-          arch:
-          - amd64
-          crictl:
-            arch:
-            - amd64
-            description: cri-tools tarball for linux/amd64
-            name: cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          description: Ubuntu Raw image for EKS-D 1-20-18 release
-          etcdadm:
-            arch:
-            - amd64
-            description: etcdadm tarball for linux/amd64
-            name: etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.20.15-eks-d-1-20-18-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.gz
-          os: linux
-          osName: ubuntu
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/raw/1-20/1-20-18/ubuntu-v1.20.15-eks-d-1-20-18-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.gz
+        bottlerocket: {}
     eksa:
       cliTools:
         arch:
@@ -356,7 +323,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.10.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.10.1-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterController:
         arch:
         - amd64
@@ -365,9 +332,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.10.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.10.1-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-anywhere/manifests/cluster-controller/v0.10.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.10.1/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -376,11 +343,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.10.1-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.0.0-dev-release-0.10+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.10.1-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.0.0-dev-release-0.11+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.3/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -389,7 +356,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -398,13 +365,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.3/metadata.yaml
-      version: v1.0.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5/metadata.yaml
+      version: v1.0.5+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.1/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -413,7 +380,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -422,10 +389,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.1/metadata.yaml
-      version: v1.0.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4/metadata.yaml
+      version: v1.0.4+abcdef1
     flux:
       helmController:
         arch:
@@ -435,7 +402,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.20.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-release-0.11-build.1
       kustomizeController:
         arch:
         - amd64
@@ -444,7 +411,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.24.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-release-0.11-build.1
       notificationController:
         arch:
         - amd64
@@ -453,7 +420,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.23.4-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-release-0.11-build.1
       sourceController:
         arch:
         - amd64
@@ -462,8 +429,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.24.2-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.29.4+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.31.3+abcdef1
     haproxy:
       image:
         arch:
@@ -473,18 +440,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.12.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.14.0-eks-a-v0.0.0-dev-release-0.11-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/kind/manifests/kindnetd/v0.12.0/kindnetd.yaml
-      version: v0.12.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/kind/manifests/kindnetd/v0.14.0/kindnetd.yaml
+      version: v0.14.0+abcdef1
     kubeVersion: "1.20"
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.0-alpha.6-eks-a-v0.0.0-dev-release-0.11-build.1
       packageController:
         arch:
         - amd64
@@ -493,8 +460,17 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.1.13+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.0-alpha.6-eks-a-v0.0.0-dev-release-0.11-build.1
+      tokenRefresher:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for ecr-token-refresher image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: ecr-token-refresher
+        os: linux
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.0-alpha.6-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.2.0-alpha.6+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -510,11 +486,20 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+      envoy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for envoy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: envoy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVip:
         arch:
         - amd64
@@ -523,9 +508,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -536,7 +521,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           imageToDisk:
             arch:
             - amd64
@@ -545,7 +530,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           kexec:
             arch:
             - amd64
@@ -554,7 +539,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           ociToDisk:
             arch:
             - amd64
@@ -563,7 +548,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           reboot:
             arch:
             - amd64
@@ -572,7 +557,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           writeFile:
             arch:
             - amd64
@@ -581,7 +566,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
         boots:
           arch:
           - amd64
@@ -590,7 +575,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-release-0.11-build.1
         cfssl:
           arch:
           - amd64
@@ -599,7 +584,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: cfssl
           os: linux
-          uri: public.ecr.aws/release-container-registry/cloudflare/cfssl:v1.6.1-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/cloudflare/cfssl:v1.6.1-eks-a-v0.0.0-dev-release-0.11-build.1
         hegel:
           arch:
           - amd64
@@ -608,7 +593,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.11-build.1
         hook:
           bootkit:
             arch:
@@ -618,7 +603,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.11-build.1
           docker:
             arch:
             - amd64
@@ -627,18 +612,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.11-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -647,18 +632,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.11-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -667,7 +652,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.11-build.1
         tink:
           tinkController:
             arch:
@@ -677,7 +662,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.11-build.1
           tinkServer:
             arch:
             - amd64
@@ -686,7 +671,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.11-build.1
           tinkWorker:
             arch:
             - amd64
@@ -695,7 +680,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.11-build.1
         tinkerbellChart:
           arch:
           - amd64
@@ -704,7 +689,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.4-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -715,11 +700,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.1.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.1.1-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -728,7 +713,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -737,7 +722,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVip:
         arch:
         - amd64
@@ -746,7 +731,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-release-0.11-build.1
       manager:
         arch:
         - amd64
@@ -755,9 +740,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.20.0-eks-d-1-20-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.20.1-eks-d-1-20-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -766,13 +751,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v1.1.1+abcdef1
   - aws:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
       controller:
         arch:
         - amd64
@@ -781,7 +766,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-aws-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -790,13 +775,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
       version: v0.6.4+abcdef1
     bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.1.3/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -805,7 +790,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -814,10 +799,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     bottlerocketAdmin:
       admin:
         arch:
@@ -836,7 +821,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-16-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-17-eks-a-v0.0.0-dev-release-0.11-build.1
     certManager:
       acmesolver:
         arch:
@@ -846,7 +831,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       cainjector:
         arch:
         - amd64
@@ -855,7 +840,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       controller:
         arch:
         - amd64
@@ -864,7 +849,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       ctl:
         arch:
         - amd64
@@ -873,10 +858,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cert-manager/manifests/v1.7.2/cert-manager.yaml
-      version: v1.7.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cert-manager/manifests/v1.8.2/cert-manager.yaml
+      version: v1.8.2+abcdef1
       webhook:
         arch:
         - amd64
@@ -885,7 +870,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
     cilium:
       cilium:
         arch:
@@ -901,7 +886,7 @@ spec:
         name: cilium-chart
         uri: public.ecr.aws/isovalent/cilium:1.10.11-eksa.2
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cilium/manifests/cilium/v1.10.11-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cilium/manifests/cilium/v1.10.11-eksa.2/cilium.yaml
       operator:
         arch:
         - amd64
@@ -920,9 +905,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.5-rc5-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.7-rc2-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.7-rc2/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -931,7 +916,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVip:
         arch:
         - amd64
@@ -940,13 +925,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc5/metadata.yaml
-      version: v0.4.5-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.7-rc2/metadata.yaml
+      version: v0.4.7-rc2+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/cluster-api/v1.1.3/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
       controller:
         arch:
         - amd64
@@ -955,7 +940,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -964,13 +949,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/cluster-api/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/control-plane-kubeadm/v1.1.3/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -979,7 +964,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -988,15 +973,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/control-plane-kubeadm/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -1005,7 +990,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       manager:
         arch:
         - amd64
@@ -1014,14 +999,41 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     eksD:
       channel: 1-21
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+      crictl:
+        arch:
+        - amd64
+        description: cri-tools tarball for linux/amd64
+        name: cri-tools-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+      etcdadm:
+        arch:
+        - amd64
+        description: etcdadm tarball for linux/amd64
+        name: etcdadm-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
+      imagebuilder:
+        arch:
+        - amd64
+        description: image-builder tarball for linux/amd64
+        name: image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.0/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -1030,92 +1042,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.13-eks-d-1-21-16-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVersion: v1.21.13
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-16.yaml
-      name: kubernetes-1-21-eks-16
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-17.yaml
+      name: kubernetes-1-21-eks-17
       ova:
         bottlerocket:
           arch:
           - amd64
-          crictl: {}
-          description: Bottlerocket Ova image for EKS-D 1-21-16 release
-          etcdadm: {}
-          name: bottlerocket-v1.21.13-eks-d-1-21-16-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-21-17 release
+          name: bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/ova/1-21/1-21-16/bottlerocket-v1.21.13-eks-d-1-21-16-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
-        ubuntu:
-          arch:
-          - amd64
-          crictl:
-            arch:
-            - amd64
-            description: cri-tools tarball for linux/amd64
-            name: cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          description: Ubuntu Ova image for EKS-D 1-21-16 release
-          etcdadm:
-            arch:
-            - amd64
-            description: etcdadm tarball for linux/amd64
-            name: etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.21.13-eks-d-1-21-16-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
-          os: linux
-          osName: ubuntu
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/ova/1-21/1-21-16/ubuntu-v1.21.13-eks-d-1-21-16-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-21/1-21-17/bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          crictl: {}
-          description: Bottlerocket Raw image for EKS-D 1-21-16 release
-          etcdadm: {}
-          name: bottlerocket-v1.21.13-eks-d-1-21-16-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-21-17 release
+          name: bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/raw/1-21/1-21-16/bottlerocket-v1.21.13-eks-d-1-21-16-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.img.gz
-        ubuntu:
-          arch:
-          - amd64
-          crictl:
-            arch:
-            - amd64
-            description: cri-tools tarball for linux/amd64
-            name: cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          description: Ubuntu Raw image for EKS-D 1-21-16 release
-          etcdadm:
-            arch:
-            - amd64
-            description: etcdadm tarball for linux/amd64
-            name: etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.21.13-eks-d-1-21-16-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.gz
-          os: linux
-          osName: ubuntu
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/raw/1-21/1-21-16/ubuntu-v1.21.13-eks-d-1-21-16-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-21/1-21-17/bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -1125,7 +1077,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.10.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.10.1-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterController:
         arch:
         - amd64
@@ -1134,9 +1086,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.10.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.10.1-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-anywhere/manifests/cluster-controller/v0.10.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.10.1/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1145,11 +1097,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.10.1-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.0.0-dev-release-0.10+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.10.1-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.0.0-dev-release-0.11+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.3/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1158,7 +1110,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1167,13 +1119,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.3/metadata.yaml
-      version: v1.0.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5/metadata.yaml
+      version: v1.0.5+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.1/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1182,7 +1134,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1191,10 +1143,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.1/metadata.yaml
-      version: v1.0.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4/metadata.yaml
+      version: v1.0.4+abcdef1
     flux:
       helmController:
         arch:
@@ -1204,7 +1156,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.20.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-release-0.11-build.1
       kustomizeController:
         arch:
         - amd64
@@ -1213,7 +1165,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.24.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-release-0.11-build.1
       notificationController:
         arch:
         - amd64
@@ -1222,7 +1174,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.23.4-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-release-0.11-build.1
       sourceController:
         arch:
         - amd64
@@ -1231,8 +1183,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.24.2-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.29.4+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.31.3+abcdef1
     haproxy:
       image:
         arch:
@@ -1242,18 +1194,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.12.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.14.0-eks-a-v0.0.0-dev-release-0.11-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/kind/manifests/kindnetd/v0.12.0/kindnetd.yaml
-      version: v0.12.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/kind/manifests/kindnetd/v0.14.0/kindnetd.yaml
+      version: v0.14.0+abcdef1
     kubeVersion: "1.21"
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.0-alpha.6-eks-a-v0.0.0-dev-release-0.11-build.1
       packageController:
         arch:
         - amd64
@@ -1262,8 +1214,17 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.1.13+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.0-alpha.6-eks-a-v0.0.0-dev-release-0.11-build.1
+      tokenRefresher:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for ecr-token-refresher image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: ecr-token-refresher
+        os: linux
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.0-alpha.6-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.2.0-alpha.6+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -1279,11 +1240,20 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+      envoy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for envoy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: envoy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVip:
         arch:
         - amd64
@@ -1292,9 +1262,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -1305,7 +1275,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           imageToDisk:
             arch:
             - amd64
@@ -1314,7 +1284,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           kexec:
             arch:
             - amd64
@@ -1323,7 +1293,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           ociToDisk:
             arch:
             - amd64
@@ -1332,7 +1302,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           reboot:
             arch:
             - amd64
@@ -1341,7 +1311,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           writeFile:
             arch:
             - amd64
@@ -1350,7 +1320,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
         boots:
           arch:
           - amd64
@@ -1359,7 +1329,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-release-0.11-build.1
         cfssl:
           arch:
           - amd64
@@ -1368,7 +1338,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: cfssl
           os: linux
-          uri: public.ecr.aws/release-container-registry/cloudflare/cfssl:v1.6.1-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/cloudflare/cfssl:v1.6.1-eks-a-v0.0.0-dev-release-0.11-build.1
         hegel:
           arch:
           - amd64
@@ -1377,7 +1347,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.11-build.1
         hook:
           bootkit:
             arch:
@@ -1387,7 +1357,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.11-build.1
           docker:
             arch:
             - amd64
@@ -1396,18 +1366,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.11-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -1416,18 +1386,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.11-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -1436,7 +1406,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.11-build.1
         tink:
           tinkController:
             arch:
@@ -1446,7 +1416,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.11-build.1
           tinkServer:
             arch:
             - amd64
@@ -1455,7 +1425,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.11-build.1
           tinkWorker:
             arch:
             - amd64
@@ -1464,7 +1434,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.11-build.1
         tinkerbellChart:
           arch:
           - amd64
@@ -1473,7 +1443,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.4-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -1484,11 +1454,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.1.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.1.1-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -1497,7 +1467,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1506,7 +1476,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVip:
         arch:
         - amd64
@@ -1515,7 +1485,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-release-0.11-build.1
       manager:
         arch:
         - amd64
@@ -1524,9 +1494,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.21.0-eks-d-1-21-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.21.3-eks-d-1-21-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -1535,13 +1505,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v1.1.1+abcdef1
   - aws:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
       controller:
         arch:
         - amd64
@@ -1550,7 +1520,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-aws-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1559,13 +1529,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
       version: v0.6.4+abcdef1
     bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.1.3/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1574,7 +1544,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1583,10 +1553,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     bottlerocketAdmin:
       admin:
         arch:
@@ -1605,7 +1575,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-9-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-9-eks-a-v0.0.0-dev-release-0.11-build.1
     certManager:
       acmesolver:
         arch:
@@ -1615,7 +1585,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       cainjector:
         arch:
         - amd64
@@ -1624,7 +1594,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       controller:
         arch:
         - amd64
@@ -1633,7 +1603,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       ctl:
         arch:
         - amd64
@@ -1642,10 +1612,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cert-manager/manifests/v1.7.2/cert-manager.yaml
-      version: v1.7.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cert-manager/manifests/v1.8.2/cert-manager.yaml
+      version: v1.8.2+abcdef1
       webhook:
         arch:
         - amd64
@@ -1654,7 +1624,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
     cilium:
       cilium:
         arch:
@@ -1670,7 +1640,7 @@ spec:
         name: cilium-chart
         uri: public.ecr.aws/isovalent/cilium:1.10.11-eksa.2
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cilium/manifests/cilium/v1.10.11-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cilium/manifests/cilium/v1.10.11-eksa.2/cilium.yaml
       operator:
         arch:
         - amd64
@@ -1689,9 +1659,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.5-rc5-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.7-rc2-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.7-rc2/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -1700,7 +1670,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVip:
         arch:
         - amd64
@@ -1709,13 +1679,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc5/metadata.yaml
-      version: v0.4.5-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.7-rc2/metadata.yaml
+      version: v0.4.7-rc2+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/cluster-api/v1.1.3/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
       controller:
         arch:
         - amd64
@@ -1724,7 +1694,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1733,13 +1703,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/cluster-api/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/control-plane-kubeadm/v1.1.3/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -1748,7 +1718,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1757,15 +1727,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/control-plane-kubeadm/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -1774,7 +1744,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       manager:
         arch:
         - amd64
@@ -1783,14 +1753,41 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     eksD:
       channel: 1-22
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+      crictl:
+        arch:
+        - amd64
+        description: cri-tools tarball for linux/amd64
+        name: cri-tools-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+      etcdadm:
+        arch:
+        - amd64
+        description: etcdadm tarball for linux/amd64
+        name: etcdadm-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
+      imagebuilder:
+        arch:
+        - amd64
+        description: image-builder tarball for linux/amd64
+        name: image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.0/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -1799,7 +1796,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVersion: v1.22.10
       manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-9.yaml
       name: kubernetes-1-22-eks-9
@@ -1807,84 +1804,24 @@ spec:
         bottlerocket:
           arch:
           - amd64
-          crictl: {}
           description: Bottlerocket Ova image for EKS-D 1-22-9 release
-          etcdadm: {}
-          name: bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
+          name: bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/ova/1-22/1-22-9/bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
-        ubuntu:
-          arch:
-          - amd64
-          crictl:
-            arch:
-            - amd64
-            description: cri-tools tarball for linux/amd64
-            name: cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          description: Ubuntu Ova image for EKS-D 1-22-9 release
-          etcdadm:
-            arch:
-            - amd64
-            description: etcdadm tarball for linux/amd64
-            name: etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
-          os: linux
-          osName: ubuntu
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/ova/1-22/1-22-9/ubuntu-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-22/1-22-9/bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          crictl: {}
           description: Bottlerocket Raw image for EKS-D 1-22-9 release
-          etcdadm: {}
-          name: bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.img.gz
+          name: bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/raw/1-22/1-22-9/bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.img.gz
-        ubuntu:
-          arch:
-          - amd64
-          crictl:
-            arch:
-            - amd64
-            description: cri-tools tarball for linux/amd64
-            name: cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          description: Ubuntu Raw image for EKS-D 1-22-9 release
-          etcdadm:
-            arch:
-            - amd64
-            description: etcdadm tarball for linux/amd64
-            name: etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.gz
-          os: linux
-          osName: ubuntu
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/raw/1-22/1-22-9/ubuntu-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-22/1-22-9/bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -1894,7 +1831,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.10.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.10.1-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterController:
         arch:
         - amd64
@@ -1903,9 +1840,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.10.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.10.1-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-anywhere/manifests/cluster-controller/v0.10.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.10.1/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1914,11 +1851,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.10.1-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.0.0-dev-release-0.10+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.10.1-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.0.0-dev-release-0.11+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.3/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1927,7 +1864,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1936,13 +1873,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.3/metadata.yaml
-      version: v1.0.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5/metadata.yaml
+      version: v1.0.5+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.1/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1951,7 +1888,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1960,10 +1897,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.1/metadata.yaml
-      version: v1.0.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4/metadata.yaml
+      version: v1.0.4+abcdef1
     flux:
       helmController:
         arch:
@@ -1973,7 +1910,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.20.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-release-0.11-build.1
       kustomizeController:
         arch:
         - amd64
@@ -1982,7 +1919,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.24.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-release-0.11-build.1
       notificationController:
         arch:
         - amd64
@@ -1991,7 +1928,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.23.4-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-release-0.11-build.1
       sourceController:
         arch:
         - amd64
@@ -2000,8 +1937,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.24.2-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.29.4+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.31.3+abcdef1
     haproxy:
       image:
         arch:
@@ -2011,18 +1948,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.12.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.14.0-eks-a-v0.0.0-dev-release-0.11-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/kind/manifests/kindnetd/v0.12.0/kindnetd.yaml
-      version: v0.12.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/kind/manifests/kindnetd/v0.14.0/kindnetd.yaml
+      version: v0.14.0+abcdef1
     kubeVersion: "1.22"
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.0-alpha.6-eks-a-v0.0.0-dev-release-0.11-build.1
       packageController:
         arch:
         - amd64
@@ -2031,8 +1968,17 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.1.13+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.0-alpha.6-eks-a-v0.0.0-dev-release-0.11-build.1
+      tokenRefresher:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for ecr-token-refresher image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: ecr-token-refresher
+        os: linux
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.0-alpha.6-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.2.0-alpha.6+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -2048,11 +1994,20 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+      envoy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for envoy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: envoy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVip:
         arch:
         - amd64
@@ -2061,9 +2016,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -2074,7 +2029,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           imageToDisk:
             arch:
             - amd64
@@ -2083,7 +2038,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           kexec:
             arch:
             - amd64
@@ -2092,7 +2047,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           ociToDisk:
             arch:
             - amd64
@@ -2101,7 +2056,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           reboot:
             arch:
             - amd64
@@ -2110,7 +2065,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           writeFile:
             arch:
             - amd64
@@ -2119,7 +2074,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
         boots:
           arch:
           - amd64
@@ -2128,7 +2083,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-release-0.11-build.1
         cfssl:
           arch:
           - amd64
@@ -2137,7 +2092,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: cfssl
           os: linux
-          uri: public.ecr.aws/release-container-registry/cloudflare/cfssl:v1.6.1-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/cloudflare/cfssl:v1.6.1-eks-a-v0.0.0-dev-release-0.11-build.1
         hegel:
           arch:
           - amd64
@@ -2146,7 +2101,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.11-build.1
         hook:
           bootkit:
             arch:
@@ -2156,7 +2111,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.11-build.1
           docker:
             arch:
             - amd64
@@ -2165,18 +2120,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.11-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -2185,18 +2140,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.11-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -2205,7 +2160,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.11-build.1
         tink:
           tinkController:
             arch:
@@ -2215,7 +2170,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.11-build.1
           tinkServer:
             arch:
             - amd64
@@ -2224,7 +2179,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.11-build.1
           tinkWorker:
             arch:
             - amd64
@@ -2233,7 +2188,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.11-build.1
         tinkerbellChart:
           arch:
           - amd64
@@ -2242,7 +2197,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.4-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -2253,11 +2208,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.1.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.1.1-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -2266,7 +2221,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2275,7 +2230,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVip:
         arch:
         - amd64
@@ -2284,7 +2239,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-release-0.11-build.1
       manager:
         arch:
         - amd64
@@ -2293,9 +2248,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.22.5-eks-d-1-22-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.22.6-eks-d-1-22-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -2304,13 +2259,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v1.1.1+abcdef1
   - aws:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/infrastructure-components.yaml
       controller:
         arch:
         - amd64
@@ -2319,7 +2274,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-aws-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2328,13 +2283,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-aws/manifests/infrastructure-aws/v0.6.4/metadata.yaml
       version: v0.6.4+abcdef1
     bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.1.3/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2343,7 +2298,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2352,10 +2307,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     bottlerocketAdmin:
       admin:
         arch:
@@ -2374,7 +2329,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-4-eks-a-v0.0.0-dev-release-0.11-build.1
     certManager:
       acmesolver:
         arch:
@@ -2384,7 +2339,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       cainjector:
         arch:
         - amd64
@@ -2393,7 +2348,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       controller:
         arch:
         - amd64
@@ -2402,7 +2357,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       ctl:
         arch:
         - amd64
@@ -2411,10 +2366,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cert-manager/manifests/v1.7.2/cert-manager.yaml
-      version: v1.7.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cert-manager/manifests/v1.8.2/cert-manager.yaml
+      version: v1.8.2+abcdef1
       webhook:
         arch:
         - amd64
@@ -2423,7 +2378,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.7.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.8.2-eks-a-v0.0.0-dev-release-0.11-build.1
     cilium:
       cilium:
         arch:
@@ -2439,7 +2394,7 @@ spec:
         name: cilium-chart
         uri: public.ecr.aws/isovalent/cilium:1.10.11-eksa.2
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cilium/manifests/cilium/v1.10.11-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cilium/manifests/cilium/v1.10.11-eksa.2/cilium.yaml
       operator:
         arch:
         - amd64
@@ -2458,9 +2413,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.5-rc5-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.7-rc2-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.7-rc2/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -2469,7 +2424,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVip:
         arch:
         - amd64
@@ -2478,13 +2433,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.5-rc5/metadata.yaml
-      version: v0.4.5-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.7-rc2/metadata.yaml
+      version: v0.4.7-rc2+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/cluster-api/v1.1.3/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
       controller:
         arch:
         - amd64
@@ -2493,7 +2448,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2502,13 +2457,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/cluster-api/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/control-plane-kubeadm/v1.1.3/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -2517,7 +2472,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2526,15 +2481,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/control-plane-kubeadm/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -2543,7 +2498,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       manager:
         arch:
         - amd64
@@ -2552,14 +2507,41 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api/manifests/infrastructure-docker/v1.1.3/metadata.yaml
-      version: v1.1.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
     eksD:
       channel: 1-23
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+      crictl:
+        arch:
+        - amd64
+        description: cri-tools tarball for linux/amd64
+        name: cri-tools-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+      etcdadm:
+        arch:
+        - amd64
+        description: etcdadm tarball for linux/amd64
+        name: etcdadm-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
+      imagebuilder:
+        arch:
+        - amd64
+        description: image-builder tarball for linux/amd64
+        name: image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.0/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -2568,92 +2550,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.7-eks-d-1-23-3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVersion: v1.23.7
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-3.yaml
-      name: kubernetes-1-23-eks-3
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-4.yaml
+      name: kubernetes-1-23-eks-4
       ova:
         bottlerocket:
           arch:
           - amd64
-          crictl: {}
-          description: Bottlerocket Ova image for EKS-D 1-23-3 release
-          etcdadm: {}
-          name: bottlerocket-v1.23.7-eks-d-1-23-3-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-23-4 release
+          name: bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/ova/1-23/1-23-3/bottlerocket-v1.23.7-eks-d-1-23-3-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
-        ubuntu:
-          arch:
-          - amd64
-          crictl:
-            arch:
-            - amd64
-            description: cri-tools tarball for linux/amd64
-            name: cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          description: Ubuntu Ova image for EKS-D 1-23-3 release
-          etcdadm:
-            arch:
-            - amd64
-            description: etcdadm tarball for linux/amd64
-            name: etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.23.7-eks-d-1-23-3-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
-          os: linux
-          osName: ubuntu
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/ova/1-23/1-23-3/ubuntu-v1.23.7-eks-d-1-23-3-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-23/1-23-4/bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          crictl: {}
-          description: Bottlerocket Raw image for EKS-D 1-23-3 release
-          etcdadm: {}
-          name: bottlerocket-v1.23.7-eks-d-1-23-3-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-23-4 release
+          name: bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/raw/1-23/1-23-3/bottlerocket-v1.23.7-eks-d-1-23-3-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.img.gz
-        ubuntu:
-          arch:
-          - amd64
-          crictl:
-            arch:
-            - amd64
-            description: cri-tools tarball for linux/amd64
-            name: cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cri-tools/v1.20.0/cri-tools-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          description: Ubuntu Raw image for EKS-D 1-23-3 release
-          etcdadm:
-            arch:
-            - amd64
-            description: etcdadm tarball for linux/amd64
-            name: etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-            os: linux
-            sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.10+build.0-linux-amd64.tar.gz
-          name: ubuntu-v1.23.7-eks-d-1-23-3-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.gz
-          os: linux
-          osName: ubuntu
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-distro/raw/1-23/1-23-3/ubuntu-v1.23.7-eks-d-1-23-3-eks-a-v0.0.0-dev-release-0.10-build.0-amd64.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-23/1-23-4/bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -2663,7 +2585,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.10.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.10.1-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterController:
         arch:
         - amd64
@@ -2672,9 +2594,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.10.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.10.1-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/eks-anywhere/manifests/cluster-controller/v0.10.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.10.1/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -2683,11 +2605,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.10.1-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.0.0-dev-release-0.10+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.10.1-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.0.0-dev-release-0.11+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.3/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2696,7 +2618,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2705,13 +2627,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.3/metadata.yaml
-      version: v1.0.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5/metadata.yaml
+      version: v1.0.5+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.1/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2720,7 +2642,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2729,10 +2651,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.1/metadata.yaml
-      version: v1.0.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4/metadata.yaml
+      version: v1.0.4+abcdef1
     flux:
       helmController:
         arch:
@@ -2742,7 +2664,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.20.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-release-0.11-build.1
       kustomizeController:
         arch:
         - amd64
@@ -2751,7 +2673,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.24.3-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-release-0.11-build.1
       notificationController:
         arch:
         - amd64
@@ -2760,7 +2682,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.23.4-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-release-0.11-build.1
       sourceController:
         arch:
         - amd64
@@ -2769,8 +2691,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.24.2-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.29.4+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.31.3+abcdef1
     haproxy:
       image:
         arch:
@@ -2780,18 +2702,18 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.12.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.14.0-eks-a-v0.0.0-dev-release-0.11-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/kind/manifests/kindnetd/v0.12.0/kindnetd.yaml
-      version: v0.12.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/kind/manifests/kindnetd/v0.14.0/kindnetd.yaml
+      version: v0.14.0+abcdef1
     kubeVersion: "1.23"
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.0-alpha.6-eks-a-v0.0.0-dev-release-0.11-build.1
       packageController:
         arch:
         - amd64
@@ -2800,8 +2722,17 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.1.13-eks-a-v0.0.0-dev-release-0.10-build.1
-      version: v0.1.13+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.0-alpha.6-eks-a-v0.0.0-dev-release-0.11-build.1
+      tokenRefresher:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for ecr-token-refresher image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: ecr-token-refresher
+        os: linux
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.0-alpha.6-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.2.0-alpha.6+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -2817,11 +2748,20 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+      envoy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for envoy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: envoy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVip:
         arch:
         - amd64
@@ -2830,9 +2770,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -2843,7 +2783,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           imageToDisk:
             arch:
             - amd64
@@ -2852,7 +2792,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           kexec:
             arch:
             - amd64
@@ -2861,7 +2801,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           ociToDisk:
             arch:
             - amd64
@@ -2870,7 +2810,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           reboot:
             arch:
             - amd64
@@ -2879,7 +2819,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
           writeFile:
             arch:
             - amd64
@@ -2888,7 +2828,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.11-build.1
         boots:
           arch:
           - amd64
@@ -2897,7 +2837,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-release-0.11-build.1
         cfssl:
           arch:
           - amd64
@@ -2906,7 +2846,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: cfssl
           os: linux
-          uri: public.ecr.aws/release-container-registry/cloudflare/cfssl:v1.6.1-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/cloudflare/cfssl:v1.6.1-eks-a-v0.0.0-dev-release-0.11-build.1
         hegel:
           arch:
           - amd64
@@ -2915,7 +2855,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.11-build.1
         hook:
           bootkit:
             arch:
@@ -2925,7 +2865,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.11-build.1
           docker:
             arch:
             - amd64
@@ -2934,18 +2874,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.11-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -2954,18 +2894,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-release-0.11-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -2974,7 +2914,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.11-build.1
         tink:
           tinkController:
             arch:
@@ -2984,7 +2924,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.11-build.1
           tinkServer:
             arch:
             - amd64
@@ -2993,7 +2933,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.11-build.1
           tinkWorker:
             arch:
             - amd64
@@ -3002,7 +2942,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.10-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.11-build.1
         tinkerbellChart:
           arch:
           - amd64
@@ -3011,7 +2951,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.3-eks-a-v0.0.0-dev-release-0.10-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.4-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -3022,11 +2962,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.1.1-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.1.1-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -3035,7 +2975,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3044,7 +2984,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.8.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVip:
         arch:
         - amd64
@@ -3053,7 +2993,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.4.2-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-release-0.11-build.1
       manager:
         arch:
         - amd64
@@ -3062,9 +3002,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.23.0-eks-d-1-23-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.23.1-eks-d-1-23-eks-a-v0.0.0-dev-release-0.11-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.10-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -3073,6 +3013,6 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.10-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v1.1.1+abcdef1
 status: {}


### PR DESCRIPTION
Ubuntu references were removed from the bundle spec in #2952, but we also need to remove the download/upload operations for Ubuntu artifacts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

