### PR TITLE
Use raw string in clusterctlNetworkErrorRegex

### DIFF
--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -36,7 +36,7 @@ const (
 //go:embed config/clusterctl.yaml
 var clusterctlConfigTemplate string
 
-var clusterctlNetworkErrorRegex = regexp.MustCompile(".*failed to connect to the management cluster\\:.*")
+var clusterctlNetworkErrorRegex = regexp.MustCompile(`.*failed to connect to the management cluster:.*`)
 
 type Clusterctl struct {
 	Executable


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

