### PR TITLE
Add mutation webhook for vsphere machine configs

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -47,6 +47,7 @@ resources:
   kind: VSphereMachineConfig
   version: v1alpha1
   webhooks:
+    defaulting: true
     validation: true
     webhookVersion: v1
 - api:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -5804,6 +5804,27 @@ webhooks:
     resources:
     - snowmachineconfigs
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: eksa-webhook-service
+      namespace: eksa-system
+      path: /mutate-anywhere-eks-amazonaws-com-v1alpha1-vspheremachineconfig
+  failurePolicy: Fail
+  name: mutation.vspheremachineconfig.anywhere.amazonaws.com
+  rules:
+  - apiGroups:
+    - anywhere.eks.amazonaws.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspheremachineconfigs
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -69,6 +69,27 @@ webhooks:
     resources:
     - snowmachineconfigs
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-anywhere-eks-amazonaws-com-v1alpha1-vspheremachineconfig
+  failurePolicy: Fail
+  name: mutation.vspheremachineconfig.anywhere.amazonaws.com
+  rules:
+  - apiGroups:
+    - anywhere.eks.amazonaws.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspheremachineconfigs
+  sideEffects: None
 
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/pkg/api/v1alpha1/vspheremachineconfig.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig.go
@@ -7,6 +7,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
 const (
@@ -15,6 +17,8 @@ const (
 	DefaultVSphereNumCPUs    = 2
 	DefaultVSphereMemoryMiB  = 8192
 	DefaultVSphereOSFamily   = Bottlerocket
+	bottlerocketDefaultUser  = "ec2-user"
+	ubuntuDefaultUser        = "capv"
 )
 
 // Used for generating yaml for generate clusterconfig command
@@ -75,4 +79,47 @@ func GetVSphereMachineConfigs(fileName string) (map[string]*VSphereMachineConfig
 		return nil, fmt.Errorf("unable to find kind %v in file", VSphereMachineConfigKind)
 	}
 	return configs, nil
+}
+
+func setVSphereMachineConfigDefaults(machineConfig *VSphereMachineConfig) {
+	if len(machineConfig.Spec.Folder) <= 0 {
+		logger.Info("VSphereMachineConfig Folder is not set or is empty. Defaulting to root vSphere folder.")
+	}
+
+	if machineConfig.Spec.MemoryMiB <= 0 {
+		logger.V(1).Info("VSphereMachineConfig MemoryMiB is not set or is empty. Defaulting to 8192.", "machineConfig", machineConfig.Name)
+		machineConfig.Spec.MemoryMiB = 8192
+	}
+
+	if machineConfig.Spec.MemoryMiB < 2048 {
+		logger.Info("Warning: VSphereMachineConfig MemoryMiB should not be less than 2048. Defaulting to 2048. Recommended memory is 8192.", "machineConfig", machineConfig.Name)
+		machineConfig.Spec.MemoryMiB = 2048
+	}
+
+	if machineConfig.Spec.NumCPUs <= 0 {
+		logger.V(1).Info("VSphereMachineConfig NumCPUs is not set or is empty. Defaulting to 2.", "machineConfig", machineConfig.Name)
+		machineConfig.Spec.NumCPUs = 2
+	}
+
+	if len(machineConfig.Spec.Users) <= 0 {
+		machineConfig.Spec.Users = []UserConfiguration{{}}
+	}
+
+	if len(machineConfig.Spec.Users[0].SshAuthorizedKeys) <= 0 {
+		machineConfig.Spec.Users[0].SshAuthorizedKeys = []string{""}
+	}
+
+	if machineConfig.Spec.OSFamily == "" {
+		logger.Info("Warning: OS family not specified in machine config specification. Defaulting to Bottlerocket.")
+		machineConfig.Spec.OSFamily = Bottlerocket
+	}
+
+	if len(machineConfig.Spec.Users) == 0 || machineConfig.Spec.Users[0].Name == "" {
+		if machineConfig.Spec.OSFamily == Bottlerocket {
+			machineConfig.Spec.Users[0].Name = bottlerocketDefaultUser
+		} else {
+			machineConfig.Spec.Users[0].Name = ubuntuDefaultUser
+		}
+		logger.V(1).Info("SSHUsername is not set or is empty for VSphereMachineConfig, using default", "machineConfig", machineConfig.Name, "user", machineConfig.Spec.Users[0].Name)
+	}
 }

