### PR TITLE
Adding check before bmc wait

### DIFF
--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -110,7 +110,7 @@ func (p *Provider) PostWorkloadInit(ctx context.Context, cluster *types.Cluster,
 
 func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpec *cluster.Spec) error {
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
-		return ErrExternalEtcdUnsupported
+		return errExternalEtcdUnsupported
 	}
 
 	if err := p.stackInstaller.CleanupLocalBoots(ctx, p.forceCleanup); err != nil {

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -70,9 +70,11 @@ func (p *Provider) PostBootstrapSetup(ctx context.Context, clusterConfig *v1alph
 	if err != nil {
 		return fmt.Errorf("applying hardware yaml: %v", err)
 	}
-	err = p.providerKubectlClient.WaitForBaseboardManagements(ctx, cluster, "5m", "Contactable", constants.EksaSystemNamespace)
-	if err != nil {
-		return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
+	if len(p.catalogue.AllBMCs()) > 0 {
+		err = p.providerKubectlClient.WaitForBaseboardManagements(ctx, cluster, "5m", "Contactable", constants.EksaSystemNamespace)
+		if err != nil {
+			return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
+		}
 	}
 	return nil
 }

--- a/pkg/providers/tinkerbell/testdata/hardware_nobmc.csv
+++ b/pkg/providers/tinkerbell/testdata/hardware_nobmc.csv
@@ -1,0 +1,5 @@
+hostname,mac,ip_address,netmask,gateway,nameservers,labels,disk
+worker1,00:00:00:00:00:01,10.10.10.10,255.255.255.0,10.10.10.1,1.1.1.1,type=cp,/dev/sda
+worker2,00:00:00:00:00:02,10.10.10.11,255.255.255.0,10.10.10.1,1.1.1.1,type=worker,/dev/sda
+worker3,00:00:00:00:00:03,10.10.10.12,255.255.255.0,10.10.10.1,1.1.1.1,type=etcd,/dev/sda
+worker4,00:00:00:00:00:04,10.10.10.13,255.255.255.0,10.10.10.1,1.1.1.1,type=cp,/dev/sda

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -33,14 +33,16 @@ const (
 	maxSurgeForRollingUpgrade = 1
 )
 
-// ErrExternalEtcdUnsupported is returned from create or update when the user attempts to create
-// or upgrade a cluster with an external etcd configuration.
-var ErrExternalEtcdUnsupported = errors.New("external etcd configuration is unsupported")
-
 var (
 	eksaTinkerbellDatacenterResourceType = fmt.Sprintf("tinkerbelldatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaTinkerbellMachineResourceType    = fmt.Sprintf("tinkerbellmachineconfigs.%s", v1alpha1.GroupVersion.Group)
 	tinkerbellStackPorts                 = []int{42113, 50051, 50061}
+
+	// errExternalEtcdUnsupported is returned from create or update when the user attempts to create
+	// or upgrade a cluster with an external etcd configuration.
+	errExternalEtcdUnsupported = errors.New("external etcd configuration is unsupported")
+	// errKubectlWaitNoResources is returned from kubectl wait when the resource is not found on the cluster.
+	errKubectlWaitNoResources = errors.New("executing wait: error: no matching resources found\n")
 )
 
 type Provider struct {

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -41,8 +41,6 @@ var (
 	// errExternalEtcdUnsupported is returned from create or update when the user attempts to create
 	// or upgrade a cluster with an external etcd configuration.
 	errExternalEtcdUnsupported = errors.New("external etcd configuration is unsupported")
-	// errKubectlWaitNoResources is returned from kubectl wait when the resource is not found on the cluster.
-	errKubectlWaitNoResources = errors.New("executing wait: error: no matching resources found\n")
 )
 
 type Provider struct {

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -442,10 +442,11 @@ func TestPostMoveManagementToBootstrapSuccess(t *testing.T) {
 	tt := []struct {
 		name     string
 		gotError error
-	}{{
-		name:     "wait returns no error",
-		gotError: nil,
-	},
+	}{
+		{
+			name:     "wait returns no error",
+			gotError: nil,
+		},
 		{
 			name:     "wait returns no resources error",
 			gotError: errKubectlWaitNoResources,

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -185,9 +185,11 @@ func (p *Provider) PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig 
 }
 
 func (p *Provider) PostMoveManagementToBootstrap(ctx context.Context, bootstrapCluster *types.Cluster) error {
-	// Waiting to ensure all the new and exisiting baseboardmanagement connections are valid.
-	if err := p.providerKubectlClient.WaitForBaseboardManagements(ctx, bootstrapCluster, "5m", "Contactable", constants.EksaSystemNamespace); err != nil {
-		return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
+	if len(p.catalogue.AllBMCs()) > 0 {
+		// Waiting to ensure all the new and exisiting baseboardmanagement connections are valid.
+		if err := p.providerKubectlClient.WaitForBaseboardManagements(ctx, bootstrapCluster, "5m", "Contactable", constants.EksaSystemNamespace); err != nil {
+			return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
*Description of changes:*
The changes add a check to only call `kubectl wait` if there are bmcs in the catalogue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

