### PR TITLE
unset explicit GitOpsref name, as it is set in WithFluxGithub

### DIFF
--- a/test/e2e/flux_test.go
+++ b/test/e2e/flux_test.go
@@ -312,7 +312,7 @@ func TestDockerInstallGithubFluxDuringUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube122,
 		framework.WithFluxGithub(),
-		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
+		framework.WithClusterUpgrade(),
 	)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Attempt to fix the test `estDockerInstallGithubFluxDuringUpgrade`.

This test was not boostraping flux during upgrade; the test would report that there was no FluxConfig present and so it did not need to bootstrap Flux during upgrade.

However, when looking at the cluster config, there WAS both a GitOpsRef and a FluxConfig; but notice the mismatched names.

GitOpsRef:

```
   gitOpsRef:
     kind: FluxConfig
     name: eksa-test

```
FluxConfig: 

```
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: FluxConfig
 metadata:
   creationTimestamp: null
   name: eksa-test-plrd4
```

It appears that we're constructing the 'upgraded' cluster spec using the wrong GitOpsRef name; therefore, tho a GitOps ref is present, it does not point to an existing FluxConfig. This appears to be happening because of the way we are constructing the cluster config to be used by the upgrade. Then, since there was no flux bootstrapped, validation would fail.

In the method `WithFluxGithub` [we generate a flux config name with a random identifier on the end (e.g. the `eksa-test-plrd4` name seen in the `FluxConfig`) and set a cluster filler to add a GitOps ref to the upgrade cluster spec pointing to that FluxConfig.](https://github.com/aws/eks-anywhere/blob/0f043866551238050e6faa721ea691a9bc61c141/test/framework/flux.go#L101) Then, when we call `WithClusterUpgrade` we add ANOTHER cluster filler, which resets the name of the GitOpsRef to the default name, a const of value `eksa-test`.

I'd like to test this theory by un-setting the explicit addition of the `GitOpsRef` of value `eksa-test`, and just use the cluster filler generated as part of `WithFluxGithub` to add the GitOps ref.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

