### PR TITLE
Inject CSI and CP vSphere Creds (#3424)

### DIFF
--- a/controllers/resource/internal/vsphere.go
+++ b/controllers/resource/internal/vsphere.go
@@ -1,0 +1,43 @@
+package internal
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func GetVSphereCredValues(credSecret *corev1.Secret) (map[string]string, error) {
+	usernameBytes, ok := credSecret.Data["username"]
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve username from secret")
+	}
+	passwordBytes, ok := credSecret.Data["password"]
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve password from secret")
+	}
+	usernameCSIBytes, ok := credSecret.Data["usernameCSI"]
+	if !ok {
+		usernameCSIBytes = usernameBytes
+	}
+	passwordCSIBytes, ok := credSecret.Data["passwordCSI"]
+	if !ok {
+		passwordCSIBytes = passwordBytes
+	}
+	usernameCPBytes, ok := credSecret.Data["usernameCP"]
+	if !ok {
+		usernameCPBytes = usernameBytes
+	}
+	passwordCPBytes, ok := credSecret.Data["passwordCP"]
+	if !ok {
+		passwordCPBytes = passwordBytes
+	}
+
+	values := map[string]string{}
+	values["eksaVsphereUsername"] = string(usernameBytes)
+	values["eksaVspherePassword"] = string(passwordBytes)
+	values["eksaCSIUsername"] = string(usernameCSIBytes)
+	values["eksaCSIPassword"] = string(passwordCSIBytes)
+	values["eksaCloudProviderUsername"] = string(usernameCPBytes)
+	values["eksaCloudProviderPassword"] = string(passwordCPBytes)
+	return values, nil
+}

--- a/controllers/resource/internal/vsphere_test.go
+++ b/controllers/resource/internal/vsphere_test.go
@@ -1,0 +1,78 @@
+package internal_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/eks-anywhere/controllers/resource/internal"
+)
+
+func getSecret() *corev1.Secret {
+	return &corev1.Secret{
+		Data: map[string][]byte{"username": []byte("username"), "password": []byte("password"), "usernameCSI": []byte("usernameCSI"), "passwordCSI": []byte("passwordCSI"), "usernameCP": []byte("usernameCP"), "passwordCP": []byte("passwordCP")},
+	}
+}
+
+func TestGetVSphereCredValues(t *testing.T) {
+	g := NewWithT(t)
+	s := getSecret()
+	values, _ := internal.GetVSphereCredValues(s)
+	g.Expect(values).ToNot(BeNil())
+}
+
+func TestGetVSphereCredValuesError(t *testing.T) {
+	for _, k := range []string{"username", "password"} {
+		t.Run(k, func(t *testing.T) {
+			s := getSecret()
+			delete(s.Data, k)
+			g := NewWithT(t)
+			_, err := internal.GetVSphereCredValues(s)
+			target := fmt.Sprintf("unable to retrieve %s from secret", k)
+			g.Expect(err.Error()).To(BeEquivalentTo(target))
+		})
+	}
+}
+
+func TestGetVSphereCredValuesMissingPassword(t *testing.T) {
+	tests := []struct {
+		defaultField  string
+		secretField   string
+		templateField string
+	}{
+		{
+			defaultField:  "username",
+			secretField:   "usernameCSI",
+			templateField: "eksaCSIUsername",
+		},
+		{
+			defaultField:  "username",
+			secretField:   "usernameCP",
+			templateField: "eksaCloudProviderUsername",
+		},
+		{
+			defaultField:  "password",
+			secretField:   "passwordCSI",
+			templateField: "eksaCSIPassword",
+		},
+		{
+			defaultField:  "password",
+			secretField:   "passwordCP",
+			templateField: "eksaCloudProviderPassword",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.secretField, func(t *testing.T) {
+			s := getSecret()
+			delete(s.Data, tt.secretField)
+			g := NewWithT(t)
+			values, _ := internal.GetVSphereCredValues(s)
+			target := s.Data[tt.defaultField]
+			res := values[tt.templateField]
+			g.Expect(res).To(BeEquivalentTo(target))
+		})
+	}
+}

--- a/controllers/resource/reconciler_test.go
+++ b/controllers/resource/reconciler_test.go
@@ -95,6 +95,12 @@ var cloudstackMachineConfigSpecPath string
 //go:embed testdata/cloudstackKubeadmconfigTemplateSpec.yaml
 var cloudstackKubeadmconfigTemplateSpecPath string
 