--- a/pkg/api/v1alpha1/vspheremachineconfig_types.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_types.go
@@ -117,6 +117,10 @@ func (c *VSphereMachineConfig) Marshallable() Marshallable {
 	return c.ConvertConfigToConfigGenerateStruct()
 }
 
+func (c *VSphereMachineConfig) SetDefaults() {
+	setVSphereMachineConfigDefaults(c)
+}
+
 func (c *VSphereMachineConfig) Validate() error {
 	return nil
 }

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
@@ -23,6 +23,16 @@ func (r *VSphereMachineConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
+//+kubebuilder:webhook:path=/mutate-anywhere-eks-amazonaws-com-v1alpha1-vspheremachineconfig,mutating=true,failurePolicy=fail,sideEffects=None,groups=anywhere.eks.amazonaws.com,resources=vspheremachineconfigs,verbs=create;update,versions=v1alpha1,name=mutation.vspheremachineconfig.anywhere.amazonaws.com,admissionReviewVersions={v1,v1beta1}
+
+var _ webhook.Defaulter = &VSphereMachineConfig{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *VSphereMachineConfig) Default() {
+	vspheremachineconfiglog.Info("Setting up VSphere Machine Config defaults for", "name", r.Name)
+	r.SetDefaults()
+}
+
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-anywhere-eks-amazonaws-com-v1alpha1-vspheremachineconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=anywhere.eks.amazonaws.com,resources=vspheremachineconfigs,verbs=create;update,versions=v1alpha1,name=validation.vspheremachineconfig.anywhere.amazonaws.com,admissionReviewVersions={v1,v1beta1}
 

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
@@ -675,6 +675,18 @@ func TestVSphereMachineValidateUpdateStoragePolicyImmutable(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
 }
 
+func TestVSphereMachineConfigSetDefaults(t *testing.T) {
+	g := NewWithT(t)
+
+	sOld := vsphereMachineConfig()
+	sOld.Default()
+
+	g.Expect(sOld.Spec.MemoryMiB).To(Equal(8192))
+	g.Expect(sOld.Spec.NumCPUs).To(Equal(2))
+	g.Expect(sOld.Spec.OSFamily).To(Equal(v1alpha1.Bottlerocket))
+	g.Expect(sOld.Spec.Users).To(Equal([]v1alpha1.UserConfiguration{{Name: "ec2-user", SshAuthorizedKeys: []string{""}}}))
+}
+
 func vsphereMachineConfig() v1alpha1.VSphereMachineConfig {
 	return v1alpha1.VSphereMachineConfig{
 		TypeMeta:   metav1.TypeMeta{},

--- a/pkg/cluster/vsphere.go
+++ b/pkg/cluster/vsphere.go
@@ -27,6 +27,12 @@ func vsphereEntry() *ConfigManagerEntry {
 				}
 				return nil
 			},
+			func(c *Config) error {
+				for _, m := range c.VSphereMachineConfigs {
+					m.SetDefaults()
+				}
+				return nil
+			},
 		},
 		Validations: []Validation{
 			func(c *Config) error {

--- a/pkg/providers/vsphere/defaults.go
+++ b/pkg/providers/vsphere/defaults.go
@@ -25,7 +25,7 @@ func NewDefaulter(govc ProviderGovcClient) *Defaulter {
 func (d *Defaulter) setDefaultsForMachineConfig(ctx context.Context, spec *Spec) error {
 	setDefaultsForEtcdMachineConfig(spec.etcdMachineConfig())
 	for _, m := range spec.machineConfigs() {
-		setDefaultsForMachineConfig(m)
+		m.SetDefaults()
 		if err := d.setDefaultTemplateIfMissing(ctx, spec, m); err != nil {
 			return err
 		}
@@ -58,45 +58,6 @@ func setDefaultsForEtcdMachineConfig(machineConfig *anywherev1.VSphereMachineCon
 	if machineConfig != nil && machineConfig.Spec.MemoryMiB < 8192 {
 		logger.Info("Warning: VSphereMachineConfig MemoryMiB for etcd machines should not be less than 8192. Defaulting to 8192")
 		machineConfig.Spec.MemoryMiB = 8192
-	}
-}
-
-func setDefaultsForMachineConfig(machineConfig *anywherev1.VSphereMachineConfig) {
-	if machineConfig.Spec.MemoryMiB <= 0 {
-		logger.V(1).Info("VSphereMachineConfig MemoryMiB is not set or is empty. Defaulting to 8192.", "machineConfig", machineConfig.Name)
-		machineConfig.Spec.MemoryMiB = 8192
-	}
-
-	if machineConfig.Spec.MemoryMiB < 2048 {
-		logger.Info("Warning: VSphereMachineConfig MemoryMiB should not be less than 2048. Defaulting to 2048. Recommended memory is 8192.", "machineConfig", machineConfig.Name)
-		machineConfig.Spec.MemoryMiB = 2048
-	}
-
-	if machineConfig.Spec.NumCPUs <= 0 {
-		logger.V(1).Info("VSphereMachineConfig NumCPUs is not set or is empty. Defaulting to 2.", "machineConfig", machineConfig.Name)
-		machineConfig.Spec.NumCPUs = 2
-	}
-
-	if len(machineConfig.Spec.Users) <= 0 {
-		machineConfig.Spec.Users = []anywherev1.UserConfiguration{{}}
-	}
-
-	if len(machineConfig.Spec.Users[0].SshAuthorizedKeys) <= 0 {
-		machineConfig.Spec.Users[0].SshAuthorizedKeys = []string{""}
-	}
-
-	if machineConfig.Spec.OSFamily == "" {
-		logger.Info("Warning: OS family not specified in machine config specification. Defaulting to Bottlerocket.")
-		machineConfig.Spec.OSFamily = anywherev1.Bottlerocket
-	}
-
-	if len(machineConfig.Spec.Users) == 0 || machineConfig.Spec.Users[0].Name == "" {
-		if machineConfig.Spec.OSFamily == anywherev1.Bottlerocket {
-			machineConfig.Spec.Users[0].Name = bottlerocketDefaultUser
-		} else {
-			machineConfig.Spec.Users[0].Name = ubuntuDefaultUser
-		}
-		logger.V(1).Info("SSHUsername is not set or is empty for VSphereMachineConfig, using default", "machineConfig", machineConfig.Name, "user", machineConfig.Spec.Users[0].Name)
 	}
 }
 

--- a/pkg/providers/vsphere/validator.go
+++ b/pkg/providers/vsphere/validator.go
@@ -110,9 +110,6 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, vsphereCl
 	if len(controlPlaneMachineConfig.Spec.Datastore) <= 0 {
 		return errors.New("VSphereMachineConfig datastore for control plane is not set or is empty")
 	}
-	if len(controlPlaneMachineConfig.Spec.Folder) <= 0 {
-		logger.Info("VSphereMachineConfig folder for control plane is not set or is empty. Will default to root vSphere folder.")
-	}
 	if len(controlPlaneMachineConfig.Spec.ResourcePool) <= 0 {
 		return errors.New("VSphereMachineConfig VM resourcePool for control plane is not set or is empty")
 	}
@@ -140,9 +137,6 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, vsphereCl
 		if len(workerNodeGroupMachineConfig.Spec.Datastore) <= 0 {
 			return errors.New("VSphereMachineConfig datastore for worker nodes is not set or is empty")
 		}
-		if len(workerNodeGroupMachineConfig.Spec.Folder) <= 0 {
-			logger.Info("VSphereMachineConfig folder for worker nodes is not set or is empty. Will default to root vSphere folder.")
-		}
 		if len(workerNodeGroupMachineConfig.Spec.ResourcePool) <= 0 {
 			return errors.New("VSphereMachineConfig VM resourcePool for worker nodes is not set or is empty")
 		}
@@ -166,9 +160,6 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, vsphereCl
 		}
 		if len(etcdMachineConfig.Spec.Datastore) <= 0 {
 			return errors.New("VSphereMachineConfig datastore for etcd machines is not set or is empty")
-		}
-		if len(etcdMachineConfig.Spec.Folder) <= 0 {
-			logger.Info("VSphereMachineConfig folder for etcd machines is not set or is empty. Will default to root vSphere folder.")
 		}
 		if len(etcdMachineConfig.Spec.ResourcePool) <= 0 {
 			return errors.New("VSphereMachineConfig VM resourcePool for etcd machines is not set or is empty")

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -50,7 +50,6 @@ const (
 	defaultTemplateLibrary   = "eks-a-templates"
 	defaultTemplatesFolder   = "vm/Templates"
 	bottlerocketDefaultUser  = "ec2-user"
-	ubuntuDefaultUser        = "capv"
 	maxRetries               = 30
 	backOffPeriod            = 5 * time.Second
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a mutation webhook to set defaults on vsphere machine configs. This is especially useful when creating clusters using the full lifecycle API via tools like `kubectl apply` or `Gitops`.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

