### PR TITLE
Enable node autoscaling option with Cluster Autoscaler

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -263,6 +263,19 @@ spec:
               workerNodeGroupConfigurations:
                 items:
                   properties:
+                    autoscalingConfiguration:
+                      description: AutoScalingConfiguration defines the auto scaling
+                        configuration
+                      properties:
+                        maxCount:
+                          description: MaxCount defines the maximum number of nodes
+                            for the associated resource group.
+                          type: integer
+                        minCount:
+                          description: MinCount defines the minimum number of nodes
+                            for the associated resource group.
+                          type: integer
+                      type: object
                     count:
                       description: Count defines the number of desired worker nodes.
                         Defaults to 1.

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -3659,6 +3659,19 @@ spec:
               workerNodeGroupConfigurations:
                 items:
                   properties:
+                    autoscalingConfiguration:
+                      description: AutoScalingConfiguration defines the auto scaling
+                        configuration
+                      properties:
+                        maxCount:
+                          description: MaxCount defines the maximum number of nodes
+                            for the associated resource group.
+                          type: integer
+                        minCount:
+                          description: MinCount defines the minimum number of nodes
+                            for the associated resource group.
+                          type: integer
+                      type: object
                     count:
                       description: Count defines the number of desired worker nodes.
                         Defaults to 1.

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -2298,6 +2298,54 @@ func TestValidateMirrorConfig(t *testing.T) {
 	}
 }
 
