### PR TITLE
Remove repeated hardware during cluster upgrade

### DIFF
--- a/pkg/providers/tinkerbell/hardware/catalogue.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue.go
@@ -28,6 +28,8 @@ type Indexer interface {
 	Insert(v interface{}) error
 	// IndexField associated index with fn such that Lookup may be used to retrieve objects.
 	IndexField(index string, fn KeyExtractorFunc)
+	// Remove deletes v from the index.
+	Remove(v interface{}) error
 }
 
 // Catalogue represents a catalogue of Tinkerbell hardware manifests to be used with Tinkerbells

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
@@ -161,15 +161,16 @@ func (c *Catalogue) RemoveHardware(hardware *tinkv1alpha1.Hardware, index int) e
 func (c *Catalogue) RemoveHardwares(hardware []tinkv1alpha1.Hardware) error {
 	m := make(map[string]int, len(c.hardware))
 	for i, hw := range c.hardware {
-		m[hw.Name+hw.Namespace] = i
+		m[hw.Name+":"+hw.Namespace] = i
 	}
 
 	for _, hw := range hardware {
-		if _, ok := m[hw.Name+hw.Namespace]; ok {
-			if err := c.RemoveHardware(c.hardware[m[hw.Name+hw.Namespace]], m[hw.Name+hw.Namespace]); err != nil {
+		key := hw.Name + ":" + hw.Namespace
+		if _, ok := m[key]; ok {
+			if err := c.RemoveHardware(c.hardware[m[key]], m[key]); err != nil {
 				return err
 			}
-			delete(m, hw.Name+hw.Namespace)
+			delete(m, key)
 		}
 	}
 	return nil

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware_test.go
@@ -71,6 +71,12 @@ func TestCatalogue_Hardware_RemoveFail(t *testing.T) {
 		},
 	}, 1)).To(gomega.HaveOccurred())
 	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(1))
+	g.Expect(catalogue.RemoveHardware(&v1alpha1.Hardware{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "hw2",
+			Namespace: "namespace",
+		},
+	}, 2)).To(gomega.HaveOccurred())
 }
 
 func TestCatalogue_Hardware_UnknownIndexErrors(t *testing.T) {

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
@@ -18,6 +19,57 @@ func TestCatalogue_Hardware_Insert(t *testing.T) {
 
 	err := catalogue.InsertHardware(&v1alpha1.Hardware{})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(1))
+}
+
+func TestCatalogue_Hardwares_Remove(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+
+	err := catalogue.InsertHardware(&v1alpha1.Hardware{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "hw1",
+			Namespace: "namespace",
+		},
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	err = catalogue.InsertHardware(&v1alpha1.Hardware{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "hw2",
+			Namespace: "namespace",
+		},
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(catalogue.RemoveHardwares([]v1alpha1.Hardware{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "hw2",
+				Namespace: "namespace",
+			},
+		},
+	})).ToNot(gomega.HaveOccurred())
+	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(1))
+}
+
+func TestCatalogue_Hardware_RemoveFail(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+
+	err := catalogue.InsertHardware(&v1alpha1.Hardware{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "hw1",
+			Namespace: "namespace",
+		},
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(catalogue.RemoveHardware(&v1alpha1.Hardware{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "hw2",
+			Namespace: "namespace",
+		},
+	}, 1)).To(gomega.HaveOccurred())
 	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(1))
 }
 

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -130,6 +130,11 @@ func (p *Provider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *
 		}
 	}
 
+	// Remove all the provisioned hardware from the existing cluster if repeated from the hardware csv input.
+	if err := p.catalogue.RemoveHardwares(hardware); err != nil {
+		return err
+	}
+
 	return p.validateAvailableHardwareForUpgrade(ctx, currentClusterSpec, clusterSpec)
 }
 


### PR DESCRIPTION
*Issue #3447*

*Description of changes:*
Adding logic to remove list of provisioned hardware objects obtained from the management cluster during cluster upgrade. This prevents prevents the scenario where user had provisioned hardware in their `hardware.csv` input from getting applied and messing up the cluster.

*Testing:*
Tested different use cases where user provides varied inputs.
```bash
./eksctl-anywhere upgrade cluster -f ./tink/tink-eks-a-cluster.yaml

./eksctl-anywhere upgrade cluster -f ./tink/tink-eks-a-cluster.yaml -z hardware.csv
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

