### PR TITLE
attempt fix for devrelease helm move

### DIFF
--- a/release/pkg/operations/upload.go
+++ b/release/pkg/operations/upload.go
@@ -82,7 +82,7 @@ func UploadArtifacts(r *releasetypes.ReleaseConfig, eksArtifacts map[string][]re
 
 			if artifact.Image != nil {
 				// If the artifact is a helm chart, skip the skopeo copy as it's handled separately.
-				if strings.HasSuffix(artifact.Image.AssetName, "helm") {
+				if !r.DevRelease && strings.HasSuffix(artifact.Image.AssetName, "helm") {
 					continue
 				}
 				sourceImageUri := artifact.Image.SourceImageURI


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

Currently if we are doing a dev release we skip helm chart.yaml fix. 

We should only do the packages chart upload skip if it's not dev release too, otherwise it will fail on dev releases.
