### PR TITLE
Add Contact us link to all docs pages

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -76,6 +76,11 @@ weight = 1
 section = ["HTML", "print"]
 
 [[menu.main]]
+    name = "Contact us"
+    weight = 70
+    url = "https://aws.amazon.com/contact-us/sales-support-eks/"
+
+[[menu.main]]
     name = "GitHub"
     weight = 50
     url = "https://github.com/aws/eks-anywhere"


### PR DESCRIPTION
*Description of changes:*

Add a "Contact us" link to the top of all docs pages that points to https://aws.amazon.com/contact-us/sales-support-eks/