### PR TITLE
kubeconfig: Modify FromEnvironment to handle lists

### DIFF
--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -25,9 +26,17 @@ func FromClusterName(clusterName string) string {
 	return filepath.Join(clusterName, fmt.Sprintf(FromClusterFormat, clusterName))
 }
 
-// FromEnvironment reads the KubeConfig path from the standard KUBECONFIG environment variable.
+// FromEnvironment returns the first kubeconfig file specified in the
+// KUBECONFIG environment variable.
+//
+// The environment variable can contain a list of files, much like how the
+// PATH environment variable contains a list of directories.
 func FromEnvironment() string {
-	return os.Getenv(EnvName)
+	trimmed := strings.TrimSpace(os.Getenv(EnvName))
+	for _, filename := range filepath.SplitList(trimmed) {
+		return filename
+	}
+	return ""
 }
 
 // ValidateFile loads a file to validate it's basic contents.

--- a/pkg/kubeconfig/kubeconfig_test.go
+++ b/pkg/kubeconfig/kubeconfig_test.go
@@ -94,3 +94,57 @@ func withFakeFileContents(t *testing.T, r io.Reader) (f *os.File) {
 
 	return f
 }
+
+func TestFromEnvironment(t *testing.T) {
+	t.Run("returns the filename from the env var", func(t *testing.T) {
+		expected := "file one"
+		t.Setenv("KUBECONFIG", expected)
+		got := FromEnvironment()
+		if got != expected {
+			t.Fatalf("expected %q, got %q", expected, got)
+		}
+	})
+
+	t.Run("works with longer paths", func(t *testing.T) {
+		expected := "/home/user/some/long/path/or file/directory structure/config"
+		t.Setenv("KUBECONFIG", expected)
+		got := FromEnvironment()
+		if got != expected {
+			t.Fatalf("expected %q, got %q", expected, got)
+		}
+	})
+
+	t.Run("returns the first file in a list", func(t *testing.T) {
+		expected := "file one"
+		t.Setenv("KUBECONFIG", expected+":filetwo")
+		got := FromEnvironment()
+		if got != expected {
+			t.Fatalf("expected %q, got %q", expected, got)
+		}
+	})
+
+	t.Run("returns an empty string if no files are found", func(t *testing.T) {
+		expected := ""
+		t.Setenv("KUBECONFIG", "")
+		got := FromEnvironment()
+		if got != expected {
+			t.Fatalf("expected %q, got %q", expected, got)
+		}
+	})
+
+	t.Run("trims whitespace, so as not to return 'empty' filenames", func(t *testing.T) {
+		expected := ""
+		t.Setenv("KUBECONFIG", " ")
+		got := FromEnvironment()
+		if got != expected {
+			t.Fatalf("expected %q, got %q", expected, got)
+		}
+
+		expected = ""
+		t.Setenv("KUBECONFIG", "\t")
+		got = FromEnvironment()
+		if got != expected {
+			t.Fatalf("expected %q, got %q", expected, got)
+		}
+	})
+}


### PR DESCRIPTION
The KUBECONFIG environment variable is defined to contain a list of filenames. If it is a list, return the first one. If it's not a list, returns the entire string (as before).

In theory, a program using this environment variable would merge the kubeconfig files listed into a larger structure containing contexts, users, and clusters. At this time however, the eksctl-anywhere command is always expecting a single user/context/cluster to be defined in a single kubeconfig file.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

