### PR TITLE
Fix Go tests

### DIFF
--- a/pkg/curatedpackages/packageclient_test.go
+++ b/pkg/curatedpackages/packageclient_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -95,7 +96,11 @@ func TestInstallPackagesSucceeds(t *testing.T) {
 	packages := []string{"harbor-test"}
 	tt.command = curatedpackages.NewPackageClient(tt.kubectl, curatedpackages.WithBundle(tt.bundle), curatedpackages.WithCustomPackages(packages))
 
+	// Suppress output temporarily since it is not needed for testing
+	temp := os.Stdout
+	os.Stdout = nil // turn it off
 	err := tt.command.InstallPackage(tt.ctx, &tt.bundle.Spec.Packages[0], "my-harbor", "")
+	os.Stdout = temp // restore it
 	tt.Expect(err).To(BeNil())
 }
 


### PR DESCRIPTION
*Description of changes:*
Suppresses output generated from fmt.Println during tests.
*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

