### PR TITLE
Upload EKS-A tarballs before running tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -92,6 +92,19 @@ env:
 phases:
   pre_build:
     commands:
+      - export GIT_HASH=$(cat bin/githash)
+      - export CLUSTER_NAME_PREFIX="${BRANCH_NAME//./-}"
+      - >
+        ./cmd/integration_test/build/script/upload_artifacts.sh
+        $ARTIFACTS_BUCKET
+        $CODEBUILD_SRC_DIR
+        "eks-a-cli"
+        $CODEBUILD_BUILD_NUMBER
+        $GIT_HASH
+        "linux,darwin"
+        "amd64"
+        $BRANCH_NAME
+        false
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/setup_profile.sh
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/create_infra_config.sh
       - ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/start_docker.sh
@@ -126,19 +139,6 @@ phases:
   post_build:
     commands:
       - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE
-      - export GIT_HASH=$(cat bin/githash)
-      - export CLUSTER_NAME_PREFIX="${BRANCH_NAME//./-}"
-      - >
-        ./cmd/integration_test/build/script/upload_artifacts.sh
-        $ARTIFACTS_BUCKET
-        $CODEBUILD_SRC_DIR
-        "eks-a-cli"
-        $CODEBUILD_BUILD_NUMBER
-        $GIT_HASH
-        "linux,darwin"
-        "amd64"
-        $BRANCH_NAME
-        false
       - >
         ./bin/test e2e cleanup vsphere
         -n ${CLUSTER_NAME_PREFIX}


### PR DESCRIPTION
Tests take a while to run, so we don't want the release to be blocked by them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

