### PR TITLE
Fix image repo name for CAPX

### DIFF
--- a/release/pkg/assets/config/bundle_release.go
+++ b/release/pkg/assets/config/bundle_release.go
@@ -244,6 +244,28 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 			},
 		},
 	},
+	// Cluster-api-provider-nutanix artifacts
+	{
+		ProjectName: "cluster-api-provider-nutanix",
+		ProjectPath: "projects/nutanix-cloud-native/cluster-api-provider-nutanix",
+		Images: []*assettypes.Image{
+			{
+				RepoName: "cluster-api-provider-nutanix",
+			},
+		},
+		ImageRepoPrefix: "nutanix-cloud-native",
+		ImageTagOptions: []string{
+			"gitTag",
+			"projectPath",
+		},
+		Manifests: []*assettypes.ManifestComponent{
+			{
+				Name:          "infrastructure-nutanix",
+				ManifestFiles: []string{"infrastructure-components.yaml", "cluster-template.yaml", "metadata.yaml"},
+			},
+		},
+		OnlyForDevRelease: true,
+	},
 	// Cluster-api-provider-tinkerbell artifacts
 	{
 		ProjectName: "cluster-api-provider-tinkerbell",
@@ -811,28 +833,6 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 			"gitTag",
 			"projectPath",
 		},
-	},
-	{
-		ProjectName: "cluster-api-provider-nutanix",
-		ProjectPath: "projects/nutanix-cloud-native/cluster-api-provider-nutanix",
-		Images: []*assettypes.Image{
-			{
-				RepoName:  "manager",
-				AssetName: "cluster-api-provider-nutanix",
-			},
-		},
-		ImageRepoPrefix: "nutanix-cloud-native/cluster-api-provider-nutanix/release",
-		ImageTagOptions: []string{
-			"gitTag",
-			"projectPath",
-		},
-		Manifests: []*assettypes.ManifestComponent{
-			{
-				Name:          "infrastructure-nutanix",
-				ManifestFiles: []string{"infrastructure-components.yaml", "cluster-template.yaml", "metadata.yaml"},
-			},
-		},
-		OnlyForDevRelease: true,
 	},
 }
 

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -429,7 +429,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix/release/manager:v0.5.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v0.5.1-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v0.5.1/cluster-template.yaml
       components:
@@ -1192,7 +1192,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix/release/manager:v0.5.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v0.5.1-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v0.5.1/cluster-template.yaml
       components:
@@ -1955,7 +1955,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix/release/manager:v0.5.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v0.5.1-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v0.5.1/cluster-template.yaml
       components:
@@ -2718,7 +2718,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix/release/manager:v0.5.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v0.5.1-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v0.5.1/cluster-template.yaml
       components:
@@ -3463,7 +3463,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix/release/manager:v0.5.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v0.5.1-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v0.5.1/cluster-template.yaml
       components:


### PR DESCRIPTION
This PR fixes the repository name for the CAPX ECR image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

