### PR TITLE
Improved validation of kubeconfig files

### DIFF
--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -21,12 +21,9 @@ type deleteClusterOptions struct {
 	forceCleanup          bool
 	hardwareFileName      string
 	tinkerbellBootstrapIP string
-	kubeconfigValidator   kubeconfig.Validator
 }
 
-var dc = &deleteClusterOptions{
-	kubeconfigValidator: kubeconfig.NewValidator(),
-}
+var dc = &deleteClusterOptions{}
 
 var deleteClusterCmd = &cobra.Command{
 	Use:          "cluster (<cluster-name>|-f <config-file>)",
@@ -72,7 +69,7 @@ func (dc *deleteClusterOptions) validate(ctx context.Context, args []string) err
 	}
 
 	kubeconfigPath := getKubeconfigPath(clusterConfig.Name, dc.wConfig)
-	if err := dc.kubeconfigValidator.ValidateFile(kubeconfigPath); err != nil {
+	if err := kubeconfig.ValidateFile(kubeconfigPath); err != nil {
 		return err
 	}
 

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -69,8 +69,8 @@ func (dc *deleteClusterOptions) validate(ctx context.Context, args []string) err
 	}
 
 	kubeconfigPath := getKubeconfigPath(clusterConfig.Name, dc.wConfig)
