### PR TITLE
Inject vSphere Creds in Controller

### DIFF
--- a/controllers/resource/internal/vsphere.go
+++ b/controllers/resource/internal/vsphere.go
@@ -1,0 +1,43 @@
+package internal
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func GetVSphereCredValues(credSecret *corev1.Secret) (map[string]string, error) {
+	usernameBytes, ok := credSecret.Data["username"]
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve username from secret")
+	}
+	passwordBytes, ok := credSecret.Data["password"]
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve password from secret")
+	}
+	usernameCSIBytes, ok := credSecret.Data["usernameCSI"]
+	if !ok {
+		usernameCSIBytes = usernameBytes
+	}
+	passwordCSIBytes, ok := credSecret.Data["passwordCSI"]
+	if !ok {
+		passwordCSIBytes = passwordBytes
+	}
+	usernameCPBytes, ok := credSecret.Data["usernameCP"]
+	if !ok {
+		usernameCPBytes = usernameBytes
+	}
+	passwordCPBytes, ok := credSecret.Data["passwordCP"]
+	if !ok {
+		passwordCPBytes = passwordBytes
+	}
+
+	values := map[string]string{}
+	values["eksaVsphereUsername"] = string(usernameBytes)
+	values["eksaVspherePassword"] = string(passwordBytes)
+	values["eksaCSIUsername"] = string(usernameCSIBytes)
+	values["eksaCSIPassword"] = string(passwordCSIBytes)
+	values["eksaCloudProviderUsername"] = string(usernameCPBytes)
+	values["eksaCloudProviderPassword"] = string(passwordCPBytes)
+	return values, nil
+}

--- a/controllers/resource/internal/vsphere_test.go
+++ b/controllers/resource/internal/vsphere_test.go
@@ -1,0 +1,78 @@
+package internal_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/eks-anywhere/controllers/resource/internal"
+)
+
+func getSecret() *corev1.Secret {
+	return &corev1.Secret{
+		Data: map[string][]byte{"username": []byte("username"), "password": []byte("password"), "usernameCSI": []byte("usernameCSI"), "passwordCSI": []byte("passwordCSI"), "usernameCP": []byte("usernameCP"), "passwordCP": []byte("passwordCP")},
+	}
+}
+
+func TestGetVSphereCredValues(t *testing.T) {
+	g := NewWithT(t)
+	s := getSecret()
+	values, _ := internal.GetVSphereCredValues(s)
+	g.Expect(values).ToNot(BeNil())
+}
+
+func TestGetVSphereCredValuesError(t *testing.T) {
+	for _, k := range []string{"username", "password"} {
+		t.Run(k, func(t *testing.T) {
+			s := getSecret()
+			delete(s.Data, k)
+			g := NewWithT(t)
+			_, err := internal.GetVSphereCredValues(s)
+			target := fmt.Sprintf("unable to retrieve %s from secret", k)
+			g.Expect(err.Error()).To(BeEquivalentTo(target))
+		})
+	}
+}
+
+func TestGetVSphereCredValuesMissingPassword(t *testing.T) {
+	tests := []struct {
+		defaultField  string
+		secretField   string
+		templateField string
+	}{
+		{
+			defaultField:  "username",
+			secretField:   "usernameCSI",
+			templateField: "eksaCSIUsername",
+		},
+		{
+			defaultField:  "username",
+			secretField:   "usernameCP",
+			templateField: "eksaCloudProviderUsername",
+		},
+		{
+			defaultField:  "password",
+			secretField:   "passwordCSI",
+			templateField: "eksaCSIPassword",
+		},
+		{
+			defaultField:  "password",
+			secretField:   "passwordCP",
+			templateField: "eksaCloudProviderPassword",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.secretField, func(t *testing.T) {
+			s := getSecret()
+			delete(s.Data, tt.secretField)
+			g := NewWithT(t)
+			values, _ := internal.GetVSphereCredValues(s)
+			target, _ := s.Data[tt.defaultField]
+			res, _ := values[tt.templateField]
+			g.Expect(res).To(BeEquivalentTo(target))
+		})
+	}
+}

