### PR TITLE
Make DiskOffering in CloudStackMachineConfig optional

### DIFF
--- a/controllers/resource/fetcher.go
+++ b/controllers/resource/fetcher.go
@@ -621,7 +621,7 @@ func MapMachineTemplateToCloudStackMachineConfigSpec(csMachineTemplate *cloudsta
 		Id:   csMachineTemplate.Spec.Spec.Spec.Template.ID,
 		Name: csMachineTemplate.Spec.Spec.Spec.Template.Name,
 	}
-	csSpec.Spec.DiskOffering = anywherev1.CloudStackResourceDiskOffering{
+	csSpec.Spec.DiskOffering = &anywherev1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: anywherev1.CloudStackResourceIdentifier{
 			Id:   csMachineTemplate.Spec.Spec.Spec.DiskOffering.ID,
 			Name: csMachineTemplate.Spec.Spec.Spec.DiskOffering.Name,

--- a/controllers/resource/fetcher_test.go
+++ b/controllers/resource/fetcher_test.go
@@ -362,7 +362,7 @@ func TestMapMachineTemplateToCloudStackWorkerMachineConfigSpec(t *testing.T) {
 				Spec: anywherev1.CloudStackMachineConfigSpec{
 					Template:        anywherev1.CloudStackResourceIdentifier{Name: "rhel8-1.20"},
 					ComputeOffering: anywherev1.CloudStackResourceIdentifier{Name: "large"},
-					DiskOffering: anywherev1.CloudStackResourceDiskOffering{
+					DiskOffering: &anywherev1.CloudStackResourceDiskOffering{
 						CloudStackResourceIdentifier: anywherev1.CloudStackResourceIdentifier{
 							Name: "Small",
 						},
@@ -447,7 +447,7 @@ func TestMapMachineTemplateToCloudStackWorkerMachineConfigSpec(t *testing.T) {
 				Spec: anywherev1.CloudStackMachineConfigSpec{
 					Template:        anywherev1.CloudStackResourceIdentifier{Name: "rhel8-1.20"},
 					ComputeOffering: anywherev1.CloudStackResourceIdentifier{Name: "large"},
-					DiskOffering: anywherev1.CloudStackResourceDiskOffering{
+					DiskOffering: &anywherev1.CloudStackResourceDiskOffering{
 						CloudStackResourceIdentifier: anywherev1.CloudStackResourceIdentifier{
 							Name: "Small",
 						},

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_test.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_test.go
@@ -15,7 +15,7 @@ var cloudStackMachineConfigSpec1 = &CloudStackMachineConfigSpec{
 	ComputeOffering: CloudStackResourceIdentifier{
 		Name: "offering1",
 	},
-	DiskOffering: CloudStackResourceDiskOffering{
+	DiskOffering: &CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -106,7 +106,7 @@ func TestGetCloudStackMachineConfigs(t *testing.T) {
 						ComputeOffering: CloudStackResourceIdentifier{
 							Id: "m4-large-id",
 						},
-						DiskOffering: CloudStackResourceDiskOffering{
+						DiskOffering: &CloudStackResourceDiskOffering{
 							CloudStackResourceIdentifier: CloudStackResourceIdentifier{
 								Name: "Small",
 							},
@@ -199,7 +199,7 @@ func TestGetCloudStackMachineConfigs(t *testing.T) {
 						ComputeOffering: CloudStackResourceIdentifier{
 							Name: "m4-large",
 						},
-						DiskOffering: CloudStackResourceDiskOffering{
+						DiskOffering: &CloudStackResourceDiskOffering{
 							CloudStackResourceIdentifier: CloudStackResourceIdentifier{
 								Name: "Small",
 							},
@@ -229,7 +229,7 @@ func TestGetCloudStackMachineConfigs(t *testing.T) {
 						ComputeOffering: CloudStackResourceIdentifier{
 							Name: "m5-xlarge",
 						},
-						DiskOffering: CloudStackResourceDiskOffering{
+						DiskOffering: &CloudStackResourceDiskOffering{
 							CloudStackResourceIdentifier: CloudStackResourceIdentifier{
 								Name: "Medium",
 							},
@@ -304,6 +304,7 @@ func TestCloudStackMachineNotEqualComputeOfferingId(t *testing.T) {
 func TestCloudStackMachineNotEqualDiskOfferingName(t *testing.T) {
 	g := NewWithT(t)
 	cloudStackMachineConfigSpec2 := cloudStackMachineConfigSpec1.DeepCopy()
+	cloudStackMachineConfigSpec2.DiskOffering = (*cloudStackMachineConfigSpec1.DiskOffering).DeepCopy()
 	cloudStackMachineConfigSpec2.DiskOffering.Name = "newDiskOffering"
 	g.Expect(cloudStackMachineConfigSpec1.Equal(cloudStackMachineConfigSpec2)).To(BeFalse(), "Disk offering name comparison in CloudStackMachineConfigSpec not detected")
 }
@@ -312,6 +313,7 @@ func TestCloudStackMachineNotEqualDiskOfferingId(t *testing.T) {
 	g := NewWithT(t)
 	cloudStackMachineConfigSpec2 := cloudStackMachineConfigSpec1.DeepCopy()
 	cloudStackMachineConfigSpec2.DiskOffering.Id = "newDiskOffering"
+	cloudStackMachineConfigSpec2.DiskOffering = (*cloudStackMachineConfigSpec1.DiskOffering).DeepCopy()
 	g.Expect(cloudStackMachineConfigSpec1.Equal(cloudStackMachineConfigSpec2)).To(BeFalse(), "Disk offering id comparison in CloudStackMachineConfigSpec not detected")
 }
 
@@ -319,6 +321,7 @@ func TestCloudStackMachineNotEqualDiskOfferingMountPath(t *testing.T) {
 	g := NewWithT(t)
 	cloudStackMachineConfigSpec2 := cloudStackMachineConfigSpec1.DeepCopy()
 	cloudStackMachineConfigSpec2.DiskOffering.MountPath = "newDiskOfferingPath"
+	cloudStackMachineConfigSpec2.DiskOffering = (*cloudStackMachineConfigSpec1.DiskOffering).DeepCopy()
 	g.Expect(cloudStackMachineConfigSpec1.Equal(cloudStackMachineConfigSpec2)).To(BeFalse(), "Disk offering path comparison in CloudStackMachineConfigSpec not detected")
 }
 
@@ -326,6 +329,7 @@ func TestCloudStackMachineNotEqualDiskOfferingDevice(t *testing.T) {
 	g := NewWithT(t)
 	cloudStackMachineConfigSpec2 := cloudStackMachineConfigSpec1.DeepCopy()
 	cloudStackMachineConfigSpec2.DiskOffering.Device = "/dev/sdb"
+	cloudStackMachineConfigSpec2.DiskOffering = (*cloudStackMachineConfigSpec1.DiskOffering).DeepCopy()
 	g.Expect(cloudStackMachineConfigSpec1.Equal(cloudStackMachineConfigSpec2)).To(BeFalse(), "Disk offering device comparison in CloudStackMachineConfigSpec not detected")
 }
 
@@ -333,6 +337,7 @@ func TestCloudStackMachineNotEqualDiskOfferingLabel(t *testing.T) {
 	g := NewWithT(t)
 	cloudStackMachineConfigSpec2 := cloudStackMachineConfigSpec1.DeepCopy()
 	cloudStackMachineConfigSpec2.DiskOffering.Label = "data_disk_new"
+	cloudStackMachineConfigSpec2.DiskOffering = (*cloudStackMachineConfigSpec1.DiskOffering).DeepCopy()
 	g.Expect(cloudStackMachineConfigSpec1.Equal(cloudStackMachineConfigSpec2)).To(BeFalse(), "Disk offering label comparison in CloudStackMachineConfigSpec not detected")
 }
 
@@ -340,6 +345,7 @@ func TestCloudStackMachineNotEqualDiskOfferingFilesystem(t *testing.T) {
 	g := NewWithT(t)
 	cloudStackMachineConfigSpec2 := cloudStackMachineConfigSpec1.DeepCopy()
 	cloudStackMachineConfigSpec2.DiskOffering.Filesystem = "ext3"
+	cloudStackMachineConfigSpec2.DiskOffering = (*cloudStackMachineConfigSpec1.DiskOffering).DeepCopy()
 	g.Expect(cloudStackMachineConfigSpec1.Equal(cloudStackMachineConfigSpec2)).To(BeFalse(), "Disk offering filesystem comparison in CloudStackMachineConfigSpec not detected")
 }
 

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
@@ -35,7 +35,7 @@ type CloudStackMachineConfigSpec struct {
 	// ComputeOffering refers to a compute offering which has been previously registered in CloudStack. It represents a VM’s instance size including number of CPU’s, memory, and CPU speed. It can either be specified as a UUID or name
 	ComputeOffering CloudStackResourceIdentifier `json:"computeOffering"`
 	// DiskOffering refers to a disk offering which has been previously registered in CloudStack. It represents a disk offering with pre-defined size or custom specified disk size. It can either be specified as a UUID or name
-	DiskOffering CloudStackResourceDiskOffering `json:"diskOffering,omitempty"`
+	DiskOffering *CloudStackResourceDiskOffering `json:"diskOffering,omitempty"`
 	// Users consists of an array of objects containing the username, as well as a list of their public keys. These users will be authorized to ssh into the machines
 	Users []UserConfiguration `json:"users,omitempty"`
 	// Defaults to `no`. Can be `pro` or `anti`. If set to `pro` or `anti`, will create an affinity group per machine set of the corresponding type
@@ -87,7 +87,7 @@ func (r *CloudStackResourceDiskOffering) Equal(o *CloudStackResourceDiskOffering
 }
 
 func (r *CloudStackResourceDiskOffering) Validate() (err error, field string, value string) {
-	if len(r.Id) > 0 || len(r.Name) > 0 {
+	if r != nil && (len(r.Id) > 0 || len(r.Name) > 0) {
 		if len(r.MountPath) < 2 || !strings.HasPrefix(r.MountPath, "/") {
 			return errors.New("must be non-empty and starts with /"), "mountPath", r.MountPath
 		}
@@ -101,7 +101,7 @@ func (r *CloudStackResourceDiskOffering) Validate() (err error, field string, va
 			return errors.New("empty label"), "label", r.Label
 		}
 	} else {
-		if len(r.MountPath)+len(r.Filesystem)+len(r.Device)+len(r.Label) > 0 {
+		if r != nil && len(r.MountPath)+len(r.Filesystem)+len(r.Device)+len(r.Label) > 0 {
 			return errors.New("empty id/name"), "id or name", r.Id
 		}
 	}
@@ -219,7 +219,7 @@ func (c *CloudStackMachineConfigSpec) Equal(o *CloudStackMachineConfigSpec) bool
 	}
 	if !c.Template.Equal(&o.Template) ||
 		!c.ComputeOffering.Equal(&o.ComputeOffering) ||
-		!c.DiskOffering.Equal(&o.DiskOffering) {
+		!c.DiskOffering.Equal(o.DiskOffering) {
 		return false
 	}
 	if c.Affinity != o.Affinity {

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types_test.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
 func TestCloudStackMachineConfigDiskOfferingEqual(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -32,7 +33,7 @@ func TestCloudStackMachineConfigDiskOfferingEqual(t *testing.T) {
 }
 
 func TestCloudStackMachineConfigDiskOfferingEqualSelf(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -42,11 +43,11 @@ func TestCloudStackMachineConfigDiskOfferingEqualSelf(t *testing.T) {
 		Label:      "data_disk",
 	}
 	g := NewWithT(t)
-	g.Expect(diskOffering1.Equal(&diskOffering1)).To(BeTrue())
+	g.Expect(diskOffering1.Equal(diskOffering1)).To(BeTrue())
 }
 
 func TestCloudStackMachineConfigDiskOfferingNotEqualNil(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -60,7 +61,7 @@ func TestCloudStackMachineConfigDiskOfferingNotEqualNil(t *testing.T) {
 }
 
 func TestCloudStackMachineConfigDiskOfferingNotEqualName(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -83,7 +84,7 @@ func TestCloudStackMachineConfigDiskOfferingNotEqualName(t *testing.T) {
 }
 
 func TestCloudStackMachineConfigDiskOfferingNotEqualMountPath(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -106,7 +107,7 @@ func TestCloudStackMachineConfigDiskOfferingNotEqualMountPath(t *testing.T) {
 }
 
 func TestCloudStackMachineConfigDiskOfferingNotEqualDevice(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -129,7 +130,7 @@ func TestCloudStackMachineConfigDiskOfferingNotEqualDevice(t *testing.T) {
 }
 
 func TestCloudStackMachineConfigDiskOfferingNotEqualFilesystem(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -152,7 +153,7 @@ func TestCloudStackMachineConfigDiskOfferingNotEqualFilesystem(t *testing.T) {
 }
 
 func TestCloudStackMachineConfigDiskOfferingNotEqualLabel(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -175,7 +176,7 @@ func TestCloudStackMachineConfigDiskOfferingNotEqualLabel(t *testing.T) {
 }
 
 func TestCloudStackMachineConfigDiskOfferingValidMountPath(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -192,7 +193,7 @@ func TestCloudStackMachineConfigDiskOfferingValidMountPath(t *testing.T) {
 }
 
 func TestCloudStackMachineConfigDiskOfferingInValidNoIDAndName(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{},
 		MountPath:                    "/data",
 		Device:                       "/dev/vdb",
@@ -208,7 +209,7 @@ func TestCloudStackMachineConfigDiskOfferingInValidNoIDAndName(t *testing.T) {
 }
 
 func TestCloudStackMachineConfigDiskOfferingValidNoIDAndName(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{},
 	}
 	g := NewWithT(t)
@@ -219,7 +220,7 @@ func TestCloudStackMachineConfigDiskOfferingValidNoIDAndName(t *testing.T) {
 }
 
 func TestCloudStackMachineConfigDiskOfferingInValidMountPathRoot(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -237,7 +238,7 @@ func TestCloudStackMachineConfigDiskOfferingInValidMountPathRoot(t *testing.T) {
 }
 
 func TestCloudStackMachineConfigDiskOfferingInValidMountPathRelative(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -255,7 +256,7 @@ func TestCloudStackMachineConfigDiskOfferingInValidMountPathRelative(t *testing.
 }
 
 func TestCloudStackMachineConfigDiskOfferingValid(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -272,7 +273,7 @@ func TestCloudStackMachineConfigDiskOfferingValid(t *testing.T) {
 }
 
 func TestCloudStackMachineConfigDiskOfferingInValidEmptyDevice(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -290,7 +291,7 @@ func TestCloudStackMachineConfigDiskOfferingInValidEmptyDevice(t *testing.T) {
 }
 
 func TestCloudStackMachineConfigDiskOfferingInValidEmptyFilesystem(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -308,7 +309,7 @@ func TestCloudStackMachineConfigDiskOfferingInValidEmptyFilesystem(t *testing.T)
 }
 
 func TestCloudStackMachineConfigDiskOfferingInValidEmptyLabel(t *testing.T) {
-	diskOffering1 := v1alpha1.CloudStackResourceDiskOffering{
+	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "diskOffering1",
 		},
@@ -356,4 +357,61 @@ func TestCloudStackMachineConfigSymlinksInValidComma(t *testing.T) {
 	g.Expect(fieldName == "symlinks").To(BeTrue())
 	g.Expect(fieldValue == "/data/var/log,d").To(BeTrue())
 	g.Expect(err.Error() == "has char not in portable file name set").To(BeTrue())
+}
+
+func TestCloudStackMachineConfigSerialize(t *testing.T) {
+	tests := map[string]struct {
+		machineConfig interface{}
+		expected      string
+	}{
+		"Serialize machine config": {
+			machineConfig: v1alpha1.CloudStackMachineConfig{
+				Spec: v1alpha1.CloudStackMachineConfigSpec{
+					DiskOffering: &v1alpha1.CloudStackResourceDiskOffering{
+						CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
+							Name: "diskOffering1",
+						},
+						MountPath:  "/data",
+						Device:     "/dev/sda1",
+						Filesystem: "ext4",
+						Label:      "data_disk",
+					},
+				},
+			},
+			expected: `metadata:
+  creationTimestamp: null
+spec:
+  computeOffering: {}
+  diskOffering:
+    device: /dev/sda1
+    filesystem: ext4
+    label: data_disk
+    mountPath: /data
+    name: diskOffering1
+  template: {}
+status: {}
+`,
+		},
+		"diskOffering should not appear when it's not defined": {
+			machineConfig: v1alpha1.CloudStackMachineConfig{
+				Spec: v1alpha1.CloudStackMachineConfigSpec{},
+			},
+			expected: `metadata:
+  creationTimestamp: null
+spec:
+  computeOffering: {}
+  template: {}
+status: {}
+`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual, err := yaml.Marshal(tc.machineConfig)
+			g := NewWithT(t)
+			g.Expect(err).To(BeNil())
+			g.Expect(string(actual)).To(Equal(tc.expected))
+		})
+	}
 }

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_webhook_test.go
@@ -34,7 +34,7 @@ func TestCloudStackMachineConfigValidateCreateValidDiskOffering(t *testing.T) {
 
 	features.ClearCache()
 	c := cloudstackMachineConfig()
-	c.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	c.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "DiskOffering",
 		},
@@ -57,7 +57,7 @@ func TestCloudStackMachineConfigValidateCreateInvalidDiskOfferingBadMountPath(t 
 
 	features.ClearCache()
 	c := cloudstackMachineConfig()
-	c.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	c.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "DiskOffering",
 		},
@@ -80,7 +80,7 @@ func TestCloudStackMachineConfigValidateCreateInvalidDiskOfferingEmptyDevice(t *
 
 	features.ClearCache()
 	c := cloudstackMachineConfig()
-	c.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	c.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "DiskOffering",
 		},
@@ -103,7 +103,7 @@ func TestCloudStackMachineConfigValidateCreateInvalidDiskOfferingEmptyFilesystem
 
 	features.ClearCache()
 	c := cloudstackMachineConfig()
-	c.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	c.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "DiskOffering",
 		},
@@ -126,7 +126,7 @@ func TestCloudStackMachineConfigValidateCreateInvalidDiskOfferingEmptyLabel(t *t
 
 	features.ClearCache()
 	c := cloudstackMachineConfig()
-	c.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	c.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "DiskOffering",
 		},
@@ -305,7 +305,7 @@ func TestCPCloudStackMachineValidateUpdateComputeOfferingMutable(t *testing.T) {
 func TestCPCloudStackMachineValidateUpdateDiskOfferingMutable(t *testing.T) {
 	vOld := cloudstackMachineConfig()
 	vOld.SetControlPlane()
-	vOld.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	vOld.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "oldDiskOffering",
 		},
@@ -316,7 +316,7 @@ func TestCPCloudStackMachineValidateUpdateDiskOfferingMutable(t *testing.T) {
 	}
 	c := vOld.DeepCopy()
 
-	c.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	c.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "newDiskOffering",
 		},
@@ -332,7 +332,7 @@ func TestCPCloudStackMachineValidateUpdateDiskOfferingMutable(t *testing.T) {
 func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailInvalidMountPath(t *testing.T) {
 	vOld := cloudstackMachineConfig()
 	vOld.SetControlPlane()
-	vOld.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	vOld.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "oldDiskOffering",
 		},
@@ -343,7 +343,7 @@ func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailInvalidMountPat
 	}
 	c := vOld.DeepCopy()
 
-	c.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	c.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "newDiskOffering",
 		},
@@ -359,7 +359,7 @@ func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailInvalidMountPat
 func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailEmptyDevice(t *testing.T) {
 	vOld := cloudstackMachineConfig()
 	vOld.SetControlPlane()
-	vOld.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	vOld.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "oldDiskOffering",
 		},
@@ -370,7 +370,7 @@ func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailEmptyDevice(t *
 	}
 	c := vOld.DeepCopy()
 
-	c.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	c.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "newDiskOffering",
 		},
@@ -386,7 +386,7 @@ func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailEmptyDevice(t *
 func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailEmptyFilesystem(t *testing.T) {
 	vOld := cloudstackMachineConfig()
 	vOld.SetControlPlane()
-	vOld.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	vOld.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "oldDiskOffering",
 		},
@@ -397,7 +397,7 @@ func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailEmptyFilesystem
 	}
 	c := vOld.DeepCopy()
 
-	c.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	c.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "newDiskOffering",
 		},
@@ -413,7 +413,7 @@ func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailEmptyFilesystem
 func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailEmptyLabel(t *testing.T) {
 	vOld := cloudstackMachineConfig()
 	vOld.SetControlPlane()
-	vOld.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	vOld.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "oldDiskOffering",
 		},
@@ -424,7 +424,7 @@ func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailEmptyLabel(t *t
 	}
 	c := vOld.DeepCopy()
 
-	c.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	c.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "newDiskOffering",
 		},
@@ -498,7 +498,7 @@ func TestWorkersCPCloudStackMachineValidateUpdateComputeOfferingMutable(t *testi
 
 func TestWorkersCPCloudStackMachineValidateUpdateDiskOfferingMutable(t *testing.T) {
 	vOld := cloudstackMachineConfig()
-	vOld.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	vOld.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "oldDiskOffering",
 		},
@@ -506,7 +506,7 @@ func TestWorkersCPCloudStackMachineValidateUpdateDiskOfferingMutable(t *testing.
 	}
 	c := vOld.DeepCopy()
 
-	c.Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	c.Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "newDiskOffering",
 		},

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -908,7 +908,7 @@ func TestKubectlGetEksaCloudStackMachineConfig(t *testing.T) {
 					ComputeOffering: v1alpha1.CloudStackResourceIdentifier{
 						Name: "testOffering",
 					},
-					DiskOffering: v1alpha1.CloudStackResourceDiskOffering{
+					DiskOffering: &v1alpha1.CloudStackResourceDiskOffering{
 						CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 							Name: "testOffering",
 						},

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -1635,6 +1635,7 @@ func TestClusterUpgradeNeededMachineConfigsChangedDiskOffering(t *testing.T) {
 		func(ctx context.Context, cloudstackMachineConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.CloudStackMachineConfig, error) {
 			if cloudstackMachineConfigName == "test" {
 				modifiedMachineConfig := machineConfigsMap["test"].DeepCopy()
+				modifiedMachineConfig.Spec.DiskOffering = (*machineConfigsMap["test"].Spec.DiskOffering).DeepCopy()
 				modifiedMachineConfig.Spec.DiskOffering.Name = "shiny-new-diskoffering"
 				return modifiedMachineConfig, nil
 			}

--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -267,8 +267,8 @@ func (v *Validator) validateMachineConfig(ctx context.Context, datacenterConfig 
 		if err := v.cmk.ValidateServiceOfferingPresent(ctx, az.CredentialsRef, zoneId, machineConfig.Spec.ComputeOffering); err != nil {
 			return fmt.Errorf("validating service offering: %v", err)
 		}
-		if len(machineConfig.Spec.DiskOffering.Id) > 0 || len(machineConfig.Spec.DiskOffering.Name) > 0 {
-			if err := v.cmk.ValidateDiskOfferingPresent(ctx, az.CredentialsRef, zoneId, machineConfig.Spec.DiskOffering); err != nil {
+		if machineConfig.Spec.DiskOffering != nil && (len(machineConfig.Spec.DiskOffering.Id) > 0 || len(machineConfig.Spec.DiskOffering.Name) > 0) {
+			if err := v.cmk.ValidateDiskOfferingPresent(ctx, az.CredentialsRef, zoneId, *machineConfig.Spec.DiskOffering); err != nil {
 				return fmt.Errorf("validating disk offering: %v", err)
 			}
 		}

--- a/pkg/providers/cloudstack/validator_test.go
+++ b/pkg/providers/cloudstack/validator_test.go
@@ -216,11 +216,11 @@ func TestSetupAndValidateDiskOfferingEmpty(t *testing.T) {
 		machineConfigsLookup: machineConfigs,
 	}
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 
 	setupMockForAvailabilityZonesValidation(cmk, ctx, datacenterConfig.Spec.AvailabilityZones)
 
@@ -255,9 +255,9 @@ func TestSetupAndValidateValidDiskOffering(t *testing.T) {
 		machineConfigsLookup: machineConfigs,
 	}
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "DiskOffering",
 		},
@@ -267,7 +267,7 @@ func TestSetupAndValidateValidDiskOffering(t *testing.T) {
 		Label:      "data_disk",
 	}
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 
 	setupMockForAvailabilityZonesValidation(cmk, ctx, datacenterConfig.Spec.AvailabilityZones)
 
@@ -302,9 +302,9 @@ func TestSetupAndValidateInvalidDiskOfferingNotPresent(t *testing.T) {
 		machineConfigsLookup: machineConfigs,
 	}
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "DiskOffering",
 		},
@@ -314,7 +314,7 @@ func TestSetupAndValidateInvalidDiskOfferingNotPresent(t *testing.T) {
 		Label:      "data_disk",
 	}
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 
 	setupMockForAvailabilityZonesValidation(cmk, ctx, datacenterConfig.Spec.AvailabilityZones)
 
@@ -348,9 +348,9 @@ func TestSetupAndValidateInValidDiskOfferingBadMountPath(t *testing.T) {
 		machineConfigsLookup: machineConfigs,
 	}
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "DiskOffering",
 		},
@@ -360,7 +360,7 @@ func TestSetupAndValidateInValidDiskOfferingBadMountPath(t *testing.T) {
 		Label:      "data_disk",
 	}
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 
 	setupMockForAvailabilityZonesValidation(cmk, ctx, datacenterConfig.Spec.AvailabilityZones)
 
@@ -392,9 +392,9 @@ func TestSetupAndValidateInValidDiskOfferingEmptyDevice(t *testing.T) {
 		machineConfigsLookup: machineConfigs,
 	}
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "DiskOffering",
 		},
@@ -404,7 +404,7 @@ func TestSetupAndValidateInValidDiskOfferingEmptyDevice(t *testing.T) {
 		Label:      "data_disk",
 	}
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 
 	setupMockForAvailabilityZonesValidation(cmk, ctx, datacenterConfig.Spec.AvailabilityZones)
 
@@ -436,9 +436,9 @@ func TestSetupAndValidateInValidDiskOfferingEmptyFilesystem(t *testing.T) {
 		machineConfigsLookup: machineConfigs,
 	}
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "DiskOffering",
 		},
@@ -448,7 +448,7 @@ func TestSetupAndValidateInValidDiskOfferingEmptyFilesystem(t *testing.T) {
 		Label:      "data_disk",
 	}
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 
 	setupMockForAvailabilityZonesValidation(cmk, ctx, datacenterConfig.Spec.AvailabilityZones)
 
@@ -480,9 +480,9 @@ func TestSetupAndValidateInValidDiskOfferingEmptyLabel(t *testing.T) {
 		machineConfigsLookup: machineConfigs,
 	}
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[controlPlaneMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{
+	cloudStackClusterSpec.machineConfigsLookup[workerNodeMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{
 			Name: "DiskOffering",
 		},
@@ -492,7 +492,7 @@ func TestSetupAndValidateInValidDiskOfferingEmptyLabel(t *testing.T) {
 		Label:      "",
 	}
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
-	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.DiskOffering = v1alpha1.CloudStackResourceDiskOffering{}
+	cloudStackClusterSpec.machineConfigsLookup[etcdMachineConfigName].Spec.DiskOffering = &v1alpha1.CloudStackResourceDiskOffering{}
 
 	setupMockForAvailabilityZonesValidation(cmk, ctx, datacenterConfig.Spec.AvailabilityZones)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`DiskOffering: {}` is present when marshaling a CloudStackMachineConfig without defining it. This might break the backward compatibility and cause unwanted rolling upgrade. 

*Testing (if applicable):*
Unit testing
Manual testing
1. Create a cluster without DiskOffering
2. Upgrade the cluster with DiskOffering
3. Upgrade the cluster without DiskOffering 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

