### PR TITLE
feat(Makefile): run unit tests for only modified packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ test: unit-test capd-test  ## Run unit and capd tests
 .PHONY: unit-test
 unit-test: ## Run unit tests
 unit-test: $(SETUP_ENVTEST) 
-unit-test: KUBEBUILDER_ASSETS ?= $(shell $(SETUP_ENVTEST) use --use-env -p path --arch amd64 $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))
+unit-test: KUBEBUILDER_ASSETS ?= $(shell $(SETUP_ENVTEST) use --use-env -p path --arch $(GO_ARCH) $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))
 unit-test:
 	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" $(GO_TEST) $$($(GO) list ./... | grep -vE "$(UNIT_TEST_PACKAGE_EXCLUSION_REGEX)") -cover -tags "$(BUILD_TAGS)" $(GO_TEST_FLAGS)
 

--- a/scripts/go-packages-in-patch.sh
+++ b/scripts/go-packages-in-patch.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Echo the names of go packages modified in the differences between the
+# working tree and the AWS main branch in github.
+
+# This is useful for limiting testing runs.
+
+set -euo pipefail
+
+function awsRemote () {
+    git remote -v \
+	| grep "github.com[:/]aws/eks-anywhere.git" \
+	| head -n 1 \
+	| awk '{print $1}' \
+	| tr -d '\n'
+}
+
+ref="$(awsRemote)/main"
+
+{
+    set +e
+    git diff --stat --name-only "$ref...HEAD"
+    git status --short
+} | grep ._test\.go \
+    | xargs -r -n1 dirname \
+    | sort \
+    | uniq \
+    | sed -e 's,^,./,'
+    | tr '\n' ' '
+
+echo
+


### PR DESCRIPTION
Two new Makefile targets:

    1. unit-test-patch

        Does a little git magic to figure out from the files that've changed
	from upstream which go packages have had changes, and then runs only
	those unit tests. This is convenient when running the tests
	frequently, as in red-green development or for careful refactoring.

    2. coverage-view-patch

        Like unit-test-patch, but generates and opens in your browser a
	coverage report for your changes. This is different from "make
	coverage-view" in that it only generates reports for files in the
	packages that are modified from upstream. What that means is that you
	have far fewer files to sort through to find useful test coverage
	information in the report, as it's likely to include only a handful of
	files, as opposed to every source file in the repo.
