### PR TITLE
Remove kubeadm apiVersion from kind config

### DIFF
--- a/pkg/executables/config/kind.yaml
+++ b/pkg/executables/config/kind.yaml
@@ -7,7 +7,6 @@ networking:
 {{- end }}
 kubeadmConfigPatches:
   - |
-    apiVersion: kubeadm.k8s.io/v1beta2
     kind: ClusterConfiguration
     dns:
       type: CoreDNS

--- a/pkg/executables/testdata/kind_config.yaml
+++ b/pkg/executables/testdata/kind_config.yaml
@@ -2,7 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
   - |
-    apiVersion: kubeadm.k8s.io/v1beta2
     kind: ClusterConfiguration
     dns:
       type: CoreDNS

--- a/pkg/executables/testdata/kind_config_docker_mount.yaml
+++ b/pkg/executables/testdata/kind_config_docker_mount.yaml
@@ -5,7 +5,6 @@ networking:
   disableDefaultCNI: true
 kubeadmConfigPatches:
   - |
-    apiVersion: kubeadm.k8s.io/v1beta2
     kind: ClusterConfiguration
     dns:
       type: CoreDNS

--- a/pkg/executables/testdata/kind_config_docker_mount_networking.yaml
+++ b/pkg/executables/testdata/kind_config_docker_mount_networking.yaml
@@ -2,7 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
   - |
-    apiVersion: kubeadm.k8s.io/v1beta2
     kind: ClusterConfiguration
     dns:
       type: CoreDNS

--- a/pkg/executables/testdata/kind_config_extra_port_mappings.yaml
+++ b/pkg/executables/testdata/kind_config_extra_port_mappings.yaml
@@ -2,7 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
   - |
-    apiVersion: kubeadm.k8s.io/v1beta2
     kind: ClusterConfiguration
     dns:
       type: CoreDNS

--- a/pkg/executables/testdata/kind_config_registry_mirror_insecure.yaml
+++ b/pkg/executables/testdata/kind_config_registry_mirror_insecure.yaml
@@ -2,7 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
   - |
-    apiVersion: kubeadm.k8s.io/v1beta2
     kind: ClusterConfiguration
     dns:
       type: CoreDNS

--- a/pkg/executables/testdata/kind_config_registry_mirror_with_ca.yaml
+++ b/pkg/executables/testdata/kind_config_registry_mirror_with_ca.yaml
@@ -2,7 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
   - |
-    apiVersion: kubeadm.k8s.io/v1beta2
     kind: ClusterConfiguration
     dns:
       type: CoreDNS


### PR DESCRIPTION
*Description of changes:*

When not specified, kind will use the right apiVersion for the desired
kubernetes version. However, when specified, the patch will only apply
if the kubernetes version requires the specified kubeadm version. This
made it a problem when supporting 1.20 and 1.23 and the same time, since
1.20 requires v1beta2 and 1.23 requires v1beta3. By removing this line,
we let kind select the right one dynamically. This only works if the
specified fields in patch are compatible with both kubeadm versions,
otherwise, one patch per apiVersion is required. For now, we only use
stable fields available in both versions, so this is the easiest
solution.

More info:
https://github.com/kubernetes-sigs/kind/issues/1839#issuecomment-1148968204
https://github.com/cert-manager/cert-manager/pull/5187

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

