### PR TITLE
Add pkg prerequisites to sidebar

### DIFF
--- a/docs/content/en/docs/tasks/packages/prereq.md
+++ b/docs/content/en/docs/tasks/packages/prereq.md
@@ -1,3 +1,11 @@
+---
+title: "Prerequisites"
+linkTitle: "Prerequisites"
+weight: 13
+description: >
+  Prerequisites for using curated packages
+---
+
 ## Prerequisites
 Before installing any curated packages for EKS Anywhere, do the following:
 

--- a/docs/content/en/docs/tasks/packages/prereq.md
+++ b/docs/content/en/docs/tasks/packages/prereq.md
@@ -1,7 +1,7 @@
 ---
 title: "Prerequisites"
 linkTitle: "Prerequisites"
-weight: 13
+weight: 10
 description: >
   Prerequisites for using curated packages
 ---


### PR DESCRIPTION
*Issue #, if available:* Package prerequisites is currently not showing in the side bar
<img width="223" alt="Screen Shot 2022-08-19 at 8 33 01 AM" src="https://user-images.githubusercontent.com/19214133/185630413-cab01af6-67b8-4326-bdbd-9c16d402ed6c.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

