### PR TITLE
Omit TinkerbellMachineTemplate from upgrade specs.

### DIFF
--- a/pkg/controller/clientutil/yaml.go
+++ b/pkg/controller/clientutil/yaml.go
@@ -3,11 +3,11 @@ package clientutil
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/eks-anywhere/pkg/unstructuredutil"
+	"github.com/aws/eks-anywhere/pkg/utils/unstructured"
 )
 
 func YamlToClientObjects(yamlObjects []byte) ([]client.Object, error) {
-	unstructuredObjs, err := unstructuredutil.YamlToUnstructured(yamlObjects)
+	unstructuredObjs, err := unstructured.YamlToUnstructured(yamlObjects)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -73,7 +73,7 @@ func (p *Provider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *
 
 	// If we've been given a CSV with additional hardware for the cluster, validate it and
 	// write it to the catalogue so it can be used for further processing.
-	if p.hardareCSVIsProvided() {
+	if p.hardwareCSVIsProvided() {
 		machineCatalogueWriter := hardware.NewMachineCatalogueWriter(p.catalogue)
 
 		writer := hardware.MultiMachineWriter(machineCatalogueWriter, &p.diskExtractor)
@@ -204,6 +204,27 @@ func (p *Provider) UpgradeNeeded(_ context.Context, _, _ *cluster.Spec, _ *types
 	return false, nil
 }
 
-func (p *Provider) hardareCSVIsProvided() bool {
+func (p *Provider) hardwareCSVIsProvided() bool {
 	return p.hardwareCSVFile != ""
+}
+
+func (p *Provider) isScaleUpDown(currentSpec *cluster.Spec, newSpec *cluster.Spec) bool {
+	if currentSpec.Cluster.Spec.ControlPlaneConfiguration.Count != newSpec.Cluster.Spec.ControlPlaneConfiguration.Count {
+		return true
+	}
+
+	workerNodeGroupMap := make(map[string]*v1alpha1.WorkerNodeGroupConfiguration)
+	for _, workerNodeGroupConfiguration := range currentSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
+		workerNodeGroupMap[workerNodeGroupConfiguration.Name] = &workerNodeGroupConfiguration
+	}
+
+	for _, nodeGroupNewSpec := range newSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
+		if workerNodeGrpOldSpec, ok := workerNodeGroupMap[nodeGroupNewSpec.Name]; ok {
+			if nodeGroupNewSpec.Count != workerNodeGrpOldSpec.Count {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/pkg/utils/unstructured/yaml.go
+++ b/pkg/utils/unstructured/yaml.go
@@ -1,4 +1,4 @@
-package unstructuredutil
+package unstructured
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -8,4 +8,9 @@ import (
 func YamlToUnstructured(yamlObjects []byte) ([]unstructured.Unstructured, error) {
 	// Using this CAPI util for now, not sure if we want to depend on it but it's well written
 	return yaml.ToUnstructured(yamlObjects)
+}
+
+func UnstructuredToYaml(yamlObjects []unstructured.Unstructured) ([]byte, error) {
+	// Using this CAPI util for now, not sure if we want to depend on it but it's well written
+	return yaml.FromUnstructured(yamlObjects)
 }

--- a/pkg/utils/unstructured/yaml_test.go
+++ b/pkg/utils/unstructured/yaml_test.go
@@ -1,12 +1,13 @@
-package unstructuredutil_test
+package unstructured_test
 
 import (
+	"bytes"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/aws/eks-anywhere/pkg/unstructuredutil"
+	unstructuredutil "github.com/aws/eks-anywhere/pkg/utils/unstructured"
 )
 
 func TestYamlToClientObjects(t *testing.T) {
@@ -76,6 +77,76 @@ spec:
 			for _, obj := range got {
 				g.Expect(obj).To(Equal(tt.want[obj.GetName()]))
 			}
+		})
+	}
+}
+
+func TestClientObjectsToYaml(t *testing.T) {
+	tests := []struct {
+		name string
+		want []byte
+		objs []unstructured.Unstructured
+	}{
+		{
+			name: "two objects",
+			want: []byte(`apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-1
+  namespace: ns-1
+spec:
+  paused: true
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-2
+  namespace: ns-1
+spec:
+  controlPlaneEndpoint:
+    host: 1.1.1.1
+    port: 8080`),
+			objs: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "cluster.x-k8s.io/v1beta1",
+						"kind":       "Cluster",
+						"metadata": map[string]interface{}{
+							"name":      "cluster-1",
+							"namespace": "ns-1",
+						},
+						"spec": map[string]interface{}{
+							"paused": true,
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "cluster.x-k8s.io/v1beta1",
+						"kind":       "Cluster",
+						"metadata": map[string]interface{}{
+							"name":      "cluster-2",
+							"namespace": "ns-1",
+						},
+						"spec": map[string]interface{}{
+							"controlPlaneEndpoint": map[string]interface{}{
+								"host": "1.1.1.1",
+								"port": float64(8080),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got, err := unstructuredutil.UnstructuredToYaml(tt.objs)
+			g.Expect(err).To(BeNil(), "ClientObjectsToYaml() returned an error")
+			g.Expect(len(got)).To(Equal(len(tt.want)), "Should have got yaml of length", len(tt.want))
+			res := bytes.Compare(tt.want, got)
+			g.Expect(res).To(Equal(0), "ClientObjectsToYaml() produced erroneous yaml")
 		})
 	}
 }


### PR DESCRIPTION
TinkerbellMachineTemplate is immutable and does not need to be reapplied during
upgrade. templateOverride string field in TinkerbellMachineTemplate may have
changed build numbers for action images across different versions of EKS Anywhere.
Not unnecessarily reapplying TinkerbellMachineTemplate mitigates this issue.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

