### PR TITLE
Rename contextutil to workflowcontext

### DIFF
--- a/pkg/workflow/task/bootstrap/bootstrap.go
+++ b/pkg/workflow/task/bootstrap/bootstrap.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/types"
-	"github.com/aws/eks-anywhere/pkg/workflow/contextutil"
+	"github.com/aws/eks-anywhere/pkg/workflow/workflowcontext"
 )
 
 // OptionsRetriever supplies bootstrap cluster options. This is typically satisfied
@@ -61,7 +61,7 @@ func (t CreateCluster) RunTask(ctx context.Context) (context.Context, error) {
 		return ctx, err
 	}
 
-	return contextutil.WithBootstrapCluster(ctx, *cluster), nil
+	return workflowcontext.WithBootstrapCluster(ctx, *cluster), nil
 }
 
 // DeleteCluster deletes a bootstrap cluster. It expects the bootstrap cluster to be
@@ -73,7 +73,7 @@ type DeleteCluster struct {
 
 // RunTask satisfies workflow.Task.
 func (t DeleteCluster) RunTask(ctx context.Context) (context.Context, error) {
-	cluster := contextutil.BootstrapCluster(ctx)
+	cluster := workflowcontext.BootstrapCluster(ctx)
 
 	if err := t.Bootstrapper.DeleteBootstrapCluster(ctx, &cluster, constants.Create, false); err != nil {
 		return ctx, err

--- a/pkg/workflow/workflowcontext/bootstrap.go
+++ b/pkg/workflow/workflowcontext/bootstrap.go
@@ -1,4 +1,4 @@
-package contextutil
+package workflowcontext
 
 import (
 	"context"

--- a/pkg/workflow/workflowcontext/contextutil.go
+++ b/pkg/workflow/workflowcontext/contextutil.go
@@ -1,5 +1,5 @@
 /*
-Package contextutil contains utility functions for populating workflow context specific data
+Package workflowcontext contains utility functions for populating workflow context specific data
 in a context.Context.
 
 Data appropriate for the context includes anything that cannot be determined at time of
@@ -7,4 +7,4 @@ object construction. For example, a bootstrap cluster does not exist when execut
 workflows, therefore a Kubeconfig isn't available to communicate with the cluster so must be passed
 as contextual data.
 */
-package contextutil
+package workflowcontext

--- a/pkg/workflow/workflowcontext/key.go
+++ b/pkg/workflow/workflowcontext/key.go
@@ -1,4 +1,4 @@
-package contextutil
+package workflowcontext
 
 // contextKey is used to create collisionless context keys.
 type contextKey string


### PR DESCRIPTION
`contextutil` was too ambiguous for how closely related to workflow execution it is. While `workflowcontext` creates an undesirable directory hierarchy, it provides clarity for consumers when leveraging the behavior it provides.

For example

```go
func foo(ctx context.Context) {
	_ = contextutil.BootstrapCluster(ctx) // Not clear its specific to workflows
}
```

```go
func foo(ctx context.Context) {
	_ = workflowcontext.BootstrapCluster(ctx) // Clear its specific to workflows
}
```
