### PR TITLE
Add cluster name to several package commands

### DIFF
--- a/cmd/eksctl-anywhere/cmd/installpackages.go
+++ b/cmd/eksctl-anywhere/cmd/installpackages.go
@@ -14,6 +14,7 @@ import (
 type installPackageOptions struct {
 	source        curatedpackages.BundleSource
 	kubeVersion   string
+	clusterName   string
 	packageName   string
 	registry      string
 	customConfigs []string
@@ -39,12 +40,17 @@ func init() {
 		[]string{}, "Provide custom configurations for curated packages. Format key:value")
 	installPackageCommand.Flags().StringVar(&ipo.kubeConfig, "kubeconfig", "",
 		"Path to an optional kubeconfig file to use.")
+	installPackageCommand.Flags().StringVar(&ipo.clusterName, "cluster", "",
+		"Target cluster for installation.")
 
 	if err := installPackageCommand.MarkFlagRequired("source"); err != nil {
 		log.Fatalf("marking source flag as required: %s", err)
 	}
 	if err := installPackageCommand.MarkFlagRequired("package-name"); err != nil {
 		log.Fatalf("marking package-name flag as required: %s", err)
+	}
+	if err := installPackageCommand.MarkFlagRequired("cluster"); err != nil {
+		log.Fatalf("marking cluster flag as required: %s", err)
 	}
 }
 
@@ -81,6 +87,7 @@ func installPackages(ctx context.Context, args []string) error {
 
 	b := curatedpackages.NewBundleReader(
 		kubeConfig,
+		ipo.clusterName,
 		ipo.source,
 		deps.Kubectl,
 		bm,
@@ -104,7 +111,7 @@ func installPackages(ctx context.Context, args []string) error {
 	}
 
 	curatedpackages.PrintLicense()
-	err = packages.InstallPackage(ctx, p, ipo.packageName, kubeConfig)
+	err = packages.InstallPackage(ctx, p, ipo.packageName, ipo.clusterName, kubeConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/listpackages.go
+++ b/cmd/eksctl-anywhere/cmd/listpackages.go
@@ -14,6 +14,7 @@ import (
 
 type listPackagesOption struct {
 	kubeVersion string
+	clusterName string
 	source      curatedpackages.BundleSource
 	registry    string
 	// kubeConfig is an optional kubeconfig file to use when querying an
@@ -34,9 +35,14 @@ func init() {
 		"Specifies an alternative registry for packages discovery.")
 	listPackagesCommand.Flags().StringVar(&lpo.kubeConfig, "kubeconfig", "",
 		"Path to a kubeconfig file to use when source is a cluster.")
+	listPackagesCommand.Flags().StringVar(&lpo.clusterName, "cluster", "",
+		"Name of cluster for package list.")
 
 	if err := listPackagesCommand.MarkFlagRequired("source"); err != nil {
 		log.Fatalf("marking source flag required: %s", err)
+	}
+	if err := listPackagesCommand.MarkFlagRequired("cluster"); err != nil {
+		log.Fatalf("cluster flag required: %s", err)
 	}
 }
 
@@ -71,6 +77,7 @@ func listPackages(ctx context.Context) error {
 
 	b := curatedpackages.NewBundleReader(
 		kubeConfig,
+		lpo.clusterName,
 		lpo.source,
 		deps.Kubectl,
 		bm,

--- a/cmd/eksctl-anywhere/cmd/upgradepackages.go
+++ b/cmd/eksctl-anywhere/cmd/upgradepackages.go
@@ -15,7 +15,8 @@ type upgradePackageOptions struct {
 	bundleVersion string
 	// kubeConfig is an optional kubeconfig file to use when querying an
 	// existing cluster
-	kubeConfig string
+	kubeConfig  string
+	clusterName string
 }
 
 var upo = &upgradePackageOptions{}
@@ -27,8 +28,14 @@ func init() {
 		"", "Bundle version to use")
 	upgradePackagesCommand.Flags().StringVar(&upo.kubeConfig, "kubeconfig",
 		"", "Path to an optional kubeconfig file to use.")
+	upgradePackagesCommand.Flags().StringVar(&upo.clusterName, "cluster",
+		"", "Cluster to upgrade.")
 
 	err := upgradePackagesCommand.MarkFlagRequired("bundle-version")
+	if err != nil {
+		log.Fatalf("Error marking flag as required: %v", err)
+	}
+	err = upgradePackagesCommand.MarkFlagRequired("cluster")
 	if err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
 	}
@@ -60,6 +67,7 @@ func upgradePackages(ctx context.Context) error {
 
 	b := curatedpackages.NewBundleReader(
 		kubeConfig,
+		upo.clusterName,
 		ipo.source,
 		deps.Kubectl,
 		nil,

--- a/pkg/curatedpackages/packageclient_test.go
+++ b/pkg/curatedpackages/packageclient_test.go
@@ -66,7 +66,7 @@ func TestGeneratePackagesSucceed(t *testing.T) {
 	packages := []string{"harbor-test"}
 	tt.command = curatedpackages.NewPackageClient(tt.kubectl, curatedpackages.WithBundle(tt.bundle), curatedpackages.WithCustomPackages(packages))
 
-	result, err := tt.command.GeneratePackages()
+	result, err := tt.command.GeneratePackages("billy")
 
 	tt.Expect(err).To(BeNil())
 	tt.Expect(result[0].Name).To(Equal(curatedpackages.CustomName + packages[0]))
@@ -77,7 +77,7 @@ func TestGeneratePackagesFail(t *testing.T) {
 	packages := []string{"unknown-package"}
 	tt.command = curatedpackages.NewPackageClient(tt.kubectl, curatedpackages.WithBundle(tt.bundle), curatedpackages.WithCustomPackages(packages))
 
-	result, err := tt.command.GeneratePackages()
+	result, err := tt.command.GeneratePackages("billy")
 	tt.Expect(err).NotTo(BeNil())
 	tt.Expect(result).To(BeNil())
 }
@@ -111,7 +111,7 @@ func TestInstallPackagesSucceeds(t *testing.T) {
 	// Suppress output temporarily since it is not needed for testing
 	temp := os.Stdout
 	os.Stdout = nil // turn it off
-	err := tt.command.InstallPackage(tt.ctx, &tt.bundle.Spec.Packages[0], "my-harbor", "")
+	err := tt.command.InstallPackage(tt.ctx, &tt.bundle.Spec.Packages[0], "my-harbor", "billy", "")
 	os.Stdout = temp // restore it
 	tt.Expect(err).To(BeNil())
 }
@@ -122,7 +122,7 @@ func TestInstallPackagesFails(t *testing.T) {
 	packages := []string{"harbor-test"}
 	tt.command = curatedpackages.NewPackageClient(tt.kubectl, curatedpackages.WithBundle(tt.bundle), curatedpackages.WithCustomPackages(packages))
 
-	err := tt.command.InstallPackage(tt.ctx, &tt.bundle.Spec.Packages[0], "my-harbor", "")
+	err := tt.command.InstallPackage(tt.ctx, &tt.bundle.Spec.Packages[0], "my-harbor", "billy", "")
 	tt.Expect(err).To(MatchError(ContainSubstring("error installing package. Package exists")))
 }
 
@@ -132,7 +132,7 @@ func TestInstallPackagesFailsWhenInvalidConfigs(t *testing.T) {
 	customConfigs := []string{"test"}
 	tt.command = curatedpackages.NewPackageClient(tt.kubectl, curatedpackages.WithBundle(tt.bundle), curatedpackages.WithCustomPackages(packages), curatedpackages.WithCustomConfigs(customConfigs))
 
-	err := tt.command.InstallPackage(tt.ctx, &tt.bundle.Spec.Packages[0], "my-harbor", "")
+	err := tt.command.InstallPackage(tt.ctx, &tt.bundle.Spec.Packages[0], "my-harbor", "billy", "")
 	tt.Expect(err).NotTo(BeNil())
 }
 


### PR DESCRIPTION
Supporting remote management of packages requires that the user specify the cluster they want to take an action on. The management cluster may be managing packages for several workload clusters. This PR adds support for the list packages, generate packages, install package and upgrade packages commands.