-	if !validations.FileExistsAndIsNotEmpty(kubeconfigPath) {
-		return kubeconfig.NewMissingFileError(kubeconfigPath)
+	if err := validations.KubeConfigFile(kubeconfigPath); err != nil {
+		return err
 	}
 
 	return nil

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -21,9 +21,12 @@ type deleteClusterOptions struct {
 	forceCleanup          bool
 	hardwareFileName      string
 	tinkerbellBootstrapIP string
+	kubeconfigValidator   kubeconfig.Validator
 }
 
-var dc = &deleteClusterOptions{}
+var dc = &deleteClusterOptions{
+	kubeconfigValidator: kubeconfig.NewValidator(),
+}
 
 var deleteClusterCmd = &cobra.Command{
 	Use:          "cluster (<cluster-name>|-f <config-file>)",
@@ -69,7 +72,7 @@ func (dc *deleteClusterOptions) validate(ctx context.Context, args []string) err
 	}
 
 	kubeconfigPath := getKubeconfigPath(clusterConfig.Name, dc.wConfig)
-	if err := validations.KubeConfigFile(kubeconfigPath); err != nil {
+	if err := dc.kubeconfigValidator.ValidateFile(kubeconfigPath); err != nil {
 		return err
 	}
 

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -66,8 +66,8 @@ func (csbo *createSupportBundleOptions) validate(ctx context.Context) error {
 	}
 
 	kubeconfigPath := kubeconfig.FromClusterName(clusterConfig.Name)
-	if !validations.FileExistsAndIsNotEmpty(kubeconfigPath) {
-		return kubeconfig.NewMissingFileError(kubeconfigPath)
+	if err := validations.KubeConfigFile(kubeconfigPath); err != nil {
+		return err
 	}
 
 	return nil

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -24,12 +24,9 @@ type createSupportBundleOptions struct {
 	bundleConfig          string
 	hardwareFileName      string
 	tinkerbellBootstrapIP string
-	kubeconfigValidator   kubeconfig.Validator
 }
 
-var csbo = &createSupportBundleOptions{
-	kubeconfigValidator: kubeconfig.NewValidator(),
-}
+var csbo = &createSupportBundleOptions{}
 
 var supportbundleCmd = &cobra.Command{
 	Use:          "support-bundle -f my-cluster.yaml",
@@ -68,7 +65,7 @@ func (csbo *createSupportBundleOptions) validate(ctx context.Context) error {
 	}
 
 	kubeconfigPath := kubeconfig.FromClusterName(clusterConfig.Name)
-	if err := csbo.kubeconfigValidator.ValidateFile(kubeconfigPath); err != nil {
+	if err := kubeconfig.ValidateFile(kubeconfigPath); err != nil {
 		return err
 	}
 

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/diagnostics"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
-	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/version"
 )
 
@@ -25,9 +24,12 @@ type createSupportBundleOptions struct {
 	bundleConfig          string
 	hardwareFileName      string
 	tinkerbellBootstrapIP string
+	kubeconfigValidator   kubeconfig.Validator
 }
 
-var csbo = &createSupportBundleOptions{}
+var csbo = &createSupportBundleOptions{
+	kubeconfigValidator: kubeconfig.NewValidator(),
+}
 
 var supportbundleCmd = &cobra.Command{
 	Use:          "support-bundle -f my-cluster.yaml",
@@ -66,7 +68,7 @@ func (csbo *createSupportBundleOptions) validate(ctx context.Context) error {
 	}
 
 	kubeconfigPath := kubeconfig.FromClusterName(clusterConfig.Name)
-	if err := validations.KubeConfigFile(kubeconfigPath); err != nil {
+	if err := csbo.kubeconfigValidator.ValidateFile(kubeconfigPath); err != nil {
 		return err
 	}
 

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/dependencies"
+	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/upgradevalidations"
@@ -22,9 +23,12 @@ type upgradeClusterOptions struct {
 	forceClean            bool
 	hardwareCSVPath       string
 	tinkerbellBootstrapIP string
+	kubeconfigValidator   kubeconfig.Validator
 }
 
-var uc = &upgradeClusterOptions{}
+var uc = &upgradeClusterOptions{
+	kubeconfigValidator: kubeconfig.NewValidator(),
+}
 
 var upgradeClusterCmd = &cobra.Command{
 	Use:          "cluster",
@@ -170,7 +174,7 @@ func (uc *upgradeClusterOptions) commonValidations(ctx context.Context) (cluster
 	}
 
 	kubeconfigPath := getKubeconfigPath(clusterConfig.Name, uc.wConfig)
-	if err := validations.KubeConfigFile(kubeconfigPath); err != nil {
+	if err := uc.kubeconfigValidator.ValidateFile(kubeconfigPath); err != nil {
 		return nil, err
 	}
 

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/dependencies"
-	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/upgradevalidations"
@@ -171,8 +170,8 @@ func (uc *upgradeClusterOptions) commonValidations(ctx context.Context) (cluster
 	}
 
 	kubeconfigPath := getKubeconfigPath(clusterConfig.Name, uc.wConfig)
-	if !validations.FileExistsAndIsNotEmpty(kubeconfigPath) {
-		return nil, kubeconfig.NewMissingFileError(kubeconfigPath)
+	if err := validations.KubeConfigFile(kubeconfigPath); err != nil {
+		return nil, err
 	}
 
 	return clusterConfig, nil

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -23,12 +23,9 @@ type upgradeClusterOptions struct {
 	forceClean            bool
 	hardwareCSVPath       string
 	tinkerbellBootstrapIP string
-	kubeconfigValidator   kubeconfig.Validator
 }
 
-var uc = &upgradeClusterOptions{
-	kubeconfigValidator: kubeconfig.NewValidator(),
-}
+var uc = &upgradeClusterOptions{}
 
 var upgradeClusterCmd = &cobra.Command{
 	Use:          "cluster",
@@ -174,7 +171,7 @@ func (uc *upgradeClusterOptions) commonValidations(ctx context.Context) (cluster
 	}
 
 	kubeconfigPath := getKubeconfigPath(clusterConfig.Name, uc.wConfig)
-	if err := uc.kubeconfigValidator.ValidateFile(kubeconfigPath); err != nil {
+	if err := kubeconfig.ValidateFile(kubeconfigPath); err != nil {
 		return nil, err
 	}
 

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // FromClusterFormat defines the format of the kubeconfig of the
@@ -29,52 +30,90 @@ func FromEnvironment() string {
 	return os.Getenv(EnvName)
 }
 
-type missingFileError struct {
-	Path string
-}
-
-// NewMissingFileError creates a missing kubeconfig file error.
-func NewMissingFileError(path string) error {
-	return missingFileError{Path: path}
-}
-
-func (m missingFileError) Error() string {
-	return fmt.Sprintf("kubeconfig file missing: path=%v", m.Path)
-}
-
-// Validate checks that kubeconfig data is readable.
+// Loader abstracts the unmarshaling of a kubeconfig file into a Config.
 //
-// This does not validate the values contained within; just that the data has
-// the basic structure of a kubeconfig.
-func Validate(r io.Reader) error {
+// This is essentially building an interface around the clientcmd.Load
+// function so that it can be swapped out for tests.
+type Loader interface {
+	// Load a Config from a byte slice.
+	//
+	// (Why do the k8s authors avoid io.Reader, forcing me to waste heap space
+	// with extra byte slices?)
+	Load([]byte) (*clientcmdapi.Config, error)
+}
+
+// clientcmdLoader loads a Config via the clientcmd.Load function.
+type clientcmdLoader struct{}
+
+var _ Loader = (*clientcmdLoader)(nil)
+
+// Load implements Loader.
+func (l *clientcmdLoader) Load(b []byte) (*clientcmdapi.Config, error) {
+	return clientcmd.Load(b)
+}
+
+// Validator abstracts the validation of kubeconfig data.
+type Validator interface {
+	// Validate config data from an io.Reader.
+	Validate(r io.Reader) error
+
+	// ValidateFile validates config data from a filename.
+	ValidateFile(filename string) error
+}
+
+type validator struct {
+	loader Loader
+}
+
+var _ Validator = (*validator)(nil)
+
+// NewValidatorWithLoader creates a Validator that loads config data with
+// Loader.
+//
+// Most users will want to use NewValidator, which uses a default Loader.
+func NewValidatorWithLoader(loader Loader) Validator {
+	// Use the default if nil is passed, to avoid a nil pointer dereference.
+	if loader == nil {
+		loader = &clientcmdLoader{}
+	}
+	return &validator{
+		loader: loader,
+	}
+}
+
+// NewValidator creates a default Validator for kubeconfig data.
+func NewValidator() Validator {
+	return NewValidatorWithLoader(&clientcmdLoader{})
+}
+
+// Validate implements the Validator interface.
+func (v *validator) Validate(r io.Reader) error {
 	kubeConfigData, err := ioutil.ReadAll(r)
 	if err != nil {
 		return err
 	}
 
-	// I wish I knew why the k8s authors avoid Reader/Writer interfaces so
-	// much. :(
-	if err := validator(kubeConfigData); err != nil {
-		return err
+	// This is the only validation done at the moment. However, it
+	// accomplishes a few things:
+	//   1. Checks that the data exist (size > 0).
+	//   2. Checks that the data fits the basic schema of a Config.
+	//   3. If called via ValidateFile, checks that the file exists.
+	if _, err := v.loader.Load(kubeConfigData); err != nil {
+		return fmt.Errorf("validating kubeconfig: %w", err)
 	}
-
 	return nil
 }
 
-// validator can be overridden for easier testing.
-var validator = func(b []byte) error { _, err := clientcmd.Load(b); return err }
-
-// ValidateFile is a helper for Validate.
-func ValidateFile(filename string) error {
+// ValidateFile implements the Validator interface.
+func (v *validator) ValidateFile(filename string) error {
 	f, err := os.Open(filename)
 	if err != nil {
 		return fmt.Errorf("%q: %w", filename, err)
 	}
 	defer f.Close()
 
-	if err := Validate(f); err != nil {
+	if err := v.Validate(f); err != nil {
 		return fmt.Errorf("%q: %w", filename, err)
 	}
-
 	return nil
 }

--- a/pkg/kubeconfig/kubeconfig_test.go
+++ b/pkg/kubeconfig/kubeconfig_test.go
@@ -9,21 +9,23 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func TestValidate(t *testing.T) {
 	t.Run("reports errors from validator", func(t *testing.T) {
-		withValidationError(t, testError)
+		v := NewValidatorWithLoader(newTestLoader(testError))
 
-		if err := Validate(&bytes.Buffer{}); err == nil {
+		if err := v.Validate(&bytes.Buffer{}); err == nil {
 			t.Fatalf("expected error, got nil")
 		}
 	})
 
 	t.Run("returns nil when valid", func(t *testing.T) {
-		withValidationError(t, nil)
+		v := NewValidatorWithLoader(newTestLoader(nil))
 
-		if err := Validate(&bytes.Buffer{}); err != nil {
+		if err := v.Validate(&bytes.Buffer{}); err != nil {
 			t.Fatalf("expected no error, got %s", err)
 		}
 	})
@@ -32,24 +34,25 @@ func TestValidate(t *testing.T) {
 func TestValidateFile(t *testing.T) {
 	t.Run("reports errors for files that don't exist", func(t *testing.T) {
 		doesntExist := filepath.Join(t.TempDir(), "does-not-exist")
-		err := ValidateFile(doesntExist)
+		v := NewValidator()
+		err := v.ValidateFile(doesntExist)
 		if err == nil || !errors.Is(err, fs.ErrNotExist) {
 			t.Fatalf("expected fs.IsNotExist, got %s", err)
 		}
 	})
 
 	t.Run("reports errors from validator", func(t *testing.T) {
-		withValidationError(t, testError)
+		v := NewValidatorWithLoader(newTestLoader(testError))
 
-		if err := ValidateFile(withFakeFile(t).Name()); err == nil {
+		if err := v.ValidateFile(withFakeFile(t).Name()); err == nil {
 			t.Fatalf("expected error, got nil")
 		}
 	})
 
 	t.Run("returns nil if valid", func(t *testing.T) {
-		withValidationError(t, nil)
+		v := NewValidatorWithLoader(newTestLoader(nil))
 
-		if err := ValidateFile(withFakeFile(t).Name()); err != nil {
+		if err := v.ValidateFile(withFakeFile(t).Name()); err != nil {
 			t.Fatalf("expected no error, got %s", err)
 		}
 	})
@@ -57,20 +60,6 @@ func TestValidateFile(t *testing.T) {
 
 // testError is... a test error!
 var testError = fmt.Errorf("test error")
-
-// withValidationError is a helper for setting the validator for a test, and
-// automatically reverting the change afterward.
-//
-// This is *NOT* thread safe! (Because it manipulates package-level variables).
-var withValidationError = func(t *testing.T, err error) {
-	oldValidator := validator
-	validator = func([]byte) error {
-		return err
-	}
-	t.Cleanup(func() {
-		validator = oldValidator
-	})
-}
 
 // withFakeFile returns a throwaway file in a test-specific directory.
 //
@@ -86,4 +75,21 @@ func withFakeFile(t *testing.T) (f *os.File) {
 	})
 
 	return f
+}
+
+type testLoader struct {
+	testError error
+}
+
+var _ Loader = (*testLoader)(nil)
+
+func newTestLoader(err error) *testLoader {
+	return &testLoader{testError: err}
+}
+
+func (t *testLoader) Load([]byte) (*clientcmdapi.Config, error) {
+	if t.testError != nil {
+		return nil, t.testError
+	}
+	return &clientcmdapi.Config{}, nil
 }

--- a/pkg/kubeconfig/kubeconfig_test.go
+++ b/pkg/kubeconfig/kubeconfig_test.go
@@ -1,0 +1,89 @@
+package kubeconfig
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	t.Run("reports errors from validator", func(t *testing.T) {
+		withValidationError(t, testError)
+
+		if err := Validate(&bytes.Buffer{}); err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+	})
+
+	t.Run("returns nil when valid", func(t *testing.T) {
+		withValidationError(t, nil)
+
+		if err := Validate(&bytes.Buffer{}); err != nil {
+			t.Fatalf("expected no error, got %s", err)
+		}
+	})
+}
+
+func TestValidateFile(t *testing.T) {
+	t.Run("reports errors for files that don't exist", func(t *testing.T) {
+		doesntExist := filepath.Join(t.TempDir(), "does-not-exist")
+		err := ValidateFile(doesntExist)
+		if err == nil || !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("expected fs.IsNotExist, got %s", err)
+		}
+	})
+
+	t.Run("reports errors from validator", func(t *testing.T) {
+		withValidationError(t, testError)
+
+		if err := ValidateFile(withFakeFile(t).Name()); err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+	})
+
+	t.Run("returns nil if valid", func(t *testing.T) {
+		withValidationError(t, nil)
+
+		if err := ValidateFile(withFakeFile(t).Name()); err != nil {
+			t.Fatalf("expected no error, got %s", err)
+		}
+	})
+}
+
+// testError is... a test error!
+var testError = fmt.Errorf("test error")
+
+// withValidationError is a helper for setting the validator for a test, and
+// automatically reverting the change afterward.
+//
+// This is *NOT* thread safe! (Because it manipulates package-level variables).
+var withValidationError = func(t *testing.T, err error) {
+	oldValidator := validator
+	validator = func([]byte) error {
+		return err
+	}
+	t.Cleanup(func() {
+		validator = oldValidator
+	})
+}
+
+// withFakeFile returns a throwaway file in a test-specific directory.
+//
+// The file is automatically closed and removed when the test ends.
+func withFakeFile(t *testing.T) (f *os.File) {
+	f, err := ioutil.TempFile(t.TempDir(), "fake-file")
+	if err != nil {
+		t.Fatalf("opening temp file: %s", err)
+	}
+
+	t.Cleanup(func() {
+		f.Close()
+	})
+
+	return f
+}

--- a/pkg/validations/input.go
+++ b/pkg/validations/input.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 )
 
 func ValidateClusterNameArg(args []string) (string, error) {
@@ -32,8 +31,3 @@ func FileExistsAndIsNotEmpty(filename string) bool {
 	info, err := os.Stat(filename)
 	return err == nil && info.Size() > 0
 }
-
-var (
-	KubeConfigFile = kubeconfig.ValidateFile
-	KubeConfig     = kubeconfig.Validate
-)

--- a/pkg/validations/input.go
+++ b/pkg/validations/input.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 )
 
 func ValidateClusterNameArg(args []string) (string, error) {
@@ -31,3 +32,8 @@ func FileExistsAndIsNotEmpty(filename string) bool {
 	info, err := os.Stat(filename)
 	return err == nil && info.Size() > 0
 }
+
+var (
+	KubeConfigFile = kubeconfig.ValidateFile
+	KubeConfig     = kubeconfig.Validate
+)


### PR DESCRIPTION
Instead of just checking that the file exists, the k8s client-go library is
used to load the file's data, which validates its basic structure, as well as
its existence.

This small step is a precursor to further work to concentrate how kubeconfig
files are handled across the various eksctl-anywhere subcommands.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

