### PR TITLE
Validate vsphere datacenter config at api level

### DIFF
--- a/pkg/api/v1alpha1/vspheredatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_types.go
@@ -83,7 +83,7 @@ func (v *VSphereDatacenterConfig) SetDefaults() {
 	}
 }
 
-func (v *VSphereDatacenterConfig) ValidateFields() error {
+func (v *VSphereDatacenterConfig) Validate() error {
 	if len(v.Spec.Server) <= 0 {
 		return errors.New("VSphereDatacenterConfig server is not set or is empty")
 	}
@@ -123,10 +123,6 @@ func (v *VSphereDatacenterConfig) ConvertConfigToConfigGenerateStruct() *VSphere
 
 func (v *VSphereDatacenterConfig) Marshallable() Marshallable {
 	return v.ConvertConfigToConfigGenerateStruct()
-}
-
-func (v *VSphereDatacenterConfig) Validate() error {
-	return nil
 }
 
 // +kubebuilder:object:generate=false

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_webhook.go
@@ -56,6 +56,17 @@ var _ webhook.Validator = &VSphereDatacenterConfig{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *VSphereDatacenterConfig) ValidateCreate() error {
 	vspheredatacenterconfiglog.Info("validate create", "name", r.Name)
+
+	if err := r.Validate(); err != nil {
+		return apierrors.NewInvalid(
+			GroupVersion.WithKind(VSphereDatacenterKind).GroupKind(),
+			r.Name,
+			field.ErrorList{
+				field.Invalid(field.NewPath("spec"), r.Spec, err.Error()),
+			},
+		)
+	}
+
 	if r.IsReconcilePaused() {
 		vspheredatacenterconfiglog.Info("VSphereDatacenterConfig is paused, so allowing create", "name", r.Name)
 		return nil
@@ -63,6 +74,7 @@ func (r *VSphereDatacenterConfig) ValidateCreate() error {
 	if !features.IsActive(features.FullLifecycleAPI()) {
 		return apierrors.NewBadRequest("Creating new VSphereDatacenterConfig on existing cluster is not supported")
 	}
+
 	return nil
 }
 
@@ -75,6 +87,16 @@ func (r *VSphereDatacenterConfig) ValidateUpdate(old runtime.Object) error {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a VSphereDataCenterConfig but got a %T", old))
 	}
 
+	if err := r.Validate(); err != nil {
+		return apierrors.NewInvalid(
+			GroupVersion.WithKind(VSphereDatacenterKind).GroupKind(),
+			r.Name,
+			field.ErrorList{
+				field.Invalid(field.NewPath("spec"), r.Spec, err.Error()),
+			},
+		)
+	}
+
 	if oldDatacenterConfig.IsReconcilePaused() {
 		vspheredatacenterconfiglog.Info("Reconciliation is paused")
 		return nil
@@ -82,19 +104,11 @@ func (r *VSphereDatacenterConfig) ValidateUpdate(old runtime.Object) error {
 
 	r.SetDefaults()
 
-	var allErrs field.ErrorList
-
-	if err := r.ValidateFields(); err != nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec"), r.Spec, err.Error()))
+	if allErrs := validateImmutableFieldsVSphereCluster(r, oldDatacenterConfig); len(allErrs) != 0 {
+		return apierrors.NewInvalid(GroupVersion.WithKind(VSphereDatacenterKind).GroupKind(), r.Name, allErrs)
 	}
 
-	allErrs = append(allErrs, validateImmutableFieldsVSphereCluster(r, oldDatacenterConfig)...)
-
-	if len(allErrs) == 0 {
-		return nil
-	}
-
-	return apierrors.NewInvalid(GroupVersion.WithKind(VSphereDatacenterKind).GroupKind(), r.Name, allErrs)
+	return nil
 }
 
 func validateImmutableFieldsVSphereCluster(new, old *VSphereDatacenterConfig) field.ErrorList {

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_webhook_test.go
@@ -62,10 +62,10 @@ func TestVSphereDatacenterValidateUpdateTlsThumbprintImmutable(t *testing.T) {
 
 func TestVSphereDatacenterValidateUpdateWithPausedAnnotation(t *testing.T) {
 	vOld := vsphereDatacenterConfig()
-	vOld.Spec.Network = "oldNetwork"
+	vOld.Spec.Network = "/datacenter/oldNetwork"
 	c := vOld.DeepCopy()
 
-	c.Spec.Network = "newNetwork"
+	c.Spec.Network = "/datacenter/network/newNetwork"
 
 	vOld.PauseReconcile()
 
@@ -139,12 +139,23 @@ func vsphereDatacenterConfig() v1alpha1.VSphereDatacenterConfig {
 func TestVSphereDatacenterValidateCreateFullManagementCycleOn(t *testing.T) {
 	os.Setenv("FULL_LIFECYCLE_API", "true")
 	dataCenterConfig := vsphereDatacenterConfig()
-	dataCenterConfig.Spec.Network = "Network"
-	c := dataCenterConfig.DeepCopy()
-
-	c.Spec.Network = "Network"
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateCreate()).To(Succeed())
+	g.Expect(dataCenterConfig.ValidateCreate()).To(Succeed())
 	os.Unsetenv("FULL_LIFECYCLE_API")
+}
+
+func TestVSphereDatacenterValidateCreate(t *testing.T) {
+	dataCenterConfig := vsphereDatacenterConfig()
+
+	g := NewWithT(t)
+	g.Expect(dataCenterConfig.ValidateCreate()).To(Succeed())
+}
+
+func TestVSphereDatacenterValidateCreateFail(t *testing.T) {
+	dataCenterConfig := vsphereDatacenterConfig()
+	dataCenterConfig.Spec.Datacenter = ""
+
+	g := NewWithT(t)
+	g.Expect(dataCenterConfig.ValidateCreate()).NotTo(Succeed())
 }

--- a/pkg/cluster/parse_test.go
+++ b/pkg/cluster/parse_test.go
@@ -85,7 +85,7 @@ func TestParseConfig(t *testing.T) {
 				},
 				Spec: anywherev1.VSphereDatacenterConfigSpec{
 					Datacenter: "myDatacenter",
-					Network:    "myNetwork",
+					Network:    "/myDatacenter/network-1",
 					Server:     "myServer",
 					Thumbprint: "myTlsThumbprint",
 					Insecure:   false,

--- a/pkg/cluster/testdata/cluster_1_19.yaml
+++ b/pkg/cluster/testdata/cluster_1_19.yaml
@@ -35,7 +35,7 @@ metadata:
   name: eksa-unit-test
 spec:
   datacenter: "myDatacenter"
-  network: "myNetwork"
+  network: "/myDatacenter/network-1"
   server: "myServer"
   insecure: false
   thumbprint: "myTlsThumbprint"

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -386,7 +386,7 @@ func (p *vsphereProvider) SetupAndValidateCreateCluster(ctx context.Context, clu
 		return fmt.Errorf("failed setting default values for vsphere datacenter config: %v", err)
 	}
 
-	if err := vSphereClusterSpec.datacenterConfig.ValidateFields(); err != nil {
+	if err := vSphereClusterSpec.datacenterConfig.Validate(); err != nil {
 		return err
 	}
 
@@ -482,7 +482,7 @@ func (p *vsphereProvider) SetupAndValidateUpgradeCluster(ctx context.Context, cl
 		return fmt.Errorf("failed setting default values for vsphere datacenter config: %v", err)
 	}
 
-	if err := vSphereClusterSpec.datacenterConfig.ValidateFields(); err != nil {
+	if err := vSphereClusterSpec.datacenterConfig.Validate(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Move vsphere datacenter config validation to api level
*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

