### PR TITLE
Fix Cilium reconciler flaky tests

### DIFF
--- a/internal/test/envtest/client.go
+++ b/internal/test/envtest/client.go
@@ -1,0 +1,45 @@
+package envtest
+
+import (
+	"context"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Object interface {
+	client.Object
+	schema.ObjectKind
+}
+
+// CreateObjs creates Objects using the provided kube client and waits until its cache
+// has been updated with those objects
+func CreateObjs(ctx context.Context, t testing.TB, client client.Client, objs ...Object) {
+	t.Helper()
+	for _, obj := range objs {
+		// client.Create cleans the group version and kind of the objects
+		// We just save it before calling and it and restore it later,
+		// just so we can use it to perform the get later
+		objKind := obj.GroupVersionKind()
+		if err := client.Create(ctx, obj); err != nil {
+			t.Fatal(err)
+		}
+		obj.SetGroupVersionKind(objKind)
+	}
+
+	for _, obj := range objs {
+		for {
+			o := &unstructured.Unstructured{}
+			o.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
+			if err := client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, o); err == nil {
+				break
+			} else if !apierrors.IsNotFound(err) {
+				t.Fatal(err)
+			}
+		}
+	}
+}

--- a/internal/test/envtest/client_test.go
+++ b/internal/test/envtest/client_test.go
@@ -1,0 +1,99 @@
+package envtest_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aws/eks-anywhere/internal/test/envtest"
+)
+
+type notFailT struct {
+	*testing.T
+	failed       bool
+	panicMessage string
+}
+
+func (n *notFailT) Fatal(args ...interface{}) {
+	n.Logf("Expected failure: %s", fmt.Sprint(args...))
+	n.failed = true
+	panic(n.panicMessage)
+}
+
+func newNotFailT(t *testing.T) *notFailT {
+	return &notFailT{
+		T:            t,
+		panicMessage: "failed in notFailT",
+	}
+}
+
+func expectToFailTest(t *testing.T, f func(t testing.TB)) {
+	t.Helper()
+	testT := newNotFailT(t)
+	defer func() {
+		if r := recover(); r != nil {
+			if s, ok := r.(string); !ok || s != testT.panicMessage {
+				panic(r)
+			}
+		}
+	}()
+
+	f(testT)
+	t.Fatal("Expected to fail test but didn't")
+}
+
+func TestCreateObjs(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	ctx := context.Background()
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "s",
+			Namespace: "eksa-system",
+		},
+	}
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm",
+			Namespace: "eksa-system",
+		},
+	}
+
+	envtest.CreateObjs(ctx, t, client, secret, cm)
+}
+
+func TestCreateObjsErrorGet(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	ctx := context.Background()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "s",
+			Namespace: "eksa-system",
+		},
+	}
+
+	expectToFailTest(t, func(tb testing.TB) {
+		envtest.CreateObjs(ctx, tb, client, secret)
+	})
+}
+
+func TestCreateObjsErrorCreate(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	ctx := context.Background()
+	secret := &corev1.Secret{}
+
+	expectToFailTest(t, func(tb testing.TB) {
+		envtest.CreateObjs(ctx, tb, client, secret)
+	})
+}

