### PR TITLE
Adding IP check for cloudstack cluster creation

### DIFF
--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/networkutils"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 	"github.com/aws/eks-anywhere/pkg/providers/common"
@@ -62,7 +63,6 @@ type cloudstackProvider struct {
 	writer                filewriter.FileWriter
 	selfSigned            bool
 	templateBuilder       *CloudStackTemplateBuilder
-	skipIpCheck           bool
 	validator             *Validator
 	execConfig            *decoder.CloudStackExecConfig
 }
@@ -255,8 +255,7 @@ func NewProvider(datacenterConfig *v1alpha1.CloudStackDatacenterConfig, machineC
 			etcdMachineSpec:             etcdMachineSpec,
 			now:                         now,
 		},
-		skipIpCheck: skipIpCheck,
-		validator:   NewValidator(providerCmkClient),
+		validator: NewValidator(providerCmkClient, &networkutils.DefaultNetClient{}, skipIpCheck),
 	}
 }
 
@@ -471,10 +470,6 @@ func (p *cloudstackProvider) SetupAndValidateCreateCluster(ctx context.Context, 
 			return fmt.Errorf("CloudStackDatacenter %s already exists", clusterSpec.CloudStackDatacenter.Name)
 		}
 	}
-	if p.skipIpCheck {
-		logger.Info("Skipping check for whether control plane ip is in use")
-		return nil
-	}
 
 	return nil
 }
@@ -599,10 +594,10 @@ func AnyImmutableFieldChanged(oldCsdc, newCsdc *v1alpha1.CloudStackDatacenterCon
 		}
 	}
 
