### PR TITLE
Add cert-manager-ctl image to artifacts list

### DIFF
--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -155,6 +155,7 @@ func (vb *VersionsBundle) SharedImages() []Image {
 		vb.CertManager.Acmesolver,
 		vb.CertManager.Cainjector,
 		vb.CertManager.Controller,
+		vb.CertManager.Ctl,
 		vb.CertManager.Webhook,
 		vb.Cilium.Cilium,
 		vb.Cilium.Operator,


### PR DESCRIPTION
Since this image was not part of the artifacts list, it wasn't going through the previous bundle digest check and added a new tag each time, leading to hitting ECR tag limits for the same digest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

