### PR TITLE
Allow workerNodeGroupConfigs to be empty

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -392,7 +392,7 @@ func validateControlPlaneLabels(clusterConfig *Cluster) error {
 func validateWorkerNodeGroups(clusterConfig *Cluster) error {
 	workerNodeGroupConfigs := clusterConfig.Spec.WorkerNodeGroupConfigurations
 	if len(workerNodeGroupConfigs) <= 0 {
-		return errors.New("worker node group must be specified")
+		logger.Info("Warning: No configurations provided for worker node groups, pods will be scheduled on control-plane nodes")
 	}
 
 	workerNodeGroupNames := make(map[string]bool, len(workerNodeGroupConfigs))
@@ -431,8 +431,12 @@ func validateWorkerNodeGroups(clusterConfig *Cluster) error {
 		workerNodeGroupNames[workerNodeGroupConfig.Name] = true
 	}
 
-	if len(noExecuteNoScheduleTaintedNodeGroups) == len(workerNodeGroupConfigs) {
+	if len(workerNodeGroupConfigs) > 0 && len(noExecuteNoScheduleTaintedNodeGroups) == len(workerNodeGroupConfigs) {
 		return errors.New("at least one WorkerNodeGroupConfiguration must not have NoExecute and/or NoSchedule taints")
+	}
+
+	if len(workerNodeGroupConfigs) == 0 && len(clusterConfig.Spec.ControlPlaneConfiguration.Taints) != 0 {
+		return errors.New("cannot taint control plane when there is no worker node")
 	}
 
 	return nil

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -303,11 +303,6 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			testName: "worker node count equals  0",
-			fileName: "testdata/cluster_invalid_worker_node_count.yaml",
-			wantErr:  true,
-		},
-		{
 			testName: "namespace mismatch between cluster and datacenter",
 			fileName: "cluster_1_20_namespace_mismatch_between_cluster_and_datacenter.yaml",
 			wantErr:  true,
@@ -824,6 +819,56 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 		{
 			testName:    "with not supported CNI",
 			fileName:    "testdata/cluster_not_supported_cni.yaml",
+			wantCluster: nil,
+			wantErr:     true,
+		},
+		{
+			testName: "without worker nodes",
+			fileName: "testdata/cluster_without_worker_nodes.yaml",
+			wantCluster: &Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       ClusterKind,
+					APIVersion: SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "single-node",
+				},
+				Spec: ClusterSpec{
+					KubernetesVersion: Kube123,
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						Count: 1,
+						Endpoint: &Endpoint{
+							Host: "10.80.8.90",
+						},
+						MachineGroupRef: &Ref{
+							Kind: TinkerbellMachineConfigKind,
+							Name: "single-node-cp",
+						},
+					},
+					WorkerNodeGroupConfigurations: nil,
+					DatacenterRef: Ref{
+						Kind: TinkerbellDatacenterKind,
+						Name: "single-node",
+					},
+					ClusterNetwork: ClusterNetwork{
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
+						Pods: Pods{
+							CidrBlocks: []string{"192.168.0.0/16"},
+						},
+						Services: Services{
+							CidrBlocks: []string{"10.96.0.0/12"},
+						},
+					},
+					ManagementCluster: ManagementCluster{
+						Name: "single-node",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			testName:    "without worker nodes but has control plane taints",
+			fileName:    "testdata/cluster_without_worker_nodes_has_cp_taints.yaml",
 			wantCluster: nil,
 			wantErr:     true,
 		},

--- a/pkg/api/v1alpha1/testdata/cluster_without_worker_nodes.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_without_worker_nodes.yaml
@@ -1,0 +1,44 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: single-node
+spec:
+  clusterNetwork:
+    cniConfig:
+      cilium: {}
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+    endpoint:
+      host: "10.80.8.90"
+    machineGroupRef:
+      kind: TinkerbellMachineConfig
+      name: single-node-cp
+  datacenterRef:
+    kind: TinkerbellDatacenterConfig
+    name: single-node
+  kubernetesVersion: "1.23"
+  managementCluster:
+    name: single-node
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellDatacenterConfig
+metadata:
+  name: single-node
+spec:
+  tinkerbellIP: "10.80.8.91"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellMachineConfig
+metadata:
+  name: single-node-cp
+spec:
+  hardwareSelector:
+    type: cp
+  osFamily: bottlerocket
+  templateRef: {}

--- a/pkg/api/v1alpha1/testdata/cluster_without_worker_nodes_has_cp_taints.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_without_worker_nodes_has_cp_taints.yaml
@@ -1,0 +1,48 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: single-node
+spec:
+  clusterNetwork:
+    cniConfig:
+      cilium: {}
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+    taints:
+      - key: test
+        value: test
+        effect: NoSchedule
+    endpoint:
+      host: "10.80.8.90"
+    machineGroupRef:
+      kind: TinkerbellMachineConfig
+      name: single-node-cp
+  datacenterRef:
+    kind: TinkerbellDatacenterConfig
+    name: single-node
+  kubernetesVersion: "1.23"
+  managementCluster:
+    name: single-node
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellDatacenterConfig
+metadata:
+  name: single-node
+spec:
+  tinkerbellIP: "10.80.8.91"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellMachineConfig
+metadata:
+  name: single-node-cp
+spec:
+  hardwareSelector:
+    type: cp
+  osFamily: bottlerocket
+  templateRef: {}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
For creating single-node cluster
1. Allow workerNodeGroupConfigs to be empty
2. Check if control plane taints is empty when there is no worker node
3. Warn when there is no worker node

*Testing (if applicable):*
1. unit-test
2. Invoke eksa create cluster without workerNodeGroups. Validation pass
```
2022-09-09T11:26:48.464-0400    V0      Private key saved to single-node/eks-a-id_rsa. Use 'ssh -i single-node/eks-a-id_rsa <username>@<Node-IP-Address>' to login to your cluster node
2022-09-09T11:26:50.968-0400    V0      ✅ Tinkerbell Provider setup is valid
2022-09-09T11:26:50.968-0400    V0      ✅ Validate certificate for registry mirror
2022-09-09T11:26:50.968-0400    V0      ✅ Validate authentication for git provider
2022-09-09T11:26:50.968-0400    V0      ✅ Create preflight validations pass
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

