### PR TITLE
Adding retries for reading remote EKS-D CRD's/manifests

### DIFF
--- a/pkg/eksd/installer.go
+++ b/pkg/eksd/installer.go
@@ -27,22 +27,21 @@ type Reader interface {
 
 type Installer struct {
 	client  EksdInstallerClient
-	// Exposing for unit testing purposes
-	Retrier *retrier.Retrier
+	retrier *retrier.Retrier
 	reader  Reader
 }
 
 func NewEksdInstaller(client EksdInstallerClient, reader Reader) *Installer {
 	return &Installer{
 		client:  client,
-		Retrier: retrier.NewWithMaxRetries(maxRetries, backOffPeriod),
+		retrier: retrier.NewWithMaxRetries(maxRetries, backOffPeriod),
 		reader:  reader,
 	}
 }
 
 func (i *Installer) InstallEksdCRDs(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster) error {
 	var eksdCRDs []byte
-	if err := i.Retrier.Retry(
+	if err := i.retrier.Retry(
 		func() error {
 			var readerErr error
 			eksdCRDs, readerErr = i.reader.ReadFile(clusterSpec.VersionsBundle.EksD.Components)
@@ -52,7 +51,7 @@ func (i *Installer) InstallEksdCRDs(ctx context.Context, clusterSpec *cluster.Sp
 		return fmt.Errorf("loading manifest for eksd components: %v", err)
 	}
 
-	if err := i.Retrier.Retry(
+	if err := i.retrier.Retry(
 		func() error {
 			return i.client.ApplyKubeSpecFromBytesWithNamespace(ctx, cluster, eksdCRDs, constants.EksaSystemNamespace)
 		},
@@ -63,9 +62,14 @@ func (i *Installer) InstallEksdCRDs(ctx context.Context, clusterSpec *cluster.Sp
 	return nil
 }
 
+// SetRetrier Exposing retrier for unit testing purposes
+func (i *Installer) SetRetrier(retrier *retrier.Retrier) {
+	i.retrier = retrier
+}
+
 func (i *Installer) InstallEksdManifest(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster) error {
 	var eksdReleaseManifest []byte
-	if err := i.Retrier.Retry(
+	if err := i.retrier.Retry(
 		func() error {
 			var readerErr error
 			eksdReleaseManifest, readerErr = i.reader.ReadFile(clusterSpec.VersionsBundle.EksD.EksDReleaseUrl)
@@ -76,7 +80,7 @@ func (i *Installer) InstallEksdManifest(ctx context.Context, clusterSpec *cluste
 	}
 
 	logger.V(4).Info("Applying eksd manifest to cluster")
-	if err := i.Retrier.Retry(
+	if err := i.retrier.Retry(
 		func() error {
 			return i.client.ApplyKubeSpecFromBytesWithNamespace(ctx, cluster, eksdReleaseManifest, constants.EksaSystemNamespace)
 		},

--- a/pkg/eksd/installer.go
+++ b/pkg/eksd/installer.go
@@ -62,7 +62,8 @@ func (i *Installer) InstallEksdCRDs(ctx context.Context, clusterSpec *cluster.Sp
 	return nil
 }
 
-// SetRetrier Exposing retrier for unit testing purposes
+// SetRetrier allows to modify the internal retrier
+// For unit testing purposes only. It is not thread safe
 func (i *Installer) SetRetrier(retrier *retrier.Retrier) {
 	i.retrier = retrier
 }

--- a/pkg/eksd/installer_test.go
+++ b/pkg/eksd/installer_test.go
@@ -91,7 +91,7 @@ func TestInstallEksdManifestErrorReadingManifest(t *testing.T) {
 	tt := newInstallerTest(t)
 	tt.clusterSpec.VersionsBundle.EksD.EksDReleaseUrl = "fake.yaml"
 
-	tt.reader.EXPECT().ReadFile(tt.clusterSpec.VersionsBundle.EksD.EksDReleaseUrl).Return([]byte(""), fmt.Errorf("error"))
+	tt.reader.EXPECT().ReadFile(tt.clusterSpec.VersionsBundle.EksD.EksDReleaseUrl).Return([]byte(""), fmt.Errorf("error")).Times(5)
 	if err := tt.eksdInstaller.InstallEksdManifest(tt.ctx, tt.clusterSpec, tt.cluster); err == nil {
 		t.Error("Eksd.InstallEksdManifest() error = nil, wantErr not nil")
 	}

--- a/pkg/eksd/installer_test.go
+++ b/pkg/eksd/installer_test.go
@@ -3,9 +3,10 @@ package eksd_test
 import (
 	"context"
 	"fmt"
-	"github.com/aws/eks-anywhere/pkg/retrier"
 	"os"
 	"testing"
+
+	"github.com/aws/eks-anywhere/pkg/retrier"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
@@ -90,7 +91,7 @@ func TestInstallEksdManifestSuccess(t *testing.T) {
 
 func TestInstallEksdManifestErrorReadingManifest(t *testing.T) {
 	tt := newInstallerTest(t)
-	tt.eksdInstaller.Retrier = retrier.NewWithMaxRetries(1, 0)
+	tt.eksdInstaller.SetRetrier(retrier.NewWithMaxRetries(1, 0))
 	tt.clusterSpec.VersionsBundle.EksD.EksDReleaseUrl = "fake.yaml"
 
 	tt.reader.EXPECT().ReadFile(tt.clusterSpec.VersionsBundle.EksD.EksDReleaseUrl).Return([]byte(""), fmt.Errorf("error"))

--- a/pkg/eksd/installer_test.go
+++ b/pkg/eksd/installer_test.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/aws/eks-anywhere/pkg/retrier"
-
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 
@@ -18,6 +16,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/eksd"
 	"github.com/aws/eks-anywhere/pkg/eksd/mocks"
 	"github.com/aws/eks-anywhere/pkg/features"
+	"github.com/aws/eks-anywhere/pkg/retrier"
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 

--- a/pkg/eksd/installer_test.go
+++ b/pkg/eksd/installer_test.go
@@ -3,6 +3,7 @@ package eksd_test
 import (
 	"context"
 	"fmt"
+	"github.com/aws/eks-anywhere/pkg/retrier"
 	"os"
 	"testing"
 
@@ -89,9 +90,10 @@ func TestInstallEksdManifestSuccess(t *testing.T) {
 
 func TestInstallEksdManifestErrorReadingManifest(t *testing.T) {
 	tt := newInstallerTest(t)
+	tt.eksdInstaller.Retrier = retrier.NewWithMaxRetries(1, 0)
 	tt.clusterSpec.VersionsBundle.EksD.EksDReleaseUrl = "fake.yaml"
 
-	tt.reader.EXPECT().ReadFile(tt.clusterSpec.VersionsBundle.EksD.EksDReleaseUrl).Return([]byte(""), fmt.Errorf("error")).Times(5)
+	tt.reader.EXPECT().ReadFile(tt.clusterSpec.VersionsBundle.EksD.EksDReleaseUrl).Return([]byte(""), fmt.Errorf("error"))
 	if err := tt.eksdInstaller.InstallEksdManifest(tt.ctx, tt.clusterSpec, tt.cluster); err == nil {
 		t.Error("Eksd.InstallEksdManifest() error = nil, wantErr not nil")
 	}

--- a/pkg/eksd/upgrader_test.go
+++ b/pkg/eksd/upgrader_test.go
@@ -3,7 +3,6 @@ package eksd_test
 import (
 	"context"
 	"fmt"
-	"github.com/aws/eks-anywhere/pkg/retrier"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -15,6 +14,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/eksd"
 	"github.com/aws/eks-anywhere/pkg/eksd/mocks"
+	"github.com/aws/eks-anywhere/pkg/retrier"
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 
@@ -88,7 +88,7 @@ func TestEksdUpgradeSuccess(t *testing.T) {
 
 func TestUpgraderEksdUpgradeInstallError(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.eksdUpgrader.Retrier = retrier.NewWithMaxRetries(1, 0)
+	tt.eksdUpgrader.SetRetrier(retrier.NewWithMaxRetries(1, 0))
 	tt.newSpec.VersionsBundle.EksD.Name = "eks-d-2"
 
 	tt.reader.EXPECT().ReadFile(tt.newSpec.VersionsBundle.EksD.EksDReleaseUrl).Return([]byte(""), fmt.Errorf("error"))

--- a/pkg/eksd/upgrader_test.go
+++ b/pkg/eksd/upgrader_test.go
@@ -3,6 +3,7 @@ package eksd_test
 import (
 	"context"
 	"fmt"
+	"github.com/aws/eks-anywhere/pkg/retrier"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -87,10 +88,10 @@ func TestEksdUpgradeSuccess(t *testing.T) {
 
 func TestUpgraderEksdUpgradeInstallError(t *testing.T) {
 	tt := newUpgraderTest(t)
-
+	tt.eksdUpgrader.Retrier = retrier.NewWithMaxRetries(1, 0)
 	tt.newSpec.VersionsBundle.EksD.Name = "eks-d-2"
 
-	tt.reader.EXPECT().ReadFile(tt.newSpec.VersionsBundle.EksD.EksDReleaseUrl).Return([]byte(""), fmt.Errorf("error")).Times(5)
+	tt.reader.EXPECT().ReadFile(tt.newSpec.VersionsBundle.EksD.EksDReleaseUrl).Return([]byte(""), fmt.Errorf("error"))
 	// components file not set so this should return an error in failing to load manifest
 	_, err := tt.eksdUpgrader.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)
 	tt.Expect(err).NotTo(BeNil())

--- a/pkg/eksd/upgrader_test.go
+++ b/pkg/eksd/upgrader_test.go
@@ -90,7 +90,7 @@ func TestUpgraderEksdUpgradeInstallError(t *testing.T) {
 
 	tt.newSpec.VersionsBundle.EksD.Name = "eks-d-2"
 
-	tt.reader.EXPECT().ReadFile(tt.newSpec.VersionsBundle.EksD.EksDReleaseUrl).Return([]byte(""), fmt.Errorf("error"))
+	tt.reader.EXPECT().ReadFile(tt.newSpec.VersionsBundle.EksD.EksDReleaseUrl).Return([]byte(""), fmt.Errorf("error")).Times(5)
 	// components file not set so this should return an error in failing to load manifest
 	_, err := tt.eksdUpgrader.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)
 	tt.Expect(err).NotTo(BeNil())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While performing some scaling testing, I observed several occasions where EKS-A was unable to fetch EKS-D CRDs/manifests and never retried. This connection failure resulted in cluster creation failing. This felt like a defect as we work to make EKS-A more robust, so this PR adds retry logic to the reader calls.

Adding this retry logic does slow down the unit tests to account for the retries and waits.

This logic could also be added at the Reader level itself. However, that leads to a myriad of other issues, including unit tests failing in the cluster_manager because the gomock matcher no longer recognizes two cluster.Specs as equivalent because their nested Reader resources differ. 

*Testing (if applicable):*
Created cluster using debugger in goland and observed that the EKS-D resources were correctly retrieved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

