### PR TITLE
Adding tools to fetch external etcd cluster from EKS-A Controller

### DIFF
--- a/pkg/controller/clusterapi.go
+++ b/pkg/controller/clusterapi.go
@@ -2,7 +2,9 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
+	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -30,6 +32,22 @@ func GetCAPICluster(ctx context.Context, client client.Client, cluster *anywhere
 		return nil, err
 	}
 	return capiCluster, nil
+}
+
+// GetEtcdCluster reads a EtcdadmCluster for an eks-a cluster using a kube client
+// If the EtcdadmCluster is not found, the method returns (nil, nil)
+func GetEtcdCluster(ctx context.Context, client client.Client, cluster *anywherev1.Cluster) (*etcdv1.EtcdadmCluster, error) {
+	etcdClusterName := fmt.Sprintf("%s-etcd", clusterapi.ClusterName(cluster))
+
+	etcdCluster := &etcdv1.EtcdadmCluster{}
+	key := types.NamespacedName{Namespace: constants.EksaSystemNamespace, Name: etcdClusterName}
+
+	err := client.Get(ctx, key, etcdCluster)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+
+	return etcdCluster, err
 }
 
 // CapiClusterObjectKey generates an ObjectKey for the CAPI cluster owned by

--- a/pkg/controller/clusters/clusterapi_test.go
+++ b/pkg/controller/clusters/clusterapi_test.go
@@ -135,6 +135,19 @@ func TestCheckEtcdReadyItIsReady(t *testing.T) {
 	g.Expect(result).To(Equal(controller.Result{}))
 }
 
+func TestCheckEtcdReadyNoEtcdSet(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	eksaCluster := eksaCluster()
+	eksaCluster.Spec.ExternalEtcdConfiguration = nil
+
+	client := fake.NewClientBuilder().WithObjects(eksaCluster).Build()
+
+	result, err := clusters.CheckEtcdReady(ctx, client, test.NewNullLogger(), eksaCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(controller.Result{}))
+}
+
 func TestCheckEtcdReadyNoCluster(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
@@ -172,7 +185,7 @@ func TestCheckEtcdReadyErrorReading(t *testing.T) {
 	// This should make the client fail because CRDs are not registered
 	client := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
 
-	_, err := clusters.CheckControlPlaneReady(ctx, client, test.NewNullLogger(), eksaCluster)
+	_, err := clusters.CheckEtcdReady(ctx, client, test.NewNullLogger(), eksaCluster)
 	g.Expect(err).To(MatchError(ContainSubstring("no kind is registered for the type")))
 }
 

--- a/pkg/controller/clusters/clusterapi_test.go
+++ b/pkg/controller/clusters/clusterapi_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
-
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/2260

*Description of changes:*
This PR adds the functions for the EKS-A controller to reconcile upgrades and consider an external etcd cluster.

*Testing (if applicable):*
Successfully scaled cluster with changes from https://github.com/aws/eks-anywhere/pull/2938, unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

