### PR TITLE
Fix gitopsConfig validation for workload cluster

### DIFF
--- a/pkg/validations/createvalidations/gitops.go
+++ b/pkg/validations/createvalidations/gitops.go
@@ -68,6 +68,12 @@ func validateFluxConfig(ctx context.Context, k validations.KubectlClient, cluste
 		return nil
 	}
 
+	// when processing deprecated gitopsConfig, we parse and convert it to fluxConfig.
+	// for this case both fluxConfig and gitopsConfig can exist in spec. Skip fluxConfig validation.
+	if clusterSpec.GitOpsConfig != nil {
+		return nil
+	}
+
 	fluxConfig := &v1alpha1.FluxConfig{}
 	err := k.GetObject(ctx, fluxConfigResourceType, clusterSpec.FluxConfig.Name, clusterSpec.Cluster.Namespace, cluster.KubeconfigFile, fluxConfig)
 	if err == nil {

--- a/pkg/validations/createvalidations/gitops_test.go
+++ b/pkg/validations/createvalidations/gitops_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/validations/createvalidations"
 )
 
-func TestValidateGitOpsConfigNil(t *testing.T) {
+func TestValidateGitOpsConfigFluxConfigBothNil(t *testing.T) {
 	tt := newPreflightValidationsTest(t)
 	tt.Expect(createvalidations.ValidateGitOps(tt.ctx, tt.k, tt.c.Opts.ManagementCluster, tt.c.Opts.Spec)).To(Succeed())
 }
@@ -89,6 +89,7 @@ func TestValidateGitOpsConfigNotEqual(t *testing.T) {
 
 func TestValidateGitOpsConfigSuccess(t *testing.T) {
 	tt := newPreflightValidationsTest(t)
+	tt.c.Opts.Spec.FluxConfig = &v1alpha1.FluxConfig{}
 	tt.c.Opts.Spec.GitOpsConfig = &v1alpha1.GitOpsConfig{}
 	tt.k.EXPECT().GetObject(tt.ctx, "gitopsconfigs.anywhere.eks.amazonaws.com", "", "", "kubeconfig", &v1alpha1.GitOpsConfig{}).Return(apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: ""}, ""))
 	tt.k.EXPECT().


### PR DESCRIPTION
*Issue #, if available:*

Fix a validation bug introduced in #3517 

*Description of changes:*

When using the deprecated `gitopsConfig`, CLI converts the object to `fluxConfig` and adds it in Spec. We need to skip the fluxConfig validation for this case since it's actually a gitOpsConfig validation that is covered in different method.

*Testing (if applicable):*

Unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

