### PR TITLE
Removing unused cfssl from bundle

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -2160,35 +2160,6 @@ spec:
                                   description: The image repository, name, and tag
                                   type: string
                               type: object
-                            cfssl:
-                              properties:
-                                arch:
-                                  description: Architectures of the asset
-                                  items:
-                                    type: string
-                                  type: array
-                                description:
-                                  type: string
-                                imageDigest:
-                                  description: The SHA256 digest of the image manifest
-                                  type: string
-                                name:
-                                  description: The asset name
-                                  type: string
-                                os:
-                                  description: Operating system of the asset
-                                  enum:
-                                  - linux
-                                  - darwin
-                                  - windows
-                                  type: string
-                                osName:
-                                  description: Name of the OS like ubuntu, bottlerocket
-                                  type: string
-                                uri:
-                                  description: The image repository, name, and tag
-                                  type: string
-                              type: object
                             hegel:
                               properties:
                                 arch:
@@ -2638,7 +2609,6 @@ spec:
                           required:
                           - actions
                           - boots
-                          - cfssl
                           - hegel
                           - hook
                           - rufio

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -2328,35 +2328,6 @@ spec:
                                   description: The image repository, name, and tag
                                   type: string
                               type: object
-                            cfssl:
-                              properties:
-                                arch:
-                                  description: Architectures of the asset
-                                  items:
-                                    type: string
-                                  type: array
-                                description:
-                                  type: string
-                                imageDigest:
-                                  description: The SHA256 digest of the image manifest
-                                  type: string
-                                name:
-                                  description: The asset name
-                                  type: string
-                                os:
-                                  description: Operating system of the asset
-                                  enum:
-                                  - linux
-                                  - darwin
-                                  - windows
-                                  type: string
-                                osName:
-                                  description: Name of the OS like ubuntu, bottlerocket
-                                  type: string
-                                uri:
-                                  description: The image repository, name, and tag
-                                  type: string
-                              type: object
                             hegel:
                               properties:
                                 arch:
@@ -2806,7 +2777,6 @@ spec:
                           required:
                           - actions
                           - boots
-                          - cfssl
                           - hegel
                           - hook
                           - rufio

--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -139,7 +139,6 @@ func (vb *VersionsBundle) TinkerbellImages() []Image {
 		vb.Tinkerbell.TinkerbellStack.Actions.WriteFile,
 		vb.Tinkerbell.TinkerbellStack.Actions.Reboot,
 		vb.Tinkerbell.TinkerbellStack.Boots,
-		vb.Tinkerbell.TinkerbellStack.Cfssl,
 		vb.Tinkerbell.TinkerbellStack.Hegel,
 		vb.Tinkerbell.TinkerbellStack.Hook.Bootkit,
 		vb.Tinkerbell.TinkerbellStack.Hook.Docker,

--- a/release/api/v1alpha1/bundle_types.go
+++ b/release/api/v1alpha1/bundle_types.go
@@ -270,7 +270,6 @@ type EtcdadmControllerBundle struct {
 type TinkerbellStackBundle struct {
 	Actions        ActionsBundle `json:"actions"`
 	Boots          Image         `json:"boots"`
-	Cfssl          Image         `json:"cfssl"`
 	Hegel          Image         `json:"hegel"`
 	TinkebellChart Image         `json:"tinkerbellChart"`
 	Hook           HookBundle    `json:"hook"`

--- a/release/api/v1alpha1/zz_generated.deepcopy.go
+++ b/release/api/v1alpha1/zz_generated.deepcopy.go
@@ -796,7 +796,6 @@ func (in *TinkerbellStackBundle) DeepCopyInto(out *TinkerbellStackBundle) {
 	*out = *in
 	in.Actions.DeepCopyInto(&out.Actions)
 	in.Boots.DeepCopyInto(&out.Boots)
-	in.Cfssl.DeepCopyInto(&out.Cfssl)
 	in.Hegel.DeepCopyInto(&out.Hegel)
 	in.TinkebellChart.DeepCopyInto(&out.TinkebellChart)
 	in.Hook.DeepCopyInto(&out.Hook)

--- a/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -2160,35 +2160,6 @@ spec:
                                   description: The image repository, name, and tag
                                   type: string
                               type: object
-                            cfssl:
-                              properties:
-                                arch:
-                                  description: Architectures of the asset
-                                  items:
-                                    type: string
-                                  type: array
-                                description:
-                                  type: string
-                                imageDigest:
-                                  description: The SHA256 digest of the image manifest
-                                  type: string
-                                name:
-                                  description: The asset name
-                                  type: string
-                                os:
-                                  description: Operating system of the asset
-                                  enum:
-                                  - linux
-                                  - darwin
-                                  - windows
-                                  type: string
-                                osName:
-                                  description: Name of the OS like ubuntu, bottlerocket
-                                  type: string
-                                uri:
-                                  description: The image repository, name, and tag
-                                  type: string
-                              type: object
                             hegel:
                               properties:
                                 arch:
@@ -2638,7 +2609,6 @@ spec:
                           required:
                           - actions
                           - boots
-                          - cfssl
                           - hegel
                           - hook
                           - rufio

--- a/release/pkg/assets/config/bundle_release.go
+++ b/release/pkg/assets/config/bundle_release.go
@@ -90,21 +90,6 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 			},
 		},
 	},
-	// Cfssl artifacts
-	{
-		ProjectName: "cfssl",
-		ProjectPath: "projects/cloudflare/cfssl",
-		Images: []*assettypes.Image{
-			{
-				RepoName: "cfssl",
-			},
-		},
-		ImageRepoPrefix: "cloudflare",
-		ImageTagOptions: []string{
-			"gitTag",
-			"projectPath",
-		},
-	},
 	// Cilium artifacts
 	{
 		ProjectName: "cilium",

--- a/release/pkg/bundles/tinkerbell.go
+++ b/release/pkg/bundles/tinkerbell.go
@@ -34,7 +34,6 @@ func GetTinkerbellBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]
 		"envoy":                           r.BundleArtifactsTable["envoy"],
 		"tink":                            r.BundleArtifactsTable["tink"],
 		"hegel":                           r.BundleArtifactsTable["hegel"],
-		"cfssl":                           r.BundleArtifactsTable["cfssl"],
 		"boots":                           r.BundleArtifactsTable["boots"],
 		"hub":                             r.BundleArtifactsTable["hub"],
 		"hook":                            r.BundleArtifactsTable["hook"],
@@ -142,7 +141,6 @@ func GetTinkerbellBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]
 				WriteFile:   bundleImageArtifacts["writefile"],
 			},
 			Boots: bundleImageArtifacts["boots"],
