### PR TITLE
Push Helm charts along with other image uploads

### DIFF
--- a/release/pkg/bundles/tinkerbell.go
+++ b/release/pkg/bundles/tinkerbell.go
@@ -22,7 +22,6 @@ import (
 
 	anywherev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	"github.com/aws/eks-anywhere/release/pkg/constants"
-	"github.com/aws/eks-anywhere/release/pkg/helm"
 	releasetypes "github.com/aws/eks-anywhere/release/pkg/types"
 	bundleutils "github.com/aws/eks-anywhere/release/pkg/util/bundles"
 	"github.com/aws/eks-anywhere/release/pkg/version"
@@ -44,29 +43,6 @@ func GetTinkerbellBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]
 	}
 	sortedComponentNames := bundleutils.SortArtifactsMap(tinkerbellBundleArtifacts)
 
-	var helmdir string
-	var URI string
-
-	// Find the source of the Helm chart prior to the initial loop.
-	for _, componentName := range sortedComponentNames {
-		for _, artifact := range tinkerbellBundleArtifacts[componentName] {
-			if artifact.Image != nil && strings.HasSuffix(artifact.Image.AssetName, "chart") {
-				URI = artifact.Image.SourceImageURI
-			}
-		}
-	}
-	driver, err := helm.NewHelm()
-	if err != nil {
-		return anywherev1alpha1.TinkerbellBundle{}, fmt.Errorf("creating helm client: %w", err)
-	}
-
-	if !r.DryRun {
-		helmdir, err = helm.GetHelmDest(driver, URI, "tinkerbell-chart")
-		if err != nil {
-			return anywherev1alpha1.TinkerbellBundle{}, errors.Wrap(err, "Error GetHelmDest")
-		}
-	}
-
 	var sourceBranch string
 	var componentChecksum string
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
@@ -83,26 +59,21 @@ func GetTinkerbellBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]
 					sourceBranch = imageArtifact.SourcedFromBranch
 				}
 				if strings.HasSuffix(imageArtifact.AssetName, "chart") {
-					if !r.DryRun {
-						err := helm.ModifyChartYaml(*imageArtifact, r, driver, helmdir)
-						if err != nil {
-							return anywherev1alpha1.TinkerbellBundle{}, errors.Wrap(err, "Error modifying and pushing helm Chart.yaml")
-						}
-					}
 					bundleImageArtifact = anywherev1alpha1.Image{
 						Name:        imageArtifact.AssetName,
 						Description: fmt.Sprintf("Helm chart for %s", imageArtifact.AssetName),
 						URI:         imageArtifact.ReleaseImageURI,
 						ImageDigest: imageDigests[imageArtifact.ReleaseImageURI],
 					}
-				}
-				bundleImageArtifact = anywherev1alpha1.Image{
-					Name:        imageArtifact.AssetName,
-					Description: fmt.Sprintf("Container image for %s image", imageArtifact.AssetName),
-					OS:          imageArtifact.OS,
-					Arch:        imageArtifact.Arch,
-					URI:         imageArtifact.ReleaseImageURI,
-					ImageDigest: imageDigests[imageArtifact.ReleaseImageURI],
+				} else {
+					bundleImageArtifact = anywherev1alpha1.Image{
+						Name:        imageArtifact.AssetName,
+						Description: fmt.Sprintf("Container image for %s image", imageArtifact.AssetName),
+						OS:          imageArtifact.OS,
+						Arch:        imageArtifact.Arch,
+						URI:         imageArtifact.ReleaseImageURI,
+						ImageDigest: imageDigests[imageArtifact.ReleaseImageURI],
+					}
 				}
 				bundleImageArtifacts[imageArtifact.AssetName] = bundleImageArtifact
 				artifactHashes = append(artifactHashes, bundleImageArtifact.ImageDigest)

--- a/release/pkg/helm/helm.go
+++ b/release/pkg/helm/helm.go
@@ -96,7 +96,7 @@ func GetChartImageTags(d *helmDriver, helmDest string) (*Requires, error) {
 	return helmRequires, nil
 }
 
-func ModifyChartYaml(i releasetypes.ImageArtifact, r *releasetypes.ReleaseConfig, d *helmDriver, helmDest string) error {
+func ModifyAndPushChartYaml(i releasetypes.ImageArtifact, r *releasetypes.ReleaseConfig, d *helmDriver, helmDest string) error {
 	helmChart := strings.Split(i.ReleaseImageURI, ":")
 	helmtag := helmChart[1]
 

--- a/release/pkg/operations/upload.go
+++ b/release/pkg/operations/upload.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/aws/eks-anywhere/release/pkg/aws/s3"
 	"github.com/aws/eks-anywhere/release/pkg/constants"
+	"github.com/aws/eks-anywhere/release/pkg/helm"
 	"github.com/aws/eks-anywhere/release/pkg/images"
 	releasetypes "github.com/aws/eks-anywhere/release/pkg/types"
 )
@@ -81,9 +82,26 @@ func UploadArtifacts(r *releasetypes.ReleaseConfig, eksArtifacts map[string][]re
 			}
 
 			if artifact.Image != nil {
-				// If the artifact is a helm chart, skip the skopeo copy as it's handled separately.
+				// If the artifact is a helm chart, skip the skopeo copy. Instead, modify the Chart.yaml to match the release tag
+				// and then use Helm package and push commands to upload chart to ECR Public
 				if !r.DryRun && (strings.HasSuffix(artifact.Image.AssetName, "helm") || strings.HasSuffix(artifact.Image.AssetName, "chart")) {
-					continue
+					// Trim -helm on the packages helm chart, but don't need to trim tinkerbell chart since the AssetName is the same as the repoName
+					trimmedAsset := strings.Trim(artifact.Image.AssetName, "-helm")
+
+					helmDriver, err := helm.NewHelm()
+					if err != nil {
+						return fmt.Errorf("creating helm client: %v", err)
+					}
+
+					helmDest, err := helm.GetHelmDest(helmDriver, artifact.Image.SourceImageURI, trimmedAsset)
+					if err != nil {
+						return fmt.Errorf("getting Helm destination: %v", err)
+					}
+
+					err = helm.ModifyAndPushChartYaml(*artifact.Image, r, helmDriver, helmDest)
+					if err != nil {
+						return fmt.Errorf("modifying Chart.yaml and pushing Helm chart to destination: %v", err)
+					}
 				}
 				sourceImageUri := artifact.Image.SourceImageURI
 				releaseImageUri := artifact.Image.ReleaseImageURI

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -691,13 +691,9 @@ spec:
             os: linux
             uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for tinkerbell-chart image
+          description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.5-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
@@ -1454,13 +1450,9 @@ spec:
             os: linux
             uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for tinkerbell-chart image
+          description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.5-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
@@ -2217,13 +2209,9 @@ spec:
             os: linux
             uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for tinkerbell-chart image
+          description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.5-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
@@ -2980,13 +2968,9 @@ spec:
             os: linux
             uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for tinkerbell-chart image
+          description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.5-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
@@ -3725,13 +3709,9 @@ spec:
             os: linux
             uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for tinkerbell-chart image
+          description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.5-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:


### PR DESCRIPTION
Due to the way the code is structured, the release code was performing a ECR Public lookup to fetch the image digest even before the modified Helm chart had been pushed. This PR modifies the code to modify and push Helm charts at the same time as other images so we shouldn't see this problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

