### PR TITLE
Upgrading CloudStack e2e tests to use AvailabilityZones

### DIFF
--- a/internal/pkg/api/cloudstack.go
+++ b/internal/pkg/api/cloudstack.go
@@ -62,12 +62,6 @@ func WithCloudStackComputeOfferingForAllMachines(value string) CloudStackFiller 
 	}
 }
 
-func WithCloudStackManagementServer(value string) CloudStackFiller {
-	return func(config CloudStackConfig) {
-		config.datacenterConfig.Spec.AvailabilityZones[0].ManagementApiEndpoint = value
-	}
-}
-
 func WithCloudStackAz(az anywherev1.CloudStackAvailabilityZone) CloudStackFiller {
 	return func(config CloudStackConfig) {
 		config.datacenterConfig.Spec.AvailabilityZones = append(config.datacenterConfig.Spec.AvailabilityZones, az)
@@ -145,18 +139,6 @@ func WithCloudStackAccount(value string) CloudStackFiller {
 		for _, az := range config.datacenterConfig.Spec.AvailabilityZones {
 			az.Account = value
 		}
-	}
-}
-
-func WithCloudStackZone(value string) CloudStackFiller {
-	return func(config CloudStackConfig) {
-		config.datacenterConfig.Spec.AvailabilityZones[0].Zone.Name = value
-	}
-}
-
-func WithCloudStackNetwork(value string) CloudStackFiller {
-	return func(config CloudStackConfig) {
-		config.datacenterConfig.Spec.AvailabilityZones[0].Zone.Network.Name = value
 	}
 }
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -440,7 +440,7 @@ func TestCloudStackKubernetes120RedhatWorkerNodeUpgrade(t *testing.T) {
 }
 
 func TestCloudStackKubernetes121AddRemoveAz(t *testing.T) {
-	provider := framework.NewCloudStackWithAzs(t, framework.WithCloudStackRedhat121())
+	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat121())
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,

--- a/test/framework/cloudstack.go
+++ b/test/framework/cloudstack.go
@@ -85,35 +85,7 @@ func RemoveAllCloudStackAzs() api.CloudStackFiller {
 	return api.RemoveCloudStackAzs()
 }
 
-// NewCloudStack deprecated - moving forward, we should use NewCloudStackWithAzs
 func NewCloudStack(t *testing.T, opts ...CloudStackOpt) *CloudStack {
-	checkRequiredEnvVars(t, requiredCloudStackEnvVars)
-	c := &CloudStack{
-		t: t,
-		fillers: []api.CloudStackFiller{
-			api.WithCloudStackStringFromEnvVar(cloudstackDomainVar, api.WithCloudStackDomain),
-			api.WithCloudStackStringFromEnvVar(cloudstackManagementServerVar, api.WithCloudStackManagementServer),
-			api.WithCloudStackStringFromEnvVar(cloudstackZoneVar, api.WithCloudStackZone),
-			api.WithCloudStackStringFromEnvVar(cloudstackNetworkVar, api.WithCloudStackNetwork),
-			api.WithCloudStackStringFromEnvVar(cloudstackAccountVar, api.WithCloudStackAccount),
-			api.WithCloudStackStringFromEnvVar(cloudstackSshAuthorizedKeyVar, api.WithCloudStackSSHAuthorizedKey),
-			api.WithCloudStackStringFromEnvVar(cloudstackTemplateRedhat120Var, api.WithCloudStackTemplateForAllMachines),
-			api.WithCloudStackStringFromEnvVar(cloudstackComputeOfferingLargeVar, api.WithCloudStackComputeOfferingForAllMachines),
-		},
-	}
-
-	c.cidr = os.Getenv(cloudStackCidrVar)
-	c.podCidr = os.Getenv(podCidrVar)
-	c.serviceCidr = os.Getenv(serviceCidrVar)
-
-	for _, opt := range opts {
-		opt(c)
-	}
-
-	return c
-}
-
-func NewCloudStackWithAzs(t *testing.T, opts ...CloudStackOpt) *CloudStack {
 	checkRequiredEnvVars(t, requiredCloudStackEnvVars)
 	c := &CloudStack{
 		t: t,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Deprecating old CloudStack schema for e2e tests in favor of using AvailabilityZones, and removing some unused methods

*Testing (if applicable):*
Running the following e2e tests locally succeeded
TestCloudStackKubernetes120GitopsOptionsFluxLegacy
TestCloudStackKubernetes120RedhatTo121MultipleFieldsUpgrade
TestCloudStackKubernetes120RedhatTo121Upgrade
TestCloudStackKubernetes120RedhatWorkerNodeUpgrade
TestCloudStackKubernetes120UpgradeFromLatestMinorRelease
TestCloudStackKubernetes121RedhatAndRemoveWorkerNodeGroups

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

