### PR TITLE
now passing recently made mandatory parameter named cluster

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -907,6 +907,7 @@ func (e *ClusterE2ETest) InstallCuratedPackage(packageName, packagePrefix string
 		"install", "package", packageName,
 		"--source=cluster",
 		"--package-name=" + packagePrefix, "-v=9",
+		"--cluster=" + e.ClusterName,
 		strings.Join(opts, " "),
 	})
 }


### PR DESCRIPTION
ref: https://github.com/aws/eks-anywhere/pull/3479

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*
before the change
<pre>
2022-10-12T11:02:15.777-0700	V6	Executing command	{"cmd": "/usr/local/bin/docker rm -f -v eksa_1665597120452455000"}
    cluster.go:675: Running shell command [ bin/eksctl-anywhere install package hello-eks-anywhere --source=cluster --package-name=test -v=9 --kubeconfig=eksa-test-33c83fb/eksa-test-33c83fb-eks-a-cluster.kubeconfig  ]
2022-10-12T11:02:16.088-0700	V4	Logger init completed	{"vlevel": 9}
Error: required flag(s) "cluster" not set
    cluster.go:712: Command bin/eksctl-anywhere [install package hello-eks-anywhere --source=cluster --package-name=test -v=9 --kubeconfig=eksa-test-33c83fb/eksa-test-33c83fb-eks-a-cluster.kubeconfig ] failed with error: exit status 255: Error: required flag(s) "cluster" not set
    cluster.go:675: Running shell command [ bin/eksctl-anywhere delete cluster eksa-test-33c83fb -v 10 --bundles-override bin/local-bundle-release.yaml ]
</pre>

after the change
<pre>
2022-10-12T11:30:10.970-0700	V6	Executing command	{"cmd": "/usr/local/bin/docker rm -f -v eksa_1665598755868127000"}
    cluster.go:675: Running shell command [ bin/eksctl-anywhere install package hello-eks-anywhere --source=cluster --package-name=test -v=9 --cluster=eksa-test-33c83fb  ]
</pre>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

