### PR TITLE
Build cluster-controller image for consumption in E2E presubmit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,9 +91,16 @@ DOCKERFILE_FOLDER = ./manager/docker/linux/eks-anywhere-cluster-controller
 
 IMAGE_REPO?=$(if $(AWS_ACCOUNT_ID),$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com,localhost:5000)
 IMAGE_TAG?=$(GIT_TAG)-$(shell git rev-parse HEAD)
+# Tagging with the commit hash and the branch the PR is raised against
+ifeq ($(JOB_NAME),eks-anywhere-e2e-presubmit)
+	IMAGE_PLATFORMS=linux/amd64
+	IMAGE_TAG=$(PULL_PULL_SHA).$(PULL_BASE_REF)
+	IMAGES_TO_BUILD?=$(CLUSTER_CONTROLLER_IMAGE)
+endif
 CLUSTER_CONTROLLER_IMAGE_NAME=eks-anywhere-cluster-controller
 CLUSTER_CONTROLLER_IMAGE=$(IMAGE_REPO)/$(CLUSTER_CONTROLLER_IMAGE_NAME):$(IMAGE_TAG)
 CLUSTER_CONTROLLER_LATEST_IMAGE=$(IMAGE_REPO)/$(CLUSTER_CONTROLLER_IMAGE_NAME):$(LATEST)
+IMAGES_TO_BUILD?=$(CLUSTER_CONTROLLER_IMAGE),$(CLUSTER_CONTROLLER_LATEST_IMAGE)
 
 # Branch builds should look at the current branch latest image for cache as well as main branch latest for cache to cover the cases
 # where its the first build from a new release branch
