### PR TITLE
Bugfix: Ensure `nutanixInsecure` is always set

### DIFF
--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -138,10 +138,7 @@ func buildTemplateMapCP(
 		"nutanixPEClusterName":         controlPlaneMachineSpec.Cluster.Name, // TODO(nutanix): pass name or uuid based on type of identifier
 		"subnetName":                   controlPlaneMachineSpec.Subnet.Name,  // TODO(nutanix): pass name or uuid based on type of identifier
 	}
-
-	if datacenterSpec.AdditionalTrustBundle != "" {
-		values["nutanixInsecure"] = true
-	}
+	values["nutanixInsecure"] = datacenterSpec.AdditionalTrustBundle != ""
 
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		values["externalEtcd"] = true


### PR DESCRIPTION
This is to ensure that the underlying yaml manifests get populated with the correct true/false value regardless of whether a trust bundle is present or not. Earlier the manifest would show up as `no data` in case of the trust bundle was not provided.