### PR TITLE
Fix URI argument to helm push command

### DIFF
--- a/release/pkg/helm/helm.go
+++ b/release/pkg/helm/helm.go
@@ -118,7 +118,7 @@ func ModifyAndPushChartYaml(i releasetypes.ImageArtifact, r *releasetypes.Releas
 	if err != nil {
 		return fmt.Errorf("packaging the helm chart: %w", err)
 	}
-	err = d.PushHelmChart(packaged, r.ReleaseContainerRegistry)
+	err = d.PushHelmChart(packaged, filepath.Dir(helmChart[0]))
 	if err != nil {
 		return fmt.Errorf("pushing the helm chart: %w", err)
 	}


### PR DESCRIPTION
Helm push command takes in a tarball and a remote URI as arguments. If the destination repo name has many parts like `foo/bar/baz`, the tarball should be baz.tar.gz while the remote URI would be `oci://registry/foo/bar`. Currently, the release code does not append the prefix to the registry URI, which causes errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

