### PR TITLE
Update the generated go code for pkg/api/v1alpha1

### DIFF
--- a/pkg/api/v1alpha1/cloudstackmachineconfig_test.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_test.go
@@ -312,40 +312,40 @@ func TestCloudStackMachineNotEqualDiskOfferingName(t *testing.T) {
 func TestCloudStackMachineNotEqualDiskOfferingId(t *testing.T) {
 	g := NewWithT(t)
 	cloudStackMachineConfigSpec2 := cloudStackMachineConfigSpec1.DeepCopy()
-	cloudStackMachineConfigSpec2.DiskOffering.Id = "newDiskOffering"
 	cloudStackMachineConfigSpec2.DiskOffering = (*cloudStackMachineConfigSpec1.DiskOffering).DeepCopy()
+	cloudStackMachineConfigSpec2.DiskOffering.Id = "newDiskOffering"
 	g.Expect(cloudStackMachineConfigSpec1.Equal(cloudStackMachineConfigSpec2)).To(BeFalse(), "Disk offering id comparison in CloudStackMachineConfigSpec not detected")
 }
 
 func TestCloudStackMachineNotEqualDiskOfferingMountPath(t *testing.T) {
 	g := NewWithT(t)
 	cloudStackMachineConfigSpec2 := cloudStackMachineConfigSpec1.DeepCopy()
-	cloudStackMachineConfigSpec2.DiskOffering.MountPath = "newDiskOfferingPath"
 	cloudStackMachineConfigSpec2.DiskOffering = (*cloudStackMachineConfigSpec1.DiskOffering).DeepCopy()
+	cloudStackMachineConfigSpec2.DiskOffering.MountPath = "newDiskOfferingPath"
 	g.Expect(cloudStackMachineConfigSpec1.Equal(cloudStackMachineConfigSpec2)).To(BeFalse(), "Disk offering path comparison in CloudStackMachineConfigSpec not detected")
 }
 
 func TestCloudStackMachineNotEqualDiskOfferingDevice(t *testing.T) {
 	g := NewWithT(t)
 	cloudStackMachineConfigSpec2 := cloudStackMachineConfigSpec1.DeepCopy()
-	cloudStackMachineConfigSpec2.DiskOffering.Device = "/dev/sdb"
 	cloudStackMachineConfigSpec2.DiskOffering = (*cloudStackMachineConfigSpec1.DiskOffering).DeepCopy()
+	cloudStackMachineConfigSpec2.DiskOffering.Device = "/dev/sdb"
 	g.Expect(cloudStackMachineConfigSpec1.Equal(cloudStackMachineConfigSpec2)).To(BeFalse(), "Disk offering device comparison in CloudStackMachineConfigSpec not detected")
 }
 
 func TestCloudStackMachineNotEqualDiskOfferingLabel(t *testing.T) {
 	g := NewWithT(t)
 	cloudStackMachineConfigSpec2 := cloudStackMachineConfigSpec1.DeepCopy()
-	cloudStackMachineConfigSpec2.DiskOffering.Label = "data_disk_new"
 	cloudStackMachineConfigSpec2.DiskOffering = (*cloudStackMachineConfigSpec1.DiskOffering).DeepCopy()
+	cloudStackMachineConfigSpec2.DiskOffering.Label = "data_disk_new"
 	g.Expect(cloudStackMachineConfigSpec1.Equal(cloudStackMachineConfigSpec2)).To(BeFalse(), "Disk offering label comparison in CloudStackMachineConfigSpec not detected")
 }
 
 func TestCloudStackMachineNotEqualDiskOfferingFilesystem(t *testing.T) {
 	g := NewWithT(t)
 	cloudStackMachineConfigSpec2 := cloudStackMachineConfigSpec1.DeepCopy()
-	cloudStackMachineConfigSpec2.DiskOffering.Filesystem = "ext3"
 	cloudStackMachineConfigSpec2.DiskOffering = (*cloudStackMachineConfigSpec1.DiskOffering).DeepCopy()
+	cloudStackMachineConfigSpec2.DiskOffering.Filesystem = "ext3"
 	g.Expect(cloudStackMachineConfigSpec1.Equal(cloudStackMachineConfigSpec2)).To(BeFalse(), "Disk offering filesystem comparison in CloudStackMachineConfigSpec not detected")
 }
 

--- a/pkg/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha1/zz_generated.deepcopy.go
@@ -457,7 +457,11 @@ func (in *CloudStackMachineConfigSpec) DeepCopyInto(out *CloudStackMachineConfig
 	*out = *in
 	out.Template = in.Template
 	out.ComputeOffering = in.ComputeOffering
-	out.DiskOffering = in.DiskOffering
+	if in.DiskOffering != nil {
+		in, out := &in.DiskOffering, &out.DiskOffering
+		*out = new(CloudStackResourceDiskOffering)
+		**out = **in
+	}
 	if in.Users != nil {
 		in, out := &in.Users, &out.Users
 		*out = make([]UserConfiguration, len(*in))


### PR DESCRIPTION
PR #3181 updated the CloudStack types but did not trigger `make generate`
to update the `zz_generated.deepcopy.go`. This causes a few unit tests
to fail when others try to regenerate the file. This PR updates the generated
code and fixes the broken testcases for CloudStackMachineConfig.