### PR TITLE
Delete package resources on cluster delete

### DIFF
--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -116,13 +116,15 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 	var cluster *types.Cluster
 	if clusterSpec.ManagementCluster == nil {
 		cluster = &types.Cluster{
-			Name:           clusterSpec.Cluster.Name,
-			KubeconfigFile: kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
+			Name:               clusterSpec.Cluster.Name,
+			KubeconfigFile:     kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
+			ExistingManagement: false,
 		}
 	} else {
 		cluster = &types.Cluster{
-			Name:           clusterSpec.Cluster.Name,
-			KubeconfigFile: clusterSpec.ManagementCluster.KubeconfigFile,
+			Name:               clusterSpec.Cluster.Name,
+			KubeconfigFile:     clusterSpec.ManagementCluster.KubeconfigFile,
+			ExistingManagement: true,
 		}
 	}
 

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -86,6 +86,7 @@ type ClusterClient interface {
 	DeleteOIDCConfig(ctx context.Context, managementCluster *types.Cluster, oidcConfigName, oidcConfigNamespace string) error
 	DeleteAWSIamConfig(ctx context.Context, managementCluster *types.Cluster, awsIamConfigName, awsIamConfigNamespace string) error
 	DeleteEKSACluster(ctx context.Context, managementCluster *types.Cluster, eksaClusterName, eksaClusterNamespace string) error
+	DeletePackageResources(ctx context.Context, managementCluster *types.Cluster, clusterName string) error
 	InitInfrastructure(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
 	WaitForDeployment(ctx context.Context, cluster *types.Cluster, timeout string, condition string, target string, namespace string) error
 	SaveLog(ctx context.Context, cluster *types.Cluster, deployment *types.Deployment, fileName string, writer filewriter.FileWriter) error
@@ -1126,4 +1127,8 @@ func (c *ClusterManager) DeleteAWSIamConfig(ctx context.Context, managementClust
 
 func (c *ClusterManager) DeleteEKSACluster(ctx context.Context, managementCluster *types.Cluster, name string, namespace string) error {
 	return c.clusterClient.DeleteEKSACluster(ctx, managementCluster, name, namespace)
+}
+
+func (c *ClusterManager) DeletePackageResources(ctx context.Context, managementCluster *types.Cluster, clusterName string) error {
+	return c.clusterClient.DeletePackageResources(ctx, managementCluster, clusterName)
 }

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -1930,3 +1930,12 @@ func TestClusterManagerGetCurrentClusterSpecGetBundlesError(t *testing.T) {
 	_, err := tt.clusterManager.GetCurrentClusterSpec(tt.ctx, tt.cluster, tt.clusterName)
 	tt.Expect(err).ToNot(BeNil())
 }
+
+func TestClusterManagerDeletePackageResources(t *testing.T) {
+	tt := newTest(t)
+
+	tt.mocks.client.EXPECT().DeletePackageResources(tt.ctx, tt.cluster, tt.clusterName).Return(nil)
+
+	err := tt.clusterManager.DeletePackageResources(tt.ctx, tt.cluster, tt.clusterName)
+	tt.Expect(err).To(BeNil())
+}

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -200,6 +200,20 @@ func (mr *MockClusterClientMockRecorder) DeleteOldWorkerNodeGroup(arg0, arg1, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOldWorkerNodeGroup", reflect.TypeOf((*MockClusterClient)(nil).DeleteOldWorkerNodeGroup), arg0, arg1, arg2)
 }
 
+// DeletePackageResources mocks base method.
+func (m *MockClusterClient) DeletePackageResources(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeletePackageResources", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeletePackageResources indicates an expected call of DeletePackageResources.
+func (mr *MockClusterClientMockRecorder) DeletePackageResources(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePackageResources", reflect.TypeOf((*MockClusterClient)(nil).DeletePackageResources), arg0, arg1, arg2)
+}
+
 // GetApiServerUrl mocks base method.
 func (m *MockClusterClient) GetApiServerUrl(arg0 context.Context, arg1 *types.Cluster) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -454,6 +454,20 @@ func (k *Kubectl) DeleteFluxConfig(ctx context.Context, managementCluster *types
 	return nil
 }
 
+func (k *Kubectl) DeletePackageResources(ctx context.Context, managementCluster *types.Cluster, clusterName string) error {
+	params := []string{"delete", "pbc", clusterName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", "eksa-packages", "--ignore-not-found=true"}
+	_, err := k.Execute(ctx, params...)
+	if err != nil {
+		return fmt.Errorf("deleting package resources for %s: %v", clusterName, err)
+	}
+	params = []string{"delete", "namespace", "eksa-packages-" + clusterName, "--kubeconfig", managementCluster.KubeconfigFile, "--ignore-not-found=true"}
+	_, err = k.Execute(ctx, params...)
+	if err != nil {
+		return fmt.Errorf("deleting package resources for %s: %v", clusterName, err)
+	}
+	return nil
+}
+
 func (k *Kubectl) DeleteSecret(ctx context.Context, managementCluster *types.Cluster, secretName, namespace string) error {
 	params := []string{"delete", "secret", secretName, "--kubeconfig", managementCluster.KubeconfigFile, "--namespace", namespace}
 	_, err := k.Execute(ctx, params...)

--- a/pkg/workflows/delete.go
+++ b/pkg/workflows/delete.go
@@ -237,9 +237,11 @@ func (s *deletePackageResources) Run(ctx context.Context, commandContext *task.C
 	if cluster == nil {
 		cluster = commandContext.BootstrapCluster
 	}
-	if err := commandContext.ClusterManager.DeletePackageResources(ctx, cluster, commandContext.WorkloadCluster.Name); err != nil {
-		commandContext.SetError(err)
+	err := commandContext.ClusterManager.DeletePackageResources(ctx, cluster, commandContext.WorkloadCluster.Name)
+	if err != nil {
+		logger.Info("Problem delete package resources: %v", err)
 	}
+
 	// A bit odd to traverse to this state here, but it is the terminal state
 	return &deleteManagementCluster{}
 }

--- a/pkg/workflows/delete_test.go
+++ b/pkg/workflows/delete_test.go
@@ -88,6 +88,14 @@ func (c *deleteTestSetup) expectNotToCreateBootstrap() {
 	c.clusterManager.EXPECT().InstallCAPI(c.ctx, gomock.Not(gomock.Nil()), c.bootstrapCluster, c.provider).Times(0)
 }
 
+func (c *deleteTestSetup) expectDeletePackageResources() {
+	c.clusterManager.EXPECT().DeletePackageResources(c.ctx, c.clusterSpec.ManagementCluster, gomock.Any()).Return(nil)
+}
+
+func (c *deleteTestSetup) expectNotToDeletePackageResources() {
+	c.clusterManager.EXPECT().DeletePackageResources(c.ctx, c.clusterSpec.ManagementCluster, gomock.Any()).Return(nil).Times(0)
+}
+
 func (c *deleteTestSetup) expectDeleteBootstrap() {
 	gomock.InOrder(
 		c.bootstrapper.EXPECT().DeleteBootstrapCluster(
@@ -145,6 +153,7 @@ func TestDeleteRunSuccess(t *testing.T) {
 	test.expectDeleteWorkload(test.bootstrapCluster)
 	test.expectCleanupGitRepo()
 	test.expectMoveManagement()
+	test.expectNotToDeletePackageResources()
 	test.expectDeleteBootstrap()
 
 	err := test.run()
@@ -166,6 +175,7 @@ func TestDeleteWorkloadRunSuccess(t *testing.T) {
 	test.expectDeleteWorkload(test.clusterSpec.ManagementCluster)
 	test.expectCleanupGitRepo()
 	test.expectNotToMoveManagement()
+	test.expectDeletePackageResources()
 	test.expectNotToDeleteBootstrap()
 
 	err := test.run()

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -40,6 +40,7 @@ type ClusterManager interface {
 	Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error)
 	InstallAwsIamAuth(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec) error
 	CreateAwsIamAuthCaSecret(ctx context.Context, cluster *types.Cluster) error
+	DeletePackageResources(ctx context.Context, managementCluster *types.Cluster, clusterName string) error
 }
 
 type GitOpsManager interface {

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -182,6 +182,20 @@ func (mr *MockClusterManagerMockRecorder) DeleteCluster(arg0, arg1, arg2, arg3, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockClusterManager)(nil).DeleteCluster), arg0, arg1, arg2, arg3, arg4)
 }
 
+// DeletePackageResources mocks base method.
+func (m *MockClusterManager) DeletePackageResources(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeletePackageResources", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeletePackageResources indicates an expected call of DeletePackageResources.
+func (mr *MockClusterManagerMockRecorder) DeletePackageResources(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePackageResources", reflect.TypeOf((*MockClusterManager)(nil).DeletePackageResources), arg0, arg1, arg2)
+}
+
 // EKSAClusterSpecChanged mocks base method.
 func (m *MockClusterManager) EKSAClusterSpecChanged(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec) (bool, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
When a workload cluster is deleted, there are package resources on the management cluster that should be cleaned up. These package resources are the PackageBundleController and the Package custom resources. If they are not removed there are several negative consequences:

1) The controller will try to reconcile them to a non-existent cluster
2) If someone created a new cluster of the same name, it would get the configuration from the previous cluster

This change makes deleting these custom resources part of the delete workflow

