### PR TITLE
Remove redundant copyright notices

### DIFF
--- a/cmd/eksctl-anywhere/cmd/downloadimages.go
+++ b/cmd/eksctl-anywhere/cmd/downloadimages.go
@@ -1,7 +1,3 @@
-/*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
-
-*/
 package cmd
 
 import (

--- a/cmd/eksctl-anywhere/cmd/import.go
+++ b/cmd/eksctl-anywhere/cmd/import.go
@@ -1,7 +1,3 @@
-/*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
-
-*/
 package cmd
 
 import (

--- a/cmd/eksctl-anywhere/cmd/import_images.go
+++ b/cmd/eksctl-anywhere/cmd/import_images.go
@@ -1,7 +1,3 @@
-/*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
-
-*/
 package cmd
 
 import (


### PR DESCRIPTION
Remove redundant copyright notices in cmd files. These notices keep getting edited by IDEs as they have unnecessary newline characters but the notices are redundant anyway.