### PR TITLE
Add CAPI provider Workers

### DIFF
--- a/pkg/clusterapi/controlplane_test.go
+++ b/pkg/clusterapi/controlplane_test.go
@@ -2,22 +2,18 @@ package clusterapi_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/aws/eks-anywhere/internal/test"
-	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
@@ -72,69 +68,6 @@ func TestControlPlaneObjects(t *testing.T) {
 			g.Expect(tt.controlPlane.Objects()).To(ConsistOf(tt.want))
 		})
 	}
-}
-
-func TestEnsureNewNameIfChangedObjectDoesNotExist(t *testing.T) {
-	g := NewWithT(t)
-	ctx := context.Background()
-	originalName := "my-machine-template-1"
-	mt := dockerMachineTemplate()
-	mt.Name = originalName
-	client := test.NewFakeKubeClient()
-
-	g.Expect(clusterapi.EnsureNewNameIfChanged(ctx, client, notFoundRetriever, withChangesCompare, mt)).To(Succeed())
-	g.Expect(mt.Name).To(Equal(originalName))
-}
-
-func TestEnsureNewNameIfChangedErrorReadingObject(t *testing.T) {
-	g := NewWithT(t)
-	ctx := context.Background()
-	mt := dockerMachineTemplate()
-	mt.Name = "my-machine-template"
-	client := test.NewFakeKubeClient()
-
-	g.Expect(
-		clusterapi.EnsureNewNameIfChanged(ctx, client, errorRetriever, withChangesCompare, mt),
-	).To(
-		MatchError(ContainSubstring("reading DockerMachineTemplate eksa-system/my-machine-template from API")),
-	)
-}
-
-func TestEnsureNewNameIfChangedErrorIncrementingName(t *testing.T) {
-	g := NewWithT(t)
-	ctx := context.Background()
-	mt := dockerMachineTemplate()
-	mt.Name = "my-machine-template"
-	client := test.NewFakeKubeClient()
-
-	g.Expect(
-		clusterapi.EnsureNewNameIfChanged(ctx, client, dummyRetriever, withChangesCompare, mt),
-	).To(
-		MatchError(ContainSubstring("incrementing name for DockerMachineTemplate eksa-system/my-machine-template")),
-	)
-}
-
-func TestEnsureNewNameIfChangedObjectNeedsNewName(t *testing.T) {
-	g := NewWithT(t)
-	ctx := context.Background()
-	mt := dockerMachineTemplate()
-	mt.Name = "my-machine-template-1"
-	client := test.NewFakeKubeClient()
-
-	g.Expect(clusterapi.EnsureNewNameIfChanged(ctx, client, dummyRetriever, withChangesCompare, mt)).To(Succeed())
-	g.Expect(mt.Name).To(Equal("my-machine-template-2"))
-}
-
-func TestEnsureNewNameIfChangedObjectHasNotChanged(t *testing.T) {
-	g := NewWithT(t)
-	ctx := context.Background()
-	originalName := "my-machine-template-1"
-	mt := dockerMachineTemplate()
-	mt.Name = originalName
-	client := test.NewFakeKubeClient()
-
-	g.Expect(clusterapi.EnsureNewNameIfChanged(ctx, client, dummyRetriever, noChangesCompare, mt)).To(Succeed())
-	g.Expect(mt.Name).To(Equal(originalName))
 }
 
 func TestControlPlaneUpdateImmutableObjectNamesNoKubeadmControlPlane(t *testing.T) {
@@ -257,26 +190,6 @@ func TestControlPlaneUpdateImmutableObjectNamesSuccessUnstackedEtcd(t *testing.T
 	g.Expect(cp.UpdateImmutableObjectNames(ctx, client, dummyRetriever, noChangesCompare)).To(Succeed())
 }
 
-func dummyRetriever(_ context.Context, _ kubernetes.Client, _, _ string) (*dockerv1.DockerMachineTemplate, error) {
-	return dockerMachineTemplate(), nil
-}
-
-func errorRetriever(_ context.Context, _ kubernetes.Client, _, _ string) (*dockerv1.DockerMachineTemplate, error) {
-	return nil, errors.New("reading object")
-}
-
-func notFoundRetriever(_ context.Context, _ kubernetes.Client, _, _ string) (*dockerv1.DockerMachineTemplate, error) {
-	return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
-}
-
-func noChangesCompare(_, _ *dockerv1.DockerMachineTemplate) bool {
-	return true
-}
-
-func withChangesCompare(_, _ *dockerv1.DockerMachineTemplate) bool {
-	return false
-}
-
 func capiCluster() *clusterv1.Cluster {
 	return &clusterv1.Cluster{}
 }
@@ -296,6 +209,7 @@ func dockerMachineTemplate() *dockerv1.DockerMachineTemplate {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: constants.EksaSystemNamespace,
+			Name:      "mt-1",
 		},
 	}
 }

