### PR TITLE
feat(CLI): Add --kubeconfig flag to curated packages commands

### DIFF
--- a/cmd/eksctl-anywhere/cmd/applypackages.go
+++ b/cmd/eksctl-anywhere/cmd/applypackages.go
@@ -9,17 +9,26 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/validations"
 )
 
 type applyPackageOptions struct {
 	fileName string
+	// kubeConfig is an optional kubeconfig file to use when querying an
+	// existing cluster
+	kubeConfig string
 }
 
 var apo = &applyPackageOptions{}
 
 func init() {
 	applyCmd.AddCommand(applyPackagesCommand)
-	applyPackagesCommand.Flags().StringVarP(&apo.fileName, "filename", "f", "", "Filename that contains curated packages custom resources to apply")
+
+	applyPackagesCommand.Flags().StringVarP(&apo.fileName, "filename", "f",
+		"", "Filename that contains curated packages custom resources to apply")
+	applyPackagesCommand.Flags().StringVar(&apo.kubeConfig, "kubeconfig", "",
+		"Path to an optional kubeconfig file to use.")
+
 	err := applyPackagesCommand.MarkFlagRequired("filename")
 	if err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
@@ -42,7 +51,12 @@ var applyPackagesCommand = &cobra.Command{
 }
 
 func applyPackages(ctx context.Context) error {
-	kubeConfig := kubeconfig.FromEnvironment()
+	kubeConfig := apo.kubeConfig
+	if kubeConfig == "" {
+		kubeConfig = kubeconfig.FromEnvironment()
+	} else if !validations.FileExistsAndIsNotEmpty(kubeConfig) {
+		return fmt.Errorf("kubeconfig file %q is empty or does not exist", kubeConfig)
+	}
 	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)

--- a/cmd/eksctl-anywhere/cmd/createpackages.go
+++ b/cmd/eksctl-anywhere/cmd/createpackages.go
@@ -9,17 +9,26 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/validations"
 )
 
 type createPackageOptions struct {
 	fileName string
+	// kubeConfig is an optional kubeconfig file to use when querying an
+	// existing cluster
+	kubeConfig string
 }
 
 var cpo = &createPackageOptions{}
 
 func init() {
 	createCmd.AddCommand(createPackagesCommand)
-	createPackagesCommand.Flags().StringVarP(&cpo.fileName, "filename", "f", "", "Filename that contains curated packages custom resources to create")
+
+	createPackagesCommand.Flags().StringVarP(&cpo.fileName, "filename", "f",
+		"", "Filename that contains curated packages custom resources to create")
+	createPackagesCommand.Flags().StringVar(&cpo.kubeConfig, "kubeconfig", "",
+		"Path to an optional kubeconfig file to use.")
+
 	err := createPackagesCommand.MarkFlagRequired("filename")
 	if err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
@@ -42,7 +51,12 @@ var createPackagesCommand = &cobra.Command{
 }
 
 func createPackages(ctx context.Context) error {
-	kubeConfig := kubeconfig.FromEnvironment()
+	kubeConfig := cpo.kubeConfig
+	if kubeConfig == "" {
+		kubeConfig = kubeconfig.FromEnvironment()
+	} else if !validations.FileExistsAndIsNotEmpty(kubeConfig) {
+		return fmt.Errorf("kubeconfig file %q is empty or does not exist", kubeConfig)
+	}
 	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)

--- a/cmd/eksctl-anywhere/cmd/get.go
+++ b/cmd/eksctl-anywhere/cmd/get.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 )
 
 var getCmd = &cobra.Command{
@@ -32,9 +31,7 @@ func preRunPackages(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getResources(ctx context.Context, resourceType string, output string, args []string) error {
-	kubeConfig := kubeconfig.FromEnvironment()
-
+func getResources(ctx context.Context, resourceType, output, kubeConfig string, args []string) error {
 	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)

--- a/cmd/eksctl-anywhere/cmd/getpackagebundle.go
+++ b/cmd/eksctl-anywhere/cmd/getpackagebundle.go
@@ -1,18 +1,30 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/validations"
 )
 
 type getPackageBundleOptions struct {
 	output string
+	// kubeConfig is an optional kubeconfig file to use when querying an
+	// existing cluster
+	kubeConfig string
 }
 
 var gpbo = &getPackageBundleOptions{}
 
 func init() {
 	getCmd.AddCommand(getPackageBundleCommand)
-	getPackageBundleCommand.Flags().StringVarP(&gpbo.output, "output", "o", "", "Specifies the output format (valid option: json, yaml)")
+
+	getPackageBundleCommand.Flags().StringVarP(&gpbo.output, "output", "o", "",
+		"Specifies the output format (valid option: json, yaml)")
+	getPackageBundleCommand.Flags().StringVar(&gpbo.kubeConfig, "kubeconfig", "",
+		"Path to an optional kubeconfig file.")
 }
 
 var getPackageBundleCommand = &cobra.Command{
@@ -23,6 +35,12 @@ var getPackageBundleCommand = &cobra.Command{
 	PreRunE:      preRunPackages,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return getResources(cmd.Context(), "packagebundles", gpbo.output, args)
+		kubeConfig := gpbo.kubeConfig
+		if kubeConfig == "" {
+			kubeConfig = kubeconfig.FromEnvironment()
+		} else if !validations.FileExistsAndIsNotEmpty(kubeConfig) {
+			return fmt.Errorf("kubeconfig file %q is empty or does not exist", kubeConfig)
+		}
+		return getResources(cmd.Context(), "packagebundles", gpbo.output, kubeConfig, args)
 	},
 }

--- a/cmd/eksctl-anywhere/cmd/getpackagebundlecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/getpackagebundlecontroller.go
@@ -1,18 +1,30 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/validations"
 )
 
 type getPackageBundleControllerOptions struct {
 	output string
+	// kubeConfig is an optional kubeconfig file to use when querying an
+	// existing cluster
+	kubeConfig string
 }
 
 var gpbco = &getPackageBundleControllerOptions{}
 
 func init() {
 	getCmd.AddCommand(getPackageBundleControllerCommand)
-	getPackageBundleControllerCommand.Flags().StringVarP(&gpbco.output, "output", "o", "", "Specifies the output format (valid option: json, yaml)")
+
+	getPackageBundleControllerCommand.Flags().StringVarP(&gpbco.output, "output",
+		"o", "", "Specifies the output format (valid option: json, yaml)")
+	getPackageBundleControllerCommand.Flags().StringVar(&gpbco.kubeConfig,
+		"kubeconfig", "", "Path to an optional kubeconfig file.")
 }
 
 var getPackageBundleControllerCommand = &cobra.Command{
@@ -23,6 +35,12 @@ var getPackageBundleControllerCommand = &cobra.Command{
 	PreRunE:      preRunPackages,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return getResources(cmd.Context(), "packagebundlecontrollers", gpbco.output, args)
+		kubeConfig := gpbco.kubeConfig
+		if kubeConfig == "" {
+			kubeConfig = kubeconfig.FromEnvironment()
+		} else if !validations.FileExistsAndIsNotEmpty(kubeConfig) {
+			return fmt.Errorf("kubeconfig file %q is empty or does not exist", kubeConfig)
+		}
+		return getResources(cmd.Context(), "packagebundlecontrollers", gpbco.output, kubeConfig, args)
 	},
 }

--- a/cmd/eksctl-anywhere/cmd/listpackages.go
+++ b/cmd/eksctl-anywhere/cmd/listpackages.go
@@ -9,12 +9,16 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/validations"
 )
 
 type listPackagesOption struct {
 	kubeVersion string
 	source      curatedpackages.BundleSource
 	registry    string
+	// kubeConfig is an optional kubeconfig file to use when querying an
+	// existing cluster
+	kubeConfig string
 }
 
 var lpo = &listPackagesOption{}
