### PR TITLE
Add vcenter session validate permission analyzer

### DIFF
--- a/pkg/diagnostics/analyzers_test.go
+++ b/pkg/diagnostics/analyzers_test.go
@@ -49,13 +49,15 @@ func TestVsphereDataCenterConfigAnalyzers(t *testing.T) {
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.VSphereDatacenterKind}
 	analyzerFactory := diagnostics.NewAnalyzerFactory()
 	analyzers := analyzerFactory.DataCenterConfigAnalyzers(datacenter)
-	g.Expect(analyzers).To(HaveLen(3), "DataCenterConfigAnalyzers() mismatch between desired analyzers and actual")
+	g.Expect(analyzers).To(HaveLen(4), "DataCenterConfigAnalyzers() mismatch between desired analyzers and actual")
 	g.Expect(analyzers[0].CustomResourceDefinition.CustomResourceDefinitionName).To(Equal("vspheredatacenterconfigs.anywhere.eks.amazonaws.com"),
 		"vSphere generateCrdAnalyzers() mismatch between desired datacenter config group version and actual")
 	g.Expect(analyzers[1].CustomResourceDefinition.CustomResourceDefinitionName).To(Equal("vspheremachineconfigs.anywhere.eks.amazonaws.com"),
 		"vSphere generateCrdAnalyzers() mismatch between desired machine config group version and actual")
 	g.Expect(analyzers[2].TextAnalyze.RegexPattern).To(Equal("exit code: 0"),
-		"controlPlaneIPAnalyzer() mismatch between desired regexPattern and actual")
+		"validControlPlaneIPAnalyzer() mismatch between desired regexPattern and actual")
+	g.Expect(analyzers[3].TextAnalyze.RegexPattern).To(Equal("session \"msg\"=\"error checking if session is active\" \"error\"=\"ServerFaultCode: Permission to perform this operation was denied.\""),
+		"vcenterSessionValidatePermissionAnalyzer() mismatch between desired regexPattern and actual")
 }
 
 func TestDockerDataCenterConfigAnalyzers(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add analyzer for checking `Sessions.ValidateSession` permission global role that was added as part of https://github.com/aws/eks-anywhere/pull/3416

This won't cause the cluster creation to fail if it is missing, but if cluster creation or upgrade fails for any other reason, the analyzer will point this issue out as well.

Also changed an existing analyzer to return a single analyze object instead of an array as it seems like we aren't creating multiple in that method.

*Testing (if applicable):*
make and ran manual cluster creation generating support bundle with and without permission

Success:
```
{
        "name": "log.analysis.session.validate.permission.missing.log.logs.capv.system.capv.controller.manager.log",
        "labels": {
            "desiredPosition": "1",
            "iconKey": "kubernetes_text_analyze",
            "iconUri": "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg"
        },
        "insight": {
            "name": "log.analysis.session.validate.permission.missing.log.logs.capv.system.capv.controller.manager.log",
            "labels": {
                "iconKey": "kubernetes_text_analyze",
                "iconUri": "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg"
            },
            "primary": "log analysis::  Session Validate permission missing. Log: logs/capv-system/capv-controller-manager-*.log",
            "detail": "VCenter user has Sessions.ValidateSession permission.",
            "severity": "debug"
        },
        "severity": "debug",
        "analyzerSpec": ""
    },
```

Failure:
```
{
        "name": "log.analysis.session.validate.permission.missing.log.logs.capv.system.capv.controller.manager.log",
        "labels": {
            "desiredPosition": "1",
            "iconKey": "kubernetes_text_analyze",
            "iconUri": "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg"
        },
        "insight": {
            "name": "log.analysis.session.validate.permission.missing.log.logs.capv.system.capv.controller.manager.log",
            "labels": {
                "iconKey": "kubernetes_text_analyze",
                "iconUri": "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg"
            },
            "primary": "log analysis::  Session Validate permission missing. Log: logs/capv-system/capv-controller-manager-*.log",
            "detail": "VCenter user doesn't have Sessions.ValidateSession permission. See logs/capv-system/capv-controller-manager-*.log",
            "severity": "error"
        },
        "severity": "error",
        "analyzerSpec": "",
        "error": "VCenter user doesn't have Sessions.ValidateSession permission. See logs/capv-system/capv-controller-manager-*.log"
    },
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

