### PR TITLE
feat(CLI): wait for bundle activation at package controller install

### DIFF
--- a/pkg/curatedpackages/kubectlrunner.go
+++ b/pkg/curatedpackages/kubectlrunner.go
@@ -3,11 +3,17 @@ package curatedpackages
 import (
 	"bytes"
 	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type KubectlRunner interface {
 	ExecuteCommand(ctx context.Context, opts ...string) (bytes.Buffer, error)
 	ExecuteFromYaml(ctx context.Context, yaml []byte, opts ...string) (bytes.Buffer, error)
+	// GetObject performs a GET call to the kube API server authenticating with a kubeconfig file
+	// and unmarshalls the response into the provdied Object
+	// If the object is not found, it returns an error implementing apimachinery errors.APIStatus
+	GetObject(ctx context.Context, resourceType, name, namespece, kubeconfig string, obj runtime.Object) error
 	// HasResource is true if the resource can be retrieved from the API and has length > 0.
 	HasResource(ctx context.Context, resourceType string, name string, kubeconfig string, namespace string) (bool, error)
 }

--- a/pkg/curatedpackages/mocks/kubectlrunner.go
+++ b/pkg/curatedpackages/mocks/kubectlrunner.go
@@ -10,6 +10,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
 // MockKubectlRunner is a mock of KubectlRunner interface.
@@ -73,6 +74,20 @@ func (mr *MockKubectlRunnerMockRecorder) ExecuteFromYaml(ctx, yaml interface{}, 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, yaml}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteFromYaml", reflect.TypeOf((*MockKubectlRunner)(nil).ExecuteFromYaml), varargs...)
+}
+
+// GetObject mocks base method.
+func (m *MockKubectlRunner) GetObject(ctx context.Context, resourceType, name, namespece, kubeconfig string, obj runtime.Object) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetObject", ctx, resourceType, name, namespece, kubeconfig, obj)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetObject indicates an expected call of GetObject.
+func (mr *MockKubectlRunnerMockRecorder) GetObject(ctx, resourceType, name, namespece, kubeconfig, obj interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObject", reflect.TypeOf((*MockKubectlRunner)(nil).GetObject), ctx, resourceType, name, namespece, kubeconfig, obj)
 }
 
 // HasResource mocks base method.

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -5,7 +5,9 @@ import (
 	_ "embed"
 	"fmt"
 	"strings"
+	"time"
 
+	packagesv1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/templater"
@@ -36,6 +38,8 @@ type PackageControllerClient struct {
 	httpProxy           string
 	httpsProxy          string
 	noProxy             []string
+	// activeBundleTimeout is the timeout to activate a bundle on installation.
+	activeBundleTimeout time.Duration
 }
 
 type ChartInstaller interface {
@@ -59,6 +63,14 @@ func NewPackageControllerClient(chartInstaller ChartInstaller, kubectl KubectlRu
 	return pcc
 }
 
+// InstallController installs the curated packages controller.
+//
+// This includes all necessary steps for functionality. These include:
+//
+//    - helm chart installation
+//    - credentials secret creation
+//    - credentials refreshing cron job creation
+//    - activation of a curated packages bundle
 func (pc *PackageControllerClient) InstallController(ctx context.Context) error {
 	ociUri := fmt.Sprintf("%s%s", "oci://", pc.uri)
 	registry := GetRegistry(pc.uri)
@@ -89,12 +101,73 @@ func (pc *PackageControllerClient) InstallController(ctx context.Context) error 
 	if err = pc.CreateCronJob(ctx); err != nil {
 		logger.Info("Warning: not able to trigger cron job, please be aware this will prevent the package controller from installing curated packages.")
 	}
+
+	if err := pc.waitForActiveBundle(ctx); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// packageBundleControllerResource is the name of the package bundle controller
+// resource in the API.
+const packageBundleControllerResource string = "packageBundleController"
+
+// waitForActiveBundle polls the package bundle controller for its active bundle.
+//
+// It returns nil on success. Success is defined as receiving a valid package
+// bundle controller from the API with a non-empty active bundle.
+//
+// If no timeout is specified, a default of 1 minute is used.
+func (pc *PackageControllerClient) waitForActiveBundle(ctx context.Context) error {
+	timeout := time.Minute
+	if pc.activeBundleTimeout > 0 {
+		timeout = pc.activeBundleTimeout
+	}
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	done := make(chan error)
+	go func() {
+		defer close(done)
+		pbc := &packagesv1.PackageBundleController{}
+		for {
+			err := pc.kubectl.GetObject(timeoutCtx, packageBundleControllerResource, pc.clusterName,
+				packagesv1.PackageNamespace, pc.kubeConfig, pbc)
+			if err != nil {
+				done <- fmt.Errorf("getting package bundle controller: %w", err)
+				return
+			}
+
+			if pbc.Spec.ActiveBundle != "" {
+				logger.V(6).Info("found packages bundle controller active bundle",
+					"name", pbc.Spec.ActiveBundle)
+				return
+			}
+
+			logger.V(6).Info("waiting for package bundle controller to activate a bundle",
+				"clusterName", pc.clusterName)
+			// TODO read a polling interval value from the context, falling
+			// back to this as a default.
+			time.Sleep(time.Second)
+		}
+	}()
+
+	select {
+	case <-timeoutCtx.Done():
+		return timeoutCtx.Err()
+	case err := <-done:
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
 }
 
 // IsInstalled checks if a package controller custom resource exists.
 func (pc *PackageControllerClient) IsInstalled(ctx context.Context) bool {
-	bool, err := pc.kubectl.HasResource(ctx, "packageBundleController", pc.clusterName, pc.kubeConfig, constants.EksaPackagesName)
+	bool, err := pc.kubectl.HasResource(ctx, packageBundleControllerResource, pc.clusterName, pc.kubeConfig, constants.EksaPackagesName)
 	return bool && err == nil
 }
 
@@ -133,6 +206,12 @@ func (pc *PackageControllerClient) CreateCronJob(ctx context.Context) error {
 func WithEksaAccessKeyId(eksaAccessKeyId string) func(client *PackageControllerClient) {
 	return func(config *PackageControllerClient) {
 		config.eksaAccessKeyId = eksaAccessKeyId
+	}
+}
+
+func WithActiveBundleTimeout(timeout time.Duration) func(client *PackageControllerClient) {
+	return func(config *PackageControllerClient) {
+		config.activeBundleTimeout = timeout
 	}
 }
 

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -9,10 +9,12 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 
+	packagesv1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/curatedpackages/mocks"
@@ -93,10 +95,33 @@ func TestInstallControllerSuccess(t *testing.T) {
 	params = []string{"create", "job", jobName, "--from=" + cronJobName, "--kubeconfig", tt.kubeConfig, "--namespace", constants.EksaPackagesName}
 	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, nil)
 	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chartName, "oci://"+tt.ociUri, tt.chartVersion, tt.kubeConfig, values).Return(nil)
+	any := gomock.Any()
+	tt.kubectl.EXPECT().
+		GetObject(any, any, any, any, any, any).
+		DoAndReturn(getPBCSuccess(t)).
+		AnyTimes()
 
 	err = tt.command.InstallController(tt.ctx)
 	if err != nil {
 		t.Errorf("Install Controller Should succeed when installation passes")
+	}
+}
+
+func getPBCSuccess(t *testing.T) func(context.Context, string, string, string, string, *packagesv1.PackageBundleController) error {
+	return func(_ context.Context, _, _, _, _ string, obj *packagesv1.PackageBundleController) error {
+		pbc := &packagesv1.PackageBundleController{
+			Spec: packagesv1.PackageBundleControllerSpec{
+				ActiveBundle: "test-bundle",
+			},
+		}
+		pbc.DeepCopyInto(obj)
+		return nil
+	}
+}
+
+func getPBCFail(t *testing.T) func(context.Context, string, string, string, string, *packagesv1.PackageBundleController) error {
+	return func(_ context.Context, _, _, _, _ string, obj *packagesv1.PackageBundleController) error {
+		return fmt.Errorf("test error")
 	}
 }
 
@@ -127,6 +152,11 @@ func TestInstallControllerWithProxy(t *testing.T) {
 	params = []string{"create", "job", jobName, "--from=" + cronJobName, "--kubeconfig", tt.kubeConfig, "--namespace", constants.EksaPackagesName}
 	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, nil)
 	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chartName, "oci://"+tt.ociUri, tt.chartVersion, tt.kubeConfig, values).Return(nil)
+	any := gomock.Any()
+	tt.kubectl.EXPECT().
+		GetObject(any, any, any, any, any, any).
+		DoAndReturn(getPBCSuccess(t)).
+		AnyTimes()
 
 	err = tt.command.InstallController(tt.ctx)
 	if err != nil {
@@ -158,6 +188,11 @@ func TestInstallControllerWithEmptyProxy(t *testing.T) {
 	params = []string{"create", "job", jobName, "--from=" + cronJobName, "--kubeconfig", tt.kubeConfig, "--namespace", constants.EksaPackagesName}
 	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, nil)
 	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chartName, "oci://"+tt.ociUri, tt.chartVersion, tt.kubeConfig, values).Return(nil)
+	any := gomock.Any()
+	tt.kubectl.EXPECT().
+		GetObject(any, any, any, any, any, any).
+		DoAndReturn(getPBCSuccess(t)).
+		AnyTimes()
 
 	err = tt.command.InstallController(tt.ctx)
 	if err != nil {
@@ -173,10 +208,41 @@ func TestInstallControllerFail(t *testing.T) {
 	values := []string{sourceRegistry, clusterName}
 
 	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chartName, "oci://"+tt.ociUri, tt.chartVersion, tt.kubeConfig, values).Return(errors.New("login failed"))
+	any := gomock.Any()
+	tt.kubectl.EXPECT().
+		GetObject(any, any, any, any, any, any).
+		DoAndReturn(getPBCSuccess(t)).
+		AnyTimes()
 
 	err := tt.command.InstallController(tt.ctx)
 	if err == nil {
 		t.Errorf("Install Controller Should fail when installation fails")
+	}
+}
+
+func TestInstallControllerFailNoActiveBundle(t *testing.T) {
+	tt := newPackageControllerTest(t)
+
+	registry := curatedpackages.GetRegistry(tt.ociUri)
+	sourceRegistry := fmt.Sprintf("sourceRegistry=%s", registry)
+	clusterName := fmt.Sprintf("clusterName=%s", "billy")
+	values := []string{sourceRegistry, clusterName}
+	params := []string{"create", "-f", "-", "--kubeconfig", tt.kubeConfig}
+	dat, err := os.ReadFile("testdata/awssecret_test.yaml")
+	tt.Expect(err).NotTo(HaveOccurred())
+	tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, dat, params).Return(bytes.Buffer{}, nil)
+	params = []string{"create", "job", jobName, "--from=" + cronJobName, "--kubeconfig", tt.kubeConfig, "--namespace", constants.EksaPackagesName}
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, nil)
+	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chartName, "oci://"+tt.ociUri, tt.chartVersion, tt.kubeConfig, values).Return(nil)
+	any := gomock.Any()
+	tt.kubectl.EXPECT().
+		GetObject(any, any, any, any, any, any).
+		DoAndReturn(getPBCFail(t)).
+		AnyTimes()
+
+	err = tt.command.InstallController(tt.ctx)
+	if err == nil {
+		t.Errorf("expected error, got nil")
 	}
 }
 
