### PR TITLE
Adding new test for detecting workload cluster rollingupgrade

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -295,6 +295,10 @@ func (k *Kubectl) WaitForManagedExternalEtcdNotReady(ctx context.Context, cluste
 	return k.Wait(ctx, cluster.KubeconfigFile, timeout, "ManagedEtcdReady=false", fmt.Sprintf("clusters.%s/%s", clusterv1.GroupVersion.Group, newClusterName), constants.EksaSystemNamespace)
 }
 
+func (k *Kubectl) WaitForMachineDeploymentReady(ctx context.Context, cluster *types.Cluster, timeout string, machineDeploymentName string) error {
+	return k.Wait(ctx, cluster.KubeconfigFile, timeout, "Ready=true", fmt.Sprintf("machinedeployments.%s/%s", clusterv1.GroupVersion.Group, machineDeploymentName), constants.EksaSystemNamespace)
+}
+
 // WaitForService blocks until an IP address is assigned.
 //
 // Until more generic status matching comes around (possibly in 1.23), poll

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -608,6 +608,9 @@ func TestKubectlGetMachines(t *testing.T) {
 			jsonResponseFile: "testdata/kubectl_machines_no_node_ref_no_labels.json",
 			wantMachines: []types.Machine{
 				{
+					Metadata: types.MachineMetadata{
+						Name: "eksa-test-capd-control-plane-5nfdg",
+					},
 					Status: types.MachineStatus{
 						Conditions: types.Conditions{
 							{
@@ -650,6 +653,9 @@ func TestKubectlGetMachines(t *testing.T) {
 					},
 				},
 				{
+					Metadata: types.MachineMetadata{
+						Name: "eksa-test-capd-md-0-bb7885f6f-gkb85",
+					},
 					Status: types.MachineStatus{
 						Conditions: types.Conditions{
 							{
@@ -683,6 +689,7 @@ func TestKubectlGetMachines(t *testing.T) {
 							"cluster.x-k8s.io/cluster-name":  "eksa-test-capd",
 							"cluster.x-k8s.io/control-plane": "",
 						},
+						Name: "eksa-test-capd-control-plane-5nfdg",
 					},
 					Status: types.MachineStatus{
 						NodeRef: &types.ResourceRef{
@@ -699,6 +706,7 @@ func TestKubectlGetMachines(t *testing.T) {
 							"cluster.x-k8s.io/deployment-name": "eksa-test-capd-md-0",
 							"machine-template-hash":            "663441929",
 						},
+						Name: "eksa-test-capd-md-0-bb7885f6f-gkb85",
 					},
 					Status: types.MachineStatus{
 						NodeRef: &types.ResourceRef{
@@ -720,6 +728,7 @@ func TestKubectlGetMachines(t *testing.T) {
 							"cluster.x-k8s.io/cluster-name":  "eksa-test-capd",
 							"cluster.x-k8s.io/control-plane": "",
 						},
+						Name: "eksa-test-capd-control-plane-5nfdg",
 					},
 					Status: types.MachineStatus{
 						NodeRef: &types.ResourceRef{
@@ -774,6 +783,7 @@ func TestKubectlGetMachines(t *testing.T) {
 							"cluster.x-k8s.io/deployment-name": "eksa-test-capd-md-0",
 							"machine-template-hash":            "663441929",
 						},
+						Name: "eksa-test-capd-md-0-bb7885f6f-gkb85",
 					},
 					Status: types.MachineStatus{
 						NodeRef: &types.ResourceRef{
@@ -813,6 +823,7 @@ func TestKubectlGetMachines(t *testing.T) {
 							"cluster.x-k8s.io/cluster-name": "eksa-test-capd",
 							"cluster.x-k8s.io/etcd-cluster": "",
 						},
+						Name: "eksa-test-capd-control-plane-5nfdg",
 					},
 					Status: types.MachineStatus{
 						Conditions: types.Conditions{
@@ -2421,6 +2432,19 @@ func TestKubectlWaitForManagedExternalEtcdNotReady(t *testing.T) {
 	).Return(bytes.Buffer{}, nil)
 
 	tt.Expect(tt.k.WaitForManagedExternalEtcdNotReady(tt.ctx, tt.cluster, timeout, "test")).To(Succeed())
+}
+
+func TestKubectlWaitForMachineDeploymentReady(t *testing.T) {
+	tt := newKubectlTest(t)
+	timeout := "5m"
+	expectedTimeout := "300.00s"
+
+	tt.e.EXPECT().Execute(
+		tt.ctx,
+		"wait", "--timeout", expectedTimeout, "--for=condition=Ready=true", "machinedeployments.cluster.x-k8s.io/test", "--kubeconfig", tt.cluster.KubeconfigFile, "-n", "eksa-system",
+	).Return(bytes.Buffer{}, nil)
+
+	tt.Expect(tt.k.WaitForMachineDeploymentReady(tt.ctx, tt.cluster, timeout, "test")).To(Succeed())
 }
 
 func TestKubectlWaitForClusterReady(t *testing.T) {

--- a/pkg/types/resources.go
+++ b/pkg/types/resources.go
@@ -28,6 +28,7 @@ type MachineStatus struct {
 }
 
 type MachineMetadata struct {
+	Name   string            `json:"name,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/test/e2e/workload_clusters_test.go
+++ b/test/e2e/workload_clusters_test.go
@@ -4,11 +4,13 @@
 package e2e
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -34,6 +36,48 @@ func runWorkloadClusterFlowWithGitOps(test *framework.MulticlusterE2ETest, clust
 	})
 	time.Sleep(5 * time.Minute)
 	test.DeleteManagementCluster()
+}
+
+func runWorkloadClusterUpgradeFlowCheckWorkloadRollingUpgrade(test *framework.MulticlusterE2ETest, clusterOpts ...framework.ClusterE2ETestOpt) {
+	latest := latestMinorRelease(test.T)
+	test.CreateManagementClusterForVersion(latest.Version, framework.ExecuteWithEksaRelease(latest))
+	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
+		w.GenerateClusterConfigForVersion(latest.Version)
+		w.CreateCluster(framework.ExecuteWithEksaRelease(latest))
+	})
+	preUpgradeMachines := make(map[string]map[string]types.Machine, 0)
+	for key, workloadCluster := range test.WorkloadClusters {
+		test.T.Logf("Capturing CAPI machines for cluster %v", workloadCluster)
+		mdName := fmt.Sprintf("%s-%s", workloadCluster.ClusterName, "md-0")
+		test.ManagementCluster.WaitForMachineDeploymentReady(mdName)
+		preUpgradeMachines[key] = test.ManagementCluster.GetCapiMachinesForCluster(workloadCluster.ClusterName)
+	}
+	test.ManagementCluster.UpgradeCluster(clusterOpts)
+	test.T.Logf("Waiting for EKS-A controller to reconcile clusters")
+	time.Sleep(2 * time.Minute) // Time for new eks-a controller to kick in and potentially trigger rolling upgrade
+	for key, workloadCluster := range test.WorkloadClusters {
+		test.T.Logf("Capturing CAPI machines for cluster %v", workloadCluster)
+		postUpgradeMachines := test.ManagementCluster.GetCapiMachinesForCluster(workloadCluster.ClusterName)
+		if anyMachinesChanged(preUpgradeMachines[key], postUpgradeMachines) {
+			test.T.Fatalf("Found CAPI machines of workload cluster were changed after upgrading management cluster")
+		}
+	}
+	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
+		w.DeleteCluster()
+	})
+	test.DeleteManagementCluster()
+}
+
+func anyMachinesChanged(machineMap1 map[string]types.Machine, machineMap2 map[string]types.Machine) bool {
+	if len(machineMap1) != len(machineMap2) {
+		return true
+	}
+	for machineName := range machineMap1 {
+		if _, found := machineMap2[machineName]; !found {
+			return true
+		}
+	}
+	return false
 }
 
 func TestVSphereKubernetes121MulticlusterWorkloadCluster(t *testing.T) {
@@ -286,4 +330,32 @@ func TestCloudStackUpgradeMulticlusterWorkloadClusterWithFluxLegacy(t *testing.T
 			framework.UpdateRedhatTemplate121Var(),
 		),
 	)
+}
+
+func TestCloudStackKubernetes121ManagementClusterUpgradeFromLatest(t *testing.T) {
+	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat121())
+	test := framework.NewMulticlusterE2ETest(
+		t,
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterFiller(
+				api.WithKubernetesVersion(v1alpha1.Kube121),
+				api.WithControlPlaneCount(1),
+				api.WithWorkerNodeCount(1),
+				api.WithEtcdCountIfExternal(1),
+			),
+		),
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterFiller(
+				api.WithKubernetesVersion(v1alpha1.Kube121),
+				api.WithControlPlaneCount(1),
+				api.WithWorkerNodeCount(1),
+				api.WithEtcdCountIfExternal(1),
+			),
+		),
+	)
+	runWorkloadClusterUpgradeFlowCheckWorkloadRollingUpgrade(test)
 }

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -537,6 +537,28 @@ func (e *ClusterE2ETest) ValidateCluster(kubeVersion v1alpha1.KubernetesVersion)
 	}
 }
 
+func (e *ClusterE2ETest) WaitForMachineDeploymentReady(machineDeploymentName string) {
+	ctx := context.Background()
+	e.T.Logf("Waiting for machine deployment %s to be ready for cluster %s", machineDeploymentName, e.ClusterName)
+	err := e.KubectlClient.WaitForMachineDeploymentReady(ctx, e.cluster(), "5m", machineDeploymentName)
+	if err != nil {
+		e.T.Fatal(err)
+	}
+}
+
+func (e *ClusterE2ETest) GetCapiMachinesForCluster(clusterName string) map[string]types.Machine {
+	ctx := context.Background()
+	capiMachines, err := e.KubectlClient.GetMachines(ctx, e.cluster(), clusterName)
+	if err != nil {
+		e.T.Fatal(err)
+	}
+	machinesMap := make(map[string]types.Machine, 0)
+	for _, machine := range capiMachines {
+		machinesMap[machine.Metadata.Name] = machine
+	}
+	return machinesMap
+}
+
 func WithClusterUpgrade(fillers ...api.ClusterFiller) ClusterE2ETestOpt {
 	return func(e *ClusterE2ETest) {
 		e.ClusterConfigB = e.customizeClusterConfig(e.ClusterConfigLocation, fillers...)

--- a/test/framework/multicluster.go
+++ b/test/framework/multicluster.go
@@ -40,9 +40,14 @@ func (m *MulticlusterE2ETest) RunInWorkloadClusters(flow func(*WorkloadCluster))
 	}
 }
 
-func (m *MulticlusterE2ETest) CreateManagementCluster() {
+func (m *MulticlusterE2ETest) CreateManagementClusterForVersion(eksaVersion string, opts ...CommandOpt) {
+	m.ManagementCluster.GenerateClusterConfigForVersion(eksaVersion)
+	m.ManagementCluster.CreateCluster(opts...)
+}
+
+func (m *MulticlusterE2ETest) CreateManagementCluster(opts ...CommandOpt) {
 	m.ManagementCluster.GenerateClusterConfig()
-	m.ManagementCluster.CreateCluster()
+	m.ManagementCluster.CreateCluster(opts...)
 }
 
 func (m *MulticlusterE2ETest) DeleteManagementCluster() {


### PR DESCRIPTION
*Issue #, if available:*
Resolves https://github.com/aws/eks-anywhere/issues/3543

*Description of changes:*
The test performs a management cluster upgrade to a newer EKS-A version and checks if the workload cluster also observed a rolling upgrade.

*Testing (if applicable):*
Tested end to end and observed expected rollingupgrade detected. I was able to work around the current nutanix bundles issue by manually applying eks-a components to the mgmt cluster during the mgmt cluster's upgrade.

```
2022-10-06T12:27:13.094-0400	V2	Executing command	{"cmd": "/usr/local/bin/docker exec -i eksa_1665072583805575000 kind delete cluster --name eksa-test-047cdee-eks-a-cluster"}
2022-10-06T12:27:24.380-0400	V0	🎉 Cluster upgraded!
2022-10-06T12:27:24.380-0400	V4	Task finished	{"task_name": "delete-kind-cluster", "duration": "13.6399998s"}
2022-10-06T12:27:24.381-0400	V4	----------------------------------
2022-10-06T12:27:24.381-0400	V4	Tasks completed	{"duration": "17m39.245482653s"}
2022-10-06T12:27:24.400-0400	V3	Cleaning up long running container	{"name": "eksa_1665072583805575000"}
2022-10-06T12:27:24.400-0400	V2	Executing command	{"cmd": "/usr/local/bin/docker rm -f -v eksa_1665072583805575000"}
2022-10-06T12:28:25.165-0400	V2	e2e	Executing command	{"cmd": "/usr/local/bin/docker exec -i eksa_1665071770892974000 kubectl get machines -o json --kubeconfig eksa-test-047cdee/eksa-test-047cdee-eks-a-cluster.kubeconfig --selector=cluster.x-k8s.io/cluster-name=eksa-test-047cdee-w-0 --namespace eksa-system"}
    workload_clusters_test.go:59: Found CAPI machines of workload cluster were changed after upgrading management cluster
    cluster.go:641: Skipping VM cleanup
2022-10-06T12:28:29.797-0400	V3	e2e	Cleaning up long running container	{"name": "eksa_1665071773164462000"}
2022-10-06T12:28:29.798-0400	V2	e2e	Executing command	{"cmd": "/usr/local/bin/docker rm -f -v eksa_1665071773164462000"}
    cluster.go:641: Skipping VM cleanup
2022-10-06T12:28:30.828-0400	V3	e2e	Cleaning up long running container	{"name": "eksa_1665071770892974000"}
2022-10-06T12:28:30.830-0400	V2	e2e	Executing command	{"cmd": "/usr/local/bin/docker rm -f -v eksa_1665071770892974000"}
--- FAIL: TestCloudStackKubernetes121ManagementClusterUpgradeFromLatest (1942.06s)
FAIL
```

The rolling upgrade is expected but undesirable due to https://github.com/aws/eks-anywhere/pull/3402

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

