### PR TITLE
Remove extra replica of cilium operator on single-node

### DIFF
--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -213,6 +213,10 @@ func templateValues(spec *cluster.Spec) values {
 		},
 	}
 
+	if len(spec.Cluster.Spec.WorkerNodeGroupConfigurations) == 0 && spec.Cluster.Spec.ControlPlaneConfiguration.Count == 1 {
+		val["operator"].(values)["replicas"] = 1
+	}
+
 	if spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode != "" {
 		val["policyEnforcementMode"] = spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode
 	}


### PR DESCRIPTION
*Issue #, if available:* On single-node cluster, an extra pod for cilium-operator is scheduled, but it will never run since the cluster has only 1 host.

*Description of changes:* Add replicas = 1 [parameter](https://github.com/cilium/cilium/blob/v1.11.8/install/kubernetes/cilium/values.yaml#L1362) to cilium chart.

*Testing (if applicable):*
1. Unit test
2. Manual e2e test on Dell single-node cluster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

