### PR TITLE
Upgrade bmc wait check after CAPI move

### DIFF
--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -1206,6 +1206,11 @@ func (p *cloudstackProvider) PostClusterDeleteValidate(_ context.Context, _ *typ
 	return nil
 }
 
+func (p *cloudstackProvider) PostMoveManagementToBootstrap(_ context.Context, _ *types.Cluster) error {
+	// NOOP
+	return nil
+}
+
 func (p *cloudstackProvider) GenerateStorageClass() []byte {
 	return nil
 }

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -117,6 +117,11 @@ func (p *provider) PostClusterDeleteValidate(_ context.Context, _ *types.Cluster
 	return nil
 }
 
+func (p *provider) PostMoveManagementToBootstrap(_ context.Context, _ *types.Cluster) error {
+	// NOOP
+	return nil
+}
+
 func (p *provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpec *cluster.Spec) error {
 	logger.Info("Warning: The docker infrastructure provider is meant for local development and testing only")
 	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint != nil && clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host != "" {

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -311,6 +311,20 @@ func (mr *MockProviderMockRecorder) PostClusterDeleteValidate(arg0, arg1 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostClusterDeleteValidate", reflect.TypeOf((*MockProvider)(nil).PostClusterDeleteValidate), arg0, arg1)
 }
 
+// PostMoveManagementToBootstrap mocks base method.
+func (m *MockProvider) PostMoveManagementToBootstrap(arg0 context.Context, arg1 *types.Cluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostMoveManagementToBootstrap", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PostMoveManagementToBootstrap indicates an expected call of PostMoveManagementToBootstrap.
+func (mr *MockProviderMockRecorder) PostMoveManagementToBootstrap(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostMoveManagementToBootstrap", reflect.TypeOf((*MockProvider)(nil).PostMoveManagementToBootstrap), arg0, arg1)
+}
+
 // PostWorkloadInit mocks base method.
 func (m *MockProvider) PostWorkloadInit(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec) error {
 	m.ctrl.T.Helper()

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -42,6 +42,8 @@ type Provider interface {
 	DeleteResources(ctx context.Context, clusterSpec *cluster.Spec) error
 	InstallCustomProviderComponents(ctx context.Context, kubeconfigFile string) error
 	PostClusterDeleteValidate(ctx context.Context, managementCluster *types.Cluster) error
+	// PostMoveManagementToBootstrap is called after the CAPI management is moved back to the bootstrap cluster.
+	PostMoveManagementToBootstrap(ctx context.Context, bootstrapCluster *types.Cluster) error
 }
 
 type DatacenterConfig interface {

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -292,6 +292,11 @@ func (p *SnowProvider) PostClusterDeleteValidate(_ context.Context, _ *types.Clu
 	return nil
 }
 
+func (p *SnowProvider) PostMoveManagementToBootstrap(_ context.Context, _ *types.Cluster) error {
+	// NOOP
+	return nil
+}
+
 func (p *SnowProvider) InstallCustomProviderComponents(ctx context.Context, kubeconfigFile string) error {
 	return nil
 }

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -176,10 +176,16 @@ func (p *Provider) PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig 
 	if err != nil {
 		return fmt.Errorf("applying hardware yaml: %v", err)
 	}
-	err = p.providerKubectlClient.WaitForBaseboardManagements(ctx, cluster, "5m", "Contactable", constants.EksaSystemNamespace)
-	if err != nil {
+
+	return nil
+}
+
+func (p *Provider) PostMoveManagementToBootstrap(ctx context.Context, bootstrapCluster *types.Cluster) error {
+	// Waiting to ensure all the new and exisiting baseboardmanagement connections are valid.
+	if err := p.providerKubectlClient.WaitForBaseboardManagements(ctx, bootstrapCluster, "5m", "Contactable", constants.EksaSystemNamespace); err != nil {
 		return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
 	}
+
 	return nil
 }
 

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -371,6 +371,11 @@ func (p *vsphereProvider) PostClusterDeleteValidate(_ context.Context, _ *types.
 	return nil
 }
 
+func (p *vsphereProvider) PostMoveManagementToBootstrap(_ context.Context, _ *types.Cluster) error {
+	// NOOP
+	return nil
+}
+
 func (p *vsphereProvider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpec *cluster.Spec) error {
 	if err := SetupEnvVars(p.datacenterConfig); err != nil {
 		return fmt.Errorf("failed setup and validations: %v", err)

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -446,6 +446,14 @@ func (s *moveManagementToBootstrapTask) Run(ctx context.Context, commandContext 
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}
 	}
+
+	logger.V(3).Info("Provider specific post management move")
+	err = commandContext.Provider.PostMoveManagementToBootstrap(ctx, commandContext.BootstrapCluster)
+	if err != nil {
+		commandContext.SetError(err)
+		return &CollectDiagnosticsTask{}
+	}
+
 	commandContext.ManagementCluster = commandContext.BootstrapCluster
 	return &upgradeWorkloadClusterTask{}
 }

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -248,6 +248,9 @@ func (c *upgradeTestSetup) expectMoveManagementToBootstrap() {
 		c.clusterManager.EXPECT().MoveCAPI(
 			c.ctx, c.managementCluster, c.bootstrapCluster, gomock.Any(), c.newClusterSpec, gomock.Any(),
 		),
+		c.provider.EXPECT().PostMoveManagementToBootstrap(
+			c.ctx, c.bootstrapCluster,
+		),
 	)
 }
 


### PR DESCRIPTION
*Description of changes:*
BMC wait check fails for `cluster upgrade` flow for Tinkerbell provider, if new hardware is  not provided via hardware csv.
Added a provider specific call after management is moved to bootstrap cluster during upgrade, this enables checking all the BMCs (pre-existing and newly loaded from csv).

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

