### PR TITLE
Setup vSphere User Config Read & Validation

### DIFF
--- a/pkg/providers/vsphere/setupuser/testdata/configs/missing_objects.yaml
+++ b/pkg/providers/vsphere/setupuser/testdata/configs/missing_objects.yaml
@@ -1,0 +1,9 @@
+apiVersion: "eks-anywhere.amazon.com/v1"
+kind: vSphereUser
+spec:
+  datacenter: "MyDatacenter"
+  vSphereDomain: "vsphere.local"
+  connection:
+    server: "https://my-vsphere.internal.acme.com"
+    insecure: false
+  objects:

--- a/pkg/providers/vsphere/setupuser/testdata/configs/not_yaml.yaml
+++ b/pkg/providers/vsphere/setupuser/testdata/configs/not_yaml.yaml
@@ -1,0 +1,1 @@
+this is not yaml

--- a/pkg/providers/vsphere/setupuser/testdata/configs/valid.yaml
+++ b/pkg/providers/vsphere/setupuser/testdata/configs/valid.yaml
@@ -1,0 +1,24 @@
+apiVersion: "eks-anywhere.amazon.com/v1"
+kind: vSphereUser
+spec:
+  username: "eksa"
+  group: "MyExistingGroup"
+  globalRole: "MyExistingGlobalRole"
+  userRole: "MyExistingUserRole"
+  adminRole: "MyExistingEKSAAdminRole"
+  datacenter: "MyDatacenter"
+  vSphereDomain: "vsphere.local"
+  connection:
+    server: "https://my-vsphere.internal.acme.com"
+    insecure: false
+  objects:
+    networks:
+      - !!str "/MyDatacenter/network/My Network"
+    datastores:
+      - !!str "/MyDatacenter/datastore/MyDatastore2"
+    resourcePools:
+      - !!str "/MyDatacenter/host/Cluster-03/MyResourcePool"
+    folders:
+      - !!str "/MyDatacenter/vm/OrgDirectory/MyVMs"
+    templates:
+      - !!str "/MyDatacenter/vm/Templates/MyTemplates"

--- a/pkg/providers/vsphere/setupuser/testdata/configs/valid_minimal.yaml
+++ b/pkg/providers/vsphere/setupuser/testdata/configs/valid_minimal.yaml
@@ -1,0 +1,19 @@
+apiVersion: "eks-anywhere.amazon.com/v1"
+kind: vSphereUser
+spec:
+  datacenter: "MyDatacenter"
+  vSphereDomain: "vsphere.local"
+  connection:
+    server: "https://my-vsphere.internal.acme.com"
+    insecure: false
+  objects:
+    networks:
+      - !!str "/MyDatacenter/network/My Network"
+    datastores:
+      - !!str "/MyDatacenter/datastore/MyDatastore2"
+    resourcePools:
+      - !!str "/MyDatacenter/host/Cluster-03/MyResourcePool"
+    folders:
+      - !!str "/MyDatacenter/vm/OrgDirectory/MyVMs"
+    templates:
+      - !!str "/MyDatacenter/vm/Templates/MyTemplates"

--- a/pkg/providers/vsphere/setupuser/validator.go
+++ b/pkg/providers/vsphere/setupuser/validator.go
@@ -155,32 +155,4 @@ func setDefaults(c *VSphereSetupUserConfig) {
 	if c.Spec.Username == "" {
 		c.Spec.Username = DefaultUsername
 	}
-
-	if c.Spec.Objects.Networks == nil {
-		c.Spec.Objects.Networks = []string{}
-	}
-
-	if c.Spec.Objects.Networks == nil {
-		c.Spec.Objects.Networks = []string{}
-	}
-
-	if c.Spec.Objects.Networks == nil {
-		c.Spec.Objects.Networks = []string{}
-	}
-
-	if c.Spec.Objects.Datastores == nil {
-		c.Spec.Objects.Datastores = []string{}
-	}
-
-	if c.Spec.Objects.ResourcePools == nil {
-		c.Spec.Objects.ResourcePools = []string{}
-	}
-
-	if c.Spec.Objects.Folders == nil {
-		c.Spec.Objects.Folders = []string{}
-	}
-
-	if c.Spec.Objects.Folders == nil {
-		c.Spec.Objects.Folders = []string{}
-	}
 }

