### PR TITLE
Remove all references to AWS bundle

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -427,7 +427,6 @@ func createBundle(cluster *anywherev1.Cluster) *v1alpha1.Bundles {
 					ClusterAPI:             v1alpha1.CoreClusterAPI{},
 					Bootstrap:              v1alpha1.KubeadmBootstrapBundle{},
 					ControlPlane:           v1alpha1.KubeadmControlPlaneBundle{},
-					Aws:                    &v1alpha1.AwsBundle{},
 					VSphere:                v1alpha1.VSphereBundle{},
 					Docker:                 v1alpha1.DockerBundle{},
 					Eksa:                   v1alpha1.EksaBundle{},

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -467,13 +467,6 @@ var versionBundle = &cluster.VersionsBundle{
 				URI: "testdata/fake_manifest.yaml",
 			},
 		},
-		Aws: &v1alpha1.AwsBundle{
-			Version: "v0.6.4",
-			Controller: v1alpha1.Image{
-				URI: "public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller:v0.6.4-25df7d96779e2a305a22c6e3f9425c3465a77244",
-			},
-			KubeProxy: kubeProxyVersion08,
-		},
 		Snow: v1alpha1.SnowBundle{
 			Version: "v0.0.0",
 		},

--- a/pkg/providers/snow/reconciler/reconciler_test.go
+++ b/pkg/providers/snow/reconciler/reconciler_test.go
@@ -380,7 +380,6 @@ func createBundle() *releasev1.Bundles {
 					ClusterAPI:             releasev1.CoreClusterAPI{},
 					Bootstrap:              releasev1.KubeadmBootstrapBundle{},
 					ControlPlane:           releasev1.KubeadmControlPlaneBundle{},
-					Aws:                    &releasev1.AwsBundle{},
 					VSphere:                releasev1.VSphereBundle{},
 					Docker:                 releasev1.DockerBundle{},
 					Eksa:                   releasev1.EksaBundle{},

--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -16,11 +16,6 @@ package v1alpha1
 
 func (vb *VersionsBundle) Manifests() map[string][]*string {
 	return map[string][]*string{
-		"cluster-api-provider-aws": {
-			&vb.Aws.Components.URI,
-			&vb.Aws.ClusterTemplate.URI,
-			&vb.Aws.Metadata.URI,
-		},
 		"core-cluster-api": {
 			&vb.ClusterAPI.Components.URI,
 			&vb.ClusterAPI.Metadata.URI,


### PR DESCRIPTION
*Description of changes:*
We made AWS a pointer and we don't include it in the bundle manifest
anymore, which means that all the code the references that field (while
assuming it was a struct a not a pointer) blows up when with a nil
pointer when facing the new bundle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

