### PR TITLE
Setting filewriter so it's non-nil to avoid panic

### DIFF
--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -123,6 +123,7 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 		deps.Provider,
 		deps.ClusterManager,
 		deps.GitOpsFlux,
+		deps.Writer,
 	)
 
 	var cluster *types.Cluster

--- a/pkg/workflows/delete.go
+++ b/pkg/workflows/delete.go
@@ -22,12 +22,14 @@ type Delete struct {
 
 func NewDelete(bootstrapper interfaces.Bootstrapper, provider providers.Provider,
 	clusterManager interfaces.ClusterManager, gitOpsManager interfaces.GitOpsManager,
+	writer filewriter.FileWriter,
 ) *Delete {
 	return &Delete{
 		bootstrapper:   bootstrapper,
 		provider:       provider,
 		clusterManager: clusterManager,
 		gitOpsManager:  gitOpsManager,
+		writer:         writer,
 	}
 }
 

--- a/pkg/workflows/delete_test.go
+++ b/pkg/workflows/delete_test.go
@@ -36,9 +36,9 @@ func newDeleteTest(t *testing.T) *deleteTestSetup {
 	mockBootstrapper := mocks.NewMockBootstrapper(mockCtrl)
 	clusterManager := mocks.NewMockClusterManager(mockCtrl)
 	gitOpsManager := mocks.NewMockGitOpsManager(mockCtrl)
-	_, w := test.NewWriter(t)
+	_, writer := test.NewWriter(t)
 	provider := providermocks.NewMockProvider(mockCtrl)
-	workflow := workflows.NewDelete(mockBootstrapper, provider, clusterManager, gitOpsManager, w)
+	workflow := workflows.NewDelete(mockBootstrapper, provider, clusterManager, gitOpsManager, writer)
 
 	return &deleteTestSetup{
 		t:                t,
@@ -47,7 +47,7 @@ func newDeleteTest(t *testing.T) *deleteTestSetup {
 		gitOpsManager:    gitOpsManager,
 		provider:         provider,
 		workflow:         workflow,
-		writer:           w,
+		writer:           writer,
 		ctx:              context.Background(),
 		clusterSpec:      test.NewClusterSpec(func(s *cluster.Spec) { s.Cluster.Name = "cluster-name" }),
 		bootstrapCluster: &types.Cluster{Name: "bootstrap"},

--- a/pkg/workflows/delete_test.go
+++ b/pkg/workflows/delete_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/bootstrapper"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/filewriter"
 	providermocks "github.com/aws/eks-anywhere/pkg/providers/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/workflows"
@@ -20,6 +21,7 @@ type deleteTestSetup struct {
 	bootstrapper     *mocks.MockBootstrapper
 	clusterManager   *mocks.MockClusterManager
 	gitOpsManager    *mocks.MockGitOpsManager
+	writer           filewriter.FileWriter
 	provider         *providermocks.MockProvider
 	workflow         *workflows.Delete
 	ctx              context.Context
@@ -34,8 +36,9 @@ func newDeleteTest(t *testing.T) *deleteTestSetup {
 	mockBootstrapper := mocks.NewMockBootstrapper(mockCtrl)
 	clusterManager := mocks.NewMockClusterManager(mockCtrl)
 	gitOpsManager := mocks.NewMockGitOpsManager(mockCtrl)
+	_, w := test.NewWriter(t)
 	provider := providermocks.NewMockProvider(mockCtrl)
-	workflow := workflows.NewDelete(mockBootstrapper, provider, clusterManager, gitOpsManager)
+	workflow := workflows.NewDelete(mockBootstrapper, provider, clusterManager, gitOpsManager, w)
 
 	return &deleteTestSetup{
 		t:                t,
@@ -44,6 +47,7 @@ func newDeleteTest(t *testing.T) *deleteTestSetup {
 		gitOpsManager:    gitOpsManager,
 		provider:         provider,
 		workflow:         workflow,
+		writer:           w,
 		ctx:              context.Background(),
 		clusterSpec:      test.NewClusterSpec(func(s *cluster.Spec) { s.Cluster.Name = "cluster-name" }),
 		bootstrapCluster: &types.Cluster{Name: "bootstrap"},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I observed a panic overnight in an e2e test which referenced a nil writer being dereferenced inside the TaskRunner's`RunTask` method. It appears that the writer in this workflow was never passed in or set, so this PR adds a writer in. Full panic below:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x2664a05]

goroutine 1 [running]:
github.com/aws/eks-anywhere/pkg/task.(*taskRunner).saveCheckpoint(0xc0002dfd10, {0x2da535d}, {0xc0003bcb70, 0x27})
        /codebuild/output/src406348551/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere/pkg/task/task.go:194 +0x165
github.com/aws/eks-anywhere/pkg/task.(*taskRunner).RunTask(0xc0002dfd10, {0x3235758, 0xc00013a000}, 0xc00047c0f0)
        /codebuild/output/src406348551/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere/pkg/task/task.go:164 +0x6db
github.com/aws/eks-anywhere/pkg/workflows.(*Delete).Run(0xc000a43cc8, {0x3235758, 0xc00013a000}, 0xc0002dfce0, 0xc000590a80, 0x80, {0xc000492400, 0x0})
        /codebuild/output/src406348551/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere/pkg/workflows/delete.go:56 +0x1df
github.com/aws/eks-anywhere/cmd/eksctl-anywhere/cmd.(*deleteClusterOptions).deleteCluster(0x478aa80, {0x3235758, 0xc00013a000})
        /codebuild/output/src406348551/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere/cmd/eksctl-anywhere/cmd/deletecluster.go:141 +0x5da
github.com/aws/eks-anywhere/cmd/eksctl-anywhere/cmd.glob..func5(0x4768500, {0xc0000b63f0, 0x3, 0x3})
        /codebuild/output/src406348551/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere/cmd/eksctl-anywhere/cmd/deletecluster.go:41 +0x72
github.com/spf13/cobra.(*Command).execute(0x4768500, {0xc0000b63c0, 0x3, 0x3})
        /go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0x476cd80)
        /go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
        /go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:902
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        /go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:895
github.com/aws/eks-anywhere/cmd/eksctl-anywhere/cmd.Execute()
        /codebuild/output/src406348551/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere/cmd/eksctl-anywhere/cmd/root.go:43 +0x54
main.main()
        /codebuild/output/src406348551/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere/cmd/eksctl-anywhere/main.go:29 +0x12a
    cluster.go:681: Error running command eksctl anywhere [delete cluster release-i-0f0f5-a2c976d -v 4]: exit status 2
```

*Testing (if applicable):*
Unit tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

