### PR TITLE
Adding quotes for datacenter field

### DIFF
--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -50,7 +50,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{.vsphereDatacenter}}
+      datacenter: '{{.vsphereDatacenter}}'
       datastore: {{.controlPlaneVsphereDatastore}}
       diskGiB: {{.controlPlaneDiskGiB}}
       folder: '{{.controlPlaneVsphereFolder}}'
@@ -514,7 +514,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{.vsphereDatacenter}}
+      datacenter: '{{.vsphereDatacenter}}'
       datastore: {{.etcdVsphereDatastore}}
       diskGiB: {{.etcdDiskGiB}}
       folder: '{{.etcdVsphereFolder}}'

--- a/pkg/providers/vsphere/config/template-md.yaml
+++ b/pkg/providers/vsphere/config/template-md.yaml
@@ -145,7 +145,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{.vsphereDatacenter}}
+      datacenter: '{{.vsphereDatacenter}}'
       datastore: {{.workerVsphereDatastore}}
       diskGiB: {{.workloadDiskGiB}}
       folder: '{{.workerVsphereFolder}}'

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -465,7 +465,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_md.yaml
@@ -73,7 +73,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -464,7 +464,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_md.yaml
@@ -75,7 +75,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -518,7 +518,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_md.yaml
@@ -93,7 +93,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -440,7 +440,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
@@ -44,7 +44,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_controller_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_controller_md.yaml
@@ -68,7 +68,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -438,7 +438,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_md.yaml
@@ -67,7 +67,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -438,7 +438,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -438,7 +438,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -438,7 +438,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -438,7 +438,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_md.yaml
@@ -67,7 +67,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_multiple_worker_node_groups.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_multiple_worker_node_groups.yaml
@@ -70,7 +70,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -159,7 +159,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -438,7 +438,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_md.yaml
@@ -67,7 +67,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -440,7 +440,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_md.yaml
@@ -68,7 +68,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -456,7 +456,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_md.yaml
@@ -70,7 +70,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_add_worker_node_group.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_add_worker_node_group.yaml
@@ -70,7 +70,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -159,7 +159,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -245,7 +245,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_autoscaling_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_autoscaling_md.yaml
@@ -70,7 +70,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
@@ -44,7 +44,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_md.yaml
@@ -67,7 +67,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
@@ -44,7 +44,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -449,7 +449,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_md.yaml
@@ -77,7 +77,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -489,7 +489,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
@@ -99,7 +99,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'
@@ -439,7 +439,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: '/SDDC-Datacenter/vm'

--- a/pkg/providers/vsphere/testdata/original_077.yaml
+++ b/pkg/providers/vsphere/testdata/original_077.yaml
@@ -40,7 +40,7 @@ spec:
         datacenters: SDDC-Datacenter
         thumbprint: ABCDEFG
     workspace:
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       folder: /SDDC-Datacenter/vm
       resourcePool: '*/Resources'
@@ -60,7 +60,7 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: SDDC-Datacenter
+      datacenter: 'SDDC-Datacenter'
       datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
       diskGiB: 25
       folder: /SDDC-Datacenter/vm


### PR DESCRIPTION
*Issue #, if available:* [#3381](https://github.com/aws/eks-anywhere/issues/3381)

*Description of changes:*
Added quotes to the `spec.template.spec.datacenter` value in VSphereMachineTemplate to ensure that the value type is always a string.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

