### PR TITLE
Fix flux git e2e

### DIFF
--- a/test/e2e/flux_test.go
+++ b/test/e2e/flux_test.go
@@ -290,7 +290,7 @@ func TestVSphereKubernetes122To123GitFluxUpgrade(t *testing.T) {
 	)
 }
 
-func TestDockerInstallFluxGitDuringUpgrade(t *testing.T) {
+func TestDockerInstallGitFluxDuringUpgrade(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
@@ -303,7 +303,7 @@ func TestDockerInstallFluxGitDuringUpgrade(t *testing.T) {
 	)
 }
 
-func TestDockerInstallFluxGithubDuringUpgrade(t *testing.T) {
+func TestDockerInstallGithubFluxDuringUpgrade(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
@@ -316,7 +316,7 @@ func TestDockerInstallFluxGithubDuringUpgrade(t *testing.T) {
 	)
 }
 
-func TestVSphereInstallFluxGitDuringUpgrade(t *testing.T) {
+func TestVSphereInstallGitFluxDuringUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu122())
 	test := framework.NewClusterE2ETest(t,
 		provider,


### PR DESCRIPTION
*Issue #, if available:*

Flux Git upgrade tests #3030 in are failing

```
2022-08-19T15:44:46.138Z	V3	Cleaning up long running container	{"name": "eksa_1660923081000441388"}
    envars.go:11: Required env var [EKSA_GIT_KNOWN_HOSTS] not present
```

*Description of changes:*

Update the e2e method names to follow the regex pattern: https://github.com/aws/eks-anywhere/blob/main/internal/test/e2e/fluxGit.go#L37 so that the required git envs will be set in CI.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