-			Cfssl: bundleImageArtifacts["cfssl"],
 			Hegel: bundleImageArtifacts["hegel"],
 			Hook: anywherev1alpha1.HookBundle{
 				Bootkit: bundleImageArtifacts["hook-bootkit"],

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -442,7 +442,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.8-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -451,7 +451,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.8-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -460,8 +460,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-build.1
-      version: v0.2.7+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.8-eks-a-v0.0.0-dev-build.1
+      version: v0.2.8+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml
@@ -585,15 +585,6 @@ spec:
           name: boots
           os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-build.1
-        cfssl:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for cfssl image
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: cfssl
-          os: linux
-          uri: public.ecr.aws/release-container-registry/cloudflare/cfssl:v1.6.1-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
@@ -1201,7 +1192,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.8-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1210,7 +1201,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.8-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1219,8 +1210,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-build.1
-      version: v0.2.7+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.8-eks-a-v0.0.0-dev-build.1
+      version: v0.2.8+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml
@@ -1344,15 +1335,6 @@ spec:
           name: boots
           os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-build.1
-        cfssl:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for cfssl image
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: cfssl
-          os: linux
-          uri: public.ecr.aws/release-container-registry/cloudflare/cfssl:v1.6.1-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
@@ -1960,7 +1942,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.8-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1969,7 +1951,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.8-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1978,8 +1960,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-build.1
-      version: v0.2.7+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.8-eks-a-v0.0.0-dev-build.1
+      version: v0.2.8+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml
@@ -2103,15 +2085,6 @@ spec:
           name: boots
           os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-build.1
-        cfssl:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for cfssl image
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: cfssl
-          os: linux
-          uri: public.ecr.aws/release-container-registry/cloudflare/cfssl:v1.6.1-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
@@ -2719,7 +2692,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.8-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -2728,7 +2701,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.8-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2737,8 +2710,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-build.1
-      version: v0.2.7+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.8-eks-a-v0.0.0-dev-build.1
+      version: v0.2.8+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml
@@ -2862,15 +2835,6 @@ spec:
           name: boots
           os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-build.1
-        cfssl:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for cfssl image
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: cfssl
-          os: linux
-          uri: public.ecr.aws/release-container-registry/cloudflare/cfssl:v1.6.1-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
@@ -3460,7 +3424,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.8-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -3469,7 +3433,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.8-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -3478,8 +3442,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.7-eks-a-v0.0.0-dev-build.1
-      version: v0.2.7+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.8-eks-a-v0.0.0-dev-build.1
+      version: v0.2.8+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml
@@ -3603,15 +3567,6 @@ spec:
           name: boots
           os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/boots:94e4b4899b383e28b6002750b14e254cfbbdd81f-eks-a-v0.0.0-dev-build.1
-        cfssl:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for cfssl image
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: cfssl
-          os: linux
-          uri: public.ecr.aws/release-container-registry/cloudflare/cfssl:v1.6.1-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -60,7 +60,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -69,7 +69,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -78,7 +78,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-build.1
       ctl:
         arch:
         - amd64
@@ -87,10 +87,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.8.2/cert-manager.yaml
-      version: v1.8.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
+      version: v1.9.1+abcdef1
       webhook:
         arch:
         - amd64
@@ -99,7 +99,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -801,7 +801,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -810,7 +810,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -819,7 +819,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-build.1
       ctl:
         arch:
         - amd64
@@ -828,10 +828,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.8.2/cert-manager.yaml
-      version: v1.8.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
+      version: v1.9.1+abcdef1
       webhook:
         arch:
         - amd64
@@ -840,7 +840,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -1551,7 +1551,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -1560,7 +1560,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -1569,7 +1569,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-build.1
       ctl:
         arch:
         - amd64
@@ -1578,10 +1578,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.8.2/cert-manager.yaml
-      version: v1.8.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
+      version: v1.9.1+abcdef1
       webhook:
         arch:
         - amd64
@@ -1590,7 +1590,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -2301,7 +2301,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -2310,7 +2310,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -2319,7 +2319,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-build.1
       ctl:
         arch:
         - amd64
@@ -2328,10 +2328,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.8.2/cert-manager.yaml
-      version: v1.8.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
+      version: v1.9.1+abcdef1
       webhook:
         arch:
         - amd64
@@ -2340,7 +2340,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -3051,7 +3051,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -3060,7 +3060,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -3069,7 +3069,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-build.1
       ctl:
         arch:
         - amd64
@@ -3078,10 +3078,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.8.2/cert-manager.yaml
-      version: v1.8.2+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
+      version: v1.9.1+abcdef1
       webhook:
         arch:
         - amd64
@@ -3090,7 +3090,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.8.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:


### PR DESCRIPTION
*Description of changes:*
`cloudflare/cfssl` is no longer used by tinkerbell project. Removing reference from bundle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

