### PR TITLE
Add preflight to check port availability on the host for baremetal

### DIFF
--- a/pkg/networkutils/networkutils.go
+++ b/pkg/networkutils/networkutils.go
@@ -43,6 +43,17 @@ func IsIPInUse(client NetClient, ip string) bool {
 	return false
 }
 
+func IsPortInUse(client NetClient, host string, port string) bool {
+	address := net.JoinHostPort(host, port)
+	conn, err := client.DialTimeout("tcp", address, 500*time.Millisecond)
+	if err == nil {
+		conn.Close()
+		return true
+	}
+
+	return false
+}
+
 func GetLocalIP() (net.IP, error) {
 	conn, err := net.Dial("udp", "1.2.3.4:80")
 	if err != nil {

--- a/pkg/networkutils/networkutils_test.go
+++ b/pkg/networkutils/networkutils_test.go
@@ -63,6 +63,33 @@ func TestIsIPInUseFail(t *testing.T) {
 	g.Expect(res).To(gomega.BeTrue())
 }
 
+func TestIsPortInUsePass(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := gomega.NewWithT(t)
+
+	client := mocks.NewMockNetClient(ctrl)
+	client.EXPECT().DialTimeout("tcp", "10.10.10.10:80", 500*time.Millisecond).
+		Return(nil, errors.New("no connection"))
+
+	res := networkutils.IsPortInUse(client, "10.10.10.10", "80")
+	g.Expect(res).To(gomega.BeFalse())
+}
+
+func TestIsPortInUseFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := gomega.NewWithT(t)
+
+	conn := NewMockConn(ctrl)
+	conn.EXPECT().Close().Return(nil)
+
+	client := mocks.NewMockNetClient(ctrl)
+	client.EXPECT().DialTimeout("tcp", "10.10.10.10:80", 500*time.Millisecond).
+		Return(conn, nil)
+
+	res := networkutils.IsPortInUse(client, "10.10.10.10", "80")
+	g.Expect(res).To(gomega.BeTrue())
+}
+
 func TestGetLocalIP(t *testing.T) {
 	_, err := networkutils.GetLocalIP()
 	if err != nil {

--- a/pkg/providers/tinkerbell/assert.go
+++ b/pkg/providers/tinkerbell/assert.go
@@ -119,6 +119,17 @@ func AssertTinkerbellIPAndControlPlaneIPNotSame(spec *ClusterSpec) error {
 	return nil
 }
 
+func AssertPort80IsNotInUse(client networkutils.NetClient) ClusterSpecAssertion {
+	return func(spec *ClusterSpec) error {
+		port := "80"
+		host := "0.0.0.0"
+		if networkutils.IsPortInUse(client, host, port) {
+			return fmt.Errorf("port 80 of host is already in use")
+		}
+		return nil
+	}
+}
+
 // HardwareSatisfiesOnlyOneSelectorAssertion ensures hardware in catalogue only satisfies 1
 // of the MachineConfig's HardwareSelector's from the spec.
 func HardwareSatisfiesOnlyOneSelectorAssertion(catalogue *hardware.Catalogue) ClusterSpecAssertion {

--- a/pkg/providers/tinkerbell/assert.go
+++ b/pkg/providers/tinkerbell/assert.go
@@ -119,12 +119,12 @@ func AssertTinkerbellIPAndControlPlaneIPNotSame(spec *ClusterSpec) error {
 	return nil
 }
 
-func AssertPort80IsNotInUse(client networkutils.NetClient) ClusterSpecAssertion {
+// AssertPortsNotInUse ensures that ports 80, 42113, and 50061 are available
+func AssertPortsNotInUse(client networkutils.NetClient) ClusterSpecAssertion {
 	return func(spec *ClusterSpec) error {
-		port := "80"
 		host := "0.0.0.0"
-		if networkutils.IsPortInUse(client, host, port) {
-			return fmt.Errorf("port 80 of host is already in use")
+		if err := validatePortsAvailable(client, host); err != nil {
+			return err
 		}
 		return nil
 	}

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -142,7 +142,7 @@ func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpe
 		HardwareSatisfiesOnlyOneSelectorAssertion(p.catalogue),
 	)
 
-	clusterSpecValidator.Register(AssertPort80IsNotInUse(p.netClient))
+	clusterSpecValidator.Register(AssertPortsNotInUse(p.netClient))
 
 	if !p.skipIpCheck {
 		clusterSpecValidator.Register(NewIPNotInUseAssertion(p.netClient))

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -142,6 +142,8 @@ func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpe
 		HardwareSatisfiesOnlyOneSelectorAssertion(p.catalogue),
 	)
 
+	clusterSpecValidator.Register(AssertPort80IsNotInUse(p.netClient))
+
 	if !p.skipIpCheck {
 		clusterSpecValidator.Register(NewIPNotInUseAssertion(p.netClient))
 		clusterSpecValidator.Register(AssertTinkerbellIPNotInUse(p.netClient))

--- a/pkg/providers/tinkerbell/validate.go
+++ b/pkg/providers/tinkerbell/validate.go
@@ -125,6 +125,26 @@ func validateIPUnused(client networkutils.NetClient, ip string) error {
 	return nil
 }
 
+func validatePortsAvailable(client networkutils.NetClient, host string) error {
+	unavailablePorts := getPortsUnavailable(client, host)
+
+	if len(unavailablePorts) != 0 {
+		return fmt.Errorf("localhost ports [%v] are already in use, please ensure these ports are available", strings.Join(unavailablePorts, ", "))
+	}
+	return nil
+}
+
+func getPortsUnavailable(client networkutils.NetClient, host string) []string {
+	ports := []string{"80", "42113", "50061"}
+	var unavailablePorts []string
+	for _, port := range ports {
+		if networkutils.IsPortInUse(client, host, port) {
+			unavailablePorts = append(unavailablePorts, port)
+		}
+	}
+	return unavailablePorts
+}
+
 // minimumHardwareRequirement defines the minimum requirement for a hardware selector.
 type minimumHardwareRequirement struct {
 	// MinCount is the minimum number of hardware required to satisfy the requirement


### PR DESCRIPTION
*Issue #, if available:*
#3238 

*Description of changes:*
Added a preflight to ensure ports 80, 42113, and 50061 are not in use for baremetal

*Testing (if applicable):*
Tried creating a cluster and verified:
`❌ Validation failed	{"validation": "tinkerbell Provider setup is valid", "error": "port 42113 of host is already in use, please clean up ports", "remediation": ""}`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

