### PR TITLE
Refactor oras

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,7 @@ mocks: ## Generate mocks
 	${GOPATH}/bin/mockgen -destination=pkg/curatedpackages/mocks/kubectlrunner.go -package=mocks -source "pkg/curatedpackages/kubectlrunner.go" KubectlRunner
 	${GOPATH}/bin/mockgen -destination=pkg/curatedpackages/mocks/packageinstaller.go -package=mocks -source "pkg/curatedpackages/packageinstaller.go" PackageController PackageHandler
 	${GOPATH}/bin/mockgen -destination=pkg/curatedpackages/mocks/reader.go -package=mocks -source "pkg/curatedpackages/bundle.go" Reader BundleRegistry
-	${GOPATH}/bin/mockgen -destination=pkg/curatedpackages/mocks/packagereader.go -package=mocks -source "pkg/curatedpackages/reader.go" ManifestReader
+	${GOPATH}/bin/mockgen -destination=pkg/curatedpackages/mocks/packagereader.go -package=mocks -source "pkg/curatedpackages/reader.go" ManifestReader BundlePuller
 	${GOPATH}/bin/mockgen -destination=pkg/curatedpackages/mocks/bundlemanager.go -package=mocks -source "pkg/curatedpackages/bundlemanager.go" Manager
 	${GOPATH}/bin/mockgen -destination=pkg/clients/kubernetes/mocks/kubectl.go -package=mocks -source "pkg/clients/kubernetes/unauth.go"
 	${GOPATH}/bin/mockgen -destination=pkg/clients/kubernetes/mocks/kubeconfig.go -package=mocks -source "pkg/clients/kubernetes/kubeconfig.go"

--- a/cmd/eksctl-anywhere/cmd/downloadimages.go
+++ b/cmd/eksctl-anywhere/cmd/downloadimages.go
@@ -109,6 +109,7 @@ func packagerForFile(file string) packager {
 	}
 }
 
