### PR TITLE
Fixing unintended rollingupgrade from older clusters related to diskoffering

### DIFF
--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
@@ -15,7 +15,6 @@
 package v1alpha1
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -94,8 +93,8 @@ func (r *CloudStackResourceDiskOffering) Equal(o *CloudStackResourceDiskOffering
 // was initially added to the CloudStackMachineConfig type, it was added with omitempty at the top level, but
 // the subtypes were *not* optional, so we have old clusters today with "empty" CloudStackResourceDiskOffering objects,
 // like {CustomSize: 0, MountPath: "", Label: "", Device: "", FileSystem: ""}.
-// Since then, we have made DiskOffering a pointer, and everything below it as optional. Functionally, setting DiskOffering=nil
-// is equivalent to have an "empty" DiskOffering as shown above. Introducing this check should help prevent unintended RollingUpgrades
+// Since then, we have made DiskOffering an optional pointer, with everything inside it as optional. Functionally, setting DiskOffering=nil
+// is equivalent to having an "empty" DiskOffering as shown above. Introducing this check should help prevent unintended RollingUpgrades
 // when upgrading a cluster which has this "empty" DiskOffering in it.
 func (r *CloudStackResourceDiskOffering) IsEmpty() bool {
 	if r == nil {

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
@@ -15,6 +15,7 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -69,7 +70,10 @@ func (r *CloudStackResourceDiskOffering) Equal(o *CloudStackResourceDiskOffering
 	if r == o {
 		return true
 	}
-	if r == nil || o == nil {
+	if r.IsEmpty() && o.IsEmpty() {
+		return true
+	}
+	if r.IsEmpty() || o.IsEmpty() {
 		return false
 	}
 	if r.Id != o.Id {
@@ -84,6 +88,21 @@ func (r *CloudStackResourceDiskOffering) Equal(o *CloudStackResourceDiskOffering
 		return false
 	}
 	return r.Id == "" && o.Id == "" && r.Name == o.Name
+}
+
+// IsEmpty Introduced for backwards compatibility purposes. When CloudStackResourceDiskOffering
+// was initially added to the CloudStackMachineConfig type, it was added with omitempty at the top level, but
+// the subtypes were *not* optional, so we have old clusters today with "empty" CloudStackResourceDiskOffering objects,
+// like {CustomSize: 0, MountPath: "", Label: "", Device: "", FileSystem: ""}.
+// Since then, we have made DiskOffering a pointer, and everything below it as optional. Functionally, setting DiskOffering=nil
+// is equivalent to have an "empty" DiskOffering as shown above. Introducing this check should help prevent unintended RollingUpgrades
+// when upgrading a cluster which has this "empty" DiskOffering in it.
+func (r *CloudStackResourceDiskOffering) IsEmpty() bool {
+	if r == nil {
+		return true
+	}
+	return r.Id == "" && r.Name == "" && r.Label == "" && r.Device == "" &&
+		r.Filesystem == "" && r.MountPath == "" && r.CustomSize == 0
 }
 
 func (r *CloudStackResourceDiskOffering) Validate() (err error, field string, value string) {

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types_test.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types_test.go
@@ -32,7 +32,7 @@ func TestCloudStackMachineConfigDiskOfferingEqual(t *testing.T) {
 	g.Expect(diskOffering1.Equal(diskOffering2)).To(BeTrue())
 }
 
-func TestCloudStackMachineConfigEmptyDiskOfferingEqual(t *testing.T) {
+func TestCloudStackMachineConfigNilDiskOfferingEqual(t *testing.T) {
 	var nilDiskOffering *v1alpha1.CloudStackResourceDiskOffering
 	emptyDiskOffering := &v1alpha1.CloudStackResourceDiskOffering{
 		MountPath:  "",
@@ -42,6 +42,18 @@ func TestCloudStackMachineConfigEmptyDiskOfferingEqual(t *testing.T) {
 	}
 	g := NewWithT(t)
 	g.Expect(nilDiskOffering.Equal(emptyDiskOffering)).To(BeTrue())
+}
+
+func TestCloudStackMachineConfigEmptyDiskOfferingEqual(t *testing.T) {
+	emptyDiskOffering1 := v1alpha1.CloudStackResourceDiskOffering{}
+	emptyDiskOffering2 := &v1alpha1.CloudStackResourceDiskOffering{
+		MountPath:  "",
+		Device:     "",
+		Filesystem: "",
+		Label:      "",
+	}
+	g := NewWithT(t)
+	g.Expect(emptyDiskOffering1.Equal(emptyDiskOffering2)).To(BeTrue())
 }
 
 func TestCloudStackMachineConfigDiskOfferingEqualSelf(t *testing.T) {

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types_test.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types_test.go
@@ -32,6 +32,18 @@ func TestCloudStackMachineConfigDiskOfferingEqual(t *testing.T) {
 	g.Expect(diskOffering1.Equal(diskOffering2)).To(BeTrue())
 }
 
+func TestCloudStackMachineConfigEmptyDiskOfferingEqual(t *testing.T) {
+	var nilDiskOffering v1alpha1.CloudStackResourceDiskOffering
+	emptyDiskOffering := &v1alpha1.CloudStackResourceDiskOffering{
+		MountPath:  "",
+		Device:     "",
+		Filesystem: "",
+		Label:      "",
+	}
+	g := NewWithT(t)
+	g.Expect(nilDiskOffering.Equal(emptyDiskOffering)).To(BeTrue())
+}
+
 func TestCloudStackMachineConfigDiskOfferingEqualSelf(t *testing.T) {
 	diskOffering1 := &v1alpha1.CloudStackResourceDiskOffering{
 		CloudStackResourceIdentifier: v1alpha1.CloudStackResourceIdentifier{

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types_test.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types_test.go
@@ -33,7 +33,7 @@ func TestCloudStackMachineConfigDiskOfferingEqual(t *testing.T) {
 }
 
 func TestCloudStackMachineConfigEmptyDiskOfferingEqual(t *testing.T) {
-	var nilDiskOffering v1alpha1.CloudStackResourceDiskOffering
+	var nilDiskOffering *v1alpha1.CloudStackResourceDiskOffering
 	emptyDiskOffering := &v1alpha1.CloudStackResourceDiskOffering{
 		MountPath:  "",
 		Device:     "",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As described in the comment below, clusters created with older versions of eks-a will have an empty diskoffering included on the CloudStackMachineConfig, like

```
  diskOffering:
    mountPath: ""
    filesystem: ""
    label: ""
    device: ""
```

However, we have since made this field into a pointer and optional, so new versions of eks-a expect an unset diskoffering to have 
```
  diskOffering: nil
```

This resulted in unintended rollingupgrades taking place where the eks-a controller would think there's a [difference between the diskofferings in old and new](https://github.com/aws/eks-anywhere/blob/main/pkg/providers/cloudstack/cloudstack.go#L608), and create a new CloudStackMachineTemplate. This change serves to align the two definitions to make them equivalent and prevent the rollingupgrade from taking place.

*Testing (if applicable):*
Unit test added, and e2e test succeeds where cluster is created with EKS-A 11.1 and empty diskoffering, then upgraded to EKS-A 11.3, still with empty diskoffering.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

