### PR TITLE
Add provider CAPI control plane

### DIFF
--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -24,6 +24,7 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -48,6 +49,7 @@ func init() {
 	utilruntime.Must(controlplanev1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(bootstrapv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(vspherev1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(dockerv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(cloudstackv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(etcdv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(admissionv1beta1.AddToScheme(scheme.Scheme))

--- a/internal/test/kubernetes.go
+++ b/internal/test/kubernetes.go
@@ -1,0 +1,42 @@
+package test
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	_ "github.com/aws/eks-anywhere/internal/test/envtest"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+)
+
+// KubeClient implements kubernetes.Client by using client.Client
+type KubeClient struct {
+	client client.Client
+}
+
+func NewKubeClient(client client.Client) *KubeClient {
+	return &KubeClient{
+		client: client,
+	}
+}
+
+// Get retrieves an obj for the given name and namespace from the Kubernetes Cluster.
+func (c *KubeClient) Get(ctx context.Context, name, namespace string, obj kubernetes.Object) error {
+	return c.client.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj)
+}
+
+// NewFakeKubeClient returns a KubeClient that uses a fake client.Client under the hood
+func NewFakeKubeClient(objs ...client.Object) *KubeClient {
+	return NewKubeClient(fake.NewClientBuilder().WithObjects(objs...).Build())
+}
+
+// NewFakeKubeClientAlwaysError returns a KubeClient that will always fail in any operation
+// This is achieved by injecting an empty Scheme, which will make the underlying client.Client
+// incapable of determining the resource type for a particular client.Object
+func NewFakeKubeClientAlwaysError(objs ...client.Object) *KubeClient {
+	return NewKubeClient(
+		fake.NewClientBuilder().WithScheme(runtime.NewScheme()).WithObjects(objs...).Build(),
+	)
+}

--- a/pkg/clusterapi/controlplane.go
+++ b/pkg/clusterapi/controlplane.go
@@ -1,0 +1,142 @@
+package clusterapi
+
+import (
+	"context"
+
+	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+)
+
+// Object represents a kubernetes API object
+type Object interface {
+	kubernetes.Object
+}
+
+// ObjectComparator returns true only if only both kubernetes Object's are identical
+// Most of the time, this only requires comparing the Spec field, but that can variate
+// from object to object
+type ObjectComparator[O Object] func(current, new O) bool
+
+// ObjectRetriever gets a kubernetes API object using the provided client
+// If the object doesn't exist, it returns a NotFound error
+type ObjectRetriever[O Object] func(ctx context.Context, client kubernetes.Client, name, namespace string) (O, error)
+
+// ControlPlane represents the provider-specific spec for a CAPI control plane using the kubeadm CP provider
+type ControlPlane[C, M Object] struct {
+	Cluster *clusterv1.Cluster
+
+	// ProviderCluster is the provider-specific resource that holds the details
+	// for provisioning the infrastructure, referenced in Cluster.Spec.InfrastructureRef
+	ProviderCluster C
+
+	KubeadmControlPlane *controlplanev1.KubeadmControlPlane
+
+	// ControlPlaneMachineTemplate is the provider-specific machine template referenced
+	// in KubeadmControlPlane.Spec.MachineTemplate.InfrastructureRef
+	ControlPlaneMachineTemplate M
+
+	EtcdCluster *etcdv1.EtcdadmCluster
+
+	// EtcdMachineTemplate is the provider-specific machine template referenced
+	// in EtcdCluster.Spec.InfrastructureTemplate
+	EtcdMachineTemplate M
+}
+
+// Objects returns all API objects that form a concrete provider-specific control plane
+func (cp *ControlPlane[C, M]) Objects() []kubernetes.Object {
+	objs := make([]kubernetes.Object, 0, 4)
+	objs = append(objs, cp.Cluster, cp.KubeadmControlPlane, cp.ProviderCluster, cp.ControlPlaneMachineTemplate)
+	if cp.EtcdCluster != nil {
+		objs = append(objs, cp.EtcdCluster, cp.EtcdMachineTemplate)
+	}
+
+	return objs
+}
+
+// UpdateImmutableObjectNames checks if any control plane immutable objects have changed by comparing the new definition
+// with the current state of the cluster. If they had, it generates a new name for them by increasing a monotonic number
+// at the end of the name
+// This is applied to all provider machine templates
+func (cp *ControlPlane[C, M]) UpdateImmutableObjectNames(
+	ctx context.Context,
+	client kubernetes.Client,
+	machineTemplateRetriever ObjectRetriever[M],
+	machineTemplateComparator ObjectComparator[M],
+) error {
+	currentKCP := &controlplanev1.KubeadmControlPlane{}
+	err := client.Get(ctx, cp.KubeadmControlPlane.Name, cp.KubeadmControlPlane.Namespace, currentKCP)
+	if apierrors.IsNotFound(err) {
+		// KubeadmControlPlane doesn't exist, this is a new cluster so machine templates should use their default name
+		return nil
+	}
+	if err != nil {
+		return errors.Wrap(err, "reading current kubeadm control plane from API")
+	}
+
+	cp.ControlPlaneMachineTemplate.SetName(currentKCP.Spec.MachineTemplate.InfrastructureRef.Name)
+	if err = EnsureNewNameIfChanged(ctx, client, machineTemplateRetriever, machineTemplateComparator, cp.ControlPlaneMachineTemplate); err != nil {
+		return err
+	}
+
+	if cp.EtcdCluster == nil {
+		return nil
+	}
+
+	currentEtcdCluster := &etcdv1.EtcdadmCluster{}
+	err = client.Get(ctx, cp.EtcdCluster.Name, cp.EtcdCluster.Namespace, currentEtcdCluster)
+	if apierrors.IsNotFound(err) {
+		// EtcdadmCluster doesn't exist, this is a new cluster so machine templates should use their default name
+		return nil
+	}
+	if err != nil {
+		return errors.Wrap(err, "reading current etcdadm cluster from API")
+	}
+
+	cp.EtcdMachineTemplate.SetName(currentEtcdCluster.Spec.InfrastructureTemplate.Name)
+	if err = EnsureNewNameIfChanged(ctx, client, machineTemplateRetriever, machineTemplateComparator, cp.EtcdMachineTemplate); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// EnsureNewNameIfChanged updates an object's name if such object is different from its current state in the cluster
+func EnsureNewNameIfChanged[M Object](ctx context.Context,
+	client kubernetes.Client,
+	retrieve ObjectRetriever[M],
+	equal ObjectComparator[M],
+	new M,
+) error {
+	current, err := retrieve(ctx, client, new.GetName(), new.GetNamespace())
+	if apierrors.IsNotFound(err) {
+		// if object doesn't exist with same name in same namespace, no need to compare, there won't be a conflict
+		return nil
+	}
+	if err != nil {
+		return errors.Wrapf(err, "reading %s %s/%s from API",
+			new.GetObjectKind().GroupVersionKind().Kind,
+			new.GetNamespace(),
+			new.GetName(),
+		)
+	}
+
+	if !equal(new, current) {
+		newName, err := IncrementName(new.GetName())
+		if err != nil {
+			return errors.Wrapf(err, "incrementing name for %s %s/%s",
+				new.GetObjectKind().GroupVersionKind().Kind,
+				new.GetNamespace(),
+				new.GetName(),
+			)
+		}
+
+		new.SetName(newName)
+	}
+
+	return nil
+}

--- a/pkg/clusterapi/controlplane_test.go
+++ b/pkg/clusterapi/controlplane_test.go
@@ -1,0 +1,322 @@
+package clusterapi_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
+)
+
+type dockerControlPlane = clusterapi.ControlPlane[*dockerv1.DockerCluster, *dockerv1.DockerMachineTemplate]
+
+func TestControlPlaneObjects(t *testing.T) {
+	tests := []struct {
+		name         string
+		controlPlane *dockerControlPlane
+		want         []clusterapi.Object
+	}{
+		{
+			name: "stacked etcd",
+			controlPlane: &dockerControlPlane{
+				Cluster:                     capiCluster(),
+				ProviderCluster:             dockerCluster(),
+				KubeadmControlPlane:         kubeadmControlPlane(),
+				ControlPlaneMachineTemplate: dockerMachineTemplate(),
+			},
+			want: []clusterapi.Object{
+				capiCluster(),
+				dockerCluster(),
+				kubeadmControlPlane(),
+				dockerMachineTemplate(),
+			},
+		},
+		{
+			name: "unstacked etcd",
+			controlPlane: &dockerControlPlane{
+				Cluster:                     capiCluster(),
+				ProviderCluster:             dockerCluster(),
+				KubeadmControlPlane:         kubeadmControlPlane(),
+				ControlPlaneMachineTemplate: dockerMachineTemplate(),
+				EtcdCluster:                 etcdCluster(),
+				EtcdMachineTemplate:         dockerMachineTemplate(),
+			},
+			want: []clusterapi.Object{
+				capiCluster(),
+				dockerCluster(),
+				kubeadmControlPlane(),
+				dockerMachineTemplate(),
+				etcdCluster(),
+				dockerMachineTemplate(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.controlPlane.Objects()).To(ConsistOf(tt.want))
+		})
+	}
+}
+
+func TestEnsureNewNameIfChangedObjectDoesNotExist(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	originalName := "my-machine-template-1"
+	mt := dockerMachineTemplate()
+	mt.Name = originalName
+	client := test.NewFakeKubeClient()
+
+	g.Expect(clusterapi.EnsureNewNameIfChanged(ctx, client, notFoundRetriever, withChangesCompare, mt)).To(Succeed())
+	g.Expect(mt.Name).To(Equal(originalName))
+}
+
+func TestEnsureNewNameIfChangedErrorReadingObject(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	mt := dockerMachineTemplate()
+	mt.Name = "my-machine-template"
+	client := test.NewFakeKubeClient()
+
+	g.Expect(
+		clusterapi.EnsureNewNameIfChanged(ctx, client, errorRetriever, withChangesCompare, mt),
+	).To(
+		MatchError(ContainSubstring("reading DockerMachineTemplate eksa-system/my-machine-template from API")),
+	)
+}
+
+func TestEnsureNewNameIfChangedErrorIncrementingName(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	mt := dockerMachineTemplate()
+	mt.Name = "my-machine-template"
+	client := test.NewFakeKubeClient()
+
+	g.Expect(
+		clusterapi.EnsureNewNameIfChanged(ctx, client, dummyRetriever, withChangesCompare, mt),
+	).To(
+		MatchError(ContainSubstring("incrementing name for DockerMachineTemplate eksa-system/my-machine-template")),
+	)
+}
+
+func TestEnsureNewNameIfChangedObjectNeedsNewName(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	mt := dockerMachineTemplate()
+	mt.Name = "my-machine-template-1"
+	client := test.NewFakeKubeClient()
+
+	g.Expect(clusterapi.EnsureNewNameIfChanged(ctx, client, dummyRetriever, withChangesCompare, mt)).To(Succeed())
+	g.Expect(mt.Name).To(Equal("my-machine-template-2"))
+}
+
+func TestEnsureNewNameIfChangedObjectHasNotChanged(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	originalName := "my-machine-template-1"
+	mt := dockerMachineTemplate()
+	mt.Name = originalName
+	client := test.NewFakeKubeClient()
+
+	g.Expect(clusterapi.EnsureNewNameIfChanged(ctx, client, dummyRetriever, noChangesCompare, mt)).To(Succeed())
+	g.Expect(mt.Name).To(Equal(originalName))
+}
+
+func TestControlPlaneUpdateImmutableObjectNamesNoKubeadmControlPlane(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	client := test.NewFakeKubeClient()
+	cp := controlPlaneStackedEtcd()
+	originalCPMachineTemplateName := "my-machine-template-1"
+	cp.ControlPlaneMachineTemplate.Name = originalCPMachineTemplateName
+
+	g.Expect(cp.UpdateImmutableObjectNames(ctx, client, dummyRetriever, noChangesCompare)).To(Succeed())
+	g.Expect(cp.ControlPlaneMachineTemplate.Name).To(Equal(originalCPMachineTemplateName))
+}
+
+func TestControlPlaneUpdateImmutableObjectNamesErrorReadingControlPlane(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	cp := controlPlaneStackedEtcd()
+	client := test.NewFakeKubeClientAlwaysError()
+
+	g.Expect(
+		cp.UpdateImmutableObjectNames(ctx, client, dummyRetriever, noChangesCompare),
+	).To(
+		MatchError(ContainSubstring("reading current kubeadm control plane from API")),
+	)
+}
+
+func TestControlPlaneUpdateImmutableObjectNamesErrorUpdatingName(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	cp := controlPlaneStackedEtcd()
+	originalCPMachineTemplateName := "my-machine-template"
+	cp.ControlPlaneMachineTemplate.Name = originalCPMachineTemplateName
+	cp.KubeadmControlPlane.Spec.MachineTemplate.InfrastructureRef.Name = originalCPMachineTemplateName
+	client := test.NewFakeKubeClient(clientutil.ObjectsToClientObjects(cp.Objects())...)
+
+	g.Expect(
+		cp.UpdateImmutableObjectNames(ctx, client, dummyRetriever, withChangesCompare),
+	).To(
+		MatchError(ContainSubstring("incrementing name for DockerMachineTemplate eksa-system/my-machine-template")),
+	)
+}
+
+func TestControlPlaneUpdateImmutableObjectNamesSuccessStackedEtcd(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	cp := controlPlaneStackedEtcd()
+	originalCPMachineTemplateName := "my-machine-template-1"
+	cp.ControlPlaneMachineTemplate.Name = originalCPMachineTemplateName
+	cp.KubeadmControlPlane.Spec.MachineTemplate.InfrastructureRef.Name = originalCPMachineTemplateName
+	client := test.NewFakeKubeClient(clientutil.ObjectsToClientObjects(cp.Objects())...)
+
+	g.Expect(cp.UpdateImmutableObjectNames(ctx, client, dummyRetriever, noChangesCompare)).To(Succeed())
+}
+
+func TestControlPlaneUpdateImmutableObjectNamesNoEtcdCluster(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	cp := controlPlaneStackedEtcd()
+	originalCPMachineTemplateName := "my-machine-template-1"
+	cp.ControlPlaneMachineTemplate.Name = originalCPMachineTemplateName
+	cp.KubeadmControlPlane.Spec.MachineTemplate.InfrastructureRef.Name = originalCPMachineTemplateName
+	client := test.NewFakeKubeClient(clientutil.ObjectsToClientObjects(cp.Objects())...)
+	cp.EtcdCluster = etcdCluster()
+
+	g.Expect(cp.UpdateImmutableObjectNames(ctx, client, dummyRetriever, noChangesCompare)).To(Succeed())
+}
+
+func TestControlPlaneUpdateImmutableObjectNamesErrorReadingEtcdCluster(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	cp := controlPlaneUnStackedEtcd()
+	originalCPMachineTemplateName := "my-machine-template-1"
+	cp.ControlPlaneMachineTemplate.Name = originalCPMachineTemplateName
+	cp.KubeadmControlPlane.Spec.MachineTemplate.InfrastructureRef.Name = originalCPMachineTemplateName
+	scheme := runtime.NewScheme()
+	g.Expect(controlplanev1.AddToScheme(scheme)).To(Succeed())
+	client := test.NewKubeClient(
+		fake.NewClientBuilder().WithScheme(scheme).WithObjects(cp.KubeadmControlPlane).Build(),
+	)
+
+	g.Expect(
+		cp.UpdateImmutableObjectNames(ctx, client, dummyRetriever, noChangesCompare),
+	).To(
+		MatchError(ContainSubstring("reading current etcdadm cluster from API")),
+	)
+}
+
+func TestControlPlaneUpdateImmutableObjectNamesErrorUpdatingEtcdName(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	cp := controlPlaneUnStackedEtcd()
+	originalCPMachineTemplateName := "my-machine-template-1"
+	cp.ControlPlaneMachineTemplate.Name = originalCPMachineTemplateName
+	cp.KubeadmControlPlane.Spec.MachineTemplate.InfrastructureRef.Name = originalCPMachineTemplateName
+	originalEtcdMachineTemplateName := "my-etcd-machine-template"
+	cp.EtcdMachineTemplate.Name = originalEtcdMachineTemplateName
+	cp.EtcdCluster.Spec.InfrastructureTemplate.Name = originalEtcdMachineTemplateName
+	client := test.NewFakeKubeClient(clientutil.ObjectsToClientObjects(cp.Objects())...)
+
+	g.Expect(
+		cp.UpdateImmutableObjectNames(ctx, client, dummyRetriever, withChangesCompare),
+	).To(
+		MatchError(ContainSubstring("incrementing name for DockerMachineTemplate eksa-system/my-etcd-machine-template")),
+	)
+}
+
+func TestControlPlaneUpdateImmutableObjectNamesSuccessUnstackedEtcd(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	cp := controlPlaneUnStackedEtcd()
+	originalCPMachineTemplateName := "my-machine-template-1"
+	cp.ControlPlaneMachineTemplate.Name = originalCPMachineTemplateName
+	cp.KubeadmControlPlane.Spec.MachineTemplate.InfrastructureRef.Name = originalCPMachineTemplateName
+	originalEtcdMachineTemplateName := "my-etcd-machine-template-2"
+	cp.EtcdMachineTemplate.Name = originalEtcdMachineTemplateName
+	cp.EtcdCluster.Spec.InfrastructureTemplate.Name = originalEtcdMachineTemplateName
+	client := test.NewFakeKubeClient(clientutil.ObjectsToClientObjects(cp.Objects())...)
+
+	g.Expect(cp.UpdateImmutableObjectNames(ctx, client, dummyRetriever, noChangesCompare)).To(Succeed())
+}
+
+func dummyRetriever(_ context.Context, _ kubernetes.Client, _, _ string) (*dockerv1.DockerMachineTemplate, error) {
+	return dockerMachineTemplate(), nil
+}
+
+func errorRetriever(_ context.Context, _ kubernetes.Client, _, _ string) (*dockerv1.DockerMachineTemplate, error) {
+	return nil, errors.New("reading object")
+}
+
+func notFoundRetriever(_ context.Context, _ kubernetes.Client, _, _ string) (*dockerv1.DockerMachineTemplate, error) {
+	return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
+}
+
+func noChangesCompare(_, _ *dockerv1.DockerMachineTemplate) bool {
+	return true
+}
+
+func withChangesCompare(_, _ *dockerv1.DockerMachineTemplate) bool {
+	return false
+}
+
+func capiCluster() *clusterv1.Cluster {
+	return &clusterv1.Cluster{}
+}
+
+func dockerCluster() *dockerv1.DockerCluster {
+	return &dockerv1.DockerCluster{}
+}
+
+func kubeadmControlPlane() *controlplanev1.KubeadmControlPlane {
+	return &controlplanev1.KubeadmControlPlane{}
+}
+
+func dockerMachineTemplate() *dockerv1.DockerMachineTemplate {
+	return &dockerv1.DockerMachineTemplate{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "DockerMachineTemplate",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.EksaSystemNamespace,
+		},
+	}
+}
+
+func etcdCluster() *etcdv1.EtcdadmCluster {
+	return &etcdv1.EtcdadmCluster{}
+}
+
+func controlPlaneStackedEtcd() *dockerControlPlane {
+	return &dockerControlPlane{
+		Cluster:                     capiCluster(),
+		ProviderCluster:             dockerCluster(),
+		KubeadmControlPlane:         kubeadmControlPlane(),
+		ControlPlaneMachineTemplate: dockerMachineTemplate(),
+	}
+}
+
+func controlPlaneUnStackedEtcd() *dockerControlPlane {
+	cp := controlPlaneStackedEtcd()
+	cp.EtcdCluster = etcdCluster()
+	cp.EtcdMachineTemplate = dockerMachineTemplate()
+
+	return cp
+}


### PR DESCRIPTION
*Description of changes:*

This allows to represent a provider specific CAPI control plane for both stacked and unstacked etcd. It implements logic to generate new names for immutable objects when these change. It does this by comparing the new spec to the current state of the objects in the cluster.

This is part of a bigger effort, allowing a transition from yaml go templates to go structs. For context: https://github.com/aws/eks-anywhere/pull/3432

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

