### PR TITLE
Fix Ubuntu 22.04 troubleshooting instructions

### DIFF
--- a/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
+++ b/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
@@ -75,9 +75,10 @@ To verify cgroups version
 ```
 To use _cgroups v1_ you need to _sudo_ and edit _/etc/default/grub_ to set _GRUB_CMDLINE_LINUX_ to "systemd.unified_cgroup_hierarchy=0" and reboot.
 ```
-%sudo <editor> /etc/default/group
+%sudo <editor> /etc/default/grub
 GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=0"
 
+sudo update-grub
 sudo reboot now
 ```
 Then verify you are using _cgroups v1_.


### PR DESCRIPTION
Issue #, if available:
Current documentation has an errata when enabling Cgroups v1 on Ubuntu 21 and 22 versions:
%sudo /etc/default/group

It should be:
%sudo /etc/default/grub

Also, when modifying this file, it is needed to execute update-grub command to apply changes included on this file. If you don't do this, Cgroups v2 will be used.

Description of changes:
Include in troubleshooting.md the changes needed to set Cgroups v1 in Ubuntu.

Testing (if applicable):
This has been tested using make serve from the docs path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.