### PR TITLE
Add snow analyzers and collectors in support bundle

### DIFF
--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -159,6 +159,8 @@ func (a *analyzerFactory) DataCenterConfigAnalyzers(datacenter v1alpha1.Ref) []*
 		return a.eksaDockerAnalyzers()
 	case v1alpha1.CloudStackDatacenterKind:
 		return a.eksaCloudstackAnalyzers()
+	case v1alpha1.SnowDatacenterKind:
+		return a.eksaSnowAnalyzers()
 	default:
 		return nil
 	}
@@ -181,6 +183,15 @@ func (a *analyzerFactory) eksaCloudstackAnalyzers() []*Analyze {
 		fmt.Sprintf("cloudstackmachineconfigs.%s", v1alpha1.GroupVersion.Group),
 	}
 	return a.generateCrdAnalyzers(crds)
+}
+
+func (a *analyzerFactory) eksaSnowAnalyzers() []*Analyze {
+	crds := []string{
+		fmt.Sprintf("snowdatacenterconfigs.%s", v1alpha1.GroupVersion.Group),
+		fmt.Sprintf("snowmachineconfigs.%s", v1alpha1.GroupVersion.Group),
+	}
+	analyzers := a.generateCrdAnalyzers(crds)
+	return append(analyzers, a.validControlPlaneIPAnalyzer())
 }
 
 func (a *analyzerFactory) eksaDockerAnalyzers() []*Analyze {

--- a/pkg/diagnostics/analyzers_test.go
+++ b/pkg/diagnostics/analyzers_test.go
@@ -75,3 +75,11 @@ func TestCloudStackDataCenterConfigAnalyzers(t *testing.T) {
 	analyzers := analyzerFactory.DataCenterConfigAnalyzers(datacenter)
 	g.Expect(analyzers).To(HaveLen(2), "DataCenterConfigAnalyzers() mismatch between desired analyzers and actual")
 }
+
+func TestSnowAnalyzers(t *testing.T) {
+	g := NewGomegaWithT(t)
+	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.SnowDatacenterKind}
+	analyzerFactory := diagnostics.NewAnalyzerFactory()
+	analyzers := analyzerFactory.DataCenterConfigAnalyzers(datacenter)
+	g.Expect(analyzers).To(HaveLen(3), "DataCenterConfigAnalyzers() mismatch between desired analyzers and actual")
+}

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
@@ -72,9 +72,23 @@ func (c *collectorFactory) DataCenterConfigCollectors(datacenter v1alpha1.Ref, s
 		return c.eksaCloudstackCollectors()
 	case v1alpha1.TinkerbellDatacenterKind:
 		return c.eksaTinkerbellCollectors()
+	case v1alpha1.SnowDatacenterKind:
+		return c.eksaSnowCollectors()
 	default:
 		return nil
 	}
+}
+
+func (c *collectorFactory) eksaSnowCollectors() []*Collect {
+	snowLogs := []*Collect{
+		{
+			Logs: &logs{
+				Namespace: constants.CapasSystemNamespace,
+				Name:      logpath(constants.CapasSystemNamespace),
+			},
+		},
+	}
+	return append(snowLogs, c.snowCrdCollectors()...)
 }
 
 func (c *collectorFactory) eksaTinkerbellCollectors() []*Collect {
@@ -288,6 +302,17 @@ func (c *collectorFactory) managementClusterCrdCollectors() []*Collect {
 		"kubeadmcontrolplane.controlplane.cluster.x-k8s.io",
 	}
 	return c.generateCrdCollectors(mgmtCrds)
+}
+
+func (c *collectorFactory) snowCrdCollectors() []*Collect {
+	capasCrds := []string{
+		"awssnowclusters.infrastructure.cluster.x-k8s.io",
+		"awssnowmachines.infrastructure.cluster.x-k8s.io",
+		"awssnowmachinetemplates.infrastructure.cluster.x-k8s.io",
+		"snowdatacenterconfigs.anywhere.eks.amazonaws.com",
+		"snowmachineconfigs.anywhere.eks.amazonaws.com",
+	}
+	return c.generateCrdCollectors(capasCrds)
 }
 
 func (c *collectorFactory) tinkerbellCrdCollectors() []*Collect {

--- a/pkg/diagnostics/collectors_test.go
+++ b/pkg/diagnostics/collectors_test.go
@@ -93,3 +93,18 @@ func TestTinkerbellDataCenterConfigCollectors(t *testing.T) {
 		g.Expect("eksa-diagnostics").To(Equal(collector.RunPod.Namespace))
 	}
 }
+
+func TestSnowCollectors(t *testing.T) {
+	g := NewGomegaWithT(t)
+	spec := test.NewClusterSpec(func(s *cluster.Spec) {})
+	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.SnowDatacenterKind}
+	factory := diagnostics.NewDefaultCollectorFactory()
+	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
+	g.Expect(collectors).To(HaveLen(6), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
+	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapasSystemNamespace))
+	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CapasSystemNamespace)))
+	for _, collector := range collectors[1:] {
+		g.Expect([]string{"kubectl"}).To(Equal(collector.RunPod.PodSpec.Containers[0].Command))
+		g.Expect("eksa-diagnostics").To(Equal(collector.RunPod.Namespace))
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add snow crd, controller analyzers and collectors in the support bundle.

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

