### PR TITLE
Move docker validation to api level

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -168,7 +168,7 @@ var clusterConfigValidations = []func(*Cluster) error{
 	validateClusterConfigName,
 	// TODO(chrisdoherty) Uncomment and fix unit tests. This broke _lots_ of unit tests so will
 	// return shortly.
-	// validateControlPlaneEndpoint,
+	validateControlPlaneEndpoint,
 	// validateControlPlaneMachineRef,
 	validateControlPlaneReplicas,
 	validateWorkerNodeGroups,
@@ -385,6 +385,13 @@ func validateControlPlaneReplicas(clusterConfig *Cluster) error {
 func validateControlPlaneLabels(clusterConfig *Cluster) error {
 	if err := validateNodeLabels(clusterConfig.Spec.ControlPlaneConfiguration.Labels, field.NewPath("spec", "controlPlaneConfiguration", "labels")); err != nil {
 		return fmt.Errorf("labels for control plane not valid: %v", err)
+	}
+	return nil
+}
+
+func validateControlPlaneEndpoint(clusterConfig *Cluster) error {
+	if clusterConfig.Spec.DatacenterRef.Kind == DockerDatacenterKind && clusterConfig.Spec.ControlPlaneConfiguration.Endpoint != nil && clusterConfig.Spec.ControlPlaneConfiguration.Endpoint.Host != "" {
+		return fmt.Errorf("specifying endpoint host configuration in Cluster is not supported")
 	}
 	return nil
 }

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -872,6 +872,12 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 			wantCluster: nil,
 			wantErr:     true,
 		},
+		{
+			testName:    "docker config with endpoint specified",
+			fileName:    "testdata/cluster_invalid_docker_with_endpoint.yaml",
+			wantCluster: nil,
+			wantErr:     true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {

--- a/pkg/api/v1alpha1/testdata/cluster_invalid_docker_with_endpoint.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_invalid_docker_with_endpoint.yaml
@@ -1,0 +1,37 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  clusterNetwork:
+    cniConfig:
+      cilium: {}
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+    endpoint:
+      host: "test-ip"
+  datacenterRef:
+    kind: DockerDatacenterConfig
+    name: eksa-unit-test
+  externalEtcdConfiguration:
+    count: 1
+  kubernetesVersion: "1.22"
+  managementCluster:
+    name: dev-cluster
+  workerNodeGroupConfigurations:
+    - count: 1
+      name: md-0
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: DockerDatacenterConfig
+metadata:
+  name: eksa-unit-test
+spec: {}
+---

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -124,9 +124,6 @@ func (p *provider) PostMoveManagementToBootstrap(_ context.Context, _ *types.Clu
 
 func (p *provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpec *cluster.Spec) error {
 	logger.Info("Warning: The docker infrastructure provider is meant for local development and testing only")
-	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint != nil && clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host != "" {
-		return fmt.Errorf("specifying endpoint host configuration in Cluster is not supported")
-	}
 	return nil
 }
 

--- a/pkg/providers/docker/docker_test.go
+++ b/pkg/providers/docker/docker_test.go
@@ -3,7 +3,6 @@ package docker_test
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -452,24 +451,6 @@ func TestProviderGenerateDeploymentFileSuccessNotUpdateMachineTemplate(t *testin
 
 	test.AssertContentToFile(t, string(cpContent), "testdata/no_machinetemplate_update_cp_expected.yaml")
 	test.AssertContentToFile(t, string(mdContent), "testdata/no_machinetemplate_update_md_expected.yaml")
-}
-
-func TestSetupAndValidateClusterWithEndpoint(t *testing.T) {
-	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Cluster.Name = "test-cluster"
-		s.Cluster.Spec.ControlPlaneConfiguration.Endpoint = &v1alpha1.Endpoint{Host: "test-ip"}
-	})
-	mockCtrl := gomock.NewController(t)
-	client := dockerMocks.NewMockProviderClient(mockCtrl)
-	kubectl := dockerMocks.NewMockProviderKubectlClient(mockCtrl)
-	p := docker.NewProvider(&v1alpha1.DockerDatacenterConfig{}, client, kubectl, test.FakeNow)
-	ctx := context.Background()
-	err := p.SetupAndValidateCreateCluster(ctx, clusterSpec)
-	wantErr := fmt.Errorf("specifying endpoint host configuration in Cluster is not supported")
-
-	if !reflect.DeepEqual(wantErr, err) {
-		t.Errorf("got = <%v>, want = <%v>", err, wantErr)
-	}
 }
 
 func TestGetInfrastructureBundleSuccess(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Moves docker validation to api level to use both with eksa cli commands & in the controller

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

