### PR TITLE
Add support for weekly bundle creation and Github release

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -28,6 +28,9 @@ SOURCE_BUCKET=projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f
 else
 DRY_RUN=false
 endif
+DATE_YYYYMMDD=$(shell date "+%F")
+WEEKLY?=false
+WEEKLY_BUNDLE_MANIFEST_URL=https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/weekly-releases/bundles/$(DATE_YYYYMMDD)/manifest.yaml
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
@@ -130,13 +133,16 @@ run: manifests generate fmt vet ## Run a controller from your host.
 ##@ Release
 
 dev-release: build ## Perform a dev release of EKS-A bundles and CLI manifests
-	scripts/release.sh $(REPO_ROOT)/release/downloaded-artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(SOURCE_CONTAINER_REGISTRY) $(RELEASE_CONTAINER_REGISTRY) $(BUILD_REPO_URL) $(CLI_REPO_URL) $(BUILD_REPO_BRANCH_NAME) $(CLI_REPO_BRANCH_NAME) $(DRY_RUN)
+	scripts/release.sh $(REPO_ROOT)/release/downloaded-artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(SOURCE_CONTAINER_REGISTRY) $(RELEASE_CONTAINER_REGISTRY) $(BUILD_REPO_URL) $(CLI_REPO_URL) $(BUILD_REPO_BRANCH_NAME) $(CLI_REPO_BRANCH_NAME) $(DRY_RUN) $(WEEKLY)
 
 bundle-release: build ## Perform EKS-A versioned bundles release
 	scripts/bundle-release.sh $(REPO_ROOT)/release/downloaded-artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(BUNDLE_NUMBER) $(CLI_MIN_VERSION) $(CLI_MAX_VERSION) $(SOURCE_CONTAINER_REGISTRY) $(RELEASE_CONTAINER_REGISTRY) $(RELEASE_ENVIRONMENT) $(BUILD_REPO_BRANCH_NAME) $(CLI_REPO_BRANCH_NAME) $(BUILD_REPO_URL) $(CLI_REPO_URL)
 
 eks-a-release: build ## Perform EKS-A CLI release
 	scripts/eks-a-release.sh $(RELEASE_VERSION) $(REPO_ROOT)/release/downloaded-artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(BUNDLE_NUMBER) $(RELEASE_NUMBER) $(RELEASE_ENVIRONMENT) $(CLI_REPO_BRANCH_NAME) $(BUILD_REPO_URL) $(CLI_REPO_URL)
+
+github-bundle-release:
+	scripts/github-bundle-release.sh $(REPO_ROOT)/release/downloaded-artifacts $(WEEKLY_BUNDLE_MANIFEST_URL)
 
 ##@ Deployment
 

--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -207,6 +207,6 @@ func (vb *VersionsBundle) Charts() map[string]*Image {
 	return map[string]*Image{
 		"cilium":                &vb.Cilium.HelmChart,
 		"eks-anywhere-packages": &vb.PackageController.HelmChart,
-		"tinkerbell-chart": &vb.Tinkerbell.TinkerbellStack.TinkebellChart,
+		"tinkerbell-chart":      &vb.Tinkerbell.TinkerbellStack.TinkebellChart,
 	}
 }

--- a/release/buildspecs/github-bundle-release.yml
+++ b/release/buildspecs/github-bundle-release.yml
@@ -1,0 +1,6 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+    - make github-bundle-release -C $PROJECT_PATH

--- a/release/pkg/assets/archives/archives_test.go
+++ b/release/pkg/assets/archives/archives_test.go
@@ -40,7 +40,7 @@ var releaseConfig = &releasetypes.ReleaseConfig{
 	BundleNumber:             1,
 	ReleaseNumber:            1,
 	ReleaseVersion:           "vDev",
-	ReleaseDate:              time.Unix(0, 0),
+	ReleaseTime:              time.Unix(0, 0),
 	DevRelease:               true,
 	DryRun:                   true,
 }

