### PR TITLE
Fetch only repo tags that match semver

### DIFF
--- a/release/pkg/git/git.go
+++ b/release/pkg/git/git.go
@@ -38,7 +38,7 @@ func DescribeTag(gitRoot string) (string, error) {
 }
 
 func GetRepoTagsDescending(gitRoot string) (string, error) {
-	cmd := exec.Command("git", "-C", gitRoot, "tag", "-l", "--sort", "-v:refname")
+	cmd := exec.Command("git", "-C", gitRoot, "tag", "-l", "v*.*.*", "--sort", "-v:refname")
 	return commandutils.ExecCommand(cmd)
 }
 

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -50,7 +50,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-19-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-20-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -271,21 +271,21 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-19-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-20-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.20.15
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-19.yaml
-      name: kubernetes-1-20-eks-19
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-20.yaml
+      name: kubernetes-1-20-eks-20
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-20-19 release
-          name: bottlerocket-v1.20.15-eks-d-1-20-19-eks-a-v0.0.0-dev-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-20-20 release
+          name: bottlerocket-v1.20.15-eks-d-1-20-20-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-20/1-20-19/bottlerocket-v1.20.15-eks-d-1-20-19-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-20/1-20-20/bottlerocket-v1.20.15-eks-d-1-20-20-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket: {}
     eksa:
