### PR TITLE
feat(CLI): error getting a bundle without providing a name

### DIFF
--- a/pkg/curatedpackages/bundle.go
+++ b/pkg/curatedpackages/bundle.go
@@ -76,8 +76,11 @@ func (b *BundleReader) getActiveBundleFromCluster(ctx context.Context) (*package
 	return bundle, nil
 }
 
-func (b *BundleReader) getPackageBundle(ctx context.Context, activeBundle string) (*packagesv1.PackageBundle, error) {
-	params := []string{"get", "packageBundle", "-o", "json", "--kubeconfig", b.kubeConfig, "--namespace", constants.EksaPackagesName, activeBundle}
+func (b *BundleReader) getPackageBundle(ctx context.Context, bundleName string) (*packagesv1.PackageBundle, error) {
+	params := []string{"get", "packageBundle", "-o", "json", "--kubeconfig", b.kubeConfig, "--namespace", constants.EksaPackagesName, bundleName}
+	if bundleName == "" {
+		return nil, fmt.Errorf("no bundle name specified")
+	}
 	stdOut, err := b.kubectl.ExecuteCommand(ctx, params...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previously, this didn't error out, which led to other processes failing, and often with much harder to debug error messages.

The most likely reason this would be called with an empty bundle name is the case where a packages controller has come online, but has not yet activated a bundle. In that case, it's Spec.ActiveBundle value will be the empty string.

More quick PRs in this series will follow. Be on the lookout!