--- a/release/pkg/assets/images/images_test.go
+++ b/release/pkg/assets/images/images_test.go
@@ -40,7 +40,7 @@ var releaseConfig = &releasetypes.ReleaseConfig{
 	BundleNumber:             1,
 	ReleaseNumber:            1,
 	ReleaseVersion:           "vDev",
-	ReleaseDate:              time.Unix(0, 0),
+	ReleaseTime:              time.Unix(0, 0),
 	DevRelease:               true,
 	DryRun:                   true,
 }

--- a/release/pkg/assets/manifests/manifests_test.go
+++ b/release/pkg/assets/manifests/manifests_test.go
@@ -40,7 +40,7 @@ var releaseConfig = &releasetypes.ReleaseConfig{
 	BundleNumber:             1,
 	ReleaseNumber:            1,
 	ReleaseVersion:           "vDev",
-	ReleaseDate:              time.Unix(0, 0),
+	ReleaseTime:              time.Unix(0, 0),
 	DevRelease:               true,
 	DryRun:                   true,
 }

--- a/release/pkg/bundles/bundles.go
+++ b/release/pkg/bundles/bundles.go
@@ -41,7 +41,7 @@ func NewBaseBundles(r *releasetypes.ReleaseConfig) *anywherev1alpha1.Bundles {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              NewBundlesName(r),
-			CreationTimestamp: metav1.Time{Time: r.ReleaseDate},
+			CreationTimestamp: metav1.Time{Time: r.ReleaseTime},
 		},
 		Spec: anywherev1alpha1.BundlesSpec{
 			Number: r.BundleNumber,

--- a/release/pkg/bundles/eksctl-anywhere.go
+++ b/release/pkg/bundles/eksctl-anywhere.go
@@ -88,7 +88,7 @@ func GetEksARelease(r *releasetypes.ReleaseConfig) (anywherev1alpha1.EksARelease
 
 	artifacts := r.EksAArtifactsTable["eks-a-cli"]
 
-	bundleManifestFilePath := artifactutils.GetManifestFilepaths(r.DevRelease, r.BundleNumber, constants.BundlesKind, r.BuildRepoBranchName)
+	bundleManifestFilePath := artifactutils.GetManifestFilepaths(r.DevRelease, r.Weekly, r.BundleNumber, constants.BundlesKind, r.BuildRepoBranchName, r.ReleaseDate)
 	bundleManifestUrl, err := artifactutils.GetURI(r.CDN, bundleManifestFilePath)
 	if err != nil {
 		return anywherev1alpha1.EksARelease{}, errors.Cause(err)
@@ -118,7 +118,7 @@ func GetEksARelease(r *releasetypes.ReleaseConfig) (anywherev1alpha1.EksARelease
 	}
 
 	eksARelease := anywherev1alpha1.EksARelease{
-		Date:      r.ReleaseDate.String(),
+		Date:      r.ReleaseTime.String(),
 		Version:   r.ReleaseVersion,
 		Number:    r.ReleaseNumber,
 		GitCommit: r.CliRepoHead,

--- a/release/pkg/constants/constants.go
+++ b/release/pkg/constants/constants.go
@@ -42,4 +42,12 @@ const (
 	KindProjectPath                     = "projects/kubernetes-sigs/kind"
 	KubeRbacProxyProjectPath            = "projects/brancz/kube-rbac-proxy"
 	PackagesProjectPath                 = "projects/aws/eks-anywhere-packages"
+
+	// Date format with standard reference time values
+	// The reference time used is the specific time stamp:
+	//
+	//	01/02 03:04:05PM '06 -0700
+	//
+	// (January 2, 15:04:05, 2006, in time zone seven hours west of GMT).
+	YYYYMMDD = "2006-01-02"
 )

--- a/release/pkg/filereader/file_reader.go
+++ b/release/pkg/filereader/file_reader.go
@@ -208,30 +208,35 @@ func GetCurrentEksADevReleaseVersion(releaseVersion string, r *releasetypes.Rele
 		latestReleaseKey = fmt.Sprintf("%s/LATEST_RELEASE_VERSION", r.BuildRepoBranchName)
 	}
 
-	if s3.KeyExists(r.ReleaseBucket, latestReleaseKey) {
-		err := s3.DownloadFile(tempFileName, r.ReleaseBucket, latestReleaseKey)
-		if err != nil {
-			return "", errors.Cause(err)
-		}
-
-		// Check if current version and latest version are the same semver
-		latestBuildS3, err := ioutil.ReadFile(tempFileName)
-		if err != nil {
-			return "", errors.Cause(err)
-		}
-		latestBuildVersion = string(latestBuildS3)
-		newDevReleaseVersion, err = GenerateNewDevReleaseVersion(latestBuildVersion, releaseVersion, r.BuildRepoBranchName)
-		if err != nil {
-			return "", errors.Cause(err)
-		}
-		fmt.Printf("Previous release version: %s\n", latestBuildVersion)
-		fmt.Printf("Current release version provided: %s\n", releaseVersion)
+	if r.Weekly {
+		newDevReleaseVersion = fmt.Sprintf("v0.0.0-dev+build.%s", r.ReleaseDate)
 	} else {
-		newDevReleaseVersion = "v0.0.0-dev+build.0"
-		if r.BuildRepoBranchName != "main" {
-			newDevReleaseVersion = fmt.Sprintf("v0.0.0-dev-%s+build.0", r.BuildRepoBranchName)
+		if s3.KeyExists(r.ReleaseBucket, latestReleaseKey) {
+			err := s3.DownloadFile(tempFileName, r.ReleaseBucket, latestReleaseKey)
+			if err != nil {
+				return "", errors.Cause(err)
+			}
+
+			// Check if current version and latest version are the same semver
+			latestBuildS3, err := ioutil.ReadFile(tempFileName)
+			if err != nil {
+				return "", errors.Cause(err)
+			}
+			latestBuildVersion = string(latestBuildS3)
+			newDevReleaseVersion, err = GenerateNewDevReleaseVersion(latestBuildVersion, releaseVersion, r.BuildRepoBranchName)
+			if err != nil {
+				return "", errors.Cause(err)
+			}
+			fmt.Printf("Previous release version: %s\n", latestBuildVersion)
+			fmt.Printf("Current release version provided: %s\n", releaseVersion)
+		} else {
+			newDevReleaseVersion = "v0.0.0-dev+build.0"
+			if r.BuildRepoBranchName != "main" {
+				newDevReleaseVersion = fmt.Sprintf("v0.0.0-dev-%s+build.0", r.BuildRepoBranchName)
+			}
 		}
 	}
+
 	fmt.Printf("New dev release release version: %s\n", newDevReleaseVersion)
 
 	fmt.Printf("%s Successfully computed current dev release version\n", constants.SuccessIcon)

--- a/release/pkg/images/images.go
+++ b/release/pkg/images/images.go
@@ -224,6 +224,9 @@ func GetReleaseImageURI(r *releasetypes.ReleaseConfig, name, repoName string, ta
 
 	var semver string
 	if r.DevRelease {
+		if r.Weekly {
+			semver = r.DevReleaseUriVersion
+		}
 		currentSourceImageUri, _, err := GetSourceImageURI(r, name, repoName, tagOptions, imageTagConfiguration, trimVersionSignifier)
 		if err != nil {
 			return "", errors.Cause(err)
@@ -303,7 +306,7 @@ func GetPreviousReleaseImageSemver(r *releasetypes.ReleaseConfig, releaseImageUr
 		semver = "v0.0.0-dev-build.0"
 	} else {
 		bundles := &anywherev1alpha1.Bundles{}
-		bundleReleaseManifestKey := artifactutils.GetManifestFilepaths(r.DevRelease, r.BundleNumber, constants.BundlesKind, r.BuildRepoBranchName)
+		bundleReleaseManifestKey := artifactutils.GetManifestFilepaths(r.DevRelease, r.Weekly, r.BundleNumber, constants.BundlesKind, r.BuildRepoBranchName, r.ReleaseDate)
 		bundleManifestUrl := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", r.ReleaseBucket, bundleReleaseManifestKey)
 		if s3.KeyExists(r.ReleaseBucket, bundleReleaseManifestKey) {
 			contents, err := filereader.ReadHttpFile(bundleManifestUrl)

--- a/release/pkg/operations/bundle_release_test.go
+++ b/release/pkg/operations/bundle_release_test.go
@@ -55,7 +55,7 @@ var releaseConfig = &releasetypes.ReleaseConfig{
 	BundleNumber:             1,
 	ReleaseNumber:            1,
 	ReleaseVersion:           "vDev",
-	ReleaseDate:              time.Unix(0, 0),
+	ReleaseTime:              time.Unix(0, 0),
 	DevRelease:               true,
 	DryRun:                   true,
 }
@@ -201,7 +201,7 @@ func TestReleaseConfigNewBaseBundles(t *testing.T) {
 	now := time.Now()
 	releaseConfig := &releasetypes.ReleaseConfig{
 		BundleNumber: 10,
-		ReleaseDate:  now,
+		ReleaseTime:  now,
 	}
 	wantBundles := &anywherev1alpha1.Bundles{
 		TypeMeta: metav1.TypeMeta{

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -425,7 +425,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.6-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -434,7 +434,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.6-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -443,8 +443,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.4-eks-a-v0.0.0-dev-build.1
-      version: v0.2.4+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.6-eks-a-v0.0.0-dev-build.1
+      version: v0.2.6+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml
@@ -1171,7 +1171,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.6-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1180,7 +1180,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.6-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1189,8 +1189,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.4-eks-a-v0.0.0-dev-build.1
-      version: v0.2.4+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.6-eks-a-v0.0.0-dev-build.1
+      version: v0.2.6+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml
@@ -1917,7 +1917,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.6-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1926,7 +1926,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.6-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1935,8 +1935,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.4-eks-a-v0.0.0-dev-build.1
-      version: v0.2.4+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.6-eks-a-v0.0.0-dev-build.1
+      version: v0.2.6+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml
@@ -2663,7 +2663,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.6-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -2672,7 +2672,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.6-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2681,8 +2681,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.4-eks-a-v0.0.0-dev-build.1
-      version: v0.2.4+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.6-eks-a-v0.0.0-dev-build.1
+      version: v0.2.6+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml
@@ -3391,7 +3391,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.6-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -3400,7 +3400,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.6-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -3409,8 +3409,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.4-eks-a-v0.0.0-dev-build.1
-      version: v0.2.4+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.6-eks-a-v0.0.0-dev-build.1
+      version: v0.2.6+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml

--- a/release/pkg/test/testdata/release-0.11-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.11-bundle-release.yaml
@@ -50,7 +50,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-19-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-20-eks-a-v0.0.0-dev-release-0.11-build.1
     certManager:
       acmesolver:
         arch:
@@ -262,7 +262,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.0/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.1/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -271,21 +271,21 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-19-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-20-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVersion: v1.20.15
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-19.yaml
-      name: kubernetes-1-20-eks-19
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-20.yaml
+      name: kubernetes-1-20-eks-20
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-20-19 release
-          name: bottlerocket-v1.20.15-eks-d-1-20-19-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-20-20 release
+          name: bottlerocket-v1.20.15-eks-d-1-20-20-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-20/1-20-19/bottlerocket-v1.20.15-eks-d-1-20-19-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-20/1-20-20/bottlerocket-v1.20.15-eks-d-1-20-20-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
       raw:
         bottlerocket: {}
     eksa:
@@ -769,7 +769,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-17-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-18-eks-a-v0.0.0-dev-release-0.11-build.1
     certManager:
       acmesolver:
         arch:
@@ -981,7 +981,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.0/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.1/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -990,32 +990,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.1
-      kubeVersion: v1.21.13
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-17.yaml
-      name: kubernetes-1-21-eks-17
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-release-0.11-build.1
+      kubeVersion: v1.21.14
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-18.yaml
+      name: kubernetes-1-21-eks-18
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-21-17 release
-          name: bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-21-18 release
+          name: bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-21/1-21-17/bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-21/1-21-18/bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-21-17 release
-          name: bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-21-18 release
+          name: bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-21/1-21-17/bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-21/1-21-18/bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -1497,7 +1497,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-9-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-10-eks-a-v0.0.0-dev-release-0.11-build.1
     certManager:
       acmesolver:
         arch:
@@ -1709,7 +1709,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.0/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.1/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -1718,32 +1718,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.1
-      kubeVersion: v1.22.10
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-9.yaml
-      name: kubernetes-1-22-eks-9
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-release-0.11-build.1
+      kubeVersion: v1.22.12
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-10.yaml
+      name: kubernetes-1-22-eks-10
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-22-9 release
-          name: bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-22-10 release
+          name: bottlerocket-v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-22/1-22-9/bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-22/1-22-10/bottlerocket-v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-22-9 release
-          name: bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-22-10 release
+          name: bottlerocket-v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-22/1-22-9/bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-22/1-22-10/bottlerocket-v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -2225,7 +2225,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-4-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-5-eks-a-v0.0.0-dev-release-0.11-build.1
     certManager:
       acmesolver:
         arch:
@@ -2437,7 +2437,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.0/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.1/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -2446,32 +2446,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.1
-      kubeVersion: v1.23.7
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-4.yaml
-      name: kubernetes-1-23-eks-4
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-release-0.11-build.1
+      kubeVersion: v1.23.9
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-5.yaml
+      name: kubernetes-1-23-eks-5
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-23-4 release
-          name: bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-23-5 release
+          name: bottlerocket-v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-23/1-23-4/bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-23/1-23-5/bottlerocket-v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-23-4 release
-          name: bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-23-5 release
+          name: bottlerocket-v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-23/1-23-4/bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-23/1-23-5/bottlerocket-v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:

--- a/release/pkg/types/types.go
+++ b/release/pkg/types/types.go
@@ -42,9 +42,11 @@ type ReleaseConfig struct {
 	ReleaseContainerRegistry string
 	CDN                      string
 	ReleaseNumber            int
-	ReleaseDate              time.Time
+	ReleaseDate              string
+	ReleaseTime              time.Time
 	DevRelease               bool
 	DryRun                   bool
+	Weekly                   bool
 	ReleaseEnvironment       string
 	SourceClients            *clients.SourceClients
 	ReleaseClients           *clients.ReleaseClients

--- a/release/pkg/util/artifacts/artifacts.go
+++ b/release/pkg/util/artifacts/artifacts.go
@@ -30,7 +30,7 @@ func IsImageNotFoundError(err error) bool {
 	return err.Error() == "Requested image not found"
 }
 
-func GetManifestFilepaths(devRelease bool, bundleNumber int, kind, branch string) string {
+func GetManifestFilepaths(devRelease, weekly bool, bundleNumber int, kind, branch, releaseDate string) string {
 	var manifestFilepath string
 	switch kind {
 	case constants.BundlesKind:
@@ -39,6 +39,9 @@ func GetManifestFilepaths(devRelease bool, bundleNumber int, kind, branch string
 				manifestFilepath = fmt.Sprintf("%s/bundle-release.yaml", branch)
 			} else {
 				manifestFilepath = "bundle-release.yaml"
+				if weekly {
+					manifestFilepath = fmt.Sprintf("weekly-releases/bundles/%s/manifest.yaml", releaseDate)
+				}
 			}
 		} else {
 			manifestFilepath = fmt.Sprintf("releases/bundles/%d/manifest.yaml", bundleNumber)
@@ -49,6 +52,9 @@ func GetManifestFilepaths(devRelease bool, bundleNumber int, kind, branch string
 				manifestFilepath = fmt.Sprintf("%s/eks-a-release.yaml", branch)
 			} else {
 				manifestFilepath = "eks-a-release.yaml"
+				if weekly {
+					manifestFilepath = fmt.Sprintf("weekly-releases/eks-a/manifest.yaml")
+				}
 			}
 		} else {
 			manifestFilepath = "releases/eks-a/manifest.yaml"

--- a/release/pkg/util/release/release.go
+++ b/release/pkg/util/release/release.go
@@ -41,7 +41,7 @@ func GetPreviousReleaseIfExists(r *releasetypes.ReleaseConfig) (*anywherev1alpha
 	}
 
 	release := &anywherev1alpha1.Release{}
-	eksAReleaseManifestKey := artifactutils.GetManifestFilepaths(r.DevRelease, r.BundleNumber, constants.ReleaseKind, r.BuildRepoBranchName)
+	eksAReleaseManifestKey := artifactutils.GetManifestFilepaths(r.DevRelease, r.Weekly, r.BundleNumber, constants.ReleaseKind, r.BuildRepoBranchName, r.ReleaseDate)
 	eksAReleaseManifestUrl := fmt.Sprintf("%s/%s", r.CDN, eksAReleaseManifestKey)
 
 	if s3.KeyExists(r.ReleaseBucket, eksAReleaseManifestKey) {

--- a/release/scripts/github-bundle-release-notes.tmpl
+++ b/release/scripts/github-bundle-release-notes.tmpl
@@ -1,0 +1,5 @@
+This is the weekly bundle release from main.
+
+Date: $DATE_YYYYMMDD
+Build-tooling repo commit: $BUILD_REPO_HEAD
+CLI repo commit: $CLI_REPO_HEAD

--- a/release/scripts/github-bundle-release.sh
+++ b/release/scripts/github-bundle-release.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -e
+set -x
+set -o pipefail
+
+ARTIFACTS_DIR="${1?Specify first argument - artifacts path}"
+BUNDLE_MANIFEST_URL="${2?Specify second argument - weekly bundle manifest URL}"
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+RELEASE_NOTES_PATH="$SCRIPT_ROOT/github-bundle-release-notes"
+export DATE_YYYYMMDD=$(date "+%F")
+RELEASE_TAG="weekly.$DATE_YYYYMMDD"
+
+# Authenticating to GitHub with the bot token
+echo "$GITHUB_TOKEN" | gh auth login --with-token
+
+# Filling in values for the GitHub Release notes template
+envsubst '$DATE_YYYYMMDD:$BUILD_REPO_HEAD:$CLI_REPO_HEAD' \
+    < "$RELEASE_NOTES_PATH.tmpl" \
+    > "$RELEASE_NOTES_PATH"
+
+# Downloading the weekly bundle release manifest
+mkdir -p $ARTIFACTS_DIR
+wget $BUNDLE_MANIFEST_URL $ARTIFACTS_DIR/weekly-bundle-release.yaml
+
+# Publish the asset as a Github pre-release on main branch with a new dated tag
+gh release create $RELEASE_TAG $ARTIFACTS_DIR/weekly-bundle-release.yaml --notes-file "RELEASE_NOTES_PATH" --prerelease --repo "github.com/aws/eks-anywhere" --title "Weekly Release $DATE_YYYYMMDD" --target "main"

--- a/release/scripts/release.sh
+++ b/release/scripts/release.sh
@@ -33,6 +33,7 @@ CLI_REPO_URL="${8?Specify eighth argument - CLI repo URL}"
 BUILD_REPO_BRANCH_NAME="${9?Specify ninth argument - Build repo branch name}"
 CLI_REPO_BRANCH_NAME="${10?Specify tenth argument - CLI repo branch name}"
 DRY_RUN="${11?Specify eleventh argument - Dry run}"
+WEEKLY="${12?Specify twelfth argument - Weekly release}"
 
 mkdir -p "${ARTIFACTS_DIR}"
 
@@ -48,4 +49,5 @@ ${BASE_DIRECTORY}/release/bin/eks-anywhere-release release \
     --release-bucket "${RELEASE_BUCKET}" \
     --release-container-registry "${RELEASE_CONTAINER_REGISTRY}" \
     --dev-release=true \
-    --dry-run=${DRY_RUN}
+    --dry-run=${DRY_RUN} \
+    --weekly=${WEEKLY}


### PR DESCRIPTION
This PR adds a new weekly release mode to the release tool that generates a bundle release every week with a different tagging scheme. It also adds a script that will publish this bundle release manifest as a GitHub release with a date-based tag on main branch. The release notes will contain the commit information pertaining to this release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

