### PR TITLE
ECR repo name change for Tilt

### DIFF
--- a/manager/README.md
+++ b/manager/README.md
@@ -26,7 +26,7 @@ Create a `tilt-settings.json` file in this folder
   "allowed_contexts": ["yyyyyy@zzzzz"]
 }
 ```
-* `default_registry`: your own registry where you want to push the controller images built by tilt. If using ECR, you will need to create the repository in advance (repo name is `cluster-controller`, same as the var `IMG` in the Tiltfile). You will need to be authenticated and have permissions to push images. Example for ECR:
+* `default_registry`: your own registry where you want to push the controller images built by tilt. If using ECR, you will need to create the repository in advance (repo name is `eks-a-controller-manager`, same as the var `IMG` in the Tiltfile). You will need to be authenticated and have permissions to push images. Example for ECR:
 ```sh
 aws ecr-public get-login-password --region ${REGION} | docker login --username AWS --password-stdin public.ecr.aws/${REGISTRY_ALIAS}
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating based on changes made in #3217 
The IMG is now named `eks-a-controller-manager` so the ECR repo name needs to reflect that. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

