### PR TITLE
Handle the nutanix provider case in cluster reconciler

### DIFF
--- a/controllers/resource/template.go
+++ b/controllers/resource/template.go
@@ -55,6 +55,12 @@ type TinkerbellTemplate struct {
 	now anywhereTypes.NowFunc
 }
 
+// NutanixTemplate is a struct that implements the TemplateResources method for Nutanix Provider
+type NutanixTemplate struct {
+	ResourceFetcher
+	now anywhereTypes.NowFunc
+}
+
 func (r *VsphereTemplate) TemplateResources(ctx context.Context, eksaCluster *anywherev1.Cluster, clusterSpec *cluster.Spec, vdc anywherev1.VSphereDatacenterConfig, cpVmc, etcdVmc anywherev1.VSphereMachineConfig, workerVmcs map[string]anywherev1.VSphereMachineConfig) ([]*unstructured.Unstructured, error) {
 	workerNodeGroupMachineSpecs := make(map[string]anywherev1.VSphereMachineConfigSpec, len(workerVmcs))
 	for _, wnConfig := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
@@ -480,4 +486,18 @@ func (r *AWSIamConfigTemplate) TemplateResources(ctx context.Context, clusterSpe
 		}
 	}
 	return resources, nil
+}
+
+// TemplateResources generates the templated resources for the nutanix cluster
+// TODO(nutanix): This is currently a placeholder for the actual implementation
+func (r *NutanixTemplate) TemplateResources(
+	ctx context.Context,
+	cluster *anywherev1.Cluster,
+	clusterSpec *cluster.Spec,
+	dcConf anywherev1.NutanixDatacenterConfig,
+	controlPlaneMachineConf anywherev1.NutanixMachineConfig,
+	etcdMachineConf anywherev1.NutanixMachineConfig,
+	workerMachineConfs map[string]anywherev1.NutanixMachineConfig,
+) ([]*unstructured.Unstructured, error) {
+	return []*unstructured.Unstructured{}, nil
 }

--- a/controllers/resource/testdata/nutanix/cpMachineConfig.yaml
+++ b/controllers/resource/testdata/nutanix/cpMachineConfig.yaml
@@ -1,0 +1,24 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-element"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"

--- a/controllers/resource/testdata/nutanix/datacenterConfig.yaml
+++ b/controllers/resource/testdata/nutanix/datacenterConfig.yaml
@@ -1,0 +1,8 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440

--- a/controllers/resource/testdata/nutanix/eksa-cluster.yaml
+++ b/controllers/resource/testdata/nutanix/eksa-cluster.yaml
@@ -1,0 +1,69 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  kubernetesVersion: "1.19"
+  workerNodeGroupConfigurations:
+    - count: 4
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: NutanixMachineConfig
+  externalEtcdConfiguration:
+    count: 3
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  datacenterRef:
+    kind: NutanixDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-element"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440

--- a/controllers/resource/testdata/nutanix/etcdMachineConfig.yaml
+++ b/controllers/resource/testdata/nutanix/etcdMachineConfig.yaml
@@ -1,0 +1,24 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-element"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"

--- a/controllers/resource/testdata/nutanix/workerMachineConfig.yaml
+++ b/controllers/resource/testdata/nutanix/workerMachineConfig.yaml
@@ -1,0 +1,24 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-element"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"


### PR DESCRIPTION
Currently, this is more of a placeholder to start with as the TemplateResources method
just returns an empty array.
