### PR TITLE
refactor(CLI): Use the new kubeconfig functions in CP CLI commands

### DIFF
--- a/cmd/eksctl-anywhere/cmd/applypackages.go
+++ b/cmd/eksctl-anywhere/cmd/applypackages.go
@@ -50,7 +50,7 @@ var applyPackagesCommand = &cobra.Command{
 }
 
 func applyPackages(ctx context.Context) error {
-	kubeConfig, err := kubeconfig.ValidateFileOrEnv(apo.kubeConfig)
+	kubeConfig, err := kubeconfig.ResolveAndValidateFilename(apo.kubeConfig, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/createpackages.go
+++ b/cmd/eksctl-anywhere/cmd/createpackages.go
@@ -50,7 +50,7 @@ var createPackagesCommand = &cobra.Command{
 }
 
 func createPackages(ctx context.Context) error {
-	kubeConfig, err := kubeconfig.ValidateFileOrEnv(cpo.kubeConfig)
+	kubeConfig, err := kubeconfig.ResolveAndValidateFilename(cpo.kubeConfig, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -69,7 +69,7 @@ func (dc *deleteClusterOptions) validate(ctx context.Context, args []string) err
 	}
 
 	kubeconfigPath := getKubeconfigPath(clusterConfig.Name, dc.wConfig)
-	if err := kubeconfig.ValidateFile(kubeconfigPath); err != nil {
+	if err := kubeconfig.ValidateFilename(kubeconfigPath); err != nil {
 		return err
 	}
 

--- a/cmd/eksctl-anywhere/cmd/deletepackages.go
+++ b/cmd/eksctl-anywhere/cmd/deletepackages.go
@@ -39,7 +39,7 @@ var deletePackageCommand = &cobra.Command{
 }
 
 func deleteResources(ctx context.Context, args []string) error {
-	kubeConfig, err := kubeconfig.ValidateFileOrEnv(delPkgOpts.kubeConfig)
+	kubeConfig, err := kubeconfig.ResolveAndValidateFilename(delPkgOpts.kubeConfig, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/describepackages.go
+++ b/cmd/eksctl-anywhere/cmd/describepackages.go
@@ -40,7 +40,7 @@ var describePackagesCommand = &cobra.Command{
 }
 
 func describeResources(ctx context.Context, args []string) error {
-	kubeConfig, err := kubeconfig.ValidateFileOrEnv(dpo.kubeConfig)
+	kubeConfig, err := kubeconfig.ResolveAndValidateFilename(dpo.kubeConfig, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/getpackage.go
+++ b/cmd/eksctl-anywhere/cmd/getpackage.go
@@ -32,7 +32,7 @@ var getPackageCommand = &cobra.Command{
 	PreRunE:      preRunPackages,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		kubeConfig, err := kubeconfig.ValidateFileOrEnv(gpo.kubeConfig)
+		kubeConfig, err := kubeconfig.ResolveAndValidateFilename(gpo.kubeConfig, "")
 		if err != nil {
 			return err
 		}

--- a/cmd/eksctl-anywhere/cmd/getpackagebundle.go
+++ b/cmd/eksctl-anywhere/cmd/getpackagebundle.go
@@ -32,7 +32,7 @@ var getPackageBundleCommand = &cobra.Command{
 	PreRunE:      preRunPackages,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		kubeConfig, err := kubeconfig.ValidateFileOrEnv(gpbo.kubeConfig)
+		kubeConfig, err := kubeconfig.ResolveAndValidateFilename(gpbo.kubeConfig, "")
 		if err != nil {
 			return err
 		}

--- a/cmd/eksctl-anywhere/cmd/getpackagebundlecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/getpackagebundlecontroller.go
@@ -32,7 +32,7 @@ var getPackageBundleControllerCommand = &cobra.Command{
 	PreRunE:      preRunPackages,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		kubeConfig, err := kubeconfig.ValidateFileOrEnv(gpbco.kubeConfig)
+		kubeConfig, err := kubeconfig.ResolveAndValidateFilename(gpbco.kubeConfig, "")
 		if err != nil {
 			return err
 		}

--- a/cmd/eksctl-anywhere/cmd/installpackages.go
+++ b/cmd/eksctl-anywhere/cmd/installpackages.go
@@ -68,7 +68,7 @@ func runInstallPackages(cmd *cobra.Command, args []string) error {
 }
 
 func installPackages(ctx context.Context, args []string) error {
-	kubeConfig, err := kubeconfig.ValidateFileOrEnv(ipo.kubeConfig)
+	kubeConfig, err := kubeconfig.ResolveAndValidateFilename(ipo.kubeConfig, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/listpackages.go
+++ b/cmd/eksctl-anywhere/cmd/listpackages.go
@@ -57,7 +57,7 @@ var listPackagesCommand = &cobra.Command{
 }
 
 func listPackages(ctx context.Context) error {
-	kubeConfig, err := kubeconfig.ValidateFileOrEnv(lpo.kubeConfig)
+	kubeConfig, err := kubeconfig.ResolveAndValidateFilename(lpo.kubeConfig, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -65,7 +65,7 @@ func (csbo *createSupportBundleOptions) validate(ctx context.Context) error {
 	}
 
 	kubeconfigPath := kubeconfig.FromClusterName(clusterConfig.Name)
-	if err := kubeconfig.ValidateFile(kubeconfigPath); err != nil {
+	if err := kubeconfig.ValidateFilename(kubeconfigPath); err != nil {
 		return err
 	}
 

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -154,7 +154,7 @@ func (uc *upgradeClusterOptions) commonValidations(ctx context.Context) (cluster
 	}
 
 	kubeconfigPath := getKubeconfigPath(clusterConfig.Name, uc.wConfig)
-	if err := kubeconfig.ValidateFile(kubeconfigPath); err != nil {
+	if err := kubeconfig.ValidateFilename(kubeconfigPath); err != nil {
 		return nil, err
 	}
 

--- a/cmd/eksctl-anywhere/cmd/upgradepackages.go
+++ b/cmd/eksctl-anywhere/cmd/upgradepackages.go
@@ -48,7 +48,7 @@ var upgradePackagesCommand = &cobra.Command{
 }
 
 func upgradePackages(ctx context.Context) error {
-	kubeConfig, err := kubeconfig.ValidateFileOrEnv(upo.kubeConfig)
+	kubeConfig, err := kubeconfig.ResolveAndValidateFilename(upo.kubeConfig, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Refactors the curated packages CLI commands to use the new functions introduced in ac5db7f. The non curated packages commands were not refactored, because I'm not 100% sure it's safe to do so. I'll leave that exercise for a later PR.

This helps simplify our k8s go client creation for CP CLI commands, which will be coming in a follow-up commit.