### PR TITLE
Remove test re-added due to rebase

### DIFF
--- a/test/e2e/curated_packages_test.go
+++ b/test/e2e/curated_packages_test.go
@@ -161,15 +161,6 @@ func GetLatestBundleFromCluster(test *framework.ClusterE2ETest) (string, error) 
 	return strings.Trim(bundle, "'"), nil
 }
 
-func TestPackagesInstallSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(t, framework.NewDocker(t),
-		framework.WithPackageConfig(t, EksaPackageBundleURI, EksaPackageControllerHelmChartName,
-			EksaPackageControllerHelmURI, EksaPackageControllerHelmVersion,
-			EksaPackageControllerHelmValues),
-	)
-	runCuratedPackageInstallSimpleFlow(test) // other args as necessary
-}
-
 // packageBundleURI uses a KubernetesVersion argument to complete a package
 // bundle URI by adding the approprate tag.
 func packageBundleURI(version v1alpha1.KubernetesVersion) string {


### PR DESCRIPTION
The test was previously deleted in https://github.com/aws/eks-anywhere/pull/2801/files#diff-e04741f3b0c5b687abeb91625437530ddf182779c1b1b5fa4df95b9c59717c5eL28
Rebase brought it back by mistake.