### PR TITLE
add omitempty for optional strings in disk offering spec

### DIFF
--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
@@ -56,13 +56,13 @@ type CloudStackResourceDiskOffering struct {
 	// +optional
 	CustomSize int64 `json:"customSizeInGB,omitempty"`
 	// path the filesystem will use to mount in VM
-	MountPath string `json:"mountPath"`
+	MountPath string `json:"mountPath,omitempty"`
 	// device name of the disk offering in VM, shows up in lsblk command
-	Device string `json:"device"`
+	Device string `json:"device,omitempty"`
 	// filesystem used to mkfs in disk offering partition
-	Filesystem string `json:"filesystem"`
+	Filesystem string `json:"filesystem,omitempty"`
 	// disk label used to label disk partition
-	Label string `json:"label"`
+	Label string `json:"label,omitempty"`
 }
 
 func (r *CloudStackResourceDiskOffering) Equal(o *CloudStackResourceDiskOffering) bool {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A customer reported the empty strings under disk offering spec are not omitted. This may cause unwanted cluster upgrade to occur. 

```
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: CloudStackMachineConfig
metadata:
  creationTimestamp: null
  name: cluster-name-26z-cp
  namespace: cluster-ns
spec:
  computeOffering:
    name: 6 vCore 8GB Memory
  diskOffering:
    device: ""
    filesystem: ""
    label: ""
    mountPath: ""
  template:
```

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

