### PR TITLE
Add analyzer to analyze if vms have access to vsphere api server

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -33,7 +33,6 @@ import (
 )
 
 const (
-<<<<<<< HEAD
 	maxRetries                = 30
 	defaultBackOffPeriod      = 5 * time.Second
 	machineBackoff            = 1 * time.Second
@@ -46,18 +45,6 @@ const (
 	controlPlaneInProgressStr = "1m"
 	etcdInProgressStr         = "1m"
 	DefaultEtcdWait           = 60 * time.Minute
-=======
-	maxRetries             = 30
-	backOffPeriod          = 5 * time.Second
-	machineBackoff         = 1 * time.Second
-	machinesMinWait        = 30 * time.Minute
-	moveCAPIWait           = 15 * time.Minute
-	clusterWaitStr         = "60m"
-	ctrlPlaneWaitStr       = "60m"
-	deploymentWaitStr      = "30m"
-	ctrlPlaneInProgressStr = "1m"
-	etcdInProgressStr      = "1m"
->>>>>>> 7bcd36d1 (Add new analyzer and collector to support bundle)
 )
 
 type ClusterManager struct {

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -283,7 +283,8 @@ func (c *ClusterManager) CreateWorkloadCluster(ctx context.Context, managementCl
 				return err
 			},
 		)
-		return workloadCluster, fmt.Errorf("waiting for workload cluster control plane to be ready: %v", err)
+		// add warning here *******
+		return nil, fmt.Errorf("waiting for workload cluster control plane to be ready: %v", err)
 	}
 
 	logger.V(3).Info("Waiting for workload kubeconfig generation", "cluster", workloadCluster.Name)

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -278,14 +278,16 @@ func (c *ClusterManager) CreateWorkloadCluster(ctx context.Context, managementCl
 	err = c.clusterClient.WaitForControlPlaneReady(ctx, managementCluster, c.controlPlaneWaitTimeout.String(), workloadCluster.Name)
 	if err != nil {
 		logger.Info("Warning: attempting to create kubeconfig")
+
 		retryErr := c.Retrier.Retry(
 			func() error {
-				workloadCluster.KubeconfigFile, err = c.generateWorkloadKubeconfig(ctx, workloadCluster.Name, managementCluster, provider)
-				return err
+				var getKubconfigErr error
+				workloadCluster.KubeconfigFile, getKubconfigErr = c.generateWorkloadKubeconfig(ctx, workloadCluster.Name, managementCluster, provider)
+				return getKubconfigErr
 			},
 		)
 		if retryErr != nil {
-			logger.Info("Warning: unable to generate workload kubeconfig")
+			logger.Info("Warning: unable to generate workload kubeconfig.")
 		}
 		return workloadCluster, fmt.Errorf("waiting for workload cluster control plane to be ready: %v", err)
 	}

--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -374,7 +374,7 @@ func (a *analyzerFactory) vmsAccessAnalyzer() *Analyze {
 	return &Analyze{
 		TextAnalyze: &textAnalyze{
 			analyzeMeta: analyzeMeta{
-				CheckName: fmt.Sprintf("%s: VMs has no access to vSphere APi. Logs: %s", logAnalysisAnalyzerPrefix, vSphereCloudControllerPodLogPath),
+				CheckName: fmt.Sprintf("%s: Virtual Machine has no access to vSphere APi serveer. Logs: %s", logAnalysisAnalyzerPrefix, vSphereCloudControllerPodLogPath),
 			},
 			FileName:     vSphereCloudControllerPodLogPath,
 			RegexPattern: `Failed to create new client. err: Post (.*) dial tcp (.*) connect: connection timed out\n(.*)Failed to create govmomi client. err: Post (.*) dial tcp (.*) connect: connection timed out`,
@@ -382,13 +382,13 @@ func (a *analyzerFactory) vmsAccessAnalyzer() *Analyze {
 				{
 					Fail: &singleOutcome{
 						When:    "true",
-						Message: fmt.Sprintf("Failed to create client, Virtural Machines have no access to vSphere API. See the cloud controller log in master node: %s", vSphereCloudControllerPodLogPath),
+						Message: fmt.Sprintf("Failed to create client, Virtural Machines have no access to vSphere API server. See the cloud controller log in control plane node: %s", vSphereCloudControllerPodLogPath),
 					},
 				},
 				{
 					Pass: &singleOutcome{
 						When:    "false",
-						Message: fmt.Sprintf("Virtual Machines have access to vSphere API. See %s", vSphereCloudControllerPodLogPath),
+						Message: fmt.Sprintf("Virtual Machines have access to vSphere API server. See %s \nPlease ignore the result when this analyzer is running on bootstrap cluster", vSphereCloudControllerPodLogPath),
 					},
 				},
 			},

--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -223,7 +223,6 @@ func (a *analyzerFactory) EksaLogTextAnalyzers(collectors []*Collect) []*Analyze
 func (a *analyzerFactory) namespaceLogTextAnalyzersMap() map[string][]*Analyze {
 	return map[string][]*Analyze{
 		constants.CapiKubeadmControlPlaneSystemNamespace: a.capiKubeadmControlPlaneSystemLogAnalyzers(),
-		// constants.KubeSystemNamespace:                    a.kubeSystemLogAnalyzers(),
 	}
 }
 

--- a/pkg/diagnostics/analyzers_test.go
+++ b/pkg/diagnostics/analyzers_test.go
@@ -49,13 +49,14 @@ func TestVsphereDataCenterConfigAnalyzers(t *testing.T) {
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.VSphereDatacenterKind}
 	analyzerFactory := diagnostics.NewAnalyzerFactory()
 	analyzers := analyzerFactory.DataCenterConfigAnalyzers(datacenter)
-	g.Expect(analyzers).To(HaveLen(3), "DataCenterConfigAnalyzers() mismatch between desired analyzers and actual")
+	g.Expect(analyzers).To(HaveLen(4), "DataCenterConfigAnalyzers() mismatch between desired analyzers and actual")
 	g.Expect(analyzers[0].CustomResourceDefinition.CustomResourceDefinitionName).To(Equal("vspheredatacenterconfigs.anywhere.eks.amazonaws.com"),
 		"vSphere generateCrdAnalyzers() mismatch between desired datacenter config group version and actual")
 	g.Expect(analyzers[1].CustomResourceDefinition.CustomResourceDefinitionName).To(Equal("vspheremachineconfigs.anywhere.eks.amazonaws.com"),
 		"vSphere generateCrdAnalyzers() mismatch between desired machine config group version and actual")
 	g.Expect(analyzers[2].TextAnalyze.RegexPattern).To(Equal("exit code: 0"),
 		"controlPlaneIPAnalyzer() mismatch between desired regexPattern and actual")
+	g.Expect(analyzers[3]).ToNot(BeNil(), "vmsAccess Analyzer should be present")
 }
 
 func TestDockerDataCenterConfigAnalyzers(t *testing.T) {

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -102,7 +102,7 @@ func (c *collectorFactory) eksaVsphereCollectors(spec *cluster.Spec) []*Collect 
 	collectors = append(collectors, vsphereLogs...)
 	collectors = append(collectors, c.vsphereCrdCollectors()...)
 	collectors = append(collectors, c.apiServerCollectors(spec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host)...)
-	collectors = append(collectors, c.vmsAccessCollector(spec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host))
+	collectors = append(collectors, c.vmsAccessCollector(spec.Cluster.Spec.ControlPlaneConfiguration))
 	return collectors
 }
 
@@ -444,8 +444,12 @@ func (c *collectorFactory) pingHostCollector(hostIP string) *Collect {
 
 // vmsAccessCollector will connect to API server first, then collect vsphere-cloud-controller-manager logs
 // on control plane node
-func (c *collectorFactory) vmsAccessCollector(controlPlaneEndpoint string) *Collect {
-	makeConnection := fmt.Sprintf("curl --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s:6443/", controlPlaneEndpoint)
+func (c *collectorFactory) vmsAccessCollector(controlPlaneConfiguration v1alpha1.ControlPlaneConfiguration) *Collect {
+	controlPlaneEndpointHost := controlPlaneConfiguration.Endpoint.Host
+	taints := controlPlaneConfiguration.Taints
+	tolerations := makeTolerations(taints)
+
+	makeConnection := fmt.Sprintf("curl --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s:6443/", controlPlaneEndpointHost)
 	getLogs := "kubectl logs -n kube-system -l k8s-app=vsphere-cloud-controller-manager"
 	args := []string{fmt.Sprintf("%s && %s", makeConnection, getLogs)}
 	return &Collect{
@@ -461,21 +465,7 @@ func (c *collectorFactory) vmsAccessCollector(controlPlaneEndpoint string) *Coll
 				}},
 				ServiceAccountName: "default",
 				HostNetwork:        true,
-				Tolerations: []v1.Toleration{
-					{
-						Effect: "NoSchedule",
-						Key:    "node-role.kubernetes.io/master",
-					},
-					{
-						Key:    "node.cloudprovider.kubernetes.io/uninitialized",
-						Value:  "true",
-						Effect: "NoSchedule",
-					},
-					{
-						Key:    "node.kubernetes.io/not-ready",
-						Effect: "NoSchedule",
-					},
-				},
+				Tolerations:        tolerations,
 				Affinity: &v1.Affinity{
 					NodeAffinity: &v1.NodeAffinity{
 						PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
@@ -503,6 +493,42 @@ func (c *collectorFactory) vmsAccessCollector(controlPlaneEndpoint string) *Coll
 			Timeout: "20s",
 		},
 	}
+}
+
+func makeTolerations(taints []v1.Taint) []v1.Toleration {
+	tolerations := []v1.Toleration{
+		{
+			Key:    "node.cloudprovider.kubernetes.io/uninitialized",
+			Value:  "true",
+			Effect: "NoSchedule",
+		},
+		{
+			Key:    "node.kubernetes.io/not-ready",
+			Effect: "NoSchedule",
+		},
+	}
+	if taints == nil {
+		toleration := v1.Toleration{
+			Effect: "NoSchedule",
+			Key:    "node-role.kubernetes.io/master",
+		}
+		tolerations = append(tolerations, toleration)
+	} else {
+		for _, taint := range taints {
+			var toleration v1.Toleration
+			if taint.Key != "" {
+				toleration.Key = taint.Key
+			}
+			if taint.Value != "" {
+				toleration.Value = taint.Value
+			}
+			if taint.Effect != "" {
+				toleration.Effect = taint.Effect
+			}
+			tolerations = append(tolerations, toleration)
+		}
+	}
+	return tolerations
 }
 
 func logpath(namespace string) string {

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -478,23 +478,24 @@ func (c *collectorFactory) vmsAccessCollector(controlPlaneEndpoint string) *Coll
 				},
 				Affinity: &v1.Affinity{
 					NodeAffinity: &v1.NodeAffinity{
-						PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{{
-							Weight: 10,
-							Preference: v1.NodeSelectorTerm{
-								MatchExpressions: []v1.NodeSelectorRequirement{{
-									Key:      "node-role.kubernetes.io/control-plane",
-									Operator: "Exists",
-								}},
+						PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+							{
+								Weight: 10,
+								Preference: v1.NodeSelectorTerm{
+									MatchExpressions: []v1.NodeSelectorRequirement{{
+										Key:      "node-role.kubernetes.io/control-plane",
+										Operator: "Exists",
+									}},
+								},
+							}, {
+								Weight: 10,
+								Preference: v1.NodeSelectorTerm{
+									MatchExpressions: []v1.NodeSelectorRequirement{{
+										Key:      "node-role.kubernetes.io/master",
+										Operator: "Exists",
+									}},
+								},
 							},
-						}, {
-							Weight: 10,
-							Preference: v1.NodeSelectorTerm{
-								MatchExpressions: []v1.NodeSelectorRequirement{{
-									Key:      "node-role.kubernetes.io/master",
-									Operator: "Exists",
-								}},
-							},
-						},
 						},
 					},
 				},

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -44,7 +44,24 @@ func (c *collectorFactory) DefaultCollectors() []*Collect {
 		},
 	}
 	collectors = append(collectors, c.defaultLogCollectors()...)
+	collectors = append(collectors, c.vmsAccessCollector())
 	return collectors
+}
+
+// based on Troubleshoot.sh,
+// we expect that vmsAccessCollector can generate a .txt file with output of executed command
+// since .sh file doesn't work currently, just execute simple kubectl command for testing purpose
+func (c *collectorFactory) vmsAccessCollector() *Collect {
+	return &Collect{
+		Exec: &exec{
+			Name:      "collect-control-plane-log",
+			Namespace: constants.EksaDiagnosticsNamespace,
+			Command:   []string{"kubectl", "get"},
+			Args:      []string{"nodes", "-n", "kube-system"},
+			Selector:  []string{"node-role.kubernetes.io/control-plane"},
+			Timeout:   "30s",
+		},
+	}
 }
 
 func (c *collectorFactory) EksaHostCollectors(machineConfigs []providers.MachineConfig) []*Collect {
@@ -417,6 +434,7 @@ func (c *collectorFactory) hostPortCollector(ports []string, hostIP string) *Col
 					Args:    argsIP,
 				}},
 			},
+			Timeout: "30s",
 		},
 	}
 }
