### PR TITLE
Add comment for ignoring error

### DIFF
--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -64,12 +64,12 @@ func installPackageController(ctx context.Context) error {
 	if err = curatedpackages.VerifyCertManagerExists(ctx, deps.Kubectl, kubeConfig); err != nil {
 		return err
 	}
-	installed, err := ctrlClient.IsInstalled(ctx)
-	if err != nil {
-		return err
-	}
 
-	if installed {
+	// ignore the error because if the crds don't exist in the cluster
+	// this will return an error. If this is the case, we should still
+	// go ahead and install the controller since lack of crds indicates
+	// the controller doesn't exist
+	if installed, _ := ctrlClient.IsInstalled(ctx); installed {
 		return errors.New("curated Packages controller exists in the current cluster")
 	}
 


### PR DESCRIPTION
*Description of changes:*
- If package controller doesn't exist in the cluster, install the controller
- If an error is returned during package controller installation, there is a good reason it is due to lack of crds in which case go ahead and try installing anyways.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

