### PR TITLE
Upload EKS-A release manifest as part of weekly release

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -30,7 +30,7 @@ DRY_RUN=false
 endif
 DATE_YYYYMMDD=$(shell date "+%F")
 WEEKLY?=false
-WEEKLY_BUNDLE_MANIFEST_URL=https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/weekly-releases/bundles/$(DATE_YYYYMMDD)/manifest.yaml
+WEEKLY_RELEASES_URL_PREFIX=https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/weekly-releases
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
@@ -142,7 +142,7 @@ eks-a-release: build ## Perform EKS-A CLI release
 	scripts/eks-a-release.sh $(RELEASE_VERSION) $(REPO_ROOT)/release/downloaded-artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(BUNDLE_NUMBER) $(RELEASE_NUMBER) $(RELEASE_ENVIRONMENT) $(CLI_REPO_BRANCH_NAME) $(BUILD_REPO_URL) $(CLI_REPO_URL)
 
 github-bundle-release:
-	scripts/github-bundle-release.sh $(REPO_ROOT)/release/downloaded-artifacts $(WEEKLY_BUNDLE_MANIFEST_URL)
+	scripts/github-bundle-release.sh $(REPO_ROOT)/release/downloaded-artifacts $(WEEKLY_RELEASES_URL_PREFIX)
 
 ##@ Deployment
 

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -285,10 +285,12 @@ var releaseCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			err = filereader.PutEksAReleaseVersion(releaseVersion, releaseConfig)
-			if err != nil {
-				fmt.Printf("Error uploading latest EKS-A release version to S3: %v\n", err)
-				os.Exit(1)
+			if !weekly {
+				err = filereader.PutEksAReleaseVersion(releaseVersion, releaseConfig)
+				if err != nil {
+					fmt.Printf("Error uploading latest EKS-A release version to S3: %v\n", err)
+					os.Exit(1)
+				}
 			}
 			fmt.Printf("%s Successfully completed EKS-A release\n", constants.SuccessIcon)
 		}

