### PR TITLE
feat(CLI): go-native client for CLI commands (2 of 6)

### DIFF
--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -1,0 +1,87 @@
+package test
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// WithFakeFile returns a throwaway file in a test-specific directory.
+//
+// The file is automatically closed and removed when the test ends.
+func WithFakeFile(t *testing.T) (f *os.File) {
+	f, err := ioutil.TempFile(t.TempDir(), "fake-file")
+	if err != nil {
+		t.Fatalf("opening throwaway file: %s", err)
+	}
+
+	t.Cleanup(func() {
+		if err := f.Close(); err != nil {
+			t.Logf("closing throwaway file %q: %s", f.Name(), err)
+		}
+	})
+
+	return f
+}
+
+// WithFakeFileContents returns a throwaway file containing some data.
+//
+// The file is automatically closed and removed when the test ends.
+func WithFakeFileContents(t *testing.T, r io.Reader) (f *os.File) {
+	f = WithFakeFile(t)
+	_, err := io.Copy(f, r)
+	if err != nil {
+		t.Fatalf("copying contents into fake file %q: %s", f.Name(), err)
+	}
+
+	return f
+}
+
+// RemoveFileIfExists is a helper for ValidateFilename tests.
+func RemoveFileIfExists(t *testing.T, filename string) {
+	if err := os.Remove(filename); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("removing file %q: %s", filename, err)
+		}
+	}
+}
+
+// UseEnvTest sets up the controller-runtime EnvTest framework.
+//
+// The test will be skipped if EnvTest framework isn't detected.
+//
+// EnvTest provides fake k8s control plane components for testing
+// purposes. The process of bringing up and tearing down the EnvTest framework
+// involves running a few binaries, and is not integrated into a vanilla "go
+// test" run, but rather can be run via the unit-test target in Makefile. See
+// https://book.kubebuilder.io/reference/envtest.html for details.
+//
+// TODO: What could be done to integrate EnvTest with go test, so that "go
+// test" would work?
+func UseEnvTest(t *testing.T) *rest.Config {
+	// Detect if EnvTest has been set up.
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		// By skipping this test, we allow traditional runs of go test from
+		// the command-line (or your editor) to work.
+		t.Skip("no EnvTest assets found in KUBEBUILDER_ASSETS")
+	}
+
+	testEnv := &envtest.Environment{}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("setting up EnvTest framework: %s", err)
+	}
+	t.Cleanup(func() {
+		if err := testEnv.Stop(); err != nil {
+			t.Logf("stopping EnvTest framework: %s", err)
+		}
+	})
+
+	return cfg
+}

--- a/pkg/curatedpackages/kubeclient.go
+++ b/pkg/curatedpackages/kubeclient.go
@@ -1,0 +1,66 @@
+package curatedpackages
+
+import (
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	packagesv1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"
+)
+
+// NewKubeClientFromFilename creates a controller-runtime k8s client for use
+// by CLI commands.
+func NewKubeClientFromFilename(kubeConfigFilename string) (client.Client, error) {
+	return newKubeClient(kubeConfigFilename, nil)
+}
+
+// newKubeClient creates a controller-runtime k8s client for use by CLI commands.
+//
+// If the RESTConfigurator is nil, a default configurator will be used.
+//
+// This isn't exported because it shouldn't be necessary in normal usage. It
+// exists because we wanted to be able to inject a RESTConfigurator for tests,
+// to bypass the network calls that the k8s client makes at
+// initialization. There's no reason why the RESTConfigurator would need to be
+// modified otherwise. If that condition changes, then so too should the
+// constructor story here.
+func newKubeClient(kubeConfigFilename string, rc restConfigurator) (client.Client, error) {
+	data, err := os.ReadFile(kubeConfigFilename)
+	if err != nil {
+		return nil, err
+	}
+	if rc == nil {
+		rc = restConfigurator(clientcmd.RESTConfigFromKubeConfig)
+	}
+	restConfig, err := rc.Config(data)
+	if err != nil {
+		return nil, err
+	}
+	scheme := runtime.NewScheme()
+	if err := packagesv1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	return client.New(restConfig, client.Options{Scheme: scheme})
+}
+
+// restConfigurator abstracts the creation of a controller-runtime *rest.Config.
+//
+// This abstraction improves testing, as all known methods of instantiating a
+// *rest.Config try to make network calls, and that's something we'd like to
+// keep out of our unit tests as much as possible. In addition, where we do
+// use them in unit tests, we need to be prepared with a controller-runtime
+// EnvTest environment.
+//
+// For normal, non-test use, this can safely be ignored.
+type restConfigurator func([]byte) (*rest.Config, error)
+
+func (c restConfigurator) Config(data []byte) (*rest.Config, error) {
+	return c(data)
+}

--- a/pkg/curatedpackages/kubeclient_test.go
+++ b/pkg/curatedpackages/kubeclient_test.go
@@ -1,0 +1,24 @@
+package curatedpackages
+
+import (
+	"bytes"
+	"testing"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/aws/eks-anywhere/internal/test"
+)
+
+func TestNewKubeClient(t *testing.T) {
+	t.Parallel()
+	cfg := test.UseEnvTest(t)
+	rc := restConfigurator(func(_ []byte) (*rest.Config, error) { return cfg, nil })
+	f := test.WithFakeFileContents(t, bytes.NewBufferString(""))
+
+	t.Run("golden path", func(t *testing.T) {
+		_, err := newKubeClient(f.Name(), rc)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
This adds functions for creating a go-native kubernetes client to be used by
CLI commands.

The client is not yet used, that will be coming in follow-up commits/PRs. I've
split them up because of their size. This will work as an expand-contract
process[1], where new features like this kubernetes client are added, then
existing code will be modified to use these new features, then the old
solutions for these operations will be removed. Hopefully this will keep the
PR sizes manageable, without leaving the main branch in a broken state.

[1]: https://martinfowler.com/bliki/ParallelChange.html

Depends on #3601 