--- a/pkg/clusterapi/workers.go
+++ b/pkg/clusterapi/workers.go
@@ -1,0 +1,106 @@
+package clusterapi
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+)
+
+type Workers[M Object] struct {
+	Groups []WorkerGroup[M]
+}
+
+// UpdateImmutableObjectNames checks if any immutable objects have changed by comparing the new definition
+// with the current state of the cluster. If they had, it generates a new name for them by increasing a monotonic number
+// at the end of the name.
+func (w *Workers[M]) UpdateImmutableObjectNames(
+	ctx context.Context,
+	client kubernetes.Client,
+	machineTemplateRetriever ObjectRetriever[M],
+	machineTemplateComparator ObjectComparator[M],
+) error {
+	for _, g := range w.Groups {
+		if err := g.UpdateImmutableObjectNames(ctx, client, machineTemplateRetriever, machineTemplateComparator); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type WorkerGroup[M Object] struct {
+	KubeadmConfigTemplate   *kubeadmv1.KubeadmConfigTemplate
+	MachineDeployment       *clusterv1.MachineDeployment
+	ProviderMachineTemplate M
+}
+
+// UpdateImmutableObjectNames checks if any immutable objects have changed by comparing the new definition
+// with the current state of the cluster. If they had, it generates a new name for them by increasing a monotonic number
+// at the end of the name.
+// This process is performed to the provider machine template and the kubeadmconfigtemplate.
+// The kubeadmconfigtemplate is not immutable at the API level but we treat is a such for consistency
+func (g *WorkerGroup[M]) UpdateImmutableObjectNames(
+	ctx context.Context,
+	client kubernetes.Client,
+	machineTemplateRetriever ObjectRetriever[M],
+	machineTemplateComparator ObjectComparator[M],
+) error {
+	currentMachineDeployment := &clusterv1.MachineDeployment{}
+	err := client.Get(ctx, g.MachineDeployment.Name, g.MachineDeployment.Namespace, currentMachineDeployment)
+	if apierrors.IsNotFound(err) {
+		// MachineDeployment doesn't exist, this is a new cluster so machine templates should use their default name
+		return nil
+	}
+	if err != nil {
+		return errors.Wrap(err, "reading current machine deployment from API")
+	}
+
+	g.ProviderMachineTemplate.SetName(currentMachineDeployment.Spec.Template.Spec.InfrastructureRef.Name)
+	if err = EnsureNewNameIfChanged(ctx, client, machineTemplateRetriever, machineTemplateComparator, g.ProviderMachineTemplate); err != nil {
+		return err
+	}
+
+	g.KubeadmConfigTemplate.SetName(currentMachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef.Name)
+	if err = EnsureNewNameIfChanged(ctx, client, GetKubeadmConfigTemplate, KubeadmConfigTemplateEqual, g.KubeadmConfigTemplate); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetKubeadmConfigTemplate retrieves a KubeadmConfigTemplate using a client
+// Implements ObjectRetriever
+func GetKubeadmConfigTemplate(ctx context.Context, client kubernetes.Client, name, namespace string) (*kubeadmv1.KubeadmConfigTemplate, error) {
+	k := &kubeadmv1.KubeadmConfigTemplate{}
+	if err := client.Get(ctx, name, namespace, k); err != nil {
+		return nil, err
+	}
+
+	return k, nil
+}
+
+// KubeadmConfigTemplateEqual returns true only if the new version of a KubeadmConfigTemplate
+// involves changes with respect6 to the old one when applied to the cluster
+// Implements ObjectComparator
+func KubeadmConfigTemplateEqual(new, old *kubeadmv1.KubeadmConfigTemplate) bool {
+	// DeepDerivative treats empty map (length == 0) as unset field. We need to manually compare certain fields
+	// such as taints, so that setting it to empty will trigger machine recreate
+	return kubeadmConfigTemplateTaintsEqual(new, old) &&
+		equality.Semantic.DeepDerivative(new.Spec, old.Spec)
+}
+
+func kubeadmConfigTemplateTaintsEqual(new, old *kubeadmv1.KubeadmConfigTemplate) bool {
+	return new.Spec.Template.Spec.JoinConfiguration == nil ||
+		old.Spec.Template.Spec.JoinConfiguration == nil ||
+		anywherev1.TaintsSliceEqual(
+			new.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints,
+			old.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints,
+		)
+}

--- a/pkg/clusterapi/workers_test.go
+++ b/pkg/clusterapi/workers_test.go
@@ -1,0 +1,441 @@
+package clusterapi_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	"github.com/aws/eks-anywhere/pkg/constants"
+)
+
+type (
+	dockerGroup   = clusterapi.WorkerGroup[*dockerv1.DockerMachineTemplate]
+	dockerWorkers = clusterapi.Workers[*dockerv1.DockerMachineTemplate]
+)
+
+func TestWorkersUpdateImmutableObjectNamesError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	group1 := dockerGroup{
+		MachineDeployment: machineDeployment(),
+	}
+	group2 := dockerGroup{
+		MachineDeployment: machineDeployment(),
+	}
+
+	workers := &dockerWorkers{
+		Groups: []dockerGroup{group1, group2},
+	}
+	client := test.NewFakeKubeClientAlwaysError()
+
+	g.Expect(
+		workers.UpdateImmutableObjectNames(ctx, client, dummyRetriever, noChangesCompare),
+	).NotTo(Succeed())
+}
+
+func TestWorkersUpdateImmutableObjectNamesSuccess(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	group1 := dockerGroup{
+		MachineDeployment: machineDeployment(),
+	}
+	group2 := dockerGroup{
+		MachineDeployment: machineDeployment(),
+	}
+
+	workers := &dockerWorkers{
+		Groups: []dockerGroup{group1, group2},
+	}
+	client := test.NewFakeKubeClient()
+
+	g.Expect(
+		workers.UpdateImmutableObjectNames(ctx, client, dummyRetriever, noChangesCompare),
+	).To(Succeed())
+}
+
+func TestWorkerGroupUpdateImmutableObjectNamesNoMachineDeployment(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	group := &dockerGroup{
+		MachineDeployment: machineDeployment(),
+	}
+	client := test.NewFakeKubeClient()
+
+	g.Expect(group.UpdateImmutableObjectNames(ctx, client, dummyRetriever, noChangesCompare)).To(Succeed())
+}
+
+func TestWorkerGroupUpdateImmutableObjectNamesErrorReadingMachineDeployment(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	group := &dockerGroup{
+		MachineDeployment: machineDeployment(),
+	}
+	client := test.NewFakeKubeClientAlwaysError()
+
+	g.Expect(
+		group.UpdateImmutableObjectNames(ctx, client, dummyRetriever, noChangesCompare),
+	).To(MatchError(ContainSubstring("reading current machine deployment from API")))
+}
+
+func TestWorkerGroupUpdateImmutableObjectNamesErrorUpdatingMachineTemplateName(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	group := &dockerGroup{
+		MachineDeployment:       machineDeployment(),
+		ProviderMachineTemplate: dockerMachineTemplate(),
+		KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+	}
+	group.MachineDeployment.Spec.Template.Spec.InfrastructureRef = *objectReference(group.ProviderMachineTemplate)
+	group.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef = objectReference(group.KubeadmConfigTemplate)
+	client := test.NewFakeKubeClient(group.MachineDeployment)
+
+	g.Expect(
+		group.UpdateImmutableObjectNames(ctx, client, errorRetriever, noChangesCompare),
+	).To(MatchError(ContainSubstring("reading DockerMachineTemplate eksa-system/mt-1 from API")))
+}
+
+func TestWorkerGroupUpdateImmutableObjectNamesErrorUpdatingKubeadmConfigTemplate(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	group := &dockerGroup{
+		MachineDeployment:       machineDeployment(),
+		ProviderMachineTemplate: dockerMachineTemplate(),
+		KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+	}
+	group.MachineDeployment.Spec.Template.Spec.InfrastructureRef = *objectReference(group.ProviderMachineTemplate)
+	group.KubeadmConfigTemplate.Name = "invalid-name"
+	group.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef = objectReference(group.KubeadmConfigTemplate)
+	client := test.NewFakeKubeClient(group.MachineDeployment, group.KubeadmConfigTemplate, group.ProviderMachineTemplate)
+	group.KubeadmConfigTemplate.Spec.Template.Spec.PostKubeadmCommands = []string{"ls"}
+
+	g.Expect(
+		group.UpdateImmutableObjectNames(ctx, client, dummyRetriever, noChangesCompare),
+	).To(MatchError(ContainSubstring("incrementing name for KubeadmConfigTemplate eksa-system/invalid-name")))
+}
+
+func TestWorkerGroupUpdateImmutableObjectNamesSuccess(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	group := &dockerGroup{
+		MachineDeployment:       machineDeployment(),
+		ProviderMachineTemplate: dockerMachineTemplate(),
+		KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+	}
+	group.MachineDeployment.Spec.Template.Spec.InfrastructureRef = *objectReference(group.ProviderMachineTemplate)
+	group.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef = objectReference(group.KubeadmConfigTemplate)
+	client := test.NewFakeKubeClient(group.MachineDeployment, group.KubeadmConfigTemplate, group.ProviderMachineTemplate)
+	group.KubeadmConfigTemplate.Spec.Template.Spec.PostKubeadmCommands = []string{"ls"}
+
+	g.Expect(
+		group.UpdateImmutableObjectNames(ctx, client, dummyRetriever, withChangesCompare),
+	).To(Succeed())
+	g.Expect(group.KubeadmConfigTemplate.Name).To(Equal("template-2"))
+	g.Expect(group.ProviderMachineTemplate.Name).To(Equal("mt-2"))
+}
+
+func TestGetKubeadmConfigTemplateSuccess(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	k := kubeadmConfigTemplate()
+	client := test.NewFakeKubeClient(k)
+
+	g.Expect(clusterapi.GetKubeadmConfigTemplate(ctx, client, k.Name, k.Namespace)).To(Equal(k))
+}
+
+func TestGetKubeadmConfigTemplateError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	k := kubeadmConfigTemplate()
+	client := test.NewFakeKubeClientAlwaysError()
+
+	_, err := clusterapi.GetKubeadmConfigTemplate(ctx, client, k.Name, k.Namespace)
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestKubeadmConfigTemplateEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		new, old *kubeadmv1.KubeadmConfigTemplate
+		want     bool
+	}{
+		{
+			name: "equal",
+			new: &kubeadmv1.KubeadmConfigTemplate{
+				Spec: kubeadmv1.KubeadmConfigTemplateSpec{
+					Template: kubeadmv1.KubeadmConfigTemplateResource{
+						Spec: kubeadmv1.KubeadmConfigSpec{
+							JoinConfiguration: &kubeadmv1.JoinConfiguration{
+								NodeRegistration: kubeadmv1.NodeRegistrationOptions{
+									Taints: []corev1.Taint{
+										{
+											Key: "key",
+										},
+									},
+								},
+							},
+							Files: []kubeadmv1.File{
+								{
+									Owner: "me",
+								},
+							},
+						},
+					},
+				},
+			},
+			old: &kubeadmv1.KubeadmConfigTemplate{
+				Spec: kubeadmv1.KubeadmConfigTemplateSpec{
+					Template: kubeadmv1.KubeadmConfigTemplateResource{
+						Spec: kubeadmv1.KubeadmConfigSpec{
+							JoinConfiguration: &kubeadmv1.JoinConfiguration{
+								NodeRegistration: kubeadmv1.NodeRegistrationOptions{
+									Taints: []corev1.Taint{
+										{
+											Key: "key",
+										},
+									},
+								},
+							},
+							Files: []kubeadmv1.File{
+								{
+									Owner: "me",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "diff taints",
+			new: &kubeadmv1.KubeadmConfigTemplate{
+				Spec: kubeadmv1.KubeadmConfigTemplateSpec{
+					Template: kubeadmv1.KubeadmConfigTemplateResource{
+						Spec: kubeadmv1.KubeadmConfigSpec{
+							JoinConfiguration: &kubeadmv1.JoinConfiguration{
+								NodeRegistration: kubeadmv1.NodeRegistrationOptions{
+									Taints: []corev1.Taint{},
+								},
+							},
+							Files: []kubeadmv1.File{
+								{
+									Owner: "me",
+								},
+							},
+						},
+					},
+				},
+			},
+			old: &kubeadmv1.KubeadmConfigTemplate{
+				Spec: kubeadmv1.KubeadmConfigTemplateSpec{
+					Template: kubeadmv1.KubeadmConfigTemplateResource{
+						Spec: kubeadmv1.KubeadmConfigSpec{
+							JoinConfiguration: &kubeadmv1.JoinConfiguration{
+								NodeRegistration: kubeadmv1.NodeRegistrationOptions{
+									Taints: []corev1.Taint{
+										{
+											Key: "key",
+										},
+									},
+								},
+							},
+							Files: []kubeadmv1.File{
+								{
+									Owner: "me",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "new JoinConfiguration nil",
+			new: &kubeadmv1.KubeadmConfigTemplate{
+				Spec: kubeadmv1.KubeadmConfigTemplateSpec{
+					Template: kubeadmv1.KubeadmConfigTemplateResource{
+						Spec: kubeadmv1.KubeadmConfigSpec{
+							Files: []kubeadmv1.File{
+								{
+									Owner: "me",
+								},
+							},
+						},
+					},
+				},
+			},
+			old: &kubeadmv1.KubeadmConfigTemplate{
+				Spec: kubeadmv1.KubeadmConfigTemplateSpec{
+					Template: kubeadmv1.KubeadmConfigTemplateResource{
+						Spec: kubeadmv1.KubeadmConfigSpec{
+							JoinConfiguration: &kubeadmv1.JoinConfiguration{
+								NodeRegistration: kubeadmv1.NodeRegistrationOptions{
+									Taints: []corev1.Taint{
+										{
+											Key: "key",
+										},
+									},
+								},
+							},
+							Files: []kubeadmv1.File{
+								{
+									Owner: "me",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "old JoinConfiguration nil",
+			new: &kubeadmv1.KubeadmConfigTemplate{
+				Spec: kubeadmv1.KubeadmConfigTemplateSpec{
+					Template: kubeadmv1.KubeadmConfigTemplateResource{
+						Spec: kubeadmv1.KubeadmConfigSpec{
+							JoinConfiguration: &kubeadmv1.JoinConfiguration{
+								NodeRegistration: kubeadmv1.NodeRegistrationOptions{
+									Taints: []corev1.Taint{
+										{
+											Key: "key",
+										},
+									},
+								},
+							},
+							Files: []kubeadmv1.File{
+								{
+									Owner: "me",
+								},
+							},
+						},
+					},
+				},
+			},
+			old: &kubeadmv1.KubeadmConfigTemplate{
+				Spec: kubeadmv1.KubeadmConfigTemplateSpec{
+					Template: kubeadmv1.KubeadmConfigTemplateResource{
+						Spec: kubeadmv1.KubeadmConfigSpec{
+							Files: []kubeadmv1.File{
+								{
+									Owner: "me",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "diff spec",
+			new: &kubeadmv1.KubeadmConfigTemplate{
+				Spec: kubeadmv1.KubeadmConfigTemplateSpec{
+					Template: kubeadmv1.KubeadmConfigTemplateResource{
+						Spec: kubeadmv1.KubeadmConfigSpec{
+							JoinConfiguration: &kubeadmv1.JoinConfiguration{
+								NodeRegistration: kubeadmv1.NodeRegistrationOptions{
+									Taints: []corev1.Taint{
+										{
+											Key: "key",
+										},
+									},
+								},
+							},
+							Files: []kubeadmv1.File{
+								{
+									Owner: "me",
+								},
+							},
+						},
+					},
+				},
+			},
+			old: &kubeadmv1.KubeadmConfigTemplate{
+				Spec: kubeadmv1.KubeadmConfigTemplateSpec{
+					Template: kubeadmv1.KubeadmConfigTemplateResource{
+						Spec: kubeadmv1.KubeadmConfigSpec{
+							JoinConfiguration: &kubeadmv1.JoinConfiguration{
+								NodeRegistration: kubeadmv1.NodeRegistrationOptions{
+									Taints: []corev1.Taint{
+										{
+											Key: "key",
+										},
+									},
+								},
+							},
+							Files: []kubeadmv1.File{
+								{
+									Owner: "you",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(clusterapi.KubeadmConfigTemplateEqual(tt.new, tt.old)).To(Equal(tt.want))
+		})
+	}
+}
+
+func kubeadmConfigTemplate() *kubeadmv1.KubeadmConfigTemplate {
+	return &kubeadmv1.KubeadmConfigTemplate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeadmConfigTemplate",
+			APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-1",
+			Namespace: constants.EksaSystemNamespace,
+		},
+		Spec: kubeadmv1.KubeadmConfigTemplateSpec{
+			Template: kubeadmv1.KubeadmConfigTemplateResource{
+				Spec: kubeadmv1.KubeadmConfigSpec{
+					Files: []kubeadmv1.File{
+						{
+							Owner: "me",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func machineDeployment() *clusterv1.MachineDeployment {
+	return &clusterv1.MachineDeployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MachineDeployment",
+			APIVersion: "cluster.x-k8s.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deployment",
+			Namespace: constants.EksaSystemNamespace,
+		},
+	}
+}
+
+func objectReference(obj client.Object) *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		Kind:       obj.GetObjectKind().GroupVersionKind().Kind,
+		APIVersion: obj.GetObjectKind().GroupVersionKind().Version,
+		Name:       obj.GetName(),
+		Namespace:  obj.GetNamespace(),
+	}
+}


### PR DESCRIPTION
*Description of changes:*
This allows to represent a provider specific CAPI workers for both. It implements logic to generate new names for immutable objects when these change. It does this by comparing the new spec to the current state of the objects in the cluster.

This is part of a bigger effort, allowing a transition from yaml go templates to go structs. For context: https://github.com/aws/eks-anywhere/pull/3432

*Testing (if applicable):*
Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

