### PR TITLE
Remove bundlesRef downgrade validation temporarily

### DIFF
--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -842,33 +842,6 @@ func TestClusterValidateUpdateUnsetBundlesRefImmutable(t *testing.T) {
 	g.Expect(c.ValidateUpdate(cOld)).NotTo(Succeed())
 }
 
-func TestClusterValidateUpdateBundleRefIncreasing(t *testing.T) {
-	cOld := createCluster()
-	c := cOld.DeepCopy()
-	c.Spec.BundlesRef.Name = "bundles-10"
-
-	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(cOld)).To(Succeed())
-}
-
-func TestClusterValidateUpdateBundleRefSetCustomName(t *testing.T) {
-	cOld := createCluster()
-	c := cOld.DeepCopy()
-	c.Spec.BundlesRef.Name = "bundles-custom"
-
-	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(cOld)).To(Succeed())
-}
-
-func TestClusterValidateUpdateBundleRefRollbackInvalid(t *testing.T) {
-	cOld := createCluster()
-	c := cOld.DeepCopy()
-	c.Spec.BundlesRef.Name = "bundles-0"
-
-	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(cOld)).NotTo(Succeed())
-}
-
 func TestClusterValidateUpdateOIDCNameMutableUpdateNameWorkloadCluster(t *testing.T) {
 	cOld := createCluster()
 	cOld.Spec.IdentityProviderRefs = []v1alpha1.Ref{


### PR DESCRIPTION
*Description of changes:*
Dev bundles always have the name 'bundles-1'. Which means that when upgrading from latest prod version, the upgrade gets detected as a downgrade, hence failing. Removing this for now until we make dev bundles naming more consistent with prod.

*Testing (if applicable):*
Building the controller image, pushing to my registry and manually running e2e tests with a custom bundle

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