--- a/pkg/networking/cilium/reconciler/reconciler_test.go
+++ b/pkg/networking/cilium/reconciler/reconciler_test.go
@@ -61,7 +61,6 @@ func TestReconcilerReconcileErrorYamlReconcile(t *testing.T) {
 }
 
 func TestReconcilerReconcileAlreadyInDesiredVersion(t *testing.T) {
-	t.Skip("Flaky test, needs to be fixed")
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator)
@@ -113,7 +112,6 @@ func TestReconcilerReconcileAlreadyInDesiredVersionWithPreflightErrorFromTemplat
 }
 
 func TestReconcilerReconcileAlreadyInDesiredVersionWithPreflightErrorDeletingYaml(t *testing.T) {
-	t.Skip("Flaky test, needs to be fixed")
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	preflightDS := ciliumPreflightDaemonSet()
@@ -131,7 +129,6 @@ func TestReconcilerReconcileAlreadyInDesiredVersionWithPreflightErrorDeletingYam
 }
 
 func TestReconcilerReconcileUpgradeButCiliumDaemonSetNotReady(t *testing.T) {
-	t.Skip("Flaky test, needs to be fixed")
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator)
@@ -178,7 +175,6 @@ func TestReconcilerReconcileUpgradeErrorGeneratingPreflight(t *testing.T) {
 }
 
 func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightDeploymentNotAvailable(t *testing.T) {
-	t.Skip("Flaky test, needs to be fixed")
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator)
@@ -348,6 +344,7 @@ func TestReconcilerReconcileUpgradePreflightReady(t *testing.T) {
 
 type reconcileTest struct {
 	*WithT
+	t          *testing.T
 	ctx        context.Context
 	env        *envtest.Environment
 	spec       *cluster.Spec
@@ -362,6 +359,7 @@ func newReconcileTest(t *testing.T) *reconcileTest {
 
 	tt := &reconcileTest{
 		WithT: NewWithT(t),
+		t:     t,
 		ctx:   context.Background(),
 		spec: test.NewClusterSpec(func(s *cluster.Spec) {
 			s.VersionsBundle.Cilium.Cilium.URI = "cilium:1.10.1-eksa-1"
@@ -383,25 +381,26 @@ func (tt *reconcileTest) cleanup() {
 	tt.Expect(tt.client.DeleteAllOf(tt.ctx, &appsv1.Deployment{}, client.InNamespace("kube-system")))
 }
 
-func (tt *reconcileTest) withObjects(objs ...client.Object) *reconcileTest {
-	for _, obj := range objs {
-		tt.Expect(tt.client.Create(tt.ctx, obj)).To(Succeed())
-	}
-
+func (tt *reconcileTest) withObjects(objs ...envtest.Object) *reconcileTest {
+	tt.t.Helper()
+	envtest.CreateObjs(tt.ctx, tt.t, tt.client, objs...)
 	return tt
 }
 
 func (tt *reconcileTest) expectDSToNotExist(name, namespace string) {
+	tt.t.Helper()
 	err := tt.env.APIReader().Get(tt.ctx, types.NamespacedName{Name: name, Namespace: namespace}, &appsv1.DaemonSet{})
 	tt.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "DaemonSet %s should not exist", name)
 }
 
 func (tt *reconcileTest) expectDeploymentToNotExist(name, namespace string) {
+	tt.t.Helper()
 	err := tt.env.APIReader().Get(tt.ctx, types.NamespacedName{Name: name, Namespace: namespace}, &appsv1.Deployment{})
 	tt.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "Deployment %s should not exist", name)
 }
 
 func (tt *reconcileTest) getDaemonSet(name, namespace string) *appsv1.DaemonSet {
+	tt.t.Helper()
 	ds := &appsv1.DaemonSet{}
 	tt.Expect(tt.env.APIReader().Get(tt.ctx, types.NamespacedName{Name: name, Namespace: namespace}, ds)).To(Succeed())
 
@@ -409,6 +408,7 @@ func (tt *reconcileTest) getDaemonSet(name, namespace string) *appsv1.DaemonSet 
 }
 
 func (tt *reconcileTest) getDeployment(name, namespace string) *appsv1.Deployment {
+	tt.t.Helper()
 	deployment := &appsv1.Deployment{}
 	tt.Expect(tt.env.APIReader().Get(tt.ctx, types.NamespacedName{Name: name, Namespace: namespace}, deployment)).To(Succeed())
 
@@ -416,22 +416,27 @@ func (tt *reconcileTest) getDeployment(name, namespace string) *appsv1.Deploymen
 }
 
 func (tt *reconcileTest) getCiliumOperator() *appsv1.Deployment {
+	tt.t.Helper()
 	return tt.getDeployment(cilium.DeploymentName, "kube-system")
 }
 
 func (tt *reconcileTest) getCiliumDaemonSet() *appsv1.DaemonSet {
+	tt.t.Helper()
 	return tt.getDaemonSet(cilium.DaemonSetName, "kube-system")
 }
 
 func (tt *reconcileTest) makeCiliumDaemonSetReady() {
+	tt.t.Helper()
 	tt.makeDaemonSetReady(cilium.DaemonSetName, "kube-system")
 }
 
 func (tt *reconcileTest) makePreflightDaemonSetReady() {
+	tt.t.Helper()
 	tt.makeDaemonSetReady(cilium.PreflightDaemonSetName, "kube-system")
 }
 
 func (tt *reconcileTest) makeDaemonSetReady(name, namespace string) {
+	tt.t.Helper()
 	ds := tt.getDaemonSet(name, namespace)
 	ds.Status.ObservedGeneration = ds.Generation
 	tt.Expect(tt.client.Status().Update(tt.ctx, ds)).To(Succeed())
@@ -454,10 +459,12 @@ func (tt *reconcileTest) makeDaemonSetReady(name, namespace string) {
 }
 
 func (tt *reconcileTest) makePreflightDeploymentReady() {
+	tt.t.Helper()
 	tt.makeDeploymentReady(cilium.PreflightDeploymentName, "kube-system")
 }
 
 func (tt *reconcileTest) makeDeploymentReady(name, namespace string) {
+	tt.t.Helper()
 	deployment := tt.getDeployment(name, namespace)
 	deployment.Status.ObservedGeneration = deployment.Generation
 	tt.Expect(tt.client.Status().Update(tt.ctx, deployment)).To(Succeed())
@@ -480,6 +487,7 @@ func (tt *reconcileTest) makeDeploymentReady(name, namespace string) {
 }
 
 func (tt *reconcileTest) expectDaemonSetSemanticallyEqual(wantDS *appsv1.DaemonSet) {
+	tt.t.Helper()
 	gotDS := tt.getCiliumDaemonSet()
 	tt.Expect(equality.Semantic.DeepDerivative(wantDS.Spec, gotDS.Spec)).To(
 		BeTrue(), "Cilium DaemonSet should be semantically equivalent",
@@ -487,6 +495,7 @@ func (tt *reconcileTest) expectDaemonSetSemanticallyEqual(wantDS *appsv1.DaemonS
 }
 
 func (tt *reconcileTest) expectOperatorSemanticallyEqual(wantOperator *appsv1.Deployment) {
+	tt.t.Helper()
 	gotOperator := tt.getCiliumOperator()
 	tt.Expect(equality.Semantic.DeepDerivative(wantOperator.Spec, gotOperator.Spec)).To(
 		BeTrue(), "Cilium Operator should be semantically equivalent",
@@ -494,6 +503,7 @@ func (tt *reconcileTest) expectOperatorSemanticallyEqual(wantOperator *appsv1.De
 }
 
 func (tt *reconcileTest) buildManifest(objs ...client.Object) []byte {
+	tt.t.Helper()
 	return buildManifest(tt.WithT, objs...)
 }
 


### PR DESCRIPTION
*Description of changes:*
Add util to create objects with a kube client and wait until the client
cache gets refreshed with them. This avoid race conditions where the
tested code gets executed before those objects are available, making it
seem like they don't exist.

*Testing (if applicable):*
Ran all the package tests in loop 200 times.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

