### PR TITLE
Source latest tag for EKS-A packages Helm chart

### DIFF
--- a/release/pkg/assets/config/bundle_release.go
+++ b/release/pkg/assets/config/bundle_release.go
@@ -408,7 +408,7 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 				RepoName:             "eks-anywhere-packages",
 				TrimVersionSignifier: true,
 				ImageTagConfiguration: assettypes.ImageTagConfiguration{
-					SourceLatestTagFromECR: true,
+					NonProdSourceImageTagFormat: "<gitTag>",
 				},
 			},
 		},

--- a/release/pkg/images/images.go
+++ b/release/pkg/images/images.go
@@ -151,6 +151,9 @@ func GetSourceImageURI(r *releasetypes.ReleaseConfig, name, repoName string, tag
 				latestTag,
 			)
 		}
+		if strings.HasSuffix(name, "-helm") {
+			sourceImageUri += "-helm"
+		}
 		if !r.DryRun {
 			sourceEcrAuthConfig := r.SourceClients.ECR.AuthConfig
 			err := PollForExistence(r.DevRelease, sourceEcrAuthConfig, sourceImageUri, r.SourceContainerRegistry, r.ReleaseEnvironment, r.BuildRepoBranchName)


### PR DESCRIPTION
Instead of getting the latest tag by timestamp, this PR just sources the latest tag followed by `-helm` in case of dev release and staging release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

