### PR TITLE
IAM authenticator only on workload support

### DIFF
--- a/pkg/awsiamauth/awsiamauth.go
+++ b/pkg/awsiamauth/awsiamauth.go
@@ -92,12 +92,13 @@ func (a *AwsIamAuth) GenerateManifestForUpgrade(clusterSpec *cluster.Spec) ([]by
 	return a.templateBuilder.GenerateManifest(clusterSpec, uuid.Nil)
 }
 
-func (a *AwsIamAuth) GenerateCertKeyPairSecret() ([]byte, error) {
+func (a *AwsIamAuth) GenerateCertKeyPairSecret(bootstrapClusterName string) ([]byte, error) {
 	certPemBytes, keyPemBytes, err := a.certgen.GenerateIamAuthSelfSignCertKeyPair()
 	if err != nil {
 		return nil, fmt.Errorf("generating aws-iam-authenticator cert key pair secret: %v", err)
 	}
 	data := map[string]string{
+		"clusterName":  bootstrapClusterName,
 		"namespace":    constants.EksaSystemNamespace,
 		"certPemBytes": base64.StdEncoding.EncodeToString(certPemBytes),
 		"keyPemBytes":  base64.StdEncoding.EncodeToString(keyPemBytes),

--- a/pkg/awsiamauth/awsiamauth.go
+++ b/pkg/awsiamauth/awsiamauth.go
@@ -92,13 +92,13 @@ func (a *AwsIamAuth) GenerateManifestForUpgrade(clusterSpec *cluster.Spec) ([]by
 	return a.templateBuilder.GenerateManifest(clusterSpec, uuid.Nil)
 }
 
-func (a *AwsIamAuth) GenerateCertKeyPairSecret(bootstrapClusterName string) ([]byte, error) {
+func (a *AwsIamAuth) GenerateCertKeyPairSecret(managementClusterName string) ([]byte, error) {
 	certPemBytes, keyPemBytes, err := a.certgen.GenerateIamAuthSelfSignCertKeyPair()
 	if err != nil {
 		return nil, fmt.Errorf("generating aws-iam-authenticator cert key pair secret: %v", err)
 	}
 	data := map[string]string{
-		"clusterName":  bootstrapClusterName,
+		"clusterName":  managementClusterName,
 		"namespace":    constants.EksaSystemNamespace,
 		"certPemBytes": base64.StdEncoding.EncodeToString(certPemBytes),
 		"keyPemBytes":  base64.StdEncoding.EncodeToString(keyPemBytes),

--- a/pkg/awsiamauth/awsiamauth_test.go
+++ b/pkg/awsiamauth/awsiamauth_test.go
@@ -55,7 +55,7 @@ func TestGenerateCertKeyPairSecretSuccess(t *testing.T) {
 
 	mockCertgen.EXPECT().GenerateIamAuthSelfSignCertKeyPair().Return([]byte{}, []byte{}, nil)
 
-	gotFileContent, err := awsIamAuth.GenerateCertKeyPairSecret()
+	gotFileContent, err := awsIamAuth.GenerateCertKeyPairSecret("test-cluster")
 	if err != nil {
 		t.Fatalf("awsiamauth.GenerateCertKeyPairSecret()\n error = %v\n wantErr = nil", err)
 	}
@@ -69,7 +69,7 @@ func TestGenerateCertKeyPairSecretFail(t *testing.T) {
 
 	mockCertgen.EXPECT().GenerateIamAuthSelfSignCertKeyPair().Return(nil, nil, certGenErr)
 
-	_, err := awsIamAuth.GenerateCertKeyPairSecret()
+	_, err := awsIamAuth.GenerateCertKeyPairSecret("test-cluster")
 	if !reflect.DeepEqual(err, wantErr) {
 		t.Fatalf("error = %v\n wantErr = %v", err, wantErr)
 	}

--- a/pkg/awsiamauth/config/aws-iam-authenticator-ca-secret.yaml
+++ b/pkg/awsiamauth/config/aws-iam-authenticator-ca-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: aws-iam-authenticator-ca
+  name: {{.clusterName}}-aws-iam-authenticator-ca
   namespace: {{.namespace}}
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"

--- a/pkg/awsiamauth/testdata/want-aws-iam-authenticator-ca-secret.yaml
+++ b/pkg/awsiamauth/testdata/want-aws-iam-authenticator-ca-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: aws-iam-authenticator-ca
+  name: test-cluster-aws-iam-authenticator-ca
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"

--- a/pkg/clusterapi/identity.go
+++ b/pkg/clusterapi/identity.go
@@ -56,7 +56,7 @@ var awsIamFiles = []bootstrapv1.File{
 		Permissions: "0640",
 		ContentFrom: &bootstrapv1.FileSource{
 			Secret: bootstrapv1.SecretFileSource{
-				Name: "aws-iam-authenticator-ca",
+				Name: "test-cluster-aws-iam-authenticator-ca",
 				Key:  "cert.pem",
 			},
 		},
@@ -67,7 +67,7 @@ var awsIamFiles = []bootstrapv1.File{
 		Permissions: "0640",
 		ContentFrom: &bootstrapv1.FileSource{
 			Secret: bootstrapv1.SecretFileSource{
-				Name: "aws-iam-authenticator-ca",
+				Name: "test-cluster-aws-iam-authenticator-ca",
 				Key:  "key.pem",
 			},
 		},

--- a/pkg/clusterapi/identity_test.go
+++ b/pkg/clusterapi/identity_test.go
@@ -173,7 +173,7 @@ contexts:
 								Permissions: "0640",
 								ContentFrom: &bootstrapv1.FileSource{
 									Secret: bootstrapv1.SecretFileSource{
-										Name: "aws-iam-authenticator-ca",
+										Name: "test-cluster-aws-iam-authenticator-ca",
 										Key:  "cert.pem",
 									},
 								},
@@ -184,7 +184,7 @@ contexts:
 								Permissions: "0640",
 								ContentFrom: &bootstrapv1.FileSource{
 									Secret: bootstrapv1.SecretFileSource{
-										Name: "aws-iam-authenticator-ca",
+										Name: "test-cluster-aws-iam-authenticator-ca",
 										Key:  "key.pem",
 									},
 								},

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -123,7 +123,7 @@ type Networking interface {
 type AwsIamAuth interface {
 	GenerateManifest(clusterSpec *cluster.Spec) ([]byte, error)
 	GenerateManifestForUpgrade(clusterSpec *cluster.Spec) ([]byte, error)
-	GenerateCertKeyPairSecret() ([]byte, error)
+	GenerateCertKeyPairSecret(bootstrapClusterName string) ([]byte, error)
 	GenerateAwsIamAuthKubeconfig(clusterSpec *cluster.Spec, serverUrl, tlsCert string) ([]byte, error)
 }
 
@@ -633,12 +633,12 @@ func (c *ClusterManager) InstallAwsIamAuth(ctx context.Context, managementCluste
 	return nil
 }
 
-func (c *ClusterManager) CreateAwsIamAuthCaSecret(ctx context.Context, cluster *types.Cluster) error {
-	awsIamAuthCaSecret, err := c.awsIamAuth.GenerateCertKeyPairSecret()
+func (c *ClusterManager) CreateAwsIamAuthCaSecret(ctx context.Context, bootstrapCluster *types.Cluster, workloadClusterName string) error {
+	awsIamAuthCaSecret, err := c.awsIamAuth.GenerateCertKeyPairSecret(workloadClusterName)
 	if err != nil {
 		return fmt.Errorf("generating aws-iam-authenticator ca secret: %v", err)
 	}
-	err = c.clusterClient.ApplyKubeSpecFromBytes(ctx, cluster, awsIamAuthCaSecret)
+	err = c.clusterClient.ApplyKubeSpecFromBytes(ctx, bootstrapCluster, awsIamAuthCaSecret)
 	if err != nil {
 		return fmt.Errorf("applying aws-iam-authenticator ca secret: %v", err)
 	}

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -123,7 +123,7 @@ type Networking interface {
 type AwsIamAuth interface {
 	GenerateManifest(clusterSpec *cluster.Spec) ([]byte, error)
 	GenerateManifestForUpgrade(clusterSpec *cluster.Spec) ([]byte, error)
-	GenerateCertKeyPairSecret(bootstrapClusterName string) ([]byte, error)
+	GenerateCertKeyPairSecret(managementClusterName string) ([]byte, error)
 	GenerateAwsIamAuthKubeconfig(clusterSpec *cluster.Spec, serverUrl, tlsCert string) ([]byte, error)
 }
 

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -1985,3 +1985,13 @@ func TestClusterManagerDeletePackageResources(t *testing.T) {
 	err := tt.clusterManager.DeletePackageResources(tt.ctx, tt.cluster, tt.clusterName)
 	tt.Expect(err).To(BeNil())
 }
+
+func TestCreateAwsIamAuthCaSecretSuccess(t *testing.T) {
+	tt := newTest(t)
+
+	tt.mocks.awsIamAuth.EXPECT().GenerateCertKeyPairSecret(tt.clusterName)
+	tt.mocks.client.EXPECT().ApplyKubeSpecFromBytes(tt.ctx, tt.cluster, test.OfType("[]uint8"))
+
+	err := tt.clusterManager.CreateAwsIamAuthCaSecret(tt.ctx, tt.cluster, tt.clusterName)
+	tt.Expect(err).To(BeNil())
+}

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -804,18 +804,18 @@ func (mr *MockAwsIamAuthMockRecorder) GenerateAwsIamAuthKubeconfig(arg0, arg1, a
 }
 
 // GenerateCertKeyPairSecret mocks base method.
-func (m *MockAwsIamAuth) GenerateCertKeyPairSecret() ([]byte, error) {
+func (m *MockAwsIamAuth) GenerateCertKeyPairSecret(arg0 string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateCertKeyPairSecret")
+	ret := m.ctrl.Call(m, "GenerateCertKeyPairSecret", arg0)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GenerateCertKeyPairSecret indicates an expected call of GenerateCertKeyPairSecret.
-func (mr *MockAwsIamAuthMockRecorder) GenerateCertKeyPairSecret() *gomock.Call {
+func (mr *MockAwsIamAuthMockRecorder) GenerateCertKeyPairSecret(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateCertKeyPairSecret", reflect.TypeOf((*MockAwsIamAuth)(nil).GenerateCertKeyPairSecret))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateCertKeyPairSecret", reflect.TypeOf((*MockAwsIamAuth)(nil).GenerateCertKeyPairSecret), arg0)
 }
 
 // GenerateManifest mocks base method.

--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -308,14 +308,14 @@ spec:
       path: /var/lib/kubeadm/aws-iam-authenticator/kubeconfig.yaml
     - contentFrom:
         secret:
-          name: aws-iam-authenticator-ca
+          name: {{.clusterName}}-aws-iam-authenticator-ca
           key: cert.pem
       permissions: "0640"
       owner: root:root
       path: /var/lib/kubeadm/aws-iam-authenticator/pki/cert.pem
     - contentFrom:
         secret:
-          name: aws-iam-authenticator-ca
+          name: {{.clusterName}}-aws-iam-authenticator-ca
           key: key.pem
       permissions: "0640"
       owner: root:root

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -162,14 +162,14 @@ spec:
       path: /var/lib/kubeadm/aws-iam-authenticator/kubeconfig.yaml
     - contentFrom:
         secret:
-          name: aws-iam-authenticator-ca
+          name: {{.clusterName}}-aws-iam-authenticator-ca
           key: cert.pem
       permissions: "0640"
       owner: root:root
       path: /var/lib/kubeadm/aws-iam-authenticator/pki/cert.pem
     - contentFrom:
         secret:
-          name: aws-iam-authenticator-ca
+          name: {{.clusterName}}-aws-iam-authenticator-ca
           key: key.pem
       permissions: "0640"
       owner: root:root

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -226,14 +226,14 @@ spec:
         path: /var/lib/kubeadm/aws-iam-authenticator/kubeconfig.yaml
       - contentFrom:
           secret:
-            name: aws-iam-authenticator-ca
+            name: {{.clusterName}}-aws-iam-authenticator-ca
             key: cert.pem
         permissions: "0640"
         owner: root:root
         path: /var/lib/kubeadm/aws-iam-authenticator/pki/cert.pem
       - contentFrom:
           secret:
-            name: aws-iam-authenticator-ca
+            name: {{.clusterName}}-aws-iam-authenticator-ca
             key: key.pem
         permissions: "0640"
         owner: root:root

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_awsiam.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_awsiam.yaml
@@ -146,14 +146,14 @@ spec:
         path: /var/lib/kubeadm/aws-iam-authenticator/kubeconfig.yaml
       - contentFrom:
           secret:
-            name: aws-iam-authenticator-ca
+            name: test-aws-iam-authenticator-ca
             key: cert.pem
         permissions: "0640"
         owner: root:root
         path: /var/lib/kubeadm/aws-iam-authenticator/pki/cert.pem
       - contentFrom:
           secret:
-            name: aws-iam-authenticator-ca
+            name: test-aws-iam-authenticator-ca
             key: key.pem
         permissions: "0640"
         owner: root:root

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -309,14 +309,14 @@ spec:
       path: /var/lib/kubeadm/aws-iam-authenticator/kubeconfig.yaml
     - contentFrom:
         secret:
-          name: aws-iam-authenticator-ca
+          name: {{.clusterName}}-aws-iam-authenticator-ca
           key: cert.pem
       permissions: "0640"
       owner: root:root
       path: /var/lib/kubeadm/aws-iam-authenticator/pki/cert.pem
     - contentFrom:
         secret:
-          name: aws-iam-authenticator-ca
+          name: {{.clusterName}}-aws-iam-authenticator-ca
           key: key.pem
       permissions: "0640"
       owner: root:root

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -99,6 +99,14 @@ type InstallCuratedPackagesTask struct{}
 
 func (s *CreateBootStrapClusterTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	if commandContext.BootstrapCluster != nil {
+		if commandContext.ClusterSpec.AWSIamConfig != nil {
+			logger.Info("Creating aws-iam-authenticator certificate and key pair secret on bootstrap cluster")
+			if err := commandContext.ClusterManager.CreateAwsIamAuthCaSecret(ctx, commandContext.BootstrapCluster, commandContext.ClusterSpec.Cluster.Name); err != nil {
+				commandContext.SetError(err)
+				return &CollectMgmtClusterDiagnosticsTask{}
+			}
+		}
+
 		return &CreateWorkloadClusterTask{}
 	}
 	logger.Info("Creating new bootstrap cluster")
@@ -130,7 +138,7 @@ func (s *CreateBootStrapClusterTask) Run(ctx context.Context, commandContext *ta
 
 	if commandContext.ClusterSpec.AWSIamConfig != nil {
 		logger.Info("Creating aws-iam-authenticator certificate and key pair secret on bootstrap cluster")
-		if err = commandContext.ClusterManager.CreateAwsIamAuthCaSecret(ctx, bootstrapCluster); err != nil {
+		if err = commandContext.ClusterManager.CreateAwsIamAuthCaSecret(ctx, bootstrapCluster, commandContext.ClusterSpec.Cluster.Name); err != nil {
 			commandContext.SetError(err)
 			return &CollectMgmtClusterDiagnosticsTask{}
 		}

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -39,7 +39,7 @@ type ClusterManager interface {
 	GetCurrentClusterSpec(ctx context.Context, cluster *types.Cluster, clusterName string) (*cluster.Spec, error)
 	Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error)
 	InstallAwsIamAuth(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec) error
-	CreateAwsIamAuthCaSecret(ctx context.Context, cluster *types.Cluster) error
+	CreateAwsIamAuthCaSecret(ctx context.Context, bootstrapCluster *types.Cluster, workloadClusterName string) error
 	DeletePackageResources(ctx context.Context, managementCluster *types.Cluster, clusterName string) error
 }
 

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -112,17 +112,17 @@ func (mr *MockClusterManagerMockRecorder) ApplyBundles(arg0, arg1, arg2 interfac
 }
 
 // CreateAwsIamAuthCaSecret mocks base method.
-func (m *MockClusterManager) CreateAwsIamAuthCaSecret(arg0 context.Context, arg1 *types.Cluster) error {
+func (m *MockClusterManager) CreateAwsIamAuthCaSecret(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAwsIamAuthCaSecret", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateAwsIamAuthCaSecret", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateAwsIamAuthCaSecret indicates an expected call of CreateAwsIamAuthCaSecret.
-func (mr *MockClusterManagerMockRecorder) CreateAwsIamAuthCaSecret(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClusterManagerMockRecorder) CreateAwsIamAuthCaSecret(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAwsIamAuthCaSecret", reflect.TypeOf((*MockClusterManager)(nil).CreateAwsIamAuthCaSecret), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAwsIamAuthCaSecret", reflect.TypeOf((*MockClusterManager)(nil).CreateAwsIamAuthCaSecret), arg0, arg1, arg2)
 }
 
 // CreateEKSANamespace mocks base method.


### PR DESCRIPTION
*Issue #2814*

*Description of changes:*
Changes enable setting up `aws-iam-authenticator` on a workload cluster when its not configured on the management cluster.
We now prepend cluster name to the `aws-iam-authenticator-ca` that is needed on the bootstrap/management cluster before adding it on a workload cluster.

*Testing:*
```bash
eksctl-anywhere create cluster -f br-cluster-workload.yaml --kubeconfig ./br/br-eks-a-cluster.kubeconfig
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

