### PR TITLE
Update metallb link to their github page

### DIFF
--- a/docs/content/en/docs/reference/packagespec/_index.md
+++ b/docs/content/en/docs/reference/packagespec/_index.md
@@ -11,5 +11,5 @@ description: >
 | Name                       | Description                | Versions                  | GitHub                      |
 |----------------------------|----------------------------|---------------------------|-----------------------------|
 | [Harbor]({{< relref "./harbor" >}}) | Harbor is an open source trusted cloud native registry project that stores, signs, and scans content. | [v2.5.0]({{< relref "./harbor/v2.5.0.md" >}})<br> [v2.5.1]({{< relref "./harbor/v2.5.1.md" >}}) | https://github.com/goharbor/harbor<br>https://github.com/goharbor/harbor-helm |
-| [MetalLB]({{< relref "./metallb" >}}) | MetalLB is a virtual IP provider for services of type `LoadBalancer` supporting ARP and BGP. | [v0.12.1]({{< relref "./metallb/v0.12.1.md" >}}) | https://metallb.universe.tf/ |
+| [MetalLB]({{< relref "./metallb" >}}) | MetalLB is a virtual IP provider for services of type `LoadBalancer` supporting ARP and BGP. | [v0.12.1]({{< relref "./metallb/v0.12.1.md" >}}) | https://github.com/metallb/metallb/ |
 | [Emissary Ingress]({{< relref "./emissary" >}}) | Emissary Ingress is an open source `Ingress` supporting API Gateway + Layer 7 load balancer built on Envoy Proxy. | [v0.3.0]({{< relref "./emissary/v0.3.0.md" >}}) | https://github.com/emissary-ingress/emissary/ |


### PR DESCRIPTION
The column defined in the parent template is called "GitHub" so update the link to their github page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

