### PR TITLE
Make WorkerNodeConfiguration.Count A Pointer

### DIFF
--- a/cmd/eks-a-tool/cmd/vsphereautofill.go
+++ b/cmd/eks-a-tool/cmd/vsphereautofill.go
@@ -95,7 +95,7 @@ func autofill(ctx context.Context) error {
 	updateField("THUMBPRINT", &datacenterConfig.Spec.Thumbprint)
 
 	updateFieldInt("CONTROL_PLANE_COUNT", &clusterConfig.Spec.ControlPlaneConfiguration.Count)
-	updateFieldInt("WORKER_NODE_COUNT", &clusterConfig.Spec.WorkerNodeGroupConfigurations[0].Count)
+	updateFieldInt("WORKER_NODE_COUNT", clusterConfig.Spec.WorkerNodeGroupConfigurations[0].Count)
 
 	updateField("SSH_AUTHORIZED_KEY", &controlPlaneMachineConfig.Spec.Users[0].SshAuthorizedKeys[0])
 	updateField("SSH_USERNAME", &controlPlaneMachineConfig.Spec.Users[0].Name)

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers/vsphere"
 	"github.com/aws/eks-anywhere/pkg/providers/vsphere/mocks"
 	vspherereconciler "github.com/aws/eks-anywhere/pkg/providers/vsphere/reconciler"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
@@ -511,7 +512,7 @@ func createCluster() *anywherev1.Cluster {
 			},
 			WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
 				{
-					Count: 1,
+					Count: ptr.Int(1),
 					MachineGroupRef: &anywherev1.Ref{
 						Kind: "VSphereMachineConfig",
 						Name: name + "-wn",

--- a/controllers/resource/reconciler_test.go
+++ b/controllers/resource/reconciler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/features"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 //go:embed testdata/vsphereKubeadmcontrolplane.yaml
@@ -313,7 +314,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 
 				existingWorkerNodeGroupConfiguration := &anywherev1.WorkerNodeGroupConfiguration{
 					Name:            "md-0",
-					Count:           3,
+					Count:           ptr.Int(3),
 					MachineGroupRef: nil,
 				}
 				fetcher.EXPECT().ExistingWorkerNodeGroupConfig(ctx, gomock.Any(), gomock.Any()).Return(existingWorkerNodeGroupConfiguration, nil)
@@ -441,7 +442,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 
 				existingWorkerNodeGroupConfiguration := &anywherev1.WorkerNodeGroupConfiguration{
 					Name:            "md-0",
-					Count:           3,
+					Count:           ptr.Int(3),
 					MachineGroupRef: nil,
 					Taints: []corev1.Taint{
 						{
@@ -561,7 +562,7 @@ func TestClusterReconcilerReconcileVSphere(t *testing.T) {
 
 				existingWorkerNodeGroupConfiguration := &anywherev1.WorkerNodeGroupConfiguration{
 					Name:            "md-0",
-					Count:           3,
+					Count:           ptr.Int(3),
 					MachineGroupRef: nil,
 					Labels: map[string]string{
 						"Key1": "Val1",
@@ -780,7 +781,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 
 				existingWorkerNodeGroupConfiguration := &anywherev1.WorkerNodeGroupConfiguration{
 					Name:            "md-0",
-					Count:           3,
+					Count:           ptr.Int(3),
 					MachineGroupRef: nil,
 				}
 				fetcher.EXPECT().ExistingWorkerNodeGroupConfig(ctx, gomock.Any(), gomock.Any()).Return(existingWorkerNodeGroupConfiguration, nil)
@@ -882,7 +883,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 
 				existingWorkerNodeGroupConfiguration := &anywherev1.WorkerNodeGroupConfiguration{
 					Name:            "md-0",
-					Count:           3,
+					Count:           ptr.Int(3),
 					MachineGroupRef: nil,
 					Taints: []corev1.Taint{
 						{
@@ -986,7 +987,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 
 				existingWorkerNodeGroupConfiguration := &anywherev1.WorkerNodeGroupConfiguration{
 					Name:            "md-0",
-					Count:           3,
+					Count:           ptr.Int(3),
 					MachineGroupRef: nil,
 					Labels: map[string]string{
 						"Key1": "Val1",
@@ -1077,7 +1078,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 
 				existingWorkerNodeGroupConfiguration := &anywherev1.WorkerNodeGroupConfiguration{
 					Name:            "md-0",
-					Count:           3,
+					Count:           ptr.Int(3),
 					MachineGroupRef: nil,
 				}
 

--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -10,6 +10,7 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 type ClusterFiller func(c *anywherev1.Cluster)
@@ -104,9 +105,9 @@ func WithServiceCidr(svcCidr string) ClusterFiller {
 func WithWorkerNodeCount(r int) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		if len(c.Spec.WorkerNodeGroupConfigurations) == 0 {
-			c.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{{Count: 0}}
+			c.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{{Count: ptr.Int(0)}}
 		}
-		c.Spec.WorkerNodeGroupConfigurations[0].Count = r
+		c.Spec.WorkerNodeGroupConfigurations[0].Count = &r
 	}
 }
 

--- a/internal/pkg/api/cluster_test.go
+++ b/internal/pkg/api/cluster_test.go
@@ -1,0 +1,103 @@
+package api_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
+)
+
+func TestWithWorkerNodeCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *anywherev1.Cluster
+		want    []anywherev1.WorkerNodeGroupConfiguration
+	}{
+		{
+			name: "with worker node config empty",
+			cluster: &anywherev1.Cluster{
+				Spec: anywherev1.ClusterSpec{},
+			},
+			want: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Name:                     "",
+					Count:                    ptr.Int(5),
+					AutoScalingConfiguration: nil,
+					MachineGroupRef:          nil,
+					Taints:                   nil,
+					Labels:                   nil,
+				},
+			},
+		},
+		{
+			name: "with worker node config greater than one",
+			cluster: &anywherev1.Cluster{
+				Spec: anywherev1.ClusterSpec{
+					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+						{
+							Name:                     "md-0",
+							Count:                    ptr.Int(1),
+							AutoScalingConfiguration: nil,
+							MachineGroupRef:          nil,
+							Taints:                   nil,
+							Labels:                   nil,
+						},
+						{
+							Name:                     "md-1",
+							Count:                    ptr.Int(1),
+							AutoScalingConfiguration: nil,
+							MachineGroupRef:          nil,
+							Taints:                   nil,
+							Labels:                   nil,
+						},
+					},
+				},
+			},
+			want: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Name:                     "md-0",
+					Count:                    ptr.Int(5),
+					AutoScalingConfiguration: nil,
+					MachineGroupRef:          nil,
+					Taints:                   nil,
+					Labels:                   nil,
+				},
+				{
+					Name:                     "md-1",
+					Count:                    ptr.Int(1),
+					AutoScalingConfiguration: nil,
+					MachineGroupRef:          nil,
+					Taints:                   nil,
+					Labels:                   nil,
+				},
+			},
+		},
+		{
+			name: "with empty worker node config",
+			cluster: &anywherev1.Cluster{
+				Spec: anywherev1.ClusterSpec{},
+			},
+			want: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Name:                     "",
+					Count:                    ptr.Int(5),
+					AutoScalingConfiguration: nil,
+					MachineGroupRef:          nil,
+					Taints:                   nil,
+					Labels:                   nil,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api.WithWorkerNodeCount(5)(tt.cluster)
+			g := NewWithT(t)
+			g.Expect(tt.cluster.Spec.WorkerNodeGroupConfigurations).To(Equal(tt.want))
+		})
+	}
+}

--- a/internal/pkg/api/nodegroups.go
+++ b/internal/pkg/api/nodegroups.go
@@ -37,7 +37,7 @@ func WithLabel(key, value string) WorkerNodeGroupFiller {
 
 func WithCount(count int) WorkerNodeGroupFiller {
 	return func(w *anywherev1.WorkerNodeGroupConfiguration) {
-		w.Count = count
+		w.Count = &count
 	}
 }
 

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -78,7 +78,7 @@ func ExternalETCDConfigCount(count int) ClusterGenerateOpt {
 
 func WorkerNodeConfigCount(count int) ClusterGenerateOpt {
 	return func(c *ClusterGenerate) {
-		c.Spec.WorkerNodeGroupConfigurations = []WorkerNodeGroupConfiguration{{Count: count}}
+		c.Spec.WorkerNodeGroupConfigurations = []WorkerNodeGroupConfiguration{{Count: &count}}
 	}
 }
 
@@ -420,7 +420,7 @@ func validateWorkerNodeGroups(clusterConfig *Cluster) error {
 			return errors.New("must specify name for worker nodes")
 		}
 
-		if workerNodeGroupConfig.AutoScalingConfiguration == nil && workerNodeGroupConfig.Count <= 0 {
+		if workerNodeGroupConfig.AutoScalingConfiguration == nil && *workerNodeGroupConfig.Count <= 0 {
 			return errors.New("worker node count must be positive if autoscaling is not enabled")
 		}
 

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -420,6 +420,12 @@ func validateWorkerNodeGroups(clusterConfig *Cluster) error {
 			return errors.New("must specify name for worker nodes")
 		}
 
+		if workerNodeGroupConfig.Count == nil {
+			// This block should never fire. If it does, it means we have a bug in how we set our defaults.
+			// When Count == nil it should be set to 1 by SetDefaults method prior to reaching validation.
+			return errors.New("worker node count must be >= 0")
+		}
+
 		if workerNodeGroupConfig.AutoScalingConfiguration == nil && *workerNodeGroupConfig.Count <= 0 {
 			return errors.New("worker node count must be positive if autoscaling is not enabled")
 		}

--- a/pkg/api/v1alpha1/cluster_defaults.go
+++ b/pkg/api/v1alpha1/cluster_defaults.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 var clusterDefaults = []func(*Cluster) error{
@@ -50,6 +51,14 @@ func setWorkerNodeGroupDefaults(cluster *Cluster) error {
 		logger.V(1).Info("First worker node group name not specified. Defaulting name to md-0.")
 		cluster.Spec.WorkerNodeGroupConfigurations[0].Name = "md-0"
 	}
+
+	for i := range cluster.Spec.WorkerNodeGroupConfigurations {
+		w := &cluster.Spec.WorkerNodeGroupConfigurations[i]
+		if w.Count == nil {
+			w.Count = ptr.Int(1)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/api/v1alpha1/cluster_defaults_test.go
+++ b/pkg/api/v1alpha1/cluster_defaults_test.go
@@ -156,6 +156,46 @@ func TestSetClusterDefaults(t *testing.T) {
 			},
 			wantErr: "",
 		},
+		{
+			name: "worker node group - no count specified",
+			in: &Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       ClusterKind,
+					APIVersion: SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: ClusterSpec{
+					KubernetesVersion: Kube119,
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						Name: "worker-0",
+					}},
+				},
+			},
+			wantCluster: &Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       ClusterKind,
+					APIVersion: SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: ClusterSpec{
+					KubernetesVersion: Kube119,
+					ClusterNetwork: ClusterNetwork{
+						CNIConfig: &CNIConfig{
+							Cilium: nil,
+						},
+					},
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						Name:  "worker-0",
+						Count: ptr.Int(1),
+					}},
+				},
+			},
+			wantErr: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/api/v1alpha1/cluster_defaults_test.go
+++ b/pkg/api/v1alpha1/cluster_defaults_test.go
@@ -5,6 +5,8 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 func TestSetClusterDefaults(t *testing.T) {
@@ -36,7 +38,7 @@ func TestSetClusterDefaults(t *testing.T) {
 						},
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -81,7 +83,7 @@ func TestSetClusterDefaults(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -2501,3 +2501,35 @@ func TestGetClusterDefaultKubernetesVersion(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(GetClusterDefaultKubernetesVersion()).To(Equal(Kube123))
 }
+
+func TestClusterWorkerNodeConfigCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *Cluster
+		want    []WorkerNodeGroupConfiguration
+	}{
+		{
+			name: "with worker node config count",
+			cluster: &Cluster{
+				Spec: ClusterSpec{},
+			},
+			want: []WorkerNodeGroupConfiguration{
+				{
+					Name:                     "",
+					Count:                    ptr.Int(5),
+					AutoScalingConfiguration: nil,
+					MachineGroupRef:          nil,
+					Taints:                   nil,
+					Labels:                   nil,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cg := NewClusterGenerate("test-cluster", WorkerNodeConfigCount(5))
+			g := NewWithT(t)
+			g.Expect(cg.Spec.WorkerNodeGroupConfigurations).To(Equal(tt.want))
+		})
+	}
+}

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -10,6 +10,8 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 func TestValidateClusterName(t *testing.T) {
@@ -135,7 +137,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -183,7 +185,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -231,7 +233,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -279,7 +281,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -337,7 +339,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -385,7 +387,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test-2",
@@ -433,7 +435,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -485,7 +487,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -537,7 +539,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -590,7 +592,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -644,7 +646,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{
 						{
 							Name:  "md-0",
-							Count: 3,
+							Count: ptr.Int(3),
 							MachineGroupRef: &Ref{
 								Kind: VSphereMachineConfigKind,
 								Name: "eksa-unit-test-2",
@@ -659,7 +661,7 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 						},
 						{
 							Name:  "md-1",
-							Count: 3,
+							Count: ptr.Int(3),
 							MachineGroupRef: &Ref{
 								Kind: VSphereMachineConfigKind,
 								Name: "eksa-unit-test-2",
@@ -924,7 +926,7 @@ func TestGetClusterConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -972,7 +974,7 @@ func TestGetClusterConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -1020,7 +1022,7 @@ func TestGetClusterConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -1068,7 +1070,7 @@ func TestGetClusterConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -1145,7 +1147,7 @@ func TestParseClusterConfig(t *testing.T) {
 						},
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",
@@ -1240,7 +1242,7 @@ func TestParseClusterConfig(t *testing.T) {
 						},
 					},
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &Ref{
 							Kind: VSphereMachineConfigKind,
 							Name: "eksa-unit-test",

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -231,7 +231,7 @@ type WorkerNodeGroupConfiguration struct {
 	// Name refers to the name of the worker node group
 	Name string `json:"name,omitempty"`
 	// Count defines the number of desired worker nodes. Defaults to 1.
-	Count int `json:"count,omitempty"`
+	Count *int `json:"count,omitempty"`
 	// AutoScalingConfiguration defines the auto scaling configuration
 	AutoScalingConfiguration *AutoScalingConfiguration `json:"autoscalingConfiguration,omitempty"`
 	// MachineGroupRef defines the machine group configuration for the worker nodes.

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -250,7 +250,10 @@ func generateWorkerNodeGroupKey(c WorkerNodeGroupConfiguration) (key string) {
 	if c.AutoScalingConfiguration != nil {
 		key += "autoscaling" + strconv.Itoa(c.AutoScalingConfiguration.MaxCount) + strconv.Itoa(c.AutoScalingConfiguration.MinCount)
 	}
-	return strconv.Itoa(c.Count) + key
+	if c.Count == nil {
+		return "nil" + key
+	}
+	return strconv.Itoa(*c.Count) + key
 }
 
 func WorkerNodeGroupConfigurationsSliceEqual(a, b []WorkerNodeGroupConfiguration) bool {

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 func TestClusterMachineConfigRefs(t *testing.T) {
@@ -26,21 +27,21 @@ func TestClusterMachineConfigRefs(t *testing.T) {
 			},
 			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{
 				{
-					Count: 3,
+					Count: ptr.Int(3),
 					MachineGroupRef: &v1alpha1.Ref{
 						Kind: v1alpha1.VSphereMachineConfigKind,
 						Name: "eksa-unit-test-1",
 					},
 				},
 				{
-					Count: 3,
+					Count: ptr.Int(3),
 					MachineGroupRef: &v1alpha1.Ref{
 						Kind: v1alpha1.VSphereMachineConfigKind,
 						Name: "eksa-unit-test-2",
 					},
 				},
 				{
-					Count: 5,
+					Count: ptr.Int(5),
 					MachineGroupRef: &v1alpha1.Ref{
 						Kind: v1alpha1.VSphereMachineConfigKind,
 						Name: "eksa-unit-test", // This tests duplicates
@@ -319,7 +320,7 @@ func TestClusterEqualWorkerNodeGroupConfigurations(t *testing.T) {
 			testName: "one empty, one exists",
 			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
 				{
-					Count: 1,
+					Count: ptr.Int(1),
 				},
 			},
 			want: false,
@@ -328,7 +329,7 @@ func TestClusterEqualWorkerNodeGroupConfigurations(t *testing.T) {
 			testName: "both exist, same",
 			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
 				{
-					Count: 1,
+					Count: ptr.Int(1),
 					MachineGroupRef: &v1alpha1.Ref{
 						Kind: "k",
 						Name: "n",
@@ -337,7 +338,7 @@ func TestClusterEqualWorkerNodeGroupConfigurations(t *testing.T) {
 			},
 			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
 				{
-					Count: 1,
+					Count: ptr.Int(1),
 					MachineGroupRef: &v1alpha1.Ref{
 						Kind: "k",
 						Name: "n",
@@ -350,14 +351,14 @@ func TestClusterEqualWorkerNodeGroupConfigurations(t *testing.T) {
 			testName: "both exist, order diff",
 			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
 				{
-					Count: 1,
+					Count: ptr.Int(1),
 					MachineGroupRef: &v1alpha1.Ref{
 						Kind: "k1",
 						Name: "n1",
 					},
 				},
 				{
-					Count: 2,
+					Count: ptr.Int(2),
 					MachineGroupRef: &v1alpha1.Ref{
 						Kind: "k2",
 						Name: "n2",
@@ -366,14 +367,14 @@ func TestClusterEqualWorkerNodeGroupConfigurations(t *testing.T) {
 			},
 			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
 				{
-					Count: 2,
+					Count: ptr.Int(2),
 					MachineGroupRef: &v1alpha1.Ref{
 						Kind: "k2",
 						Name: "n2",
 					},
 				},
 				{
-					Count: 1,
+					Count: ptr.Int(1),
 					MachineGroupRef: &v1alpha1.Ref{
 						Kind: "k1",
 						Name: "n1",
@@ -386,12 +387,12 @@ func TestClusterEqualWorkerNodeGroupConfigurations(t *testing.T) {
 			testName: "both exist, count diff",
 			cluster1Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
 				{
-					Count: 1,
+					Count: ptr.Int(1),
 				},
 			},
 			cluster2Wngs: []v1alpha1.WorkerNodeGroupConfiguration{
 				{
-					Count: 2,
+					Count: ptr.Int(2),
 				},
 			},
 			want: false,

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -1444,7 +1444,7 @@ func TestClusterValidateUpdateInvalidManagementCluster(t *testing.T) {
 
 			g := NewWithT(t)
 			err := tt.clusterNew.ValidateUpdate(clusterOld)
-			g.Expect(err).To(MatchError(ContainSubstring("worker node count must be positive")))
+			g.Expect(err).To(MatchError(ContainSubstring("worker node count must be >= 0")))
 		})
 	}
 }

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/features"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 func TestClusterDefault(t *testing.T) {
@@ -966,7 +967,7 @@ func TestClusterValidateUpdateOIDCNameMutableAddConfigMgmtCluster(t *testing.T) 
 		Spec: v1alpha1.ClusterSpec{
 			IdentityProviderRefs: []v1alpha1.Ref{},
 			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
-				Count: 1,
+				Count: ptr.Int(1),
 				Name:  "test",
 			}},
 		},
@@ -981,7 +982,7 @@ func TestClusterValidateUpdateOIDCNameMutableAddConfigMgmtCluster(t *testing.T) 
 				},
 			},
 			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
-				Count: 1,
+				Count: ptr.Int(1),
 				Name:  "test",
 			}},
 		},
@@ -1096,11 +1097,11 @@ func TestClusterValidateUpdateInvalidType(t *testing.T) {
 }
 
 func TestClusterValidateUpdateSuccess(t *testing.T) {
-	workerConfiguration := append([]v1alpha1.WorkerNodeGroupConfiguration{}, v1alpha1.WorkerNodeGroupConfiguration{Count: 5, Name: "test", MachineGroupRef: &v1alpha1.Ref{Name: "ref-name"}})
+	workerConfiguration := append([]v1alpha1.WorkerNodeGroupConfiguration{}, v1alpha1.WorkerNodeGroupConfiguration{Count: ptr.Int(5), Name: "test", MachineGroupRef: &v1alpha1.Ref{Name: "ref-name"}})
 	cOld := createCluster()
 	cOld.Spec.WorkerNodeGroupConfigurations = workerConfiguration
 	c := cOld.DeepCopy()
-	c.Spec.WorkerNodeGroupConfigurations[0].Count = 10
+	c.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(10)
 
 	g := NewWithT(t)
 	g.Expect(c.ValidateUpdate(cOld)).To(Succeed())
@@ -1109,7 +1110,7 @@ func TestClusterValidateUpdateSuccess(t *testing.T) {
 func TestClusterCreateManagementCluster(t *testing.T) {
 	features.ClearCache()
 	t.Setenv(features.FullLifecycleAPIEnvVar, "true")
-	workerConfiguration := append([]v1alpha1.WorkerNodeGroupConfiguration{}, v1alpha1.WorkerNodeGroupConfiguration{Count: 5})
+	workerConfiguration := append([]v1alpha1.WorkerNodeGroupConfiguration{}, v1alpha1.WorkerNodeGroupConfiguration{Count: ptr.Int(5)})
 	cluster := &v1alpha1.Cluster{
 		Spec: v1alpha1.ClusterSpec{
 			WorkerNodeGroupConfigurations: workerConfiguration,
@@ -1131,8 +1132,8 @@ func TestClusterCreateCloudStackMultipleWorkerNodeGroupsValidation(t *testing.T)
 	t.Setenv(features.FullLifecycleAPIEnvVar, "true")
 	cluster := createCluster()
 	cluster.Spec.WorkerNodeGroupConfigurations = append([]v1alpha1.WorkerNodeGroupConfiguration{},
-		v1alpha1.WorkerNodeGroupConfiguration{Count: 5, Name: "test", MachineGroupRef: &v1alpha1.Ref{Name: "ref-name"}},
-		v1alpha1.WorkerNodeGroupConfiguration{Count: 5, Name: "test2", MachineGroupRef: &v1alpha1.Ref{Name: "ref-name"}})
+		v1alpha1.WorkerNodeGroupConfiguration{Count: ptr.Int(5), Name: "test", MachineGroupRef: &v1alpha1.Ref{Name: "ref-name"}},
+		v1alpha1.WorkerNodeGroupConfiguration{Count: ptr.Int(5), Name: "test2", MachineGroupRef: &v1alpha1.Ref{Name: "ref-name"}})
 
 	cluster.Spec.ManagementCluster.Name = "management-cluster"
 
@@ -1146,7 +1147,7 @@ func TestClusterCreateWorkloadCluster(t *testing.T) {
 	cluster := createCluster()
 	cluster.Spec.WorkerNodeGroupConfigurations = append([]v1alpha1.WorkerNodeGroupConfiguration{},
 		v1alpha1.WorkerNodeGroupConfiguration{
-			Count: 5,
+			Count: ptr.Int(5),
 			Name:  "md-0",
 			MachineGroupRef: &v1alpha1.Ref{
 				Name: "test",
@@ -1177,7 +1178,7 @@ func TestClusterUpdateWorkerNodeGroupTaintsAndLabelsSuccess(t *testing.T) {
 		Labels: map[string]string{
 			"test": "val1",
 		},
-		Count: 1,
+		Count: ptr.Int(1),
 		MachineGroupRef: &v1alpha1.Ref{
 			Name: "test",
 		},
@@ -1195,7 +1196,7 @@ func TestClusterUpdateWorkerNodeGroupTaintsInvalid(t *testing.T) {
 	cOld := &v1alpha1.Cluster{
 		Spec: v1alpha1.ClusterSpec{
 			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
-				Count: 1,
+				Count: ptr.Int(1),
 				Name:  "test",
 				Taints: []v1.Taint{{
 					Key:    "test",
@@ -1216,7 +1217,7 @@ func TestClusterUpdateWorkerNodeGroupNameInvalid(t *testing.T) {
 	cOld := &v1alpha1.Cluster{
 		Spec: v1alpha1.ClusterSpec{
 			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
-				Count: 1,
+				Count: ptr.Int(1),
 				Name:  "test",
 			}},
 		},
@@ -1232,7 +1233,7 @@ func TestClusterUpdateWorkerNodeNewMachineGroupRefNilError(t *testing.T) {
 	cOld := &v1alpha1.Cluster{
 		Spec: v1alpha1.ClusterSpec{
 			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
-				Count:           1,
+				Count:           ptr.Int(1),
 				Name:            "test",
 				MachineGroupRef: &v1alpha1.Ref{Name: "test", Kind: "MachineConfig"},
 			}},
@@ -1250,7 +1251,7 @@ func TestClusterUpdateWorkerNodeGroupLabelsInvalid(t *testing.T) {
 	cOld := &v1alpha1.Cluster{
 		Spec: v1alpha1.ClusterSpec{
 			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
-				Count: 1,
+				Count: ptr.Int(1),
 				Name:  "test",
 				Labels: map[string]string{
 					"test": "val1",
@@ -1625,7 +1626,7 @@ func TestClusterValidateUpdateValidManagementCluster(t *testing.T) {
 
 			tt.oldCluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{
 				Name:  "md-0",
-				Count: 4,
+				Count: ptr.Int(4),
 				MachineGroupRef: &v1alpha1.Ref{
 					Kind: v1alpha1.VSphereMachineConfigKind,
 					Name: "eksa-unit-test",
@@ -1690,7 +1691,7 @@ func TestClusterValidateUpdateValidWorkloadCluster(t *testing.T) {
 			clusterOld.SetManagedBy("my-management-cluster")
 			tt.clusterNew.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{
 				Name:  "md-0",
-				Count: 4,
+				Count: ptr.Int(4),
 				MachineGroupRef: &v1alpha1.Ref{
 					Kind: v1alpha1.VSphereMachineConfigKind,
 					Name: "eksa-unit-test",
@@ -1756,7 +1757,7 @@ func createCluster(opts ...clusterOpt) *v1alpha1.Cluster {
 			},
 			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
 				Name:  "md-0",
-				Count: 1,
+				Count: ptr.Int(1),
 				MachineGroupRef: &v1alpha1.Ref{
 					Kind: v1alpha1.VSphereMachineConfigKind,
 					Name: "eksa-unit-test",

--- a/pkg/cluster/config_manager_test.go
+++ b/pkg/cluster/config_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 func TestConfigManagerParseSuccess(t *testing.T) {
@@ -43,7 +44,7 @@ func TestConfigManagerParseSuccess(t *testing.T) {
 			WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
 				{
 					Name:  "workers-1",
-					Count: 1,
+					Count: ptr.Int(1),
 				},
 			},
 			DatacenterRef: anywherev1.Ref{

--- a/pkg/cluster/parse_test.go
+++ b/pkg/cluster/parse_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 func TestParseConfig(t *testing.T) {
@@ -52,7 +53,7 @@ func TestParseConfig(t *testing.T) {
 					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
 						{
 							Name:  "workers-1",
-							Count: 1,
+							Count: ptr.Int(1),
 							MachineGroupRef: &anywherev1.Ref{
 								Kind: "VSphereMachineConfig",
 								Name: "eksa-unit-test",
@@ -154,7 +155,7 @@ func TestParseConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
 						{
-							Count: 3,
+							Count: ptr.Int(3),
 							MachineGroupRef: &anywherev1.Ref{
 								Kind: "CloudStackMachineConfig",
 								Name: "eksa-unit-test",
@@ -249,7 +250,7 @@ func TestParseConfig(t *testing.T) {
 					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
 						{
 							Name:  "workers-1",
-							Count: 1,
+							Count: ptr.Int(1),
 							MachineGroupRef: &anywherev1.Ref{
 								Kind: "SnowMachineConfig",
 								Name: "eksa-unit-test",
@@ -334,7 +335,7 @@ func TestParseConfig(t *testing.T) {
 					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
 						{
 							Name:  "workers-1",
-							Count: 1,
+							Count: ptr.Int(1),
 						},
 					},
 					DatacenterRef: anywherev1.Ref{
@@ -485,7 +486,7 @@ func TestParseConfig(t *testing.T) {
 					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
 						{
 							Name:  "workers-1",
-							Count: 1,
+							Count: ptr.Int(1),
 						},
 					},
 					DatacenterRef: anywherev1.Ref{

--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -249,7 +249,7 @@ func KubeadmConfigTemplate(clusterSpec *cluster.Spec, workerNodeGroupConfig anyw
 
 func MachineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig anywherev1.WorkerNodeGroupConfiguration, bootstrapObject, infrastructureObject APIObject) clusterv1.MachineDeployment {
 	clusterName := clusterSpec.Cluster.GetName()
-	replicas := int32(workerNodeGroupConfig.Count)
+	replicas := int32(*workerNodeGroupConfig.Count)
 	version := clusterSpec.VersionsBundle.KubeDistro.Kubernetes.Tag
 
 	md := &clusterv1.MachineDeployment{

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -15,6 +15,7 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 type apiBuilerTest struct {
@@ -106,7 +107,7 @@ func newApiBuilerTest(t *testing.T) apiBuilerTest {
 
 	workerNodeGroupConfig := &anywherev1.WorkerNodeGroupConfiguration{
 		Name:  "wng-1",
-		Count: 3,
+		Count: ptr.Int(3),
 		Taints: []v1.Taint{
 			{
 				Key:       "key2",

--- a/pkg/clusterapi/extraargs_test.go
+++ b/pkg/clusterapi/extraargs_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/crypto"
 	"github.com/aws/eks-anywhere/pkg/templater"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 func TestOIDCToExtraArgs(t *testing.T) {
@@ -318,14 +319,14 @@ func TestNodeLabelsExtraArgs(t *testing.T) {
 		{
 			testName: "no labels",
 			wnc: v1alpha1.WorkerNodeGroupConfiguration{
-				Count: 3,
+				Count: ptr.Int(3),
 			},
 			want: clusterapi.ExtraArgs{},
 		},
 		{
 			testName: "with labels",
 			wnc: v1alpha1.WorkerNodeGroupConfiguration{
-				Count:  3,
+				Count:  ptr.Int(3),
 				Labels: map[string]string{"label1": "foo", "label2": "bar"},
 			},
 			want: clusterapi.ExtraArgs{

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -761,7 +761,7 @@ func (c *ClusterManager) waitForMachineDeploymentReplicasReady(ctx context.Conte
 
 	var machineDeploymentReplicasCount int
 	for _, workerNodeGroupConfiguration := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
-		machineDeploymentReplicasCount += workerNodeGroupConfiguration.Count
+		machineDeploymentReplicasCount += *workerNodeGroupConfiguration.Count
 	}
 
 	areMdReplicasReady := func() error {

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -28,6 +28,7 @@ import (
 	mocksprovider "github.com/aws/eks-anywhere/pkg/providers/mocks"
 	"github.com/aws/eks-anywhere/pkg/retrier"
 	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 var (
@@ -190,7 +191,7 @@ func TestClusterManagerSaveLogsSuccess(t *testing.T) {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = clusterName
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
 	})
 
 	bootstrapCluster := &types.Cluster{
@@ -227,7 +228,7 @@ func TestClusterManagerCreateWorkloadClusterSuccess(t *testing.T) {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = clusterName
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
 	})
 
 	mgmtCluster := &types.Cluster{
@@ -256,7 +257,7 @@ func TestClusterManagerCreateWorkloadClusterTimeoutOverrideSuccess(t *testing.T)
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = clusterName
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
 	})
 
 	mgmtCluster := &types.Cluster{
@@ -285,7 +286,7 @@ func TestClusterManagerRunPostCreateWorkloadClusterSuccess(t *testing.T) {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = clusterName
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
 	})
 
 	mgmtCluster := &types.Cluster{
@@ -311,7 +312,7 @@ func TestClusterManagerCreateWorkloadClusterWithExternalEtcdSuccess(t *testing.T
 		s.Cluster.Name = clusterName
 		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 2
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
 	})
 
 	mgmtCluster := &types.Cluster{
@@ -342,7 +343,7 @@ func TestClusterManagerCreateWorkloadClusterWithExternalEtcdTimeoutOverrideSucce
 		s.Cluster.Name = clusterName
 		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 2
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
 	})
 
 	mgmtCluster := &types.Cluster{
@@ -372,7 +373,7 @@ func TestClusterManagerRunPostCreateWorkloadClusterWaitForMachinesTimeout(t *tes
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = clusterName
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
 	})
 
 	mgmtCluster := &types.Cluster{
@@ -403,7 +404,7 @@ func TestClusterManagerRunPostCreateWorkloadClusterWaitForMachinesSuccessAfterRe
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = clusterName
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
 	})
 
 	mgmtCluster := &types.Cluster{
@@ -1025,7 +1026,7 @@ func TestClusterManagerMoveCAPISuccess(t *testing.T) {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = to.Name
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-wn"}}}
+		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-wn"}}}
 	})
 	capiClusterName := "capi-cluster"
 	clustersNotReady := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}, Status: types.ClusterStatus{
@@ -1068,7 +1069,7 @@ func TestClusterManagerMoveCAPIErrorMove(t *testing.T) {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = to.Name
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
 	})
 	ctx := context.Background()
 
@@ -1092,7 +1093,7 @@ func TestClusterManagerMoveCAPIErrorGetClustersBeforeMove(t *testing.T) {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = to.Name
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
 	})
 	ctx := context.Background()
 
@@ -1115,7 +1116,7 @@ func TestClusterManagerMoveCAPIErrorWaitForClusterReady(t *testing.T) {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = to.Name
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
 	})
 	ctx := context.Background()
 
@@ -1141,7 +1142,7 @@ func TestClusterManagerMoveCAPIErrorGetClusters(t *testing.T) {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = to.Name
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
 	})
 	ctx := context.Background()
 
@@ -1166,7 +1167,7 @@ func TestClusterManagerMoveCAPIErrorWaitForControlPlane(t *testing.T) {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = to.Name
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = 3
+		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
 	})
 	ctx := context.Background()
 
@@ -1194,7 +1195,7 @@ func TestClusterManagerMoveCAPIErrorGetMachines(t *testing.T) {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = to.Name
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-wn"}}}
+		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-wn"}}}
 	})
 	ctx := context.Background()
 
@@ -1759,7 +1760,7 @@ func newSpecChangedTest(t *testing.T, opts ...clustermanager.ClusterManagerOpt) 
 				},
 			},
 			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
-				Count: 1,
+				Count: ptr.Int(1),
 				MachineGroupRef: &v1alpha1.Ref{
 					Name: clusterName + "-worker",
 				},

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/executables"
 	mockexecutables "github.com/aws/eks-anywhere/pkg/executables/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 const (
@@ -1244,7 +1245,7 @@ func TestKubectlGetEKSAClusters(t *testing.T) {
 			expectedSpec: v1alpha1.ClusterSpec{
 				KubernetesVersion:             "1.19",
 				ControlPlaneConfiguration:     v1alpha1.ControlPlaneConfiguration{Count: 3},
-				WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3}},
+				WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3)}},
 				DatacenterRef: v1alpha1.Ref{
 					Kind: v1alpha1.VSphereDatacenterKind,
 					Name: "test-cluster",

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -867,7 +867,7 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupMachineSpec v1
 		"cloudstackSymlinks":               workerNodeGroupMachineSpec.Symlinks,
 		"cloudstackAffinity":               workerNodeGroupMachineSpec.Affinity,
 		"cloudstackAffinityGroupIds":       workerNodeGroupMachineSpec.AffinityGroupIds,
-		"workerReplicas":                   workerNodeGroupConfiguration.Count,
+		"workerReplicas":                   *workerNodeGroupConfiguration.Count,
 		"workerSshUsername":                workerNodeGroupMachineSpec.Users[0].Name,
 		"cloudstackWorkerSshAuthorizedKey": workerNodeGroupMachineSpec.Users[0].SshAuthorizedKeys[0],
 		"format":                           format,

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
@@ -1425,7 +1426,7 @@ func TestProviderGenerateCAPISpecForUpgradeMultipleWorkerNodeGroups(t *testing.T
 				},
 			}
 			newClusterSpec := givenClusterSpec(t, tt.clusterconfigFile)
-			newConfig := v1alpha1.WorkerNodeGroupConfiguration{Count: 1, MachineGroupRef: &v1alpha1.Ref{Name: "test", Kind: "CloudStackMachineConfig"}, Name: "md-2"}
+			newConfig := v1alpha1.WorkerNodeGroupConfiguration{Count: ptr.Int(1), MachineGroupRef: &v1alpha1.Ref{Name: "test", Kind: "CloudStackMachineConfig"}, Name: "md-2"}
 			newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations = append(newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations, newConfig)
 
 			kubectl.EXPECT().GetMachineDeployment(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(workerNodeGroup1MachineDeployment(), nil)

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -245,7 +245,7 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration 
 		"kindNodeImage":         bundle.EksD.KindNode.VersionedImage(),
 		"eksaSystemNamespace":   constants.EksaSystemNamespace,
 		"kubeletExtraArgs":      kubeletExtraArgs.ToPartialYaml(),
-		"workerReplicas":        workerNodeGroupConfiguration.Count,
+		"workerReplicas":        *workerNodeGroupConfiguration.Count,
 		"workerNodeGroupName":   fmt.Sprintf("%s-%s", clusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name),
 		"workerNodeGroupTaints": workerNodeGroupConfiguration.Taints,
 		"autoscalingConfig":     workerNodeGroupConfiguration.AutoScalingConfiguration,

--- a/pkg/providers/docker/docker_test.go
+++ b/pkg/providers/docker/docker_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers/docker"
 	dockerMocks "github.com/aws/eks-anywhere/pkg/providers/docker/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
@@ -134,7 +135,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.VersionsBundle = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
 			wantCPFile: "testdata/valid_deployment_cp_expected.yaml",
 			wantMDFile: "testdata/valid_deployment_md_expected.yaml",
@@ -150,7 +151,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ControlPlaneConfiguration.Taints = cpTaints
 				s.VersionsBundle = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
 			wantCPFile: "testdata/valid_deployment_cp_taints_expected.yaml",
 			wantMDFile: "testdata/valid_deployment_md_expected.yaml",
@@ -166,7 +167,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ControlPlaneConfiguration.Taints = cpTaints
 				s.VersionsBundle = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, Taints: wnTaints, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), Taints: wnTaints, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
 			wantCPFile: "testdata/valid_deployment_cp_taints_expected.yaml",
 			wantMDFile: "testdata/valid_deployment_md_taints_expected.yaml",
@@ -180,7 +181,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.Cluster.Spec.ControlPlaneConfiguration.Taints = cpTaints
-				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, Taints: wnTaints, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}, {Count: 3, Taints: wnTaints2, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-1"}}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), Taints: wnTaints, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}, {Count: ptr.Int(3), Taints: wnTaints2, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-1"}}
 				s.VersionsBundle = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 			}),
@@ -197,7 +198,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.VersionsBundle = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Labels: nodeLabels, Name: "md-0"}}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Labels: nodeLabels, Name: "md-0"}}
 			}),
 			wantCPFile: "testdata/valid_deployment_cp_expected.yaml",
 			wantMDFile: "testdata/valid_deployment_node_labels_md_expected.yaml",
@@ -213,7 +214,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ControlPlaneConfiguration.Labels = nodeLabels
 				s.VersionsBundle = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
 			wantCPFile: "testdata/valid_deployment_node_labels_cp_expected.yaml",
 			wantMDFile: "testdata/valid_deployment_md_expected.yaml",
@@ -229,7 +230,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.VersionsBundle = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
 			wantCPFile: "testdata/valid_deployment_custom_cidrs_cp_expected.yaml",
 			wantMDFile: "testdata/valid_deployment_custom_cidrs_md_expected.yaml",
@@ -244,7 +245,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.VersionsBundle = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 
 				s.OIDCConfig = &v1alpha1.OIDCConfig{
 					Spec: v1alpha1.OIDCConfigSpec{
@@ -266,7 +267,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.VersionsBundle = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 				s.OIDCConfig = &v1alpha1.OIDCConfig{
 					Spec: v1alpha1.OIDCConfigSpec{
 						ClientId:     "my-client-id",
@@ -297,7 +298,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.VersionsBundle = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0", AutoScalingConfiguration: &v1alpha1.AutoScalingConfiguration{MinCount: 3, MaxCount: 5}}}
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0", AutoScalingConfiguration: &v1alpha1.AutoScalingConfiguration{MinCount: 3, MaxCount: 5}}}
 			}),
 			wantCPFile: "testdata/valid_deployment_cp_expected.yaml",
 			wantMDFile: "testdata/valid_autoscaler_deployment_md_expected.yaml",
@@ -370,7 +371,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateKubeadmConfigTemplate(t *tes
 	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints = cpTaints
 	clusterSpec.VersionsBundle = versionsBundle
 	clusterSpec.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
+	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 
 	p := docker.NewProvider(&v1alpha1.DockerDatacenterConfig{}, client, kubectl, test.FakeNow)
 	cluster := &types.Cluster{
@@ -419,7 +420,7 @@ func TestProviderGenerateDeploymentFileSuccessNotUpdateMachineTemplate(t *testin
 	clusterSpec := test.NewClusterSpec()
 	clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
 	clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
-	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 0, MachineGroupRef: &v1alpha1.Ref{Name: "fluxTestCluster"}, Name: "md-0"}}
+	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(0), MachineGroupRef: &v1alpha1.Ref{Name: "fluxTestCluster"}, Name: "md-0"}}
 	p := docker.NewProvider(&v1alpha1.DockerDatacenterConfig{}, client, kubectl, test.FakeNow)
 	cluster := &types.Cluster{
 		Name: "test",
@@ -598,7 +599,7 @@ func TestProviderGenerateCAPISpecForCreateWithPodIAMConfig(t *testing.T) {
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 1
 		s.VersionsBundle = versionsBundle
 		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
-		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}}}
+		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}}}
 	})
 	clusterSpec.Cluster.Spec.PodIAMConfig = &v1alpha1.PodIAMConfig{ServiceAccountIssuer: "https://test"}
 
@@ -634,7 +635,7 @@ func TestProviderGenerateCAPISpecForCreateWithStackedEtcd(t *testing.T) {
 		s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 1
 		s.VersionsBundle = versionsBundle
-		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: 3, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}}}
+		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}}}
 	})
 
 	if provider == nil {

--- a/pkg/providers/snow/reconciler/reconciler_test.go
+++ b/pkg/providers/snow/reconciler/reconciler_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 	"github.com/aws/eks-anywhere/pkg/providers/snow/reconciler"
 	"github.com/aws/eks-anywhere/pkg/providers/snow/reconciler/mocks"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
@@ -239,7 +240,7 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 
 		c.Spec.WorkerNodeGroupConfigurations = append(c.Spec.WorkerNodeGroupConfigurations,
 			anywherev1.WorkerNodeGroupConfiguration{
-				Count: 1,
+				Count: ptr.Int(1),
 				MachineGroupRef: &anywherev1.Ref{
 					Kind: "SnowMachineConfig",
 					Name: machineConfigWN.Name,

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -25,6 +25,7 @@ import (
 	snowv1 "github.com/aws/eks-anywhere/pkg/providers/snow/api/v1beta1"
 	"github.com/aws/eks-anywhere/pkg/providers/snow/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
@@ -104,7 +105,7 @@ func givenClusterSpec() *cluster.Spec {
 				WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{
 					{
 						Name:  "md-0",
-						Count: 3,
+						Count: ptr.Int(3),
 						MachineGroupRef: &v1alpha1.Ref{
 							Kind: "SnowMachineConfig",
 							Name: "test-wn",

--- a/pkg/providers/tinkerbell/assert.go
+++ b/pkg/providers/tinkerbell/assert.go
@@ -195,7 +195,7 @@ func MinimumHardwareAvailableAssertionForCreate(catalogue *hardware.Catalogue) C
 		for _, nodeGroup := range spec.WorkerNodeGroupConfigurations() {
 			err := requirements.Add(
 				spec.WorkerNodeGroupMachineConfig(nodeGroup).Spec.HardwareSelector,
-				nodeGroup.Count,
+				*nodeGroup.Count,
 			)
 			if err != nil {
 				return err
@@ -254,10 +254,10 @@ func AssertionsForScaleUpDown(catalogue *hardware.Catalogue, currentSpec *cluste
 					if rollingUpgrade {
 						return fmt.Errorf("cannot perform scale up or down during rolling upgrades")
 					}
-					if nodeGroupNewSpec.Count > workerNodeGrpOldSpec.Count {
+					if *nodeGroupNewSpec.Count > *workerNodeGrpOldSpec.Count {
 						err := requirements.Add(
 							spec.WorkerNodeGroupMachineConfig(nodeGroupNewSpec).Spec.HardwareSelector,
-							nodeGroupNewSpec.Count-workerNodeGrpOldSpec.Count,
+							*nodeGroupNewSpec.Count-*workerNodeGrpOldSpec.Count,
 						)
 						if err != nil {
 							return fmt.Errorf("error during scale up: %v", err)
@@ -270,7 +270,7 @@ func AssertionsForScaleUpDown(catalogue *hardware.Catalogue, currentSpec *cluste
 				}
 				err := requirements.Add(
 					spec.WorkerNodeGroupMachineConfig(nodeGroupNewSpec).Spec.HardwareSelector,
-					nodeGroupNewSpec.Count,
+					*nodeGroupNewSpec.Count,
 				)
 				if err != nil {
 					return fmt.Errorf("error during scale up: %v", err)

--- a/pkg/providers/tinkerbell/assert_test.go
+++ b/pkg/providers/tinkerbell/assert_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/networkutils/mocks"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 func TestAssertMachineConfigsValid_ValidSucceds(t *testing.T) {
@@ -332,7 +333,7 @@ func TestMinimumHardwareAvailableAssertionForCreate_NoControlPlaneSelectorMatche
 
 	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
 	clusterSpec.ControlPlaneMachineConfig().Spec.HardwareSelector = eksav1alpha1.HardwareSelector{}
-	clusterSpec.WorkerNodeGroupConfigurations()[0].Count = 0
+	clusterSpec.WorkerNodeGroupConfigurations()[0].Count = ptr.Int(0)
 	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
 
 	catalogue := hardware.NewCatalogue()
@@ -349,7 +350,7 @@ func TestMinimumHardwareAvailableAssertionForCreate_NoExternalEtcdSelectorMatche
 
 	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
 	clusterSpec.ControlPlaneConfiguration().Count = 0
-	clusterSpec.WorkerNodeGroupConfigurations()[0].Count = 0
+	clusterSpec.WorkerNodeGroupConfigurations()[0].Count = ptr.Int(0)
 	clusterSpec.ExternalEtcdMachineConfig().Spec.HardwareSelector = eksav1alpha1.HardwareSelector{}
 
 	catalogue := hardware.NewCatalogue()

--- a/pkg/providers/tinkerbell/cluster_spec_builder_test.go
+++ b/pkg/providers/tinkerbell/cluster_spec_builder_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 type ValidClusterSpecBuilder struct {
@@ -56,7 +57,7 @@ func (b ValidClusterSpecBuilder) Build() *tinkerbell.ClusterSpec {
 						WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{
 							{
 								Name:  "worker-node-group-0",
-								Count: 1,
+								Count: ptr.Int(1),
 								MachineGroupRef: &v1alpha1.Ref{
 									Kind: v1alpha1.TinkerbellMachineConfigKind,
 									Name: b.WorkerNodeGroupMachineName,

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -142,7 +142,7 @@ func (tb *TemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, wo
 			return nil, fmt.Errorf("kubeadmconfigTemplateNames invalid in GenerateCAPISpecWorkers: %v", err)
 		}
 		values["workerSshAuthorizedKey"] = tb.WorkerNodeGroupMachineSpecs[workerNodeGroupConfiguration.MachineGroupRef.Name].Users[0].SshAuthorizedKeys[0]
-		values["workerReplicas"] = workerNodeGroupConfiguration.Count
+		values["workerReplicas"] = *workerNodeGroupConfiguration.Count
 		values["workloadTemplateName"] = workloadTemplateNames[workerNodeGroupConfiguration.Name]
 		values["workerNodeGroupName"] = workerNodeGroupConfiguration.Name
 		values["workloadkubeadmconfigTemplateName"] = kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name]

--- a/pkg/providers/vsphere/validator.go
+++ b/pkg/providers/vsphere/validator.go
@@ -295,7 +295,7 @@ func (v *Validator) validateDatastoreUsage(ctx context.Context, vsphereClusterSp
 		if err != nil {
 			return fmt.Errorf("getting datastore details: %v", err)
 		}
-		workerNeedGiB := workerMachineConfig.Spec.DiskGiB * workerNodeGroupConfiguration.Count
+		workerNeedGiB := workerMachineConfig.Spec.DiskGiB * *workerNodeGroupConfiguration.Count
 		_, ok := usage[workerMachineConfig.Spec.Datastore]
 		if ok {
 			usage[workerMachineConfig.Spec.Datastore].needGiBSpace += workerNeedGiB

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -876,7 +876,7 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, datacenterSpec v1alpha1.VSphe
 		"eksaSystemNamespace":            constants.EksaSystemNamespace,
 		"kubeletExtraArgs":               kubeletExtraArgs.ToPartialYaml(),
 		"vsphereWorkerSshAuthorizedKey":  workerNodeGroupMachineSpec.Users[0].SshAuthorizedKeys[0],
-		"workerReplicas":                 workerNodeGroupConfiguration.Count,
+		"workerReplicas":                 *workerNodeGroupConfiguration.Count,
 		"workerNodeGroupName":            fmt.Sprintf("%s-%s", clusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name),
 		"workerNodeGroupTaints":          workerNodeGroupConfiguration.Taints,
 		"autoscalingConfig":              workerNodeGroupConfiguration.AutoScalingConfiguration,

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -36,6 +36,7 @@ import (
 	govmomi_mocks "github.com/aws/eks-anywhere/pkg/govmomi/mocks"
 	"github.com/aws/eks-anywhere/pkg/providers/vsphere/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
@@ -712,7 +713,7 @@ func TestProviderGenerateCAPISpecForUpgradeMultipleWorkerNodeGroups(t *testing.T
 				},
 			}
 			newClusterSpec := givenClusterSpec(t, tt.clusterconfigFile)
-			newConfig := v1alpha1.WorkerNodeGroupConfiguration{Count: 1, MachineGroupRef: &v1alpha1.Ref{Name: "test-wn", Kind: "VSphereMachineConfig"}, Name: "md-2"}
+			newConfig := v1alpha1.WorkerNodeGroupConfiguration{Count: ptr.Int(1), MachineGroupRef: &v1alpha1.Ref{Name: "test-wn", Kind: "VSphereMachineConfig"}, Name: "md-2"}
 			newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations = append(newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations, newConfig)
 
 			kubectl.EXPECT().GetMachineDeployment(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(workerNodeGroup1MachineDeployment(), nil)

--- a/pkg/utils/ptr/ptr.go
+++ b/pkg/utils/ptr/ptr.go
@@ -1,0 +1,90 @@
+/*
+Package ptr provides utility functions for converting non-addressable primitive types to pointers.
+Its useful in contexts where a variable gives nil primitive type pointers semantics
+(often meaning "not set") which can make it annoying to set the value.
+
+Example
+
+	type Foo struct {
+		A *int
+	}
+
+	func main() {
+		foo := Foo{
+			A: ptr.Int(1)
+		}
+	}
+*/
+package ptr
+
+func Int(v int) *int {
+	return &v
+}
+
+func Int8(v int8) *int8 {
+	return &v
+}
+
+func Int16(v int16) *int16 {
+	return &v
+}
+
+func Int32(v int32) *int32 {
+	return &v
+}
+
+func Int64(v int64) *int64 {
+	return &v
+}
+
+func Uint(v uint) *uint {
+	return &v
+}
+
+func Uint8(v uint8) *uint8 {
+	return &v
+}
+
+func Uint16(v uint16) *uint16 {
+	return &v
+}
+
+func Uint32(v uint32) *uint32 {
+	return &v
+}
+
+func Uint64(v uint64) *uint64 {
+	return &v
+}
+
+func Float32(v float32) *float32 {
+	return &v
+}
+
+func Float64(v float64) *float64 {
+	return &v
+}
+
+func String(v string) *string {
+	return &v
+}
+
+func Bool(v bool) *bool {
+	return &v
+}
+
+func Byte(v byte) *byte {
+	return &v
+}
+
+func Rune(v rune) *rune {
+	return &v
+}
+
+func Complex64(v complex64) *complex64 {
+	return &v
+}
+
+func Complex128(v complex128) *complex128 {
+	return &v
+}

--- a/pkg/validations/createcluster/createcluster_test.go
+++ b/pkg/validations/createcluster/createcluster_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/gitops/flux"
 	providermocks "github.com/aws/eks-anywhere/pkg/providers/mocks"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/createcluster"
 	createmocks "github.com/aws/eks-anywhere/pkg/validations/createcluster/mocks"
@@ -78,7 +79,7 @@ func (c *createClusterValidationTest) expectValidDockerClusterSpec() {
 			},
 			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{
 				Name:  "md-0",
-				Count: 1,
+				Count: ptr.Int(1),
 			}},
 		},
 	}

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -414,7 +414,8 @@ func (e *ClusterE2ETest) validateWorkerNodeMultiConfigUpdates(ctx context.Contex
 		if err != nil {
 			return err
 		}
-		clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count += 1
+		count := *clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count + 1
+		clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = &count
 
 		providerConfig := providerConfig{
 			datacenterConfig: vsphereClusterConfig,
@@ -521,7 +522,7 @@ func (e *ClusterE2ETest) validateWorkerNodeUpdates(ctx context.Context, opts ...
 	if err != nil {
 		return err
 	}
-	if err := e.waitForWorkerScaling(clusterConfig.Spec.WorkerNodeGroupConfigurations[0].Name, clusterConfig.Spec.WorkerNodeGroupConfigurations[0].Count); err != nil {
+	if err := e.waitForWorkerScaling(clusterConfig.Spec.WorkerNodeGroupConfigurations[0].Name, *clusterConfig.Spec.WorkerNodeGroupConfigurations[0].Count); err != nil {
 		return err
 	}
 
@@ -602,7 +603,7 @@ func (e *ClusterE2ETest) updateWorkerNodeCountValue(ctx context.Context, newValu
 	if err != nil {
 		return "", err
 	}
-	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = newValue
+	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = &newValue
 
 	p, err := e.updateEKSASpecInGit(ctx, clusterSpec, *providerConfig)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*
Epic: https://github.com/aws/eks-anywhere/issues/3186
Ticket: https://github.com/aws/eks-anywhere/issues/3638

*Description of changes:*
Change the WorkerNodeGroupConfiguration.Count param to an int pointer.

*Testing (if applicable):*
Manually created a vSphere cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.