### PR TITLE
Move vsphere machine config validations to api

### DIFF
--- a/pkg/api/v1alpha1/vspheremachineconfig.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig.go
@@ -123,3 +123,20 @@ func setVSphereMachineConfigDefaults(machineConfig *VSphereMachineConfig) {
 		logger.V(1).Info("SSHUsername is not set or is empty for VSphereMachineConfig, using default", "machineConfig", machineConfig.Name, "user", machineConfig.Spec.Users[0].Name)
 	}
 }
+
+func validateVSphereMachineConfig(config *VSphereMachineConfig) error {
+	if len(config.Spec.Datastore) <= 0 {
+		return fmt.Errorf("VSphereMachineConfig %s datastore is not set or is empty", config.Name)
+	}
+	if len(config.Spec.ResourcePool) <= 0 {
+		return fmt.Errorf("VSphereMachineConfig %s VM resourcePool is not set or is empty", config.Name)
+	}
+	if config.Spec.OSFamily != Bottlerocket && config.Spec.OSFamily != Ubuntu && config.Spec.OSFamily != RedHat {
+		return fmt.Errorf("VSphereMachineConfig %s osFamily: %s is not supported, please use one of the following: %s, %s, %s", config.Name, config.Spec.OSFamily, Bottlerocket, Ubuntu, RedHat)
+	}
+	if config.Spec.OSFamily == Bottlerocket && config.Spec.Users[0].Name != bottlerocketDefaultUser {
+		return fmt.Errorf("SSHUsername %s is invalid. Please use 'ec2-user' for Bottlerocket", config.Spec.Users[0].Name)
+	}
+
+	return nil
+}

--- a/pkg/api/v1alpha1/vspheremachineconfig_test.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -220,6 +221,171 @@ func TestGetVSphereMachineConfigs(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.wantVSphereMachineConfigs) {
 				t.Fatalf("GetVSphereMachineConfigs() = %#v, want %#v", got, tt.wantVSphereMachineConfigs)
+			}
+		})
+	}
+}
+
+func TestVSphereMachineConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		obj     *VSphereMachineConfig
+		wantErr string
+	}{
+		{
+			name: "valid config",
+			obj: &VSphereMachineConfig{
+				Spec: VSphereMachineConfigSpec{
+					MemoryMiB:    64,
+					DiskGiB:      100,
+					NumCPUs:      3,
+					Template:     "templateA",
+					ResourcePool: "poolA",
+					Datastore:    "ds-aaa",
+					Folder:       "folder/A",
+					OSFamily:     "ubuntu",
+					Users: []UserConfiguration{
+						{
+							Name: "test",
+							SshAuthorizedKeys: []string{
+								"ssh_rsa",
+							},
+						},
+					},
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "valid without folder",
+			obj: &VSphereMachineConfig{
+				Spec: VSphereMachineConfigSpec{
+					MemoryMiB:    64,
+					DiskGiB:      100,
+					NumCPUs:      3,
+					Template:     "templateA",
+					ResourcePool: "poolA",
+					Datastore:    "ds-aaa",
+					OSFamily:     "ubuntu",
+					Users: []UserConfiguration{
+						{
+							Name: "test",
+							SshAuthorizedKeys: []string{
+								"ssh_rsa",
+							},
+						},
+					},
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "invalid - datastore not set",
+			obj: &VSphereMachineConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: VSphereMachineConfigSpec{
+					MemoryMiB:    64,
+					DiskGiB:      100,
+					NumCPUs:      3,
+					Template:     "templateA",
+					ResourcePool: "poolA",
+					Folder:       "folder/A",
+					OSFamily:     "ubuntu",
+					Users: []UserConfiguration{
+						{
+							Name: "test",
+							SshAuthorizedKeys: []string{
+								"ssh_rsa",
+							},
+						},
+					},
+				},
+			},
+			wantErr: "VSphereMachineConfig test datastore is not set or is empty",
+		},
+		{
+			name: "invalid - resource pool not set",
+			obj: &VSphereMachineConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: VSphereMachineConfigSpec{
+					MemoryMiB: 64,
+					DiskGiB:   100,
+					NumCPUs:   3,
+					Template:  "templateA",
+					Datastore: "ds-aaa",
+					Folder:    "folder/A",
+					OSFamily:  "ubuntu",
+					Users: []UserConfiguration{
+						{
+							Name: "test",
+							SshAuthorizedKeys: []string{
+								"ssh_rsa",
+							},
+						},
+					},
+				},
+			},
+			wantErr: "VSphereMachineConfig test VM resourcePool is not set or is empty",
+		},
+		{
+			name: "unsupported os family",
+			obj: &VSphereMachineConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: VSphereMachineConfigSpec{
+					MemoryMiB:    64,
+					DiskGiB:      100,
+					NumCPUs:      3,
+					Template:     "templateA",
+					ResourcePool: "poolA",
+					Datastore:    "ds-aaa",
+					Folder:       "folder/A",
+					OSFamily:     "suse",
+					Users: []UserConfiguration{
+						{
+							Name: "test",
+							SshAuthorizedKeys: []string{
+								"ssh_rsa",
+							},
+						},
+					},
+				},
+			},
+			wantErr: "VSphereMachineConfig test osFamily: suse is not supported, please use one of the following: bottlerocket, ubuntu",
+		},
+		{
+			name: "invalid ssh username",
+			obj: &VSphereMachineConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: VSphereMachineConfigSpec{
+					MemoryMiB:    64,
+					DiskGiB:      100,
+					NumCPUs:      3,
+					Template:     "templateA",
+					ResourcePool: "poolA",
+					Datastore:    "ds-aaa",
+					Folder:       "folder/A",
+					OSFamily:     "bottlerocket",
+					Users: []UserConfiguration{
+						{
+							Name: "test",
+							SshAuthorizedKeys: []string{
+								"ssh_rsa",
+							},
+						},
+					},
+				},
+			},
+			wantErr: "SSHUsername test is invalid",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := tt.obj.Validate()
+			if tt.wantErr == "" {
+				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
 			}
 		})
 	}

