### PR TITLE
Upload tarballs to different folder for staging EKS-A release

### DIFF
--- a/cmd/integration_test/build/script/upload_artifacts.sh
+++ b/cmd/integration_test/build/script/upload_artifacts.sh
@@ -22,6 +22,7 @@ LATEST=latest
 if [[ $BRANCH_NAME != "main" ]]; then
   LATEST=$BRANCH_NAME
 fi
+CODEBUILD_CI="${CODEBUILD_CI:-false}"
 
 function build::cli::move_artifacts() {
   local -r os=$1
@@ -93,11 +94,20 @@ function build::cli::upload() {
   local -r latesttag=$6
   local -r dry_run=$7
 
+  local upload_path="$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts
+  local latest_upload_path="$artifactsbucket"/"$projectpath"/"$latesttag"
+  
+  if [ "$CODEBUILD_CI" = "true" ]; then
+    if [[ "$(CODEBUILD_BUILD_ID)" =~ "aws-staging-eks-a-test" ]]; then
+      upload_path="$upload_path"/staging
+      latest_upload_path="$latest_upload_path"/staging
+    fi
+  fi
   echo "$githash" >> "$artifactspath"/githash
 
   if [ "$dry_run" = "true" ]; then
-    aws s3 cp "$artifactspath" "$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --recursive --dryrun
-    aws s3 cp "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --recursive --dryrun
+    aws s3 cp "$artifactspath" "$upload_path" --recursive --dryrun
+    aws s3 cp "$artifactspath"  "$latest_upload_path" --dryrun
   else
     # Upload artifacts to s3
     # 1. To proper path on s3 with buildId-githash

--- a/release/pkg/bundles/eksctl-anywhere.go
+++ b/release/pkg/bundles/eksctl-anywhere.go
@@ -43,9 +43,12 @@ func GetEksACliArtifacts(r *releasetypes.ReleaseConfig) ([]releasetypes.Artifact
 		var releaseS3Path string
 		sourcedFromBranch := r.CliRepoBranchName
 		latestPath := artifactutils.GetLatestUploadDestination(sourcedFromBranch)
-		if r.DevRelease || r.ReleaseEnvironment == "development" {
+		if r.DevRelease {
 			sourceS3Key = fmt.Sprintf("eksctl-anywhere-%s-%s.tar.gz", os, arch)
 			sourceS3Prefix = fmt.Sprintf("eks-a-cli/%s/%s/%s", latestPath, os, arch)
+		} else if r.ReleaseEnvironment == "development" {
+			sourceS3Key = fmt.Sprintf("eksctl-anywhere-%s-%s.tar.gz", os, arch)
+			sourceS3Prefix = fmt.Sprintf("eks-a-cli/%s/staging/%s/%s/", latestPath, os, arch)
 		} else {
 			sourceS3Key = fmt.Sprintf("eksctl-anywhere-%s-%s-%s.tar.gz", r.ReleaseVersion, os, arch)
 			sourceS3Prefix = fmt.Sprintf("releases/eks-a/%d/artifacts/eks-a/%s/%s/%s", r.ReleaseNumber, r.ReleaseVersion, os, arch)


### PR DESCRIPTION
This will prevent CLI tarballs uploaded by staging release from being overwritten by the e2e pipelines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

