### PR TITLE
BMC connection wait

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -13,6 +13,7 @@ import (
 
 	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
+	rufiov1alpha1 "github.com/tinkerbell/rufio/api/v1alpha1"
 	tinkv1alpha1 "github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -47,6 +48,7 @@ var (
 	eksaTinkerbellDatacenterResourceType = fmt.Sprintf("tinkerbelldatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaTinkerbellMachineResourceType    = fmt.Sprintf("tinkerbellmachineconfigs.%s", v1alpha1.GroupVersion.Group)
 	TinkerbellHardwareResourceType       = fmt.Sprintf("hardware.%s", tinkv1alpha1.GroupVersion.Group)
+	rufioBaseboardManagementResourceType = fmt.Sprintf("baseboardmanagements.%s", rufiov1alpha1.GroupVersion.Group)
 	eksaCloudStackDatacenterResourceType = fmt.Sprintf("cloudstackdatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaCloudStackMachineResourceType    = fmt.Sprintf("cloudstackmachineconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaAwsResourceType                  = fmt.Sprintf("awsdatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
@@ -330,6 +332,10 @@ func (k *Kubectl) WaitForService(ctx context.Context, kubeconfig string, timeout
 
 func (k *Kubectl) WaitForDeployment(ctx context.Context, cluster *types.Cluster, timeout string, condition string, target string, namespace string) error {
 	return k.Wait(ctx, cluster.KubeconfigFile, timeout, condition, "deployments/"+target, namespace)
+}
+
+func (k *Kubectl) WaitForBaseboardManagement(ctx context.Context, cluster *types.Cluster, timeout string, condition string, target string, namespace string) error {
+	return k.Wait(ctx, cluster.KubeconfigFile, timeout, condition, fmt.Sprintf("%s/%s", rufioBaseboardManagementResourceType, target), namespace)
 }
 
 func (k *Kubectl) Wait(ctx context.Context, kubeconfig string, timeout string, forCondition string, property string, namespace string) error {

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -2329,3 +2329,13 @@ func TestKubectlWaitForClusterReady(t *testing.T) {
 
 	tt.Expect(tt.k.WaitForClusterReady(tt.ctx, tt.cluster, "5m", "test")).To(Succeed())
 }
+
+func TestWaitForBaseboardManagement(t *testing.T) {
+	kt := newKubectlTest(t)
+	kt.e.EXPECT().Execute(
+		kt.ctx,
+		"wait", "--timeout", "5m", "--for=condition=Contactable", "baseboardmanagements.bmc.tinkerbell.org/test", "--kubeconfig", kt.cluster.KubeconfigFile, "-n", "eksa-system",
+	).Return(bytes.Buffer{}, nil)
+
+	kt.Expect(kt.k.WaitForBaseboardManagement(kt.ctx, kt.cluster, "5m", "Contactable", "test", "eksa-system")).To(Succeed())
+}

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -69,6 +69,10 @@ func (p *Provider) PostBootstrapSetup(ctx context.Context, clusterConfig *v1alph
 	if err != nil {
 		return fmt.Errorf("applying hardware yaml: %v", err)
 	}
+	err = p.WaitForBaseboardManagementsContactable(ctx, cluster, p.catalogue.AllBMCs())
+	if err != nil {
+		return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
+	}
 	return nil
 }
 

--- a/pkg/providers/tinkerbell/mocks/client.go
+++ b/pkg/providers/tinkerbell/mocks/client.go
@@ -273,6 +273,20 @@ func (mr *MockProviderKubectlClientMockRecorder) UpdateAnnotation(arg0, arg1, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAnnotation", reflect.TypeOf((*MockProviderKubectlClient)(nil).UpdateAnnotation), varargs...)
 }
 
+// WaitForBaseboardManagement mocks base method.
+func (m *MockProviderKubectlClient) WaitForBaseboardManagement(arg0 context.Context, arg1 *types.Cluster, arg2, arg3, arg4, arg5 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForBaseboardManagement", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForBaseboardManagement indicates an expected call of WaitForBaseboardManagement.
+func (mr *MockProviderKubectlClientMockRecorder) WaitForBaseboardManagement(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForBaseboardManagement", reflect.TypeOf((*MockProviderKubectlClient)(nil).WaitForBaseboardManagement), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
 // WaitForDeployment mocks base method.
 func (m *MockProviderKubectlClient) WaitForDeployment(arg0 context.Context, arg1 *types.Cluster, arg2, arg3, arg4, arg5 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
+	rufiov1alpha1 "github.com/tinkerbell/rufio/api/v1alpha1"
 	tinkv1alpha1 "github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -84,6 +85,7 @@ type ProviderKubectlClient interface {
 	WaitForDeployment(ctx context.Context, cluster *types.Cluster, timeout string, condition string, target string, namespace string) error
 	GetUnprovisionedTinkerbellHardware(_ context.Context, kubeconfig, namespace string) ([]tinkv1alpha1.Hardware, error)
 	GetProvisionedTinkerbellHardware(_ context.Context, kubeconfig, namespace string) ([]tinkv1alpha1.Hardware, error)
+	WaitForBaseboardManagement(ctx context.Context, cluster *types.Cluster, timeout string, condition string, target string, namespace string) error
 }
 
 // KeyGenerator generates ssh keys and writes them to a FileWriter.
@@ -288,5 +290,16 @@ func (p *Provider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.Compone
 }
 
 func (p *Provider) InstallCustomProviderComponents(ctx context.Context, kubeconfigFile string) error {
+	return nil
+}
+
+// WaitForBaseboardManagementsContactable executes kubectl wait for each baseboardmanagement
+func (p *Provider) WaitForBaseboardManagementsContactable(ctx context.Context, cluster *types.Cluster, bmcs []*rufiov1alpha1.BaseboardManagement) error {
+	for _, bmc := range bmcs {
+		if err := p.providerKubectlClient.WaitForBaseboardManagement(ctx, cluster, "5m", "Contactable", bmc.Name, constants.EksaSystemNamespace); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -349,6 +349,32 @@ func TestPostWorkloadInitSuccess(t *testing.T) {
 	}
 }
 
+func TestPostBootstrapSetupSuccess(t *testing.T) {
+	clusterSpecManifest := "cluster_tinkerbell_stacked_etcd.yaml"
+	mockCtrl := gomock.NewController(t)
+	docker := stackmocks.NewMockDocker(mockCtrl)
+	helm := stackmocks.NewMockHelm(mockCtrl)
+	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	writer := filewritermocks.NewMockFileWriter(mockCtrl)
+	cluster := &types.Cluster{Name: "test", KubeconfigFile: "test.kubeconfig"}
+	ctx := context.Background()
+	forceCleanup := false
+
+	clusterSpec := givenClusterSpec(t, clusterSpecManifest)
+	datacenterConfig := givenDatacenterConfig(t, clusterSpecManifest)
+	machineConfigs := givenMachineConfigs(t, clusterSpecManifest)
+
+	kubectl.EXPECT().ApplyKubeSpecFromBytesForce(ctx, cluster, gomock.Any())
+	kubectl.EXPECT().WaitForBaseboardManagement(ctx, cluster, "5m", "Contactable", gomock.Any(), gomock.Any()).MaxTimes(2)
+
+	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl, forceCleanup)
+
+	err := provider.PostBootstrapSetup(ctx, provider.clusterConfig, cluster)
+	if err != nil {
+		t.Fatalf("failed PostBootstrapSetup: %v", err)
+	}
+}
+
 func TestTinkerbellProviderGenerateDeploymentFileWithFullOIDC(t *testing.T) {
 	clusterSpecManifest := "cluster_tinkerbell_full_oidc.yaml"
 	mockCtrl := gomock.NewController(t)

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -176,6 +176,10 @@ func (p *Provider) PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig 
 	if err != nil {
 		return fmt.Errorf("applying hardware yaml: %v", err)
 	}
+	err = p.WaitForBaseboardManagementsContactable(ctx, cluster, p.catalogue.AllBMCs())
+	if err != nil {
+		return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
*Issue #2748*

*Description of changes:*
Adding a kubectl wait for BaseboardManagement objects once created to ensure the connection is successful.

*Testing :*
` ./eksctl-anywhere create cluster -f cluster.yaml -z hardware.csv`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

