### PR TITLE
improve gitops docs with ssh url format

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/optional/gitops.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/gitops.md
@@ -141,8 +141,8 @@ spec:
 
 ### git Configuration Spec Details
 ### repositoryUrl (required)
-
-* __Description__: The URL of an existing repository where EKS Anywhere will store your cluster configuration and sync it to the cluster.
+>**_NOTE:_** The `repositoryUrl` value for private SSH repositories is of the format `ssh://git@provider.com/$REPO_OWNER/$REPO_NAME.git`. This may differ from the default SSH URL given by your provider. For example, the github.com user interface provides an SSH URL containing a `:` before the repository owner, rather than a `/`. Make sure to replace this `:` with a `/`, if present.
+* __Description__: The URL of an existing repository where EKS Anywhere will store your cluster configuration and sync it to the cluster. For private repositories, the SSH URL will be of the format `ssh://git@provider.com/$REPO_OWNER/$REPO_NAME.git`
 * __Type__: string
 
 ### sshKeyAlgorithm (optional)

--- a/docs/content/en/docs/tasks/cluster/cluster-flux.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-flux.md
@@ -266,6 +266,8 @@ This will generate a known hosts file which contains only the entry necessary to
 ### Example FluxConfig cluster configuration for a generic git provider
 For a full spec reference see the [Cluster Spec reference]({{< relref "../../reference/clusterspec/optional/gitops" >}}).
 
+>**_NOTE:_** The `repositoryUrl` value is of the format `ssh://git@provider.com/$REPO_OWNER/$REPO_NAME.git`. This may differ from the default SSH URL given by your provider. For Example, the github.com user interface provides an SSH URL containing a `:` before the repository owner, rather than a `/`. Make sure to replace this `:` with a `/`, if present.
+
 ```yaml
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Cluster


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Document the correct format for SSH URLs provided to the generic git provider. This is in response to https://github.com/aws/eks-anywhere/pull/3197.


*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

