### PR TITLE
Redact snow creds in verbose logs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,7 +6,9 @@ const (
 	EksaGitKnownHostsFileEnv  = "EKSA_GIT_KNOWN_HOSTS"
 	SshKnownHostsEnv          = "SSH_KNOWN_HOSTS"
 	EksaAccessKeyIdEnv        = "EKSA_AWS_ACCESS_KEY_ID"
-	EksaSecretAcessKeyEnv     = "EKSA_AWS_SECRET_ACCESS_KEY"
+	EksaSecretAccessKeyEnv    = "EKSA_AWS_SECRET_ACCESS_KEY"
+	AwsAccessKeyIdEnv         = "AWS_ACCESS_KEY_ID"
+	AwsSecretAccessKeyEnv     = "AWS_SECRET_ACCESS_KEY"
 	EksaRegionEnv             = "EKSA_AWS_REGION"
 )
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -41,4 +41,12 @@ const (
 
 	DefaultRegistry            = "public.ecr.aws"
 	CloudstackAnnotationSuffix = "cloudstack.anywhere.eks.amazonaws.com/v1alpha1"
+
+	// provider specific env vars
+	VSphereUsernameKey = "VSPHERE_USERNAME"
+	VSpherePasswordKey = "VSPHERE_PASSWORD"
+	GovcUsernameKey    = "GOVC_USERNAME"
+	GovcPasswordKey    = "GOVC_PASSWORD"
+	SnowCredentialsKey = "AWS_B64ENCODED_CREDENTIALS"
+	SnowCertsKey       = "AWS_B64ENCODED_CA_BUNDLES"
 )

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -857,7 +857,7 @@ func (f *Factory) WithPackageControllerClient(spec *cluster.Spec) *Factory {
 		imageUrl := urls.ReplaceHost(chart.Image(), spec.Cluster.RegistryMirror())
 
 		httpProxy, httpsProxy, noProxy := getProxyConfiguration(spec)
-		eksaAccessKeyId, eksaSecretKey, eksaRegion := os.Getenv(config.EksaAccessKeyIdEnv), os.Getenv(config.EksaSecretAcessKeyEnv), os.Getenv(config.EksaRegionEnv)
+		eksaAccessKeyId, eksaSecretKey, eksaRegion := os.Getenv(config.EksaAccessKeyIdEnv), os.Getenv(config.EksaSecretAccessKeyEnv), os.Getenv(config.EksaRegionEnv)
 		f.dependencies.PackageControllerClient = curatedpackages.NewPackageControllerClient(
 			f.dependencies.Helm,
 			f.dependencies.Kubectl,

--- a/pkg/executables/dockerlinux.go
+++ b/pkg/executables/dockerlinux.go
@@ -39,7 +39,7 @@ func (e *linuxDockerExecutable) Command(ctx context.Context, args ...string) *Co
 }
 
 func (e *linuxDockerExecutable) Run(cmd *Command) (stdout bytes.Buffer, err error) {
-	return execute(cmd.ctx, "docker", cmd.stdIn, e.buildCommand(cmd.envVars, e.cli, cmd.args...)...)
+	return execute(cmd.ctx, "docker", cmd.stdIn, cmd.envVars, e.buildCommand(cmd.envVars, e.cli, cmd.args...)...)
 }
 
 func (e *linuxDockerExecutable) buildCommand(envs map[string]string, cli string, args ...string) []string {

--- a/pkg/executables/executables.go
+++ b/pkg/executables/executables.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/aws/eks-anywhere/pkg/config"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 )
@@ -19,12 +19,19 @@ const (
 )
 
 var redactedEnvKeys = []string{
-	config.EksavSphereUsernameKey,
-	config.EksavSpherePasswordKey,
+	constants.VSphereUsernameKey,
+	constants.VSpherePasswordKey,
+	constants.GovcUsernameKey,
+	constants.GovcPasswordKey,
 	decoder.CloudStackCloudConfigB64SecretKey,
 	eksaGithubTokenEnv,
+	githubTokenEnv,
 	config.EksaAccessKeyIdEnv,
-	config.EksaSecretAcessKeyEnv,
+	config.EksaSecretAccessKeyEnv,
+	config.AwsAccessKeyIdEnv,
+	config.AwsSecretAccessKeyEnv,
+	constants.SnowCredentialsKey,
+	constants.SnowCertsKey,
 }
 
 type executable struct {
@@ -63,20 +70,17 @@ func (e *executable) Command(ctx context.Context, args ...string) *Command {
 }
 
 func (e *executable) Run(cmd *Command) (stdout bytes.Buffer, err error) {
-	for k, v := range cmd.envVars {
-		os.Setenv(k, v)
-	}
-	return execute(cmd.ctx, e.cli, cmd.stdIn, cmd.args...)
+	return execute(cmd.ctx, e.cli, cmd.stdIn, cmd.envVars, cmd.args...)
 }
 
 func (e *executable) Close(ctx context.Context) error {
 	return nil
 }
 
-func redactCreds(cmd string) string {
+func redactCreds(cmd string, envMap map[string]string) string {
 	redactedEnvs := []string{}
 	for _, redactedEnvKey := range redactedEnvKeys {
-		if env, found := os.LookupEnv(redactedEnvKey); found {
+		if env, found := envMap[redactedEnvKey]; found {
 			redactedEnvs = append(redactedEnvs, env)
 		}
 	}
@@ -87,10 +91,10 @@ func redactCreds(cmd string) string {
 	return cmd
 }
 
-func execute(ctx context.Context, cli string, in []byte, args ...string) (stdout bytes.Buffer, err error) {
+func execute(ctx context.Context, cli string, in []byte, envVars map[string]string, args ...string) (stdout bytes.Buffer, err error) {
 	var stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, cli, args...)
-	logger.V(6).Info("Executing command", "cmd", redactCreds(cmd.String()))
+	logger.V(6).Info("Executing command", "cmd", redactCreds(cmd.String(), envVars))
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if len(in) != 0 {

--- a/pkg/executables/executables_test.go
+++ b/pkg/executables/executables_test.go
@@ -1,0 +1,19 @@
+package executables_test
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/executables"
+)
+
+func TestRedactCreds(t *testing.T) {
+	str := "My username is username123. My password is password456"
+	envMap := map[string]string{"var": "value", constants.VSphereUsernameKey: "username123", constants.VSpherePasswordKey: "password456"}
+	expected := "My username is *****. My password is *****"
+
+	redactedStr := executables.RedactCreds(str, envMap)
+	if redactedStr != expected {
+		t.Fatalf("executables.RedactCreds expected = %s, got = %s", expected, redactedStr)
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add snow creds & certs to redacted env vars

*Testing (if applicable):*
`eksctl-anywhere create cluster` with Snow & vSphere and viewed logs with redacted values


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

