### PR TITLE
Replace deprecated run collector to run pod and Set timeout for collectors

### DIFF
--- a/pkg/diagnostics/collector_types.go
+++ b/pkg/diagnostics/collector_types.go
@@ -12,7 +12,6 @@ type Collect struct {
 	Logs             *logs             `json:"logs,omitempty"`
 	CopyFromHost     *copyFromHost     `json:"copyFromHost,omitempty"`
 	Exec             *exec             `json:"exec,omitempty"`
-	Run              *run              `json:"run,omitempty"`
 	RunPod           *runPod           `json:"runPod,omitempty"`
 }
 
@@ -70,13 +69,6 @@ type exec struct {
 	Timeout       string   `json:"timeout,omitempty"`
 }
 
-type run struct {
-	collectorMeta `json:",inline"`
-	Name          string      `json:"name,omitempty"`
-	Namespace     string      `json:"namespace"`
-	PodSpec       *v1.PodSpec `json:"podSpec,omitempty"`
-}
-
 type imagePullSecrets struct {
 	Name       string            `json:"name,omitempty"`
 	Data       map[string]string `json:"data,omitempty"`
@@ -89,6 +81,7 @@ type collectorMeta struct {
 }
 
 type runPod struct {
+	collectorMeta    `json:",inline"`
 	Name             string      `json:"name,omitempty"`
 	Namespace        string      `json:"namespace"`
 	PodSpec          *v1.PodSpec `json:"podSpec,omitempty"`

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -358,7 +358,7 @@ func (c *collectorFactory) crdCollector(crdType string) *Collect {
 	args := []string{"get", crdType, "-o", "json", "--all-namespaces"}
 	collectorPath := crdPath(crdType)
 	return &Collect{
-		Run: &run{
+		RunPod: &runPod{
 			collectorMeta: collectorMeta{
 				CollectorName: crdType,
 			},
@@ -381,6 +381,7 @@ func (c *collectorFactory) crdCollector(crdType string) *Collect {
 					Effect: "NoSchedule",
 				}},
 			},
+			Timeout: "30s",
 		},
 	}
 }
@@ -417,6 +418,7 @@ func (c *collectorFactory) hostPortCollector(ports []string, hostIP string) *Col
 					Args:    argsIP,
 				}},
 			},
+			Timeout: "30s",
 		},
 	}
 }
@@ -436,6 +438,7 @@ func (c *collectorFactory) pingHostCollector(hostIP string) *Collect {
 					Args:    argsPing,
 				}},
 			},
+			Timeout: "30s",
 		},
 	}
 }

--- a/pkg/diagnostics/collectors_test.go
+++ b/pkg/diagnostics/collectors_test.go
@@ -48,8 +48,8 @@ func TestVsphereDataCenterConfigCollectors(t *testing.T) {
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapvSystemNamespace))
 	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CapvSystemNamespace)))
 	for _, collector := range collectors[1:7] {
-		g.Expect(collector.Run.PodSpec.Containers[0].Command).To(Equal([]string{"kubectl"}))
-		g.Expect(collector.Run.Namespace).To(Equal("eksa-diagnostics"))
+		g.Expect(collector.RunPod.PodSpec.Containers[0].Command).To(Equal([]string{"kubectl"}))
+		g.Expect(collector.RunPod.Namespace).To(Equal("eksa-diagnostics"))
 	}
 	g.Expect(collectors[8].RunPod.PodSpec.Containers[0].Name).To(Equal("check-host-port"))
 	g.Expect(collectors[9].RunPod.PodSpec.Containers[0].Name).To(Equal("ping-host-ip"))
@@ -65,8 +65,8 @@ func TestCloudStackDataCenterConfigCollectors(t *testing.T) {
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapcSystemNamespace))
 	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CapcSystemNamespace)))
 	for _, collector := range collectors[1:] {
-		g.Expect([]string{"kubectl"}).To(Equal(collector.Run.PodSpec.Containers[0].Command))
-		g.Expect("eksa-diagnostics").To(Equal(collector.Run.Namespace))
+		g.Expect([]string{"kubectl"}).To(Equal(collector.RunPod.PodSpec.Containers[0].Command))
+		g.Expect("eksa-diagnostics").To(Equal(collector.RunPod.Namespace))
 	}
 }
 
@@ -80,7 +80,7 @@ func TestTinkerbellDataCenterConfigCollectors(t *testing.T) {
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CaptSystemNamespace))
 	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CaptSystemNamespace)))
 	for _, collector := range collectors[1:] {
-		g.Expect([]string{"kubectl"}).To(Equal(collector.Run.PodSpec.Containers[0].Command))
-		g.Expect("eksa-diagnostics").To(Equal(collector.Run.Namespace))
+		g.Expect([]string{"kubectl"}).To(Equal(collector.RunPod.PodSpec.Containers[0].Command))
+		g.Expect("eksa-diagnostics").To(Equal(collector.RunPod.Namespace))
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

From [Troubleshoot.sh](https://troubleshoot.sh/docs/collect/deprecated/run/), the Run collector has been deprecated. The Run Pod collector will cover its job. It's better to keep it up-to-date in our repo. 

Another trivial change: set timeout for the collectors so that the collecting process cannot be blocked if one collector stalls or fails. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

