### PR TITLE
Skip cert validator unit test for darwin

### DIFF
--- a/pkg/crypto/validator_test.go
+++ b/pkg/crypto/validator_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -129,6 +130,15 @@ invalidCert
 )
 
 func TestIsSignedByUnknownAuthority(t *testing.T) {
+	// We need to add this check as newer version of macos require the adding trusted certs manually to test for this,
+	// through `security add-trusted-cert`, so we are only able to run this test on linux for now.
+	// This is a known issue here: https://github.com/golang/go/issues/52010
+	// Refer to https://go-review.googlesource.com/c/go/+/353132 and https://github.com/helm/helm/pull/11160
+	// Follow up tracking issue for us to fix: https://github.com/aws/eks-anywhere/issues/3267
+	if runtime.GOOS == "darwin" {
+		t.Skipf("Skipping as this test will fail on darwin because newer versions require this cert " +
+			"to be added to the system trust store")
+	}
 	certSvr, err := runTestServerWithCert(serverCert, serverKey)
 	if err != nil {
 		t.Fatalf("starting test server with certs: %v", err)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We need to add this check as newer version of macos require the adding trusted certs manually,
through `security add-trusted-cert`, so we are only able to run this test on linux for now. This is a known issue here: https://github.com/golang/go/issues/52010

Created https://github.com/aws/eks-anywhere/issues/3267 to track our fix for the above issue

Refer to https://go-review.googlesource.com/c/go/+/353132 and https://github.com/helm/helm/pull/11160 for some explanations and an example

*Testing (if applicable):*
unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

