### PR TITLE
Run snow machine validation and defaulters for the specific devices

### DIFF
--- a/pkg/providers/snow/defaults_test.go
+++ b/pkg/providers/snow/defaults_test.go
@@ -61,3 +61,11 @@ func TestSetDefaultSshKeyClientMapError(t *testing.T) {
 	err := g.machineConfigDefaulters.SetupDefaultSshKey(g.ctx, g.machineConfig)
 	g.Expect(err).NotTo(Succeed())
 }
+
+func TestSetDefaultSshKeyDeviceNotFoundInClientMap(t *testing.T) {
+	g := newConfigManagerTest(t)
+	g.machineConfig.Spec.SshKeyName = ""
+	g.machineConfig.Spec.Devices = []string{"device-not-exist"}
+	err := g.machineConfigDefaulters.SetupDefaultSshKey(g.ctx, g.machineConfig)
+	g.Expect(err).To(MatchError(ContainSubstring("credentials not found for device")))
+}

--- a/pkg/providers/snow/validator.go
+++ b/pkg/providers/snow/validator.go
@@ -31,7 +31,12 @@ func (v *AwsClientValidator) ValidateEC2SshKeyNameExists(ctx context.Context, m 
 		return err
 	}
 
-	for ip, client := range clientMap {
+	for _, ip := range m.Spec.Devices {
+		client, ok := clientMap[ip]
+		if !ok {
+			return fmt.Errorf("credentials not found for device [%s]", ip)
+		}
+
 		keyExists, err := client.EC2KeyNameExists(ctx, m.Spec.SshKeyName)
 		if err != nil {
 			return fmt.Errorf("describe key pair on snow device [%s]: %v", ip, err)
@@ -54,7 +59,12 @@ func (v *AwsClientValidator) ValidateEC2ImageExistsOnDevice(ctx context.Context,
 		return err
 	}
 
-	for ip, client := range clientMap {
+	for _, ip := range m.Spec.Devices {
+		client, ok := clientMap[ip]
+		if !ok {
+			return fmt.Errorf("credentials not found for device [%s]", ip)
+		}
+
 		imageExists, err := client.EC2ImageExists(ctx, m.Spec.AMIID)
 		if err != nil {
 			return fmt.Errorf("describe image on snow device [%s]: %v", ip, err)


### PR DESCRIPTION
*Issue #, if available:*

Relates to #2809 

In snow post beta, we introduce a `devices` field in `snowmachineconfig`. All the existing validations and default logics run against all the devices specified in the aws creds file. We should only run those logics for specific devices listed in each `snowmachineconfig`.

*Description of changes:*

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

