### PR TITLE
Update the version for audit policy

### DIFF
--- a/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
@@ -171,7 +171,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_availability_zones_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_availability_zones_cp.yaml
@@ -180,7 +180,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
@@ -184,7 +184,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -184,7 +184,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
@@ -183,7 +183,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
@@ -172,7 +172,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_minimal_cp.yaml
@@ -166,7 +166,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_minimal_proxy_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_minimal_proxy_cp.yaml
@@ -166,7 +166,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
@@ -170,7 +170,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -170,7 +170,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/common/config/audit-policy.yaml
+++ b/pkg/providers/common/config/audit-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: audit.k8s.io/v1beta1
+apiVersion: audit.k8s.io/v1
 kind: Policy
 rules:
 # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
@@ -114,7 +114,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
@@ -109,7 +109,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/no_machinetemplate_update_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/no_machinetemplate_update_cp_expected.yaml
@@ -102,7 +102,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
@@ -107,7 +107,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
@@ -108,7 +108,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/valid_deployment_cp_stacked_etcd_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_stacked_etcd_expected.yaml
@@ -102,7 +102,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
@@ -107,7 +107,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
@@ -107,7 +107,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
@@ -107,7 +107,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
@@ -199,7 +199,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
@@ -194,7 +194,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -212,7 +212,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
@@ -176,7 +176,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
@@ -168,7 +168,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
@@ -171,7 +171,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -174,7 +174,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/original_077.yaml
+++ b/pkg/providers/vsphere/testdata/original_077.yaml
@@ -164,7 +164,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:
         # Log aws-auth configmap changes


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`v1beta1` version has been deprecated, so we are updating the version to `v1`

Kubernetes [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#api-change-1) 
``
Kube-apiserver: --audit-log-version and --audit-webhook-version now only support the default value of audit.k8s.io/v1. The v1alpha1 and v1beta1 audit log versions, deprecated since 1.13, have been removed. (https://github.com/kubernetes/kubernetes/pull/108092, [@carlory](https://github.com/carlory))``

*Testing (if applicable):*
- Create cluster using 1.24 and 1.20

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