@@ -297,7 +297,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -306,9 +306,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -317,7 +317,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -425,7 +425,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -434,7 +434,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -443,8 +443,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.2-eks-a-v0.0.0-dev-build.1
-      version: v0.2.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-build.1
+      version: v0.2.7+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml
@@ -787,7 +787,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-17-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-18-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -1008,32 +1008,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-build.1
-      kubeVersion: v1.21.13
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-17.yaml
-      name: kubernetes-1-21-eks-17
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-build.1
+      kubeVersion: v1.21.14
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-18.yaml
+      name: kubernetes-1-21-eks-18
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-21-17 release
-          name: bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-21-18 release
+          name: bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-21/1-21-17/bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-21/1-21-18/bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-21-17 release
-          name: bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-21-18 release
+          name: bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-21/1-21-17/bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-21/1-21-18/bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -1043,7 +1043,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -1052,9 +1052,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1063,7 +1063,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -1171,7 +1171,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1180,7 +1180,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1189,8 +1189,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.2-eks-a-v0.0.0-dev-build.1
-      version: v0.2.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-build.1
+      version: v0.2.7+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml
@@ -1533,7 +1533,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-9-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-10-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -1754,32 +1754,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-build.1
-      kubeVersion: v1.22.10
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-9.yaml
-      name: kubernetes-1-22-eks-9
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-build.1
+      kubeVersion: v1.22.12
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-10.yaml
+      name: kubernetes-1-22-eks-10
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-22-9 release
-          name: bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-22-10 release
+          name: bottlerocket-v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-22/1-22-9/bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-22/1-22-10/bottlerocket-v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-22-9 release
-          name: bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-22-10 release
+          name: bottlerocket-v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-22/1-22-9/bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-22/1-22-10/bottlerocket-v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -1789,7 +1789,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -1798,9 +1798,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1809,7 +1809,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -1917,7 +1917,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1926,7 +1926,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1935,8 +1935,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.2-eks-a-v0.0.0-dev-build.1
-      version: v0.2.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-build.1
+      version: v0.2.7+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml
@@ -2279,7 +2279,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-5-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -2500,32 +2500,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-build.1
-      kubeVersion: v1.23.7
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-4.yaml
-      name: kubernetes-1-23-eks-4
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-build.1
+      kubeVersion: v1.23.9
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-5.yaml
+      name: kubernetes-1-23-eks-5
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-23-4 release
-          name: bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-23-5 release
+          name: bottlerocket-v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-23/1-23-4/bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-23/1-23-5/bottlerocket-v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-23-4 release
-          name: bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-23-5 release
+          name: bottlerocket-v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-23/1-23-4/bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-23/1-23-5/bottlerocket-v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -2535,7 +2535,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -2544,9 +2544,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -2555,7 +2555,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -2663,7 +2663,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -2672,7 +2672,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2681,8 +2681,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.2-eks-a-v0.0.0-dev-build.1
-      version: v0.2.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-build.1
+      version: v0.2.7+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml
@@ -2971,6 +2971,734 @@ spec:
         name: cloud-provider-vsphere
         os: linux
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.23.1-eks-d-1-23-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/metadata.yaml
+      syncer:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for vsphere-csi-syncer image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: vsphere-csi-syncer
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.4.2-eks-a-v0.0.0-dev-build.1
+      version: v1.1.1+abcdef1
+  - bootstrap:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kubeadm-bootstrap-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kubeadm-bootstrap-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
+    bottlerocketAdmin:
+      admin:
+        arch:
+        - amd64
+        description: Container image for bottlerocket-admin image
+        imageDigest: sha256:d7a394014cd60caa821d7c748637d1bf21ed955eb06a8cef7864c9a5f2e75b02
+        name: bottlerocket-admin
+        os: linux
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.0
+    bottlerocketBootstrap:
+      bootstrap:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for bottlerocket-bootstrap image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: bottlerocket-bootstrap
+        os: linux
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-24-1-eks-a-v0.0.0-dev-build.1
+    certManager:
+      acmesolver:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-acmesolver image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-acmesolver
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.8.2-eks-a-v0.0.0-dev-build.1
+      cainjector:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-cainjector image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-cainjector
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.8.2-eks-a-v0.0.0-dev-build.1
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.8.2-eks-a-v0.0.0-dev-build.1
+      ctl:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-ctl image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-ctl
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.8.2-eks-a-v0.0.0-dev-build.1
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.8.2/cert-manager.yaml
+      version: v1.8.2+abcdef1
+      webhook:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-webhook image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-webhook
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.8.2-eks-a-v0.0.0-dev-build.1
+    cilium:
+      cilium:
+        arch:
+        - amd64
+        description: Container image for cilium image
+        imageDigest: sha256:9875b3f624186dce140de81ebf1823bb1a2f7e285710026a6aee0c9a2f83a131
+        name: cilium
+        os: linux
+        uri: public.ecr.aws/isovalent/cilium:v1.10.14-eksa.1
+      helmChart:
+        description: Helm chart for cilium-chart
+        imageDigest: sha256:6690b2b07f949e0a97145703777d59e10c0ce740e4a17a46776ba14ee0073dc5
+        name: cilium-chart
+        uri: public.ecr.aws/isovalent/cilium:1.10.14-eksa.1
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.10.14-eksa.1/cilium.yaml
+      operator:
+        arch:
+        - amd64
+        description: Container image for operator-generic image
+        imageDigest: sha256:4b26d2bf579c2efcfc6633546960270d8d544352923ce328fa218718b3412a40
+        name: operator-generic
+        os: linux
+        uri: public.ecr.aws/isovalent/operator-generic:v1.10.14-eksa.1
+      version: v1.10.14-eksa.1
+    cloudStack:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-cloudstack image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-cloudstack
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.7-rc3-eks-a-v0.0.0-dev-build.1
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.7-rc3/infrastructure-components.yaml
+      kubeRbacProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.7-rc3/metadata.yaml
+      version: v0.4.7-rc3+abcdef1
+    clusterAPI:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
+    controlPlane:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kubeadm-control-plane-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kubeadm-control-plane-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
+    docker:
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-docker image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-docker
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
+    eksD:
+      channel: 1-24
+      components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+      crictl:
+        arch:
+        - amd64
+        description: cri-tools tarball for linux/amd64
+        name: cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+      etcdadm:
+        arch:
+        - amd64
+        description: etcdadm tarball for linux/amd64
+        name: etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
+      gitCommit: 0123456789abcdef0123456789abcdef01234567
+      imagebuilder:
+        arch:
+        - amd64
+        description: image-builder tarball for linux/amd64
+        name: image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.1/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+      kindNode:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kind-node image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kind-node
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.24.4-eks-d-1-24-1-eks-a-v0.0.0-dev-build.1
+      kubeVersion: v1.24.4
+      manifestUrl: https://eks-d-postsubmit-artifacts.s3.us-west-2.amazonaws.com/kubernetes-1-24/kubernetes-1-24-eks-1.yaml
+      name: kubernetes-1-24-eks-1
+      ova:
+        bottlerocket: {}
+      raw:
+        bottlerocket: {}
+    eksa:
+      cliTools:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-cli-tools image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-cli-tools
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-build.1
+      clusterController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-cluster-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-cluster-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-build.1
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
+      diagnosticCollector:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-diagnostic-collector image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-diagnostic-collector
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-build.1
+      version: v0.0.0-dev+build.0+abcdef1
+    etcdadmBootstrap:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5/bootstrap-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for etcdadm-bootstrap-provider image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: etcdadm-bootstrap-provider
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-eks-a-v0.0.0-dev-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5/metadata.yaml
+      version: v1.0.5+abcdef1
+    etcdadmController:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4/bootstrap-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for etcdadm-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: etcdadm-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-eks-a-v0.0.0-dev-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4/metadata.yaml
+      version: v1.0.4+abcdef1
+    flux:
+      helmController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for helm-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: helm-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-build.1
+      kustomizeController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kustomize-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kustomize-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-build.1
+      notificationController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for notification-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: notification-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-build.1
+      sourceController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for source-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: source-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-build.1
+      version: v0.31.3+abcdef1
+    haproxy:
+      image:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for haproxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: haproxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.14.0-eks-a-v0.0.0-dev-build.1
+    kindnetd:
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.14.0/kindnetd.yaml
+      version: v0.14.0+abcdef1
+    kubeVersion: "1.24"
+    packageController:
+      helmChart:
+        description: Helm chart for eks-anywhere-packages
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-packages
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-build.1
+      packageController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-packages image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-packages
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-build.1
+      tokenRefresher:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for ecr-token-refresher image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: ecr-token-refresher
+        os: linux
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-build.1
+      version: v0.2.7+abcdef1
+    snow:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-build.1
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-snow-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-snow-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.6-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/metadata.yaml
+      version: v0.1.6+abcdef1
+    tinkerbell:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-tinkerbell image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-tinkerbell
+        os: linux
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-build.1
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+      envoy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for envoy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: envoy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-build.1
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
+      tinkerbellStack:
+        actions:
+          cexec:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for cexec image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: cexec
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+          imageToDisk:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for image2disk image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: image2disk
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+          kexec:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for kexec image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: kexec
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+          ociToDisk:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for oci2disk image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: oci2disk
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+          reboot:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for reboot image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: reboot
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+          writeFile:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for writefile image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: writefile
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+        boots:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for boots image
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: boots
+          os: linux
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-build.1
+        cfssl:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for cfssl image
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: cfssl
+          os: linux
+          uri: public.ecr.aws/release-container-registry/cloudflare/cfssl:v1.6.1-eks-a-v0.0.0-dev-build.1
+        hegel:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for hegel image
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: hegel
+          os: linux
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-build.1
+        hook:
+          bootkit:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-bootkit image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: hook-bootkit
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-build.1
+          docker:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-docker image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: hook-docker
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-build.1
+          initramfs:
+            amd:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-x86_64
+            arm:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/initramfs-aarch64
+          kernel:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-kernel image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: hook-kernel
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:029ef8f0711579717bfd14ac5eb63cdc3e658b1d-eks-a-v0.0.0-dev-build.1
+          vmlinuz:
+            amd:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-x86_64
+            arm:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/029ef8f0711579717bfd14ac5eb63cdc3e658b1d/vmlinuz-aarch64
+        rufio:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for rufio image
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: rufio
+          os: linux
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-build.1
+        tink:
+          tinkController:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-controller image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: tink-controller
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-build.1
+          tinkServer:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-server image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: tink-server
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-build.1
+          tinkWorker:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-worker image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: tink-worker
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-build.1
+        tinkerbellChart:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for tinkerbell-chart image
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: tinkerbell-chart
+          os: linux
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.4-eks-a-v0.0.0-dev-build.1
+      version: v0.1.0
+    vSphere:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-vsphere image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-vsphere
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.1.1-eks-a-v0.0.0-dev-build.1
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/cluster-template.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/infrastructure-components.yaml
+      driver:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for vsphere-csi-driver image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: vsphere-csi-driver
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.4.2-eks-a-v0.0.0-dev-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.0-eks-a-v0.0.0-dev-build.1
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cloud-provider-vsphere image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cloud-provider-vsphere
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.24.1-eks-d-1-24-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.1.1/metadata.yaml
       syncer:

