### PR TITLE
Upgrade github.com/tinkerbell/{tink,rufio} dependencies:

### DIFF
--- a/docs/content/en/docs/reference/baremetal/netbooting-and-tinkerbell.md
+++ b/docs/content/en/docs/reference/baremetal/netbooting-and-tinkerbell.md
@@ -263,7 +263,7 @@ For example, at the start of a new provisioning event, you would see something l
 kubectl logs -n capt-system capt-controller-manager-9f8b95b-frbq | less
 ```
 ```
-..."Created BMCJob to get hardware ready for provisioning"...
+..."Created Job to get hardware ready for provisioning"...
 ```
 
 You can follow this output to see the machine as it goes through the provisioning process.

--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,8 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.0
 	github.com/stretchr/testify v1.8.0
-	github.com/tinkerbell/rufio v0.0.0-20220606134123-599b7401b5cc
-	github.com/tinkerbell/tink v0.7.1-0.20221004171112-6deeea887dac
+	github.com/tinkerbell/rufio v0.1.0
+	github.com/tinkerbell/tink v0.8.0
 	go.uber.org/zap v1.22.0
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8

--- a/go.sum
+++ b/go.sum
@@ -1040,10 +1040,10 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tinkerbell/rufio v0.0.0-20220606134123-599b7401b5cc h1:aiF/Ieu+HblpMQtHL4mQUbc9VvdIP/i5Ud6kISZjflk=
-github.com/tinkerbell/rufio v0.0.0-20220606134123-599b7401b5cc/go.mod h1:2b7/OCatuqXr3SR7lns/7iKoV4XiXYdUnqwqiUGOsr0=
-github.com/tinkerbell/tink v0.7.1-0.20221004171112-6deeea887dac h1:3VYTNuPZLheD2KhtKcMrde0NywazHIy17qVJ7WqCDto=
-github.com/tinkerbell/tink v0.7.1-0.20221004171112-6deeea887dac/go.mod h1:bfAkSH7J/QQYIyqZRR6IQp8w78aac6l8Z2Lws5uXz6A=
+github.com/tinkerbell/rufio v0.1.0 h1:EqDJZfPVrkd2f55P0ckSj3uGK07WUpAQonOBtpQUue4=
+github.com/tinkerbell/rufio v0.1.0/go.mod h1:2b7/OCatuqXr3SR7lns/7iKoV4XiXYdUnqwqiUGOsr0=
+github.com/tinkerbell/tink v0.8.0 h1:qgl/rglpO5Rvq6UKZd29O6X9mDgZZYgf841+Y0IYWak=
+github.com/tinkerbell/tink v0.8.0/go.mod h1:bfAkSH7J/QQYIyqZRR6IQp8w78aac6l8Z2Lws5uXz6A=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -317,9 +317,9 @@ func (c *collectorFactory) snowCrdCollectors() []*Collect {
 
 func (c *collectorFactory) tinkerbellCrdCollectors() []*Collect {
 	captCrds := []string{
-		"baseboardmanagements.bmc.tinkerbell.org",
-		"bmcjobs.bmc.tinkerbell.org",
-		"bmctasks.bmc.tinkerbell.org",
+		"machines.bmc.tinkerbell.org",
+		"jobs.bmc.tinkerbell.org",
+		"tasks.bmc.tinkerbell.org",
 		"hardware.tinkerbell.org",
 		"templates.tinkerbell.org",
 		"tinkerbellclusters.infrastructure.cluster.x-k8s.io",

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -55,7 +55,7 @@ var (
 	eksaTinkerbellDatacenterResourceType = fmt.Sprintf("tinkerbelldatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaTinkerbellMachineResourceType    = fmt.Sprintf("tinkerbellmachineconfigs.%s", v1alpha1.GroupVersion.Group)
 	TinkerbellHardwareResourceType       = fmt.Sprintf("hardware.%s", tinkv1alpha1.GroupVersion.Group)
-	rufioBaseboardManagementResourceType = fmt.Sprintf("baseboardmanagements.%s", rufiov1alpha1.GroupVersion.Group)
+	rufioMachineResourceType             = fmt.Sprintf("machines.%s", rufiov1alpha1.GroupVersion.Group)
 	eksaCloudStackDatacenterResourceType = fmt.Sprintf("cloudstackdatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaCloudStackMachineResourceType    = fmt.Sprintf("cloudstackmachineconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaAwsResourceType                  = fmt.Sprintf("awsdatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
@@ -348,8 +348,8 @@ func (k *Kubectl) WaitForDeployment(ctx context.Context, cluster *types.Cluster,
 	return k.Wait(ctx, cluster.KubeconfigFile, timeout, condition, "deployments/"+target, namespace)
 }
 
-func (k *Kubectl) WaitForBaseboardManagements(ctx context.Context, cluster *types.Cluster, timeout string, condition string, namespace string) error {
-	return k.Wait(ctx, cluster.KubeconfigFile, timeout, condition, rufioBaseboardManagementResourceType, namespace, WithWaitAll())
+func (k *Kubectl) WaitForBMCMachines(ctx context.Context, cluster *types.Cluster, timeout string, condition string, namespace string) error {
+	return k.Wait(ctx, cluster.KubeconfigFile, timeout, condition, rufioMachineResourceType, namespace, WithWaitAll())
 }
 
 func (k *Kubectl) Wait(ctx context.Context, kubeconfig string, timeout string, forCondition string, property string, namespace string, opts ...KubectlOpt) error {

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -2448,7 +2448,7 @@ func TestKubectlWaitForClusterReady(t *testing.T) {
 	tt.Expect(tt.k.WaitForClusterReady(tt.ctx, tt.cluster, timeout, "test")).To(Succeed())
 }
 
-func TestWaitForBaseboardManagements(t *testing.T) {
+func TestWaitForBMCMachines(t *testing.T) {
 	kt := newKubectlTest(t)
 
 	timeout := "5m"
@@ -2456,10 +2456,10 @@ func TestWaitForBaseboardManagements(t *testing.T) {
 
 	kt.e.EXPECT().Execute(
 		kt.ctx,
-		"wait", "--timeout", expectedTimeout, "--for=condition=Contactable", "baseboardmanagements.bmc.tinkerbell.org", "--kubeconfig", kt.cluster.KubeconfigFile, "-n", "eksa-system", "--all",
+		"wait", "--timeout", expectedTimeout, "--for=condition=Contactable", "machines.bmc.tinkerbell.org", "--kubeconfig", kt.cluster.KubeconfigFile, "-n", "eksa-system", "--all",
 	).Return(bytes.Buffer{}, nil)
 
-	kt.Expect(kt.k.WaitForBaseboardManagements(kt.ctx, kt.cluster, timeout, "Contactable", "eksa-system")).To(Succeed())
+	kt.Expect(kt.k.WaitForBMCMachines(kt.ctx, kt.cluster, timeout, "Contactable", "eksa-system")).To(Succeed())
 }
 
 func TestKubectlApply(t *testing.T) {

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -70,7 +70,7 @@ func (p *Provider) PostBootstrapSetup(ctx context.Context, clusterConfig *v1alph
 	if err != nil {
 		return fmt.Errorf("applying hardware yaml: %v", err)
 	}
-	err = p.providerKubectlClient.WaitForBaseboardManagements(ctx, cluster, "5m", "Contactable", constants.EksaSystemNamespace)
+	err = p.providerKubectlClient.WaitForBMCMachines(ctx, cluster, "5m", "Contactable", constants.EksaSystemNamespace)
 	if err != nil {
 		return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
 	}

--- a/pkg/providers/tinkerbell/hardware/catalogue.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue.go
@@ -38,7 +38,7 @@ type Catalogue struct {
 	hardware      []*tinkv1alpha1.Hardware
 	hardwareIndex Indexer
 
-	bmcs     []*rufiov1alpha1.BaseboardManagement
+	bmcs     []*rufiov1alpha1.Machine
 	bmcIndex Indexer
 
 	secrets     []*corev1.Secret
@@ -52,7 +52,7 @@ type CatalogueOption func(*Catalogue)
 func NewCatalogue(opts ...CatalogueOption) *Catalogue {
 	catalogue := &Catalogue{
 		hardwareIndex: NewFieldIndexer(&tinkv1alpha1.Hardware{}),
-		bmcIndex:      NewFieldIndexer(&rufiov1alpha1.BaseboardManagement{}),
+		bmcIndex:      NewFieldIndexer(&rufiov1alpha1.Machine{}),
 		secretIndex:   NewFieldIndexer(&corev1.Secret{}),
 	}
 
@@ -90,13 +90,13 @@ func ParseYAMLCatalogue(catalogue *Catalogue, r io.Reader) error {
 		if err = yaml.Unmarshal(manifest, &resource); err != nil {
 			return err
 		}
-
+		fmt.Println(resource.GetKind())
 		switch resource.GetKind() {
 		case "Hardware":
 			if err := catalogueSerializedHardware(catalogue, manifest); err != nil {
 				return err
 			}
-		case "BaseboardManagement":
+		case "Machine":
 			if err := catalogueSerializedBMC(catalogue, manifest); err != nil {
 				return err
 			}
@@ -120,7 +120,7 @@ func catalogueSerializedHardware(catalogue *Catalogue, manifest []byte) error {
 }
 
 func catalogueSerializedBMC(catalogue *Catalogue, manifest []byte) error {
-	var bmc rufiov1alpha1.BaseboardManagement
+	var bmc rufiov1alpha1.Machine
 	if err := yaml.UnmarshalStrict(manifest, &bmc); err != nil {
 		return fmt.Errorf("unable to parse bmc manifest: %v", err)
 	}
@@ -165,7 +165,7 @@ func MarshalCatalogue(c *Catalogue) ([]byte, error) {
 }
 
 // NewMachineCatalogueWriter creates a MachineWriter instance that writes Machine instances to
-// catalogue including its BaseboardManagement and Secret data.
+// catalogue including its Machine(bmc) and Secret data.
 func NewMachineCatalogueWriter(catalogue *Catalogue) MachineWriter {
 	return MultiMachineWriter(
 		NewHardwareCatalogueWriter(catalogue),

--- a/pkg/providers/tinkerbell/hardware/catalogue_bmc.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_bmc.go
@@ -14,7 +14,7 @@ func (c *Catalogue) IndexBMCs(index string, fn KeyExtractorFunc) {
 }
 
 // InsertBMC inserts BMCs into the catalogue. If any indexes exist, the BMC is indexed.
-func (c *Catalogue) InsertBMC(bmc *v1alpha1.BaseboardManagement) error {
+func (c *Catalogue) InsertBMC(bmc *v1alpha1.Machine) error {
 	if err := c.bmcIndex.Insert(bmc); err != nil {
 		return err
 	}
@@ -23,23 +23,23 @@ func (c *Catalogue) InsertBMC(bmc *v1alpha1.BaseboardManagement) error {
 }
 
 // AllBMCs retrieves a copy of the catalogued BMC instances.
-func (c *Catalogue) AllBMCs() []*v1alpha1.BaseboardManagement {
-	bmcs := make([]*v1alpha1.BaseboardManagement, len(c.bmcs))
+func (c *Catalogue) AllBMCs() []*v1alpha1.Machine {
+	bmcs := make([]*v1alpha1.Machine, len(c.bmcs))
 	copy(bmcs, c.bmcs)
 	return bmcs
 }
 
 // LookupBMC retrieves BMC instances on index with a key of key. Multiple BMCs _may_
 // have the same key hence it can return multiple BMCs.
-func (c *Catalogue) LookupBMC(index, key string) ([]*v1alpha1.BaseboardManagement, error) {
+func (c *Catalogue) LookupBMC(index, key string) ([]*v1alpha1.Machine, error) {
 	untyped, err := c.bmcIndex.Lookup(index, key)
 	if err != nil {
 		return nil, err
 	}
 
-	bmcs := make([]*v1alpha1.BaseboardManagement, len(untyped))
+	bmcs := make([]*v1alpha1.Machine, len(untyped))
 	for i, v := range untyped {
-		bmcs[i] = v.(*v1alpha1.BaseboardManagement)
+		bmcs[i] = v.(*v1alpha1.Machine)
 	}
 
 	return bmcs, nil
@@ -56,13 +56,13 @@ const BMCNameIndex = ".ObjectMeta.Name"
 func WithBMCNameIndex() CatalogueOption {
 	return func(c *Catalogue) {
 		c.IndexBMCs(BMCNameIndex, func(o interface{}) string {
-			bmc := o.(*v1alpha1.BaseboardManagement)
+			bmc := o.(*v1alpha1.Machine)
 			return bmc.ObjectMeta.Name
 		})
 	}
 }
 
-// BMCCatalogueWriter converts Machine instances to Tinkerbell BaseboardManagement and inserts them
+// BMCCatalogueWriter converts Machine instances to Tinkerbell Machine (BMC) and inserts them
 // in a catalogue.
 type BMCCatalogueWriter struct {
 	catalogue *Catalogue
@@ -75,25 +75,25 @@ func NewBMCCatalogueWriter(catalogue *Catalogue) *BMCCatalogueWriter {
 	return &BMCCatalogueWriter{catalogue: catalogue}
 }
 
-// Write converts m to a Tinkerbell BaseboardManagement and inserts it into w's Catalogue.
+// Write converts m to a Tinkerbell Machine(BMC) and inserts it into w's Catalogue.
 func (w *BMCCatalogueWriter) Write(m Machine) error {
 	if m.HasBMC() {
-		return w.catalogue.InsertBMC(baseboardManagementComputerFromMachine(m))
+		return w.catalogue.InsertBMC(bmcMachineComputerFromMachine(m))
 	}
 	return nil
 }
 
-func baseboardManagementComputerFromMachine(m Machine) *v1alpha1.BaseboardManagement {
+func bmcMachineComputerFromMachine(m Machine) *v1alpha1.Machine {
 	// TODO(chrisdoherty4)
 	// 	- Set the namespace to the CAPT namespace.
 	// 	- Patch through insecure TLS.
-	return &v1alpha1.BaseboardManagement{
-		TypeMeta: newBaseboardManagementTypeMeta(),
+	return &v1alpha1.Machine{
+		TypeMeta: newBMCMachineTypeMeta(),
 		ObjectMeta: v1.ObjectMeta{
 			Name:      formatBMCRef(m),
 			Namespace: constants.EksaSystemNamespace,
 		},
-		Spec: v1alpha1.BaseboardManagementSpec{
+		Spec: v1alpha1.MachineSpec{
 			Connection: v1alpha1.Connection{
 				Host: m.BMCIPAddress,
 				AuthSecretRef: corev1.SecretReference{

--- a/pkg/providers/tinkerbell/hardware/catalogue_bmc_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_bmc_test.go
@@ -15,7 +15,7 @@ func TestCatalogue_BMC_Insert(t *testing.T) {
 
 	catalogue := hardware.NewCatalogue()
 
-	err := catalogue.InsertBMC(&v1alpha1.BaseboardManagement{})
+	err := catalogue.InsertBMC(&v1alpha1.Machine{})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(catalogue.TotalBMCs()).To(gomega.Equal(1))
 }
@@ -35,7 +35,7 @@ func TestCatalogue_BMC_Indexed(t *testing.T) {
 	catalogue := hardware.NewCatalogue(hardware.WithBMCNameIndex())
 
 	const name = "hello"
-	expect := &v1alpha1.BaseboardManagement{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	expect := &v1alpha1.Machine{ObjectMeta: metav1.ObjectMeta{Name: name}}
 	err := catalogue.InsertBMC(expect)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -51,13 +51,13 @@ func TestCatalogue_BMC_AllBMCsReceivesCopy(t *testing.T) {
 	catalogue := hardware.NewCatalogue(hardware.WithHardwareIDIndex())
 
 	const totalHardware = 1
-	err := catalogue.InsertBMC(&v1alpha1.BaseboardManagement{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
+	err := catalogue.InsertBMC(&v1alpha1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	changedHardware := catalogue.AllBMCs()
 	g.Expect(changedHardware).To(gomega.HaveLen(totalHardware))
 
-	changedHardware[0] = &v1alpha1.BaseboardManagement{ObjectMeta: metav1.ObjectMeta{Name: "qux"}}
+	changedHardware[0] = &v1alpha1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "qux"}}
 
 	unchangedHardware := catalogue.AllBMCs()
 	g.Expect(unchangedHardware).ToNot(gomega.Equal(changedHardware))

--- a/pkg/providers/tinkerbell/hardware/catalogue_secret.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_secret.go
@@ -62,7 +62,7 @@ func WithSecretNameIndex() CatalogueOption {
 	}
 }
 
-// SecretCatalogueWriter converts Machine instances to Tinkerbell BaseboardManagement and inserts them
+// SecretCatalogueWriter converts Machine instances to Tinkerbell Machine(BMC) and inserts them
 // in a catalogue.
 type SecretCatalogueWriter struct {
 	catalogue *Catalogue
@@ -75,15 +75,15 @@ func NewSecretCatalogueWriter(catalogue *Catalogue) *SecretCatalogueWriter {
 	return &SecretCatalogueWriter{catalogue: catalogue}
 }
 
-// Write converts m to a Tinkerbell BaseboardManagement and inserts it into w's Catalogue.
+// Write converts m to a Tinkerbell Machine(BMC) and inserts it into w's Catalogue.
 func (w *SecretCatalogueWriter) Write(m Machine) error {
 	if m.HasBMC() {
-		return w.catalogue.InsertSecret(baseboardManagementSecretFromMachine(m))
+		return w.catalogue.InsertSecret(bmcMachineSecretFromMachine(m))
 	}
 	return nil
 }
 
-func baseboardManagementSecretFromMachine(m Machine) *corev1.Secret {
+func bmcMachineSecretFromMachine(m Machine) *corev1.Secret {
 	return &corev1.Secret{
 		TypeMeta: newSecretTypeMeta(),
 		ObjectMeta: v1.ObjectMeta{

--- a/pkg/providers/tinkerbell/hardware/catalogue_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_test.go
@@ -25,7 +25,7 @@ spec:
 status: {}
 ---
 apiVersion: tinkerbell.org/v1alpha1
-kind: BaseboardManagement
+kind: Machine
 metadata:
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"

--- a/pkg/providers/tinkerbell/hardware/typemeta.go
+++ b/pkg/providers/tinkerbell/hardware/typemeta.go
@@ -8,7 +8,7 @@ const (
 	rufioAPIVersion        = "bmc.tinkerbell.org/v1alpha1"
 	tinkerbellAPIVersion   = "tinkerbell.org/v1alpha1"
 	tinkerbellHardwareKind = "Hardware"
-	tinkerbellBMCKind      = "BaseboardManagement"
+	tinkerbellBMCKind      = "Machine"
 
 	secretKind       = "Secret"
 	secretAPIVersion = "v1"
@@ -21,7 +21,7 @@ func newHardwareTypeMeta() v1.TypeMeta {
 	}
 }
 
-func newBaseboardManagementTypeMeta() v1.TypeMeta {
+func newBMCMachineTypeMeta() v1.TypeMeta {
 	return v1.TypeMeta{
 		Kind:       tinkerbellBMCKind,
 		APIVersion: rufioAPIVersion,

--- a/pkg/providers/tinkerbell/hardware/yaml.go
+++ b/pkg/providers/tinkerbell/hardware/yaml.go
@@ -67,18 +67,18 @@ func (yw *TinkerbellManifestYAML) write(data []byte) error {
 }
 
 // TODO(chrisdoherty4) Patch these types so we can generate yamls again with the new Hardware
-// and BaseboardManagement types.
+// and Machine(BMC) types.
 
 func marshalTinkerbellHardwareYAML(m Machine) ([]byte, error) {
 	return yaml.Marshal(hardwareFromMachine(m))
 }
 
 func marshalTinkerbellBMCYAML(m Machine) ([]byte, error) {
-	return yaml.Marshal(baseboardManagementComputerFromMachine(m))
+	return yaml.Marshal(bmcMachineComputerFromMachine(m))
 }
 
 func marshalSecretYAML(m Machine) ([]byte, error) {
-	return yaml.Marshal(baseboardManagementSecretFromMachine(m))
+	return yaml.Marshal(bmcMachineSecretFromMachine(m))
 }
 
 // CreateOrStdout will create path and return an *os.File if path is not empty. If path is empty

--- a/pkg/providers/tinkerbell/hardware/yaml_test.go
+++ b/pkg/providers/tinkerbell/hardware/yaml_test.go
@@ -35,7 +35,7 @@ func TestTinkerbellManifestYAMLWrites(t *testing.T) {
 	err = yaml.Unmarshal(raw, &hardware)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
-	var bmc rufiov1alpha1.BaseboardManagement
+	var bmc rufiov1alpha1.Machine
 	raw, err = reader.Read()
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	err = yaml.Unmarshal(raw, &bmc)
@@ -67,7 +67,7 @@ func AssertTinkerbellHardwareRepresentsMachine(g *gomega.WithT, h tinkv1alpha1.H
 	g.Expect(h.ObjectMeta.Name).To(gomega.Equal(m.Hostname))
 }
 
-func AssertTinkerbellBMCRepresentsMachine(g *gomega.WithT, b rufiov1alpha1.BaseboardManagement, m hardware.Machine) {
+func AssertTinkerbellBMCRepresentsMachine(g *gomega.WithT, b rufiov1alpha1.Machine, m hardware.Machine) {
 	g.Expect(b.Spec.Connection.Host).To(gomega.Equal(m.BMCIPAddress))
 }
 

--- a/pkg/providers/tinkerbell/mocks/client.go
+++ b/pkg/providers/tinkerbell/mocks/client.go
@@ -273,18 +273,18 @@ func (mr *MockProviderKubectlClientMockRecorder) UpdateAnnotation(arg0, arg1, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAnnotation", reflect.TypeOf((*MockProviderKubectlClient)(nil).UpdateAnnotation), varargs...)
 }
 
-// WaitForBaseboardManagements mocks base method.
-func (m *MockProviderKubectlClient) WaitForBaseboardManagements(arg0 context.Context, arg1 *types.Cluster, arg2, arg3, arg4 string) error {
+// WaitForBMCMachines mocks base method.
+func (m *MockProviderKubectlClient) WaitForBMCMachines(arg0 context.Context, arg1 *types.Cluster, arg2, arg3, arg4 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForBaseboardManagements", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "WaitForBMCMachines", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// WaitForBaseboardManagements indicates an expected call of WaitForBaseboardManagements.
-func (mr *MockProviderKubectlClientMockRecorder) WaitForBaseboardManagements(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+// WaitForBMCMachines indicates an expected call of WaitForBMCMachines.
+func (mr *MockProviderKubectlClientMockRecorder) WaitForBMCMachines(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForBaseboardManagements", reflect.TypeOf((*MockProviderKubectlClient)(nil).WaitForBaseboardManagements), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForBMCMachines", reflect.TypeOf((*MockProviderKubectlClient)(nil).WaitForBMCMachines), arg0, arg1, arg2, arg3, arg4)
 }
 
 // WaitForDeployment mocks base method.

--- a/pkg/providers/tinkerbell/testdata/hardware_config.yaml
+++ b/pkg/providers/tinkerbell/testdata/hardware_config.yaml
@@ -14,7 +14,7 @@ spec:
 status: {}
 ---
 apiVersion: tinkerbell.org/v1alpha1
-kind: BaseboardManagement
+kind: Machine
 metadata:
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
@@ -57,7 +57,7 @@ spec:
 status: {}
 ---
 apiVersion: tinkerbell.org/v1alpha1
-kind: BaseboardManagement
+kind: Machine
 metadata:
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
@@ -100,7 +100,7 @@ spec:
 status: {}
 ---
 apiVersion: tinkerbell.org/v1alpha1
-kind: BaseboardManagement
+kind: Machine
 metadata:
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
@@ -143,7 +143,7 @@ spec:
 status: {}
 ---
 apiVersion: tinkerbell.org/v1alpha1
-kind: BaseboardManagement
+kind: Machine
 metadata:
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -84,7 +84,7 @@ type ProviderKubectlClient interface {
 	WaitForDeployment(ctx context.Context, cluster *types.Cluster, timeout string, condition string, target string, namespace string) error
 	GetUnprovisionedTinkerbellHardware(_ context.Context, kubeconfig, namespace string) ([]tinkv1alpha1.Hardware, error)
 	GetProvisionedTinkerbellHardware(_ context.Context, kubeconfig, namespace string) ([]tinkv1alpha1.Hardware, error)
-	WaitForBaseboardManagements(ctx context.Context, cluster *types.Cluster, timeout string, condition string, namespace string) error
+	WaitForBMCMachines(ctx context.Context, cluster *types.Cluster, timeout string, condition string, namespace string) error
 }
 
 // KeyGenerator generates ssh keys and writes them to a FileWriter.

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -365,7 +365,7 @@ func TestPostBootstrapSetupSuccess(t *testing.T) {
 	machineConfigs := givenMachineConfigs(t, clusterSpecManifest)
 
 	kubectl.EXPECT().ApplyKubeSpecFromBytesForce(ctx, cluster, gomock.Any())
-	kubectl.EXPECT().WaitForBaseboardManagements(ctx, cluster, "5m", "Contactable", gomock.Any()).MaxTimes(2)
+	kubectl.EXPECT().WaitForBMCMachines(ctx, cluster, "5m", "Contactable", gomock.Any()).MaxTimes(2)
 
 	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl, forceCleanup)
 

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -185,8 +185,8 @@ func (p *Provider) PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig 
 }
 
 func (p *Provider) PostMoveManagementToBootstrap(ctx context.Context, bootstrapCluster *types.Cluster) error {
-	// Waiting to ensure all the new and exisiting baseboardmanagement connections are valid.
-	if err := p.providerKubectlClient.WaitForBaseboardManagements(ctx, bootstrapCluster, "5m", "Contactable", constants.EksaSystemNamespace); err != nil {
+	// Waiting to ensure all the new and exisiting BMC Machine connections are valid.
+	if err := p.providerKubectlClient.WaitForBMCMachines(ctx, bootstrapCluster, "5m", "Contactable", constants.EksaSystemNamespace); err != nil {
 		return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is needed for VLAN ID support as the latest upstream CAPT uses these same versions.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