--- a/controllers/resource/reconciler_test.go
+++ b/controllers/resource/reconciler_test.go
@@ -109,6 +109,12 @@ var nutanixWorkerMachineConfigSpec string
 //go:embed testdata/nutanix/etcdMachineConfig.yaml
 var nutanixEtcdMachineConfigSpec string
 
+func getSecret() *corev1.Secret {
+	return &corev1.Secret{
+		Data: map[string][]byte{"username": []byte("username"), "password": []byte("password"), "usernameCSI": []byte("usernameCSI"), "passwordCSI": []byte("passwordCSI"), "usernameCP": []byte("usernameCP"), "passwordCP": []byte("passwordCP")},
+	}
+}
+
 func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 	type args struct {
 		objectKey types.NamespacedName
@@ -222,9 +228,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 				fetcher.EXPECT().ExistingVSphereEtcdMachineConfig(ctx, gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
 				fetcher.EXPECT().ExistingVSphereWorkerMachineConfig(ctx, gomock.Any(), gomock.Any()).Return(workerNodeMachineConfig, nil)
 				fetcher.EXPECT().ExistingWorkerNodeGroupConfig(ctx, gomock.Any(), gomock.Any()).Return(&anywherev1.WorkerNodeGroupConfiguration{}, nil)
-				fetcher.EXPECT().VSphereCredentials(ctx).Return(&corev1.Secret{
-					Data: map[string][]byte{"username": []byte("username"), "password": []byte("password")},
-				}, nil)
+				fetcher.EXPECT().VSphereCredentials(ctx).Return(getSecret(), nil)
 				fetcher.EXPECT().Fetch(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.NewNotFound(schema.GroupResource{Group: "testgroup", Resource: "testresource"}, ""))
 
 				resourceUpdater.EXPECT().ApplyPatch(ctx, gomock.Any(), false).Return(nil)
@@ -340,9 +344,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 				}
 				fetcher.EXPECT().MachineDeployment(ctx, gomock.Any(), gomock.Any()).Return(machineDeployment, nil)
 
-				fetcher.EXPECT().VSphereCredentials(ctx).Return(&corev1.Secret{
-					Data: map[string][]byte{"username": []byte("username"), "password": []byte("password")},
-				}, nil)
+				fetcher.EXPECT().VSphereCredentials(ctx).Return(getSecret(), nil)
 				fetcher.EXPECT().Fetch(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.NewNotFound(schema.GroupResource{Group: "testgroup", Resource: "testresource"}, ""))
 
 				resourceUpdater.EXPECT().ForceApplyTemplate(ctx, gomock.Any(), gomock.Any()).Do(func(ctx context.Context, template *unstructured.Unstructured, dryRun bool) {
@@ -456,9 +458,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 				fetcher.EXPECT().ExistingVSphereEtcdMachineConfig(ctx, gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
 				fetcher.EXPECT().ExistingVSphereWorkerMachineConfig(ctx, gomock.Any(), gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
 				fetcher.EXPECT().ExistingWorkerNodeGroupConfig(ctx, gomock.Any(), gomock.Any()).Return(existingWorkerNodeGroupConfiguration, nil)
-				fetcher.EXPECT().VSphereCredentials(ctx).Return(&corev1.Secret{
-					Data: map[string][]byte{"username": []byte("username"), "password": []byte("password")},
-				}, nil)
+				fetcher.EXPECT().VSphereCredentials(ctx).Return(getSecret(), nil)
 				fetcher.EXPECT().Fetch(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.NewNotFound(schema.GroupResource{Group: "testgroup", Resource: "testresource"}, ""))
 
 				resourceUpdater.EXPECT().ApplyPatch(ctx, gomock.Any(), false).Return(nil)
@@ -575,9 +575,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 				fetcher.EXPECT().ExistingVSphereEtcdMachineConfig(ctx, gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
 				fetcher.EXPECT().ExistingVSphereWorkerMachineConfig(ctx, gomock.Any(), gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
 				fetcher.EXPECT().ExistingWorkerNodeGroupConfig(ctx, gomock.Any(), gomock.Any()).Return(existingWorkerNodeGroupConfiguration, nil)
-				fetcher.EXPECT().VSphereCredentials(ctx).Return(&corev1.Secret{
-					Data: map[string][]byte{"username": []byte("username"), "password": []byte("password")},
-				}, nil)
+				fetcher.EXPECT().VSphereCredentials(ctx).Return(getSecret(), nil)
 				fetcher.EXPECT().Fetch(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.NewNotFound(schema.GroupResource{Group: "testgroup", Resource: "testresource"}, ""))
 
 				resourceUpdater.EXPECT().ApplyPatch(ctx, gomock.Any(), false).Return(nil)

--- a/controllers/resource/template.go
+++ b/controllers/resource/template.go
@@ -2,7 +2,6 @@ package resource
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
@@ -10,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 
+	"github.com/aws/eks-anywhere/controllers/resource/internal"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/awsiamauth"
 	"github.com/aws/eks-anywhere/pkg/cluster"
@@ -155,13 +155,9 @@ func (r *VsphereTemplate) TemplateResources(ctx context.Context, eksaCluster *an
 	if err != nil {
 		return nil, err
 	}
-	usernameBytes, ok := credSecret.Data["username"]
-	if !ok {
-		return nil, fmt.Errorf("unable to retrieve username from secret")
-	}
-	passwordBytes, ok := credSecret.Data["password"]
-	if !ok {
-		return nil, fmt.Errorf("unable to retrieve password from secret")
+	credValues, err := internal.GetVSphereCredValues(credSecret)
+	if err != nil {
+		return nil, err
 	}
 
 	cpOpt := func(values map[string]interface{}) {
@@ -169,8 +165,9 @@ func (r *VsphereTemplate) TemplateResources(ctx context.Context, eksaCluster *an
 		values["vsphereControlPlaneSshAuthorizedKey"] = sshAuthorizedKey(cpVmc.Spec.Users)
 		values["vsphereEtcdSshAuthorizedKey"] = sshAuthorizedKey(etcdVmc.Spec.Users)
 		values["etcdTemplateName"] = etcdTemplateName
-		values["eksaVsphereUsername"] = string(usernameBytes)
-		values["eksaVspherePassword"] = string(passwordBytes)
+		for k, v := range credValues {
+			values[k] = v
+		}
 	}
 
 	return generateTemplateResources(templateBuilder, clusterSpec, workloadTemplateNames, kubeadmconfigTemplateNames, cpOpt)

--- a/pkg/providers/vsphere/config/secret.yaml
+++ b/pkg/providers/vsphere/config/secret.yaml
@@ -7,6 +7,10 @@ type: kubernetes.io/basic-auth
 data:
   username: {{.vsphereUsername | b64enc}}
   password: {{.vspherePassword | b64enc}}
+  usernameCSI: "{{.eksaCSIUsername | b64enc}}"
+  passwordCSI: "{{.eksaCSIPassword | b64enc}}"
+  usernameCP: "{{.eksaCloudProviderUsername | b64enc}}"
+  passwordCP: "{{.eksaCloudProviderPassword | b64enc}}"
 ---
 apiVersion: v1
 kind: Secret

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1098,14 +1098,19 @@ func (p *vsphereProvider) createSecret(ctx context.Context, cluster *types.Clust
 	if err != nil {
 		return fmt.Errorf("creating secret object template: %v", err)
 	}
+	vuc := config.NewVsphereUserConfig()
 
 	values := map[string]string{
-		"vspherePassword":        os.Getenv(vSpherePasswordKey),
-		"vsphereUsername":        os.Getenv(vSphereUsernameKey),
-		"eksaLicense":            os.Getenv(eksaLicense),
-		"eksaSystemNamespace":    constants.EksaSystemNamespace,
-		"vsphereCredentialsName": constants.VSphereCredentialsName,
-		"eksaLicenseName":        constants.EksaLicenseName,
+		"vspherePassword":           os.Getenv(vSpherePasswordKey),
+		"vsphereUsername":           os.Getenv(vSphereUsernameKey),
+		"eksaCloudProviderUsername": vuc.EksaVsphereCPUsername,
+		"eksaCloudProviderPassword": vuc.EksaVsphereCPPassword,
+		"eksaCSIUsername":           vuc.EksaVsphereCSIUsername,
+		"eksaCSIPassword":           vuc.EksaVsphereCSIPassword,
+		"eksaLicense":               os.Getenv(eksaLicense),
+		"eksaSystemNamespace":       constants.EksaSystemNamespace,
+		"vsphereCredentialsName":    constants.VSphereCredentialsName,
+		"eksaLicenseName":           constants.EksaLicenseName,
 	}
 	err = t.Execute(contents, values)
 	if err != nil {

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -1588,13 +1588,17 @@ func TestProviderBootstrapSetup(t *testing.T) {
 		KubeconfigFile: "",
 	}
 	values := map[string]string{
-		"clusterName":       clusterConfig.Name,
-		"vspherePassword":   expectedVSphereUsername,
-		"vsphereUsername":   expectedVSpherePassword,
-		"vsphereServer":     datacenterConfig.Spec.Server,
-		"vsphereDatacenter": datacenterConfig.Spec.Datacenter,
-		"vsphereNetwork":    datacenterConfig.Spec.Network,
-		"eksaLicense":       "",
+		"clusterName":               clusterConfig.Name,
+		"vspherePassword":           expectedVSphereUsername,
+		"vsphereUsername":           expectedVSpherePassword,
+		"eksaCSIUsername":           expectedVSphereUsername,
+		"eksaCSIPassword":           expectedVSpherePassword,
+		"eksaCloudProviderUsername": expectedVSphereUsername,
+		"eksaCloudProviderPassword": expectedVSpherePassword,
+		"vsphereServer":             datacenterConfig.Spec.Server,
+		"vsphereDatacenter":         datacenterConfig.Spec.Datacenter,
+		"vsphereNetwork":            datacenterConfig.Spec.Network,
+		"eksaLicense":               "",
 	}
 
 	var tctx testContext
@@ -1629,10 +1633,15 @@ func TestProviderUpdateSecretSuccess(t *testing.T) {
 		KubeconfigFile: "",
 	}
 	values := map[string]string{
-		"vspherePassword":     expectedVSphereUsername,
-		"vsphereUsername":     expectedVSpherePassword,
-		"eksaLicense":         "",
-		"eksaSystemNamespace": constants.EksaSystemNamespace,
+		"clusterName":               clusterConfig.Name,
+		"vspherePassword":           expectedVSphereUsername,
+		"vsphereUsername":           expectedVSpherePassword,
+		"eksaCSIUsername":           expectedVSphereUsername,
+		"eksaCSIPassword":           expectedVSpherePassword,
+		"eksaCloudProviderUsername": expectedVSphereUsername,
+		"eksaCloudProviderPassword": expectedVSpherePassword,
+		"eksaLicense":               "",
+		"eksaSystemNamespace":       constants.EksaSystemNamespace,
 	}
 
 	var tctx testContext


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/3404

*Description of changes:*
The EKSA Controller didn't have necessary vsphere credentials. As a result, when it reconciled eksa-system:csi-vsphere-config it deleted the username and password.

*Testing (if applicable):*
How I tested:

* create:
    * create cluster on main
* upgrade:
    * create cluster on v0.11.1
    * upgrade on release-0.11 with my changes on top of it. Secret `eksa-system:vsphere-credentials` was correctly updated.
    * ran old controller while upgrading. `eksa-system:vsphere-credentials` was unaffected but controller continued to did still overwrite csi-vsphere-config secret
    * ran new controller after upgrade and csi-vsphere-config reconciled correctly with appropriately populated config information derived from `eksa-system:vsphere-credentials` 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.