### PR TITLE
cp e2e: Define constants where they're used.

### DIFF
--- a/test/e2e/curated_packages_test.go
+++ b/test/e2e/curated_packages_test.go
@@ -14,11 +14,6 @@ import (
 )
 
 const (
-	eksAnywherePackagesHelmChartName = "eks-anywhere-packages"
-	eksAnywherePackagesHelmUri       = "oci://public.ecr.aws/l0g8r8j6/eks-anywhere-packages"
-	eksAnywherePackagesHelmVersion   = "0.1.14-eks-a-v0.0.0-dev-build.3481"
-	eksAnywherePackagesBundleUri     = "oci://public.ecr.aws/l0g8r8j6/eks-anywhere-packages-bundles:v1-21-latest"
-
 	eksaPackageControllerHelmChartName = "eks-anywhere-packages"
 	eksaPackageControllerHelmURI       = "oci://public.ecr.aws/eks-anywhere/eks-anywhere-packages"
 	eksaPackageControllerHelmVersion   = "0.1.10-eks-a-10"

--- a/test/e2e/harbor_test.go
+++ b/test/e2e/harbor_test.go
@@ -9,6 +9,13 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
+const (
+	eksAnywherePackagesHelmChartName = "eks-anywhere-packages"
+	eksAnywherePackagesHelmUri       = "oci://public.ecr.aws/l0g8r8j6/eks-anywhere-packages"
+	eksAnywherePackagesHelmVersion   = "0.1.14-eks-a-v0.0.0-dev-build.3481"
+	eksAnywherePackagesBundleUri     = "oci://public.ecr.aws/l0g8r8j6/eks-anywhere-packages-bundles:v1-21-latest"
+)
+
 func TestCPackagesHarborInstallSimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(t, framework.NewDocker(t),
 		framework.WithPackageConfig(t, eksAnywherePackagesBundleUri,


### PR DESCRIPTION
A short term goal of the CP team is to have our E2E tests run against the
current builds of our packages. These hard-coded registries are preventing
that, so we're planning to replace them. As a first step towards that,
separating these variables will allow for smaller-step refactoring towards
that goal.
