### PR TITLE
Added NTP out of sync issue warning

### DIFF
--- a/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
+++ b/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
@@ -152,7 +152,7 @@ You can also try using techniques from [Generic cluster unavailable]({{< relref 
 ```
 level=error msg=k8sError error="github.com/cilium/cilium/pkg/k8s/watchers/endpoint_slice.go:91: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: Unauthorized" subsys=k8s
 ```
-You might notice Unauthorized errors if your EKS Anywhere control plane nodes and worker nodes are out of sync. Please ensure to make them configured with same healthy NTP servers to avoid out of sync issues.
+You might notice authorization errors if the timestamps on your EKS Anywhere control plane nodes and worker nodes are out of sync. Please ensure that all the nodes are configured with same healthy NTP servers to avoid out of sync issues.
 
 ### The connection to the server localhost:8080 was refused 
 ```

--- a/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
+++ b/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
@@ -152,7 +152,7 @@ You can also try using techniques from [Generic cluster unavailable]({{< relref 
 ```
 level=error msg=k8sError error="github.com/cilium/cilium/pkg/k8s/watchers/endpoint_slice.go:91: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: Unauthorized" subsys=k8s
 ```
-You might notice Unauthorized errors if your EKS Anywhere Master Nodes and Worker nodes are out of sync. Please ensure to make them configured with same healthy NTP servers to avoid out of sync issues.
+You might notice Unauthorized errors if your EKS Anywhere control plane nodes and worker nodes are out of sync. Please ensure to make them configured with same healthy NTP servers to avoid out of sync issues.
 
 ### The connection to the server localhost:8080 was refused 
 ```

--- a/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
+++ b/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
@@ -152,7 +152,7 @@ You can also try using techniques from [Generic cluster unavailable]({{< relref 
 ```
 level=error msg=k8sError error="github.com/cilium/cilium/pkg/k8s/watchers/endpoint_slice.go:91: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: Unauthorized" subsys=k8s
 ```
-You might notice authorization errors if the timestamps on your EKS Anywhere control plane nodes and worker nodes are out of sync. Please ensure that all the nodes are configured with same healthy NTP servers to avoid out of sync issues.
+You might notice authorization errors if the timestamps on your EKS Anywhere control plane nodes and worker nodes are out-of-sync. Please ensure that all the nodes are configured with same healthy NTP servers to avoid out-of-sync issues.
 
 ### The connection to the server localhost:8080 was refused 
 ```

--- a/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
+++ b/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
@@ -148,7 +148,7 @@ Failed to create cluster {"error": "error initializing capi resources in cluster
 This is likely a [Memory or disk resource problem]({{< relref "#memory-or-disk-resource-problem" >}}).
 You can also try using techniques from [Generic cluster unavailable]({{< relref "#generic-cluster-unavailable" >}}).
 
-### NTP Time sync issues between Master Nodes and Worker nodes
+### NTP Time sync issues between control plane nodes and worker nodes
 ```
 level=error msg=k8sError error="github.com/cilium/cilium/pkg/k8s/watchers/endpoint_slice.go:91: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: Unauthorized" subsys=k8s
 ```

--- a/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
+++ b/docs/content/en/docs/tasks/troubleshoot/troubleshooting.md
@@ -148,6 +148,11 @@ Failed to create cluster {"error": "error initializing capi resources in cluster
 This is likely a [Memory or disk resource problem]({{< relref "#memory-or-disk-resource-problem" >}}).
 You can also try using techniques from [Generic cluster unavailable]({{< relref "#generic-cluster-unavailable" >}}).
 
+### NTP Time sync issues between Master Nodes and Worker nodes
+```
+level=error msg=k8sError error="github.com/cilium/cilium/pkg/k8s/watchers/endpoint_slice.go:91: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: Unauthorized" subsys=k8s
+```
+You might notice Unauthorized errors if your EKS Anywhere Master Nodes and Worker nodes are out of sync. Please ensure to make them configured with same healthy NTP servers to avoid out of sync issues.
 
 ### The connection to the server localhost:8080 was refused 
 ```


### PR DESCRIPTION
NTP time sync issue between master and worker node could cause unauthorized errors from dataplane perspective

*Issue #, if available:*
NTP time sync issue between master and worker node could cause unauthorized errors from dataplane perspective

*Description of changes:*
Added warning in troubleshooting section

*Testing (if applicable):* NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