--- a/pkg/api/v1alpha1/vspheremachineconfig_types.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_types.go
@@ -1,8 +1,6 @@
 package v1alpha1
 
-import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
@@ -122,7 +120,7 @@ func (c *VSphereMachineConfig) SetDefaults() {
 }
 
 func (c *VSphereMachineConfig) Validate() error {
-	return nil
+	return validateVSphereMachineConfig(c)
 }
 
 // +kubebuilder:object:generate=false

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
@@ -42,7 +42,7 @@ var _ webhook.Validator = &VSphereMachineConfig{}
 func (r *VSphereMachineConfig) ValidateCreate() error {
 	vspheremachineconfiglog.Info("validate create", "name", r.Name)
 
-	return nil
+	return r.Validate()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -58,11 +58,19 @@ func (r *VSphereMachineConfig) ValidateUpdate(old runtime.Object) error {
 
 	allErrs = append(allErrs, validateImmutableFieldsVSphereMachineConfig(r, oldVSphereMachineConfig)...)
 
-	if len(allErrs) == 0 {
-		return nil
+	if len(allErrs) != 0 {
+		return apierrors.NewInvalid(GroupVersion.WithKind(VSphereMachineConfigKind).GroupKind(), r.Name, allErrs)
 	}
 
-	return apierrors.NewInvalid(GroupVersion.WithKind(VSphereMachineConfigKind).GroupKind(), r.Name, allErrs)
+	if err := r.Validate(); err != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec"), r.Spec, err.Error()))
+	}
+
+	if len(allErrs) != 0 {
+		return apierrors.NewInvalid(GroupVersion.WithKind(VSphereMachineConfigKind).GroupKind(), r.Name, allErrs)
+	}
+
+	return nil
 }
 
 func validateImmutableFieldsVSphereMachineConfig(new, old *VSphereMachineConfig) field.ErrorList {

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
@@ -675,10 +675,26 @@ func TestVSphereMachineValidateUpdateStoragePolicyImmutable(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
 }
 
+func TestVSphereMachineConfigValidateCreateSuccess(t *testing.T) {
+	config := vsphereMachineConfig()
+
+	g := NewWithT(t)
+	g.Expect(config.ValidateCreate()).To(Succeed())
+}
+
+func TestVSphereMachineConfigValidateCreateResourcePoolNotSet(t *testing.T) {
+	config := vsphereMachineConfig()
+	config.Spec.ResourcePool = ""
+
+	g := NewWithT(t)
+	g.Expect(config.ValidateCreate()).To(MatchError(ContainSubstring("resourcePool is not set or is empty")))
+}
+
 func TestVSphereMachineConfigSetDefaults(t *testing.T) {
 	g := NewWithT(t)
 
 	sOld := vsphereMachineConfig()
+	sOld.Spec.OSFamily = ""
 	sOld.Default()
 
 	g.Expect(sOld.Spec.MemoryMiB).To(Equal(8192))
@@ -691,7 +707,11 @@ func vsphereMachineConfig() v1alpha1.VSphereMachineConfig {
 	return v1alpha1.VSphereMachineConfig{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{Annotations: make(map[string]string, 2)},
-		Spec:       v1alpha1.VSphereMachineConfigSpec{},
-		Status:     v1alpha1.VSphereMachineConfigStatus{},
+		Spec: v1alpha1.VSphereMachineConfigSpec{
+			ResourcePool: "my-resourcePool",
+			Datastore:    "my-datastore",
+			OSFamily:     "ubuntu",
+		},
+		Status: v1alpha1.VSphereMachineConfigStatus{},
 	}
 }

--- a/pkg/cluster/parse_test.go
+++ b/pkg/cluster/parse_test.go
@@ -100,10 +100,12 @@ func TestParseConfig(t *testing.T) {
 						Name: "eksa-unit-test-cp",
 					},
 					Spec: anywherev1.VSphereMachineConfigSpec{
-						DiskGiB:   25,
-						MemoryMiB: 8192,
-						NumCPUs:   2,
-						OSFamily:  anywherev1.Ubuntu,
+						Datastore:    "myDatastore",
+						DiskGiB:      25,
+						MemoryMiB:    8192,
+						NumCPUs:      2,
+						OSFamily:     anywherev1.Ubuntu,
+						ResourcePool: "myResourcePool",
 						Users: []anywherev1.UserConfiguration{{
 							Name:              "mySshUsername",
 							SshAuthorizedKeys: []string{"mySshAuthorizedKey"},
@@ -119,10 +121,12 @@ func TestParseConfig(t *testing.T) {
 						Name: "eksa-unit-test",
 					},
 					Spec: anywherev1.VSphereMachineConfigSpec{
-						DiskGiB:   25,
-						MemoryMiB: 8192,
-						NumCPUs:   2,
-						OSFamily:  anywherev1.Ubuntu,
+						Datastore:    "myDatastore",
+						DiskGiB:      25,
+						MemoryMiB:    8192,
+						NumCPUs:      2,
+						OSFamily:     anywherev1.Ubuntu,
+						ResourcePool: "myResourcePool",
 						Users: []anywherev1.UserConfiguration{{
 							Name:              "mySshUsername",
 							SshAuthorizedKeys: []string{"mySshAuthorizedKey"},

--- a/pkg/cluster/testdata/cluster_1_19.yaml
+++ b/pkg/cluster/testdata/cluster_1_19.yaml
@@ -45,10 +45,12 @@ kind: VSphereMachineConfig
 metadata:
   name: eksa-unit-test-cp
 spec:
+  datastore: "myDatastore"
   diskGiB: 25
   memoryMiB: 8192
   numCPUs: 2
   osFamily: ubuntu
+  resourcePool: "myResourcePool"
   users:
     - name: mySshUsername
       sshAuthorizedKeys:
@@ -59,10 +61,12 @@ kind: VSphereMachineConfig
 metadata:
   name: eksa-unit-test
 spec:
+  datastore: "myDatastore"
   diskGiB: 25
   memoryMiB: 8192
   numCPUs: 2
   osFamily: ubuntu
+  resourcePool: "myResourcePool"
   users:
     - name: mySshUsername
       sshAuthorizedKeys:

--- a/pkg/providers/vsphere/validator.go
+++ b/pkg/providers/vsphere/validator.go
@@ -610,12 +610,10 @@ func (v *Validator) getMissingPrivs(ctx context.Context, vsc govmomi.VSphereClie
 }
 
 func (v *Validator) sameOSFamily(configs map[string]*anywherev1.VSphereMachineConfig) bool {
-	var osFamily anywherev1.OSFamily
+	c := getRandomMachineConfig(configs)
+	osFamily := c.Spec.OSFamily
+
 	for _, machineConfig := range configs {
-		if osFamily == "" {
-			osFamily = machineConfig.Spec.OSFamily
-			continue
-		}
 		if machineConfig.Spec.OSFamily != osFamily {
 			return false
 		}
@@ -624,15 +622,22 @@ func (v *Validator) sameOSFamily(configs map[string]*anywherev1.VSphereMachineCo
 }
 
 func (v *Validator) sameTemplate(configs map[string]*anywherev1.VSphereMachineConfig) bool {
-	var template string
+	c := getRandomMachineConfig(configs)
+	template := c.Spec.Template
+
 	for _, machineConfig := range configs {
-		if template == "" {
-			template = machineConfig.Spec.Template
-			continue
-		}
 		if machineConfig.Spec.Template != template {
 			return false
 		}
 	}
 	return true
+}
+
+func getRandomMachineConfig(configs map[string]*anywherev1.VSphereMachineConfig) *anywherev1.VSphereMachineConfig {
+	var machineConfig *anywherev1.VSphereMachineConfig
+	for _, c := range configs {
+		machineConfig = c
+		break
+	}
+	return machineConfig
 }

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -49,7 +49,6 @@ const (
 	expClusterResourceSetKey = "EXP_CLUSTER_RESOURCE_SET"
 	defaultTemplateLibrary   = "eks-a-templates"
 	defaultTemplatesFolder   = "vm/Templates"
-	bottlerocketDefaultUser  = "ec2-user"
 	maxRetries               = 30
 	backOffPeriod            = 5 * time.Second
 )

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -1724,96 +1724,6 @@ func TestSetupAndValidateCreateClusterNoDatacenter(t *testing.T) {
 	thenErrorExpected(t, "VSphereDatacenterConfig datacenter is not set or is empty", err)
 }
 
-func TestSetupAndValidateCreateClusterNoDatastoreControlPlane(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenEmptyClusterSpec()
-	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
-	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Datastore = ""
-	var tctx testContext
-	tctx.SaveContext()
-
-	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-
-	thenErrorExpected(t, "VSphereMachineConfig datastore for control plane is not set or is empty", err)
-}
-
-func TestSetupAndValidateCreateClusterNoDatastoreWorker(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenEmptyClusterSpec()
-	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	provider := givenProvider(t)
-	workerMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
-	provider.machineConfigs[workerMachineConfigName].Spec.Datastore = ""
-	var tctx testContext
-	tctx.SaveContext()
-
-	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-
-	thenErrorExpected(t, "VSphereMachineConfig datastore for worker nodes is not set or is empty", err)
-}
-
-func TestSetupAndValidateCreateClusterNoDatastoreEtcd(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenEmptyClusterSpec()
-	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
-	provider.machineConfigs[etcdMachineConfigName].Spec.Datastore = ""
-	var tctx testContext
-	tctx.SaveContext()
-
-	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-
-	thenErrorExpected(t, "VSphereMachineConfig datastore for etcd machines is not set or is empty", err)
-}
-
-func TestSetupAndValidateCreateClusterNoResourcePoolControlPlane(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenEmptyClusterSpec()
-	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
-	provider.machineConfigs[controlPlaneMachineConfigName].Spec.ResourcePool = ""
-	var tctx testContext
-	tctx.SaveContext()
-
-	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-
-	thenErrorExpected(t, "VSphereMachineConfig VM resourcePool for control plane is not set or is empty", err)
-}
-
-func TestSetupAndValidateCreateClusterNoResourcePoolWorker(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenEmptyClusterSpec()
-	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	provider := givenProvider(t)
-	workerMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
-	provider.machineConfigs[workerMachineConfigName].Spec.ResourcePool = ""
-	var tctx testContext
-	tctx.SaveContext()
-
-	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-
-	thenErrorExpected(t, "VSphereMachineConfig VM resourcePool for worker nodes is not set or is empty", err)
-}
-
-func TestSetupAndValidateCreateClusterNoResourcePoolEtcd(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenEmptyClusterSpec()
-	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
-	provider.machineConfigs[etcdMachineConfigName].Spec.ResourcePool = ""
-	var tctx testContext
-	tctx.SaveContext()
-
-	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-
-	thenErrorExpected(t, "VSphereMachineConfig VM resourcePool for etcd machines is not set or is empty", err)
-}
-
 func TestSetupAndValidateCreateClusterNoNetwork(t *testing.T) {
 	ctx := context.Background()
 	clusterSpec := givenEmptyClusterSpec()
@@ -2310,45 +2220,6 @@ func TestSetupAndValidateCreateClusterEtcdMachineGroupRefNonexistent(t *testing.
 	}
 }
 
-func TestSetupAndValidateCreateClusterOsFamilyInvalid(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenEmptyClusterSpec()
-	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	provider := givenProvider(t)
-	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
-	provider.machineConfigs[controlPlaneMachineConfigName].Spec.OSFamily = "suse"
-	var tctx testContext
-	tctx.SaveContext()
-	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-	thenErrorExpected(t, "control plane osFamily: suse is not supported, please use one of the following: bottlerocket, ubuntu, redhat", err)
-}
-
-func TestSetupAndValidateCreateClusterOsFamilyInvalidWorkerNode(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenEmptyClusterSpec()
-	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	provider := givenProvider(t)
-	workerMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
-	provider.machineConfigs[workerMachineConfigName].Spec.OSFamily = "suse"
-	var tctx testContext
-	tctx.SaveContext()
-	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-	thenErrorExpected(t, "worker node osFamily: suse is not supported, please use one of the following: bottlerocket, ubuntu, redhat", err)
-}
-
-func TestSetupAndValidateCreateClusterOsFamilyInvalidEtcdNode(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenEmptyClusterSpec()
-	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	provider := givenProvider(t)
-	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
-	provider.machineConfigs[etcdMachineConfigName].Spec.OSFamily = "suse"
-	var tctx testContext
-	tctx.SaveContext()
-	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-	thenErrorExpected(t, "etcd node osFamily: suse is not supported, please use one of the following: bottlerocket, ubuntu, redhat", err)
-}
-
 func TestSetupAndValidateCreateClusterOsFamilyDifferent(t *testing.T) {
 	ctx := context.Background()
 	clusterSpec := givenEmptyClusterSpec()
@@ -2356,12 +2227,13 @@ func TestSetupAndValidateCreateClusterOsFamilyDifferent(t *testing.T) {
 	provider := givenProvider(t)
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.OSFamily = "bottlerocket"
+	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].Name = "ec2-user"
 	var tctx testContext
 	tctx.SaveContext()
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
-		thenErrorExpected(t, "control plane and worker nodes must have the same osFamily specified", err)
+		thenErrorExpected(t, "all VSphereMachineConfigs must have the same osFamily specified", err)
 	}
 }
 
@@ -2372,12 +2244,13 @@ func TestSetupAndValidateCreateClusterOsFamilyDifferentForEtcd(t *testing.T) {
 	provider := givenProvider(t)
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.OSFamily = "bottlerocket"
+	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].Name = "ec2-user"
 	var tctx testContext
 	tctx.SaveContext()
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
-		thenErrorExpected(t, "control plane and etcd machines must have the same osFamily specified", err)
+		thenErrorExpected(t, "all VSphereMachineConfigs must have the same osFamily specified", err)
 	}
 }
 
@@ -2431,7 +2304,7 @@ func TestSetupAndValidateCreateClusterTemplateDifferent(t *testing.T) {
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
-		thenErrorExpected(t, "control plane and worker nodes must have the same template specified", err)
+		thenErrorExpected(t, "all VSphereMachineConfigs must have the same template specified", err)
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR moves some vsphere machine config validations to the api level. This is especially important for the full lifecycle api to validate the fields during both create and upgrade through the controller

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