--- a/release/pkg/filereader/file_reader.go
+++ b/release/pkg/filereader/file_reader.go
@@ -196,21 +196,18 @@ func GetCurrentEksADevReleaseVersion(releaseVersion string, r *releasetypes.Rele
 	fmt.Println("              Dev Release Version Computation")
 	fmt.Println("==========================================================")
 
-	var latestBuildVersion string
 	var newDevReleaseVersion string
-	tempFileName := "latest-dev-release-version"
-
-	var latestReleaseKey string
-
-	if r.BuildRepoBranchName == "main" {
-		latestReleaseKey = "LATEST_RELEASE_VERSION"
-	} else {
-		latestReleaseKey = fmt.Sprintf("%s/LATEST_RELEASE_VERSION", r.BuildRepoBranchName)
-	}
-
 	if r.Weekly {
 		newDevReleaseVersion = fmt.Sprintf("v0.0.0-dev+build.%s", r.ReleaseDate)
 	} else {
+		tempFileName := "latest-dev-release-version"
+
+		var latestReleaseKey string
+		if r.BuildRepoBranchName == "main" {
+			latestReleaseKey = "LATEST_RELEASE_VERSION"
+		} else {
+			latestReleaseKey = fmt.Sprintf("%s/LATEST_RELEASE_VERSION", r.BuildRepoBranchName)
+		}
 		if s3.KeyExists(r.ReleaseBucket, latestReleaseKey) {
 			err := s3.DownloadFile(tempFileName, r.ReleaseBucket, latestReleaseKey)
 			if err != nil {
@@ -222,7 +219,7 @@ func GetCurrentEksADevReleaseVersion(releaseVersion string, r *releasetypes.Rele
 			if err != nil {
 				return "", errors.Cause(err)
 			}
-			latestBuildVersion = string(latestBuildS3)
+			latestBuildVersion := string(latestBuildS3)
 			newDevReleaseVersion, err = GenerateNewDevReleaseVersion(latestBuildVersion, releaseVersion, r.BuildRepoBranchName)
 			if err != nil {
 				return "", errors.Cause(err)

--- a/release/pkg/git/git.go
+++ b/release/pkg/git/git.go
@@ -38,7 +38,7 @@ func DescribeTag(gitRoot string) (string, error) {
 }
 
 func GetRepoTagsDescending(gitRoot string) (string, error) {
-	cmd := exec.Command("git", "-C", gitRoot, "tag", "-l", "--sort", "-v:refname")
+	cmd := exec.Command("git", "-C", gitRoot, "tag", "-l", "v*", "--sort", "-v:refname")
 	return commandutils.ExecCommand(cmd)
 }
 

--- a/release/pkg/operations/upload.go
+++ b/release/pkg/operations/upload.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package operations
 
 import (

--- a/release/pkg/util/artifacts/artifacts.go
+++ b/release/pkg/util/artifacts/artifacts.go
@@ -40,7 +40,7 @@ func GetManifestFilepaths(devRelease, weekly bool, bundleNumber int, kind, branc
 			} else {
 				manifestFilepath = "bundle-release.yaml"
 				if weekly {
-					manifestFilepath = fmt.Sprintf("weekly-releases/bundles/%s/manifest.yaml", releaseDate)
+					manifestFilepath = fmt.Sprintf("weekly-releases/%s/bundle-release.yaml", releaseDate)
 				}
 			}
 		} else {
@@ -53,7 +53,7 @@ func GetManifestFilepaths(devRelease, weekly bool, bundleNumber int, kind, branc
 			} else {
 				manifestFilepath = "eks-a-release.yaml"
 				if weekly {
-					manifestFilepath = fmt.Sprintf("weekly-releases/eks-a/manifest.yaml")
+					manifestFilepath = fmt.Sprintf("weekly-releases/%s/eks-a-release.yaml", releaseDate)
 				}
 			}
 		} else {

--- a/release/scripts/github-bundle-release-notes.tmpl
+++ b/release/scripts/github-bundle-release-notes.tmpl
@@ -1,4 +1,4 @@
-This is the weekly bundle release from main.
+This is the weekly bundle and EKS-A CLI release from main.
 
 Date: $DATE_YYYYMMDD
 Build-tooling repo commit: $BUILD_REPO_HEAD

--- a/release/scripts/github-bundle-release.sh
+++ b/release/scripts/github-bundle-release.sh
@@ -19,7 +19,7 @@ set -x
 set -o pipefail
 
 ARTIFACTS_DIR="${1?Specify first argument - artifacts path}"
-BUNDLE_MANIFEST_URL="${2?Specify second argument - weekly bundle manifest URL}"
+WEEKLY_RELEASES_URL_PREFIX="${2?Specify second argument - weekly releases URL prefix}"
 
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 RELEASE_NOTES_PATH="$SCRIPT_ROOT/github-bundle-release-notes"
@@ -33,7 +33,9 @@ envsubst '$DATE_YYYYMMDD:$BUILD_REPO_HEAD:$CLI_REPO_HEAD' \
 
 # Downloading the weekly bundle release manifest
 mkdir -p $ARTIFACTS_DIR
-wget $BUNDLE_MANIFEST_URL -O $ARTIFACTS_DIR/$DATE_YYYYMMDD-bundle-release.yaml
+for releasetype in bundle eks-a; do
+    wget $WEEKLY_RELEASES_URL_PREFIX/$DATE_YYYYMMDD/$releasetype-release.yaml -O $ARTIFACTS_DIR/$DATE_YYYYMMDD-$releasetype-release.yaml
+done
 
 # Publish the asset as a Github pre-release on main branch with a new dated tag
-gh release create $RELEASE_TAG $ARTIFACTS_DIR/$DATE_YYYYMMDD-bundle-release.yaml --notes-file "$RELEASE_NOTES_PATH" --prerelease --repo "github.com/aws/eks-anywhere" --title "Weekly Release $DATE_YYYYMMDD" --target "main"
+gh release create $RELEASE_TAG $ARTIFACTS_DIR/*.yaml --notes-file "$RELEASE_NOTES_PATH" --prerelease --repo "github.com/aws/eks-anywhere" --title "Weekly Release $DATE_YYYYMMDD" --target "main"


### PR DESCRIPTION
This PR includes the EKS-A releases manifest in the weekly release assets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

