### PR TITLE
Remove WithoutDefaultCNI bootstrapper option

### DIFF
--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -28,7 +28,6 @@ type ClusterClient interface {
 	WithExtraDockerMounts() BootstrapClusterClientOption
 	WithExtraPortMappings([]int) BootstrapClusterClientOption
 	WithEnv(env map[string]string) BootstrapClusterClientOption
-	WithDefaultCNIDisabled() BootstrapClusterClientOption
 	ApplyKubeSpecFromBytes(ctx context.Context, cluster *types.Cluster, data []byte) error
 	GetClusters(ctx context.Context, cluster *types.Cluster) ([]types.CAPICluster, error)
 	GetKubeconfig(ctx context.Context, clusterName string) (string, error)
@@ -151,11 +150,5 @@ func WithExtraPortMappings(ports []int) BootstrapClusterOption {
 func WithEnv(env map[string]string) BootstrapClusterOption {
 	return func(b *Bootstrapper) BootstrapClusterClientOption {
 		return b.clusterClient.WithEnv(env)
-	}
-}
-
-func WithDefaultCNIDisabled() BootstrapClusterOption {
-	return func(b *Bootstrapper) BootstrapClusterClientOption {
-		return b.clusterClient.WithDefaultCNIDisabled()
 	}
 }

--- a/pkg/bootstrapper/mocks/client.go
+++ b/pkg/bootstrapper/mocks/client.go
@@ -158,20 +158,6 @@ func (mr *MockClusterClientMockRecorder) ValidateClustersCRD(arg0, arg1 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateClustersCRD", reflect.TypeOf((*MockClusterClient)(nil).ValidateClustersCRD), arg0, arg1)
 }
 
-// WithDefaultCNIDisabled mocks base method.
-func (m *MockClusterClient) WithDefaultCNIDisabled() bootstrapper.BootstrapClusterClientOption {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WithDefaultCNIDisabled")
-	ret0, _ := ret[0].(bootstrapper.BootstrapClusterClientOption)
-	return ret0
-}
-
-// WithDefaultCNIDisabled indicates an expected call of WithDefaultCNIDisabled.
-func (mr *MockClusterClientMockRecorder) WithDefaultCNIDisabled() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithDefaultCNIDisabled", reflect.TypeOf((*MockClusterClient)(nil).WithDefaultCNIDisabled))
-}
-
 // WithEnv mocks base method.
 func (m *MockClusterClient) WithEnv(arg0 map[string]string) bootstrapper.BootstrapClusterClientOption {
 	m.ctrl.T.Helper()

--- a/pkg/executables/config/kind.yaml
+++ b/pkg/executables/config/kind.yaml
@@ -1,10 +1,5 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-{{- if .DisableDefaultCNI }}
-networking:
-  # the default CNI will not be installed
-  disableDefaultCNI: true
-{{- end }}
 kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration

--- a/pkg/executables/kind.go
+++ b/pkg/executables/kind.go
@@ -165,18 +165,6 @@ func (k *Kind) WithEnv(env map[string]string) bootstrapper.BootstrapClusterClien
 	}
 }
 