+func getSecret() *corev1.Secret {
+	return &corev1.Secret{
+		Data: map[string][]byte{"username": []byte("username"), "password": []byte("password"), "usernameCSI": []byte("usernameCSI"), "passwordCSI": []byte("passwordCSI"), "usernameCP": []byte("usernameCP"), "passwordCP": []byte("passwordCP")},
+	}
+}
+
 func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 	type args struct {
 		objectKey types.NamespacedName
@@ -208,9 +214,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 				fetcher.EXPECT().ExistingVSphereEtcdMachineConfig(ctx, gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
 				fetcher.EXPECT().ExistingVSphereWorkerMachineConfig(ctx, gomock.Any(), gomock.Any()).Return(workerNodeMachineConfig, nil)
 				fetcher.EXPECT().ExistingWorkerNodeGroupConfig(ctx, gomock.Any(), gomock.Any()).Return(&anywherev1.WorkerNodeGroupConfiguration{}, nil)
-				fetcher.EXPECT().VSphereCredentials(ctx).Return(&corev1.Secret{
-					Data: map[string][]byte{"username": []byte("username"), "password": []byte("password")},
-				}, nil)
+				fetcher.EXPECT().VSphereCredentials(ctx).Return(getSecret(), nil)
 				fetcher.EXPECT().Fetch(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.NewNotFound(schema.GroupResource{Group: "testgroup", Resource: "testresource"}, ""))
 
 				resourceUpdater.EXPECT().ApplyPatch(ctx, gomock.Any(), false).Return(nil)
@@ -326,9 +330,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 				}
 				fetcher.EXPECT().MachineDeployment(ctx, gomock.Any(), gomock.Any()).Return(machineDeployment, nil)
 
-				fetcher.EXPECT().VSphereCredentials(ctx).Return(&corev1.Secret{
-					Data: map[string][]byte{"username": []byte("username"), "password": []byte("password")},
-				}, nil)
+				fetcher.EXPECT().VSphereCredentials(ctx).Return(getSecret(), nil)
 				fetcher.EXPECT().Fetch(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.NewNotFound(schema.GroupResource{Group: "testgroup", Resource: "testresource"}, ""))
 
 				resourceUpdater.EXPECT().ForceApplyTemplate(ctx, gomock.Any(), gomock.Any()).Do(func(ctx context.Context, template *unstructured.Unstructured, dryRun bool) {
@@ -442,9 +444,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 				fetcher.EXPECT().ExistingVSphereEtcdMachineConfig(ctx, gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
 				fetcher.EXPECT().ExistingVSphereWorkerMachineConfig(ctx, gomock.Any(), gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
 				fetcher.EXPECT().ExistingWorkerNodeGroupConfig(ctx, gomock.Any(), gomock.Any()).Return(existingWorkerNodeGroupConfiguration, nil)
-				fetcher.EXPECT().VSphereCredentials(ctx).Return(&corev1.Secret{
-					Data: map[string][]byte{"username": []byte("username"), "password": []byte("password")},
-				}, nil)
+				fetcher.EXPECT().VSphereCredentials(ctx).Return(getSecret(), nil)
 				fetcher.EXPECT().Fetch(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.NewNotFound(schema.GroupResource{Group: "testgroup", Resource: "testresource"}, ""))
 
 				resourceUpdater.EXPECT().ApplyPatch(ctx, gomock.Any(), false).Return(nil)
@@ -561,9 +561,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 				fetcher.EXPECT().ExistingVSphereEtcdMachineConfig(ctx, gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
 				fetcher.EXPECT().ExistingVSphereWorkerMachineConfig(ctx, gomock.Any(), gomock.Any()).Return(&anywherev1.VSphereMachineConfig{}, nil)
 				fetcher.EXPECT().ExistingWorkerNodeGroupConfig(ctx, gomock.Any(), gomock.Any()).Return(existingWorkerNodeGroupConfiguration, nil)
-				fetcher.EXPECT().VSphereCredentials(ctx).Return(&corev1.Secret{
-					Data: map[string][]byte{"username": []byte("username"), "password": []byte("password")},
-				}, nil)
+				fetcher.EXPECT().VSphereCredentials(ctx).Return(getSecret(), nil)
 				fetcher.EXPECT().Fetch(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.NewNotFound(schema.GroupResource{Group: "testgroup", Resource: "testresource"}, ""))
 
 				resourceUpdater.EXPECT().ApplyPatch(ctx, gomock.Any(), false).Return(nil)

--- a/pkg/providers/vsphere/config/secret.yaml
+++ b/pkg/providers/vsphere/config/secret.yaml
@@ -7,6 +7,10 @@ type: kubernetes.io/basic-auth
 data:
   username: {{.vsphereUsername | b64enc}}
   password: {{.vspherePassword | b64enc}}
+  usernameCSI: "{{.eksaCSIUsername | b64enc}}"
+  passwordCSI: "{{.eksaCSIPassword | b64enc}}"
+  usernameCP: "{{.eksaCloudProviderUsername | b64enc}}"
+  passwordCP: "{{.eksaCloudProviderPassword | b64enc}}"
 ---
 apiVersion: v1
 kind: Secret

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1092,14 +1092,19 @@ func (p *vsphereProvider) createSecret(ctx context.Context, cluster *types.Clust
 	if err != nil {
 		return fmt.Errorf("creating secret object template: %v", err)
 	}
+	vuc := config.NewVsphereUserConfig()
 
 	values := map[string]string{
-		"vspherePassword":        os.Getenv(vSpherePasswordKey),
-		"vsphereUsername":        os.Getenv(vSphereUsernameKey),
-		"eksaLicense":            os.Getenv(eksaLicense),
-		"eksaSystemNamespace":    constants.EksaSystemNamespace,
-		"vsphereCredentialsName": constants.VSphereCredentialsName,
-		"eksaLicenseName":        constants.EksaLicenseName,
+		"vspherePassword":           os.Getenv(vSpherePasswordKey),
+		"vsphereUsername":           os.Getenv(vSphereUsernameKey),
+		"eksaCloudProviderUsername": vuc.EksaVsphereCPUsername,
+		"eksaCloudProviderPassword": vuc.EksaVsphereCPPassword,
+		"eksaCSIUsername":           vuc.EksaVsphereCSIUsername,
+		"eksaCSIPassword":           vuc.EksaVsphereCSIPassword,
+		"eksaLicense":               os.Getenv(eksaLicense),
+		"eksaSystemNamespace":       constants.EksaSystemNamespace,
+		"vsphereCredentialsName":    constants.VSphereCredentialsName,
+		"eksaLicenseName":           constants.EksaLicenseName,
 	}
 	err = t.Execute(contents, values)
 	if err != nil {

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -1582,13 +1582,17 @@ func TestProviderBootstrapSetup(t *testing.T) {
 		KubeconfigFile: "",
 	}
 	values := map[string]string{
-		"clusterName":       clusterConfig.Name,
-		"vspherePassword":   expectedVSphereUsername,
-		"vsphereUsername":   expectedVSpherePassword,
-		"vsphereServer":     datacenterConfig.Spec.Server,
-		"vsphereDatacenter": datacenterConfig.Spec.Datacenter,
-		"vsphereNetwork":    datacenterConfig.Spec.Network,
-		"eksaLicense":       "",
+		"clusterName":               clusterConfig.Name,
+		"vspherePassword":           expectedVSphereUsername,
+		"vsphereUsername":           expectedVSpherePassword,
+		"eksaCSIUsername":           expectedVSphereUsername,
+		"eksaCSIPassword":           expectedVSpherePassword,
+		"eksaCloudProviderUsername": expectedVSphereUsername,
+		"eksaCloudProviderPassword": expectedVSpherePassword,
+		"vsphereServer":             datacenterConfig.Spec.Server,
+		"vsphereDatacenter":         datacenterConfig.Spec.Datacenter,
+		"vsphereNetwork":            datacenterConfig.Spec.Network,
+		"eksaLicense":               "",
 	}
 
 	var tctx testContext
@@ -1623,10 +1627,15 @@ func TestProviderUpdateSecretSuccess(t *testing.T) {
 		KubeconfigFile: "",
 	}
 	values := map[string]string{
-		"vspherePassword":     expectedVSphereUsername,
-		"vsphereUsername":     expectedVSpherePassword,
-		"eksaLicense":         "",
-		"eksaSystemNamespace": constants.EksaSystemNamespace,
+		"clusterName":               clusterConfig.Name,
+		"vspherePassword":           expectedVSphereUsername,
+		"vsphereUsername":           expectedVSpherePassword,
+		"eksaCSIUsername":           expectedVSphereUsername,
+		"eksaCSIPassword":           expectedVSpherePassword,
+		"eksaCloudProviderUsername": expectedVSphereUsername,
+		"eksaCloudProviderPassword": expectedVSpherePassword,
+		"eksaLicense":               "",
+		"eksaSystemNamespace":       constants.EksaSystemNamespace,
 	}
 
 	var tctx testContext


### PR DESCRIPTION
The controller was not injecting the extra CSI/CP credentials.

*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/3404

*Description of changes:*
The EKSA Controller didn't have necessary vsphere credentials. As a result, when it reconciled eksa-system:csi-vsphere-config it deleted the username and password.

*Testing (if applicable):*

* create:
    * create cluster on main
* upgrade:
    * create cluster on v0.11.1
    * upgrade on release-0.11 with my changes on top of it. Secret `eksa-system:vsphere-credentials` was correctly updated.
    * ran old controller while upgrading. `eksa-system:vsphere-credentials` was unaffected but controller continued to did still overwrite csi-vsphere-config secret
    * ran new controller after upgrade and csi-vsphere-config reconciled correctly with appropriately populated config information derived from `eksa-system:vsphere-credentials` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