--- a/release/pkg/test/testdata/release-0.11-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.11-bundle-release.yaml
@@ -50,7 +50,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-19-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-20-eks-a-v0.0.0-dev-release-0.11-build.1
     certManager:
       acmesolver:
         arch:
@@ -262,7 +262,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.0/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.1/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -271,21 +271,21 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-19-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-20-eks-a-v0.0.0-dev-release-0.11-build.1
       kubeVersion: v1.20.15
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-19.yaml
-      name: kubernetes-1-20-eks-19
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-20.yaml
+      name: kubernetes-1-20-eks-20
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-20-19 release
-          name: bottlerocket-v1.20.15-eks-d-1-20-19-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-20-20 release
+          name: bottlerocket-v1.20.15-eks-d-1-20-20-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-20/1-20-19/bottlerocket-v1.20.15-eks-d-1-20-19-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-20/1-20-20/bottlerocket-v1.20.15-eks-d-1-20-20-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
       raw:
         bottlerocket: {}
     eksa:
@@ -297,7 +297,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.1-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterController:
         arch:
         - amd64
@@ -306,9 +306,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.1-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -317,7 +317,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.1-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v0.0.0-dev-release-0.11+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -425,7 +425,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       packageController:
         arch:
         - amd64
@@ -434,7 +434,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -443,8 +443,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
-      version: v0.2.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.2.7+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -769,7 +769,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-17-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-18-eks-a-v0.0.0-dev-release-0.11-build.1
     certManager:
       acmesolver:
         arch:
