### PR TITLE
Add mounts and insecure to import images

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -218,18 +218,26 @@ func (cc *createClusterOptions) directoriesToMount(clusterSpec *cluster.Spec, cl
 	}
 
 	if clusterSpec.Config.Cluster.Spec.DatacenterRef.Kind == v1alpha1.CloudStackDatacenterKind {
-		env, found := os.LookupEnv(decoder.EksaCloudStackHostPathToMount)
-		if found && len(env) > 0 {
-			mountDirs := strings.Split(env, ",")
-			for _, dir := range mountDirs {
-				if _, err := os.Stat(dir); err != nil {
-					return nil, fmt.Errorf("invalid host path to mount: %v", err)
-				}
-				dirs = append(dirs, dir)
-			}
+		if extraDirs, err := cc.extraDirectoriesToMount(); err == nil {
+			dirs = append(dirs, extraDirs...)
 		}
 	}
 
+	return dirs, nil
+}
+
+func (cc *createClusterOptions) extraDirectoriesToMount() ([]string, error) {
+	dirs := []string{}
+	env, found := os.LookupEnv(decoder.EksaCloudStackHostPathToMount)
+	if found && len(env) > 0 {
+		mountDirs := strings.Split(env, ",")
+		for _, dir := range mountDirs {
+			if _, err := os.Stat(dir); err != nil {
+				return nil, fmt.Errorf("invalid host path to mount: %v", err)
+			}
+			dirs = append(dirs, dir)
+		}
+	}
 	return dirs, nil
 }
 


### PR DESCRIPTION
*Issue #, if available:*

`import images` command has also a similar issue described in https://github.com/aws/eks-anywhere/issues/2878

*Description of changes:*

Adding --insecure flag to `import images` command (Refer to https://github.com/aws/eks-anywhere/pull/2879)
Mount `certs` directories if EKSA_CLOUDSTACK_HOST_PATHS_TO_MOUNT env var is defined

*Testing (if applicable):*

Manual test on a customer environment. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

