### PR TITLE
Remove Tink CLI image from assets list

### DIFF
--- a/release/pkg/assets/config/bundle_release.go
+++ b/release/pkg/assets/config/bundle_release.go
@@ -757,9 +757,6 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 		ProjectPath: "projects/tinkerbell/tink",
 		Images: []*assettypes.Image{
 			{
-				RepoName: "tink-cli",
-			},
-			{
 				RepoName: "tink-controller",
 			},
 			{

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -105,26 +105,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:9875b3f624186dce140de81ebf1823bb1a2f7e285710026a6aee0c9a2f83a131
+        imageDigest: sha256:4a778c1df3ad766771e951bfb451d4ec81cef8b1516c04a9d82ee61258e1ea86
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:v1.11.8-eksa.1
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:6690b2b07f949e0a97145703777d59e10c0ce740e4a17a46776ba14ee0073dc5
+        imageDigest: sha256:ee2450e71d015f6e2d88d37ddb13bf9e77a56311cf34fb7260ef0bce6c1698ef
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:1.11.8-eksa.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.10.14-eksa.1/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.11.8-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:4b26d2bf579c2efcfc6633546960270d8d544352923ce328fa218718b3412a40
+        imageDigest: sha256:36befe05f9cafac9a7f3c7dee047c18c250d0dd8bebed7eff8592b0083e12412
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.10.14-eksa.1
-      version: v1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/operator-generic:v1.11.8-eksa.1
+      version: v1.11.8-eksa.1
     cloudStack:
       clusterAPIController:
         arch:
@@ -262,7 +262,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.1/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -297,7 +297,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.3-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -306,9 +306,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.3-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.3/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -317,7 +317,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.3-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -447,7 +447,7 @@ spec:
       version: v0.2.7+abcdef1
     snow:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.7/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -465,10 +465,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.7-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/metadata.yaml
-      version: v0.1.6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.7/metadata.yaml
+      version: v0.1.7+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -681,7 +681,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.4-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.5-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -842,26 +842,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:9875b3f624186dce140de81ebf1823bb1a2f7e285710026a6aee0c9a2f83a131
+        imageDigest: sha256:4a778c1df3ad766771e951bfb451d4ec81cef8b1516c04a9d82ee61258e1ea86
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:v1.11.8-eksa.1
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:6690b2b07f949e0a97145703777d59e10c0ce740e4a17a46776ba14ee0073dc5
+        imageDigest: sha256:ee2450e71d015f6e2d88d37ddb13bf9e77a56311cf34fb7260ef0bce6c1698ef
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:1.11.8-eksa.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.10.14-eksa.1/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.11.8-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:4b26d2bf579c2efcfc6633546960270d8d544352923ce328fa218718b3412a40
+        imageDigest: sha256:36befe05f9cafac9a7f3c7dee047c18c250d0dd8bebed7eff8592b0083e12412
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.10.14-eksa.1
-      version: v1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/operator-generic:v1.11.8-eksa.1
+      version: v1.11.8-eksa.1
     cloudStack:
       clusterAPIController:
         arch:
@@ -999,7 +999,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.1/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -1043,7 +1043,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.3-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -1052,9 +1052,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.3-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.3/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1063,7 +1063,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.3-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -1193,7 +1193,7 @@ spec:
       version: v0.2.7+abcdef1
     snow:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.7/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -1211,10 +1211,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.7-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/metadata.yaml
-      version: v0.1.6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.7/metadata.yaml
+      version: v0.1.7+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -1427,7 +1427,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.4-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.5-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -1588,26 +1588,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:9875b3f624186dce140de81ebf1823bb1a2f7e285710026a6aee0c9a2f83a131
+        imageDigest: sha256:4a778c1df3ad766771e951bfb451d4ec81cef8b1516c04a9d82ee61258e1ea86
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:v1.11.8-eksa.1
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:6690b2b07f949e0a97145703777d59e10c0ce740e4a17a46776ba14ee0073dc5
+        imageDigest: sha256:ee2450e71d015f6e2d88d37ddb13bf9e77a56311cf34fb7260ef0bce6c1698ef
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:1.11.8-eksa.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.10.14-eksa.1/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.11.8-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:4b26d2bf579c2efcfc6633546960270d8d544352923ce328fa218718b3412a40
+        imageDigest: sha256:36befe05f9cafac9a7f3c7dee047c18c250d0dd8bebed7eff8592b0083e12412
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.10.14-eksa.1
-      version: v1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/operator-generic:v1.11.8-eksa.1
+      version: v1.11.8-eksa.1
     cloudStack:
       clusterAPIController:
         arch:
@@ -1745,7 +1745,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.1/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -1789,7 +1789,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.3-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -1798,9 +1798,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.3-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.3/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1809,7 +1809,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.3-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -1939,7 +1939,7 @@ spec:
       version: v0.2.7+abcdef1
     snow:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.7/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -1957,10 +1957,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.7-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/metadata.yaml
-      version: v0.1.6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.7/metadata.yaml
+      version: v0.1.7+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -2173,7 +2173,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.4-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.5-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -2334,26 +2334,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:9875b3f624186dce140de81ebf1823bb1a2f7e285710026a6aee0c9a2f83a131
+        imageDigest: sha256:4a778c1df3ad766771e951bfb451d4ec81cef8b1516c04a9d82ee61258e1ea86
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:v1.11.8-eksa.1
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:6690b2b07f949e0a97145703777d59e10c0ce740e4a17a46776ba14ee0073dc5
+        imageDigest: sha256:ee2450e71d015f6e2d88d37ddb13bf9e77a56311cf34fb7260ef0bce6c1698ef
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:1.11.8-eksa.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.10.14-eksa.1/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.11.8-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:4b26d2bf579c2efcfc6633546960270d8d544352923ce328fa218718b3412a40
+        imageDigest: sha256:36befe05f9cafac9a7f3c7dee047c18c250d0dd8bebed7eff8592b0083e12412
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.10.14-eksa.1
-      version: v1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/operator-generic:v1.11.8-eksa.1
+      version: v1.11.8-eksa.1
     cloudStack:
       clusterAPIController:
         arch:
@@ -2491,7 +2491,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.1/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -2535,7 +2535,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.3-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -2544,9 +2544,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.3-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.3/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -2555,7 +2555,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.3-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -2685,7 +2685,7 @@ spec:
       version: v0.2.7+abcdef1
     snow:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.7/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2703,10 +2703,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.7-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/metadata.yaml
-      version: v0.1.6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.7/metadata.yaml
+      version: v0.1.7+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -2919,7 +2919,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.4-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.5-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -3080,26 +3080,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:9875b3f624186dce140de81ebf1823bb1a2f7e285710026a6aee0c9a2f83a131
+        imageDigest: sha256:4a778c1df3ad766771e951bfb451d4ec81cef8b1516c04a9d82ee61258e1ea86
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:v1.11.8-eksa.1
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:6690b2b07f949e0a97145703777d59e10c0ce740e4a17a46776ba14ee0073dc5
+        imageDigest: sha256:ee2450e71d015f6e2d88d37ddb13bf9e77a56311cf34fb7260ef0bce6c1698ef
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:1.11.8-eksa.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.10.14-eksa.1/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.11.8-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:4b26d2bf579c2efcfc6633546960270d8d544352923ce328fa218718b3412a40
+        imageDigest: sha256:36befe05f9cafac9a7f3c7dee047c18c250d0dd8bebed7eff8592b0083e12412
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.10.14-eksa.1
-      version: v1.10.14-eksa.1
+        uri: public.ecr.aws/isovalent/operator-generic:v1.11.8-eksa.1
+      version: v1.11.8-eksa.1
     cloudStack:
       clusterAPIController:
         arch:
@@ -3237,7 +3237,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.1/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -3263,7 +3263,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.3-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -3272,9 +3272,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.3-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.11.3/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -3283,7 +3283,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.3-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -3413,7 +3413,7 @@ spec:
       version: v0.2.7+abcdef1
     snow:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.7/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -3431,10 +3431,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.7-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.6/metadata.yaml
-      version: v0.1.6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.7/metadata.yaml
+      version: v0.1.7+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -3647,7 +3647,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.4-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.5-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:

--- a/release/pkg/test/testdata/release-0.11-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.11-bundle-release.yaml
@@ -297,7 +297,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.3-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterController:
         arch:
         - amd64
@@ -306,9 +306,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.3-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.3/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -317,7 +317,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.3-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v0.0.0-dev-release-0.11+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -425,7 +425,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       packageController:
         arch:
         - amd64
@@ -434,7 +434,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -443,8 +443,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
-      version: v0.2.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.2.7+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -1025,7 +1025,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.3-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterController:
         arch:
         - amd64
@@ -1034,9 +1034,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.3-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.3/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1045,7 +1045,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.3-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v0.0.0-dev-release-0.11+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -1153,7 +1153,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       packageController:
         arch:
         - amd64
@@ -1162,7 +1162,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1171,8 +1171,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
-      version: v0.2.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.2.7+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -1753,7 +1753,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.3-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterController:
         arch:
         - amd64
@@ -1762,9 +1762,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.3-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.3/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1773,7 +1773,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.3-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v0.0.0-dev-release-0.11+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -1881,7 +1881,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       packageController:
         arch:
         - amd64
@@ -1890,7 +1890,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1899,8 +1899,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
-      version: v0.2.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.2.7+abcdef1
     snow:
       components: {}
       kubeVip: {}
@@ -2481,7 +2481,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.11.3-eks-a-v0.0.0-dev-release-0.11-build.1
       clusterController:
         arch:
         - amd64
@@ -2490,9 +2490,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.11.3-eks-a-v0.0.0-dev-release-0.11-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.11-build.0/eks-anywhere/manifests/cluster-controller/v0.11.3/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -2501,7 +2501,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.11.3-eks-a-v0.0.0-dev-release-0.11-build.1
       version: v0.0.0-dev-release-0.11+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -2609,7 +2609,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       packageController:
         arch:
         - amd64
@@ -2618,7 +2618,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2627,8 +2627,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.2-eks-a-v0.0.0-dev-release-0.11-build.1
-      version: v0.2.2+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-release-0.11-build.1
+      version: v0.2.7+abcdef1
     snow:
       components: {}
       kubeVip: {}


### PR DESCRIPTION
Removing tink CLI that was originally removed in #2540 but re-added to assets list during the release refactor #1161.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

