### PR TITLE
Update 1.23 references

### DIFF
--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -62,7 +62,7 @@ sudo mv /tmp/eksctl /usr/local/bin/
 Install the `eksctl-anywhere` plugin.
 
 ```bash
-export EKSA_RELEASE="0.10.1" OS="$(uname -s | tr A-Z a-z)" RELEASE_NUMBER=15
+export EKSA_RELEASE="0.11.0" OS="$(uname -s | tr A-Z a-z)" RELEASE_NUMBER=16
 curl "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/${RELEASE_NUMBER}/artifacts/eks-a/v${EKSA_RELEASE}/${OS}/amd64/eksctl-anywhere-v${EKSA_RELEASE}-${OS}-amd64.tar.gz" \
     --silent --location \
     | tar xz ./eksctl-anywhere

--- a/docs/content/en/docs/reference/artifacts.md
+++ b/docs/content/en/docs/reference/artifacts.md
@@ -72,13 +72,13 @@ CARGO_NET_GIT_FETCH_WITH_CLI=true cargo install --force tuftool
 curl -O "https://cache.bottlerocket.aws/root.json"
 sha512sum -c <<<"e9b1ea5f9b4f95c9b55edada4238bf00b12845aa98bdd2d3edb63ff82a03ada19444546337ec6d6806cbf329027cf49f7fde31f54d551c5e02acbed7efe75785  root.json"
 ```
-4. Export the desired Kubernetes Version. EKS Anywhere currently supports 1.22, 1.21 and 1.20
+4. Export the desired Kubernetes Version. EKS Anywhere currently supports 1.23, 1.22, 1.21 and 1.20
 ```
-export KUBEVERSION="1.22"
+export KUBEVERSION="1.23"
 ```
 5. Download the OVA
 ```
-OVA="bottlerocket-vmware-k8s-${KUBEVERSION}-x86_64-v1.8.0.ova"
+OVA="bottlerocket-vmware-k8s-${KUBEVERSION}-x86_64-v1.9.0.ova"
 tuftool download ${TMPDIR:-/tmp/bottlerocket-ovas} --target-name "${OVA}" \
    --root ./root.json \
    --metadata-url "https://updates.bottlerocket.aws/2020-07-07/vmware-k8s-${KUBEVERSION}/x86_64/" \
@@ -91,11 +91,13 @@ OS Family - `os:bottlerocket`
 
 EKS-D Release
 
+1.23 - `eksdRelease:kubernetes-1-23-eks-4`
+
 1.22 - `eksdRelease:kubernetes-1-22-eks-9`
 
-1.21 - `eksdRelease:kubernetes-1-21-eks-16`
+1.21 - `eksdRelease:kubernetes-1-21-eks-17`
 
-1.20 - `eksdRelease:kubernetes-1-20-eks-18`
+1.20 - `eksdRelease:kubernetes-1-20-eks-19`
 
 ## Ubuntu with Kubernetes 1.22 OVA
 
@@ -212,7 +214,7 @@ govc library.create "CodeBuild"
 `image-builder/images/capi/packer/ova/ubuntu-2004.json`
 9. Setup image-builder and run the OVA build for the Kubernetes version.
 ```
-RELEASE_BRANCH=1-22 make release-ova-ubuntu-2004
+RELEASE_BRANCH=1-23 make release-ova-ubuntu-2004
 ```
 
 # Images

--- a/docs/content/en/docs/reference/clusterspec/baremetal.md
+++ b/docs/content/en/docs/reference/clusterspec/baremetal.md
@@ -40,7 +40,7 @@ spec:
   datacenterRef:
     kind: TinkerbellDatacenterConfig
     name: my-cluster-name
-  kubernetesVersion: "1.22"
+  kubernetesVersion: "1.23"
   managementCluster:
     name: my-cluster-name
   workerNodeGroupConfigurations:

--- a/docs/content/en/docs/reference/clusterspec/vsphere.md
+++ b/docs/content/en/docs/reference/clusterspec/vsphere.md
@@ -55,7 +55,7 @@ spec:
      machineGroupRef:
         kind: VSphereMachineConfig
         name: my-cluster-machines
-   kubernetesVersion: "1.22"
+   kubernetesVersion: "1.23"
    workerNodeGroupConfigurations:
    - count: 1
      machineGroupRef:

--- a/docs/content/en/docs/reference/vsphere/vsphere-ovas.md
+++ b/docs/content/en/docs/reference/vsphere/vsphere-ovas.md
@@ -99,7 +99,7 @@ environment variables to run `govc` GOVC_USERNAME, GOVC_PASSWORD and GOVC_URL.
    and cluster creation will be faster. If you prefer not to take snapshot, skip this step)
 
     ```
-    govc snapshot.create -vm ubuntu-2004-kube-v1.22.6 root
+    govc snapshot.create -vm ubuntu-2004-kube-v1.23.7 root
     ```
 
 4. Mark the new VM as a template
@@ -127,7 +127,7 @@ environment variables to run `govc` GOVC_USERNAME, GOVC_PASSWORD and GOVC_URL.
    ![Import ova wizard](/images/ss10.jpg)
 1. Click *Assign* -> *Add Tag* to create a new tag and attach it
    ![Import ova wizard](/images/ss11.jpg)
-1. Name the tag *eksdRelease:{eksd release for the selected ova}*, for example *eksdRelease:kubernetes-1-22-eks-6* for the 1.22 ova. You can find the rest of eksd releases in the previous [section](#import-an-ovaovf-template-to-vsphere). If it's the first time you add an `eksdRelease` tag, you would need to create the category first. Click on "Create New Category" and name it `eksdRelease`.
+1. Name the tag *eksdRelease:{eksd release for the selected ova}*, for example *eksdRelease:kubernetes-1-23-eks-4* for the 1.23 ova. You can find the rest of eksd releases in the previous [section](#import-an-ovaovf-template-to-vsphere). If it's the first time you add an `eksdRelease` tag, you would need to create the category first. Click on "Create New Category" and name it `eksdRelease`.
    ![Import ova wizard](/images/ss13.png)
 
 ### Using govc
@@ -162,13 +162,13 @@ govc tags.ls <Template Path>
 ```
 govc tags.category.create -t VirtualMachine eksdRelease
 ```
-2. Create the proper eksd release Tag, depending on your template. You can find the eksd releases in the previous [section](#import-an-ovaovf-template-to-vsphere). For example *eksdRelease:kubernetes-1-22-eks-6* for the 1.22 template.
+2. Create the proper eksd release Tag, depending on your template. You can find the eksd releases in the previous [section](#import-an-ovaovf-template-to-vsphere). For example *eksdRelease:kubernetes-1-23-eks-4* for the 1.23 template.
 ```
-govc tags.create -c eksdRelease eksdRelease:kubernetes-1-22-eks-6
+govc tags.create -c eksdRelease eksdRelease:kubernetes-1-23-eks-4
 ```
 3. Attach newly created tag to the template
 ```
-govc tags.attach eksdRelease:kubernetes-1-22-eks-6 <Template Path>
+govc tags.attach eksdRelease:kubernetes-1-23-eks-4 <Template Path>
 ```
 4. Verify tag is attached to the template 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating docs to reference 1.23 instead of 1.22, as well as update the other EKS-D releases. Using https://github.com/aws/eks-anywhere/pull/1560 as a reference

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

