### PR TITLE
Move capi obj key method to controller capi file

### DIFF
--- a/pkg/controller/clusterapi.go
+++ b/pkg/controller/clusterapi.go
@@ -31,3 +31,13 @@ func GetCAPICluster(ctx context.Context, client client.Client, cluster *anywhere
 	}
 	return capiCluster, nil
 }
+
+// CapiClusterObjectKey generates an ObjectKey for the CAPI cluster owned by
+// the provided eks-a cluster
+func CapiClusterObjectKey(cluster *anywherev1.Cluster) client.ObjectKey {
+	// TODO: we should consider storing a reference to the CAPI cluster in the eksa cluster status
+	return client.ObjectKey{
+		Name:      clusterapi.ClusterName(cluster),
+		Namespace: constants.EksaSystemNamespace,
+	}
+}

--- a/pkg/controller/clusterapi_test.go
+++ b/pkg/controller/clusterapi_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -43,6 +44,19 @@ func TestGetCAPIClusterError(t *testing.T) {
 
 	_, err := controller.GetCAPICluster(ctx, client, eksaCluster)
 	g.Expect(err).To(MatchError(ContainSubstring("no kind is registered for the type")))
+}
+
+func TestGetCapiClusterObjectKey(t *testing.T) {
+	g := NewWithT(t)
+	eksaCluster := eksaCluster()
+
+	expected := types.NamespacedName{
+		Name:      "my-cluster",
+		Namespace: "eksa-system",
+	}
+
+	key := controller.CapiClusterObjectKey(eksaCluster)
+	g.Expect(key).To(Equal(expected))
 }
 
 func eksaCluster() *anywherev1.Cluster {

--- a/pkg/providers/snow/reconciler/reconciler.go
+++ b/pkg/providers/snow/reconciler/reconciler.go
@@ -10,8 +10,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/clusterapi"
-	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/controller"
 	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 	"github.com/aws/eks-anywhere/pkg/controller/clusters"
@@ -94,7 +92,7 @@ func (r *Reconciler) CheckControlPlaneReady(ctx context.Context, log logr.Logger
 func (s *Reconciler) ReconcileCNI(ctx context.Context, log logr.Logger, clusterSpec *cluster.Spec) (controller.Result, error) {
 	log = log.WithValues("phase", "reconcileCNI")
 
-	client, err := s.remoteClientRegistry.GetClient(ctx, capiClusterObjectKey(clusterSpec.Cluster))
+	client, err := s.remoteClientRegistry.GetClient(ctx, controller.CapiClusterObjectKey(clusterSpec.Cluster))
 	if err != nil {
 		return controller.Result{}, err
 	}
@@ -109,12 +107,4 @@ func (s *Reconciler) ReconcileWorkers(ctx context.Context, log logr.Logger, clus
 	return s.Apply(ctx, func() ([]kubernetes.Object, error) {
 		return snow.WorkersObjects(ctx, clusterSpec, clientutil.NewKubeClient(s.client))
 	})
-}
-
-func capiClusterObjectKey(cluster *anywherev1.Cluster) client.ObjectKey {
-	// TODO: we should consider storing a reference to the CAPI cluster in the eksa cluster status
-	return client.ObjectKey{
-		Name:      clusterapi.ClusterName(cluster),
-		Namespace: constants.EksaSystemNamespace,
-	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Follow up from this [discussion](https://github.com/aws/eks-anywhere/pull/3192#discussion_r957774271)

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

