### PR TITLE
Update project path for EKS-A cluster controller

### DIFF
--- a/release/pkg/assets/config/bundle_release.go
+++ b/release/pkg/assets/config/bundle_release.go
@@ -351,7 +351,7 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 	// EKS-A cluster-controller artifacts
 	{
 		ProjectName:    "eks-anywhere-cluster-controller",
-		ProjectPath:    "projects/aws/eks-anywhere",
+		ProjectPath:    "projects/aws/eks-anywhere-cluster-controller",
 		GitTagAssigner: tagger.CliGitTagAssigner,
 		Images: []*assettypes.Image{
 			{

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -3298,9 +3298,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.24.4-eks-d-1-24-1-eks-a-v0.0.0-dev-build.1
-      kubeVersion: v1.24.4
-      manifestUrl: https://eks-d-postsubmit-artifacts.s3.us-west-2.amazonaws.com/kubernetes-1-24/kubernetes-1-24-eks-1.yaml
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.24.6-eks-d-1-24-1-eks-a-v0.0.0-dev-build.1
+      kubeVersion: v1.24.6
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-24/kubernetes-1-24-eks-1.yaml
       name: kubernetes-1-24-eks-1
       ova:
         bottlerocket: {}


### PR DESCRIPTION
EKS-A cluster controller artifacts are being uploaded to a different path now but the release tool is still getting it from the old path where artifacts are not being updated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

