### PR TITLE
Add generic yaml parser for Kubernetes manifests

### DIFF
--- a/pkg/yamlutil/apiobject.go
+++ b/pkg/yamlutil/apiobject.go
@@ -1,0 +1,39 @@
+package yamlutil
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// APIObject represents a kubernetes API object
+type APIObject interface {
+	runtime.Object
+	GetName() string
+}
+
+// ObjectLookup allows to search APIObjects by a unique key composed of apiVersion, kind, and name
+type ObjectLookup map[string]APIObject
+
+// GetFromRef searches in a ObjectLookup for an APIObject referenced by a corev1.ObjectReference
+func (o ObjectLookup) GetFromRef(ref corev1.ObjectReference) APIObject {
+	return o[keyForRef(ref)]
+}
+
+func (o ObjectLookup) add(obj APIObject) {
+	o[keyForObject(obj)] = obj
+}
+
+func keyForRef(ref corev1.ObjectReference) string {
+	return key(ref.APIVersion, ref.Kind, ref.Name)
+}
+
+func key(apiVersion, kind, name string) string {
+	// this assumes we don't allow to have objects in multiple namespaces
+	return fmt.Sprintf("%s%s%s", apiVersion, kind, name)
+}
+
+func keyForObject(o APIObject) string {
+	return key(o.GetObjectKind().GroupVersionKind().GroupVersion().String(), o.GetObjectKind().GroupVersionKind().Kind, o.GetName())
+}

--- a/pkg/yamlutil/apiobject_test.go
+++ b/pkg/yamlutil/apiobject_test.go
@@ -1,0 +1,43 @@
+package yamlutil
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestObjectLookupGetFromRef(t *testing.T) {
+	g := NewWithT(t)
+	o := ObjectLookup{}
+	want := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "eksa-system",
+			Name:      "my-secret",
+		},
+		Data: map[string][]byte{
+			"username": []byte("test"),
+			"password": []byte("test"),
+		},
+	}
+	objRef := corev1.ObjectReference{
+		Kind:       want.Kind,
+		APIVersion: want.APIVersion,
+		Name:       want.Name,
+		Namespace:  want.Namespace,
+	}
+
+	o.add(want)
+
+	otherSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "eksa-system",
+			Name:      "my-other-secret",
+		},
+	}
+	o.add(otherSecret)
+
+	got := o.GetFromRef(objRef)
+	g.Expect(got).To(Equal(want))
+}

