### PR TITLE
Generalize the package installation

### DIFF
--- a/docs/content/en/docs/getting-started/local-environment/_index.md
+++ b/docs/content/en/docs/getting-started/local-environment/_index.md
@@ -68,108 +68,50 @@ To install the EKS Anywhere binaries and see system requirements please follow t
       * [proxy]({{< relref "../../reference/clusterspec/optional/proxy" >}})
       * [gitops]({{< relref "../../reference/clusterspec/optional/gitops" >}})
 
-2. Create Cluster: Create your cluster either with or without curated packages:
+1. Configure Curated Packages
 
-   - Cluster creation without curated packages installation
+   The Amazon EKS Anywhere Curated Packages are only available to customers with the Amazon EKS Anywhere Enterprise Subscription. To request a free trial, talk to your Amazon representative or connect with one [here](https://aws.amazon.com/contact-us/sales-support-eks/). Cluster creation will succeed if authentication is not set up, but some warnings may be genered.  Detailed package configurations can be found [here]({{< relref "../../tasks/packages" >}}).
+
+   If you are going to use packages, set up authentication:
+   ```bash
+   export EKSA_AWS_ACCESS_KEY_ID="your*access*id"
+   export EKSA_AWS_SECRET_ACCESS_KEY="your*secret*key"  
+   ```
      
-      *Note* The Amazon EKS Anywhere Curated Packages are only available to customers with the Amazon EKS Anywhere Enterprise Subscription. Due to this there might be some warnings in the CLI if proper authentication is not set up. 
-      ```bash
-      eksctl anywhere create cluster -f $CLUSTER_NAME.yaml
-      ```
-      Example command output
-      ```
-      Performing setup and validations
-      ✅ validation succeeded {"validation": "docker Provider setup is valid"}
-      Creating new bootstrap cluster
-      Installing cluster-api providers on bootstrap cluster
-      Provider specific setup
-      Creating new workload cluster
-      Installing networking on workload cluster
-      Installing cluster-api providers on workload cluster
-      Moving cluster management from bootstrap to workload cluster
-      Installing EKS-A custom components (CRD and controller) on workload cluster
-      Creating EKS-A CRDs instances on workload cluster
-      Installing GitOps Toolkit on workload cluster
-      GitOps field not specified, bootstrap flux skipped
-      Deleting bootstrap cluster
-      🎉 Cluster created!
-      ----------------------------------------------------------------------------------
-      The Amazon EKS Anywhere Curated Packages are only available to customers with the
-      Amazon EKS Anywhere Enterprise Subscription
-      ----------------------------------------------------------------------------------
-      Installing helm chart on cluster	{"chart": "eks-anywhere-packages", "version": "0.2.0-eks-a-v0.0.0-dev-build.3842"}
-      secret/aws-secret created
-      job.batch/eksa-auth-refresher created
-      ```
-   - Cluster creation with optional curated packages
+1. Create cluster
 
-     {{% alert title="Note" color="primary" %}}
-   * It is *optional* to install curated packages as part of the cluster creation.
-   * `eksctl anywhere version` version should be `v0.11.0` or later.
-   * Post-creation installation and detailed package configurations can be found [here.]({{< relref "../../tasks/packages" >}})
-   * The Amazon EKS Anywhere Curated Packages are only available to customers with the Amazon EKS Anywhere Enterprise Subscription. To request a free trial, talk to your Amazon representative or connect with one [here](https://aws.amazon.com/contact-us/sales-support-eks/)
-     {{% /alert %}}
+   ```bash
+   # Create a cluster with curated packages installation
+   eksctl anywhere create cluster -f $CLUSTER_NAME.yaml
+   ```
 
-      * Setup authentication to use curated-packages
-         ```bash
-         $ export EKSA_AWS_ACCESS_KEY_ID="your*access*id"
-         $ export EKSA_AWS_SECRET_ACCESS_KEY="your*secret*key"  
-         ```
-     
-      * Discover curated-packages to install
-         ```bash
-         eksctl anywhere list packages --source registry --kube-version 1.23
-         ```
-         Example command output
-         ```                 
-         Package                 Version(s)                                       
-         -------                 ----------                                       
-         hello-eks-anywhere      0.1.1-a217465b3b2d165634f9c24a863fa67349c7268a   
-         harbor                  2.5.1-a217465b3b2d165634f9c24a863fa67349c7268a   
-         metallb                 0.12.1-b9e4e5d941ccd20c72b4fec366ffaddb79bbc578  
-         emissary                3.0.0-a507e09c2a92c83d65737835f6bac03b9b341467
-         ```
-        
-      * Generate a curated-packages config
+   Example command output
+   ```
+   Performing setup and validations
+   ✅ validation succeeded {"validation": "docker Provider setup is valid"}
+   Creating new bootstrap cluster
+   Installing cluster-api providers on bootstrap cluster
+   Provider specific setup
+   Creating new workload cluster
+   Installing networking on workload cluster
+   Installing cluster-api providers on workload cluster
+   Moving cluster management from bootstrap to workload cluster
+   Installing EKS-A custom components (CRD and controller) on workload cluster
+   Creating EKS-A CRDs instances on workload cluster
+   Installing GitOps Toolkit on workload cluster
+   GitOps field not specified, bootstrap flux skipped
+   Deleting bootstrap cluster
+   🎉 Cluster created!
+   ------------------------------------------------------------------------------------------------------------------------------
+   The Amazon EKS Anywhere Curated Packages are only available to customers with the Amazon EKS Anywhere Enterprise Subscription.
+   ------------------------------------------------------------------------------------------------------------------------------
+   Installing helm chart on cluster	{"chart": "eks-anywhere-packages", "version": "0.2.0-eks-a-v0.0.0-dev-build.3842"}
+   secret/aws-secret created
+   job.batch/eksa-auth-refresher created
+   package.packages.eks.amazonaws.com/my-harbor created
+   ```
 
-         The example shows how to install the `harbor` package from the [curated package list]({{< relref "../../reference/packagespec" >}}).
-         ```bash
-         eksctl anywhere generate package harbor --source registry --kube-version 1.23 > packages.yaml
-         ```
-
-      * Create a cluster
-
-         ```bash
-         # Create a cluster with curated packages installation
-         eksctl anywhere create cluster -f $CLUSTER_NAME.yaml --install-packages packages.yaml
-         ```
-         Example command output
-         ```
-         Performing setup and validations
-         ✅ validation succeeded {"validation": "docker Provider setup is valid"}
-         Creating new bootstrap cluster
-         Installing cluster-api providers on bootstrap cluster
-         Provider specific setup
-         Creating new workload cluster
-         Installing networking on workload cluster
-         Installing cluster-api providers on workload cluster
-         Moving cluster management from bootstrap to workload cluster
-         Installing EKS-A custom components (CRD and controller) on workload cluster
-         Creating EKS-A CRDs instances on workload cluster
-         Installing GitOps Toolkit on workload cluster
-         GitOps field not specified, bootstrap flux skipped
-         Deleting bootstrap cluster
-         🎉 Cluster created!
-         ------------------------------------------------------------------------------------------------------------------------------
-         The Amazon EKS Anywhere Curated Packages are only available to customers with the Amazon EKS Anywhere Enterprise Subscription.
-         ------------------------------------------------------------------------------------------------------------------------------
-         Installing helm chart on cluster	{"chart": "eks-anywhere-packages", "version": "0.2.0-eks-a-v0.0.0-dev-build.3842"}
-         secret/aws-secret created
-         job.batch/eksa-auth-refresher created
-         package.packages.eks.amazonaws.com/my-harbor created
-         ```
-
-3. Use the cluster
+1. Use the cluster
 
    Once the cluster is created you can use it with the generated `KUBECONFIG` file in your local directory
 

--- a/docs/content/en/docs/getting-started/production-environment/baremetal-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/baremetal-getstarted.md
@@ -53,62 +53,29 @@ Follow these steps to create an EKS Anywhere cluster.
 
    After you have created your `eksa-mgmt-cluster.yaml` and set your credential environment variables, you will be ready to create the cluster.
 
-1. Create the cluster, using the `hardware.csv` file you made in [Bare Metal preparation]({{< relref "/docs/reference/baremetal/bare-preparation.md" >}}),
-   either with or without curated packages:
-   - Cluster creation without curated packages installation
-      ```bash
-      # Create a cluster without curated packages installation
-      eksctl anywhere create cluster --hardware-csv hardware.csv -f eksa-mgmt-cluster.yaml
-      ```
 
-   - Cluster creation with optional curated packages
+1. Configure Curated Packages
 
-     {{% alert title="Note" color="primary" %}}
-   * It is *optional* to install the curated packages as part of the cluster creation.
-   * `eksctl anywhere version` version should be `v0.11.0` or later.
-   * Post-creation installation and detailed package configurations can be found [here.]({{< relref "../../tasks/packages" >}})
-   * The Amazon EKS Anywhere Curated Packages are only available to customers with the Amazon EKS Anywhere Enterprise Subscription. To request a free trial, talk to your Amazon representative or connect with one [here](https://aws.amazon.com/contact-us/sales-support-eks/)
-     {{% /alert %}}
-   
-      * Setup authentication to use curated-packages
-         ```bash
-         $ export EKSA_AWS_ACCESS_KEY_ID="your*access*id"
-         $ export EKSA_AWS_SECRET_ACCESS_KEY="your*secret*key"  
-         ```
+   The Amazon EKS Anywhere Curated Packages are only available to customers with the Amazon EKS Anywhere Enterprise Subscription. To request a free trial, talk to your Amazon representative or connect with one [here](https://aws.amazon.com/contact-us/sales-support-eks/). Cluster creation will succeed if authentication is not set up, but some warnings may be genered.  Detailed package configurations can be found [here]({{< relref "../../tasks/packages" >}}).
 
-      * Discover curated packages to install
-         ```bash
-         eksctl anywhere list packages --source registry --kube-version 1.23
-         ```
-         Example command output:
-         ```                 
-         Package                 Version(s)                                       
-         -------                 ----------                                       
-         hello-eks-anywhere      0.1.1-a217465b3b2d165634f9c24a863fa67349c7268a   
-         harbor                  2.5.1-a217465b3b2d165634f9c24a863fa67349c7268a   
-         metallb                 0.12.1-b9e4e5d941ccd20c72b4fec366ffaddb79bbc578  
-         emissary                3.0.0-a507e09c2a92c83d65737835f6bac03b9b341467
-         ```
-      * Generate a curated-packages config
-
-         The example shows how to install the `harbor` package from the [curated package list]({{< relref "../../reference/packagespec" >}}).
-         ```bash
-         eksctl anywhere generate package harbor --source registry --kube-version 1.23 > packages.yaml
-         ```
-
-      * Create the initial cluster
-
-         ```bash
-         # Create a cluster with curated packages installation
-         eksctl anywhere create cluster -f eksa-mgmt-cluster.yaml \
-            --hardware-csv hardware.csv --install-packages packages.yaml
-         ```
+   If you are going to use packages, set up authentication:
+   ```bash
+   export EKSA_AWS_ACCESS_KEY_ID="your*access*id"
+   export EKSA_AWS_SECRET_ACCESS_KEY="your*secret*key"  
+   ```
+     
+1. Create the cluster, using the `hardware.csv` file you made in [Bare Metal preparation]({{< relref "/docs/reference/baremetal/bare-preparation.md" >}}):
+   ```bash
+   # Create a cluster without curated packages installation
+   eksctl anywhere create cluster --hardware-csv hardware.csv -f eksa-mgmt-cluster.yaml
+   ```
 
 1. Once the cluster is created you can use it with the generated `KUBECONFIG` file in your local directory:
 
    ```bash
    export KUBECONFIG=${PWD}/${CLUSTER_NAME}/${CLUSTER_NAME}-eks-a-cluster.kubeconfig
    ```
+
 1. Check the cluster nodes:
 
    To check that the cluster completed, list the machines to see the control plane and worker nodes:

--- a/docs/content/en/docs/getting-started/production-environment/vsphere-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/vsphere-getstarted.md
@@ -93,9 +93,9 @@ Make sure you use single quotes around the values so that your shell does not in
    export EKSA_AWS_SECRET_ACCESS_KEY="your*secret*key"  
    ```
      
-1. Create initial cluster: Create your initial cluster either with or without curated packages:
+1. Create cluster
+
    ```bash
-   # Create a cluster without curated packages installation
    eksctl anywhere create cluster -f eksa-mgmt-cluster.yaml
    ```
 

--- a/docs/content/en/docs/getting-started/production-environment/vsphere-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/vsphere-getstarted.md
@@ -83,54 +83,21 @@ Make sure you use single quotes around the values so that your shell does not in
    After you have created your `eksa-mgmt-cluster.yaml` and set your credential environment variables, you will be ready to create the cluster.
 
 
+1. Configure Curated Packages
+
+   The Amazon EKS Anywhere Curated Packages are only available to customers with the Amazon EKS Anywhere Enterprise Subscription. To request a free trial, talk to your Amazon representative or connect with one [here](https://aws.amazon.com/contact-us/sales-support-eks/). Cluster creation will succeed if authentication is not set up, but some warnings may be genered.  Detailed package configurations can be found [here]({{< relref "../../tasks/packages" >}}).
+
+   If you are going to use packages, set up authentication:
+   ```bash
+   export EKSA_AWS_ACCESS_KEY_ID="your*access*id"
+   export EKSA_AWS_SECRET_ACCESS_KEY="your*secret*key"  
+   ```
+     
 1. Create initial cluster: Create your initial cluster either with or without curated packages:
-   - Cluster creation  without curated packages installation
-      ```bash
-      # Create a cluster without curated packages installation
-      eksctl anywhere create cluster -f eksa-mgmt-cluster.yaml
-      ```
-
-   - Cluster creation with optional curated packages
-
-     {{% alert title="Note" color="primary" %}}
-   * It is *optional* to install the curated packages as part of the cluster creation.
-   * `eksctl anywhere version` version should be `v0.11.0` or later.
-   * Post-creation installation and detailed package configurations can be found [here.]({{< relref "../../tasks/packages" >}})
-   * The Amazon EKS Anywhere Curated Packages are only available to customers with the Amazon EKS Anywhere Enterprise Subscription. To request a free trial, talk to your Amazon representative or connect with one [here](https://aws.amazon.com/contact-us/sales-support-eks/).
-     {{% /alert %}}
-
-      * Setup authentication to use curated-packages
-         ```bash
-         $ export EKSA_AWS_ACCESS_KEY_ID="your*access*id"
-         $ export EKSA_AWS_SECRET_ACCESS_KEY="your*secret*key"  
-         ```
-
-      * Discover curated packages to install
-         ```bash
-         eksctl anywhere list packages --source registry --kube-version 1.23
-         ```
-         Example command output
-         ```                 
-         Package                 Version(s)                                       
-         -------                 ----------                                       
-         hello-eks-anywhere      0.1.1-a217465b3b2d165634f9c24a863fa67349c7268a   
-         harbor                  2.5.1-a217465b3b2d165634f9c24a863fa67349c7268a   
-         metallb                 0.12.1-b9e4e5d941ccd20c72b4fec366ffaddb79bbc578  
-         emissary                3.0.0-a507e09c2a92c83d65737835f6bac03b9b341467
-         ```
-      * Generate a curated-packages config
-
-         The example shows how to install the `harbor` package from the [curated package list]({{< relref "../../reference/packagespec" >}}).
-         ```bash
-         eksctl anywhere generate package harbor --source registry --kube-version 1.23 > packages.yaml
-         ```
-
-      * Create the initial cluster
-
-         ```bash
-         # Create a cluster with curated packages installation
-         eksctl anywhere create cluster -f eksa-mgmt-cluster.yaml --install-packages packages.yaml
-         ```
+   ```bash
+   # Create a cluster without curated packages installation
+   eksctl anywhere create cluster -f eksa-mgmt-cluster.yaml
+   ```
 
 1. Once the cluster is created you can use it with the generated `KUBECONFIG` file in your local directory:
 

--- a/docs/content/en/docs/tasks/packages/_index.md
+++ b/docs/content/en/docs/tasks/packages/_index.md
@@ -9,4 +9,40 @@ description: >
 
 The main goal of EKS Anywhere curated packages is to make it easy to install, configure and maintain operational components in an EKS Anywhere cluster. EKS Anywhere curated packages offers to run secure and tested operational components on EKS Anywhere clusters. Please check out [EKS Anywhere curated packages concepts]({{< relref "../../concepts/packages" >}}) and [EKS Anywhere curated packages configurations]({{< relref "../../reference/clusterspec/packages.md" >}}) for more details.
 
+Use the `eksctl anywhere version` command to verify you are running `v0.11.0` or later for curated package support. Amazon EKS Anywhere Curated Packages are only available to customers with the Amazon EKS Anywhere Enterprise Subscription. To request a free trial, talk to your Amazon representative or connect with one [here](https://aws.amazon.com/contact-us/sales-support-eks/).
+
+### Setup authentication to use curated-packages
+
+When you are creating a cluster, you must set and export the following environment variables:
+
+```bash
+export EKSA_AWS_ACCESS_KEY_ID="your*access*id"
+export EKSA_AWS_SECRET_ACCESS_KEY="your*secret*key"  
+```
+
+### Discover curated packages
+
+You can get a list of the available packages from the commanhd line:
+
+```bash
+eksctl anywhere list packages --source registry --kube-version 1.23
+```
+
+Example command output:
+```                 
+Package                 Version(s)                                       
+-------                 ----------                                       
+hello-eks-anywhere      0.1.1-a217465b3b2d165634f9c24a863fa67349c7268a   
+harbor                  2.5.1-a217465b3b2d165634f9c24a863fa67349c7268a   
+metallb                 0.12.1-b9e4e5d941ccd20c72b4fec366ffaddb79bbc578  
+emissary                3.0.0-a507e09c2a92c83d65737835f6bac03b9b341467
+```
+
+### Generate a curated-packages config
+
+The example shows how to install the `harbor` package from the [curated package list]({{< relref "../../reference/packagespec" >}}).
+```bash
+eksctl anywhere generate package harbor --source registry --kube-version 1.23 > packages.yaml
+```
+
 Available curated packages are listed below.

--- a/docs/content/en/docs/tasks/troubleshoot/packages.md
+++ b/docs/content/en/docs/tasks/troubleshoot/packages.md
@@ -100,6 +100,29 @@ This is most like because the machine running kubelet in your Kubernetes cluster
 ctr image pull public.ecr.aws/eks-anywhere/eks-anywhere-packages@sha256:whateveritis
 ```
 
+### Package pod cannot pull images
+If a package pod cannot pull images, you may not have your AWS credentials set up properly:
+
+#### Verify you are authenticated with the CLI
+
+Make sure you are authenticated with the AWS CLI
+
+```
+aws sts get-caller-identity
+```
+
+#### Login to docker
+
+`aws ecr get-login-password |docker login --username AWS --password-stdin 783794618700.dkr.ecr.us-west-2.amazonaws.com`
+
+#### Verify you can pull an image
+
+```
+docker pull 783794618700.dkr.ecr.us-west-2.amazonaws.com/emissary-ingress/emissary:v3.0.0-9ded128b4606165b41aca52271abe7fa44fa7109
+```
+
+If the image downloads successfully, it worked!
+
 ### Error: cert-manager is not present in the cluster
 ```
 Error: curated packages cannot be installed as cert-manager is not present in the cluster


### PR DESCRIPTION
The docs claim that curated packages installation is optional and that is not the case anymore. The package controller gets installed every time, but may not be used.

I also pulled out the repeated text and moved it to the packages tasks docs.