### PR TITLE
Package proxy fix

### DIFF
--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"github.com/aws/eks-anywhere/pkg/cluster"
 
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/executables"
@@ -38,6 +39,7 @@ func NewDependenciesForPackages(ctx context.Context, opts ...PackageOpt) (*depen
 		WithKubectl().
 		WithHelm(executables.WithInsecure()).
 		WithCuratedPackagesRegistry(config.registryName, config.kubeVersion, version.Get()).
+		WithPackageControllerClient(config.spec).
 		Build(ctx)
 }
 
@@ -47,6 +49,7 @@ type PackageConfig struct {
 	registryName string
 	kubeVersion  string
 	mountPaths   []string
+	spec         *cluster.Spec
 }
 
 func New(options ...PackageOpt) *PackageConfig {
@@ -72,5 +75,11 @@ func WithKubeVersion(kubeVersion string) func(*PackageConfig) {
 func WithMountPaths(mountPaths ...string) func(*PackageConfig) {
 	return func(config *PackageConfig) {
 		config.mountPaths = mountPaths
+	}
+}
+
+func WithClusterSpec(spec *cluster.Spec) func(config *PackageConfig) {
+	return func(config *PackageConfig) {
+		config.spec = spec
 	}
 }

--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"context"
-	"github.com/aws/eks-anywhere/pkg/cluster"
 
+	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -69,9 +69,11 @@ func installPackageController(ctx context.Context) error {
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {
 		registryEndpoint = clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Endpoint
 	}
+	proxyConfiguration := clusterSpec.Cluster.Spec.ProxyConfiguration
 	helmChart := versionBundle.PackageController.HelmChart
 	imageUrl := urls.ReplaceHost(helmChart.Image(), registryEndpoint)
 	eksaAccessKeyId, eksaSecretKey, eksaRegion := os.Getenv(config.EksaAccessKeyIdEnv), os.Getenv(config.EksaSecretAcessKeyEnv), os.Getenv(config.EksaRegionEnv)
+
 	ctrlClient := curatedpackages.NewPackageControllerClient(
 		deps.Helm,
 		deps.Kubectl,
@@ -83,6 +85,9 @@ func installPackageController(ctx context.Context) error {
 		curatedpackages.WithEksaRegion(eksaRegion),
 		curatedpackages.WithEksaSecretAccessKey(eksaSecretKey),
 		curatedpackages.WithEksaAccessKeyId(eksaAccessKeyId),
+		curatedpackages.WithHttpProxy(proxyConfiguration.HttpProxy),
+		curatedpackages.WithHttpsProxy(proxyConfiguration.HttpsProxy),
+		curatedpackages.WithNoProxy(proxyConfiguration.NoProxy),
 	)
 
 	if err = curatedpackages.VerifyCertManagerExists(ctx, deps.Kubectl, kubeConfig); err != nil {

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -64,7 +64,7 @@ func installPackageController(ctx context.Context) error {
 		return err
 	}
 
-	if err = ctrlClient.IsInstalled(ctx); err != nil {
+	if isInstalled, err := ctrlClient.IsInstalled(ctx); isInstalled {
 		return err
 	}
 

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/spf13/cobra"
+
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/version"
-	"github.com/spf13/cobra"
 )
 
 type installControllerOptions struct {

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -64,8 +64,12 @@ func installPackageController(ctx context.Context) error {
 	if err = curatedpackages.VerifyCertManagerExists(ctx, deps.Kubectl, kubeConfig); err != nil {
 		return err
 	}
+	installed, err := ctrlClient.IsInstalled(ctx)
+	if err != nil {
+		return err
+	}
 
-	if ctrlClient.IsInstalled(ctx) {
+	if installed {
 		return errors.New("curated Packages controller exists in the current cluster")
 	}
 

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -3,14 +3,13 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/spf13/cobra"
 	"log"
 
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/version"
+	"github.com/spf13/cobra"
 )
 
 type installControllerOptions struct {
@@ -75,12 +74,4 @@ func installPackageController(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func getProxyConfiguration(clusterSpec *cluster.Spec) (string, string, []string) {
-	proxyConfiguration := clusterSpec.Cluster.Spec.ProxyConfiguration
-	if proxyConfiguration != nil {
-		return proxyConfiguration.HttpProxy, proxyConfiguration.HttpsProxy, proxyConfiguration.NoProxy
-	}
-	return "", "", []string{}
 }

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -64,7 +64,7 @@ func installPackageController(ctx context.Context) error {
 		return err
 	}
 
-	if err = ctrlClient.ValidateControllerDoesNotExist(ctx); err != nil {
+	if err = ctrlClient.IsInstalled(ctx); err != nil {
 		return err
 	}
 

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 
@@ -64,8 +65,8 @@ func installPackageController(ctx context.Context) error {
 		return err
 	}
 
-	if isInstalled, err := ctrlClient.IsInstalled(ctx); isInstalled {
-		return err
+	if ctrlClient.IsInstalled(ctx) {
+		return errors.New("curated Packages controller exists in the current cluster")
 	}
 
 	curatedpackages.PrintLicense()

--- a/pkg/curatedpackages/mocks/packageinstaller.go
+++ b/pkg/curatedpackages/mocks/packageinstaller.go
@@ -49,12 +49,11 @@ func (mr *MockPackageControllerMockRecorder) InstallController(ctx interface{}) 
 }
 
 // IsInstalled mocks base method.
-func (m *MockPackageController) IsInstalled(ctx context.Context) (bool, error) {
+func (m *MockPackageController) IsInstalled(ctx context.Context) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsInstalled", ctx)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // IsInstalled indicates an expected call of IsInstalled.

--- a/pkg/curatedpackages/mocks/packageinstaller.go
+++ b/pkg/curatedpackages/mocks/packageinstaller.go
@@ -48,18 +48,18 @@ func (mr *MockPackageControllerMockRecorder) InstallController(ctx interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallController", reflect.TypeOf((*MockPackageController)(nil).InstallController), ctx)
 }
 
-// ValidateControllerDoesNotExist mocks base method.
-func (m *MockPackageController) ValidateControllerDoesNotExist(ctx context.Context) error {
+// IsInstalled mocks base method.
+func (m *MockPackageController) IsInstalled(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateControllerDoesNotExist", ctx)
+	ret := m.ctrl.Call(m, "IsInstalled", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ValidateControllerDoesNotExist indicates an expected call of ValidateControllerDoesNotExist.
-func (mr *MockPackageControllerMockRecorder) ValidateControllerDoesNotExist(ctx interface{}) *gomock.Call {
+// IsInstalled indicates an expected call of IsInstalled.
+func (mr *MockPackageControllerMockRecorder) IsInstalled(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateControllerDoesNotExist", reflect.TypeOf((*MockPackageController)(nil).ValidateControllerDoesNotExist), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsInstalled", reflect.TypeOf((*MockPackageController)(nil).IsInstalled), ctx)
 }
 
 // MockPackageHandler is a mock of PackageHandler interface.

--- a/pkg/curatedpackages/mocks/packageinstaller.go
+++ b/pkg/curatedpackages/mocks/packageinstaller.go
@@ -48,6 +48,20 @@ func (mr *MockPackageControllerMockRecorder) InstallController(ctx interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallController", reflect.TypeOf((*MockPackageController)(nil).InstallController), ctx)
 }
 
+// ValidateControllerDoesNotExist mocks base method.
+func (m *MockPackageController) ValidateControllerDoesNotExist(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateControllerDoesNotExist", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateControllerDoesNotExist indicates an expected call of ValidateControllerDoesNotExist.
+func (mr *MockPackageControllerMockRecorder) ValidateControllerDoesNotExist(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateControllerDoesNotExist", reflect.TypeOf((*MockPackageController)(nil).ValidateControllerDoesNotExist), ctx)
+}
+
 // MockPackageHandler is a mock of PackageHandler interface.
 type MockPackageHandler struct {
 	ctrl     *gomock.Controller

--- a/pkg/curatedpackages/mocks/packageinstaller.go
+++ b/pkg/curatedpackages/mocks/packageinstaller.go
@@ -49,11 +49,12 @@ func (mr *MockPackageControllerMockRecorder) InstallController(ctx interface{}) 
 }
 
 // IsInstalled mocks base method.
-func (m *MockPackageController) IsInstalled(ctx context.Context) bool {
+func (m *MockPackageController) IsInstalled(ctx context.Context) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsInstalled", ctx)
 	ret0, _ := ret[0].(bool)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // IsInstalled indicates an expected call of IsInstalled.

--- a/pkg/curatedpackages/mocks/packageinstaller.go
+++ b/pkg/curatedpackages/mocks/packageinstaller.go
@@ -49,11 +49,12 @@ func (mr *MockPackageControllerMockRecorder) InstallController(ctx interface{}) 
 }
 
 // IsInstalled mocks base method.
-func (m *MockPackageController) IsInstalled(ctx context.Context) error {
+func (m *MockPackageController) IsInstalled(ctx context.Context) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsInstalled", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // IsInstalled indicates an expected call of IsInstalled.

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -94,12 +94,12 @@ func (pc *PackageControllerClient) InstallController(ctx context.Context) error 
 	return nil
 }
 
-func (pc *PackageControllerClient) IsInstalled(ctx context.Context) error {
+func (pc *PackageControllerClient) IsInstalled(ctx context.Context) (bool, error) {
 	found, _ := pc.kubectl.GetResource(ctx, "packageBundleController", packagesv1.PackageBundleControllerName, pc.kubeConfig, constants.EksaPackagesName)
 	if found {
-		return errors.New("curated Packages controller exists in the current cluster")
+		return true, errors.New("curated Packages controller exists in the current cluster")
 	}
-	return nil
+	return false, nil
 }
 
 func (pc *PackageControllerClient) ApplySecret(ctx context.Context) error {

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -162,7 +162,7 @@ func WithHTTPProxy(httpProxy string) func(client *PackageControllerClient) {
 	}
 }
 
-func WithHttpsProxy(httpsProxy string) func(client *PackageControllerClient) {
+func WithHTTPSProxy(httpsProxy string) func(client *PackageControllerClient) {
 	return func(config *PackageControllerClient) {
 		config.httpsProxy = httpsProxy
 	}

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	packagesv1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/templater"
@@ -93,9 +92,8 @@ func (pc *PackageControllerClient) InstallController(ctx context.Context) error 
 	return nil
 }
 
-func (pc *PackageControllerClient) IsInstalled(ctx context.Context) bool {
-	found, _ := pc.kubectl.GetResource(ctx, "packageBundleController", packagesv1.PackageBundleControllerName, pc.kubeConfig, constants.EksaPackagesName)
-	return found
+func (pc *PackageControllerClient) IsInstalled(ctx context.Context) (bool, error) {
+	return pc.kubectl.GetResource(ctx, "packageBundleController", pc.clusterName, pc.kubeConfig, constants.EksaPackagesName)
 }
 
 func (pc *PackageControllerClient) ApplySecret(ctx context.Context) error {

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -170,6 +170,8 @@ func WithHTTPSProxy(httpsProxy string) func(client *PackageControllerClient) {
 
 func WithNoProxy(noProxy []string) func(client *PackageControllerClient) {
 	return func(config *PackageControllerClient) {
-		config.noProxy = noProxy
+		if noProxy != nil {
+			config.noProxy = noProxy
+		}
 	}
 }

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -3,7 +3,6 @@ package curatedpackages
 import (
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -94,12 +93,9 @@ func (pc *PackageControllerClient) InstallController(ctx context.Context) error 
 	return nil
 }
 
-func (pc *PackageControllerClient) IsInstalled(ctx context.Context) (bool, error) {
+func (pc *PackageControllerClient) IsInstalled(ctx context.Context) bool {
 	found, _ := pc.kubectl.GetResource(ctx, "packageBundleController", packagesv1.PackageBundleControllerName, pc.kubeConfig, constants.EksaPackagesName)
-	if found {
-		return true, errors.New("curated Packages controller exists in the current cluster")
-	}
-	return false, nil
+	return found
 }
 
 func (pc *PackageControllerClient) ApplySecret(ctx context.Context) error {

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -156,7 +156,7 @@ func WithEksaRegion(eksaRegion string) func(client *PackageControllerClient) {
 	}
 }
 
-func WithHttpProxy(httpProxy string) func(client *PackageControllerClient) {
+func WithHTTPProxy(httpProxy string) func(client *PackageControllerClient) {
 	return func(config *PackageControllerClient) {
 		config.httpProxy = httpProxy
 	}

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -94,7 +94,7 @@ func (pc *PackageControllerClient) InstallController(ctx context.Context) error 
 	return nil
 }
 
-func (pc *PackageControllerClient) ValidateControllerDoesNotExist(ctx context.Context) error {
+func (pc *PackageControllerClient) IsInstalled(ctx context.Context) error {
 	found, _ := pc.kubectl.GetResource(ctx, "packageBundleController", packagesv1.PackageBundleControllerName, pc.kubeConfig, constants.EksaPackagesName)
 	if found {
 		return errors.New("curated Packages controller exists in the current cluster")

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -225,7 +225,7 @@ func TestGetActiveControllerSuccess(t *testing.T) {
 
 	tt.kubectl.EXPECT().GetResource(tt.ctx, "packageBundleController", packagesv1.PackageBundleControllerName, tt.kubeConfig, constants.EksaPackagesName).Return(true, nil)
 
-	err := tt.command.IsInstalled(tt.ctx)
+	_, err := tt.command.IsInstalled(tt.ctx)
 	if err == nil {
 		t.Errorf("Get Active Controller should not succeed when controller exists")
 	}
@@ -236,7 +236,7 @@ func TestGetActiveControllerFail(t *testing.T) {
 
 	tt.kubectl.EXPECT().GetResource(tt.ctx, "packageBundleController", packagesv1.PackageBundleControllerName, tt.kubeConfig, constants.EksaPackagesName).Return(false, errors.New("controller doesn't exist"))
 
-	err := tt.command.IsInstalled(tt.ctx)
+	_, err := tt.command.IsInstalled(tt.ctx)
 	if err != nil {
 		t.Errorf("Get Active Controller should succeed when controller doesn't exist")
 	}

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -223,22 +223,22 @@ func TestInstallControllerSuccessWhenCronJobFails(t *testing.T) {
 func TestGetActiveControllerSuccess(t *testing.T) {
 	tt := newPackageControllerTest(t)
 
-	tt.kubectl.EXPECT().GetResource(tt.ctx, "packageBundleController", packagesv1.PackageBundleControllerName, tt.kubeConfig, constants.EksaPackagesName).Return(true, nil)
+	tt.kubectl.EXPECT().GetResource(tt.ctx, "packageBundleController", packagesv1.PackageBundleControllerName, tt.kubeConfig, constants.EksaPackagesName).Return(false, nil)
 
-	found := tt.command.IsInstalled(tt.ctx)
-	if !found {
-		t.Errorf("Get Active Controller should return true when controller exists")
+	found, err := tt.command.IsInstalled(tt.ctx)
+	if err != nil || found {
+		t.Errorf("Get Active Controller should return false when controller doesn't exist")
 	}
 }
 
 func TestGetActiveControllerFail(t *testing.T) {
 	tt := newPackageControllerTest(t)
 
-	tt.kubectl.EXPECT().GetResource(tt.ctx, "packageBundleController", packagesv1.PackageBundleControllerName, tt.kubeConfig, constants.EksaPackagesName).Return(false, errors.New("controller doesn't exist"))
+	tt.kubectl.EXPECT().GetResource(tt.ctx, "packageBundleController", packagesv1.PackageBundleControllerName, tt.kubeConfig, constants.EksaPackagesName).Return(true, errors.New("controller doesn't exist"))
 
-	found := tt.command.IsInstalled(tt.ctx)
-	if found {
-		t.Errorf("Get Active Controller should return false when controller doesn't exist")
+	found, err := tt.command.IsInstalled(tt.ctx)
+	if !found || err == nil {
+		t.Errorf("Get Active Controller should return true when controller exists")
 	}
 }
 

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -36,6 +37,9 @@ type packageControllerTest struct {
 	eksaAccessId   string
 	eksaAccessKey  string
 	eksaRegion     string
+	httpProxy      string
+	httpsProxy     string
+	noProxy        []string
 }
 
 func newPackageControllerTest(t *testing.T) *packageControllerTest {
@@ -67,6 +71,9 @@ func newPackageControllerTest(t *testing.T) *packageControllerTest {
 		eksaAccessId:  eksaAccessId,
 		eksaAccessKey: eksaAccessKey,
 		eksaRegion:    eksaRegion,
+		httpProxy:     "1.1.1.1",
+		httpsProxy:    "1.1.1.1",
+		noProxy:       []string{"1.1.1.1/24"},
 	}
 }
 
@@ -76,6 +83,71 @@ func TestInstallControllerSuccess(t *testing.T) {
 	registry := curatedpackages.GetRegistry(tt.ociUri)
 	sourceRegistry := fmt.Sprintf("sourceRegistry=%s", registry)
 	clusterName := fmt.Sprintf("clusterName=%s", "billy")
+	values := []string{sourceRegistry, clusterName}
+	params := []string{"create", "-f", "-", "--kubeconfig", tt.kubeConfig}
+	dat, err := os.ReadFile("testdata/awssecret_test.yaml")
+	tt.Expect(err).NotTo(HaveOccurred())
+	tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, dat, params).Return(bytes.Buffer{}, nil)
+	params = []string{"create", "job", jobName, "--from=" + cronJobName, "--kubeconfig", tt.kubeConfig, "--namespace", constants.EksaPackagesName}
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, nil)
+	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chartName, "oci://"+tt.ociUri, tt.chartVersion, tt.kubeConfig, values).Return(nil)
+
+	err = tt.command.InstallController(tt.ctx)
+	if err != nil {
+		t.Errorf("Install Controller Should succeed when installation passes")
+	}
+}
+
+func TestInstallControllerWithProxy(t *testing.T) {
+	tt := newPackageControllerTest(t)
+	tt.command = curatedpackages.NewPackageControllerClient(
+		tt.chartInstaller, tt.kubectl, "billy", tt.kubeConfig, tt.ociUri, tt.chartName, tt.chartVersion,
+		curatedpackages.WithEksaSecretAccessKey(tt.eksaAccessKey),
+		curatedpackages.WithEksaRegion(tt.eksaRegion),
+		curatedpackages.WithEksaAccessKeyId(tt.eksaAccessId),
+		curatedpackages.WithHttpProxy(tt.httpProxy),
+		curatedpackages.WithHttpsProxy(tt.httpsProxy),
+		curatedpackages.WithNoProxy(tt.noProxy),
+	)
+
+	registry := curatedpackages.GetRegistry(tt.ociUri)
+	sourceRegistry := fmt.Sprintf("sourceRegistry=%s", registry)
+	clusterName := fmt.Sprintf("clusterName=%s", "billy")
+	httpProxy := fmt.Sprintf("proxy.HTTP_PROXY=%s", tt.httpProxy)
+	httpsProxy := fmt.Sprintf("proxy.HTTPS_PROXY=%s", tt.httpsProxy)
+	noProxy := fmt.Sprintf("proxy.NO_PROXY=%s", strings.Join(tt.noProxy, "\\,"))
+
+	values := []string{sourceRegistry, clusterName, httpProxy, httpsProxy, noProxy}
+	params := []string{"create", "-f", "-", "--kubeconfig", tt.kubeConfig}
+	dat, err := os.ReadFile("testdata/awssecret_test.yaml")
+	tt.Expect(err).NotTo(HaveOccurred())
+	tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, dat, params).Return(bytes.Buffer{}, nil)
+	params = []string{"create", "job", jobName, "--from=" + cronJobName, "--kubeconfig", tt.kubeConfig, "--namespace", constants.EksaPackagesName}
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, nil)
+	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chartName, "oci://"+tt.ociUri, tt.chartVersion, tt.kubeConfig, values).Return(nil)
+
+	err = tt.command.InstallController(tt.ctx)
+	if err != nil {
+		t.Errorf("Install Controller Should succeed when installation passes")
+	}
+}
+
+func TestInstallControllerWithEmptyProxy(t *testing.T) {
+	tt := newPackageControllerTest(t)
+	tt.command = curatedpackages.NewPackageControllerClient(
+		tt.chartInstaller, tt.kubectl, "billy", tt.kubeConfig, tt.ociUri, tt.chartName, tt.chartVersion,
+		curatedpackages.WithEksaSecretAccessKey(tt.eksaAccessKey),
+		curatedpackages.WithEksaRegion(tt.eksaRegion),
+		curatedpackages.WithEksaAccessKeyId(tt.eksaAccessId),
+		curatedpackages.WithHttpProxy(""),
+		curatedpackages.WithHttpsProxy(""),
+		curatedpackages.WithNoProxy([]string{}),
+	)
+
+	registry := curatedpackages.GetRegistry(tt.ociUri)
+	sourceRegistry := fmt.Sprintf("sourceRegistry=%s", registry)
+	clusterName := fmt.Sprintf("clusterName=%s", "billy")
+
 	values := []string{sourceRegistry, clusterName}
 	params := []string{"create", "-f", "-", "--kubeconfig", tt.kubeConfig}
 	dat, err := os.ReadFile("testdata/awssecret_test.yaml")

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -225,9 +225,9 @@ func TestGetActiveControllerSuccess(t *testing.T) {
 
 	tt.kubectl.EXPECT().GetResource(tt.ctx, "packageBundleController", packagesv1.PackageBundleControllerName, tt.kubeConfig, constants.EksaPackagesName).Return(true, nil)
 
-	_, err := tt.command.IsInstalled(tt.ctx)
-	if err == nil {
-		t.Errorf("Get Active Controller should not succeed when controller exists")
+	found := tt.command.IsInstalled(tt.ctx)
+	if !found {
+		t.Errorf("Get Active Controller should return true when controller exists")
 	}
 }
 
@@ -236,9 +236,9 @@ func TestGetActiveControllerFail(t *testing.T) {
 
 	tt.kubectl.EXPECT().GetResource(tt.ctx, "packageBundleController", packagesv1.PackageBundleControllerName, tt.kubeConfig, constants.EksaPackagesName).Return(false, errors.New("controller doesn't exist"))
 
-	_, err := tt.command.IsInstalled(tt.ctx)
-	if err != nil {
-		t.Errorf("Get Active Controller should succeed when controller doesn't exist")
+	found := tt.command.IsInstalled(tt.ctx)
+	if found {
+		t.Errorf("Get Active Controller should return false when controller doesn't exist")
 	}
 }
 

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -105,8 +105,8 @@ func TestInstallControllerWithProxy(t *testing.T) {
 		curatedpackages.WithEksaSecretAccessKey(tt.eksaAccessKey),
 		curatedpackages.WithEksaRegion(tt.eksaRegion),
 		curatedpackages.WithEksaAccessKeyId(tt.eksaAccessId),
-		curatedpackages.WithHttpProxy(tt.httpProxy),
-		curatedpackages.WithHttpsProxy(tt.httpsProxy),
+		curatedpackages.WithHTTPProxy(tt.httpProxy),
+		curatedpackages.WithHTTPSProxy(tt.httpsProxy),
 		curatedpackages.WithNoProxy(tt.noProxy),
 	)
 
@@ -139,8 +139,8 @@ func TestInstallControllerWithEmptyProxy(t *testing.T) {
 		curatedpackages.WithEksaSecretAccessKey(tt.eksaAccessKey),
 		curatedpackages.WithEksaRegion(tt.eksaRegion),
 		curatedpackages.WithEksaAccessKeyId(tt.eksaAccessId),
-		curatedpackages.WithHttpProxy(""),
-		curatedpackages.WithHttpsProxy(""),
+		curatedpackages.WithHTTPProxy(""),
+		curatedpackages.WithHTTPSProxy(""),
 		curatedpackages.WithNoProxy([]string{}),
 	)
 
@@ -225,7 +225,7 @@ func TestGetActiveControllerSuccess(t *testing.T) {
 
 	tt.kubectl.EXPECT().GetResource(tt.ctx, "packageBundleController", packagesv1.PackageBundleControllerName, tt.kubeConfig, constants.EksaPackagesName).Return(true, nil)
 
-	err := tt.command.ValidateControllerDoesNotExist(tt.ctx)
+	err := tt.command.IsInstalled(tt.ctx)
 	if err == nil {
 		t.Errorf("Get Active Controller should not succeed when controller exists")
 	}
@@ -236,7 +236,7 @@ func TestGetActiveControllerFail(t *testing.T) {
 
 	tt.kubectl.EXPECT().GetResource(tt.ctx, "packageBundleController", packagesv1.PackageBundleControllerName, tt.kubeConfig, constants.EksaPackagesName).Return(false, errors.New("controller doesn't exist"))
 
-	err := tt.command.ValidateControllerDoesNotExist(tt.ctx)
+	err := tt.command.IsInstalled(tt.ctx)
 	if err != nil {
 		t.Errorf("Get Active Controller should succeed when controller doesn't exist")
 	}

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -141,7 +141,7 @@ func TestInstallControllerWithEmptyProxy(t *testing.T) {
 		curatedpackages.WithEksaAccessKeyId(tt.eksaAccessId),
 		curatedpackages.WithHTTPProxy(""),
 		curatedpackages.WithHTTPSProxy(""),
-		curatedpackages.WithNoProxy([]string{}),
+		curatedpackages.WithNoProxy(nil),
 	)
 
 	registry := curatedpackages.GetRegistry(tt.ociUri)

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -10,7 +10,7 @@ import (
 
 type PackageController interface {
 	InstallController(ctx context.Context) error
-	IsInstalled(ctx context.Context) (bool, error)
+	IsInstalled(ctx context.Context) bool
 }
 
 type PackageHandler interface {

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -10,7 +10,7 @@ import (
 
 type PackageController interface {
 	InstallController(ctx context.Context) error
-	IsInstalled(ctx context.Context) bool
+	IsInstalled(ctx context.Context) (bool, error)
 }
 
 type PackageHandler interface {

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -10,6 +10,7 @@ import (
 
 type PackageController interface {
 	InstallController(ctx context.Context) error
+	ValidateControllerDoesNotExist(ctx context.Context) error
 }
 
 type PackageHandler interface {
@@ -78,4 +79,12 @@ func (pi *Installer) installPackages(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+func getProxyConfiguration(clusterSpec *cluster.Spec) (string, string, []string) {
+	proxyConfiguration := clusterSpec.Cluster.Spec.ProxyConfiguration
+	if proxyConfiguration != nil {
+		return proxyConfiguration.HttpProxy, proxyConfiguration.HttpsProxy, proxyConfiguration.NoProxy
+	}
+	return "", "", []string{}
 }

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -10,7 +10,7 @@ import (
 
 type PackageController interface {
 	InstallController(ctx context.Context) error
-	ValidateControllerDoesNotExist(ctx context.Context) error
+	IsInstalled(ctx context.Context) error
 }
 
 type PackageHandler interface {

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -80,11 +80,3 @@ func (pi *Installer) installPackages(ctx context.Context) error {
 	}
 	return nil
 }
-
-func getProxyConfiguration(clusterSpec *cluster.Spec) (string, string, []string) {
-	proxyConfiguration := clusterSpec.Cluster.Spec.ProxyConfiguration
-	if proxyConfiguration != nil {
-		return proxyConfiguration.HttpProxy, proxyConfiguration.HttpsProxy, proxyConfiguration.NoProxy
-	}
-	return "", "", []string{}
-}

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -10,7 +10,7 @@ import (
 
 type PackageController interface {
 	InstallController(ctx context.Context) error
-	IsInstalled(ctx context.Context) error
+	IsInstalled(ctx context.Context) (bool, error)
 }
 
 type PackageHandler interface {

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -1093,7 +1093,7 @@ func (f *Factory) WithVSphereDefaulter() *Factory {
 	return f
 }
 
-func getProxyConfiguration(clusterSpec *cluster.Spec) (string, string, []string) {
+func getProxyConfiguration(clusterSpec *cluster.Spec) (httpProxy, httpsProxy string, noProxy []string) {
 	proxyConfiguration := clusterSpec.Cluster.Spec.ProxyConfiguration
 	if proxyConfiguration != nil {
 		return proxyConfiguration.HttpProxy, proxyConfiguration.HttpsProxy, proxyConfiguration.NoProxy

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -865,8 +865,8 @@ func (f *Factory) WithPackageControllerClient(spec *cluster.Spec) *Factory {
 			curatedpackages.WithEksaAccessKeyId(eksaAccessKeyId),
 			curatedpackages.WithEksaSecretAccessKey(eksaSecretKey),
 			curatedpackages.WithEksaRegion(eksaRegion),
-			curatedpackages.WithHttpProxy(httpProxy),
-			curatedpackages.WithHttpsProxy(httpsProxy),
+			curatedpackages.WithHTTPProxy(httpProxy),
+			curatedpackages.WithHTTPSProxy(httpsProxy),
 			curatedpackages.WithNoProxy(noProxy),
 		)
 		return nil

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -844,7 +844,7 @@ func (f *Factory) WithPackageControllerClient(spec *cluster.Spec) *Factory {
 	f.WithHelm(executables.WithInsecure()).WithKubectl()
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
-		if f.dependencies.PackageControllerClient != nil {
+		if f.dependencies.PackageControllerClient != nil || spec == nil {
 			return nil
 		}
 		kubeConfig := kubeconfig.FromClusterName(spec.Cluster.Name)

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -81,7 +81,7 @@ type Dependencies struct {
 	CliConfig                 *config.CliConfig
 	PackageInstaller          interfaces.PackageInstaller
 	BundleRegistry            curatedpackages.BundleRegistry
-	PackageControllerClient   curatedpackages.PackageController
+	PackageControllerClient   *curatedpackages.PackageControllerClient
 	PackageClient             curatedpackages.PackageHandler
 	VSphereValidator          *vsphere.Validator
 	VSphereDefaulter          *vsphere.Defaulter

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -1098,5 +1098,5 @@ func getProxyConfiguration(clusterSpec *cluster.Spec) (httpProxy, httpsProxy str
 	if proxyConfiguration != nil {
 		return proxyConfiguration.HttpProxy, proxyConfiguration.HttpsProxy, proxyConfiguration.NoProxy
 	}
-	return "", "", []string{}
+	return "", "", nil
 }

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -851,6 +851,8 @@ func (f *Factory) WithPackageControllerClient(spec *cluster.Spec) *Factory {
 
 		chart := spec.VersionsBundle.PackageController.HelmChart
 		imageUrl := urls.ReplaceHost(chart.Image(), spec.Cluster.RegistryMirror())
+
+		httpProxy, httpsProxy, noProxy := getProxyConfiguration(spec)
 		eksaAccessKeyId, eksaSecretKey, eksaRegion := os.Getenv(config.EksaAccessKeyIdEnv), os.Getenv(config.EksaSecretAcessKeyEnv), os.Getenv(config.EksaRegionEnv)
 		f.dependencies.PackageControllerClient = curatedpackages.NewPackageControllerClient(
 			f.dependencies.Helm,
@@ -863,6 +865,9 @@ func (f *Factory) WithPackageControllerClient(spec *cluster.Spec) *Factory {
 			curatedpackages.WithEksaAccessKeyId(eksaAccessKeyId),
 			curatedpackages.WithEksaSecretAccessKey(eksaSecretKey),
 			curatedpackages.WithEksaRegion(eksaRegion),
+			curatedpackages.WithHttpProxy(httpProxy),
+			curatedpackages.WithHttpsProxy(httpsProxy),
+			curatedpackages.WithNoProxy(noProxy),
 		)
 		return nil
 	})
@@ -1086,4 +1091,12 @@ func (f *Factory) WithVSphereDefaulter() *Factory {
 	})
 
 	return f
+}
+
+func getProxyConfiguration(clusterSpec *cluster.Spec) (string, string, []string) {
+	proxyConfiguration := clusterSpec.Cluster.Spec.ProxyConfiguration
+	if proxyConfiguration != nil {
+		return proxyConfiguration.HttpProxy, proxyConfiguration.HttpsProxy, proxyConfiguration.NoProxy
+	}
+	return "", "", []string{}
 }

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -247,12 +247,52 @@ func TestFactoryBuildWithPackageClient(t *testing.T) {
 	tt.Expect(deps.PackageClient).NotTo(BeNil())
 }
 
-func TestFactoryBuildWithPackageControllerClient(t *testing.T) {
+func TestFactoryBuildWithPackageControllerClientNoProxy(t *testing.T) {
 	spec := &cluster.Spec{
 		Config: &cluster.Config{
 			Cluster: &anywherev1.Cluster{
 				ObjectMeta: v1.ObjectMeta{
 					Name: "test-cluster",
+				},
+			},
+		},
+		VersionsBundle: &cluster.VersionsBundle{
+			VersionsBundle: &v1alpha1.VersionsBundle{
+				PackageController: v1alpha1.PackageBundle{
+					HelmChart: v1alpha1.Image{
+						URI:  "test_registry/test/eks-anywhere-packages:v1",
+						Name: "test_chart",
+					},
+				},
+			},
+		},
+	}
+
+	tt := newTest(t, vsphere)
+	deps, err := dependencies.NewFactory().
+		WithLocalExecutables().
+		WithHelm(executables.WithInsecure()).
+		WithKubectl().
+		WithPackageControllerClient(spec).
+		Build(context.Background())
+
+	tt.Expect(err).To(BeNil())
+	tt.Expect(deps.PackageControllerClient).NotTo(BeNil())
+}
+
+func TestFactoryBuildWithPackageControllerClientProxy(t *testing.T) {
+	spec := &cluster.Spec{
+		Config: &cluster.Config{
+			Cluster: &anywherev1.Cluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: anywherev1.ClusterSpec{
+					ProxyConfiguration: &anywherev1.ProxyConfiguration{
+						HttpProxy:  "1.1.1.1",
+						HttpsProxy: "1.1.1.1",
+						NoProxy:    []string{"1.1.1.1"},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
*Description of changes:*
- Currently curated packages don't work behind a proxy. This enables curated packages to be installed behind a proxy.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

