### PR TITLE
Adding retry clients wrapping kubectl apply

### DIFF
--- a/pkg/bootstrapper/bootstrapper_test.go
+++ b/pkg/bootstrapper/bootstrapper_test.go
@@ -3,8 +3,11 @@ package bootstrapper_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/aws/eks-anywhere/pkg/retrier"
 
 	"github.com/golang/mock/gomock"
 
@@ -70,6 +73,25 @@ func TestBootstrapperCreateBootstrapClusterSuccessExtraObjects(t *testing.T) {
 
 	if !reflect.DeepEqual(got, wantCluster) {
 		t.Fatalf("Bootstrapper.CreateBootstrapCluster() cluster = %#v, want %#v", got, wantCluster)
+	}
+}
+
+func TestBootstrapperCreateBootstrapClusterFailApplyExtraObjects(t *testing.T) {
+	kubeconfigFile := "c.kubeconfig"
+	clusterName := "cluster-name"
+	clusterSpec, wantCluster := given(t, clusterName, kubeconfigFile)
+	clusterSpec.VersionsBundle.KubeVersion = "1.20"
+	clusterSpec.VersionsBundle.KubeDistro.CoreDNS.Tag = "v1.8.3-eks-1-20-1"
+
+	ctx := context.Background()
+	b, client := newBootstrapper(t, bootstrapper.WithRetrier(retrier.NewWithMaxRetries(1, 0)))
+	client.EXPECT().CreateBootstrapCluster(ctx, clusterSpec).Return(kubeconfigFile, nil)
+	client.EXPECT().CreateNamespaceIfNotPresent(ctx, kubeconfigFile, constants.EksaSystemNamespace)
+	client.EXPECT().ApplyKubeSpecFromBytes(ctx, wantCluster, gomock.Any()).Return(fmt.Errorf("error"))
+
+	_, err := b.CreateBootstrapCluster(ctx, clusterSpec)
+	if err == nil {
+		t.Fatalf("expected error when creating bootstrap cluster")
 	}
 }
 
@@ -314,11 +336,11 @@ func TestBootstrapperDeleteBootstrapClusterUpgrade(t *testing.T) {
 	}
 }
 
