### PR TITLE
Fix source image format for Tinkerbell chart

### DIFF
--- a/release/pkg/assets/config/bundle_release.go
+++ b/release/pkg/assets/config/bundle_release.go
@@ -782,7 +782,7 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 				RepoName:             "tinkerbell-chart",
 				TrimVersionSignifier: true,
 				ImageTagConfiguration: assettypes.ImageTagConfiguration{
-					SourceLatestTagFromECR: true,
+					NonProdSourceImageTagFormat: "<gitTag>",
 				},
 			},
 		},

--- a/release/pkg/bundles/package-controller.go
+++ b/release/pkg/bundles/package-controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/aws/eks-anywhere/release/pkg/constants"
 	"github.com/aws/eks-anywhere/release/pkg/helm"
 	releasetypes "github.com/aws/eks-anywhere/release/pkg/types"
-
 	bundleutils "github.com/aws/eks-anywhere/release/pkg/util/bundles"
 	"github.com/aws/eks-anywhere/release/pkg/version"
 )

--- a/release/pkg/constants/constants.go
+++ b/release/pkg/constants/constants.go
@@ -24,6 +24,7 @@ const (
 	FakeGitCommit            = "0123456789abcdef0123456789abcdef01234567"
 	ReleaseFolderName        = "release"
 	EksDReleaseComponentsUrl = "https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml"
+	YamlSeparator            = "\n---\n"
 
 	// Project paths
 	CapasProjectPath                    = "projects/aws/cluster-api-provider-aws-snow"

--- a/release/pkg/images/images.go
+++ b/release/pkg/images/images.go
@@ -151,7 +151,7 @@ func GetSourceImageURI(r *releasetypes.ReleaseConfig, name, repoName string, tag
 				latestTag,
 			)
 		}
-		if strings.HasSuffix(name, "-helm") {
+		if strings.HasSuffix(name, "-helm") || strings.HasSuffix(name, "-chart") {
 			sourceImageUri += "-helm"
 		}
 		if trimVersionSignifier {


### PR DESCRIPTION
This PR modifies the Tinkerbell chart tagging to follow the format `<gitTag>-latest-helm`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

