### PR TITLE
Fix iam auth role upgrades

### DIFF
--- a/controllers/resource/fetcher.go
+++ b/controllers/resource/fetcher.go
@@ -392,6 +392,15 @@ func (r *CapiResourceFetcher) oidcConfig(ctx context.Context, name, namespace st
 	return clusterOIDC, nil
 }
 
+func (r *CapiResourceFetcher) awsIamConfig(ctx context.Context, name, namespace string) (*anywherev1.AWSIamConfig, error) {
+	awsIamConfig := &anywherev1.AWSIamConfig{}
+	err := r.FetchObjectByName(ctx, name, namespace, awsIamConfig)
+	if err != nil {
+		return nil, err
+	}
+	return awsIamConfig, nil
+}
+
 func (r *CapiResourceFetcher) ControlPlane(ctx context.Context, cs *anywherev1.Cluster) (*controlplanev1.KubeadmControlPlane, error) {
 	// Fetch capi cluster
 	capiCluster := &clusterv1.Cluster{}
@@ -437,7 +446,7 @@ func (r *CapiResourceFetcher) OIDCConfig(ctx context.Context, ref *anywherev1.Re
 }
 
 func (r *CapiResourceFetcher) FetchAppliedSpec(ctx context.Context, cs *anywherev1.Cluster) (*cluster.Spec, error) {
-	return cluster.BuildSpecForCluster(ctx, cs, r.bundles, r.eksdRelease, nil, nil, r.oidcConfig)
+	return cluster.BuildSpecForCluster(ctx, cs, r.bundles, r.eksdRelease, nil, nil, r.oidcConfig, r.awsIamConfig)
 }
 
 func (r *CapiResourceFetcher) ExistingVSphereDatacenterConfig(ctx context.Context, cs *anywherev1.Cluster, wnc anywherev1.WorkerNodeGroupConfiguration) (*anywherev1.VSphereDatacenterConfig, error) {

--- a/pkg/cluster/fetch_test.go
+++ b/pkg/cluster/fetch_test.go
@@ -128,6 +128,65 @@ func TestGetFluxConfigForCluster(t *testing.T) {
 	g.Expect(gotFlux).To(Equal(wantFlux))
 }
 
+func TestGetAWSIamConfigForCluster(t *testing.T) {
+	g := NewWithT(t)
+	c := &anywherev1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eksa-cluster",
+			Namespace: "eksa",
+		},
+		Spec: anywherev1.ClusterSpec{
+			IdentityProviderRefs: []anywherev1.Ref{
+				{
+					Kind: anywherev1.AWSIamConfigKind,
+					Name: "eksa-cluster",
+				},
+			},
+		},
+	}
+	wantIamConfig := &anywherev1.AWSIamConfig{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec:       anywherev1.AWSIamConfigSpec{},
+		Status:     anywherev1.AWSIamConfigStatus{},
+	}
+
+	mockFetch := func(ctx context.Context, name, namespace string) (*anywherev1.AWSIamConfig, error) {
+		g.Expect(name).To(Equal(c.Name))
+		g.Expect(namespace).To(Equal(c.Namespace))
+
+		return wantIamConfig, nil
+	}
+
+	gotIamConfig, err := cluster.GetAWSIamConfigForCluster(context.Background(), c, mockFetch)
+	g.Expect(err).To(BeNil())
+	g.Expect(gotIamConfig).To(Equal(wantIamConfig))
+}
+
+func TestGetAWSIamConfigForClusterIsNil(t *testing.T) {
+	g := NewWithT(t)
+	c := &anywherev1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eksa-cluster",
+			Namespace: "eksa",
+		},
+		Spec: anywherev1.ClusterSpec{
+			IdentityProviderRefs: nil,
+		},
+	}
+	var wantIamConfig *anywherev1.AWSIamConfig
+	mockFetch := func(ctx context.Context, name, namespace string) (*anywherev1.AWSIamConfig, error) {
+		g.Expect(name).To(Equal(c.Name))
+		g.Expect(namespace).To(Equal(c.Namespace))
+
+		return wantIamConfig, nil
+	}
+
+	gotIamConfig, err := cluster.GetAWSIamConfigForCluster(context.Background(), c, mockFetch)
+	g.Expect(err).To(BeNil())
+	g.Expect(gotIamConfig).To(Equal(wantIamConfig))
+}
+
 type buildSpecTest struct {
 	*WithT
 	ctx         context.Context

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -146,6 +146,12 @@ func WithOIDCConfig(oidcConfig *eksav1alpha1.OIDCConfig) SpecOpt {
 	}
 }
 