@@ -23,11 +27,13 @@ func init() {
 	listCmd.AddCommand(listPackagesCommand)
 
 	listPackagesCommand.Flags().Var(&lpo.source, "source",
-		"Packages info discovery source. Options: cluster, registry.")
+		"Packages discovery source. Options: cluster, registry.")
 	listPackagesCommand.Flags().StringVar(&lpo.kubeVersion, "kube-version", "",
-		"Kubernetes version of the packages to list, for example: \"1.23\".")
+		"Kubernetes version <major>.<minor> of the packages to list, for example: \"1.23\".")
 	listPackagesCommand.Flags().StringVar(&lpo.registry, "registry", "",
 		"Specifies an alternative registry for packages discovery.")
+	listPackagesCommand.Flags().StringVar(&lpo.kubeConfig, "kubeconfig", "",
+		"Path to a kubeconfig file to use when source is a cluster.")
 
 	if err := listPackagesCommand.MarkFlagRequired("source"); err != nil {
 		log.Fatalf("marking source flag required: %s", err)
@@ -52,7 +58,12 @@ var listPackagesCommand = &cobra.Command{
 }
 
 func listPackages(ctx context.Context) error {
-	kubeConfig := kubeconfig.FromEnvironment()
+	kubeConfig := lpo.kubeConfig
+	if kubeConfig == "" {
+		kubeConfig = kubeconfig.FromEnvironment()
+	} else if !validations.FileExistsAndIsNotEmpty(kubeConfig) {
+		return fmt.Errorf("kubeconfig file %q is empty or does not exist", kubeConfig)
+	}
 	deps, err := NewDependenciesForPackages(ctx, WithRegistryName(lpo.registry), WithKubeVersion(lpo.kubeVersion), WithMountPaths(kubeConfig))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)

--- a/cmd/eksctl-anywhere/cmd/upgradepackages.go
+++ b/cmd/eksctl-anywhere/cmd/upgradepackages.go
@@ -9,17 +9,26 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/validations"
 )
 
 type upgradePackageOptions struct {
 	bundleVersion string
+	// kubeConfig is an optional kubeconfig file to use when querying an
+	// existing cluster
+	kubeConfig string
 }
 
 var upo = &upgradePackageOptions{}
 
 func init() {
 	upgradeCmd.AddCommand(upgradePackagesCommand)
-	upgradePackagesCommand.Flags().StringVar(&upo.bundleVersion, "bundle-version", "", "Bundle version to use")
+
+	upgradePackagesCommand.Flags().StringVar(&upo.bundleVersion, "bundle-version",
+		"", "Bundle version to use")
+	upgradePackagesCommand.Flags().StringVar(&upo.kubeConfig, "kubeconfig",
+		"", "Path to an optional kubeconfig file to use.")
+
 	err := upgradePackagesCommand.MarkFlagRequired("bundle-version")
 	if err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
@@ -40,7 +49,12 @@ var upgradePackagesCommand = &cobra.Command{
 }
 
 func upgradePackages(ctx context.Context) error {
-	kubeConfig := kubeconfig.FromEnvironment()
+	kubeConfig := upo.kubeConfig
+	if kubeConfig == "" {
+		kubeConfig = kubeconfig.FromEnvironment()
+	} else if !validations.FileExistsAndIsNotEmpty(kubeConfig) {
+		return fmt.Errorf("kubeconfig file %q is empty or does not exist", kubeConfig)
+	}
 	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)


### PR DESCRIPTION
Previously kubeconfig information was only loaded from an environment file. Now each of the curated packages commands takes an optional --kubeconfig flag, that if specified, loads the kubeconfig from that file, and errors if the file doesn't exist or fails to load. When no --kubeconfig is specified, it uses the previous behavior of loading kubeconfig info from the KUBECONFIG environment variable.

Flags have also been reorganized to be consistent with the style introduced in aws/eks-anywhere#3299.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

