### PR TITLE
refactor(CLI): IsInstalled returns a single boolean.

### DIFF
--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -65,11 +65,7 @@ func installPackageController(ctx context.Context) error {
 		return err
 	}
 
-	// ignore the error because if the crds don't exist in the cluster
-	// this will return an error. If this is the case, we should still
-	// go ahead and install the controller since lack of crds indicates
-	// the controller doesn't exist
-	if installed, _ := ctrlClient.IsInstalled(ctx); installed {
+	if ctrlClient.IsInstalled(ctx) {
 		return errors.New("curated Packages controller exists in the current cluster")
 	}
 

--- a/pkg/curatedpackages/mocks/packageinstaller.go
+++ b/pkg/curatedpackages/mocks/packageinstaller.go
@@ -49,12 +49,11 @@ func (mr *MockPackageControllerMockRecorder) InstallController(ctx interface{}) 
 }
 
 // IsInstalled mocks base method.
-func (m *MockPackageController) IsInstalled(ctx context.Context) (bool, error) {
+func (m *MockPackageController) IsInstalled(ctx context.Context) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsInstalled", ctx)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // IsInstalled indicates an expected call of IsInstalled.

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -92,8 +92,10 @@ func (pc *PackageControllerClient) InstallController(ctx context.Context) error 
 	return nil
 }
 
-func (pc *PackageControllerClient) IsInstalled(ctx context.Context) (bool, error) {
-	return pc.kubectl.GetResource(ctx, "packageBundleController", pc.clusterName, pc.kubeConfig, constants.EksaPackagesName)
+// IsInstalled checks if a package controller custom resource exists.
+func (pc *PackageControllerClient) IsInstalled(ctx context.Context) bool {
+	bool, err := pc.kubectl.GetResource(ctx, "packageBundleController", pc.clusterName, pc.kubeConfig, constants.EksaPackagesName)
+	return bool && err == nil
 }
 
 func (pc *PackageControllerClient) ApplySecret(ctx context.Context) error {

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -222,25 +222,26 @@ func TestInstallControllerSuccessWhenCronJobFails(t *testing.T) {
 	}
 }
 
-func TestGetActiveControllerSuccess(t *testing.T) {
+func TestIsInstalledTrue(t *testing.T) {
 	tt := newPackageControllerTest(t)
 
 	tt.kubectl.EXPECT().GetResource(tt.ctx, "packageBundleController", tt.clusterName, tt.kubeConfig, constants.EksaPackagesName).Return(false, nil)
 
-	found, err := tt.command.IsInstalled(tt.ctx)
-	if err != nil || found {
-		t.Errorf("Get Active Controller should return false when controller doesn't exist")
+	found := tt.command.IsInstalled(tt.ctx)
+	if found {
+		t.Errorf("expected true, got %t", found)
 	}
 }
 
-func TestGetActiveControllerFail(t *testing.T) {
+func TestIsInstalledFalse(t *testing.T) {
 	tt := newPackageControllerTest(t)
 
-	tt.kubectl.EXPECT().GetResource(tt.ctx, "packageBundleController", tt.clusterName, tt.kubeConfig, constants.EksaPackagesName).Return(true, errors.New("controller doesn't exist"))
+	tt.kubectl.EXPECT().GetResource(tt.ctx, "packageBundleController", tt.clusterName, tt.kubeConfig, constants.EksaPackagesName).
+		Return(false, errors.New("controller doesn't exist"))
 
-	found, err := tt.command.IsInstalled(tt.ctx)
-	if !found || err == nil {
-		t.Errorf("Get Active Controller should return true when controller exists")
+	found := tt.command.IsInstalled(tt.ctx)
+	if found {
+		t.Errorf("expected false, got %t", found)
 	}
 }
 

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -10,7 +10,7 @@ import (
 
 type PackageController interface {
 	InstallController(ctx context.Context) error
-	IsInstalled(ctx context.Context) (bool, error)
+	IsInstalled(ctx context.Context) bool
 }
 
 type PackageHandler interface {


### PR DESCRIPTION
Any error indicates that the controller isn't installed, so this simplifies
the logic.

IsInstalled has only one caller, to the impact is minimal.

Depends on #3510
