### PR TITLE
Fix GitHub upgrade tests

### DIFF
--- a/internal/pkg/api/flux.go
+++ b/internal/pkg/api/flux.go
@@ -27,6 +27,12 @@ func NewFluxConfig(name string, opts ...FluxConfigOpt) *v1alpha1.FluxConfig {
 	return config
 }
 
+func WithFluxConfigName(n string) FluxConfigOpt {
+	return func(c *v1alpha1.FluxConfig) {
+		c.Name = n
+	}
+}
+
 func WithFluxConfigNamespace(ns string) FluxConfigOpt {
 	return func(c *v1alpha1.FluxConfig) {
 		c.Namespace = ns

--- a/test/e2e/flux_test.go
+++ b/test/e2e/flux_test.go
@@ -311,8 +311,8 @@ func TestDockerInstallGithubFluxDuringUpgrade(t *testing.T) {
 	runUpgradeFlowWithFlux(
 		test,
 		v1alpha1.Kube122,
-		framework.WithFluxGithub(),
-		framework.WithClusterUpgrade(),
+		framework.WithFluxGithub(api.WithFluxConfigName(framework.DefaultFluxConfigName)),
+		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
 	)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
alright, let's see if this addresses the issue with the name overrides -- we're adding an option to explicitly set the name in the FluxConfig, so that it uses the same name as we're expecting in the upgrade filler.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

