### PR TITLE
Add snowballdevice endpoint

### DIFF
--- a/pkg/aws/client_test.go
+++ b/pkg/aws/client_test.go
@@ -26,3 +26,15 @@ func TestLoadConfig(t *testing.T) {
 	_, err := aws.LoadConfig(tt.ctx)
 	tt.Expect(err).To(Succeed())
 }
+
+func TestLoadConfigSnow(t *testing.T) {
+	tt := newAwsTest(t)
+	config, err := aws.LoadConfig(tt.ctx, aws.WithSnowEndpointAccess("1.2.3.4", certificatesFile, credentialsFile))
+	tt.Expect(err).To(Succeed())
+	snowballDeviceEndpoint, err := config.EndpointResolverWithOptions.ResolveEndpoint("Snowball Device", "snow")
+	tt.Expect(snowballDeviceEndpoint.URL).To(Equal("https://1.2.3.4:9092"))
+	tt.Expect(err).To(Succeed())
+	ec2Endpoint, err := config.EndpointResolverWithOptions.ResolveEndpoint("EC2", "snow")
+	tt.Expect(ec2Endpoint.URL).To(Equal("https://1.2.3.4:8243"))
+	tt.Expect(err).To(Succeed())
+}


### PR DESCRIPTION
*Issue #, if available:*

Fix snowballdevice validation errors

```
Post \"https://snowballdevice.snow.amazonaws.com/\": dial tcp: lookup snowballdevice.snow.amazonaws.com on 34.223.14.129:53: no such host
```

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