+// Temporary: Move to factory.go
 func fetchManifestDownloader(downloadFolder string, includePackages bool) artifacts.ManifestDownloader {
 	if includePackages {
 		bundlePuller := oras.NewPuller(packageartifacts.NewRegistryPuller())

--- a/cmd/eksctl-anywhere/cmd/import_images.go
+++ b/cmd/eksctl-anywhere/cmd/import_images.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"oras.land/oras-go/pkg/content"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -17,6 +16,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/helm"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
+	"oras.land/oras-go/pkg/content"
 )
 
 // imagesCmd represents the images command

--- a/cmd/eksctl-anywhere/cmd/import_images.go
+++ b/cmd/eksctl-anywhere/cmd/import_images.go
@@ -150,6 +150,7 @@ func (c ImportImagesCommand) Call(ctx context.Context) error {
 	return importArtifacts.Run(ctx)
 }
 
+// Temporary: Move to factory.go
 func fetchFileRegistry(registryEndpoint, username, password, artifactsFolder string, includePackages bool) (artifacts.FileImporter, error) {
 	if includePackages {
 		registry, err := content.NewRegistry(content.RegistryOptions{})

--- a/cmd/eksctl-anywhere/cmd/import_images.go
+++ b/cmd/eksctl-anywhere/cmd/import_images.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"log"
+	"oras.land/oras-go/pkg/content"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -143,7 +144,13 @@ func (c ImportImagesCommand) Call(ctx context.Context) error {
 
 func fetchFileRegistry(registryEndpoint, username, password, artifactsFolder string, includePackages bool) artifacts.FileImporter {
 	if includePackages {
-		return oras.NewFileRegistryImporter(registryEndpoint, username, password, artifactsFolder)
+		registry, _ := content.NewRegistry(content.RegistryOptions{})
+		//if err != nil {
+		//	return fmt.Errorf("creating registry: %w", err)
+		//}
+		memoryStore := content.NewMemory()
+		bundlePusher := oras.NewPusher(registry, memoryStore)
+		return oras.NewFileRegistryImporter(registryEndpoint, username, password, artifactsFolder, bundlePusher)
 	}
 	return &artifacts.Noop{}
 }

--- a/cmd/eksctl-anywhere/cmd/import_images.go
+++ b/cmd/eksctl-anywhere/cmd/import_images.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"oras.land/oras-go/pkg/content"
 
 	"github.com/aws/eks-anywhere/cmd/eksctl-anywhere/cmd/internal/commands/artifacts"
 	"github.com/aws/eks-anywhere/pkg/config"
@@ -16,7 +17,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/helm"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
-	"oras.land/oras-go/pkg/content"
 )
 
 // imagesCmd represents the images command

--- a/pkg/curatedpackages/mocks/packagereader.go
+++ b/pkg/curatedpackages/mocks/packagereader.go
@@ -78,3 +78,41 @@ func (mr *MockManifestReaderMockRecorder) ReadImagesFromBundles(ctx, bundles int
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadImagesFromBundles", reflect.TypeOf((*MockManifestReader)(nil).ReadImagesFromBundles), ctx, bundles)
 }
+
+// MockBundlePuller is a mock of BundlePuller interface.
+type MockBundlePuller struct {
+	ctrl     *gomock.Controller
+	recorder *MockBundlePullerMockRecorder
+}
+
+// MockBundlePullerMockRecorder is the mock recorder for MockBundlePuller.
+type MockBundlePullerMockRecorder struct {
+	mock *MockBundlePuller
+}
+
+// NewMockBundlePuller creates a new mock instance.
+func NewMockBundlePuller(ctrl *gomock.Controller) *MockBundlePuller {
+	mock := &MockBundlePuller{ctrl: ctrl}
+	mock.recorder = &MockBundlePullerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockBundlePuller) EXPECT() *MockBundlePullerMockRecorder {
+	return m.recorder
+}
+
+// PullLatestBundle mocks base method.
+func (m *MockBundlePuller) PullLatestBundle(ctx context.Context, art string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PullLatestBundle", ctx, art)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PullLatestBundle indicates an expected call of PullLatestBundle.
+func (mr *MockBundlePullerMockRecorder) PullLatestBundle(ctx, art interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullLatestBundle", reflect.TypeOf((*MockBundlePuller)(nil).PullLatestBundle), ctx, art)
+}

--- a/pkg/curatedpackages/oras/import.go
+++ b/pkg/curatedpackages/oras/import.go
@@ -14,6 +14,7 @@ import (
 type BundlePusher interface {
 	PushBundle(ctx context.Context, ref, fileName string, fileContent []byte) error
 }
+
 type FileRegistryImporter struct {
 	registry           string
 	username, password string

--- a/pkg/curatedpackages/oras/puller.go
+++ b/pkg/curatedpackages/oras/puller.go
@@ -1,0 +1,32 @@
+package oras
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/aws/eks-anywhere-packages/pkg/artifacts"
+)
+
+type Puller struct {
+	registryPuller *artifacts.RegistryPuller
+}
+
+func NewPuller(registryPuller *artifacts.RegistryPuller) *Puller {
+	return &Puller{
+		registryPuller: registryPuller,
+	}
+}
+
+func (bp *Puller) PullLatestBundle(ctx context.Context, art string) ([]byte, error) {
+
+	data, err := bp.registryPuller.Pull(ctx, art)
+	if err != nil {
+		return nil, fmt.Errorf("unable to pull artifacts %v", err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, fmt.Errorf("latest package bundle artifact is empty")
+	}
+
+	return data, nil
+}

--- a/pkg/curatedpackages/oras/puller.go
+++ b/pkg/curatedpackages/oras/puller.go
@@ -19,7 +19,6 @@ func NewPuller(registryPuller *artifacts.RegistryPuller) *Puller {
 }
 
 func (bp *Puller) PullLatestBundle(ctx context.Context, art string) ([]byte, error) {
-
 	data, err := bp.registryPuller.Pull(ctx, art)
 	if err != nil {
 		return nil, fmt.Errorf("unable to pull artifacts %v", err)

--- a/pkg/curatedpackages/oras/pusher.go
+++ b/pkg/curatedpackages/oras/pusher.go
@@ -1,0 +1,48 @@
+package oras
+
+import (
+	"context"
+	"fmt"
+
+	"oras.land/oras-go/pkg/content"
+	"oras.land/oras-go/pkg/oras"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
+)
+
+type Pusher struct {
+	registry *content.Registry
+	store    *content.Memory
+}
+
+func NewPusher(registry *content.Registry, store *content.Memory) *Pusher {
+	return &Pusher{
+		registry: registry,
+		store:    store,
+	}
+}
+
+func (p *Pusher) PushBundle(ctx context.Context, ref, fileName string, fileContent []byte) error {
+	desc, err := p.store.Add("bundle.yaml", "", fileContent)
+	if err != nil {
+		return err
+	}
+
+	manifest, manifestDesc, config, configDesc, err := content.GenerateManifestAndConfig(nil, nil, desc)
+	if err != nil {
+		return err
+	}
+
+	p.store.Set(configDesc, config)
+	err = p.store.StoreManifest(ref, manifestDesc, manifest)
+	if err != nil {
+		return err
+	}
+	logger.Info(fmt.Sprintf("Pushing %s to %s...", fileName, ref))
+	desc, err = oras.Copy(ctx, p.store, ref, p.registry, "")
+	if err != nil {
+		return err
+	}
+	logger.Info(fmt.Sprintf("Pushed to %s with digest %s", ref, desc.Digest))
+	return nil
+}

--- a/pkg/curatedpackages/packagereader_test.go
+++ b/pkg/curatedpackages/packagereader_test.go
@@ -3,12 +3,12 @@ package curatedpackages_test
 import (
 	"context"
 	"errors"
-	packagesv1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 
+	packagesv1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/curatedpackages/mocks"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"

--- a/pkg/curatedpackages/reader.go
+++ b/pkg/curatedpackages/reader.go
@@ -44,6 +44,9 @@ func NewPackageReader(mr ManifestReader, bundlePuller BundlePuller) *PackageRead
 
 func (r *PackageReader) ReadImagesFromBundles(ctx context.Context, b *releasev1.Bundles) ([]releasev1.Image, error) {
 	images, err := r.ManifestReader.ReadImagesFromBundles(ctx, b)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, vb := range b.Spec.VersionsBundles {
 		artifact, err := GetPackageBundleRef(vb)
@@ -59,7 +62,7 @@ func (r *PackageReader) ReadImagesFromBundles(ctx context.Context, b *releasev1.
 		images = append(images, packageImages...)
 	}
 
-	return images, err
+	return images, nil
 }
 
 func (r *PackageReader) ReadChartsFromBundles(ctx context.Context, b *releasev1.Bundles) []releasev1.Image {

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -1062,21 +1062,6 @@ func (f *Factory) WithBundleReader(includePackages bool) *Factory {
 	return f
 }
 
-func (f *Factory) WithReader() *Factory {
-	f.WithManifestReader()
-
-	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
-		if f.dependencies.ManifestReader != nil {
-			return nil
-		}
-
-		f.dependencies.ManifestReader = manifests.NewReader(f.dependencies.FileReader)
-		return nil
-	})
-
-	return f
-}
-
 func (f *Factory) WithUnAuthKubeClient() *Factory {
 	f.WithKubectl()
 

--- a/pkg/docker/registry.go
+++ b/pkg/docker/registry.go
@@ -17,6 +17,7 @@ const (
 	packageDevDomain  = "857151390494.dkr.ecr.us-west-2.amazonaws.com"
 	publicProdECRName = "eks-anywhere"
 	publicDevECRName  = "l0g8r8j6"
+	defaultRegistry   = "public.ecr.aws"
 )
 
 // ImageRegistryDestination implements the ImageDestination interface, writing images and tags from
@@ -41,12 +42,15 @@ func (d *ImageRegistryDestination) Write(ctx context.Context, images ...string) 
 	logger.V(3).Info("Starting registry write", "numberOfImages", len(images))
 	err := d.processor.Process(ctx, images, func(ctx context.Context, image string) error {
 		endpoint := getUpdatedEndpoint(d.endpoint, image)
-		image = removeDigestReference(image)
-		if err := d.client.TagImage(ctx, image, endpoint); err != nil {
+		replacer := strings.NewReplacer(defaultRegistry, endpoint, packageProdDomain, endpoint, packageDevDomain, endpoint)
+		localImage := replacer.Replace(image)
+		localImage = removeDigestReference(localImage)
+
+		if err := d.client.TagImage(ctx, image, localImage); err != nil {
 			return err
 		}
 
-		if err := d.client.PushImage(ctx, image, endpoint); err != nil {
+		if err := d.client.PushImage(ctx, image, localImage); err != nil {
 			return err
 		}
 

--- a/pkg/docker/registry_test.go
+++ b/pkg/docker/registry_test.go
@@ -19,12 +19,13 @@ func TestNewRegistryDestination(t *testing.T) {
 	client := mocks.NewMockImageTaggerPusher(ctrl)
 
 	registry := "https://registry"
-	images := []string{"image1:1", "image2:2"}
+	images := []string{"public.ecr.aws/image1:1", "public.ecr.aws/image2:2"}
+	localImages := []string{"https://registry/image1:1", "https://registry/image2:2"}
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
-	for _, i := range images {
-		client.EXPECT().TagImage(test.AContext(), i, registry)
-		client.EXPECT().PushImage(test.AContext(), i, registry)
+	for index, i := range images {
+		client.EXPECT().TagImage(test.AContext(), i, localImages[index])
+		client.EXPECT().PushImage(test.AContext(), i, localImages[index])
 	}
 
 	g.Expect(dstLoader.Write(ctx, images...)).To(Succeed())
@@ -36,12 +37,12 @@ func TestNewRegistryDestinationWhenDigestSpecified(t *testing.T) {
 	client := mocks.NewMockImageTaggerPusher(ctrl)
 
 	registry := "https://registry"
-	image := "image1@sha256:v1"
-	expectedImage := "image1:v1"
+	image := "public.ecr.aws/image1@sha256:v1"
+	expectedImage := "https://registry/image1:v1"
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
-	client.EXPECT().TagImage(test.AContext(), expectedImage, registry)
-	client.EXPECT().PushImage(test.AContext(), expectedImage, registry)
+	client.EXPECT().TagImage(test.AContext(), image, expectedImage)
+	client.EXPECT().PushImage(test.AContext(), image, expectedImage)
 
 	g.Expect(dstLoader.Write(ctx, image)).To(Succeed())
 }
@@ -52,12 +53,12 @@ func TestNewRegistryDestinationWhenPackagesDevProvided(t *testing.T) {
 	client := mocks.NewMockImageTaggerPusher(ctrl)
 
 	registry := "https://registry"
-	expectedRegistry := "https://registry/l0g8r8j6"
-	image := "857151390494.dkr.ecr.us-west-2.amazonaws.com:v1"
+	image := "857151390494.dkr.ecr.us-west-2.amazonaws.com/image1:v1"
+	expectedImage := "https://registry/l0g8r8j6/image1:v1"
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
-	client.EXPECT().TagImage(test.AContext(), image, expectedRegistry)
-	client.EXPECT().PushImage(test.AContext(), image, expectedRegistry)
+	client.EXPECT().TagImage(test.AContext(), image, expectedImage)
+	client.EXPECT().PushImage(test.AContext(), image, expectedImage)
 
 	g.Expect(dstLoader.Write(ctx, image)).To(Succeed())
 }
@@ -68,12 +69,12 @@ func TestNewRegistryDestinationWhenPackagesProdProvided(t *testing.T) {
 	client := mocks.NewMockImageTaggerPusher(ctrl)
 
 	registry := "https://registry"
-	expectedRegistry := "https://registry/eks-anywhere"
-	image := "783794618700.dkr.ecr.us-west-2.amazonaws.com:v1"
+	image := "783794618700.dkr.ecr.us-west-2.amazonaws.com/image1:v1"
+	expectedImage := "https://registry/eks-anywhere/image1:v1"
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
-	client.EXPECT().TagImage(test.AContext(), image, expectedRegistry)
-	client.EXPECT().PushImage(test.AContext(), image, expectedRegistry)
+	client.EXPECT().TagImage(test.AContext(), image, expectedImage)
+	client.EXPECT().PushImage(test.AContext(), image, expectedImage)
 
 	g.Expect(dstLoader.Write(ctx, image)).To(Succeed())
 }
@@ -84,12 +85,13 @@ func TestNewRegistryDestinationErrorTag(t *testing.T) {
 	client := mocks.NewMockImageTaggerPusher(ctrl)
 
 	registry := "https://registry"
-	images := []string{"image1:1", "image2:2"}
+	images := []string{"public.ecr.aws/image1:1", "public.ecr.aws/image2:2"}
+	localImages := []string{"https://registry/image1:1", "https://registry/image2:2"}
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
-	client.EXPECT().TagImage(test.AContext(), images[0], registry).Return(errors.New("error tagging"))
-	client.EXPECT().TagImage(test.AContext(), images[1], registry).MaxTimes(1)
-	client.EXPECT().PushImage(test.AContext(), images[1], registry).MaxTimes(1)
+	client.EXPECT().TagImage(test.AContext(), images[0], localImages[0]).Return(errors.New("error tagging"))
+	client.EXPECT().TagImage(test.AContext(), images[1], localImages[1]).MaxTimes(1)
+	client.EXPECT().PushImage(test.AContext(), images[1], localImages[1]).MaxTimes(1)
 
 	g.Expect(dstLoader.Write(ctx, images...)).To(MatchError(ContainSubstring("error tagging")))
 }
@@ -100,13 +102,14 @@ func TestNewRegistryDestinationErrorPush(t *testing.T) {
 	client := mocks.NewMockImageTaggerPusher(ctrl)
 
 	registry := "https://registry"
-	images := []string{"image1:1", "image2:2"}
+	images := []string{"public.ecr.aws/image1:1", "public.ecr.aws/image2:2"}
+	localImages := []string{"https://registry/image1:1", "https://registry/image2:2"}
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
-	client.EXPECT().TagImage(test.AContext(), images[0], registry)
-	client.EXPECT().PushImage(test.AContext(), images[0], registry).Return(errors.New("error pushing"))
-	client.EXPECT().TagImage(test.AContext(), images[1], registry).MaxTimes(1)
-	client.EXPECT().PushImage(test.AContext(), images[1], registry).MaxTimes(1)
+	client.EXPECT().TagImage(test.AContext(), images[0], localImages[0])
+	client.EXPECT().PushImage(test.AContext(), images[0], localImages[0]).Return(errors.New("error pushing"))
+	client.EXPECT().TagImage(test.AContext(), images[1], localImages[1]).MaxTimes(1)
+	client.EXPECT().PushImage(test.AContext(), images[1], localImages[1]).MaxTimes(1)
 
 	g.Expect(dstLoader.Write(ctx, images...)).To(MatchError(ContainSubstring("error pushing")))
 }

--- a/pkg/executables/docker.go
+++ b/pkg/executables/docker.go
@@ -102,7 +102,6 @@ func (d *Docker) Login(ctx context.Context, endpoint, username, password string)
 }
 
 func (d *Docker) LoadFromFile(ctx context.Context, filepath string) error {
-	logger.Info("FilePath: " + filepath)
 	if _, err := d.Execute(ctx, "load", "-i", filepath); err != nil {
 		return fmt.Errorf("loading images from file: %v", err)
 	}

--- a/pkg/executables/docker.go
+++ b/pkg/executables/docker.go
@@ -9,13 +9,8 @@ import (
 	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
-// Temporary: Curated packages dev and prod accounts are currently hard coded
-// This is because there is no mechanism to extract these values as of now
 const (
-	dockerPath        = "docker"
-	defaultRegistry   = "public.ecr.aws"
-	packageProdDomain = "783794618700.dkr.ecr.us-west-2.amazonaws.com"
-	packageDevDomain  = "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+	dockerPath = "docker"
 )
 
 type Docker struct {
@@ -161,17 +156,4 @@ func (d *Docker) CheckContainerExistence(ctx context.Context, name string) (bool
 	}
 
 	return false, fmt.Errorf("checking if a docker container with name %s exists: %v", name, err)
-}
-
-// Curated packages are currently referenced by digest
-// Docker doesn't support tagging images with digest
-// This method extracts any @ in the image tag
-func removeDigestReference(image string) string {
-	imageSplit := strings.Split(image, "@")
-	if len(imageSplit) < 2 {
-		return image
-	}
-	imageLocation, digest := imageSplit[0], imageSplit[1]
-	digestSplit := strings.Split(digest, ":")
-	return fmt.Sprintf("%s:%s", imageLocation, digestSplit[1])
 }

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -9,7 +9,14 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
+	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
+
+type BundleReader interface {
+	ReadBundlesForVersion(eksaVersion string) (*releasev1.Bundles, error)
+	ReadImagesFromBundles(ctx context.Context, bundles *releasev1.Bundles) ([]releasev1.Image, error)
+	ReadChartsFromBundles(ctx context.Context, bundles *releasev1.Bundles) []releasev1.Image
+}
 
 type Bootstrapper interface {
 	CreateBootstrapCluster(ctx context.Context, clusterSpec *cluster.Spec, opts ...bootstrapper.BootstrapClusterOption) (*types.Cluster, error)


### PR DESCRIPTION
*Description of changes:*
1. Refactor Oras to prevent live connection during unit tests
2. Refactor Docker TagImage and PushImage so that there is no logic and the logic is moved to Registry.go
3. Create New Objects in factory instead of import or download images cmd/ package.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