--- a/pkg/providers/vsphere/setupuser/validator.go
+++ b/pkg/providers/vsphere/setupuser/validator.go
@@ -56,12 +56,12 @@ func GenerateConfig(ctx context.Context, filepath string) (*VSphereSetupUserConf
 		return nil, err
 	}
 
-	err = validate(ctx, c)
+	err = validate(c)
 	if err != nil {
 		return nil, err
 	}
 
-	setDefaults(ctx, c)
+	setDefaults(c)
 
 	return c, nil
 }
@@ -81,22 +81,22 @@ func readConfig(ctx context.Context, filepath string) (*VSphereSetupUserConfig, 
 	return &c, nil
 }
 
-func validate(ctx context.Context, c *VSphereSetupUserConfig) error {
+func validate(c *VSphereSetupUserConfig) error {
 	results := []validations.ValidationResult{
 		{
 			Name:        "validate datacenter",
 			Remediation: "",
-			Err:         validateDatacenter(ctx, c),
+			Err:         validateDatacenter(c),
 		},
 		{
 			Name:        "validate vspheredomain",
 			Remediation: "",
-			Err:         validateVSphereDomain(ctx, c),
+			Err:         validateVSphereDomain(c),
 		},
 		{
 			Name:        "validate connection",
 			Remediation: "",
-			Err:         validateConnection(ctx, c),
+			Err:         validateConnection(c),
 		},
 	}
 
@@ -114,28 +114,28 @@ func validate(ctx context.Context, c *VSphereSetupUserConfig) error {
 	return nil
 }
 
-func validateDatacenter(ctx context.Context, c *VSphereSetupUserConfig) error {
+func validateDatacenter(c *VSphereSetupUserConfig) error {
 	if c.Spec.Datacenter == "" {
 		return fmt.Errorf("datacenter cannot be empty")
 	}
 	return nil
 }
 
-func validateVSphereDomain(ctx context.Context, c *VSphereSetupUserConfig) error {
+func validateVSphereDomain(c *VSphereSetupUserConfig) error {
 	if c.Spec.VSphereDomain == "" {
 		return fmt.Errorf("vSphereDomain cannot be empty")
 	}
 	return nil
 }
 
-func validateConnection(ctx context.Context, c *VSphereSetupUserConfig) error {
+func validateConnection(c *VSphereSetupUserConfig) error {
 	if c.Spec.Connection.Server == "" {
 		return fmt.Errorf("server cannot be empty")
 	}
 	return nil
 }
 
-func setDefaults(ctx context.Context, c *VSphereSetupUserConfig) {
+func setDefaults(c *VSphereSetupUserConfig) {
 	if c.Spec.GlobalRole == "" {
 		c.Spec.GlobalRole = DefaultGlobalRole
 	}

--- a/pkg/providers/vsphere/setupuser/validator.go
+++ b/pkg/providers/vsphere/setupuser/validator.go
@@ -1,0 +1,186 @@
+package setupuser
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/aws/eks-anywhere/pkg/validations"
+)
+
+const (
+	DefaultUsername   = "eksa"
+	DefaultGroup      = "EKSAUsers"
+	DefaultGlobalRole = "EKSAGlobalRole"
+	DefaultUserRole   = "EKSAUserRole"
+	DefaultAdminRole  = "EKSACloudAdminRole"
+)
+
+type connection struct {
+	Server   string `yaml:"server"`
+	Insecure bool   `yaml:"insecure"`
+}
+
+type objects struct {
+	Networks      []string `yaml:"networks"`
+	Datastores    []string `yaml:"datastores"`
+	ResourcePools []string `yaml:"resourcePools"`
+	Folders       []string `yaml:"folders"`
+	Templates     []string `yaml:"templates"`
+}
+
+type vSphereUserSpec struct {
+	Datacenter    string     `yaml:"datacenter"`
+	VSphereDomain string     `yaml:"vSphereDomain"`
+	Connection    connection `yaml:"connection"`
+	Objects       objects    `yaml:"objects"`
+	// Below are optional fields with defaults
+	Username   string `yaml:"username"`
+	GroupName  string `yaml:"group"`
+	GlobalRole string `yaml:"globalRole"`
+	UserRole   string `yaml:"userRole"`
+	AdminRole  string `yaml:"adminRole"`
+}
+
+type VSphereSetupUserConfig struct {
+	ApiVersion string          `yaml:"apiVersion"`
+	Kind       string          `yaml:"kind"`
+	Spec       vSphereUserSpec `yaml:"spec"`
+}
+
+func GenerateConfig(ctx context.Context, filepath string) (*VSphereSetupUserConfig, error) {
+	c, err := readConfig(ctx, filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validate(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	setDefaults(ctx, c)
+
+	return c, nil
+}
+
+func readConfig(ctx context.Context, filepath string) (*VSphereSetupUserConfig, error) {
+	file, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read file %s, err = %v", filepath, err)
+	}
+
+	c := VSphereSetupUserConfig{}
+
+	if err = yaml.Unmarshal(file, &c); err != nil {
+		return nil, fmt.Errorf("Failed to parse %s, err = %v", filepath, err)
+	}
+
+	return &c, nil
+}
+
+func validate(ctx context.Context, c *VSphereSetupUserConfig) error {
+	results := []validations.ValidationResult{
+		{
+			Name:        "validate datacenter",
+			Remediation: "",
+			Err:         validateDatacenter(ctx, c),
+		},
+		{
+			Name:        "validate vspheredomain",
+			Remediation: "",
+			Err:         validateVSphereDomain(ctx, c),
+		},
+		{
+			Name:        "validate connection",
+			Remediation: "",
+			Err:         validateConnection(ctx, c),
+		},
+	}
+
+	errs := []string{}
+	for _, r := range results {
+		if r.Err != nil {
+			errs = append(errs, r.Err.Error())
+		}
+	}
+
+	if len(errs) > 0 {
+		return &validations.ValidationError{Errs: errs}
+	}
+
+	return nil
+}
+
+func validateDatacenter(ctx context.Context, c *VSphereSetupUserConfig) error {
+	if c.Spec.Datacenter == "" {
+		return fmt.Errorf("datacenter cannot be empty")
+	}
+	return nil
+}
+
+func validateVSphereDomain(ctx context.Context, c *VSphereSetupUserConfig) error {
+	if c.Spec.VSphereDomain == "" {
+		return fmt.Errorf("vSphereDomain cannot be empty")
+	}
+	return nil
+}
+
+func validateConnection(ctx context.Context, c *VSphereSetupUserConfig) error {
+	if c.Spec.Connection.Server == "" {
+		return fmt.Errorf("server cannot be empty")
+	}
+	return nil
+}
+
+func setDefaults(ctx context.Context, c *VSphereSetupUserConfig) {
+	if c.Spec.GlobalRole == "" {
+		c.Spec.GlobalRole = DefaultGlobalRole
+	}
+
+	if c.Spec.UserRole == "" {
+		c.Spec.UserRole = DefaultUserRole
+	}
+
+	if c.Spec.AdminRole == "" {
+		c.Spec.AdminRole = DefaultAdminRole
+	}
+
+	if c.Spec.GroupName == "" {
+		c.Spec.GroupName = DefaultGroup
+	}
+
+	if c.Spec.Username == "" {
+		c.Spec.Username = DefaultUsername
+	}
+
+	if c.Spec.Objects.Networks == nil {
+		c.Spec.Objects.Networks = []string{}
+	}
+
+	if c.Spec.Objects.Networks == nil {
+		c.Spec.Objects.Networks = []string{}
+	}
+
+	if c.Spec.Objects.Networks == nil {
+		c.Spec.Objects.Networks = []string{}
+	}
+
+	if c.Spec.Objects.Datastores == nil {
+		c.Spec.Objects.Datastores = []string{}
+	}
+
+	if c.Spec.Objects.ResourcePools == nil {
+		c.Spec.Objects.ResourcePools = []string{}
+	}
+
+	if c.Spec.Objects.Folders == nil {
+		c.Spec.Objects.Folders = []string{}
+	}
+
+	if c.Spec.Objects.Folders == nil {
+		c.Spec.Objects.Folders = []string{}
+	}
+}

--- a/pkg/providers/vsphere/setupuser/validator.go
+++ b/pkg/providers/vsphere/setupuser/validator.go
@@ -69,13 +69,13 @@ func GenerateConfig(ctx context.Context, filepath string) (*VSphereSetupUserConf
 func readConfig(ctx context.Context, filepath string) (*VSphereSetupUserConfig, error) {
 	file, err := ioutil.ReadFile(filepath)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read file %s, err = %v", filepath, err)
+		return nil, fmt.Errorf("failed to read file %s, err = %v", filepath, err)
 	}
 
 	c := VSphereSetupUserConfig{}
 
 	if err = yaml.Unmarshal(file, &c); err != nil {
-		return nil, fmt.Errorf("Failed to parse %s, err = %v", filepath, err)
+		return nil, fmt.Errorf("failed to parse %s, err = %v", filepath, err)
 	}
 
 	return &c, nil

--- a/pkg/providers/vsphere/setupuser/validator.go
+++ b/pkg/providers/vsphere/setupuser/validator.go
@@ -18,12 +18,12 @@ const (
 	DefaultAdminRole  = "EKSACloudAdminRole"
 )
 
-type connection struct {
+type Connection struct {
 	Server   string `yaml:"server"`
 	Insecure bool   `yaml:"insecure"`
 }
 
-type objects struct {
+type Objects struct {
 	Networks      []string `yaml:"networks"`
 	Datastores    []string `yaml:"datastores"`
 	ResourcePools []string `yaml:"resourcePools"`
@@ -31,11 +31,11 @@ type objects struct {
 	Templates     []string `yaml:"templates"`
 }
 
-type vSphereUserSpec struct {
+type VSphereUserSpec struct {
 	Datacenter    string     `yaml:"datacenter"`
 	VSphereDomain string     `yaml:"vSphereDomain"`
-	Connection    connection `yaml:"connection"`
-	Objects       objects    `yaml:"objects"`
+	Connection    Connection `yaml:"connection"`
+	Objects       Objects    `yaml:"objects"`
 	// Below are optional fields with defaults
 	Username   string `yaml:"username"`
 	GroupName  string `yaml:"group"`
@@ -47,7 +47,7 @@ type vSphereUserSpec struct {
 type VSphereSetupUserConfig struct {
 	ApiVersion string          `yaml:"apiVersion"`
 	Kind       string          `yaml:"kind"`
-	Spec       vSphereUserSpec `yaml:"spec"`
+	Spec       VSphereUserSpec `yaml:"spec"`
 }
 
 func GenerateConfig(ctx context.Context, filepath string) (*VSphereSetupUserConfig, error) {

--- a/pkg/providers/vsphere/setupuser/validator_test.go
+++ b/pkg/providers/vsphere/setupuser/validator_test.go
@@ -91,7 +91,7 @@ func TestGenerateConfigValidations(t *testing.T) {
 				g.Expect(err).To(BeNil())
 				g.Expect(c).ToNot(BeNil())
 			} else {
-				g.Expect(err).To(ContainSubstring(tt.wantErr))
+				g.Expect(err.Error()).To(ContainSubstring(tt.wantErr))
 			}
 		},
 		)

--- a/pkg/providers/vsphere/setupuser/validator_test.go
+++ b/pkg/providers/vsphere/setupuser/validator_test.go
@@ -1,0 +1,134 @@
+package setupuser_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/providers/vsphere/setupuser"
+)
+
+func TestGenerateConfigReadFile(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		filepath string
+		wantErr  string
+	}{
+		{
+			name:     "test generateconfig read file happy path",
+			filepath: "./testdata/configs/valid.yaml",
+			wantErr:  "",
+		},
+		{
+			name:     "test generateconfig read file bad yaml",
+			filepath: "./testdata/configs/not_yaml.yaml",
+			wantErr:  "Failed to parse ./testdata/configs/not_yaml.yaml, err = yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `this is...` ",
+		},
+		{
+			name:     "test generateconfig read file does not exist",
+			filepath: "./testdata/configs/not_a_file.yaml",
+			wantErr:  "Failed to read file ./testdata/configs/not_a_file.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			c, err := setupuser.GenerateConfig(ctx, tt.filepath)
+
+			if tt.wantErr == "" {
+				g.Expect(err).To(Succeed())
+				g.Expect(c).ToNot(BeNil())
+			} else {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			}
+		},
+		)
+	}
+}
+
+func TestGenerateConfigValidations(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		filepath string
+		wantErr  string
+	}{
+		{
+			name:     "test read file happy path",
+			filepath: "./testdata/configs/valid.yaml",
+			wantErr:  "",
+		},
+		{
+			name:     "test validate datacenter not empty",
+			filepath: "./testdata/configs/empty.yaml",
+			wantErr:  "datacenter cannot be empty",
+		},
+		{
+			name:     "test validate vspheredomain not empty",
+			filepath: "./testdata/configs/empty.yaml",
+			wantErr:  "vSphereDomain cannot be empty",
+		},
+		{
+			name:     "test validate connection",
+			filepath: "./testdata/configs/empty.yaml",
+			wantErr:  "server cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			c, err := setupuser.GenerateConfig(ctx, tt.filepath)
+
+			if tt.wantErr == "" {
+				g.Expect(err).To(BeNil())
+				g.Expect(c).ToNot(BeNil())
+			} else {
+				g.Expect(err).To(ContainSubstring(tt.wantErr))
+			}
+		},
+		)
+	}
+}
+
+func TestGenerateConfigSetDefaults(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		filepath string
+	}{
+		{
+			name:     "test populating config with defaults happy path",
+			filepath: "./testdata/configs/missing_objects.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			c, err := setupuser.GenerateConfig(ctx, tt.filepath)
+			g.Expect(err).To(Succeed())
+
+			g.Expect(c.Spec.Username).To(Equal(setupuser.DefaultUsername))
+			g.Expect(c.Spec.GroupName).To(Equal(setupuser.DefaultGroup))
+			g.Expect(c.Spec.GlobalRole).To(Equal(setupuser.DefaultGlobalRole))
+			g.Expect(c.Spec.UserRole).To(Equal(setupuser.DefaultUserRole))
+			g.Expect(c.Spec.AdminRole).To(Equal(setupuser.DefaultAdminRole))
+			g.Expect(c.Spec.Objects.Networks).To(Equal([]string{}))
+			g.Expect(c.Spec.Objects.Datastores).To(Equal([]string{}))
+			g.Expect(c.Spec.Objects.ResourcePools).To(Equal([]string{}))
+			g.Expect(c.Spec.Objects.Folders).To(Equal([]string{}))
+			g.Expect(c.Spec.Objects.Templates).To(BeNil())
+		},
+		)
+	}
+}

--- a/pkg/providers/vsphere/setupuser/validator_test.go
+++ b/pkg/providers/vsphere/setupuser/validator_test.go
@@ -25,12 +25,12 @@ func TestGenerateConfigReadFile(t *testing.T) {
 		{
 			name:     "test generateconfig read file bad yaml",
 			filepath: "./testdata/configs/not_yaml.yaml",
-			wantErr:  "Failed to parse ./testdata/configs/not_yaml.yaml, err = yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `this is...` ",
+			wantErr:  "failed to parse ./testdata/configs/not_yaml.yaml, err = yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `this is...` ",
 		},
 		{
 			name:     "test generateconfig read file does not exist",
 			filepath: "./testdata/configs/not_a_file.yaml",
-			wantErr:  "Failed to read file ./testdata/configs/not_a_file.yaml",
+			wantErr:  "failed to read file ./testdata/configs/not_a_file.yaml",
 		},
 	}
 

--- a/pkg/providers/vsphere/setupuser/validator_test.go
+++ b/pkg/providers/vsphere/setupuser/validator_test.go
@@ -107,7 +107,7 @@ func TestGenerateConfigSetDefaults(t *testing.T) {
 	}{
 		{
 			name:     "test populating config with defaults happy path",
-			filepath: "./testdata/configs/missing_objects.yaml",
+			filepath: "./testdata/configs/valid_minimal.yaml",
 		},
 	}
 
@@ -123,11 +123,6 @@ func TestGenerateConfigSetDefaults(t *testing.T) {
 			g.Expect(c.Spec.GlobalRole).To(Equal(setupuser.DefaultGlobalRole))
 			g.Expect(c.Spec.UserRole).To(Equal(setupuser.DefaultUserRole))
 			g.Expect(c.Spec.AdminRole).To(Equal(setupuser.DefaultAdminRole))
-			g.Expect(c.Spec.Objects.Networks).To(Equal([]string{}))
-			g.Expect(c.Spec.Objects.Datastores).To(Equal([]string{}))
-			g.Expect(c.Spec.Objects.ResourcePools).To(Equal([]string{}))
-			g.Expect(c.Spec.Objects.Folders).To(Equal([]string{}))
-			g.Expect(c.Spec.Objects.Templates).To(BeNil())
 		},
 		)
 	}

--- a/pkg/validations/errors.go
+++ b/pkg/validations/errors.go
@@ -12,3 +12,7 @@ type ValidationError struct {
 func (v *ValidationError) Error() string {
 	return fmt.Sprintf("validation failed with %d errors: %s", len(v.Errs), strings.Join(v.Errs[:], ","))
 }
+
+func (v *ValidationError) String() string {
+	return v.Error()
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/3248

*Description of changes:*
This adds business logic to read and validate a config file for the vSphere setup user command.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->