### PR TITLE
refactor: Replace errors.As with errors.Is

### DIFF
--- a/pkg/git/gitclient/gitclient.go
+++ b/pkg/git/gitclient/gitclient.go
@@ -222,7 +222,7 @@ func (g *GitClient) Branch(name string) error {
 	}
 
 	err = g.Client.CreateBranch(r, branchOpts)
-	branchExistsLocally := errors.As(err, &gogit.ErrBranchExists)
+	branchExistsLocally := errors.Is(err, gogit.ErrBranchExists)
 
 	if err != nil && !branchExistsLocally {
 		return fmt.Errorf("creating branch %s: %v", name, err)
@@ -417,7 +417,7 @@ func (gg *goGit) CreateBranch(repo *gogit.Repository, config *config.Branch) err
 func (gg *goGit) ListRemotes(r *gogit.Repository, auth transport.AuthMethod) ([]*plumbing.Reference, error) {
 	remote, err := r.Remote(gogit.DefaultRemoteName)
 	if err != nil {
-		if errors.As(err, &gogit.ErrRemoteNotFound) {
+		if errors.Is(err, gogit.ErrRemoteNotFound) {
 			return []*plumbing.Reference{}, nil
 		}
 		return nil, err


### PR DESCRIPTION
In some cases, errors.As was being used instead of errors.Is. The primary difference being that errors.As alters the target error. This can make for awkward error initializations, but also costs a bit of time to process.

More to the point, tests were failing with specific versions of go (namely 1.19).

Docs:

https://pkg.go.dev/errors#As

https://pkg.go.dev/errors#Is

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

