### PR TITLE
Fix metadata urls for bottlerocket

### DIFF
--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
@@ -13,7 +13,8 @@ func TestWithDefaultActionsFromBundle(t *testing.T) {
 	vBundle := givenVersionBundle()
 	tinkerbellLocalIp := "127.0.0.1"
 	tinkerbellLBIP := "1.2.3.4"
-	metadataString := fmt.Sprintf("'http://%s:50061','http://%s:50061'", tinkerbellLocalIp, tinkerbellLBIP)
+	metadataString := fmt.Sprintf("http://%s:50061,http://%s:50061", tinkerbellLocalIp, tinkerbellLBIP)
+	rhelMetadataString := fmt.Sprintf("'http://%s:50061','http://%s:50061'", tinkerbellLocalIp, tinkerbellLBIP)
 	cloudInit := `datasource:
   Ec2:
     metadata_urls: [%s]
@@ -228,7 +229,7 @@ warnings:
 						"DEST_DISK": "/dev/sda1",
 						"FS_TYPE":   "ext4",
 						"DEST_PATH": "/etc/cloud/cloud.cfg.d/10_tinkerbell.cfg",
-						"CONTENTS":  fmt.Sprintf(cloudInit, metadataString),
+						"CONTENTS":  fmt.Sprintf(cloudInit, rhelMetadataString),
 						"UID":       "0",
 						"GID":       "0",
 						"MODE":      "0600",

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml
@@ -184,7 +184,7 @@ spec:
               CONTENTS: |
                 datasource:
                   Ec2:
-                    metadata_urls: ['http://5.6.7.8:50061','http://5.6.7.8:50061']
+                    metadata_urls: [http://5.6.7.8:50061,http://5.6.7.8:50061]
                     strict_id: false
                 manage_etc_hosts: localhost
                 warnings:


### PR DESCRIPTION
*Description of changes:*
Fixes `metadataUrls` for Bottlerocket for baremetal cluster creation

Currently, we are putting quotes around the metadata URLs (`'http://1.2.3.4:50061'`) because RHEL expects it.
But adding the quotes breaks the metadata url parsing for Bottlerocket. 
With this change, the quotes are conditionally added only to RHEL since that's the only OS that expects it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

