### PR TITLE
(docs)Makefile: update the default CP E2E test name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ capd-test-%: e2e ## Run CAPD tests
 	./bin/e2e.test -test.v -test.run TestDockerKubernetes$*SimpleFlow
 
 
-PACKAGES_E2E_TESTS ?= TestVSphereKubernetes121PackagesInstallSimpleFlow
+PACKAGES_E2E_TESTS ?= TestCPackagesDockerUbuntuKubernetes121SimpleFlow
 ifeq ($(PACKAGES_E2E_TESTS),all)
 PACKAGES_E2E_TESTS='TestCPackages.*'
 endif


### PR DESCRIPTION
All curated packages e2e tests have been renamed to start with "TestCPackages" for convenience. Plus changing this to a docker test will make it easier to potentially run on presubmit as part of docker-e2e-test.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

