### PR TITLE
Allow Private SSH Git Urls using FluxConfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tinkerbell/rufio v0.0.0-20220606134123-599b7401b5cc
 	github.com/tinkerbell/tink v0.6.1-0.20220509141453-30fe9e015575
+	github.com/whilp/git-urls v1.0.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8

--- a/go.sum
+++ b/go.sum
@@ -1681,6 +1681,8 @@ github.com/vmware/govmomi v0.29.0 h1:SHJQ7DUc4fltFZv16znJNGHR1/XhiDK5iKxm2OqwkuU
 github.com/vmware/govmomi v0.29.0/go.mod h1:F7adsVewLNHsW/IIm7ziFURaXDaHEwcc+ym4r3INMdY=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/vmware/vmw-ovflib v0.0.0-20170608004843-1f217b9dc714/go.mod h1:jiPk45kn7klhByRvUq5i2vo1RtHKBHj+iWGFpxbXuuI=
+github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
+github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 github.com/xanzy/go-gitlab v0.50.0/go.mod h1:Q+hQhV508bDPoBijv7YjK/Lvlb4PhVhJdKqXVQrUoAE=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=

--- a/pkg/api/v1alpha1/fluxconfig.go
+++ b/pkg/api/v1alpha1/fluxconfig.go
@@ -3,9 +3,8 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
-	"net/url"
-
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/whilp/git-urls"
 )
 
 const (
@@ -75,7 +74,7 @@ func validateGithubProviderConfig(config GithubProviderConfig) error {
 }
 
 func validateRepositoryUrl(repositoryUrl string) error {
-	url, err := url.Parse(repositoryUrl)
+	url, err := giturls.Parse(repositoryUrl)
 	if err != nil {
 		return fmt.Errorf("unable to parse repository url: %v", err)
 	}

--- a/pkg/git/factory/gitfactory.go
+++ b/pkg/git/factory/gitfactory.go
@@ -65,7 +65,10 @@ func Build(ctx context.Context, cluster *v1alpha1.Cluster, fluxConfig *v1alpha1.
 		if err != nil {
 			return nil, err
 		}
-		repoUrl = fluxConfig.Spec.Git.RepositoryUrl
+		// go-git fails to parse private git repo urls if the URL scheme is ssh
+		// The url is a valid SSH url even if we strip ssh://
+		// For example git@github.com:ORGNAME/reponame.git
+		repoUrl = strings.TrimPrefix(fluxConfig.Spec.Git.RepositoryUrl, "ssh://")
 		repo = path.Base(strings.TrimSuffix(repoUrl, filepath.Ext(repoUrl)))
 	default:
 		return nil, fmt.Errorf("no valid git provider in FluxConfigSpec. Spec: %v", fluxConfig)


### PR DESCRIPTION
*Issue #, if available:*
#3195 

*Description of changes:*
Allows private ssh git urls

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

