### PR TITLE
Add placeholder files for CloudStack docs

### DIFF
--- a/docs/content/en/docs/getting-started/production-environment/cloudstack-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/cloudstack-getstarted.md
@@ -1,0 +1,8 @@
+---
+title: "Create CloudStack production cluster" 
+linkTitle: "CloudStack cluster" 
+weight: 40
+description: >
+  Create a production-quality cluster on CloudStack 
+---
+

--- a/docs/content/en/docs/reference/cloudstack/_index.md
+++ b/docs/content/en/docs/reference/cloudstack/_index.md
@@ -1,0 +1,7 @@
+---
+title: "ClusterStack"
+linkTitle: "ClusterStack"
+weight: 15
+description: >
+  Preparing a ClusterStack provider for EKS Anywhere
+---

--- a/docs/content/en/docs/reference/cloudstack/_index.md
+++ b/docs/content/en/docs/reference/cloudstack/_index.md
@@ -1,7 +1,7 @@
 ---
-title: "ClusterStack"
-linkTitle: "ClusterStack"
+title: "CloudStack"
+linkTitle: "CloudStack"
 weight: 15
 description: >
-  Preparing a ClusterStack provider for EKS Anywhere
+  Preparing a CloudStack provider for EKS Anywhere
 ---

--- a/docs/content/en/docs/reference/cloudstack/cloudstack-preparation.md
+++ b/docs/content/en/docs/reference/cloudstack/cloudstack-preparation.md
@@ -1,0 +1,7 @@
+---
+title: "Preparing CloudStack for EKS Anywhere"
+linkTitle: "Preparing CloudStack"
+weight: 20
+description: >
+  Set up a CloudStack cluster to prepare it for EKS Anywhere
+---

--- a/docs/content/en/docs/reference/cloudstack/cloudstack-prereq.md
+++ b/docs/content/en/docs/reference/cloudstack/cloudstack-prereq.md
@@ -1,7 +1,7 @@
 ---
-title: "Requirements for EKS Anywhere on ClusterStack"
+title: "Requirements for EKS Anywhere on CloudStack"
 linkTitle: "Requirements"
 weight: 15
 description: >
-  ClusterStack provider requirements for EKS Anywhere
+  CloudStack provider requirements for EKS Anywhere
 ---

--- a/docs/content/en/docs/reference/cloudstack/cloudstack-prereq.md
+++ b/docs/content/en/docs/reference/cloudstack/cloudstack-prereq.md
@@ -1,0 +1,7 @@
+---
+title: "Requirements for EKS Anywhere on ClusterStack"
+linkTitle: "Requirements"
+weight: 15
+description: >
+  ClusterStack provider requirements for EKS Anywhere
+---

--- a/docs/content/en/docs/reference/clusterspec/cloudstack.md
+++ b/docs/content/en/docs/reference/clusterspec/cloudstack.md
@@ -1,0 +1,8 @@
+---
+title: "CloudStack configuration"
+linkTitle: "CloudStack configuration"
+weight: 30
+description: >
+  Full EKS Anywhere configuration reference for a CloudStack cluster.
+---
+


### PR DESCRIPTION
*Issue #, if available:* [#3658](https://github.com/aws/eks-anywhere/issues/3658)

*Description of changes:*
Add placeholder files for CloudStack provider documentation. This allows us to begin adding links to the EKS-A CloudStack docs as those docs are being created, without breaking the docs build process.


