### PR TITLE
Move some cluster validations to api

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -166,10 +166,8 @@ func NewCluster(clusterName string) *Cluster {
 
 var clusterConfigValidations = []func(*Cluster) error{
 	validateClusterConfigName,
-	// TODO(chrisdoherty) Uncomment and fix unit tests. This broke _lots_ of unit tests so will
-	// return shortly.
 	validateControlPlaneEndpoint,
-	// validateControlPlaneMachineRef,
+	validateMachineGroupRefs,
 	validateControlPlaneReplicas,
 	validateWorkerNodeGroups,
 	validateNetworking,
@@ -344,24 +342,23 @@ func validateClusterConfigName(clusterConfig *Cluster) error {
 	return nil
 }
 
-// func validateControlPlaneEndpoint(cluster *Cluster) error {
-// 	if cluster.Spec.ControlPlaneConfiguration.Endpoint.Host == "" {
-// 		return errors.New("control plane endpoint host cannot be empty")
-// 	}
+func validateMachineGroupRefs(cluster *Cluster) error {
+	if cluster.Spec.DatacenterRef.Kind != DockerDatacenterKind {
+		if cluster.Spec.ControlPlaneConfiguration.MachineGroupRef == nil {
+			return errors.New("must specify machineGroupRef control plane machines")
+		}
+		for _, workerNodeGroupConfiguration := range cluster.Spec.WorkerNodeGroupConfigurations {
+			if workerNodeGroupConfiguration.MachineGroupRef == nil {
+				return errors.New("must specify machineGroupRef for worker nodes")
+			}
+		}
+		if cluster.Spec.ExternalEtcdConfiguration != nil && cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef == nil {
+			return errors.New("must specify machineGroupRef for etcd machines")
+		}
+	}
 
-// 	if err := networkutils.ValidateIP(cluster.Spec.ControlPlaneConfiguration.Endpoint.Host); err != nil {
-// 		return fmt.Errorf("invalid control plane endpoint host: %v", err)
-// 	}
-
-// 	return nil
-// }
-
-// func validateControlPlaneMachineRef(cluster *Cluster) error {
-// 	if cluster.Spec.ControlPlaneConfiguration.MachineGroupRef == nil {
-// 		return errors.New("control plane machine group ref cannot be nil")
-// 	}
-// 	return nil
-// }
+	return nil
+}
 
 func validateControlPlaneReplicas(clusterConfig *Cluster) error {
 	if clusterConfig.Spec.ControlPlaneConfiguration.Count <= 0 {
@@ -390,9 +387,23 @@ func validateControlPlaneLabels(clusterConfig *Cluster) error {
 }
 
 func validateControlPlaneEndpoint(clusterConfig *Cluster) error {
-	if clusterConfig.Spec.DatacenterRef.Kind == DockerDatacenterKind && clusterConfig.Spec.ControlPlaneConfiguration.Endpoint != nil && clusterConfig.Spec.ControlPlaneConfiguration.Endpoint.Host != "" {
-		return fmt.Errorf("specifying endpoint host configuration in Cluster is not supported")
+	if clusterConfig.Spec.DatacenterRef.Kind == DockerDatacenterKind {
+		if clusterConfig.Spec.ControlPlaneConfiguration.Endpoint != nil {
+			return fmt.Errorf("specifying endpoint host configuration in Cluster is not supported")
+		}
+		return nil
 	}
+
+	if clusterConfig.Spec.ControlPlaneConfiguration.Endpoint == nil || len(clusterConfig.Spec.ControlPlaneConfiguration.Endpoint.Host) <= 0 {
+		return errors.New("cluster controlPlaneConfiguration.Endpoint.Host is not set or is empty")
+	}
+
+	// TODO: validate IP
+	//if err := networkutils.ValidateIP(clusterConfig.Spec.ControlPlaneConfiguration.Endpoint.Host); err != nil {
+	//
+	//	return fmt.Errorf("invalid control plane endpoint host: %v", err)
+	//}
+
 	return nil
 }
 
@@ -433,11 +444,6 @@ func validateWorkerNodeGroups(clusterConfig *Cluster) error {
 		if err := validateNodeLabels(workerNodeGroupConfig.Labels, field.NewPath("spec", workerNodeGroupField, "labels")); err != nil {
 			return fmt.Errorf("labels for worker node group %v not valid: %v", workerNodeGroupConfig.Name, err)
 		}
-
-		// TODO(chrisdoherty4) uncomment and fix
-		// if workerNodeGroupConfig.MachineGroupRef == nil {
-		// 	return fmt.Errorf("worker node group missing machineg roup ref: name=%v", workerNodeGroupConfig.Name)
-		// }
 
 		workerNodeGroupNames[workerNodeGroupConfig.Name] = true
 	}

--- a/pkg/providers/vsphere/validator.go
+++ b/pkg/providers/vsphere/validator.go
@@ -94,15 +94,6 @@ func (v *Validator) ValidateVCenterConfig(ctx context.Context, datacenterConfig 
 func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, vsphereClusterSpec *Spec) error {
 	var etcdMachineConfig *anywherev1.VSphereMachineConfig
 
-	// TODO: move this to api Cluster validations
-	if len(vsphereClusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host) <= 0 {
-		return errors.New("cluster controlPlaneConfiguration.Endpoint.Host is not set or is empty")
-	}
-
-	if vsphereClusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef == nil {
-		return errors.New("must specify machineGroupRef for control plane")
-	}
-
 	controlPlaneMachineConfig := vsphereClusterSpec.controlPlaneMachineConfig()
 	if controlPlaneMachineConfig == nil {
 		return fmt.Errorf("cannot find VSphereMachineConfig %v for control plane", vsphereClusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name)
@@ -129,9 +120,6 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, vsphereCl
 
 	var workerNodeGroupMachineConfigs []*anywherev1.VSphereMachineConfig
 	for _, workerNodeGroupConfiguration := range vsphereClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
-		if workerNodeGroupConfiguration.MachineGroupRef == nil {
-			return errors.New("must specify machineGroupRef for worker nodes")
-		}
 		workerNodeGroupMachineConfig := vsphereClusterSpec.workerMachineConfig(workerNodeGroupConfiguration)
 		workerNodeGroupMachineConfigs = append(workerNodeGroupMachineConfigs, workerNodeGroupMachineConfig)
 		if workerNodeGroupMachineConfig == nil {
@@ -157,9 +145,6 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, vsphereCl
 		}
 	}
 	if vsphereClusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
-		if vsphereClusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef == nil {
-			return errors.New("must specify machineGroupRef for etcd machines")
-		}
 		etcdMachineConfig = vsphereClusterSpec.etcdMachineConfig()
 		if etcdMachineConfig == nil {
 			return fmt.Errorf("cannot find VSphereMachineConfig %v for etcd machines", vsphereClusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name)

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -1696,20 +1696,6 @@ func TestSetupAndValidateCreateClusterInsecure(t *testing.T) {
 	}
 }
 
-func TestSetupAndValidateCreateClusterNoControlPlaneEndpointIP(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenEmptyClusterSpec()
-	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	provider := givenProvider(t)
-	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host = ""
-	var tctx testContext
-	tctx.SaveContext()
-
-	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-
-	thenErrorExpected(t, "cluster controlPlaneConfiguration.Endpoint.Host is not set or is empty", err)
-}
-
 func TestSetupAndValidateCreateClusterNoDatacenter(t *testing.T) {
 	ctx := context.Background()
 	clusterSpec := givenEmptyClusterSpec()
@@ -2217,51 +2203,6 @@ func TestSetupAndValidateSshAuthorizedKeysNil(t *testing.T) {
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
 		t.Fatalf("provider.SetupAndValidateCreateCluster() err = %v, want err = nil", err)
-	}
-}
-
-func TestSetupAndValidateCreateClusterCPMachineGroupRefNil(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenEmptyClusterSpec()
-	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	provider := givenProvider(t)
-	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef = nil
-	var tctx testContext
-	tctx.SaveContext()
-
-	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-	if err != nil {
-		thenErrorExpected(t, "must specify machineGroupRef for control plane", err)
-	}
-}
-
-func TestSetupAndValidateCreateClusterWorkerMachineGroupRefNil(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenEmptyClusterSpec()
-	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	provider := givenProvider(t)
-	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef = nil
-	var tctx testContext
-	tctx.SaveContext()
-
-	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-	if err != nil {
-		thenErrorExpected(t, "must specify machineGroupRef for worker nodes", err)
-	}
-}
-
-func TestSetupAndValidateCreateClusterEtcdMachineGroupRefNil(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenEmptyClusterSpec()
-	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	provider := givenProvider(t)
-	clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef = nil
-	var tctx testContext
-	tctx.SaveContext()
-
-	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-	if err != nil {
-		thenErrorExpected(t, "must specify machineGroupRef for etcd machines", err)
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR moves some cluster validations from the provider to the Cluster object API. This removes the need to redefine the same validations across providers because they will now happen at he cluster level. These changes also allow us to validate these fields in the controller during cluster reconciliation. These changes are particularly important for the new full lifecycle API that will allow us to also create additional workload clusters managed by an initial EKS-A cluster

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

