### PR TITLE
Fix trimming of Helm chart asset name

### DIFF
--- a/release/pkg/operations/upload.go
+++ b/release/pkg/operations/upload.go
@@ -86,7 +86,7 @@ func UploadArtifacts(r *releasetypes.ReleaseConfig, eksArtifacts map[string][]re
 				// and then use Helm package and push commands to upload chart to ECR Public
 				if !r.DryRun && (strings.HasSuffix(artifact.Image.AssetName, "helm") || strings.HasSuffix(artifact.Image.AssetName, "chart")) {
 					// Trim -helm on the packages helm chart, but don't need to trim tinkerbell chart since the AssetName is the same as the repoName
-					trimmedAsset := strings.Trim(artifact.Image.AssetName, "-helm")
+					trimmedAsset := strings.TrimSuffix(artifact.Image.AssetName, "-helm")
 
 					helmDriver, err := helm.NewHelm()
 					if err != nil {


### PR DESCRIPTION
`strings.Trim`'s second argument is a cutset, so it trims any character in the set if found at the start or end. The method that we want is `strings.TrimSuffix`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

