### PR TITLE
Add os family validation when performing upgrade for vsphere

### DIFF
--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1295,6 +1295,10 @@ func (p *vsphereProvider) validateMachineConfigImmutability(ctx context.Context,
 		return fmt.Errorf("spec.storagePolicyName is immutable. Previous value %s, new value %s", prevMachineConfig.Spec.StoragePolicyName, newConfig.Spec.StoragePolicyName)
 	}
 
+	if newConfig.Spec.OSFamily != prevMachineConfig.Spec.OSFamily {
+		return fmt.Errorf("spec.osFamily os immutable. Previous value %v, new value %v", prevMachineConfig.Spec.OSFamily, newConfig.Spec.OSFamily)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When looking for whether we validated `OSFamily` changes during upgrade, I noticed that we had it defined in our webhook here but not through the CLI.

https://github.com/aws/eks-anywhere/blob/main/pkg/api/v1alpha1/vspheremachineconfig_webhook.go#L67

When I tested if we can upgrade a cluster from Ubuntu to Bottlerocket, it failed due to some of the values of the mounts that CAPI expects for Bottlerocket being immutable. We don't support this at this moment then, so adding the validation. But this is something that we should consider in the future on how to get users from Ubuntu clusters to Bottlerocket if they prefer.

*Testing (if applicable):*
unit testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

