### PR TITLE
bugfix(Makefile): adds a missing '\'

### DIFF
--- a/scripts/go-packages-in-patch.sh
+++ b/scripts/go-packages-in-patch.sh
@@ -25,7 +25,7 @@ ref="$(awsRemote)/main"
     | xargs -r -n1 dirname \
     | sort \
     | uniq \
-    | sed -e 's,^,./,'
+    | sed -e 's,^,./,' \
     | tr '\n' ' '
 
 echo


### PR DESCRIPTION
My ability to somehow miss these things today is amazing. At least to me.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

