### PR TITLE
go-native client preparations (1 of 6)

### DIFF
--- a/cmd/eksctl-anywhere/cmd/applypackages.go
+++ b/cmd/eksctl-anywhere/cmd/applypackages.go
@@ -14,7 +14,7 @@ import (
 type applyPackageOptions struct {
 	fileName string
 	// kubeConfig is an optional kubeconfig file to use when querying an
-	// existing cluster
+	// existing cluster.
 	kubeConfig string
 }
 

--- a/cmd/eksctl-anywhere/cmd/createpackages.go
+++ b/cmd/eksctl-anywhere/cmd/createpackages.go
@@ -14,7 +14,7 @@ import (
 type createPackageOptions struct {
 	fileName string
 	// kubeConfig is an optional kubeconfig file to use when querying an
-	// existing cluster
+	// existing cluster.
 	kubeConfig string
 }
 

--- a/cmd/eksctl-anywhere/cmd/deletepackages.go
+++ b/cmd/eksctl-anywhere/cmd/deletepackages.go
@@ -13,7 +13,7 @@ import (
 
 type deletePackageOptions struct {
 	// kubeConfig is an optional kubeconfig file to use when querying an
-	// existing cluster
+	// existing cluster.
 	kubeConfig  string
 	clusterName string
 }

--- a/cmd/eksctl-anywhere/cmd/describepackages.go
+++ b/cmd/eksctl-anywhere/cmd/describepackages.go
@@ -13,7 +13,7 @@ import (
 
 type describePackagesOption struct {
 	// kubeConfig is an optional kubeconfig file to use when querying an
-	// existing cluster
+	// existing cluster.
 	kubeConfig  string
 	clusterName string
 }

--- a/cmd/eksctl-anywhere/cmd/getpackage.go
+++ b/cmd/eksctl-anywhere/cmd/getpackage.go
@@ -11,7 +11,7 @@ import (
 type getPackageOptions struct {
 	output string
 	// kubeConfig is an optional kubeconfig file to use when querying an
-	// existing cluster
+	// existing cluster.
 	kubeConfig  string
 	clusterName string
 }

--- a/cmd/eksctl-anywhere/cmd/getpackagebundle.go
+++ b/cmd/eksctl-anywhere/cmd/getpackagebundle.go
@@ -9,7 +9,7 @@ import (
 type getPackageBundleOptions struct {
 	output string
 	// kubeConfig is an optional kubeconfig file to use when querying an
-	// existing cluster
+	// existing cluster.
 	kubeConfig string
 }
 

--- a/cmd/eksctl-anywhere/cmd/getpackagebundlecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/getpackagebundlecontroller.go
@@ -9,7 +9,7 @@ import (
 type getPackageBundleControllerOptions struct {
 	output string
 	// kubeConfig is an optional kubeconfig file to use when querying an
-	// existing cluster
+	// existing cluster.
 	kubeConfig string
 }
 

--- a/cmd/eksctl-anywhere/cmd/installpackages.go
+++ b/cmd/eksctl-anywhere/cmd/installpackages.go
@@ -19,7 +19,7 @@ type installPackageOptions struct {
 	registry      string
 	customConfigs []string
 	// kubeConfig is an optional kubeconfig file to use when querying an
-	// existing cluster
+	// existing cluster.
 	kubeConfig string
 }
 

--- a/cmd/eksctl-anywhere/cmd/listpackages.go
+++ b/cmd/eksctl-anywhere/cmd/listpackages.go
@@ -18,7 +18,7 @@ type listPackagesOption struct {
 	source      curatedpackages.BundleSource
 	registry    string
 	// kubeConfig is an optional kubeconfig file to use when querying an
-	// existing cluster
+	// existing cluster.
 	kubeConfig string
 }
 

--- a/cmd/eksctl-anywhere/cmd/upgradepackages.go
+++ b/cmd/eksctl-anywhere/cmd/upgradepackages.go
@@ -14,7 +14,7 @@ import (
 type upgradePackageOptions struct {
 	bundleVersion string
 	// kubeConfig is an optional kubeconfig file to use when querying an
-	// existing cluster
+	// existing cluster.
 	kubeConfig  string
 	clusterName string
 }


### PR DESCRIPTION
These two small commits are a precursor to a series of PRs I'll be opening to bring a go-native k8s client to the curated packages CLI commands.