### PR TITLE
Add validate session permission for vcenter global role

### DIFF
--- a/docs/content/en/docs/reference/vsphere/vsphere-preparation.md
+++ b/docs/content/en/docs/reference/vsphere/vsphere-preparation.md
@@ -77,6 +77,8 @@ Three roles are needed to be able to create the EKS Anywhere cluster:
    * Edit vSphere Tag Category
    * Modify UsedBy Field For Category
    * Modify UsedBy Field For Tag
+   > Sessions
+   * Validate session
    ```
 1. **Create a user custom role**: The second role is also a custom role that you could call, for example, EKS Anywhere User.
    Define this role with the following objects and children objects. 

--- a/pkg/config/static/globalPrivs.json
+++ b/pkg/config/static/globalPrivs.json
@@ -13,6 +13,7 @@
   "InventoryService.Tagging.ModifyUsedByForCategory",
   "InventoryService.Tagging.ModifyUsedByForTag",
   "InventoryService.Tagging.ObjectAttachable",
+  "Sessions.ValidateSession",
   "System.Anonymous",
   "System.Read",
   "System.View"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
After working with a user on this, we found out that missing the `Sessions.ValidateSession` permission results in the capv caching mechanism for sessions to not work, resulting in new sessions to be created all the time. This results in the session limit being breached if there are a lot of nodes running in the vcenter environment.

Error observed in capv logs:
```
E0921 19:13:06.002439       1 session.go:124] session "msg"="error checking if session is active" "error"="ServerFaultCode: Permission to perform this operation was denied." "datacenter"="Datacenter" "server"="10.61.250.74" 
```

*Testing (if applicable):*
Tested manually creating a cluster and running a create with the validation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

