### PR TITLE
Passing zone and network ID through to CAPC

### DIFF
--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -482,7 +482,7 @@ func TestProviderGenerateCAPISpecForCreateWithZoneIdAndNetworkId(t *testing.T) {
 	clusterSpec := givenClusterSpec(t, clusterSpecManifest)
 	datacenterConfig := givenDatacenterConfig(t, clusterSpecManifest)
 	datacenterConfig.Spec.AvailabilityZones[0].Zone = v1alpha1.CloudStackZone{
-		Id:      "zoneId",
+		Id: "zoneId",
 		Network: v1alpha1.CloudStackResourceIdentifier{
 			Id: "networkId",
 		},

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -473,6 +473,39 @@ func TestProviderGenerateCAPISpecForCreateWithAffinity(t *testing.T) {
 	test.AssertContentToFile(t, string(md), "testdata/expected_results_affinity_md.yaml")
 }
 
+func TestProviderGenerateCAPISpecForCreateWithZoneIdAndNetworkId(t *testing.T) {
+	clusterSpecManifest := "cluster_main.yaml"
+	mockCtrl := gomock.NewController(t)
+	setupContext(t)
+	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	cluster := &types.Cluster{Name: "test"}
+	clusterSpec := givenClusterSpec(t, clusterSpecManifest)
+	datacenterConfig := givenDatacenterConfig(t, clusterSpecManifest)
+	datacenterConfig.Spec.AvailabilityZones[0].Zone = v1alpha1.CloudStackZone{
+		Id:      "zoneId",
+		Network: v1alpha1.CloudStackResourceIdentifier{
+			Id: "networkId",
+		},
+	}
+	clusterSpec.CloudStackDatacenter = datacenterConfig
+	machineConfigs := givenMachineConfigs(t, clusterSpecManifest)
+	ctx := context.Background()
+	cmk := givenWildcardCmk(mockCtrl)
+	provider := newProviderWithKubectl(t, datacenterConfig, machineConfigs, clusterSpec.Cluster, kubectl, cmk)
+
+	if err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec); err != nil {
+		t.Fatalf("failed to setup and validate: %v", err)
+	}
+
+	cp, md, err := provider.GenerateCAPISpecForCreate(context.Background(), cluster, clusterSpec)
+	if err != nil {
+		t.Fatalf("failed to generate cluster api spec contents: %v", err)
+	}
+
+	test.AssertContentToFile(t, string(cp), "testdata/expected_results_resourceids_cp.yaml")
+	test.AssertContentToFile(t, string(md), "testdata/expected_results_main_md.yaml")
+}
+
 func TestProviderGenerateCAPISpecForCreateWithMirrorConfig(t *testing.T) {
 	clusterSpecManifest := "cluster_mirror_config.yaml"
 	mockCtrl := gomock.NewController(t)

--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -41,8 +41,10 @@ spec:
   failureDomains:{{ range $az := .cloudstackAvailabilityZones }}
   - name: {{ $az.Name }}
     zone:
+      id: {{ $az.Zone.Id }}
       name: {{ $az.Zone.Name }}
       network:
+        id: {{ $az.Zone.Network.Id }}
         name: {{ $az.Zone.Network.Name }}
     domain: {{ $az.Domain }}
     account: {{ $az.Account }}

--- a/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
@@ -39,8 +39,10 @@ spec:
   failureDomains:
   - name: default-az-0
     zone:
+      id: 
       name: zone1
       network:
+        id: 
         name: net1
     domain: domain1
     account: admin

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
@@ -39,8 +39,10 @@ spec:
   failureDomains:
   - name: default-az-0
     zone:
+      id: 
       name: zone1
       network:
+        id: 
         name: net1
     domain: domain1
     account: admin

--- a/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -39,8 +39,10 @@ spec:
   failureDomains:
   - name: default-az-0
     zone:
+      id: 
       name: zone1
       network:
+        id: 
         name: net1
     domain: domain1
     account: admin

--- a/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
@@ -39,8 +39,10 @@ spec:
   failureDomains:
   - name: default-az-0
     zone:
+      id: 
       name: zone1
       network:
+        id: 
         name: net1
     domain: domain1
     account: admin

--- a/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
@@ -39,8 +39,10 @@ spec:
   failureDomains:
   - name: default-az-0
     zone:
+      id: 
       name: zone1
       network:
+        id: 
         name: net1
     domain: domain1
     account: admin

--- a/pkg/providers/cloudstack/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_minimal_cp.yaml
@@ -35,8 +35,10 @@ spec:
   failureDomains:
   - name: default-az-0
     zone:
+      id: 
       name: zone1
       network:
+        id: 
         name: net1
     domain: domain1
     account: admin

--- a/pkg/providers/cloudstack/testdata/expected_results_minimal_proxy_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_minimal_proxy_cp.yaml
@@ -35,8 +35,10 @@ spec:
   failureDomains:
   - name: default-az-0
     zone:
+      id: 
       name: zone1
       network:
+        id: 
         name: net1
     domain: domain1
     account: admin

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
@@ -39,8 +39,10 @@ spec:
   failureDomains:
   - name: default-az-0
     zone:
+      id: 
       name: zone1
       network:
+        id: 
         name: net1
     domain: domain1
     account: admin

--- a/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
@@ -39,11 +39,11 @@ spec:
   failureDomains:
   - name: default-az-0
     zone:
-      id: 
-      name: zone1
+      id: zoneId
+      name: 
       network:
-        id: 
-        name: net1
+        id: networkId
+        name: 
     domain: domain1
     account: admin
     acsEndpoint:
@@ -55,6 +55,12 @@ kind: CloudStackMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
   namespace: eksa-system
+  annotations:
+    mountpath.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: /data-small
+    device.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: /dev/vdb
+    filesystem.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: ext4
+    label.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: data_disk
+    symlinks.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: /var/log/kubernetes:/data-small/var/log/kubernetes
 spec:
   template:
     spec:
@@ -62,6 +68,14 @@ spec:
         name: m4-large
       template:
         name: centos7-k8s-118
+      diskOffering:
+        name: Small
+        mountPath: /data-small
+        device: /dev/vdb
+        filesystem: ext4
+        label: data_disk
+      affinityGroupIDs:
+      - control-plane-anti-affinity
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -329,34 +343,6 @@ spec:
           - "RequestReceived"
       owner: root:root
       path: /etc/kubernetes/audit-policy.yaml
-    - content: |
-        -----BEGIN CERTIFICATE-----
-        MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV
-        BAMTCnRlc3QubG9jYWwwHhcNMjEwOTIzMjAxOTEyWhcNMzEwOTIxMjAxOTEyWjAV
-        MRMwEQYDVQQDEwp0ZXN0LmxvY2FsMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
-        CgKCAQEAwDHozKwX0kAGICTaV1XoMdJ+t+8LQsAGmzIKYhrSh+WdEcx/xc1SDJcp
-        EBFeUmVuFwI5DYX2BTvJ0AApSBuViNZn669yn1dBV7PHM27NV37/dDCFkjiqBtax
-        lOXchrL6IoZirmMgMnI/PfASdI/PCR75DNCIQFGZbwWAbEBxxLHgWPEFJ5TWP6fD
-        2s95gbc9gykI09ta/H5ITKCd3EVtiAlcQ86Ax9EZRmvJYGw5NFmPnJ0X/OmXmLXx
-        o0ggkjHTeyG8sZQpDTs6oQrX/XLfLOvrJi3suiiJXz0pNAXZoFaLu8Z0Ci+EoquM
-        cFh4NhfSAD5BJADxwf7iv7KXCWtQTwIDAQABoxkwFzAVBgNVHREEDjAMggp0ZXN0
-        LmxvY2FsMA0GCSqGSIb3DQEBBQUAA4IBAQBr4qDklaG/ZLcrkc0PBo9ylj3rtt1M
-        ar1nv+Nv8zXByTsYs9muEQYBKpzvk9SJZ4OfYVcx6qETbG7z7kdgZtDktQULw5fQ
-        hsiy0flLv+JkdD4M30rtjhDIiuNH2ew6+2JB80QaSznW7Z3Fd18BmDaE1qqLYQFX
-        iCau7fRD2aQyVluuJ0OeDOuk33jY3Vn3gyKGfnjPAnb4DxCg7v1IeazGSVK18urL
-        zkYl4nSFENRLV5sL/wox2ohjMLff2lv6gyqkMFrLNSeHSQLGu8diat4UVDk8MMza
-        9n5t2E4AHPen+YrGeLY1qEn9WMv0XRGWrgJyLW9VSX8T3SlWO2w3okcw
-        -----END CERTIFICATE-----
-      owner: root:root
-      path: "/etc/containerd/certs.d/1.2.3.4/ca.crt"
-    - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://1.2.3.4"]
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4".tls]
-            ca_file = "/etc/containerd/certs.d/1.2.3.4/ca.crt"
-      owner: root:root
-      path: "/etc/containerd/config_append.toml"
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -377,14 +363,35 @@ spec:
         name: '{{ ds.meta_data.local_hostname }}'
     preKubeadmCommands:
     - swapoff -a
-    - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
-    - sudo systemctl daemon-reload
-    - sudo systemctl restart containerd
     - hostname "{{ ds.meta_data.local_hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
     - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
     - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - >-
+      if [ ! -L /var/log/kubernetes ] ;
+        then
+          mv /var/log/kubernetes /var/log/kubernetes-$(tr -dc A-Za-z0-9 < /dev/urandom | head -c 10) ;
+          mkdir -p /data-small/var/log/kubernetes && ln -s /data-small/var/log/kubernetes /var/log/kubernetes ;
+        else echo "/var/log/kubernetes already symlnk";
+      fi
+    diskSetup:
+      filesystems:
+        - device: /dev/vdb1
+          overwrite: false
+          extraOpts:
+            - -E
+            - lazy_itable_init=1,lazy_journal_init=1
+          filesystem: ext4
+          label: data_disk
+      partitions:
+        - device: /dev/vdb
+          layout: true
+          overwrite: false
+          tableType: gpt
+    mounts:
+      - - LABEL=data_disk
+        - /data-small
     useExperimentalRetryJoin: true
     users:
     - name: mySshUsername
@@ -420,32 +427,26 @@ spec:
     - echo "127.0.0.1   localhost" >>/etc/hosts
     - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
     - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - >-
+      echo "type=83" | sfdisk /dev/vdb &&
+      mkfs -t ext4 /dev/vdb1 &&
+      mkdir -p /data-small &&
+      echo /dev/vdb1 /data-small ext4 defaults 0 2 >> /etc/fstab &&
+      mount /data-small
+    - >-
+      if [ ! -L /var/lib/ ] ;
+        then
+          mv /var/lib/ /var/lib/-$(tr -dc A-Za-z0-9 < /dev/urandom | head -c 10) ;
+          mkdir -p /data-small/var/lib && ln -s /data-small/var/lib /var/lib/ ;
+        else
+          echo "/var/lib/ already symlnk" ;
+      fi
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
     - name: mySshUsername
       sshAuthorizedKeys:
       - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
       sudo: ALL=(ALL) NOPASSWD:ALL
-    registryMirror:
-      endpoint: 1.2.3.4
-      caCert: |
-        -----BEGIN CERTIFICATE-----
-        MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV
-        BAMTCnRlc3QubG9jYWwwHhcNMjEwOTIzMjAxOTEyWhcNMzEwOTIxMjAxOTEyWjAV
-        MRMwEQYDVQQDEwp0ZXN0LmxvY2FsMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
-        CgKCAQEAwDHozKwX0kAGICTaV1XoMdJ+t+8LQsAGmzIKYhrSh+WdEcx/xc1SDJcp
-        EBFeUmVuFwI5DYX2BTvJ0AApSBuViNZn669yn1dBV7PHM27NV37/dDCFkjiqBtax
-        lOXchrL6IoZirmMgMnI/PfASdI/PCR75DNCIQFGZbwWAbEBxxLHgWPEFJ5TWP6fD
-        2s95gbc9gykI09ta/H5ITKCd3EVtiAlcQ86Ax9EZRmvJYGw5NFmPnJ0X/OmXmLXx
-        o0ggkjHTeyG8sZQpDTs6oQrX/XLfLOvrJi3suiiJXz0pNAXZoFaLu8Z0Ci+EoquM
-        cFh4NhfSAD5BJADxwf7iv7KXCWtQTwIDAQABoxkwFzAVBgNVHREEDjAMggp0ZXN0
-        LmxvY2FsMA0GCSqGSIb3DQEBBQUAA4IBAQBr4qDklaG/ZLcrkc0PBo9ylj3rtt1M
-        ar1nv+Nv8zXByTsYs9muEQYBKpzvk9SJZ4OfYVcx6qETbG7z7kdgZtDktQULw5fQ
-        hsiy0flLv+JkdD4M30rtjhDIiuNH2ew6+2JB80QaSznW7Z3Fd18BmDaE1qqLYQFX
-        iCau7fRD2aQyVluuJ0OeDOuk33jY3Vn3gyKGfnjPAnb4DxCg7v1IeazGSVK18urL
-        zkYl4nSFENRLV5sL/wox2ohjMLff2lv6gyqkMFrLNSeHSQLGu8diat4UVDk8MMza
-        9n5t2E4AHPen+YrGeLY1qEn9WMv0XRGWrgJyLW9VSX8T3SlWO2w3okcw
-        -----END CERTIFICATE-----
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: CloudStackMachineTemplate
@@ -456,6 +457,12 @@ kind: CloudStackMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000
   namespace: 'eksa-system'
+  annotations:
+    mountpath.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: /data-small
+    device.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: /dev/vdb
+    filesystem.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: ext4
+    label.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: data_disk
+    symlinks.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: /var/lib/:/data-small/var/lib
 spec:
   template:
     spec:
@@ -463,3 +470,11 @@ spec:
         name: m4-large
       template:
         name: centos7-k8s-118
+      diskOffering:
+        name: Small
+        mountPath: /data-small
+        device: /dev/vdb
+        filesystem: ext4
+        label: data_disk
+      affinityGroupIDs:
+      - etcd-affinity


### PR DESCRIPTION
*Issue #, if available:*
Resolves https://github.com/aws/eks-anywhere/issues/3609

*Description of changes:*
Previously we had missed an attribute to pass through from EKS-A to CAPC. This PR enables the pass-through to occur. Without it, clusters would fail to start if only zone name/network name were not specified. If both id and name were specified, we observed a continuous rollingupgrade on the EKS-A manager because the controller expected ID's and names to both be passed through both ways.

*Testing (if applicable):*
Unit tests pass. Manual cluster creation test allowed successful creation of a cluster when zoneId and network id were specified without rolling upgrade.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