@@ -981,7 +981,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.0/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.1/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -990,32 +990,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.1
-      kubeVersion: v1.21.13
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-17.yaml
-      name: kubernetes-1-21-eks-17
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-release-0.11-build.1
+      kubeVersion: v1.21.14
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-18.yaml
+      name: kubernetes-1-21-eks-18
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-21-17 release
-          name: bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-21-18 release
+          name: bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-21/1-21-17/bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-21/1-21-18/bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-21-17 release
-          name: bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-21-18 release
+          name: bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-21/1-21-17/bottlerocket-v1.21.13-eks-d-1-21-17-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-21/1-21-18/bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -1025,7 +1025,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.1-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterController:
         arch:
         - amd64
@@ -1034,9 +1034,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.1-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1045,7 +1045,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.1-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v0.0.0-dev-release-0.11+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -1153,7 +1153,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       packageController:
         arch:
         - amd64
@@ -1162,7 +1162,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1171,8 +1171,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
-      version: v0.2.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.2.7+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -1497,7 +1497,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-9-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-10-eks-a-v0.0.0-dev-release-0.11-build.1
     certManager:
       acmesolver:
         arch:
@@ -1709,7 +1709,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.0/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.1/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -1718,32 +1718,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.1
-      kubeVersion: v1.22.10
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-9.yaml
-      name: kubernetes-1-22-eks-9
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-release-0.11-build.1
+      kubeVersion: v1.22.12
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-10.yaml
+      name: kubernetes-1-22-eks-10
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-22-9 release
-          name: bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-22-10 release
+          name: bottlerocket-v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-22/1-22-9/bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-22/1-22-10/bottlerocket-v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-22-9 release
-          name: bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-22-10 release
+          name: bottlerocket-v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-22/1-22-9/bottlerocket-v1.22.10-eks-d-1-22-9-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-22/1-22-10/bottlerocket-v1.22.12-eks-d-1-22-10-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -1753,7 +1753,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.1-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterController:
         arch:
         - amd64
@@ -1762,9 +1762,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.1-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1773,7 +1773,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.1-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v0.0.0-dev-release-0.11+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -1881,7 +1881,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       packageController:
         arch:
         - amd64
@@ -1890,7 +1890,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1899,8 +1899,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
-      version: v0.2.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.2.7+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -2225,7 +2225,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-4-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-5-eks-a-v0.0.0-dev-release-0.11-build.1
     certManager:
       acmesolver:
         arch:
@@ -2437,7 +2437,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.0/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/image-builder/0.1.1/image-builder-v0.0.0-dev-release-0.11-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -2446,32 +2446,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.1
-      kubeVersion: v1.23.7
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-4.yaml
-      name: kubernetes-1-23-eks-4
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-release-0.11-build.1
+      kubeVersion: v1.23.9
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-5.yaml
+      name: kubernetes-1-23-eks-5
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-23-4 release
-          name: bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-23-5 release
+          name: bottlerocket-v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-23/1-23-4/bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/ova/1-23/1-23-5/bottlerocket-v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-23-4 release
-          name: bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-23-5 release
+          name: bottlerocket-v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-23/1-23-4/bottlerocket-v1.23.7-eks-d-1-23-4-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-distro/raw/1-23/1-23-5/bottlerocket-v1.23.9-eks-d-1-23-5-eks-a-v0.0.0-dev-release-0.11-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -2481,7 +2481,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.1-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterController:
         arch:
         - amd64
@@ -2490,9 +2490,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.1-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -2501,7 +2501,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.1-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v0.0.0-dev-release-0.11+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -2609,7 +2609,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       packageController:
         arch:
         - amd64
@@ -2618,7 +2618,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2627,8 +2627,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
-      version: v0.2.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.2.7+abcdef1
     snow:
       components: {}
       kubeVip: {}


### PR DESCRIPTION
This PR fixes the logic of fetching repo tags to list only those that match semver format.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

