### PR TITLE
refactor(CLI): more idiomatic output writing for "list packages"

### DIFF
--- a/cmd/eksctl-anywhere/cmd/listpackages.go
+++ b/cmd/eksctl-anywhere/cmd/listpackages.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -84,6 +85,5 @@ func listPackages(ctx context.Context) error {
 		deps.Kubectl,
 		curatedpackages.WithBundle(bundle),
 	)
-	packages.DisplayPackages()
-	return nil
+	return packages.DisplayPackages(os.Stdout)
 }

--- a/pkg/curatedpackages/cptabwriter.go
+++ b/pkg/curatedpackages/cptabwriter.go
@@ -1,0 +1,76 @@
+package curatedpackages
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+// cpTabwriter is a modified tabwriter for curated packages CLI duty.
+type cpTabwriter struct {
+	*tabwriter.Writer
+}
+
+// newCPTabwriter instantiates a curated packages custom tabwriter.
+//
+// If customParams is nil, cpTabwriterDefaultParams will be used. The caller
+// should call Flush just as they would with an unmodified tabwriter.Writer.
+func newCPTabwriter(w io.Writer, customParams *cpTabwriterParams) *cpTabwriter {
+	if customParams == nil {
+		customParams = cpTabwriterDefaultParams()
+	}
+	tw := tabwriter.NewWriter(w, customParams.minWidth, customParams.tabWidth,
+		customParams.padding, customParams.padChar, customParams.flags)
+	return &cpTabwriter{Writer: tw}
+}
+
+// writeTable from a 2-D slice of strings, joining every string with tabs.
+//
+// Tab characters and newlines will be added to the end of each rank.
+func (w *cpTabwriter) writeTable(lines [][]string) error {
+	var err error
+
+	for _, line := range lines {
+		joined := strings.Join(line, "\t")
+		// A final "\t" is added, as tabwriter is tab-terminated, not the more
+		// common tab-separated. See https://pkg.go.dev/text/tabwriter#Writer
+		// for details. There are cases where one might not want this trailing
+		// tab, but it hasn't come up yet, and is easily worked around when
+		// the time comes.
+		if !strings.HasSuffix(joined, "\t") {
+			joined += "\t"
+		}
+		_, err = fmt.Fprintln(w, joined)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// cpTabwriterParams makes it easier to reuse common tabwriter parameters.
+//
+// See https://pkg.go.dev/text/tabwriter#Writer.Init for details.
+type cpTabwriterParams struct {
+	// minWidth is the minimal cell width including any padding
+	minWidth int
+	// tabWidth width of tab characters (equivalent number of spaces)
+	tabWidth int
+	// padding added to a cell before computing its width
+	padding int
+	// padChar ASCII char used for padding
+	padChar byte
+	// flags formatting control
+	flags uint
+}
+
+// cpTabwriterDefaultParams is just a convenience when making tabwriters.
+//
+// Its implemented as a function to make it harder to override the defaults
+// accidentally.
+func cpTabwriterDefaultParams() *cpTabwriterParams {
+	return &cpTabwriterParams{
+		minWidth: 16, tabWidth: 8, padding: 0, padChar: '\t', flags: 0,
+	}
+}

--- a/pkg/curatedpackages/cptabwriter_test.go
+++ b/pkg/curatedpackages/cptabwriter_test.go
@@ -1,0 +1,49 @@
+package curatedpackages
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestCPTabwriterDefaultParams(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w := newCPTabwriter(buf, nil)
+
+	baseBuf := &bytes.Buffer{}
+	baseline := newCPTabwriter(baseBuf, nil)
+	fmt.Fprint(baseline, "one\ta\t\ntwo\tb\t\nthree\tc\t\n")
+	baseline.Flush()
+
+	err := w.writeTable([][]string{{"one", "a"}, {"two", "b"}, {"three", "c"}})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	w.Flush()
+
+	if baseBuf.String() != buf.String() {
+		t.Fatalf("expected %q, got %q", baseBuf.String(), buf.String())
+	}
+}
+
+func TestCPTabwriterCustomPadChar(t *testing.T) {
+	buf := &bytes.Buffer{}
+	params := cpTabwriterDefaultParams()
+	params.padChar = '='
+	w := newCPTabwriter(buf, params)
+
+	baseBuf := &bytes.Buffer{}
+	baseline := newCPTabwriter(baseBuf, params)
+	fmt.Fprint(baseline, "one\ta\t\ntwo\tb\t\nthree\tc\t\n")
+	baseline.Flush()
+
+	err := w.writeTable([][]string{{"one", "a"}, {"two", "b"}, {"three", "c"}})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	w.Flush()
+
+	if baseBuf.String() != buf.String() {
+		t.Fatalf("expected %q, got %q", baseBuf.String(), buf.String())
+	}
+}

--- a/pkg/curatedpackages/packageclient.go
+++ b/pkg/curatedpackages/packageclient.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
+	"io"
 	"strings"
-	"text/tabwriter"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -17,11 +16,6 @@ import (
 )
 
 const (
-	minWidth   = 16
-	tabWidth   = 8
-	padding    = 0
-	padChar    = '\t'
-	flags      = 0
 	CustomName = "generated-"
 	kind       = "Package"
 )
@@ -45,24 +39,37 @@ func NewPackageClient(kubectl KubectlRunner, options ...PackageClientOpt) *Packa
 	return pc
 }
 
-func (pc *PackageClient) DisplayPackages() {
-	w := new(tabwriter.Writer)
-	defer w.Flush()
-	w.Init(os.Stdout, minWidth, tabWidth, padding, padChar, flags)
-	fmt.Fprintf(w, "%s\t%s\t \n", "Package", "Version(s)")
-	fmt.Fprintf(w, "%s\t%s\t \n", "-------", "----------")
-	for _, pkg := range pc.bundle.Spec.Packages {
-		versions := convertBundleVersionToPackageVersion(pkg.Source.Versions)
-		fmt.Fprintf(w, "%s\t%s\t \n", pkg.Name, strings.Join(versions, ","))
-	}
-}
+// sourceWithVersions is a wrapper to help get package versions.
+//
+// This should be pushed upstream to eks-anywhere-packages, then this
+// implementation can be removed.
+type sourceWithVersions packagesv1.BundlePackageSource
 
-func convertBundleVersionToPackageVersion(bundleVersions []packagesv1.SourceVersion) []string {
-	var versions []string
-	for _, v := range bundleVersions {
-		versions = append(versions, v.Name)
+func (s sourceWithVersions) VersionsSlice() []string {
+	versions := []string{}
+	for _, ver := range packagesv1.BundlePackageSource(s).Versions {
+		versions = append(versions, ver.Name)
 	}
 	return versions
+}
+
+// DisplayPackages pretty-prints a table of available packages.
+func (pc *PackageClient) DisplayPackages(w io.Writer) error {
+	lines := append([][]string{}, packagesHeaderLines...)
+	for _, pkg := range pc.bundle.Spec.Packages {
+		versions := sourceWithVersions(pkg.Source).VersionsSlice()
+		lines = append(lines, []string{pkg.Name, strings.Join(versions, ", ")})
+	}
+
+	tw := newCPTabwriter(w, nil)
+	defer tw.Flush()
+	return tw.writeTable(lines)
+}
+
+// packagesHeaderLines pretties-up a table of curated packages info.
+var packagesHeaderLines = [][]string{
+	{"Package", "Version(s)"},
+	{"-------", "----------"},
 }
 
 func (pc *PackageClient) GeneratePackages() ([]packagesv1.Package, error) {

--- a/pkg/curatedpackages/packageclient_test.go
+++ b/pkg/curatedpackages/packageclient_test.go
@@ -37,9 +37,21 @@ func newPackageTest(t *testing.T) *packageTest {
 				Packages: []packagesv1.BundlePackage{
 					{
 						Name: "harbor-test",
+						Source: packagesv1.BundlePackageSource{
+							Versions: []packagesv1.SourceVersion{
+								{Name: "0.0.1"},
+								{Name: "0.0.2"},
+							},
+						},
 					},
 					{
 						Name: "redis-test",
+						Source: packagesv1.BundlePackageSource{
+							Versions: []packagesv1.SourceVersion{
+								{Name: "0.0.3"},
+								{Name: "0.0.4"},
+							},
+						},
 					},
 				},
 			},
@@ -243,4 +255,18 @@ func TestDescribePackagesWhenEmptyResources(t *testing.T) {
 
 	err := tt.command.DescribePackages(tt.ctx, args, tt.kubeConfig)
 	tt.Expect(err).To(MatchError(ContainSubstring("no resources found")))
+}
+
+func TestDisplayPackages(t *testing.T) {
+	tt := newPackageTest(t)
+	bundle := curatedpackages.WithBundle(tt.bundle)
+	pc := curatedpackages.NewPackageClient(nil, bundle)
+	buf := &bytes.Buffer{}
+	err := pc.DisplayPackages(buf)
+	tt.Expect(err).To(BeNil())
+	// The expected string needs to have whitespace at the end of the strings,
+	// which some editors will remove by default, so it's probably best to use
+	// this format, even though it's a little harder to read for humans.
+	expected := "Package\t\tVersion(s)\t\n-------\t\t----------\t\nharbor-test\t0.0.1, 0.0.2\t\nredis-test\t0.0.3, 0.0.4\t\n"
+	tt.Expect(buf.String()).To(Equal(expected))
 }


### PR DESCRIPTION
The DisplayPackages function is modified to take an io.Writer into which it'll write. This better conforms with go idioms and makes testing easier.

In the process of doing so, a customized tabwriter is implemented to make working with tabwriter more uniform. Helpers for instantiation and writing a table from a 2-D slice of strings make the code easier to read, and should make changes to the output less error prone (less fiddling with '\t' and other spacings).

For testing, among other things, I did:

```sh
diff <(bin/eksctl-anywhere list packages --source cluster) <(~/bin/eksctl-anywhere list packages --source cluster)
diff <(bin/eksctl-anywhere list packages --source registry --kube-version 1.23)  <(~/bin/eksctl-anywhere list packages --source registry --kube-version 1.23)
```

Which indicates the results are identical.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

