### PR TITLE
Handle Nutanix Provider in create cluster and generate clusterconifg commands

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -135,6 +135,10 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		return fmt.Errorf("provider snow is not supported in this release")
 	}
 
+	if !features.IsActive(features.NutanixProvider()) && deps.Provider.Name() == constants.NutanixProviderName {
+		return fmt.Errorf("provider nutanix is not supported in this release")
+	}
+
 	createCluster := workflows.NewCreate(
 		deps.Bootstrapper,
 		deps.Provider,

--- a/cmd/eksctl-anywhere/cmd/generateclusterconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generateclusterconfig.go
@@ -218,6 +218,39 @@ func generateClusterConfig(clusterName string) error {
 			return fmt.Errorf("generating cluster yaml: %v", err)
 		}
 		machineGroupYaml = append(machineGroupYaml, cpMcYaml, workerMcYaml)
+	case constants.NutanixProviderName:
+		if !features.IsActive(features.NutanixProvider()) {
+			return fmt.Errorf("the nutanix infrastructure provider is still under development")
+		}
+
+		datacenterConfig := v1alpha1.NewNutanixDatacenterConfigGenerate(clusterName)
+		dcYaml, err := yaml.Marshal(datacenterConfig)
+		if err != nil {
+			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+		}
+		datacenterYaml = dcYaml
+		clusterConfigOpts = append(clusterConfigOpts, v1alpha1.WithDatacenterRef(datacenterConfig))
+		clusterConfigOpts = append(clusterConfigOpts, v1alpha1.WithClusterEndpoint())
+		clusterConfigOpts = append(clusterConfigOpts,
+			v1alpha1.ControlPlaneConfigCount(3),
+			v1alpha1.WorkerNodeConfigCount(3),
+			v1alpha1.WorkerNodeConfigName(constants.DefaultWorkerNodeGroupName),
+		)
+
+		cpMachineConfig := v1alpha1.NewNutanixMachineConfigGenerate(providers.GetControlPlaneNodeName(clusterName))
+		cpMcYaml, err := yaml.Marshal(cpMachineConfig)
+		if err != nil {
+			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+		}
+		clusterConfigOpts = append(clusterConfigOpts, v1alpha1.WithCPMachineGroupRef(cpMachineConfig))
+
+		workerMachineConfig := v1alpha1.NewNutanixMachineConfigGenerate(clusterName)
+		workerMcYaml, err := yaml.Marshal(workerMachineConfig)
+		if err != nil {
+			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+		}
+		clusterConfigOpts = append(clusterConfigOpts, v1alpha1.WithWorkerMachineGroupRef(workerMachineConfig))
+		machineGroupYaml = append(machineGroupYaml, cpMcYaml, workerMcYaml)
 	default:
 		return fmt.Errorf("not a valid provider")
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -33,6 +33,7 @@ const (
 	SnowProviderName       = "snow"
 	TinkerbellProviderName = "tinkerbell"
 	CloudStackProviderName = "cloudstack"
+	NutanixProviderName    = "nutanix"
 
 	VSphereCredentialsName = "vsphere-credentials"
 	EksaLicenseName        = "eksa-license"

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -7,6 +7,7 @@ const (
 	FullLifecycleAPIEnvVar          = "FULL_LIFECYCLE_API"
 	FullLifecycleGate               = "FullLifecycleAPI"
 	CheckpointEnabledEnvVar         = "CHECKPOINT_ENABLED"
+	NutanixProviderEnvVar           = "NUTANIX_PROVIDER"
 )
 
 func FeedGates(featureGates []string) {
@@ -59,5 +60,13 @@ func CheckpointEnabled() Feature {
 	return Feature{
 		Name:     "Checkpoint to rerun commands enabled",
 		IsActive: globalFeatures.isActiveForEnvVar(CheckpointEnabledEnvVar),
+	}
+}
+
+// NutanixProvider returns a feature that is active if the NUTANIX_PROVIDER environment variable is true
+func NutanixProvider() Feature {
+	return Feature{
+		Name:     "Nutanix provider support",
+		IsActive: globalFeatures.isActiveForEnvVar(NutanixProviderEnvVar),
 	}
 }

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -75,3 +75,11 @@ func TestIsActiveWithFeatureGatesTrue(t *testing.T) {
 
 	g.Expect(IsActive(fakeFeatureWithGate())).To(BeTrue())
 }
+
+func TestWithNutanixFeatureFlag(t *testing.T) {
+	g := NewWithT(t)
+	setupContext(t)
+
+	g.Expect(os.Setenv(NutanixProviderEnvVar, "true")).To(Succeed())
+	g.Expect(IsActive(NutanixProvider())).To(BeTrue())
+}


### PR DESCRIPTION
Add the case for adding Nutanix DatacenterConfig and MachineConfig
to cluster config options when generate clusterconfig and create cluster commands
are run for Nutanix provider with NUTANIX_PROVIDER environment variable
set to true.