### PR TITLE
add govulncheck make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ BUILDKIT := $(BUILD_LIB)/buildkit.sh
 CONTROLLER_GEN_BIN := controller-gen
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/$(CONTROLLER_GEN_BIN)
 
+GO_VULNCHECK_BIN := govulncheck
+GO_VULNCHECK := $(TOOLS_BIN_DIR)/$(GO_VULNCHECK_BIN)
+
 SETUP_ENVTEST_BIN := setup-envtest
 SETUP_ENVTEST := $(TOOLS_BIN_DIR)/$(SETUP_ENVTEST_BIN)
 
@@ -258,6 +261,14 @@ bin/golangci-lint: ## Download golangci-lint
 bin/golangci-lint: GOLANGCI_LINT_VERSION?=$(shell cat .github/workflows/golangci-lint.yml | yq e '.jobs.golangci.steps[] | select(.name == "golangci-lint") .with.version' -)
 bin/golangci-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
+
+.PHONY: vulncheck
+vulncheck: govulncheck
+	$(TOOLS_BIN_DIR)/govulncheck ./...
+
+govulncheck: ## Download and install govulncheck
+govulncheck:
+	$(call go-get-tool,$(GO_VULNCHECK),golang.org/x/vuln/cmd/govulncheck@latest)
 
 .PHONY: build-cross-platform
 build-cross-platform: eks-a-cross-platform


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a make target to EKS A for executing `govulncheck`.

`govulncheck` is:

> a low-noise, reliable way for Go users to learn about known vulnerabilities that may affect their projects. Govulncheck analyzes your codebase and only surfaces vulnerabilities that actually affect you, based on which functions in your code are transitively calling vulnerable functions.

For the whole story, check out: https://go.dev/blog/vuln

To use this, just run `make vulncheck` to execut the command against the EKS Anywhere module.

The use of this command in the EKS Anywhere module highlights the importance of regular Go updates and the need to migrate to the latest patch version of 1.18.

*Testing (if applicable):*

`make vulncheck`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