@@ -194,6 +260,11 @@ func TestInstallControllerSuccessWhenApplySecretFails(t *testing.T) {
 	params = []string{"create", "job", jobName, "--from=" + cronJobName, "--kubeconfig", tt.kubeConfig, "--namespace", constants.EksaPackagesName}
 	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, nil)
 	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chartName, "oci://"+tt.ociUri, tt.chartVersion, tt.kubeConfig, values).Return(nil)
+	any := gomock.Any()
+	tt.kubectl.EXPECT().
+		GetObject(any, any, any, any, any, any).
+		DoAndReturn(getPBCSuccess(t)).
+		AnyTimes()
 
 	err = tt.command.InstallController(tt.ctx)
 	if err != nil {
@@ -215,6 +286,11 @@ func TestInstallControllerSuccessWhenCronJobFails(t *testing.T) {
 	params = []string{"create", "job", jobName, "--from=" + cronJobName, "--kubeconfig", tt.kubeConfig, "--namespace", constants.EksaPackagesName}
 	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, errors.New("error creating cron job"))
 	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chartName, "oci://"+tt.ociUri, tt.chartVersion, tt.kubeConfig, values).Return(nil)
+	any := gomock.Any()
+	tt.kubectl.EXPECT().
+		GetObject(any, any, any, any, any, any).
+		DoAndReturn(getPBCSuccess(t)).
+		AnyTimes()
 
 	err = tt.command.InstallController(tt.ctx)
 	if err != nil {
@@ -259,6 +335,11 @@ func TestDefaultEksaRegionSetWhenNoRegionSpecified(t *testing.T) {
 	params = []string{"create", "job", jobName, "--from=" + cronJobName, "--kubeconfig", tt.kubeConfig, "--namespace", constants.EksaPackagesName}
 	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, errors.New("error creating cron job"))
 	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chartName, "oci://"+tt.ociUri, tt.chartVersion, tt.kubeConfig, values).Return(nil)
