### PR TITLE
local registry e2e test change - added port to the cluster config

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -173,12 +173,13 @@ func WithProxyConfig(httpProxy, httpsProxy string, noProxy []string) ClusterFill
 	}
 }
 
-func WithRegistryMirror(endpoint, caCert string) ClusterFiller {
+func WithRegistryMirror(endpoint, port string, caCert string) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		if c.Spec.RegistryMirrorConfiguration == nil {
 			c.Spec.RegistryMirrorConfiguration = &anywherev1.RegistryMirrorConfiguration{}
 		}
 		c.Spec.RegistryMirrorConfiguration.Endpoint = endpoint
+		c.Spec.RegistryMirrorConfiguration.Port = port
 		c.Spec.RegistryMirrorConfiguration.CACertContent = caCert
 	}
 }

--- a/test/framework/registryMirror.go
+++ b/test/framework/registryMirror.go
@@ -31,6 +31,7 @@ var (
 func WithRegistryMirrorEndpointAndCert(providerName string) ClusterE2ETestOpt {
 	return func(e *ClusterE2ETest) {
 		var endpoint, hostPort, username, password, registryCert string
+		port := "443"
 
 		switch providerName {
 		case constants.TinkerbellProviderName:
@@ -40,6 +41,9 @@ func WithRegistryMirrorEndpointAndCert(providerName string) ClusterE2ETestOpt {
 			username = os.Getenv(RegistryUsernameTinkerbellVar)
 			password = os.Getenv(RegistryPasswordTinkerbellVar)
 			registryCert = os.Getenv(RegistryCACertTinkerbellVar)
+			if os.Getenv(RegistryPortTinkerbellVar) != "" {
+				port = os.Getenv(RegistryPortTinkerbellVar)
+			}
 		default:
 			checkRequiredEnvVars(e.T, registryMirrorRequiredEnvVars)
 			endpoint = os.Getenv(RegistryEndpointVar)
@@ -47,6 +51,9 @@ func WithRegistryMirrorEndpointAndCert(providerName string) ClusterE2ETestOpt {
 			username = os.Getenv(RegistryUsernameVar)
 			password = os.Getenv(RegistryPasswordVar)
 			registryCert = os.Getenv(RegistryCACertVar)
+			if os.Getenv(RegistryPortVar) != "" {
+				port = os.Getenv(RegistryPortVar)
+			}
 		}
 
 		err := buildDocker(e.T).Login(context.Background(), hostPort, username, password)
@@ -56,7 +63,7 @@ func WithRegistryMirrorEndpointAndCert(providerName string) ClusterE2ETestOpt {
 		certificate, err := base64.StdEncoding.DecodeString(registryCert)
 		if err == nil {
 			e.clusterFillers = append(e.clusterFillers,
-				api.WithRegistryMirror(endpoint, string(certificate)),
+				api.WithRegistryMirror(endpoint, port, string(certificate)),
 			)
 		}
 		// Set env vars for helm login/push


### PR DESCRIPTION
*Description of changes:*
Added port to the local registry cluster config file for e2e tests. It now creates certificate in the /etc/docker/certs.d file which is needed for baremetal e2e cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

