### PR TITLE
Implement storage class installation hook

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -167,6 +167,13 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 			CreateBootstrapClusterOptions: deps.Provider,
 		}
 		wflw.WithHookRegistrar(awsiamauth.NewHookRegistrar(deps.AwsIamAuth, clusterSpec))
+
+		// Not all provider implementations want to bind hooks so we explicitly check if they
+		// want to bind hooks before registering it.
+		if registrar, ok := deps.Provider.(management.CreateClusterHookRegistrar); ok {
+			wflw.WithHookRegistrar(registrar)
+		}
+
 		err = wflw.Run(ctx)
 	} else {
 		err = createCluster.Run(ctx, clusterSpec, createValidations, cc.forceClean)

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -1239,10 +1239,6 @@ func (p *cloudstackProvider) PostMoveManagementToBootstrap(_ context.Context, _ 
 	return nil
 }
 
-func (p *cloudstackProvider) GenerateStorageClass() []byte {
-	return nil
-}
-
 func (p *cloudstackProvider) setupSSHAuthKeysForUpgrade() error {
 	var err error
 	controlPlaneUser := p.machineConfigs[p.clusterConfig.Spec.ControlPlaneConfiguration.MachineGroupRef.Name].Spec.Users[0]

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -471,10 +471,6 @@ func (p *provider) GenerateCAPISpecForUpgrade(ctx context.Context, bootstrapClus
 	return controlPlaneSpec, workersSpec, nil
 }
 
-func (p *provider) GenerateStorageClass() []byte {
-	return nil
-}
-
 func (p *provider) UpdateKubeConfig(content *[]byte, clusterName string) error {
 	// The Docker provider is for testing only. We don't want to change the interface just for the test
 	ctx := context.Background()

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -157,20 +157,6 @@ func (mr *MockProviderMockRecorder) GenerateCAPISpecForUpgrade(arg0, arg1, arg2,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateCAPISpecForUpgrade", reflect.TypeOf((*MockProvider)(nil).GenerateCAPISpecForUpgrade), arg0, arg1, arg2, arg3, arg4)
 }
 
-// GenerateStorageClass mocks base method.
-func (m *MockProvider) GenerateStorageClass() []byte {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateStorageClass")
-	ret0, _ := ret[0].([]byte)
-	return ret0
-}
-
-// GenerateStorageClass indicates an expected call of GenerateStorageClass.
-func (mr *MockProviderMockRecorder) GenerateStorageClass() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateStorageClass", reflect.TypeOf((*MockProvider)(nil).GenerateStorageClass))
-}
-
 // GetDeployments mocks base method.
 func (m *MockProvider) GetDeployments() map[string][]string {
 	m.ctrl.T.Helper()

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -17,7 +17,6 @@ type Provider interface {
 	UpdateSecrets(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
 	GenerateCAPISpecForCreate(ctx context.Context, managementCluster *types.Cluster, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error)
 	GenerateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currrentSpec, newClusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error)
-	GenerateStorageClass() []byte
 	// PreCAPIInstallOnBootstrap is called after the bootstrap cluster is setup but before CAPI resources are installed on it. This allows us to do provider specific configuration on the bootstrap cluster.
 	PreCAPIInstallOnBootstrap(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
 	PostBootstrapSetup(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -145,10 +145,6 @@ func (p *SnowProvider) GenerateCAPISpecForUpgrade(ctx context.Context, bootstrap
 	return p.generateCAPISpec(ctx, bootstrapCluster, clusterSpec)
 }
 
-func (p *SnowProvider) GenerateStorageClass() []byte {
-	return nil
-}
-
 func (p *SnowProvider) PreCAPIInstallOnBootstrap(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	return nil
 }

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -343,11 +343,6 @@ func (p *Provider) generateCAPISpecForCreate(ctx context.Context, clusterSpec *c
 	return controlPlaneSpec, workersSpec, nil
 }
 
-func (p *Provider) GenerateStorageClass() []byte {
-	// TODO: determine if we need something else here
-	return nil
-}
-
 func (p *Provider) needsNewMachineTemplate(ctx context.Context, workloadCluster *types.Cluster, currentSpec, newClusterSpec *cluster.Spec, workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration, vdc *v1alpha1.TinkerbellDatacenterConfig, prevWorkerNodeGroupConfigs map[string]v1alpha1.WorkerNodeGroupConfiguration) (bool, error) {
 	if _, ok := prevWorkerNodeGroupConfigs[workerNodeGroupConfiguration.Name]; ok {
 		workerMachineConfig := p.machineConfigs[workerNodeGroupConfiguration.MachineGroupRef.Name]

--- a/pkg/providers/vsphere/hook.go
+++ b/pkg/providers/vsphere/hook.go
@@ -1,0 +1,28 @@
+package vsphere
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/eks-anywhere/pkg/workflow"
+	"github.com/aws/eks-anywhere/pkg/workflow/management"
+	"github.com/aws/eks-anywhere/pkg/workflow/workflowcontext"
+)
+
+func (p *vsphereProvider) RegisterCreateManagementClusterHooks(binder workflow.HookBinder) {
+	if !p.csiEnabled {
+		return
+	}
+
+	binder.BindPostTaskHook(
+		management.CreateWorkloadCluster,
+		workflow.TaskFunc(func(ctx context.Context) (context.Context, error) {
+			cluster := workflowcontext.WorkloadCluster(ctx)
+			if cluster == nil {
+				return ctx, errors.New("workload cluster not found in context")
+			}
+
+			return ctx, p.InstallStorageClass(ctx, cluster)
+		}),
+	)
+}

--- a/pkg/providers/vsphere/testdata/TestProviderInstallStorageClass_expect.yaml
+++ b/pkg/providers/vsphere/testdata/TestProviderInstallStorageClass_expect.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: standard
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: csi.vsphere.vmware.com
+parameters:
+    storagePolicyName: "vSAN Default Storage Policy"

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -694,11 +694,12 @@ func (p *vsphereProvider) GenerateCAPISpecForCreate(ctx context.Context, _ *type
 	return controlPlaneSpec, workersSpec, nil
 }
 
-func (p *vsphereProvider) GenerateStorageClass() []byte {
+func (p *vsphereProvider) InstallStorageClass(ctx context.Context, cluster *types.Cluster) error {
 	if !p.csiEnabled {
 		return nil
 	}
-	return defaultStorageClass
+
+	return p.providerKubectlClient.ApplyKubeSpecFromBytes(ctx, cluster, defaultStorageClass)
 }
 
 func (p *vsphereProvider) createSecret(ctx context.Context, cluster *types.Cluster, contents *bytes.Buffer) error {


### PR DESCRIPTION
### Description

Dependencies: https://github.com/aws/eks-anywhere/pull/3476

This change removes the `GenerateStorageClass()` from the provider interface and shifts the responsibility of storage class installation to providers. The only provider performing storage class installation is vSphere. A new workflow hook has been written using the same install method that the cluster manager now tests for and calls ensuring existing code paths are unaffected.

#### Rationale for anonymous interfaces

The implementation in the cluster manager uses an anonymous interface type assertion to determine if the provider has the necessary behavior for storage class installation. It was written this way acknowledging that the cluster managers storage class installation orchestration will be deleted when we switch to new workflows as the storage class will be opt-in from the vSphere provider only via a workflow hook.

To ensure the vSphere provider still honors existing behavior a unit test verifying the storage class installation behavior is still available with commentary on the cluster managers current usage.
