### PR TITLE
Update BundlesRef when building a Spec from file

### DIFF
--- a/pkg/cluster/spec_test.go
+++ b/pkg/cluster/spec_test.go
@@ -288,11 +288,7 @@ func TestBundlesRefDefaulter(t *testing.T) {
 			want: &cluster.Config{
 				Cluster: &anywherev1.Cluster{
 					Spec: anywherev1.ClusterSpec{
-						BundlesRef: &anywherev1.BundlesRef{
-							Name:       "bundles-1",
-							Namespace:  "eksa-system",
-							APIVersion: "anywhere.eks.amazonaws.com/v1alpha1",
-						},
+						BundlesRef: &anywherev1.BundlesRef{},
 					},
 				},
 			},
@@ -331,7 +327,7 @@ func TestBundlesRefDefaulter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			defaulter := cluster.BundlesRefDefaulter(tt.bundles)
+			defaulter := cluster.BundlesRefDefaulter()
 			g.Expect(defaulter(tt.config)).To(Succeed())
 			g.Expect(tt.config).To(Equal(tt.want))
 		})


### PR DESCRIPTION
*Description of changes:*
This method always pulls the latest available Bundles from S3, that's
what the callers expect (create and upgrade commands). We should update
the ref to make sure the cluster.Spec is consistent and the cluster
references the Bundles included in the Spec.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

