### PR TITLE
take bundle override into account when generating cluster spec during…

### DIFF
--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -907,9 +907,17 @@ func (e *ClusterE2ETest) clusterConfigGitPath() string {
 }
 
 func (e *ClusterE2ETest) clusterSpecFromGit() (*cluster.Spec, error) {
+	var opts []cluster.SpecOpt
+	if getBundlesOverride() == "true" {
+		// This makes sure that the cluster.Spec uses the same Bundles we pass to the CLI
+		// It avoids the budlesRef getting overwritten with whatever default Bundles the
+		// e2e test build is configured to use
+		opts = append(opts, cluster.WithOverrideBundlesManifest(defaultBundleReleaseManifestFile))
+	}
 	s, err := cluster.NewSpecFromClusterConfig(
 		e.clusterConfigGitPath(),
 		version.Get(),
+		opts...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to build spec from git: %v", err)


### PR DESCRIPTION
… gitops tests

*Issue #, if available:*

*Description of changes:*

Flux tests on the release branch in the staging build were failing. When they were committing changes to the cluster spec in order to test scaling via flux, they were including an erroneous override of the `bundleRef` `name` along with it, which was leading the controller to be unable to reconcile the changes. This is a pass at understanding + fixing that.

My thought on what's happening:

when we create the cluster in these tests, we're using a bundle-override.

so when the cluster spec is created, it passes in an option, [cluster.WithOverrideBundlesManifest](https://github.com/aws/eks-anywhere/blob/05089f61a33fcfa67bc090fba819a0dcb23001cf/cmd/eksctl-anywhere/cmd/options.go#L29) which over-rides the [spec.bundlesManifestUrl](https://github.com/aws/eks-anywhere/blob/5ff9a6c56eff4f27cc5c5cc8c3dc86fbfe8f85d1/pkg/cluster/spec.go#L34) to use the file url 

however, when we are getting the spec for use with GitOps validation, we're invoking [clusterSpecFromGit](https://github.com/aws/eks-anywhere/blob/56b4bdd357b2b0abb5717dccf8f95deb8a08cc39/test/framework/flux.go#L909); like during create, this also uses [NewSpecFromClusterConfig](https://github.com/aws/eks-anywhere/blob/5ff9a6c56eff4f27cc5c5cc8c3dc86fbfe8f85d1/pkg/cluster/spec.go#L171), reading in the cluster config that's committed to the git path.
but it does not pass in the cluster.WithOverrideBundlesManifest option

meaning that the cluster config we get from the invocation of clusterSpecFromGit  has the bundleRef name set to the name of the bundle associated with the CLI version (see [here](https://github.com/aws/eks-anywhere/blob/5ff9a6c56eff4f27cc5c5cc8c3dc86fbfe8f85d1/pkg/cluster/spec.go#L313)) while the spec we read in from Create has the bundleRef name set to the bundle associated with the override and since the override used is the bundles-17, I think, but the latest head for the dev CLI is bundles-1 , we get the bs above

*Testing (if applicable):*

hasn't been tested; needs to be run as part of an e2e test using Flux and a bundle override

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