-func (k *Kind) WithDefaultCNIDisabled() bootstrapper.BootstrapClusterClientOption {
-	return func() error {
-		if k.execConfig == nil {
-			return errors.New("kind exec config is not ready")
-		}
-
-		k.execConfig.DisableDefaultCNI = true
-
-		return nil
-	}
-}
-
 func (k *Kind) WithRegistryMirror(endpoint string, caCertFile string) bootstrapper.BootstrapClusterClientOption {
 	return func() error {
 		if k.execConfig == nil {

--- a/pkg/executables/kind_test.go
+++ b/pkg/executables/kind_test.go
@@ -102,21 +102,6 @@ func TestKindCreateBootstrapClusterSuccess(t *testing.T) {
 			registryMirrorTest: false,
 		},
 		{
-			name:           "With docker option and disable CNI option",
-			wantKubeconfig: kubeConfigFile,
-			options: []testKindOption{
-				func(k *executables.Kind) bootstrapper.BootstrapClusterClientOption {
-					return k.WithExtraDockerMounts()
-				},
-				func(k *executables.Kind) bootstrapper.BootstrapClusterClientOption {
-					return k.WithDefaultCNIDisabled()
-				},
-			},
-			env:                map[string]string{},
-			wantKindConfig:     "testdata/kind_config_docker_mount.yaml",
-			registryMirrorTest: false,
-		},
-		{
 			name:           "With docker option and env option",
 			wantKubeconfig: kubeConfigFile,
 			options: []testKindOption{
@@ -129,24 +114,6 @@ func TestKindCreateBootstrapClusterSuccess(t *testing.T) {
 			},
 			env:                map[string]string{"ENV_VAR1": "VALUE1", "ENV_VAR2": "VALUE2"},
 			wantKindConfig:     "testdata/kind_config_docker_mount_networking.yaml",
-			registryMirrorTest: false,
-		},
-		{
-			name:           "With docker option, env option and disable CNI option",
-			wantKubeconfig: kubeConfigFile,
-			options: []testKindOption{
-				func(k *executables.Kind) bootstrapper.BootstrapClusterClientOption {
-					return k.WithEnv(map[string]string{"ENV_VAR1": "VALUE1", "ENV_VAR2": "VALUE2"})
-				},
-				func(k *executables.Kind) bootstrapper.BootstrapClusterClientOption {
-					return k.WithExtraDockerMounts()
-				},
-				func(k *executables.Kind) bootstrapper.BootstrapClusterClientOption {
-					return k.WithDefaultCNIDisabled()
-				},
-			},
-			env:                map[string]string{"ENV_VAR1": "VALUE1", "ENV_VAR2": "VALUE2"},
-			wantKindConfig:     "testdata/kind_config_docker_mount.yaml",
 			registryMirrorTest: false,
 		},
 		{

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -83,15 +83,13 @@ func (c *createTestSetup) expectSetup() {
 }
 
 func (c *createTestSetup) expectCreateBootstrap() {
-	opts := []bootstrapper.BootstrapClusterOption{
-		bootstrapper.WithDefaultCNIDisabled(), bootstrapper.WithExtraDockerMounts(),
-	}
+	opts := []bootstrapper.BootstrapClusterOption{bootstrapper.WithExtraDockerMounts()}
 
 	gomock.InOrder(
 		c.provider.EXPECT().BootstrapClusterOpts(c.clusterSpec).Return(opts, nil),
 		// Checking for not nil because in go you can't compare closures
 		c.bootstrapper.EXPECT().CreateBootstrapCluster(
-			c.ctx, c.clusterSpec, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()),
+			c.ctx, c.clusterSpec, gomock.Not(gomock.Nil()),
 		).Return(c.bootstrapCluster, nil),
 
 		c.provider.EXPECT().PreCAPIInstallOnBootstrap(c.ctx, c.bootstrapCluster, c.clusterSpec),

--- a/pkg/workflows/delete_test.go
+++ b/pkg/workflows/delete_test.go
@@ -61,7 +61,7 @@ func (c *deleteTestSetup) expectSetup() {
 
 func (c *deleteTestSetup) expectCreateBootstrap() {
 	opts := []bootstrapper.BootstrapClusterOption{
-		bootstrapper.WithDefaultCNIDisabled(), bootstrapper.WithExtraDockerMounts(),
+		bootstrapper.WithExtraDockerMounts(),
 	}
 
 	gomock.InOrder(
@@ -77,7 +77,7 @@ func (c *deleteTestSetup) expectCreateBootstrap() {
 
 func (c *deleteTestSetup) expectNotToCreateBootstrap() {
 	opts := []bootstrapper.BootstrapClusterOption{
-		bootstrapper.WithDefaultCNIDisabled(), bootstrapper.WithExtraDockerMounts(),
+		bootstrapper.WithExtraDockerMounts(),
 	}
 
 	c.provider.EXPECT().BootstrapClusterOpts(c.clusterSpec).Return(opts, nil).Times(0)

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -182,7 +182,7 @@ func (c *upgradeTestSetup) expectUpgradeCoreComponents(managementCluster *types.
 
 func (c *upgradeTestSetup) expectCreateBootstrap() {
 	opts := []bootstrapper.BootstrapClusterOption{
-		bootstrapper.WithDefaultCNIDisabled(), bootstrapper.WithExtraDockerMounts(),
+		bootstrapper.WithExtraDockerMounts(),
 	}
 
 	gomock.InOrder(


### PR DESCRIPTION
The WithoutDefaultCNI is a relic from when we tried installing a different CNI into the KinD cluster. We have no desire to do this any longer.