### PR TITLE
Add description for etcd backup and restore

### DIFF
--- a/docs/content/en/docs/tasks/cluster/etcd-backup-restore.md
+++ b/docs/content/en/docs/tasks/cluster/etcd-backup-restore.md
@@ -3,6 +3,8 @@ title: "Etcd Backup and Restore"
 linkTitle: "Etcd Backup and Restore"
 weight: 11
 date: 2021-11-04
+description: >
+  How to backup and restore an EKS Anywhere cluster
 ---
 
 >**_NOTE_**: External etcd topology is supported for vSphere clusters, but not yet for Bare Metal clusters.


### PR DESCRIPTION
*Issue #, if available:*

https://anywhere.eks.amazonaws.com/docs/tasks/cluster/

Etcd Backup and Restore section is missing description in the cluster management overview page.

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