+func TestValidateAutoscalingConfig(t *testing.T) {
+	tests := []struct {
+		name              string
+		wantErr           string
+		autoscalingConfig *AutoScalingConfiguration
+	}{
+		{
+			name:              "autoscaling config nil",
+			wantErr:           "",
+			autoscalingConfig: nil,
+		},
+		{
+			name:    "autoscaling config valid",
+			wantErr: "",
+			autoscalingConfig: &AutoScalingConfiguration{
+				MinCount: 1,
+				MaxCount: 2,
+			},
+		},
+		{
+			name:    "negative min count",
+			wantErr: "min count must be non negative",
+			autoscalingConfig: &AutoScalingConfiguration{
+				MinCount: -1,
+			},
+		},
+		{
+			name:    "min count > max count",
+			wantErr: "min count must be no greater than max count",
+			autoscalingConfig: &AutoScalingConfiguration{
+				MinCount: 2,
+				MaxCount: 1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := validateAutoscalingConfig(tt.autoscalingConfig)
+			if tt.wantErr == "" {
+				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			}
+		})
+	}
+}
+
 func TestClusterRegistryMirror(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -232,6 +232,8 @@ type WorkerNodeGroupConfiguration struct {
 	Name string `json:"name,omitempty"`
 	// Count defines the number of desired worker nodes. Defaults to 1.
 	Count int `json:"count,omitempty"`
+	// AutoScalingConfiguration defines the auto scaling configuration
+	AutoScalingConfiguration *AutoScalingConfiguration `json:"autoscalingConfiguration,omitempty"`
 	// MachineGroupRef defines the machine group configuration for the worker nodes.
 	MachineGroupRef *Ref `json:"machineGroupRef,omitempty"`
 	// Taints define the set of taints to be applied on worker nodes
@@ -243,7 +245,10 @@ type WorkerNodeGroupConfiguration struct {
 func generateWorkerNodeGroupKey(c WorkerNodeGroupConfiguration) (key string) {
 	key = c.Name
 	if c.MachineGroupRef != nil {
-		key = c.MachineGroupRef.Kind + c.MachineGroupRef.Name
+		key += c.MachineGroupRef.Kind + c.MachineGroupRef.Name
+	}
+	if c.AutoScalingConfiguration != nil {
+		key += "autoscaling" + strconv.Itoa(c.AutoScalingConfiguration.MaxCount) + strconv.Itoa(c.AutoScalingConfiguration.MinCount)
 	}
 	return strconv.Itoa(c.Count) + key
 }
@@ -701,6 +706,17 @@ func (n *PodIAMConfig) Equal(o *PodIAMConfig) bool {
 		return false
 	}
 	return n.ServiceAccountIssuer == o.ServiceAccountIssuer
+}
+
+// AutoScalingConfiguration defines the configuration for the node autoscaling feature
+type AutoScalingConfiguration struct {
+	// MinCount defines the minimum number of nodes for the associated resource group.
+	// +optional
+	MinCount int `json:"minCount,omitempty"`
+
+	// MaxCount defines the maximum number of nodes for the associated resource group.
+	// +optional
+	MaxCount int `json:"maxCount,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -397,6 +397,63 @@ func TestClusterEqualWorkerNodeGroupConfigurations(t *testing.T) {
 			want: false,
 		},
 		{
+			testName: "both exist, autoscaling config diff",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					AutoScalingConfiguration: &v1alpha1.AutoScalingConfiguration{
+						MinCount: 1,
+						MaxCount: 3,
+					},
+				},
+			},
+			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					AutoScalingConfiguration: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, autoscaling config min diff",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					AutoScalingConfiguration: &v1alpha1.AutoScalingConfiguration{
+						MinCount: 1,
+						MaxCount: 3,
+					},
+				},
+			},
+			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					AutoScalingConfiguration: &v1alpha1.AutoScalingConfiguration{
+						MinCount: 2,
+						MaxCount: 3,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			testName: "both exist, autoscaling config max diff",
+			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					AutoScalingConfiguration: &v1alpha1.AutoScalingConfiguration{
+						MinCount: 1,
+						MaxCount: 2,
+					},
+				},
+			},
+			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					AutoScalingConfiguration: &v1alpha1.AutoScalingConfiguration{
+						MinCount: 1,
+						MaxCount: 3,
+					},
+				},
+			},
+			want: false,
+		},
+		{
 			testName: "both exist, ref diff",
 			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
 				{

--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -252,15 +252,16 @@ func MachineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig anywhere
 	replicas := int32(workerNodeGroupConfig.Count)
 	version := clusterSpec.VersionsBundle.KubeDistro.Kubernetes.Tag
 
-	return clusterv1.MachineDeployment{
+	md := &clusterv1.MachineDeployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: clusterAPIVersion,
 			Kind:       machineDeploymentKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      MachineDeploymentName(clusterSpec, workerNodeGroupConfig),
-			Namespace: constants.EksaSystemNamespace,
-			Labels:    capiObjectLabels(clusterSpec),
+			Name:        MachineDeploymentName(clusterSpec, workerNodeGroupConfig),
+			Namespace:   constants.EksaSystemNamespace,
+			Labels:      capiObjectLabels(clusterSpec),
+			Annotations: map[string]string{},
 		},
 		Spec: clusterv1.MachineDeploymentSpec{
 			ClusterName: clusterName,
@@ -291,4 +292,8 @@ func MachineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig anywhere
 			Replicas: &replicas,
 		},
 	}
+
+	ConfigureAutoscalingInMachineDeployment(md, workerNodeGroupConfig.AutoScalingConfiguration)
+
+	return *md
 }

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -360,12 +360,10 @@ func TestKubeadmConfigTemplate(t *testing.T) {
 	tt.Expect(got).To(Equal(want))
 }
 
-func TestMachineDeployment(t *testing.T) {
-	tt := newApiBuilerTest(t)
-	got := clusterapi.MachineDeployment(tt.clusterSpec, *tt.workerNodeGroupConfig, tt.kubeadmConfigTemplate, tt.providerMachineTemplate)
+func wantMachineDeployment() clusterv1.MachineDeployment {
 	replicas := int32(3)
 	version := "v1.21.5-eks-1-21-9"
-	want := clusterv1.MachineDeployment{
+	return clusterv1.MachineDeployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "cluster.x-k8s.io/v1beta1",
 			Kind:       "MachineDeployment",
@@ -378,6 +376,7 @@ func TestMachineDeployment(t *testing.T) {
 				"cluster.anywhere.eks.amazonaws.com/cluster-name":      "test-cluster",
 				"cluster.anywhere.eks.amazonaws.com/cluster-namespace": "my-namespace",
 			},
+			Annotations: map[string]string{},
 		},
 		Spec: clusterv1.MachineDeploymentSpec{
 			ClusterName: "test-cluster",
@@ -410,7 +409,13 @@ func TestMachineDeployment(t *testing.T) {
 			Replicas: &replicas,
 		},
 	}
-	tt.Expect(got).To(Equal(want))
+}
+
+func TestMachineDeployment(t *testing.T) {
+	tt := newApiBuilerTest(t)
+	got := clusterapi.MachineDeployment(tt.clusterSpec, *tt.workerNodeGroupConfig, tt.kubeadmConfigTemplate, tt.providerMachineTemplate)
+
+	tt.Expect(got).To(Equal(wantMachineDeployment()))
 }
 
 func TestClusterName(t *testing.T) {

--- a/pkg/clusterapi/autoscaler.go
+++ b/pkg/clusterapi/autoscaler.go
@@ -1,0 +1,27 @@
+package clusterapi
+
+import (
+	"strconv"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+const (
+	nodeGroupMinSizeAnnotation = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"
+	nodeGroupMaxSizeAnnotation = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"
+)
+
+func ConfigureAutoscalingInMachineDeployment(md *clusterv1.MachineDeployment, autoscalingConfig *anywherev1.AutoScalingConfiguration) {
+	if autoscalingConfig == nil {
+		return
+	}
+
+	if md.ObjectMeta.Annotations == nil {
+		md.ObjectMeta.Annotations = map[string]string{}
+	}
+
+	md.ObjectMeta.Annotations[nodeGroupMinSizeAnnotation] = strconv.Itoa(autoscalingConfig.MinCount)
+	md.ObjectMeta.Annotations[nodeGroupMaxSizeAnnotation] = strconv.Itoa(autoscalingConfig.MaxCount)
+}

--- a/pkg/clusterapi/autoscaler_test.go
+++ b/pkg/clusterapi/autoscaler_test.go
@@ -1,0 +1,93 @@
+package clusterapi_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+)
+
+func TestConfigureAutoscalingInMachineDeployment(t *testing.T) {
+	replicas := int32(3)
+	version := "v1.21.5-eks-1-21-9"
+	tests := []struct {
+		name              string
+		autoscalingConfig *v1alpha1.AutoScalingConfiguration
+		want              clusterv1.MachineDeployment
+	}{
+		{
+			name:              "no autoscaling config",
+			autoscalingConfig: nil,
+			want:              wantMachineDeployment(),
+		},
+		{
+			name: "with autoscaling config",
+			autoscalingConfig: &v1alpha1.AutoScalingConfiguration{
+				MinCount: 1,
+				MaxCount: 3,
+			},
+			want: clusterv1.MachineDeployment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "cluster.x-k8s.io/v1beta1",
+					Kind:       "MachineDeployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster-wng-1",
+					Namespace: "eksa-system",
+					Labels: map[string]string{
+						"cluster.x-k8s.io/cluster-name":                        "test-cluster",
+						"cluster.anywhere.eks.amazonaws.com/cluster-name":      "test-cluster",
+						"cluster.anywhere.eks.amazonaws.com/cluster-namespace": "my-namespace",
+					},
+					Annotations: map[string]string{
+						"cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size": "1",
+						"cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size": "3",
+					},
+				},
+				Spec: clusterv1.MachineDeploymentSpec{
+					ClusterName: "test-cluster",
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{},
+					},
+					Template: clusterv1.MachineTemplateSpec{
+						ObjectMeta: clusterv1.ObjectMeta{
+							Labels: map[string]string{
+								"cluster.x-k8s.io/cluster-name": "test-cluster",
+							},
+						},
+						Spec: clusterv1.MachineSpec{
+							Bootstrap: clusterv1.Bootstrap{
+								ConfigRef: &v1.ObjectReference{
+									APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+									Kind:       "KubeadmConfigTemplate",
+									Name:       "md-0",
+								},
+							},
+							ClusterName: "test-cluster",
+							InfrastructureRef: v1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+								Kind:       "ProviderMachineTemplate",
+								Name:       "provider-template",
+							},
+							Version: &version,
+						},
+					},
+					Replicas: &replicas,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newApiBuilerTest(t)
+			got := wantMachineDeployment()
+			clusterapi.ConfigureAutoscalingInMachineDeployment(&got, tt.autoscalingConfig)
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -426,6 +426,7 @@ func wantMachineDeployment() *clusterv1.MachineDeployment {
 				"cluster.anywhere.eks.amazonaws.com/cluster-name":      "snow-test",
 				"cluster.anywhere.eks.amazonaws.com/cluster-namespace": "test-namespace",
 			},
+			Annotations: map[string]string{},
 		},
 		Spec: clusterv1.MachineDeploymentSpec{
 			ClusterName: "snow-test",


### PR DESCRIPTION
*Issue #, if available:*

Resolves #3188 

*Description of changes:*

Introduce `AutoScalingConfiguration` field in `WorkerNodeGroupConfiguration`. When specified, we add the Cluster Autoscaler annotation to the CAPI `MachineDeployment` resource.

API
```go
type AutoScalingConfiguration struct {
	// MinCount defines the minimum number of nodes for the associated resource group.
	// +optional
	MinCount int `json:"minCount,omitempty"`

	// MaxCount defines the maximum number of nodes for the associated resource group.
	// +optional
	MaxCount int `json:"maxCount,omitempty"`
}
```

Also add validations for the field.

Something we need to follow up:
1. In the original design: https://github.com/aws/eks-anywhere/blob/main/designs/autoscaler.md#api-design, we plan to change `WorkerNodeGroupConfiguration.Count` to be optional. This change may introduce issues in provisioning workflow since we rely on the count to calculate the total nodes and compare it with the ready node. We will need to do more investigation on the topic.
2. This PR only covers the CAPI change in `apibuilder` and only Snow provider uses it. We need to have separate PRs to update the other CAPI machine deployment templates located in other provider code.

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

