### PR TITLE
Change helm chart location to public registry

### DIFF
--- a/pkg/curatedpackages/reader.go
+++ b/pkg/curatedpackages/reader.go
@@ -12,10 +12,6 @@ import (
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
-const (
-	defaultRegistry = "783794618700.dkr.ecr.us-west-2.amazonaws.com"
-)
-
 type PackageReader struct {
 	*manifests.Reader
 }
@@ -70,9 +66,14 @@ func fetchPackages(ctx context.Context, versionsBundle releasev1.VersionsBundle,
 			Description: p.Name,
 			OS:          ctrl.OS,
 			OSName:      ctrl.OSName,
-			URI:         fmt.Sprintf("%s/%s:%s", defaultRegistry, p.Source.Repository, p.Source.Versions[0].Name),
+			URI:         fmt.Sprintf("%s/%s:%s", getDefaultRegistry(ctrl), p.Source.Repository, p.Source.Versions[0].Name),
 		}
 		images = append(images, pI)
 	}
 	return images, nil
+}
+
+func getDefaultRegistry(ctrl releasev1.Image) string {
+	registry := GetRegistry(ctrl.URI)
+	return registry
 }


### PR DESCRIPTION
*Description of changes:*
- Helm charts are currently located in public registry but only images are located in private registry.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