-	if oldCsmc.Spec.Template != newCsmc.Spec.Template {
+	if !oldCsmc.Spec.Template.Equal(&newCsmc.Spec.Template) {
 		return true
 	}
-	if oldCsmc.Spec.ComputeOffering != newCsmc.Spec.ComputeOffering {
+	if !oldCsmc.Spec.ComputeOffering.Equal(&newCsmc.Spec.ComputeOffering) {
 		return true
 	}
 	if !oldCsmc.Spec.DiskOffering.Equal(newCsmc.Spec.DiskOffering) {
@@ -624,6 +619,7 @@ func AnyImmutableFieldChanged(oldCsdc, newCsdc *v1alpha1.CloudStackDatacenterCon
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -933,7 +929,6 @@ func (p *cloudstackProvider) getWorkloadTemplateSpecForCAPISpecUpgrade(ctx conte
 		if err != nil {
 			return nil, err
 		}
-
 		needsNewKubeadmConfigTemplate, err := p.needsNewKubeadmConfigTemplate(workerNodeGroupConfiguration, previousWorkerNodeGroupConfigs)
 		if err != nil {
 			return nil, err

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -212,7 +212,7 @@ func newProvider(t *testing.T, datacenterConfig *v1alpha1.CloudStackDatacenterCo
 		cmk,
 		writer,
 		test.FakeNow,
-		false,
+		true,
 	)
 }
 

--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -5,16 +5,18 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/networkutils"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 )
 
 type Validator struct {
-	cmk ProviderCmkClient
+	cmk         ProviderCmkClient
+	netClient   networkutils.NetClient
+	skipIpCheck bool
 }
 
 // Taken from https://github.com/shapeblue/cloudstack/blob/08bb4ad9fea7e422c3d3ac6d52f4670b1e89eed7/api/src/main/java/com/cloud/vm/VmDetailConstants.java
@@ -29,9 +31,11 @@ var restrictedUserCustomDetails = [...]string{
 	"keypairnames", "controlNodeLoginUser",
 }
 
-func NewValidator(cmk ProviderCmkClient) *Validator {
+func NewValidator(cmk ProviderCmkClient, netClient networkutils.NetClient, skipIpCheck bool) *Validator {
 	return &Validator{
-		cmk: cmk,
+		cmk:         cmk,
+		netClient:   netClient,
+		skipIpCheck: skipIpCheck,
 	}
 }
 
@@ -186,12 +190,9 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, cloudStac
 		}
 	}
 
-	isPortSpecified, err := v.validateControlPlaneHost(cloudStackClusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host)
+	err := v.setDefaultAndValidateControlPlaneHostPort(cloudStackClusterSpec)
 	if err != nil {
-		return fmt.Errorf("failed to validate controlPlaneConfiguration.Endpoint.Host: %v", err)
-	}
-	if !isPortSpecified {
-		v.setDefaultControlPlanePort(cloudStackClusterSpec)
+		return fmt.Errorf("validating controlPlaneConfiguration.Endpoint.Host: %v", err)
 	}
 
 	for _, machineConfig := range cloudStackClusterSpec.machineConfigsLookup {
@@ -282,26 +283,27 @@ func (v *Validator) validateMachineConfig(ctx context.Context, datacenterConfig 
 	return nil
 }
 
-// validateControlPlaneHost checks the input host to see if it is a valid hostname. If it's valid, it checks the port
-// or returns a boolean indicating that there was no port specified, in which case the default port should be used
-func (v *Validator) validateControlPlaneHost(pHost string) (bool, error) {
-	_, port, err := net.SplitHostPort(pHost)
+// setDefaultAndValidateControlPlaneHostPort checks the input host to see if it is a valid hostname. If it's valid, it checks the port
+// to see if the default port should be used and sets it. It then ensures that there is not already a process running at that host:port.
+func (v *Validator) setDefaultAndValidateControlPlaneHostPort(cloudStackClusterSpec *Spec) error {
+	pHost := cloudStackClusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host
+	host, port, err := net.SplitHostPort(pHost)
 	if err != nil {
 		if strings.Contains(err.Error(), "missing port") {
-			return false, nil
+			host = pHost
+			port = controlEndpointDefaultPort
+			cloudStackClusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host = fmt.Sprintf("%s:%s",
+				cloudStackClusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host,
+				controlEndpointDefaultPort)
 		} else {
-			return false, fmt.Errorf("host %s is invalid: %v", pHost, err.Error())
+			return fmt.Errorf("host %s is invalid: %v", pHost, err.Error())
 		}
 	}
-	_, err = strconv.Atoi(port)
-	if err != nil {
-		return false, fmt.Errorf("host %s has an invalid port: %v", pHost, err.Error())
+	if !networkutils.IsPortValid(port) {
+		return fmt.Errorf("host %s has an invalid port", pHost)
 	}
-	return true, nil
-}
-
-func (v *Validator) setDefaultControlPlanePort(cloudStackClusterSpec *Spec) {
-	cloudStackClusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host = fmt.Sprintf("%s:%s",
-		cloudStackClusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host,
-		controlEndpointDefaultPort)
+	if !v.skipIpCheck && networkutils.IsPortInUse(v.netClient, host, port) {
+		return fmt.Errorf("cluster controlPlaneConfiguration.Endpoint.Host <%s> is already in use, please provide a unique IP:port", cloudStackClusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host)
+	}
+	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Similar to VSphere's IP check, we want to prevent clusters from being created if the IP:port are already in use. If we don't have this check, they continue to be created and start reporting an x509 certificate error. 

During upgrades, we want to skip this validation. Previously the skipIpCheck parameter was unused in the CloudStack provider, now it's being plumbed to the validator.

*Testing (if applicable):*
Unit tests pass. Also, tried creating two clusters with the same IP and observed

```
2022-09-29T11:27:25.478-0400	V6	Executing command	{"cmd": "/usr/local/bin/docker exec -i eksa_1664465238305760000 cmk -c /Users/dribinm/workspaces/eksa/eks-anywhere/drib-rollingupgrade-copy/generated/cmk_global.ini list networks domainid=\"246375f3-dd88-482f-a455-393f6e9492ab\" account=\"dribinm-admin\" zoneid=\"2b119174-1801-443c-9ed0-e09421bd427a\""}
2022-09-29T11:27:25.939-0400	V0	✅ Datacenter validated
2022-09-29T11:27:25.964-0400	V0	❌ Validation failed	{"validation": "cloudstack Provider setup is valid", "error": "validating cluster spec: validating controlPlaneConfiguration.Endpoint.Host: cluster controlPlaneConfiguration.Endpoint.Host <10.11.199.177:6443> is already in use, please provide a unique IP:port", "remediation": ""}
2022-09-29T11:27:25.966-0400	V0	✅ Validate certificate for registry mirror
2022-09-29T11:27:25.966-0400	V0	✅ Validate authentication for git provider
2022-09-29T11:27:25.966-0400	V0	✅ Create preflight validations pass
2022-09-29T11:27:25.966-0400	V4	Task finished	{"task_name": "setup-validate", "duration": "4.453518309s"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

