### PR TITLE
Skipping deploying machine deployment when there is none

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -239,6 +239,11 @@ func (k *Kubectl) ApplyKubeSpecFromBytes(ctx context.Context, cluster *types.Clu
 }
 
 func (k *Kubectl) ApplyKubeSpecFromBytesWithNamespace(ctx context.Context, cluster *types.Cluster, data []byte, namespace string) error {
+	if len(data) == 0 {
+		logger.V(6).Info("Skipping applying empty kube spec from bytes")
+		return nil
+	}
+
 	params := []string{"apply", "-f", "-", "--namespace", namespace}
 	if cluster.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -144,7 +144,7 @@ func TestKubectlDeleteSpecFromBytesError(t *testing.T) {
 }
 
 func TestKubectlApplyKubeSpecFromBytesWithNamespaceSuccess(t *testing.T) {
-	var data []byte
+	var data []byte = []byte("someData")
 	var namespace string
 
 	k, ctx, cluster, e := newKubectl(t)
@@ -155,8 +155,19 @@ func TestKubectlApplyKubeSpecFromBytesWithNamespaceSuccess(t *testing.T) {
 	}
 }
 
-func TestKubectlApplyKubeSpecFromBytesWithNamespaceError(t *testing.T) {
+func TestKubectlApplyKubeSpecFromBytesWithNamespaceSuccessWithEmptyInput(t *testing.T) {
 	var data []byte
+	var namespace string
+
+	k, ctx, cluster, e := newKubectl(t)
+	e.EXPECT().ExecuteWithStdin(ctx, data, gomock.Any()).Times(0)
+	if err := k.ApplyKubeSpecFromBytesWithNamespace(ctx, cluster, data, namespace); err != nil {
+		t.Errorf("Kubectl.ApplyKubeSpecFromBytesWithNamespace() error = %v, want nil", err)
+	}
+}
+
+func TestKubectlApplyKubeSpecFromBytesWithNamespaceError(t *testing.T) {
+	var data []byte = []byte("someData")
 	var namespace string
 
 	k, ctx, cluster, e := newKubectl(t)


### PR DESCRIPTION
## Issue
When EKSA is used to upgrade single-node cluster, there is no MachineDeployment for worker nodes. Thus EKSA is trying to `kubectl apply` empty bytes input.

"error: no objects passed to apply"

## Fix
Skipping applying empty kube spec.

## Tests
1. Unit test
2. Manual test with single-node cluster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

