### PR TITLE
Mention namespace creation in metallb docs

### DIFF
--- a/docs/content/en/docs/tasks/packages/metallb/_index.md
+++ b/docs/content/en/docs/tasks/packages/metallb/_index.md
@@ -66,6 +66,11 @@ description: >
             - default
     ```
 
+1. Create the namespace
+  (If overriding `targetNamespace`, change `metallb-system` to the value of `targetNamespace`)
+   ```bash
+   kubectl create namespace metallb-system
+   ```
 
 1. Install MetalLB
 


### PR DESCRIPTION
The namespace must be created manually and the docs don't state that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

