### PR TITLE
Kubectl wait all for bmc

### DIFF
--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -2330,12 +2330,12 @@ func TestKubectlWaitForClusterReady(t *testing.T) {
 	tt.Expect(tt.k.WaitForClusterReady(tt.ctx, tt.cluster, "5m", "test")).To(Succeed())
 }
 
-func TestWaitForBaseboardManagement(t *testing.T) {
+func TestWaitForBaseboardManagements(t *testing.T) {
 	kt := newKubectlTest(t)
 	kt.e.EXPECT().Execute(
 		kt.ctx,
-		"wait", "--timeout", "5m", "--for=condition=Contactable", "baseboardmanagements.bmc.tinkerbell.org/test", "--kubeconfig", kt.cluster.KubeconfigFile, "-n", "eksa-system",
+		"wait", "--timeout", "5m", "--for=condition=Contactable", "baseboardmanagements.bmc.tinkerbell.org", "--kubeconfig", kt.cluster.KubeconfigFile, "-n", "eksa-system", "--all",
 	).Return(bytes.Buffer{}, nil)
 
-	kt.Expect(kt.k.WaitForBaseboardManagement(kt.ctx, kt.cluster, "5m", "Contactable", "test", "eksa-system")).To(Succeed())
+	kt.Expect(kt.k.WaitForBaseboardManagements(kt.ctx, kt.cluster, "5m", "Contactable", "eksa-system")).To(Succeed())
 }

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/bootstrapper"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/stack"
@@ -69,7 +70,7 @@ func (p *Provider) PostBootstrapSetup(ctx context.Context, clusterConfig *v1alph
 	if err != nil {
 		return fmt.Errorf("applying hardware yaml: %v", err)
 	}
-	err = p.WaitForBaseboardManagementsContactable(ctx, cluster, p.catalogue.AllBMCs())
+	err = p.providerKubectlClient.WaitForBaseboardManagements(ctx, cluster, "5m", "Contactable", constants.EksaSystemNamespace)
 	if err != nil {
 		return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
 	}

--- a/pkg/providers/tinkerbell/mocks/client.go
+++ b/pkg/providers/tinkerbell/mocks/client.go
@@ -273,18 +273,18 @@ func (mr *MockProviderKubectlClientMockRecorder) UpdateAnnotation(arg0, arg1, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAnnotation", reflect.TypeOf((*MockProviderKubectlClient)(nil).UpdateAnnotation), varargs...)
 }
 
-// WaitForBaseboardManagement mocks base method.
-func (m *MockProviderKubectlClient) WaitForBaseboardManagement(arg0 context.Context, arg1 *types.Cluster, arg2, arg3, arg4, arg5 string) error {
+// WaitForBaseboardManagements mocks base method.
+func (m *MockProviderKubectlClient) WaitForBaseboardManagements(arg0 context.Context, arg1 *types.Cluster, arg2, arg3, arg4 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForBaseboardManagement", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "WaitForBaseboardManagements", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// WaitForBaseboardManagement indicates an expected call of WaitForBaseboardManagement.
-func (mr *MockProviderKubectlClientMockRecorder) WaitForBaseboardManagement(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+// WaitForBaseboardManagements indicates an expected call of WaitForBaseboardManagements.
+func (mr *MockProviderKubectlClientMockRecorder) WaitForBaseboardManagements(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForBaseboardManagement", reflect.TypeOf((*MockProviderKubectlClient)(nil).WaitForBaseboardManagement), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForBaseboardManagements", reflect.TypeOf((*MockProviderKubectlClient)(nil).WaitForBaseboardManagements), arg0, arg1, arg2, arg3, arg4)
 }
 
 // WaitForDeployment mocks base method.

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
-	rufiov1alpha1 "github.com/tinkerbell/rufio/api/v1alpha1"
 	tinkv1alpha1 "github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -85,7 +84,7 @@ type ProviderKubectlClient interface {
 	WaitForDeployment(ctx context.Context, cluster *types.Cluster, timeout string, condition string, target string, namespace string) error
 	GetUnprovisionedTinkerbellHardware(_ context.Context, kubeconfig, namespace string) ([]tinkv1alpha1.Hardware, error)
 	GetProvisionedTinkerbellHardware(_ context.Context, kubeconfig, namespace string) ([]tinkv1alpha1.Hardware, error)
-	WaitForBaseboardManagement(ctx context.Context, cluster *types.Cluster, timeout string, condition string, target string, namespace string) error
+	WaitForBaseboardManagements(ctx context.Context, cluster *types.Cluster, timeout string, condition string, namespace string) error
 }
 
 // KeyGenerator generates ssh keys and writes them to a FileWriter.
@@ -290,16 +289,5 @@ func (p *Provider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.Compone
 }
 
 func (p *Provider) InstallCustomProviderComponents(ctx context.Context, kubeconfigFile string) error {
-	return nil
-}
-
-// WaitForBaseboardManagementsContactable executes kubectl wait for each baseboardmanagement
-func (p *Provider) WaitForBaseboardManagementsContactable(ctx context.Context, cluster *types.Cluster, bmcs []*rufiov1alpha1.BaseboardManagement) error {
-	for _, bmc := range bmcs {
-		if err := p.providerKubectlClient.WaitForBaseboardManagement(ctx, cluster, "5m", "Contactable", bmc.Name, constants.EksaSystemNamespace); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -365,7 +365,7 @@ func TestPostBootstrapSetupSuccess(t *testing.T) {
 	machineConfigs := givenMachineConfigs(t, clusterSpecManifest)
 
 	kubectl.EXPECT().ApplyKubeSpecFromBytesForce(ctx, cluster, gomock.Any())
-	kubectl.EXPECT().WaitForBaseboardManagement(ctx, cluster, "5m", "Contactable", gomock.Any(), gomock.Any()).MaxTimes(2)
+	kubectl.EXPECT().WaitForBaseboardManagements(ctx, cluster, "5m", "Contactable", gomock.Any()).MaxTimes(2)
 
 	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl, forceCleanup)
 

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -176,7 +176,7 @@ func (p *Provider) PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig 
 	if err != nil {
 		return fmt.Errorf("applying hardware yaml: %v", err)
 	}
-	err = p.WaitForBaseboardManagementsContactable(ctx, cluster, p.catalogue.AllBMCs())
+	err = p.providerKubectlClient.WaitForBaseboardManagements(ctx, cluster, "5m", "Contactable", constants.EksaSystemNamespace)
 	if err != nil {
 		return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
 	}


### PR DESCRIPTION
*Issue #2748*

*Description of changes:*
Running` kubectl wait --all` for baseboardmanagements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

