### PR TITLE
Enable linters: cyclo comp, docs and naked returns

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
   pull_request:
+permissions:
+  contents: read
+  pull-requests: read
 jobs:
   golangci:
     name: lint
@@ -21,3 +24,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.0
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,10 @@ linters:
   enable:
     - gofumpt
     - gci
+    - godot
+    - nakedret
+    - gocyclo
+    - revive
 linters-settings:
   gci:
     sections:
@@ -18,6 +22,22 @@ linters-settings:
       - prefix(github.com/aws/eks-anywhere)
     custom-order: true
     skip-generated: false
+  godot:
+    exclude:
+      # Exclude todo comments.
+      - "(?i)^\\s*todo"
+    period: true
+    capital: true
+  nakedret:
+    # never allow naked returns
+    max-func-lines: 0
+  gocyclo:
+    # Minimal code complexity to report.
+    min-complexity: 10
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0
+  include:
+    - EXC0012  # EXC0012 revive: exported (.+) should have comment( \(or a comment on this block\))? or be unexported
+    - EXC0014  # EXC0014 revive: comment on exported (.+) should be of the form "(.+)..."
+    - EXC0009  # EXC0009 revive: (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)

--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ $(SETUP_ENVTEST): $(TOOLS_BIN_DIR)
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Run golangci-lint
-	$(GOLANGCI_LINT) run
+	$(GOLANGCI_LINT) run --new-from-rev main
 
 $(GOLANGCI_LINT): $(TOOLS_BIN_DIR) $(GOLANGCI_LINT_CONFIG)
 	$(eval GOLANGCI_LINT_VERSION?=$(shell cat .github/workflows/golangci-lint.yml | yq e '.jobs.golangci.steps[] | select(.name == "golangci-lint") .with.version' -))


### PR DESCRIPTION
## Description of changes

### Rules being enforced
* All exported package members need a doc comment
* Doc comments should start with capital letter and end with a period
* Minimum permissions for new created directories and files
* No naked returns
* Avoid method with high cyclomatic complexity. We are starting with a limit of 10, which is the most strict config in the recommended range 10-20. We’ll start here and we’ll make it less restrictive as we go if we see need.


### Linters
* `revive`: replacement for the deprecated golint. Enabled 3 issues that are disabled by default for exported member comments and file/dir permissions. We used to run `golint`, but then it got deprecated and dropped from golangci-lint. This means we have a bunch of issues in the code we wrote in between then and now. We should try to fix those over time.
* godot: checks that exported member comments start with upper case and end with a period (".").
* `nakedret`: forbids naked returns.
* `gocyclo`: measures cyclomatic complexity of functions. Restricted to a max of 10. Recommended is 10-20. This requisite can be lowered down if we find it to restrictive.

Now the linters only run in the diff between the current code and main. This means it will only trigger issues for infringent new code. We should strive to fix all old ocurrences if possible and add exceptions for the rest. so we can renable a full repo scan.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

