### PR TITLE
Autoscaling Config Validations

### DIFF
--- a/pkg/api/v1alpha1/cluster_defaults.go
+++ b/pkg/api/v1alpha1/cluster_defaults.go
@@ -54,7 +54,9 @@ func setWorkerNodeGroupDefaults(cluster *Cluster) error {
 
 	for i := range cluster.Spec.WorkerNodeGroupConfigurations {
 		w := &cluster.Spec.WorkerNodeGroupConfigurations[i]
-		if w.Count == nil {
+		if w.Count == nil && w.AutoScalingConfiguration != nil {
+			w.Count = &w.AutoScalingConfiguration.MinCount
+		} else if w.Count == nil {
 			w.Count = ptr.Int(1)
 		}
 	}

--- a/pkg/api/v1alpha1/cluster_defaults_test.go
+++ b/pkg/api/v1alpha1/cluster_defaults_test.go
@@ -157,6 +157,54 @@ func TestSetClusterDefaults(t *testing.T) {
 			wantErr: "",
 		},
 		{
+			name: "worker node group - no count specified with autoscaler",
+			in: &Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       ClusterKind,
+					APIVersion: SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: ClusterSpec{
+					KubernetesVersion: Kube119,
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						Name: "worker-0",
+						AutoScalingConfiguration: &AutoScalingConfiguration{
+							MinCount: 3,
+							MaxCount: 5,
+						},
+					}},
+				},
+			},
+			wantCluster: &Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       ClusterKind,
+					APIVersion: SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: ClusterSpec{
+					KubernetesVersion: Kube119,
+					ClusterNetwork: ClusterNetwork{
+						CNIConfig: &CNIConfig{
+							Cilium: nil,
+						},
+					},
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						Name:  "worker-0",
+						Count: ptr.Int(3),
+						AutoScalingConfiguration: &AutoScalingConfiguration{
+							MinCount: 3,
+							MaxCount: 5,
+						},
+					}},
+				},
+			},
+			wantErr: "",
+		},
+		{
 			name: "worker node group - no count specified",
 			in: &Cluster{
 				TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
Additionally, validate that count is within bounds of autoscaling minCount and maxCount, if present


*Issue #, if available:*
Epic: https://github.com/aws/eks-anywhere/issues/3186
Ticket: https://github.com/aws/eks-anywhere/issues/3582

*Description of changes:*
Allows count to be omitted in worker node configuration when autoscaling configuration is present. Count will default to minCount of autoscaling configuration.

*Testing (if applicable):*
Manually tested creating a cluster with a worker node configuration missing a count value and saw it correctly set to the autoscaling configuration minCount.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.