### PR TITLE
Apply eksd manifest for each kubernetes version to cluster

### DIFF
--- a/pkg/eksd/installer.go
+++ b/pkg/eksd/installer.go
@@ -41,22 +41,28 @@ func NewEksdInstaller(client EksdInstallerClient, reader Reader) *Installer {
 
 func (i *Installer) InstallEksdCRDs(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster) error {
 	var eksdCRDs []byte
-	if err := i.retrier.Retry(
-		func() error {
-			var readerErr error
-			eksdCRDs, readerErr = i.reader.ReadFile(clusterSpec.VersionsBundle.EksD.Components)
-			return readerErr
-		},
-	); err != nil {
-		return fmt.Errorf("loading manifest for eksd components: %v", err)
+	eksdCrds := map[string]struct{}{}
+	for _, vb := range clusterSpec.Bundles.Spec.VersionsBundles {
+		eksdCrds[vb.EksD.Components] = struct{}{}
 	}
+	for crd := range eksdCrds {
+		if err := i.retrier.Retry(
+			func() error {
+				var readerErr error
+				eksdCRDs, readerErr = i.reader.ReadFile(crd)
+				return readerErr
+			},
+		); err != nil {
+			return fmt.Errorf("loading manifest for eksd components: %v", err)
+		}
 
-	if err := i.retrier.Retry(
-		func() error {
-			return i.client.ApplyKubeSpecFromBytesWithNamespace(ctx, cluster, eksdCRDs, constants.EksaSystemNamespace)
-		},
-	); err != nil {
-		return fmt.Errorf("applying eksd release crd: %v", err)
+		if err := i.retrier.Retry(
+			func() error {
+				return i.client.ApplyKubeSpecFromBytesWithNamespace(ctx, cluster, eksdCRDs, constants.EksaSystemNamespace)
+			},
+		); err != nil {
+			return fmt.Errorf("applying eksd release crd: %v", err)
+		}
 	}
 
 	return nil
@@ -70,23 +76,25 @@ func (i *Installer) SetRetrier(retrier *retrier.Retrier) {
 
 func (i *Installer) InstallEksdManifest(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster) error {
 	var eksdReleaseManifest []byte
-	if err := i.retrier.Retry(
-		func() error {
-			var readerErr error
-			eksdReleaseManifest, readerErr = i.reader.ReadFile(clusterSpec.VersionsBundle.EksD.EksDReleaseUrl)
-			return readerErr
-		},
-	); err != nil {
-		return fmt.Errorf("loading manifest for eksd components: %v", err)
-	}
+	for _, vb := range clusterSpec.Bundles.Spec.VersionsBundles {
+		if err := i.retrier.Retry(
+			func() error {
+				var readerErr error
+				eksdReleaseManifest, readerErr = i.reader.ReadFile(vb.EksD.EksDReleaseUrl)
+				return readerErr
+			},
+		); err != nil {
+			return fmt.Errorf("loading manifest for eksd components: %v", err)
+		}
 
-	logger.V(4).Info("Applying eksd manifest to cluster")
-	if err := i.retrier.Retry(
-		func() error {
-			return i.client.ApplyKubeSpecFromBytesWithNamespace(ctx, cluster, eksdReleaseManifest, constants.EksaSystemNamespace)
-		},
-	); err != nil {
-		return fmt.Errorf("applying eksd release manifest: %v", err)
+		logger.V(4).Info("Applying eksd manifest to cluster")
+		if err := i.retrier.Retry(
+			func() error {
+				return i.client.ApplyKubeSpecFromBytesWithNamespace(ctx, cluster, eksdReleaseManifest, constants.EksaSystemNamespace)
+			},
+		); err != nil {
+			return fmt.Errorf("applying eksd release manifest: %v", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When upgrading a new cluster using the full lifecycle api, we can't upgrade the kubernetes version if it differs from the mgmt cluster version because only the eksd manifest for that version is applied to the cluster. To avoid needing a network connection in the controller, we will apply eks-d versions for all kubernetes versions in the bundle to the mgmt cluster.

*Testing (if applicable):*
Create docker cluster
*Testing with new api now...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

