### PR TITLE
Corrected incorrect file-path for grub default environment variables in troublehsooting docs

### DIFF
--- a/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
+++ b/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
@@ -75,7 +75,7 @@ To verify cgroups version
 ```
 To use _cgroups v1_ you need to _sudo_ and edit _/etc/default/grub_ to set _GRUB_CMDLINE_LINUX_ to "systemd.unified_cgroup_hierarchy=0" and reboot.
 ```
-%sudo <editor> /etc/default/group
+%sudo <editor> /etc/default/grub
 GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=0"
 
 sudo reboot now


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Corrected incorrect file-path for grub default environment variables.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