@@ -315,7 +322,7 @@ cluster-controller-local-images: cluster-controller-binaries $(ORGANIZE_BINARIES
 	$(BUILDCTL)
 
 .PHONY: cluster-controller-images
-cluster-controller-images: IMAGE_PLATFORMS = linux/amd64,linux/arm64
+cluster-controller-images: IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 cluster-controller-images: IMAGE_OUTPUT_TYPE = image
 cluster-controller-images: IMAGE_OUTPUT = push=true
 cluster-controller-images: cluster-controller-binaries $(ORGANIZE_BINARIES_TARGETS)
@@ -385,7 +392,7 @@ capd-test: ## Run default e2e capd test locally
 	$(MAKE) local-e2e LOCAL_E2E_TESTS=$(DOCKER_E2E_TEST)
 
 .PHONY: docker-e2e-test
-docker-e2e-test: e2e ## Run docker integration test in new ec2 instance
+docker-e2e-test: release-cluster-controller e2e ## Run docker integration test in new ec2 instance
 	scripts/e2e_test_docker.sh $(DOCKER_E2E_TEST) $(BRANCH_NAME)
 
 .PHONY: e2e-cleanup
@@ -505,12 +512,11 @@ eks-a-e2e:
 			make eks-a-release GIT_VERSION=$(DEV_GIT_VERSION); \
 			scripts/get_bundle.sh; \
 		else \
-			make check-eksa-components-override; \
 			make eks-a-cross-platform; \
 			make eks-a; \
 		fi \
 	else \
-		make check-eksa-components-override; \
+		make eksa-components-override; \
 		make eks-a; \
 	fi
 
@@ -532,9 +538,9 @@ conformance:
 conformance-tests: eks-a-e2e integration-test-binary ## Build e2e conformance tests
 	$(MAKE) e2e-tests-binary E2E_TAGS=conformance_e2e
 
-.PHONY: check-eksa-components-override
-check-eksa-components-override:
-	scripts/eksa_components_override.sh $(BUNDLE_MANIFEST_URL)
+.PHONY: eksa-components-override
+eksa-components-override:
+	scripts/eksa_components_override.sh $(BUNDLE_MANIFEST_URL) $(CLUSTER_CONTROLLER_IMAGE)
 
 .PHONY: help
 help:  ## Display this help
@@ -631,7 +637,7 @@ define BUILDCTL
 		--progress plain \
 		--local dockerfile=$(DOCKERFILE_FOLDER) \
 		--local context=. \
-		--output type=$(IMAGE_OUTPUT_TYPE),oci-mediatypes=true,\"name=$(CLUSTER_CONTROLLER_IMAGE),$(CLUSTER_CONTROLLER_LATEST_IMAGE)\",$(IMAGE_OUTPUT) \
+		--output type=$(IMAGE_OUTPUT_TYPE),oci-mediatypes=true,\"name=$(IMAGES_TO_BUILD)\",$(IMAGE_OUTPUT) \
 		$(if $(filter push=true,$(IMAGE_OUTPUT)),--export-cache type=inline,) \
 		$(foreach IMPORT_CACHE,$(IMAGE_IMPORT_CACHE),--import-cache $(IMPORT_CACHE))
 

--- a/scripts/e2e_test_docker.sh
+++ b/scripts/e2e_test_docker.sh
@@ -18,6 +18,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+delete_cluster_controller_image() {
+    aws ecr-public batch-delete-image --repository-name eks-anywhere-cluster-controller --image-ids=imageTag=${PULL_PULL_SHA}.${PULL_BASE_REF} --region us-east-1
+}
+
+trap 'unset AWS_PROFILE; delete_cluster_controller_image' EXIT
+
 if [ "$AWS_ROLE_ARN" == "" ]; then
     echo "Empty AWS_ROLE_ARN, this script must be run in a postsubmit pod with IAM Roles for Service Accounts"
     exit 1

--- a/scripts/eksa_components_override.sh
+++ b/scripts/eksa_components_override.sh
@@ -20,8 +20,7 @@ set -o nounset
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 BUNDLE_MANIFEST_URL="$1"
-CI="${CI:-false}"
-CODEBUILD_CI="${CODEBUILD_CI:-false}"
+CLUSTER_CONTROLLER_OVERRIDE_IMAGE="$2"
 
 SED=sed
 if [ "$(uname -s)" = "Darwin" ]; then
@@ -34,33 +33,8 @@ if ! yq --version; then
     exit 1
 fi
 
-# In Prow, we can get the base commit and PR commit using these
-# environment variables and check their diff to check if files under
-# config folder changed.
-if [ "$CI" = "true" ]; then
-    CONFIG_FILES_CHANGED="$(git --no-pager diff --pretty=format:"" --name-only $PULL_BASE_SHA $PULL_PULL_SHA | grep "^config/.*" || true)"
-# In Codebuild, we can do a git show on the latest commit to check
-# if files under config folder changed.
-elif [ "$CODEBUILD_CI" = "true" ]; then
-    CONFIG_FILES_CHANGED="$(git --no-pager show --pretty=format:"" --name-only HEAD | grep "^config/.*" || true)"
-else
-# For local testing, we can either do a git diff or git show on HEAD
-# based on whether the local changes have been committed
-    while true; do
-        read -p "Have you committed your local changes? (yes/no) " response
-        case $response in
-            [Yy]* ) CONFIG_FILES_CHANGED="$(git --no-pager show --pretty=format:"" --name-only HEAD | grep "^config/.*" || true)"; break;;
-            [Nn]* ) CONFIG_FILES_CHANGED="$(git --no-pager diff --pretty=format:"" --name-only HEAD | grep "^config/.*" || true)"; break;;
-            * ) echo "Please answer yes or no.";;
-        esac
-    done
-fi
-
-if [[ "$CONFIG_FILES_CHANGED" != "" ]]; then
-    mkdir -p $REPO_ROOT/bin
-    make release-manifests RELEASE_DIR=$REPO_ROOT/bin RELEASE_MANIFEST_TARGET=local-eksa-components.yaml
-    curl $BUNDLE_MANIFEST_URL -o $REPO_ROOT/bin/local-bundle-release.yaml
-    CLUSTER_CONTROLLER_OVERRIDE_IMAGE=$(yq e ".spec.versionsBundles[0].eksa.clusterController.uri" $REPO_ROOT/bin/local-bundle-release.yaml)
-    $SED -i "s,public.ecr.aws/.*/eks-anywhere-cluster-controller:.*,${CLUSTER_CONTROLLER_OVERRIDE_IMAGE}," $REPO_ROOT/bin/local-eksa-components.yaml
-    yq e -i '.spec.versionsBundles[].eksa.components.uri |= "bin/local-eksa-components.yaml"' $REPO_ROOT/bin/local-bundle-release.yaml
-fi
+mkdir -p $REPO_ROOT/bin
+make release-manifests RELEASE_DIR=$REPO_ROOT/bin RELEASE_MANIFEST_TARGET=local-eksa-components.yaml
+curl $BUNDLE_MANIFEST_URL -o $REPO_ROOT/bin/local-bundle-release.yaml
+$SED -i "s,public.ecr.aws/.*/eks-anywhere-cluster-controller:.*,${CLUSTER_CONTROLLER_OVERRIDE_IMAGE}," $REPO_ROOT/bin/local-eksa-components.yaml
+yq e -i '.spec.versionsBundles[].eksa.components.uri |= "bin/local-eksa-components.yaml"' $REPO_ROOT/bin/local-bundle-release.yaml


### PR DESCRIPTION
This PR adds logic to build the cluster-controller image in the E2E presubmit and consume it for the E2E tests. This enables the controller image to be tested in presubmits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

