### PR TITLE
Add mutation webhook for vsphere datacenter configs

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -37,6 +37,7 @@ resources:
   kind: VSphereDatacenterConfig
   version: v1alpha1
   webhooks:
+    defaulting: true
     validation: true
     webhookVersion: v1
 - api:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -5811,6 +5811,27 @@ webhooks:
     service:
       name: eksa-webhook-service
       namespace: eksa-system
+      path: /mutate-anywhere-eks-amazonaws-com-v1alpha1-vspheredatatacenterconfig
+  failurePolicy: Fail
+  name: mutation.vspheredatacenterconfig.anywhere.amazonaws.com
+  rules:
+  - apiGroups:
+    - anywhere.eks.amazonaws.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspheredatacenterconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: eksa-webhook-service
+      namespace: eksa-system
       path: /mutate-anywhere-eks-amazonaws-com-v1alpha1-vspheremachineconfig
   failurePolicy: Fail
   name: mutation.vspheremachineconfig.anywhere.amazonaws.com

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -76,6 +76,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-anywhere-eks-amazonaws-com-v1alpha1-vspheredatatacenterconfig
+  failurePolicy: Fail
+  name: mutation.vspheredatacenterconfig.anywhere.amazonaws.com
+  rules:
+  - apiGroups:
+    - anywhere.eks.amazonaws.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspheredatacenterconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-anywhere-eks-amazonaws-com-v1alpha1-vspheremachineconfig
   failurePolicy: Fail
   name: mutation.vspheremachineconfig.anywhere.amazonaws.com

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_webhook.go
@@ -38,6 +38,16 @@ func (r *VSphereDatacenterConfig) SetupWebhookWithManager(mgr ctrl.Manager) erro
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
+//+kubebuilder:webhook:path=/mutate-anywhere-eks-amazonaws-com-v1alpha1-vspheredatatacenterconfig,mutating=true,failurePolicy=fail,sideEffects=None,groups=anywhere.eks.amazonaws.com,resources=vspheredatacenterconfigs,verbs=create;update,versions=v1alpha1,name=mutation.vspheredatacenterconfig.anywhere.amazonaws.com,admissionReviewVersions={v1,v1beta1}
+
+var _ webhook.Defaulter = &VSphereDatacenterConfig{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *VSphereDatacenterConfig) Default() {
+	vspheredatacenterconfiglog.Info("Setting up VSphere Datacenter Config defaults for", "name", r.Name)
+	r.SetDefaults()
+}
+
 // change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-anywhere-eks-amazonaws-com-v1alpha1-vspheredatacenterconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=anywhere.eks.amazonaws.com,resources=vspheredatacenterconfigs,verbs=create;update,versions=v1alpha1,name=validation.vspheredatacenterconfig.anywhere.amazonaws.com,admissionReviewVersions={v1,v1beta1}
 

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_webhook_test.go
@@ -111,6 +111,16 @@ func TestVSphereDatacenterValidateUpdateInvalidNetwork(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).NotTo(Succeed())
 }
 
+func TestVSphereDatacenterConfigSetDefaults(t *testing.T) {
+	g := NewWithT(t)
+
+	sOld := vsphereDatacenterConfig()
+	sOld.Spec.Network = "network-1"
+	sOld.Default()
+
+	g.Expect(sOld.Spec.Network).To(Equal("/datacenter/network/network-1"))
+}
+
 func vsphereDatacenterConfig() v1alpha1.VSphereDatacenterConfig {
 	return v1alpha1.VSphereDatacenterConfig{
 		TypeMeta:   metav1.TypeMeta{},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a mutation webhook to set defaults on vsphere datacenter configs. This is especially useful when creating clusters using the full lifecycle API via tools like `kubectl apply` or `Gitops`.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

