### PR TITLE
bugfix: strip status information for proper package id

### DIFF
--- a/scripts/go-packages-in-patch.sh
+++ b/scripts/go-packages-in-patch.sh
@@ -20,7 +20,7 @@ ref="$(awsRemote)/main"
 {
     set +e
     git diff --stat --name-only "$ref...HEAD"
-    git status --short
+    git status --untracked-files=normal --short | awk '{ print $NF }'
 } | grep ._test\.go \
     | xargs -r -n1 dirname \
     | sort \


### PR DESCRIPTION
When git status retrieved info, in some cases, it could include the status of a file, e.g. "added" or "modified". Stripping that off ensures that just the filename is reported and can be matched to the proper Go package for use in the unit-test-patch target (and friends).

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

