### PR TITLE
Lower the secret name for backward compatibility

### DIFF
--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -135,7 +135,7 @@ func generateSecret(profile decoder.CloudStackProfileConfig) *corev1.Secret {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: constants.EksaSystemNamespace,
-			Name:      profile.Name,
+			Name:      strings.ToLower(profile.Name),
 		},
 		StringData: map[string]string{
 			"api-url":    profile.ManagementUrl,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
Historically "Global" has been used for the name of the INI section containing URL and secrets to the target CloudStack API endpoint. However, the k8s secret object only supports the lowercase name. To support the customer wanting to use the 0.8.3 release and the 0.11.x and higher releases, we need this PR.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