--- a/pkg/yamlutil/parser.go
+++ b/pkg/yamlutil/parser.go
@@ -1,0 +1,167 @@
+package yamlutil
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
+)
+
+type (
+	// APIObjectGenerator returns an implementor of the APIObject interface
+	APIObjectGenerator func() APIObject
+	// ParsedProcessor fills the struct of type T with the parsed API objects in ObjectLookup
+	ParsedProcessor[T any] func(*T, ObjectLookup)
+
+	// Parser allows to parse from yaml with kubernetes style objects and
+	// store them in a type implementing Builder
+	// It allows to dynamically register configuration for mappings between kind and concrete types
+	Parser struct {
+		apiObjectMapping map[string]APIObjectGenerator
+		logger           logr.Logger
+	}
+)
+
+func NewParser(logger logr.Logger) *Parser {
+	return &Parser{
+		apiObjectMapping: make(map[string]APIObjectGenerator),
+		logger:           logger,
+	}
+}
+
+// RegisterMapping records the mapping between a kubernetes Kind and an API concrete type
+func (c *Parser) RegisterMapping(kind string, generator APIObjectGenerator) error {
+	if _, ok := c.apiObjectMapping[kind]; ok {
+		return errors.Errorf("mapping for api object %s already registered", kind)
+	}
+
+	c.apiObjectMapping[kind] = generator
+	return nil
+}
+
+// Mapping mapping between a kubernetes Kind and an API concrete type of type T
+type Mapping[T APIObject] struct {
+	New  func() T
+	Kind string
+}
+
+func NewMapping[T APIObject](kind string, new func() T) Mapping[T] {
+	return Mapping[T]{
+		Kind: kind,
+		New:  new,
+	}
+}
+
+// ToAPIObjectMapping is helper to convert from other concrete types of Mapping
+// to a APIObject Mapping
+// This is mostly to help pass Mappings to RegisterMappings
+func (m Mapping[T]) ToAPIObjectMapping() Mapping[APIObject] {
+	return Mapping[APIObject]{
+		Kind: m.Kind,
+		New: func() APIObject {
+			return m.New()
+		},
+	}
+}
+
+// RegisterMappings records a collection of mappings
+func (c *Parser) RegisterMappings(mappings ...Mapping[APIObject]) error {
+	for _, m := range mappings {
+		if err := c.RegisterMapping(m.Kind, m.New); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Builder processes the parsed API objects contained in a lookup
+type Builder interface {
+	BuildFromParsed(ObjectLookup) error
+}
+
+// Parse reads yaml manifest content with the registered mappings and passes
+// the result to the Builder for further processing
+func (p *Parser) Parse(yamlManifest []byte, b Builder) error {
+	return p.Read(bytes.NewReader(yamlManifest), b)
+}
+
+// Read reads yaml manifest content with the registered mappings and passes
+// the result to the Builder for further processing
+func (p *Parser) Read(reader io.Reader, b Builder) error {
+	parsed, err := p.unmarshal(reader)
+	if err != nil {
+		return err
+	}
+
+	return p.buildConfigFromParsed(parsed, b)
+}
+
+type basicAPIObject struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+func (k *basicAPIObject) empty() bool {
+	return k.APIVersion == "" && k.Kind == ""
+}
+
+type parsed struct {
+	objects ObjectLookup
+}
+
+func (p *Parser) unmarshal(reader io.Reader) (*parsed, error) {
+	parsed := &parsed{
+		objects: ObjectLookup{},
+	}
+
+	yamlReader := apiyaml.NewYAMLReader(bufio.NewReader(reader))
+	for {
+		// Read one YAML document at a time, until io.EOF is returned
+		b, err := yamlReader.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, errors.Wrap(err, "failed to read yaml")
+		}
+		if len(b) == 0 {
+			break
+		}
+
+		k := &basicAPIObject{}
+		if err = yaml.Unmarshal(b, k); err != nil {
+			return nil, errors.Wrap(err, "invalid yaml kubernetes object")
+		}
+
+		// Ignore empty objects.
+		// Empty objects are generated if there are weird things in manifest files like e.g. two --- in a row without a yaml doc in the middle
+		if k.empty() {
+			continue
+		}
+
+		var obj APIObject
+		if generateApiObj, ok := p.apiObjectMapping[k.Kind]; ok {
+			obj = generateApiObj()
+		} else {
+			p.logger.V(2).Info("Ignoring object in yaml of unknown type during parsing", "kind", k.Kind)
+			continue
+		}
+
+		if err := yaml.Unmarshal(b, obj); err != nil {
+			return nil, errors.Wrapf(err, "invalid yaml for %s", k.Kind)
+		}
+		parsed.objects.add(obj)
+	}
+
+	return parsed, nil
+}
+
+func (p *Parser) buildConfigFromParsed(parsed *parsed, b Builder) error {
+	return b.BuildFromParsed(parsed.objects)
+}

--- a/pkg/yamlutil/parser_test.go
+++ b/pkg/yamlutil/parser_test.go
@@ -1,0 +1,178 @@
+package yamlutil_test
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/yamlutil"
+)
+
+type yamlHolder struct {
+	configMap *corev1.ConfigMap
+	secret    *corev1.Secret
+}
+
+func (h *yamlHolder) BuildFromParsed(l yamlutil.ObjectLookup) error {
+	processConfigMap(h, l)
+	processSecret(h, l)
+
+	return nil
+}
+
+func processConfigMap(h *yamlHolder, lookup yamlutil.ObjectLookup) {
+	for _, obj := range lookup {
+		if obj.GetObjectKind().GroupVersionKind().Kind == "ConfigMap" {
+			h.configMap = obj.(*corev1.ConfigMap)
+		}
+	}
+}
+
+func processSecret(h *yamlHolder, lookup yamlutil.ObjectLookup) {
+	for _, obj := range lookup {
+		if obj.GetObjectKind().GroupVersionKind().Kind == "Secret" {
+			h.secret = obj.(*corev1.Secret)
+		}
+	}
+}
+
+func TestParserParse(t *testing.T) {
+	g := NewWithT(t)
+	yaml := `
+apiVersion: v1
+data:
+  Corefile: "d"
+kind: ConfigMap
+metadata:
+  name: aws-iam-authenticator 
+  namespace: kube-system
+  uid: 4aa825d5-4334-4ce0-a754-0d3a3cceaefd
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-iam-authenticator 
+  namespace: kube-system
+data:
+  password: QWRtaW4=
+  username: YWRtaW4=
+`
+	parser := yamlutil.NewParser(test.NewNullLogger())
+	g.Expect(
+		parser.RegisterMappings(
+			yamlutil.NewMapping("Secret", func() yamlutil.APIObject {
+				return &corev1.Secret{}
+			}),
+			yamlutil.NewMapping("ConfigMap", func() yamlutil.APIObject {
+				return &corev1.ConfigMap{}
+			}),
+		),
+	).To(Succeed())
+
+	holder := &yamlHolder{}
+
+	g.Expect(parser.Parse([]byte(yaml), holder)).To(Succeed())
+	g.Expect(holder).NotTo(BeNil())
+	g.Expect(holder.configMap.Data).To(HaveKeyWithValue("Corefile", "d"))
+	g.Expect(holder.secret.Data["username"]).To(Equal([]byte("admin")))
+}
+
+type reader struct {
+	read int
+	err  error
+}
+
+func (r reader) Read(p []byte) (n int, err error) {
+	return r.read, r.err
+}
+
+func TestParserReadReaderError(t *testing.T) {
+	g := NewWithT(t)
+	parser := yamlutil.NewParser(test.NewNullLogger())
+	holder := &yamlHolder{}
+	r := reader{
+		err: errors.New("failed from fake reader"),
+	}
+	g.Expect(parser.Read(r, holder)).To(MatchError(ContainSubstring("failed from fake reader")))
+}
+
+func TestParserParseEmptyContent(t *testing.T) {
+	g := NewWithT(t)
+	parser := yamlutil.NewParser(test.NewNullLogger())
+	holder := &yamlHolder{}
+	g.Expect(parser.Parse([]byte("---"), holder)).NotTo(HaveOccurred())
+}
+
+func TestParserParseInvalidKubernetesYaml(t *testing.T) {
+	g := NewWithT(t)
+	parser := yamlutil.NewParser(test.NewNullLogger())
+	holder := &yamlHolder{}
+
+	g.Expect(parser.Parse([]byte("1}"), holder)).To(MatchError(ContainSubstring(
+		"invalid yaml kubernetes object",
+	)))
+}
+
+func TestParserParseInvalidRegisterObjectYaml(t *testing.T) {
+	g := NewWithT(t)
+	parser := yamlutil.NewParser(test.NewNullLogger())
+	holder := &yamlHolder{}
+	g.Expect(
+		parser.RegisterMappings(
+			yamlutil.NewMapping("Secret", func() yamlutil.APIObject {
+				return &corev1.Secret{}
+			}),
+		),
+	).To(Succeed())
+
+	g.Expect(parser.Parse([]byte("kind: Secret\ndata: 111"), holder)).To(MatchError(ContainSubstring(
+		"invalid yaml for Secret",
+	)))
+}
+
+func TestParserParseUnregisteredObject(t *testing.T) {
+	g := NewWithT(t)
+	parser := yamlutil.NewParser(test.NewNullLogger())
+	holder := &yamlHolder{}
+	g.Expect(parser.Parse([]byte("kind: Secret"), holder)).NotTo(HaveOccurred())
+}
+
+func TestParserRegisterMappingDuplicateError(t *testing.T) {
+	g := NewWithT(t)
+	parser := yamlutil.NewParser(test.NewNullLogger())
+	g.Expect(parser.RegisterMapping("Secret", func() yamlutil.APIObject {
+		return &corev1.Secret{}
+	})).To(Succeed())
+	g.Expect(parser.RegisterMapping("Secret", func() yamlutil.APIObject {
+		return &corev1.ConfigMap{}
+	})).To(MatchError(ContainSubstring("mapping for api object Secret already registered")))
+}
+
+func TestMappingToAPIObjectMapping(t *testing.T) {
+	g := NewWithT(t)
+	mapping := yamlutil.NewMapping("Secret", func() *corev1.Secret {
+		return &corev1.Secret{}
+	})
+	apiObjectMapping := mapping.ToAPIObjectMapping()
+	g.Expect(apiObjectMapping.Kind).To(Equal("Secret"))
+	secret := apiObjectMapping.New()
+	g.Expect(secret).To(BeAssignableToTypeOf(&corev1.Secret{}))
+}
+
+func TestParserRegisterMappingsError(t *testing.T) {
+	g := NewWithT(t)
+	parser := yamlutil.NewParser(test.NewNullLogger())
+	g.Expect(
+		parser.RegisterMappings(
+			yamlutil.NewMapping("Secret", func() yamlutil.APIObject {
+				return &corev1.Secret{}
+			}),
+			yamlutil.NewMapping("Secret", func() yamlutil.APIObject {
+				return &corev1.ConfigMap{}
+			}),
+		),
+	).To(MatchError(ContainSubstring("mapping for api object Secret already registered")))
+}


### PR DESCRIPTION
*Description of changes:*
This uses the same mechanism and the config manager to parse a kubernetes yaml manifest, allowing to dynamically register logic to fill a particular type with the parsed API structs.

This will be used to parse CAPI manifests generated by our providers (using go templates). The generated structs will be used from the full cluster cluster lifecycle controller.

Ref: https://github.com/aws/eks-anywhere/pull/3432

*Testing (if applicable):*
Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

