### PR TITLE
Add analyer to analyze if vms have access to api server

### DIFF
--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -362,3 +362,33 @@ func (a *analyzerFactory) controlPlaneIPAnalyzer() []*Analyze {
 		},
 	}
 }
+
+// vmsAccessAnalyzer will analyze if vms have access to the API server of vSphere cluster
+func (a *analyzerFactory) vmsAccessAnalyzer() *Analyze {
+	runBashPod := "check-cloud-controller"
+	runBashPodLog := fmt.Sprintf("%s.log", runBashPod)
+	vSphereCloudControllerPodLogPath := path.Join(runBashPod, runBashPodLog)
+	return &Analyze{
+		TextAnalyze: &textAnalyze{
+			analyzeMeta: analyzeMeta{
+				CheckName: fmt.Sprintf("%s: Virtual Machine has no access to vSphere APi serveer. Logs: %s", logAnalysisAnalyzerPrefix, vSphereCloudControllerPodLogPath),
+			},
+			FileName:     vSphereCloudControllerPodLogPath,
+			RegexPattern: `Failed to create new client. err: Post (.*) dial tcp (.*) connect: connection timed out\n(.*)Failed to create govmomi client. err: Post (.*) dial tcp (.*) connect: connection timed out`,
+			Outcomes: []*outcome{
+				{
+					Fail: &singleOutcome{
+						When:    "true",
+						Message: fmt.Sprintf("Failed to create client, Virtural Machines have no access to vSphere API server. See the cloud controller log in control plane node: %s", vSphereCloudControllerPodLogPath),
+					},
+				},
+				{
+					Pass: &singleOutcome{
+						When:    "false",
+						Message: fmt.Sprintf("Virtual Machines have access to vSphere API server. See %s \nPlease ignore the result when this analyzer is running on bootstrap cluster", vSphereCloudControllerPodLogPath),
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/diagnostics/collectors_test.go
+++ b/pkg/diagnostics/collectors_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/internal/test"
@@ -25,6 +26,13 @@ func TestVsphereDataCenterConfigCollectors(t *testing.T) {
 					Endpoint: &eksav1alpha1.Endpoint{
 						Host: "1.1.1.1",
 					},
+					Taints: []v1.Taint{
+						{
+							Key:    "test-key",
+							Value:  "test-value",
+							Effect: "NoSchedule",
+						},
+					},
 				},
 				DatacenterRef: eksav1alpha1.Ref{
 					Kind: eksav1alpha1.VSphereDatacenterKind,
@@ -44,7 +52,7 @@ func TestVsphereDataCenterConfigCollectors(t *testing.T) {
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.VSphereDatacenterKind}
 	factory := diagnostics.NewDefaultCollectorFactory()
 	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
-	g.Expect(collectors).To(HaveLen(10), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
+	g.Expect(collectors).To(HaveLen(11), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapvSystemNamespace))
 	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CapvSystemNamespace)))
 	for _, collector := range collectors[1:7] {
@@ -53,6 +61,7 @@ func TestVsphereDataCenterConfigCollectors(t *testing.T) {
 	}
 	g.Expect(collectors[8].RunPod.PodSpec.Containers[0].Name).To(Equal("check-host-port"))
 	g.Expect(collectors[9].RunPod.PodSpec.Containers[0].Name).To(Equal("ping-host-ip"))
+	g.Expect(collectors[10].RunPod.PodSpec.Containers[0].Name).To(Equal("check-cloud-controller"))
 }
 
 func TestCloudStackDataCenterConfigCollectors(t *testing.T) {

--- a/pkg/diagnostics/config/diagnostic-collector-rbac.yaml
+++ b/pkg/diagnostics/config/diagnostic-collector-rbac.yaml
@@ -15,6 +15,18 @@ rules:
     verbs:
     - get
     - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+    verbs:
+      - get
+      - list
+  - nonResourceURLs:
+      - /
+    verbs:
+      - get
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Extend the functionality of support bundle by

- adding a run-pod collector--vmsAccessCollector. It supposes to collect logs from vsphere cloud controller manager on control plane.
   - since the pod need to be deployed on control plane node, specific tolerations have been set.

   - It is also able to accept customized taints that given by user in cluster defination yaml.

- adding a vmsAccess analyzer. Based on the log from the collector, the analyzer is able to analyze if the vms have access to vsphere api server.

    - Now, the analyzer starts to work from bootstrap cluster, although we expect that the analyzer only does its work on workload cluster. A clarification was temporarily added to the output to avoid confusion.
    - Also, more work on cluster_manager.go is needed to generate kubeconfig for a cluster. Therefore, current analyzer is implemented but hasn't been used.  

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

