### PR TITLE
Pause cluster and datacenter webhook validation during upgrade

### DIFF
--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -366,10 +366,6 @@ func (s *InstallEksaComponentsTask) Run(ctx context.Context, commandContext *tas
 	datacenterConfig := commandContext.Provider.DatacenterConfig(commandContext.ClusterSpec)
 	machineConfigs := commandContext.Provider.MachineConfigs(commandContext.ClusterSpec)
 
-	// this disables create-webhook validation during create
-	commandContext.ClusterSpec.Cluster.PauseReconcile()
-	datacenterConfig.PauseReconcile()
-
 	targetCluster := commandContext.WorkloadCluster
 	if commandContext.BootstrapCluster.ExistingManagement {
 		targetCluster = commandContext.BootstrapCluster


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

During CLI upgrade w controller v2, the `Applying eksa yaml resources to cluster` step failed due to the eksa cluster webhook validation error: `admission.anywhere.amazonaws.com\" denied the request: upgrading self managed clusters is not supported`

We are adding the paused annotation to cluster/datacenterconfig during CLI upgrade, similar to create.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