+	any := gomock.Any()
+	tt.kubectl.EXPECT().
+		GetObject(any, any, any, any, any, any).
+		DoAndReturn(getPBCSuccess(t)).
+		AnyTimes()
 
 	tt.command = curatedpackages.NewPackageControllerClient(
 		tt.chartInstaller, tt.kubectl, "billy", tt.kubeConfig, tt.ociUri, tt.chartName, tt.chartVersion,
@@ -269,5 +350,120 @@ func TestDefaultEksaRegionSetWhenNoRegionSpecified(t *testing.T) {
 	err = tt.command.InstallController(tt.ctx)
 	if err != nil {
 		t.Errorf("Install Controller Should succeed when cron job fails")
+	}
+}
+
+func TestInstallControllerActiveBundleCustomTimeout(t *testing.T) {
+	tt := newPackageControllerTest(t)
+	tt.command = curatedpackages.NewPackageControllerClient(
+		tt.chartInstaller, tt.kubectl, "billy", tt.kubeConfig, tt.ociUri, tt.chartName, tt.chartVersion,
+		curatedpackages.WithEksaSecretAccessKey(tt.eksaAccessKey),
+		curatedpackages.WithEksaRegion(tt.eksaRegion),
+		curatedpackages.WithEksaAccessKeyId(tt.eksaAccessId),
+		curatedpackages.WithActiveBundleTimeout(time.Second),
+	)
+
+	registry := curatedpackages.GetRegistry(tt.ociUri)
+	sourceRegistry := fmt.Sprintf("sourceRegistry=%s", registry)
+	clusterName := fmt.Sprintf("clusterName=%s", "billy")
+	values := []string{sourceRegistry, clusterName}
+	params := []string{"create", "-f", "-", "--kubeconfig", tt.kubeConfig}
+	dat, err := os.ReadFile("testdata/awssecret_test.yaml")
+	tt.Expect(err).NotTo(HaveOccurred())
+	tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, dat, params).Return(bytes.Buffer{}, nil)
+	params = []string{"create", "job", jobName, "--from=" + cronJobName, "--kubeconfig", tt.kubeConfig, "--namespace", constants.EksaPackagesName}
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, nil)
+	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chartName, "oci://"+tt.ociUri, tt.chartVersion, tt.kubeConfig, values).Return(nil)
+	any := gomock.Any()
+	tt.kubectl.EXPECT().
+		GetObject(any, any, any, any, any, any).
+		DoAndReturn(getPBCSuccess(t)).
+		AnyTimes()
+
+	err = tt.command.InstallController(tt.ctx)
+	if err != nil {
+		t.Errorf("Install Controller Should succeed when installation passes")
+	}
+}
+
+func TestInstallControllerActiveBundleWaitLoops(t *testing.T) {
+	tt := newPackageControllerTest(t)
+
+	registry := curatedpackages.GetRegistry(tt.ociUri)
+	sourceRegistry := fmt.Sprintf("sourceRegistry=%s", registry)
+	clusterName := fmt.Sprintf("clusterName=%s", "billy")
+	values := []string{sourceRegistry, clusterName}
+	params := []string{"create", "-f", "-", "--kubeconfig", tt.kubeConfig}
+	dat, err := os.ReadFile("testdata/awssecret_test.yaml")
+	tt.Expect(err).NotTo(HaveOccurred())
+	tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, dat, params).Return(bytes.Buffer{}, nil)
+	params = []string{"create", "job", jobName, "--from=" + cronJobName, "--kubeconfig", tt.kubeConfig, "--namespace", constants.EksaPackagesName}
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, nil)
+	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chartName, "oci://"+tt.ociUri, tt.chartVersion, tt.kubeConfig, values).Return(nil)
+	any := gomock.Any()
+	tt.kubectl.EXPECT().
+		GetObject(any, any, any, any, any, any).
+		DoAndReturn(getPBCLoops(t, 3)).
+		AnyTimes()
+
+	err = tt.command.InstallController(tt.ctx)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}
+
+func getPBCLoops(t *testing.T, loops int) func(context.Context, string, string, string, string, *packagesv1.PackageBundleController) error {
+	return func(_ context.Context, _, _, _, _ string, obj *packagesv1.PackageBundleController) error {
+		loops = loops - 1
+		if loops > 0 {
+			return nil
+		}
+		pbc := &packagesv1.PackageBundleController{
+			Spec: packagesv1.PackageBundleControllerSpec{
+				ActiveBundle: "test-bundle",
+			},
+		}
+		pbc.DeepCopyInto(obj)
+		return nil
+	}
+}
+
+func TestInstallControllerActiveBundleTimesOut(t *testing.T) {
+	tt := newPackageControllerTest(t)
+	tt.command = curatedpackages.NewPackageControllerClient(
+		tt.chartInstaller, tt.kubectl, "billy", tt.kubeConfig, tt.ociUri, tt.chartName, tt.chartVersion,
+		curatedpackages.WithEksaSecretAccessKey(tt.eksaAccessKey),
+		curatedpackages.WithEksaRegion(tt.eksaRegion),
+		curatedpackages.WithEksaAccessKeyId(tt.eksaAccessId),
+		curatedpackages.WithActiveBundleTimeout(time.Millisecond),
+	)
+
+	registry := curatedpackages.GetRegistry(tt.ociUri)
+	sourceRegistry := fmt.Sprintf("sourceRegistry=%s", registry)
+	clusterName := fmt.Sprintf("clusterName=%s", "billy")
+	values := []string{sourceRegistry, clusterName}
+	params := []string{"create", "-f", "-", "--kubeconfig", tt.kubeConfig}
+	dat, err := os.ReadFile("testdata/awssecret_test.yaml")
+	tt.Expect(err).NotTo(HaveOccurred())
+	tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, dat, params).Return(bytes.Buffer{}, nil)
+	params = []string{"create", "job", jobName, "--from=" + cronJobName, "--kubeconfig", tt.kubeConfig, "--namespace", constants.EksaPackagesName}
+	tt.kubectl.EXPECT().ExecuteCommand(tt.ctx, params).Return(bytes.Buffer{}, nil)
+	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chartName, "oci://"+tt.ociUri, tt.chartVersion, tt.kubeConfig, values).Return(nil)
+	any := gomock.Any()
+	tt.kubectl.EXPECT().
+		GetObject(any, any, any, any, any, any).
+		DoAndReturn(getPBCDelay(t, time.Second)).
+		AnyTimes()
+
+	err = tt.command.InstallController(tt.ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected %v, got %v", context.DeadlineExceeded, err)
+	}
+}
+
+func getPBCDelay(t *testing.T, delay time.Duration) func(context.Context, string, string, string, string, *packagesv1.PackageBundleController) error {
+	return func(_ context.Context, _, _, _, _ string, obj *packagesv1.PackageBundleController) error {
+		time.Sleep(delay)
+		return fmt.Errorf("test error")
 	}
 }


### PR DESCRIPTION
This adds to InstallController to have it wait until a bundle has been
activated, before returning, and thus indicating that the controller is
"Installed". This help prevent subsequent activity (like package installation)
from failing because the controller isn't yet ready.

Depends on #3513 