-func newBootstrapper(t *testing.T) (*bootstrapper.Bootstrapper, *mocks.MockClusterClient) {
+func newBootstrapper(t *testing.T, opts ...bootstrapper.BootstrapperOpt) (*bootstrapper.Bootstrapper, *mocks.MockClusterClient) {
 	mockCtrl := gomock.NewController(t)
 
 	client := mocks.NewMockClusterClient(mockCtrl)
-	b := bootstrapper.New(client)
+	b := bootstrapper.New(client, opts...)
 	return b, client
 }
 

--- a/pkg/bootstrapper/retrier_client.go
+++ b/pkg/bootstrapper/retrier_client.go
@@ -1,0 +1,28 @@
+package bootstrapper
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/retrier"
+	"github.com/aws/eks-anywhere/pkg/types"
+)
+
+type retrierClient struct {
+	ClusterClient
+	*retrier.Retrier
+}
+
+func NewRetrierClient(client *ClusterClient, retrier *retrier.Retrier) *retrierClient {
+	return &retrierClient{
+		ClusterClient: *client,
+		Retrier:       retrier,
+	}
+}
+
+func (c *retrierClient) ApplyKubeSpecFromBytes(ctx context.Context, cluster *types.Cluster, data []byte) error {
+	return c.Retry(
+		func() error {
+			return c.ClusterClient.ApplyKubeSpecFromBytes(ctx, cluster, data)
+		},
+	)
+}

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -74,7 +74,7 @@ func TestClusterManagerInstallNetworkingClientError(t *testing.T) {
 	clusterSpec := test.NewClusterSpec()
 	retries := 2
 
-	c, m := newClusterManager(t)
+	c, m := newClusterManager(t, clustermanager.WithRetrier(retrier.NewWithMaxRetries(1, 0)))
 	m.provider.EXPECT().GetDeployments()
 	m.networking.EXPECT().GenerateManifest(ctx, clusterSpec, []string{}).Return(networkingManifest, nil)
 	m.client.EXPECT().ApplyKubeSpecFromBytes(ctx, cluster, networkingManifest).Return(errors.New("error from client")).Times(retries)
@@ -118,7 +118,7 @@ func TestClusterManagerInstallStorageClassClientError(t *testing.T) {
 	storageClassManifest := []byte("yaml: values")
 	retries := 2
 
-	c, m := newClusterManager(t)
+	c, m := newClusterManager(t, clustermanager.WithRetrier(retrier.NewWithMaxRetries(1, 0)))
 	m.provider.EXPECT().GenerateStorageClass().Return(storageClassManifest)
 	m.client.EXPECT().ApplyKubeSpecFromBytes(ctx, cluster, storageClassManifest).Return(
 		errors.New("error from client")).Times(retries)
@@ -413,7 +413,7 @@ func TestClusterManagerRunPostCreateWorkloadClusterErrorApplyingExtraObjects(t *
 		KubeconfigFile: "workload-kubeconfig",
 	}
 
-	c, m := newClusterManager(t)
+	c, m := newClusterManager(t, clustermanager.WithRetrier(retrier.NewWithMaxRetries(1, 0)))
 	m.client.EXPECT().GetMachines(ctx, mgmtCluster, mgmtCluster.Name).Return([]types.Machine{}, nil)
 	m.client.EXPECT().ApplyKubeSpecFromBytes(ctx, workloadCluster, gomock.Any()).Return(errors.New("error applying"))
 	if err := c.RunPostCreateWorkloadCluster(ctx, mgmtCluster, workloadCluster, clusterSpec); err == nil {
@@ -1327,7 +1327,7 @@ func TestInstallMachineHealthChecks(t *testing.T) {
 
 func TestInstallMachineHealthChecksApplyError(t *testing.T) {
 	ctx := context.Background()
-	tt := newTest(t)
+	tt := newTest(t, clustermanager.WithRetrier(retrier.NewWithMaxRetries(1, 0)))
 	tt.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Name = "worker-1"
 	tt.clusterManager.Retrier = retrier.NewWithMaxRetries(2, 1*time.Microsecond)
 	tt.mocks.client.EXPECT().ApplyKubeSpecFromBytes(ctx, tt.cluster, wantMHC).Return(errors.New("apply error")).MaxTimes(2)

--- a/pkg/clustermanager/retrier_client.go
+++ b/pkg/clustermanager/retrier_client.go
@@ -28,11 +28,7 @@ func (c *retrierClient) installCustomComponents(ctx context.Context, clusterSpec
 		return fmt.Errorf("failed loading manifest for eksa components: %v", err)
 	}
 
-	err = c.Retry(
-		func() error {
-			return c.ApplyKubeSpecFromBytes(ctx, cluster, componentsManifest.Content)
-		},
-	)
+	err = c.ApplyKubeSpecFromBytes(ctx, cluster, componentsManifest.Content)
 	if err != nil {
 		return fmt.Errorf("applying eks-a components spec: %v", err)
 	}
@@ -50,4 +46,12 @@ func (c *retrierClient) installCustomComponents(ctx context.Context, clusterSpec
 		}
 	}
 	return c.waitForDeployments(ctx, internal.EksaDeployments, cluster)
+}
+
+func (c *retrierClient) ApplyKubeSpecFromBytes(ctx context.Context, cluster *types.Cluster, data []byte) error {
+	return c.Retry(
+		func() error {
+			return c.ClusterClient.ApplyKubeSpecFromBytes(ctx, cluster, data)
+		},
+	)
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/3145

*Description of changes:*
This PR incorporates the retrierClient to the bootstrapper and the cluster_manager files to allow for retrying when usine kubectl and invoking [ApplyExtraObjects](https://github.com/aws/eks-anywhere/blob/79ee44fa3c32c9d24ba6e859f893b3e90d357113/pkg/cluster/apply.go#L16)

*Testing (if applicable):*
Unit tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