@@ -436,6 +454,7 @@ func (c *collectorFactory) pingHostCollector(hostIP string) *Collect {
 					Args:    argsPing,
 				}},
 			},
+			Timeout: "30s",
 		},
 	}
 }

--- a/pkg/diagnostics/collectors_test.go
+++ b/pkg/diagnostics/collectors_test.go
@@ -44,7 +44,7 @@ func TestVsphereDataCenterConfigCollectors(t *testing.T) {
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.VSphereDatacenterKind}
 	factory := diagnostics.NewDefaultCollectorFactory()
 	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
-	g.Expect(collectors).To(HaveLen(10), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
+	g.Expect(collectors).To(HaveLen(11), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapvSystemNamespace))
 	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CapvSystemNamespace)))
 	for _, collector := range collectors[1:7] {
@@ -53,6 +53,7 @@ func TestVsphereDataCenterConfigCollectors(t *testing.T) {
 	}
 	g.Expect(collectors[8].RunPod.PodSpec.Containers[0].Name).To(Equal("check-host-port"))
 	g.Expect(collectors[9].RunPod.PodSpec.Containers[0].Name).To(Equal("ping-host-ip"))
+	g.Expect(collectors[10].RunPod.PodSpec.Containers[0].Name).To(Equal("check-cloud-controller"))
 }
 
 func TestCloudStackDataCenterConfigCollectors(t *testing.T) {

--- a/pkg/diagnostics/config/diagnostic-collector-rbac.yaml
+++ b/pkg/diagnostics/config/diagnostic-collector-rbac.yaml
@@ -15,6 +15,18 @@ rules:
     verbs:
     - get
     - list
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    - pods/log
+    verbs:
+    - get
+    - list
+  - nonResourceURLs:
+    - /
+    verbs:
+    - get
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

To extent the functionality of support bundle by 
- adding a run-pod collector--vmsAccessCollector. It supposes to collect logs from vsphere cloud controller manager on control plane. 
    - since the pod need to be deployed on control plane node, specific tolerations have been set. 
    - It is also able to accept customized taints that given by user in cluster defination yaml. 
- adding a vmsAccess analyzer. Based on the log from the collector, the analyzer is able to analyze if the vms have access to vsphere api server. 
   - Now, the analyzer starts to work from bootstrap cluster, although we expect that the analyzer only does its work on workload cluster. A clarification was temporarily added to the output to avoid confusion. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

