### PR TITLE
Improve logging in eks-a e2e test runner

### DIFF
--- a/cmd/integration_test/cmd/run.go
+++ b/cmd/integration_test/cmd/run.go
@@ -107,6 +107,7 @@ func runE2E(ctx context.Context) error {
 		BranchName:             branchName,
 		TestInstanceConfigFile: instanceConfigFile,
 		BaremetalBranchName:    baremetalBranchName,
+		Logger:                 logger.Get(),
 	}
 
 	err := e2e.RunTestsInParallel(runConf)

--- a/internal/pkg/ssm/command.go
+++ b/internal/pkg/ssm/command.go
@@ -8,8 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/go-logr/logr"
 
-	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/retrier"
 )
 
@@ -19,7 +19,7 @@ var initE2EDirCommand = "mkdir -p /home/e2e/bin && cd /home/e2e"
 
 func WaitForSSMReady(session *session.Session, instanceId string) error {
 	err := retrier.Retry(10, 20*time.Second, func() error {
-		return Run(session, instanceId, "ls")
+		return Run(session, logr.Discard(), instanceId, "ls")
 	})
 	if err != nil {
 		return fmt.Errorf("waiting for ssm to be ready: %v", err)
@@ -53,8 +53,8 @@ var nonFinalStatuses = map[string]struct{}{
 	ssm.CommandInvocationStatusInProgress: {}, ssm.CommandInvocationStatusDelayed: {}, ssm.CommandInvocationStatusPending: {},
 }
 
-func Run(session *session.Session, instanceId, command string, opts ...CommandOpt) error {
-	o, err := RunCommand(session, instanceId, command, opts...)
+func Run(session *session.Session, logger logr.Logger, instanceId, command string, opts ...CommandOpt) error {
+	o, err := RunCommand(session, logger, instanceId, command, opts...)
 	if err != nil {
 		return err
 	}
@@ -65,10 +65,10 @@ func Run(session *session.Session, instanceId, command string, opts ...CommandOp
 	return nil
 }
 
-func RunCommand(session *session.Session, instanceId, command string, opts ...CommandOpt) (*RunOutput, error) {
+func RunCommand(session *session.Session, logger logr.Logger, instanceId, command string, opts ...CommandOpt) (*RunOutput, error) {
 	service := ssm.New(session)
 
-	result, err := sendCommand(service, instanceId, command, opts...)
+	result, err := sendCommand(service, logger, instanceId, command, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func RunCommand(session *session.Session, instanceId, command string, opts ...Co
 	}
 
 	// Make sure ssm send command is registered
-	logger.V(2).Info("Waiting for ssm command to be registered")
+	logger.V(4).Info("Waiting for ssm command to be registered")
 	err = retrier.Retry(10, 5*time.Second, func() error {
 		_, err := service.GetCommandInvocation(commandIn)
 		if err != nil {
@@ -92,7 +92,7 @@ func RunCommand(session *session.Session, instanceId, command string, opts ...Co
 		return nil, fmt.Errorf("waiting for ssm command to be registered: %v", err)
 	}
 
-	logger.V(2).Info("Waiting for ssm command to finish")
+	logger.V(4).Info("Waiting for ssm command to finish")
 	var commandOut *ssm.GetCommandInvocationOutput
 	r := retrier.New(300*time.Minute, retrier.WithMaxRetries(2160, 60*time.Second))
 	err = r.Retry(func() error {
@@ -104,7 +104,7 @@ func RunCommand(session *session.Session, instanceId, command string, opts ...Co
 
 		status := *commandOut.Status
 		if isFinalStatus(status) {
-			logger.V(2).Info("SSM command finished", "status", status, "commandId", *result.Command.CommandId)
+			logger.V(4).Info("SSM command finished", "status", status, "commandId", *result.Command.CommandId)
 			return nil
 		}
 
@@ -117,7 +117,7 @@ func RunCommand(session *session.Session, instanceId, command string, opts ...Co
 	return buildRunOutput(commandOut), nil
 }
 
-func sendCommand(service *ssm.SSM, instanceId, command string, opts ...CommandOpt) (*ssm.SendCommandOutput, error) {
+func sendCommand(service *ssm.SSM, logger logr.Logger, instanceId, command string, opts ...CommandOpt) (*ssm.SendCommandOutput, error) {
 	in := &ssm.SendCommandInput{
 		DocumentName: aws.String("AWS-RunShellScript"),
 		InstanceIds:  []*string{aws.String(instanceId)},
@@ -137,7 +137,7 @@ func sendCommand(service *ssm.SSM, instanceId, command string, opts ...CommandOp
 	}))
 	err := r.Retry(func() error {
 		var err error
-		logger.V(2).Info("Running ssm command", "cmd", command)
+		logger.V(4).Info("Running ssm command", "cmd", command)
 		result, err = service.SendCommand(in)
 		if err != nil {
 			return err
@@ -148,7 +148,7 @@ func sendCommand(service *ssm.SSM, instanceId, command string, opts ...CommandOp
 		return nil, fmt.Errorf("retries exhausted sending ssm command: %v", err)
 	}
 
-	logger.V(2).Info("SSM command started", "commandId", result.Command.CommandId)
+	logger.V(4).Info("SSM command started", "commandId", result.Command.CommandId)
 	if in.OutputS3BucketName != nil {
 		logger.V(4).Info(
 			"SSM command output to S3", "url",

--- a/internal/test/e2e/artifacts.go
+++ b/internal/test/e2e/artifacts.go
@@ -4,53 +4,54 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/go-logr/logr"
+
 	"github.com/aws/eks-anywhere/internal/pkg/s3"
 	"github.com/aws/eks-anywhere/internal/pkg/ssm"
-	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
 const e2eHomeFolder = "/home/e2e/"
 
 func (e *E2ESession) uploadGeneratedFilesFromInstance(testName string) {
-	logger.V(1).Info("Uploading log files to s3 bucket")
+	e.logger.V(1).Info("Uploading log files to s3 bucket")
 	command := newCopyCommand().from(
-		e2eHomeFolder, clusterName(e.branchName, e.instanceId, testName),
+		e2eHomeFolder, e.clusterName(e.branchName, e.instanceId, testName),
 	).to(
 		e.generatedArtifactsBucketPath(), testName,
 	).recursive().String()
 
-	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
-		logger.Error(err, "error uploading log files from instance")
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+		e.logger.Error(err, "error uploading log files from instance")
 	} else {
-		logger.V(1).Info("Successfully uploaded log files to S3")
+		e.logger.V(1).Info("Successfully uploaded log files to S3")
 	}
 }
 
 func (e *E2ESession) uploadDiagnosticArchiveFromInstance(testName string) {
 	bundleNameFormat := "support-bundle-*.tar.gz"
-	logger.V(1).Info("Uploading diagnostic bundle to s3 bucket")
+	e.logger.V(1).Info("Uploading diagnostic bundle to s3 bucket")
 	command := newCopyCommand().from(e2eHomeFolder).to(
 		e.generatedArtifactsBucketPath(), testName,
 	).recursive().exclude("*").include(bundleNameFormat).String()
 
-	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
-		logger.Error(err, "error uploading diagnostic bundle from instance")
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+		e.logger.Error(err, "error uploading diagnostic bundle from instance")
 	} else {
-		logger.V(1).Info("Successfully uploaded diagnostic bundle files to S3")
+		e.logger.V(1).Info("Successfully uploaded diagnostic bundle files to S3")
 	}
 }
 
 func (e *E2ESession) uploadJUnitReportFromInstance(testName string) {
 	junitFile := "junit-testing.xml"
-	logger.V(1).Info("Uploading JUnit report to s3 bucket")
+	e.logger.V(1).Info("Uploading JUnit report to s3 bucket")
 	command := newCopyCommand().from(e2eHomeFolder).to(
 		e.generatedArtifactsBucketPath(), testName,
 	).recursive().exclude("*").include(junitFile).String()
 
-	if err := ssm.Run(e.session, e.instanceId, command); err != nil {
-		logger.Error(err, "error uploading JUnit report from instance")
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+		e.logger.Error(err, "error uploading JUnit report from instance")
 	} else {
-		logger.V(1).Info("Successfully uploaded JUnit report files to S3")
+		e.logger.V(1).Info("Successfully uploaded JUnit report files to S3")
 	}
 }
 
@@ -59,9 +60,9 @@ func (e *E2ESession) downloadJUnitReportToLocalDisk(testName, destinationFolder 
 	key := filepath.Join(e.generatedArtifactsPath(), testName, junitFile)
 	dst := filepath.Join(destinationFolder, fmt.Sprintf("junit-testing-%s.xml", testName))
 
-	logger.V(1).Info("Downloading JUnit report to disk", "dst", dst)
+	e.logger.V(1).Info("Downloading JUnit report to disk", "dst", dst)
 	if err := s3.DownloadToDisk(e.session, key, e.storageBucket, dst); err != nil {
-		logger.Error(err, "Error downloading JUnit report from s3")
+		e.logger.Error(err, "Error downloading JUnit report from s3")
 	}
 }
 

--- a/internal/test/e2e/awsiam.go
+++ b/internal/test/e2e/awsiam.go
@@ -4,14 +4,13 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/aws/eks-anywhere/pkg/logger"
 	e2etests "github.com/aws/eks-anywhere/test/framework"
 )
 
 func (e *E2ESession) setupAwsIam(testRegex string) error {
 	re := regexp.MustCompile(`^.*AWSIamAuth.*$`)
 	if !re.MatchString(testRegex) {
-		logger.V(2).Info("Not running AWSIamAuth tests, skipping Env variable setup")
+		e.logger.V(2).Info("Not running AWSIamAuth tests, skipping Env variable setup")
 		return nil
 	}
 

--- a/internal/test/e2e/cloudstack.go
+++ b/internal/test/e2e/cloudstack.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/aws/eks-anywhere/pkg/logger"
 	e2etests "github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -15,7 +14,7 @@ const (
 func (e *E2ESession) setupCloudStackEnv(testRegex string) error {
 	re := regexp.MustCompile(cloudstackRegex)
 	if !re.MatchString(testRegex) {
-		logger.V(2).Info("Not running CloudStack tests, skipping Env variable setup")
+		e.logger.V(2).Info("Not running CloudStack tests, skipping Env variable setup")
 		return nil
 	}
 

--- a/internal/test/e2e/flux.go
+++ b/internal/test/e2e/flux.go
@@ -4,14 +4,13 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/aws/eks-anywhere/pkg/logger"
 	e2etests "github.com/aws/eks-anywhere/test/framework"
 )
 
 func (e *E2ESession) setupFluxEnv(testRegex string) error {
 	re := regexp.MustCompile(`^.*Flux.*$`)
 	if !re.MatchString(testRegex) {
-		logger.V(2).Info("Not running Flux tests, skipping Env variable setup")
+		e.logger.V(2).Info("Not running Flux tests, skipping Env variable setup")
 		return nil
 	}
 

--- a/internal/test/e2e/oidc.go
+++ b/internal/test/e2e/oidc.go
@@ -5,10 +5,11 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/go-logr/logr"
+
 	"github.com/aws/eks-anywhere/internal/pkg/oidc"
 	"github.com/aws/eks-anywhere/internal/pkg/s3"
 	"github.com/aws/eks-anywhere/internal/pkg/ssm"
-	"github.com/aws/eks-anywhere/pkg/logger"
 	e2etests "github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -21,33 +22,33 @@ const (
 func (e *E2ESession) setupOIDC(testRegex string) error {
 	re := regexp.MustCompile(`^.*OIDC.*$`)
 	if !re.MatchString(testRegex) {
-		logger.V(2).Info("Not running OIDC tests, skipping setup")
+		e.logger.V(2).Info("Not running OIDC tests, skipping setup")
 		return nil
 	}
 
-	logger.V(2).Info("Creating OIDC server for the instance.")
+	e.logger.V(2).Info("Creating OIDC server for the instance.")
 
 	folder := fmt.Sprintf("%s/%s", e.jobId, "generated-artifacts")
 	bucketUrl := s3.GetBucketPublicURL(e.session, e.storageBucket)
 	issuerURL := fmt.Sprintf("%s/%s/%s", bucketUrl, folder, "oidc")
 
-	logger.V(1).Info("OIDC test found. Checking if OIDC folder present in bucket")
+	e.logger.V(1).Info("OIDC test found. Checking if OIDC folder present in bucket")
 	oidcPresent, err := s3.ObjectPresent(e.session, filepath.Join(folder, keysPath), e.storageBucket)
 	if err != nil {
 		return fmt.Errorf("checking if oidc is present in bucket: %v", err)
 	}
 
 	if !oidcPresent {
-		logger.V(1).Info("OIDC not present in bucket, creating necessary files")
+		e.logger.V(1).Info("OIDC not present in bucket, creating necessary files")
 		err = e.createOIDCFiles(issuerURL, folder)
 		if err != nil {
 			return err
 		}
 	} else {
-		logger.V(1).Info("OIDC already present in bucket, skipping setup")
+		e.logger.V(1).Info("OIDC already present in bucket, skipping setup")
 	}
 
-	logger.V(1).Info("Getting key id from s3 bucket")
+	e.logger.V(1).Info("Getting key id from s3 bucket")
 	keyID, err := e.getKeyID(folder)
 	if err != nil {
 		return err
@@ -72,21 +73,21 @@ func (e *E2ESession) createOIDCFiles(issuerURL, folder string) error {
 		return fmt.Errorf("setting up generating oidc provider for s3: %v", err)
 	}
 
-	logger.V(2).Info("Uploading OIDC discovery file to S3")
+	e.logger.V(2).Info("Uploading OIDC discovery file to S3")
 	discoveryKey := filepath.Join(folder, openIDConfPath)
 	err = s3.Upload(e.session, provider.Discovery, discoveryKey, e.storageBucket, s3.WithPublicRead())
 	if err != nil {
 		return fmt.Errorf("uploading oidc openid-configuration to s3: %v", err)
 	}
 
-	logger.V(2).Info("Uploading OIDC keys file to S3")
+	e.logger.V(2).Info("Uploading OIDC keys file to S3")
 	keysKey := filepath.Join(folder, keysPath)
 	err = s3.Upload(e.session, provider.Keys, keysKey, e.storageBucket, s3.WithPublicRead())
 	if err != nil {
 		return fmt.Errorf("uploading oidc keys.json to s3: %v", err)
 	}
 
-	logger.V(2).Info("Uploading OIDC signer key to S3")
+	e.logger.V(2).Info("Uploading OIDC signer key to S3")
 	saSignerKey := filepath.Join(folder, saSignerPath)
 	err = s3.Upload(e.session, provider.PrivateKey, saSignerKey, e.storageBucket)
 	if err != nil {
@@ -98,7 +99,7 @@ func (e *E2ESession) createOIDCFiles(issuerURL, folder string) error {
 
 func (e *E2ESession) getKeyID(folder string) (string, error) {
 	keysKey := filepath.Join(folder, keysPath)
-	logger.V(2).Info("Downloading keys.json file from s3")
+	e.logger.V(2).Info("Downloading keys.json file from s3")
 	keysBytes, err := s3.Download(e.session, keysKey, e.storageBucket)
 	if err != nil {
 		return "", fmt.Errorf("downloading keys.json to get kid: %v", err)
@@ -114,13 +115,13 @@ func (e *E2ESession) getKeyID(folder string) (string, error) {
 
 func (e *E2ESession) downloadSignerKeyInInstance(folder string) (pathInInstance string, err error) {
 	saSignerKey := filepath.Join(folder, saSignerPath)
-	logger.V(1).Info("Downloading from s3 in instance", "key", saSignerKey)
+	e.logger.V(1).Info("Downloading from s3 in instance", "key", saSignerKey)
 	command := fmt.Sprintf("aws s3 cp s3://%s/%s ./%s", e.storageBucket, saSignerKey, saSignerPath)
 
-	if err = ssm.Run(e.session, e.instanceId, command); err != nil {
+	if err = ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
 		return "", fmt.Errorf("downloading signer key in instance: %v", err)
 	}
-	logger.V(1).Info("Successfully downloaded signer key")
+	e.logger.V(1).Info("Successfully downloaded signer key")
 
 	return saSignerPath, nil
 }

--- a/internal/test/e2e/proxy.go
+++ b/internal/test/e2e/proxy.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aws/eks-anywhere/pkg/logger"
 	e2etests "github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -19,7 +18,7 @@ var proxyVarsByProvider = map[string]e2etests.ProxyRequiredEnvVars{
 func (e *E2ESession) setupProxyEnv(testRegex string) error {
 	re := regexp.MustCompile(`^.*Proxy.*$`)
 	if !re.MatchString(testRegex) {
-		logger.V(2).Info("Not running Proxy tests, skipping Env variable setup")
+		e.logger.V(2).Info("Not running Proxy tests, skipping Env variable setup")
 		return nil
 	}
 	var requiredEnvVars e2etests.ProxyRequiredEnvVars

--- a/internal/test/e2e/vsphere.go
+++ b/internal/test/e2e/vsphere.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aws/eks-anywhere/pkg/logger"
 	e2etests "github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -19,7 +18,7 @@ const (
 func (e *E2ESession) setupVSphereEnv(testRegex string) error {
 	re := regexp.MustCompile(vsphereRegex)
 	if !re.MatchString(testRegex) {
-		logger.V(2).Info("Not running VSphere tests, skipping Env variable setup")
+		e.logger.V(2).Info("Not running VSphere tests, skipping Env variable setup")
 		return nil
 	}
 


### PR DESCRIPTION
*Description of changes:*

* Don't print output from e2e tests from instance (this is already included in their own logstream)
* Pass a logger to all downstream entities
* Use logger with values in parallel runners
* Avoid noisy debug logs when running SSM commands by using a discard logger
* Unify instance test result log

*Testing (if applicable):*
In only built the binary, so this could break the tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