+func WithAWSIamConfig(awsIamConfig *eksav1alpha1.AWSIamConfig) SpecOpt {
+	return func(s *Spec) {
+		s.AWSIamConfig = awsIamConfig
+	}
+}
+
 func NewSpec(opts ...SpecOpt) *Spec {
 	s := &Spec{
 		Config:              &Config{},

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -79,6 +80,7 @@ type ClusterClient interface {
 	GetEksaGitOpsConfig(ctx context.Context, gitOpsConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.GitOpsConfig, error)
 	GetEksaFluxConfig(ctx context.Context, fluxConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.FluxConfig, error)
 	GetEksaOIDCConfig(ctx context.Context, oidcConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.OIDCConfig, error)
+	GetEksaAWSIamConfig(ctx context.Context, awsIamConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.AWSIamConfig, error)
 	DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster) error
 	DeleteGitOpsConfig(ctx context.Context, managementCluster *types.Cluster, gitOpsName, namespace string) error
 	DeleteOIDCConfig(ctx context.Context, managementCluster *types.Cluster, oidcConfigName, oidcConfigNamespace string) error
@@ -506,6 +508,14 @@ func (c *ClusterManager) EKSAClusterSpecChanged(ctx context.Context, cluster *ty
 	if newClusterSpec.OIDCConfig != nil && currentClusterSpec.OIDCConfig != nil {
 		if !newClusterSpec.OIDCConfig.Spec.Equal(&currentClusterSpec.OIDCConfig.Spec) {
 			logger.V(3).Info("OIDC config changes detected")
+			return true, nil
+		}
+	}
+
+	if newClusterSpec.AWSIamConfig != nil && currentClusterSpec.AWSIamConfig != nil {
+		if !reflect.DeepEqual(newClusterSpec.AWSIamConfig.Spec.MapRoles, currentClusterSpec.AWSIamConfig.Spec.MapRoles) ||
+			!reflect.DeepEqual(newClusterSpec.AWSIamConfig.Spec.MapUsers, currentClusterSpec.AWSIamConfig.Spec.MapUsers) {
+			logger.V(3).Info("AWSIamConfig changes detected")
 			return true, nil
 		}
 	}
@@ -1056,7 +1066,7 @@ func (c *ClusterManager) GetCurrentClusterSpec(ctx context.Context, clus *types.
 }
 
 func (c *ClusterManager) buildSpecForCluster(ctx context.Context, clus *types.Cluster, eksaCluster *v1alpha1.Cluster) (*cluster.Spec, error) {
-	return cluster.BuildSpecForCluster(ctx, eksaCluster, c.bundlesFetcher(clus), c.eksdReleaseFetcher(clus), c.gitOpsFetcher(clus), c.fluxConfigFetcher(clus), c.oidcFetcher(clus))
+	return cluster.BuildSpecForCluster(ctx, eksaCluster, c.bundlesFetcher(clus), c.eksdReleaseFetcher(clus), c.gitOpsFetcher(clus), c.fluxConfigFetcher(clus), c.oidcFetcher(clus), c.awsIamConfigFetcher(clus))
 }
 
 func (c *ClusterManager) bundlesFetcher(cluster *types.Cluster) cluster.BundlesFetch {
@@ -1086,6 +1096,12 @@ func (c *ClusterManager) fluxConfigFetcher(cluster *types.Cluster) cluster.FluxC
 func (c *ClusterManager) oidcFetcher(cluster *types.Cluster) cluster.OIDCFetch {
 	return func(ctx context.Context, name, namespace string) (*v1alpha1.OIDCConfig, error) {
 		return c.clusterClient.GetEksaOIDCConfig(ctx, name, cluster.KubeconfigFile, namespace)
+	}
+}
+
+func (c *ClusterManager) awsIamConfigFetcher(cluster *types.Cluster) cluster.AWSIamConfigFetch {
+	return func(ctx context.Context, name, namespace string) (*v1alpha1.AWSIamConfig, error) {
+		return c.clusterClient.GetEksaAWSIamConfig(ctx, name, cluster.KubeconfigFile, namespace)
 	}
 }
 

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -1839,6 +1839,26 @@ func TestClusterManagerClusterSpecChangedGitOpsDefault(t *testing.T) {
 	assert.False(t, diff, "No changes should have been detected")
 }
 
+func TestClusterManagerClusterSpecChangedAWSIamConfigChanged(t *testing.T) {
+	tt := newSpecChangedTest(t)
+	tt.clusterSpec.Cluster.Spec.IdentityProviderRefs = []v1alpha1.Ref{{Kind: v1alpha1.AWSIamConfigKind, Name: tt.clusterName}}
+	tt.clusterSpec.AWSIamConfig = &v1alpha1.AWSIamConfig{}
+	tt.oldClusterConfig = tt.clusterSpec.Cluster.DeepCopy()
+	oldIamConfig := tt.clusterSpec.AWSIamConfig.DeepCopy()
+	tt.clusterSpec.AWSIamConfig = &v1alpha1.AWSIamConfig{Spec: v1alpha1.AWSIamConfigSpec{
+		MapRoles: []v1alpha1.MapRoles{},
+	}}
+
+	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterSpec.Cluster.Name).Return(tt.oldClusterConfig, nil)
+	tt.mocks.client.EXPECT().GetBundles(tt.ctx, tt.cluster.KubeconfigFile, tt.cluster.Name, "").Return(test.Bundles(t), nil)
+	tt.mocks.client.EXPECT().GetEksdRelease(tt.ctx, gomock.Any(), constants.EksaSystemNamespace, gomock.Any())
+	tt.mocks.client.EXPECT().GetEksaAWSIamConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, tt.cluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(oldIamConfig, nil)
+	diff, err := tt.clusterManager.EKSAClusterSpecChanged(tt.ctx, tt.cluster, tt.clusterSpec)
+
+	assert.Nil(t, err, "Error should be nil")
+	assert.True(t, diff, "Changes should have been detected")
+}
+
 type testSetup struct {
 	*WithT
 	clusterManager *clustermanager.ClusterManager

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -260,6 +260,21 @@ func (mr *MockClusterClientMockRecorder) GetClusters(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusters", reflect.TypeOf((*MockClusterClient)(nil).GetClusters), arg0, arg1)
 }
 
+// GetEksaAWSIamConfig mocks base method.
+func (m *MockClusterClient) GetEksaAWSIamConfig(arg0 context.Context, arg1, arg2, arg3 string) (*v1alpha1.AWSIamConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEksaAWSIamConfig", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*v1alpha1.AWSIamConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEksaAWSIamConfig indicates an expected call of GetEksaAWSIamConfig.
+func (mr *MockClusterClientMockRecorder) GetEksaAWSIamConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEksaAWSIamConfig", reflect.TypeOf((*MockClusterClient)(nil).GetEksaAWSIamConfig), arg0, arg1, arg2, arg3)
+}
+
 // GetEksaCloudStackMachineConfig mocks base method.
 func (m *MockClusterClient) GetEksaCloudStackMachineConfig(arg0 context.Context, arg1, arg2, arg3 string) (*v1alpha1.CloudStackMachineConfig, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
*Issue #3390*

*Description of changes:*
Changes enable detection of diff in the cluster config for AWSIamConfig `MapRoles` and `MapUsers` during upgrade.

*Testing:*
```bash
./eksctl-anywhere upgrade cluster -f ./eks-a-cluster.yaml
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

