### PR TITLE
Create workload cluster from management cluster for baremetal

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -823,6 +823,11 @@ type CloudStackDatacenterConfigResponse struct {
 	Items []*v1alpha1.CloudStackDatacenterConfig `json:"items,omitempty"`
 }
 
+// TinkerbellDatacenterConfigResponse contains list of TinkerbellDatacenterConfig.
+type TinkerbellDatacenterConfigResponse struct {
+	Items []*v1alpha1.TinkerbellDatacenterConfig `json:"items,omitempty"`
+}
+
 type NutanixDatacenterConfigResponse struct {
 	Items []*v1alpha1.NutanixDatacenterConfig `json:"items,omitempty"`
 }
@@ -837,6 +842,11 @@ type VSphereMachineConfigResponse struct {
 
 type CloudStackMachineConfigResponse struct {
 	Items []*v1alpha1.CloudStackMachineConfig `json:"items,omitempty"`
+}
+
+// TinkerbellMachineConfigResponse contains list of TinkerbellMachineConfig.
+type TinkerbellMachineConfigResponse struct {
+	Items []*v1alpha1.TinkerbellMachineConfig `json:"items,omitempty"`
 }
 
 type NutanixMachineConfigResponse struct {
@@ -1205,6 +1215,26 @@ func (k *Kubectl) SearchVsphereMachineConfig(ctx context.Context, name string, k
 	return response.Items, nil
 }
 
+// SearchTinkerbellMachineConfig returns the list of TinkerbellMachineConfig in the cluster.
+func (k *Kubectl) SearchTinkerbellMachineConfig(ctx context.Context, name string, kubeconfigFile string, namespace string) ([]*v1alpha1.TinkerbellMachineConfig, error) {
+	params := []string{
+		"get", eksaTinkerbellMachineResourceType, "-o", "json", "--kubeconfig",
+		kubeconfigFile, "--namespace", namespace, "--field-selector=metadata.name=" + name,
+	}
+	stdOut, err := k.Execute(ctx, params...)
+	if err != nil {
+		return nil, fmt.Errorf("searching eksa TinkerbellMachineConfigResponse: %v", err)
+	}
+
+	response := &TinkerbellMachineConfigResponse{}
+	err = json.Unmarshal(stdOut.Bytes(), response)
+	if err != nil {
+		return nil, fmt.Errorf("parsing TinkerbellMachineConfigResponse response: %v", err)
+	}
+
+	return response.Items, nil
+}
+
 func (k *Kubectl) SearchIdentityProviderConfig(ctx context.Context, ipName string, kind string, kubeconfigFile string, namespace string) ([]*v1alpha1.VSphereDatacenterConfig, error) {
 	var internalType string
 
@@ -1249,6 +1279,26 @@ func (k *Kubectl) SearchVsphereDatacenterConfig(ctx context.Context, datacenterN
 	err = json.Unmarshal(stdOut.Bytes(), response)
 	if err != nil {
 		return nil, fmt.Errorf("parsing VSphereDatacenterConfigResponse response: %v", err)
+	}
+
+	return response.Items, nil
+}
+
+// SearchTinkerbellDatacenterConfig returns the list of TinkerbellDatacenterConfig in the cluster.
+func (k *Kubectl) SearchTinkerbellDatacenterConfig(ctx context.Context, datacenterName string, kubeconfigFile string, namespace string) ([]*v1alpha1.TinkerbellDatacenterConfig, error) {
+	params := []string{
+		"get", eksaTinkerbellDatacenterResourceType, "-o", "json", "--kubeconfig",
+		kubeconfigFile, "--namespace", namespace, "--field-selector=metadata.name=" + datacenterName,
+	}
+	stdOut, err := k.Execute(ctx, params...)
+	if err != nil {
+		return nil, fmt.Errorf("searching eksa TinkerbellDatacenterConfigResponse: %v", err)
+	}
+
+	response := &TinkerbellDatacenterConfigResponse{}
+	err = json.Unmarshal(stdOut.Bytes(), response)
+	if err != nil {
+		return nil, fmt.Errorf("parsing TinkerbellDatacenterConfigResponse response: %v", err)
 	}
 
 	return response.Items, nil

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -2836,3 +2836,71 @@ func TestKubectlDeleteEksaNutanixMachineConfigError(t *testing.T) {
 	).Return(bytes.Buffer{}, fmt.Errorf("error"))
 	tt.Expect(tt.k.DeleteEksaNutanixMachineConfig(tt.ctx, "eksa-unit-test", tt.kubeconfig, tt.namespace)).NotTo(Succeed())
 }
+
+func TestKubectlSearchTinkerbellMachineConfig(t *testing.T) {
+	var kubeconfig, namespace, name string
+	buffer := bytes.Buffer{}
+	buffer.WriteString(test.ReadFile(t, "testdata/kubectl_no_cs_machineconfigs.json"))
+	k, ctx, _, e := newKubectl(t)
+
+	expectedParam := []string{
+		"get", fmt.Sprintf("tinkerbellmachineconfigs.%s", v1alpha1.GroupVersion.Group), "-o", "json", "--kubeconfig",
+		kubeconfig, "--namespace", namespace, "--field-selector=metadata.name=" + name,
+	}
+	e.EXPECT().Execute(ctx, gomock.Eq(expectedParam)).Return(buffer, nil)
+	mc, err := k.SearchTinkerbellMachineConfig(ctx, name, kubeconfig, namespace)
+	if err != nil {
+		t.Errorf("Kubectl.SearchTinkerbellMachineConfig() error = %v, want nil", err)
+	}
+	if len(mc) > 0 {
+		t.Errorf("expected 0 machine configs, got %d", len(mc))
+	}
+}
+
+func TestKubectlSearchTinkerbellMachineConfigNotFound(t *testing.T) {
+	var kubeconfigfile string
+	tt := newKubectlTest(t)
+
+	params := []string{
+		"get", fmt.Sprintf("tinkerbellmachineconfigs.%s", v1alpha1.GroupVersion.Group), "-o", "json", "--kubeconfig",
+		kubeconfigfile, "--namespace", tt.namespace, "--field-selector=metadata.name=test",
+	}
+	tt.e.EXPECT().Execute(tt.ctx, gomock.Eq(params)).Return(*bytes.NewBufferString(""), errors.New("machineconfig not found"))
+
+	_, err := tt.k.SearchTinkerbellMachineConfig(tt.ctx, "test", kubeconfigfile, tt.namespace)
+	tt.Expect(err).NotTo(BeNil())
+}
+
+func TestKubectlSearchTinkerbellDatacenterConfigs(t *testing.T) {
+	var kubeconfig, namespace, name string
+	buffer := bytes.Buffer{}
+	buffer.WriteString(test.ReadFile(t, "testdata/kubectl_no_cs_datacenterconfigs.json"))
+	k, ctx, _, e := newKubectl(t)
+
+	expectedParam := []string{
+		"get", fmt.Sprintf("tinkerbelldatacenterconfigs.%s", v1alpha1.GroupVersion.Group), "-o", "json", "--kubeconfig",
+		kubeconfig, "--namespace", namespace, "--field-selector=metadata.name=" + name,
+	}
+	e.EXPECT().Execute(ctx, gomock.Eq(expectedParam)).Return(buffer, nil)
+	mc, err := k.SearchTinkerbellDatacenterConfig(ctx, name, kubeconfig, namespace)
+	if err != nil {
+		t.Errorf("Kubectl.SearchTinkerbellDatacenterConfig() error = %v, want nil", err)
+	}
+	if len(mc) > 0 {
+		t.Errorf("expected 0 datacenter configs, got %d", len(mc))
+	}
+}
+
+func TestKubectlSearchTinkerbellDatacenterConfigNotFound(t *testing.T) {
+	var kubeconfigfile string
+	tt := newKubectlTest(t)
+
+	params := []string{
+		"get", fmt.Sprintf("tinkerbelldatacenterconfigs.%s", v1alpha1.GroupVersion.Group), "-o", "json", "--kubeconfig",
+		kubeconfigfile, "--namespace", tt.namespace, "--field-selector=metadata.name=test",
+	}
+	tt.e.EXPECT().Execute(tt.ctx, gomock.Eq(params)).Return(*bytes.NewBufferString(""), errors.New("datacenterconfig not found"))
+
+	_, err := tt.k.SearchTinkerbellDatacenterConfig(tt.ctx, "test", kubeconfigfile, tt.namespace)
+	tt.Expect(err).NotTo(BeNil())
+}

--- a/pkg/providers/tinkerbell/mocks/client.go
+++ b/pkg/providers/tinkerbell/mocks/client.go
@@ -254,6 +254,36 @@ func (mr *MockProviderKubectlClientMockRecorder) GetUnprovisionedTinkerbellHardw
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnprovisionedTinkerbellHardware", reflect.TypeOf((*MockProviderKubectlClient)(nil).GetUnprovisionedTinkerbellHardware), arg0, arg1, arg2)
 }
 
+// SearchTinkerbellDatacenterConfig mocks base method.
+func (m *MockProviderKubectlClient) SearchTinkerbellDatacenterConfig(arg0 context.Context, arg1, arg2, arg3 string) ([]*v1alpha1.TinkerbellDatacenterConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchTinkerbellDatacenterConfig", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]*v1alpha1.TinkerbellDatacenterConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchTinkerbellDatacenterConfig indicates an expected call of SearchTinkerbellDatacenterConfig.
+func (mr *MockProviderKubectlClientMockRecorder) SearchTinkerbellDatacenterConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchTinkerbellDatacenterConfig", reflect.TypeOf((*MockProviderKubectlClient)(nil).SearchTinkerbellDatacenterConfig), arg0, arg1, arg2, arg3)
+}
+
+// SearchTinkerbellMachineConfig mocks base method.
+func (m *MockProviderKubectlClient) SearchTinkerbellMachineConfig(arg0 context.Context, arg1, arg2, arg3 string) ([]*v1alpha1.TinkerbellMachineConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchTinkerbellMachineConfig", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]*v1alpha1.TinkerbellMachineConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchTinkerbellMachineConfig indicates an expected call of SearchTinkerbellMachineConfig.
+func (mr *MockProviderKubectlClientMockRecorder) SearchTinkerbellMachineConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchTinkerbellMachineConfig", reflect.TypeOf((*MockProviderKubectlClient)(nil).SearchTinkerbellMachineConfig), arg0, arg1, arg2, arg3)
+}
+
 // UpdateAnnotation mocks base method.
 func (m *MockProviderKubectlClient) UpdateAnnotation(arg0 context.Context, arg1, arg2 string, arg3 map[string]string, arg4 ...executables.KubectlOpt) error {
 	m.ctrl.T.Helper()

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -85,6 +85,8 @@ type ProviderKubectlClient interface {
 	GetUnprovisionedTinkerbellHardware(_ context.Context, kubeconfig, namespace string) ([]tinkv1alpha1.Hardware, error)
 	GetProvisionedTinkerbellHardware(_ context.Context, kubeconfig, namespace string) ([]tinkv1alpha1.Hardware, error)
 	WaitForBaseboardManagements(ctx context.Context, cluster *types.Cluster, timeout string, condition string, namespace string) error
+	SearchTinkerbellMachineConfig(ctx context.Context, name string, kubeconfigFile string, namespace string) ([]*v1alpha1.TinkerbellMachineConfig, error)
+	SearchTinkerbellDatacenterConfig(ctx context.Context, name string, kubeconfigFile string, namespace string) ([]*v1alpha1.TinkerbellDatacenterConfig, error)
 }
 
 // KeyGenerator generates ssh keys and writes them to a FileWriter.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently a user can only create a management cluster for the provider Tinkerbell. This PR will add creating workload cluster from management cluster functionality for Tinkerbell. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

