### PR TITLE
AWS IAM Auth upgrade workload cluster

### DIFF
--- a/controllers/resource/reconciler.go
+++ b/controllers/resource/reconciler.go
@@ -193,11 +193,14 @@ func (cor *clusterReconciler) Reconcile(ctx context.Context, objectKey types.Nam
 	for _, identityProvider := range cs.Spec.IdentityProviderRefs {
 		switch identityProvider.Kind {
 		case anywherev1.AWSIamConfigKind:
-			r, err := cor.awsIamConfigTemplate.TemplateResources(ctx, spec)
-			if err != nil {
-				return err
+			// Block controller from updating the self-managed cluster IAM Configmap when reconciling for workload cluster spec.
+			if cs.IsSelfManaged() {
+				r, err := cor.awsIamConfigTemplate.TemplateResources(ctx, spec)
+				if err != nil {
+					return err
+				}
+				resources = append(resources, r...)
 			}
-			resources = append(resources, r...)
 		}
 	}
 	return cor.applyTemplates(ctx, cs, resources, dryRun)

--- a/pkg/awsiamauth/awsiamauth.go
+++ b/pkg/awsiamauth/awsiamauth.go
@@ -46,11 +46,19 @@ func NewAwsIamAuthTemplateBuilder() *AwsIamAuthTemplateBuilder {
 }
 
 func (a *AwsIamAuthTemplateBuilder) GenerateManifest(clusterSpec *cluster.Spec, clusterId uuid.UUID) ([]byte, error) {
+	var clusterIdValue string
+	// If clusterId is Nil; set value as empty string.
+	if clusterId == uuid.Nil {
+		clusterIdValue = ""
+	} else {
+		clusterIdValue = clusterId.String()
+	}
+
 	data := map[string]interface{}{
 		"image":              clusterSpec.VersionsBundle.KubeDistro.AwsIamAuthImage.VersionedImage(),
 		"initContainerImage": clusterSpec.VersionsBundle.Eksa.DiagnosticCollector.VersionedImage(),
 		"awsRegion":          clusterSpec.AWSIamConfig.Spec.AWSRegion,
-		"clusterID":          clusterId.String(),
+		"clusterID":          clusterIdValue,
 		"backendMode":        strings.Join(clusterSpec.AWSIamConfig.Spec.BackendMode, ","),
 		"partition":          clusterSpec.AWSIamConfig.Spec.Partition,
 	}
@@ -78,6 +86,10 @@ func (a *AwsIamAuthTemplateBuilder) GenerateManifest(clusterSpec *cluster.Spec, 
 
 func (a *AwsIamAuth) GenerateManifest(clusterSpec *cluster.Spec) ([]byte, error) {
 	return a.templateBuilder.GenerateManifest(clusterSpec, a.clusterId)
+}
+
+func (a *AwsIamAuth) GenerateManifestForUpgrade(clusterSpec *cluster.Spec) ([]byte, error) {
+	return a.templateBuilder.GenerateManifest(clusterSpec, uuid.Nil)
 }
 
 func (a *AwsIamAuth) GenerateCertKeyPairSecret() ([]byte, error) {

--- a/pkg/awsiamauth/awsiamauth_test.go
+++ b/pkg/awsiamauth/awsiamauth_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	wantManifestContent   = "testdata/want-aws-iam-authenticator.yaml"
-	wantSecretContent     = "testdata/want-aws-iam-authenticator-ca-secret.yaml"
-	wantKubeconfigContent = "testdata/want-aws-iam-authenticator-kubeconfig.yaml"
+	wantManifestContent        = "testdata/want-aws-iam-authenticator.yaml"
+	wantManifestContentUpgrade = "testdata/want-aws-iam-authenticator-upgrade.yaml"
+	wantSecretContent          = "testdata/want-aws-iam-authenticator-ca-secret.yaml"
+	wantKubeconfigContent      = "testdata/want-aws-iam-authenticator-kubeconfig.yaml"
 )
 
 func TestGenerateManifestSuccess(t *testing.T) {
@@ -32,6 +33,21 @@ func TestGenerateManifestSuccess(t *testing.T) {
 		t.Fatalf("awsiamauth.GenerateManifest()\n error = %v\n wantErr = nil", err)
 	}
 	test.AssertContentToFile(t, string(gotFileContent), wantManifestContent)
+}
+
+func TestGenerateManifestForUpgradeSuccess(t *testing.T) {
+	s := givenClusterSpec()
+
+	mockCtrl := gomock.NewController(t)
+	mockCertgen := mocks.NewMockCertificateGenerator(mockCtrl)
+	mockClusterId := uuid.Nil
+	awsIamAuth := awsiamauth.NewAwsIamAuth(mockCertgen, mockClusterId)
+
+	gotFileContent, err := awsIamAuth.GenerateManifestForUpgrade(s)
+	if err != nil {
+		t.Fatalf("awsiamauth.GenerateManifestForUpgrade()\n error = %v\n wantErr = nil", err)
+	}
+	test.AssertContentToFile(t, string(gotFileContent), wantManifestContentUpgrade)
 }
 
 func TestGenerateCertKeyPairSecretSuccess(t *testing.T) {

--- a/pkg/awsiamauth/config/aws-iam-authenticator.yaml
+++ b/pkg/awsiamauth/config/aws-iam-authenticator.yaml
@@ -180,7 +180,7 @@ spec:
       - name: key
         hostPath:
           path: /var/lib/kubeadm/aws-iam-authenticator/pki/key.pem
-{{- if (ne .clusterID "")}}
+{{- if (ne .clusterID "") }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -192,7 +192,7 @@ metadata:
 data:
   config.yaml: |
     clusterID: {{.clusterID}}
-{{- end}}
+{{- end }}
 
 ---
 # EKS-Style ConfigMap: roles and users can be mapped in the same way as supported on EKS.
@@ -202,11 +202,11 @@ metadata:
   name: aws-auth
   namespace: kube-system
 data:
-{{- if (ne .mapRoles "")}}
+{{- if (ne .mapRoles "") }}
   mapRoles: |
 {{ .mapRoles | indent 4 }}
-{{- end}}
-{{- if (ne .mapUsers "")}}
+{{- end }}
+{{- if (ne .mapUsers "") }}
   mapUsers: |
 {{ .mapUsers | indent 4 }}
-{{- end}}
+{{- end }}

--- a/pkg/awsiamauth/testdata/want-aws-iam-authenticator-upgrade.yaml
+++ b/pkg/awsiamauth/testdata/want-aws-iam-authenticator-upgrade.yaml
@@ -100,16 +100,6 @@ spec:
         key: node-role.kubernetes.io/master
       - key: CriticalAddonsOnly
         operator: Exists
-{{- if .controlPlaneTaints }}
-{{- range .controlPlaneTaints }}
-      - key: {{ .Key }}
-        value: {{ .Value }}
-        effect: {{ .Effect }}
-{{- if .TimeAdded }}
-        timeAdded: {{ .TimeAdded }}
-{{- end }}
-{{- end }}
-{{- end }}
 
       # `aws-iam-authenticator server` has four volumes
       # - config (mounted from the ConfigMap at /etc/aws-iam-authenticator/config.yaml)
@@ -117,14 +107,14 @@ spec:
       # - kubeconfig (kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
       - name: aws-iam-authenticator
-        image: {{.image}}
+        image: public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.5.2-eks-1-18-11
         env:
         - name: AWS_REGION
-          value: {{.awsRegion}}
+          value: test-region
         args:
         - server
-        - --backend-mode={{.backendMode}}
-        - --partition={{.partition}}
+        - --backend-mode=mode1,mode2
+        - --partition=test
         - --config=/etc/aws-iam-authenticator/config.yaml
         - --state-dir=/var/aws-iam-authenticator
         - --generate-kubeconfig=/etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml
@@ -157,7 +147,7 @@ spec:
       # init container to set permissions for the mount paths
       initContainers:
       - name: chown
-        image: {{.initContainerImage}}
+        image: public.ecr.aws/eks-anywhere/diagnostic-collector:v0.9.1-eks-a-10
         command: ['sh', '-c', 'chown 10000:10000 /var/aws-iam-authenticator/cert.pem; chown 10000:10000 /var/aws-iam-authenticator/key.pem; chown 10000:10000 /etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml']
         volumeMounts:
         - name: cert
@@ -180,19 +170,6 @@ spec:
       - name: key
         hostPath:
           path: /var/lib/kubeadm/aws-iam-authenticator/pki/key.pem
-{{- if (ne .clusterID "")}}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: kube-system
-  name: aws-iam-authenticator
-  labels:
-    k8s-app: aws-iam-authenticator
-data:
-  config.yaml: |
-    clusterID: {{.clusterID}}
-{{- end}}
 
 ---
 # EKS-Style ConfigMap: roles and users can be mapped in the same way as supported on EKS.
@@ -202,11 +179,15 @@ metadata:
   name: aws-auth
   namespace: kube-system
 data:
-{{- if (ne .mapRoles "")}}
   mapRoles: |
-{{ .mapRoles | indent 4 }}
-{{- end}}
-{{- if (ne .mapUsers "")}}
+    - rolearn: test-role-arn
+      username: test
+      groups:
+        - group1
+        - group2
   mapUsers: |
-{{ .mapUsers | indent 4 }}
-{{- end}}
+    - userarn: test-user-arn
+      username: test
+      groups:
+        - group1
+        - group2

--- a/pkg/awsiamauth/testdata/want-aws-iam-authenticator.yaml
+++ b/pkg/awsiamauth/testdata/want-aws-iam-authenticator.yaml
@@ -170,7 +170,6 @@ spec:
       - name: key
         hostPath:
           path: /var/lib/kubeadm/aws-iam-authenticator/pki/key.pem
-
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -486,7 +486,7 @@ func (c *ClusterManager) UpgradeCluster(ctx context.Context, managementCluster, 
 	if newClusterSpec.AWSIamConfig != nil {
 		logger.V(3).Info("Run aws-iam-authenticator upgrade operations")
 		if err = c.generateAndApplyAwsIamAuthForUpgrade(ctx, workloadCluster, newClusterSpec); err != nil {
-			return fmt.Errorf("running aws-iam-authenticator upgrade operations")
+			return fmt.Errorf("running aws-iam-authenticator upgrade operations: %v", err)
 		}
 	}
 

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -832,3 +832,18 @@ func (mr *MockAwsIamAuthMockRecorder) GenerateManifest(arg0 interface{}) *gomock
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateManifest", reflect.TypeOf((*MockAwsIamAuth)(nil).GenerateManifest), arg0)
 }
+
+// GenerateManifestForUpgrade mocks base method.
+func (m *MockAwsIamAuth) GenerateManifestForUpgrade(arg0 *cluster.Spec) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenerateManifestForUpgrade", arg0)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GenerateManifestForUpgrade indicates an expected call of GenerateManifestForUpgrade.
+func (mr *MockAwsIamAuthMockRecorder) GenerateManifestForUpgrade(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateManifestForUpgrade", reflect.TypeOf((*MockAwsIamAuth)(nil).GenerateManifestForUpgrade), arg0)
+}


### PR DESCRIPTION
*Issues #3391 #3560*

*Description of changes:*
Changes include steps in the cluster upgrade workflow to upgrade aws-iam-authenticator components for workload clusters. Also added a check to prevent `eks-a-controller` from reconciling on management for workload cluster spec. 

*Testing:*
```bash
./eksctl-anywhere upgrade cluster -f ./test/test-eks-a-cluster.yaml

./eksctl-anywhere upgrade cluster -f ./test-workload/test-workload-eks-a-cluster.yaml --kubeconfig ./test/test-eks-a-cluster.kubeconfig
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

