### PR TITLE
Handle kube-vip deployment in single-node cluster

### DIFF
--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -182,7 +182,13 @@ spec:
                 value: "2"
               - name: address
                 value: {{.controlPlaneEndpointIp}}
-              image: {{.kubeVipImage}}
+{{- if and (not .workerNodeGroupConfigurations) (not .skipLoadBalancerDeployment) }}
+                # kube-vip daemon in worker node watches for LoadBalancer services.
+                # When there is no worker node, make kube-vip in control-plane nodes watch
+              - name: svc_enable
+                value: "true"
+{{- end }}
+              image: {{ .kubeVipImage }}
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -95,7 +95,9 @@ func (p *Provider) PostWorkloadInit(ctx context.Context, cluster *types.Cluster,
 		stack.WithBootsOnKubernetes(),
 		stack.WithHostPortEnabled(false), // disable host port on workload cluster
 		stack.WithEnvoyEnabled(true),     // use envoy on workload cluster
-		stack.WithLoadBalancerEnabled(!p.datacenterConfig.Spec.SkipLoadBalancerDeployment), // configure load balancer based on datacenterConfig.Spec.SkipLoadBalancerDeployment
+		stack.WithLoadBalancerEnabled(
+			len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations) != 0 && // load balancer is handled by kube-vip in control plane nodes
+				!p.datacenterConfig.Spec.SkipLoadBalancerDeployment), // configure load balancer based on datacenterConfig.Spec.SkipLoadBalancerDeployment
 	)
 	if err != nil {
 		return fmt.Errorf("installing stack on workload cluster: %v", err)

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -98,7 +98,7 @@ func (tb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spe
 			return nil, fmt.Errorf("failed to get ETCD TinkerbellTemplateConfig: %v", err)
 		}
 	}
-	values := buildTemplateMapCP(clusterSpec, *tb.controlPlaneMachineSpec, etcdMachineSpec, cpTemplateString, etcdTemplateString)
+	values := buildTemplateMapCP(clusterSpec, *tb.controlPlaneMachineSpec, etcdMachineSpec, cpTemplateString, etcdTemplateString, *tb.datacenterSpec)
 
 	for _, buildOption := range buildOptions {
 		buildOption(values)
@@ -367,7 +367,7 @@ func machineDeploymentName(clusterName, nodeGroupName string) string {
 	return fmt.Sprintf("%s-%s", clusterName, nodeGroupName)
 }
 
-func buildTemplateMapCP(clusterSpec *cluster.Spec, controlPlaneMachineSpec, etcdMachineSpec v1alpha1.TinkerbellMachineConfigSpec, cpTemplateOverride, etcdTemplateOverride string) map[string]interface{} {
+func buildTemplateMapCP(clusterSpec *cluster.Spec, controlPlaneMachineSpec, etcdMachineSpec v1alpha1.TinkerbellMachineConfigSpec, cpTemplateOverride, etcdTemplateOverride string, datacenterSpec v1alpha1.TinkerbellDatacenterConfigSpec) map[string]interface{} {
 	bundle := clusterSpec.VersionsBundle
 	format := "cloud-config"
 
@@ -410,6 +410,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, controlPlaneMachineSpec, etcd
 		"hardwareSelector":              controlPlaneMachineSpec.HardwareSelector,
 		"controlPlaneTaints":            clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints,
 		"workerNodeGroupConfigurations": clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations,
+		"skipLoadBalancerDeployment":    datacenterSpec.SkipLoadBalancerDeployment,
 	}
 
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_single_node_skip_lb.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_single_node_skip_lb.yaml
@@ -1,0 +1,52 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: single-node
+spec:
+  clusterNetwork:
+    cniConfig:
+      cilium: {}
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+    endpoint:
+      host: 1.2.3.4
+    machineGroupRef:
+      kind: TinkerbellMachineConfig
+      name: single-node-cp
+    taints: []
+  datacenterRef:
+    kind: TinkerbellDatacenterConfig
+    name: single-node
+  kubernetesVersion: "1.21"
+  managementCluster:
+    name: single-node
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellDatacenterConfig
+metadata:
+  name: single-node
+spec:
+  tinkerbellIP: "5.6.7.8"
+  osImageURL: "https://ubuntu.gz"
+  skipLoadBalancerDeployment: true
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellMachineConfig
+metadata:
+  name: single-node-cp
+spec:
+  hardwareSelector:
+    type: cp
+  osFamily: ubuntu
+  templateRef: {}
+  users:
+    - name: tink-user
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_skip_lb.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_skip_lb.yaml
@@ -95,10 +95,6 @@ spec:
                 value: "2"
               - name: address
                 value: 1.2.3.4
-                # kube-vip daemon in worker node watches for LoadBalancer services.
-                # When there is no worker node, make kube-vip in control-plane nodes watch
-              - name: svc_enable
-                value: "true"
               image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
               imagePullPolicy: IfNotPresent
               name: kube-vip

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -821,3 +821,39 @@ func TestProviderGenerateDeploymentFileForSingleNodeCluster(t *testing.T) {
 	}
 	test.AssertContentToFile(t, string(cp), "testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml")
 }
+
+func TestProviderGenerateDeploymentFileForSingleNodeClusterSkipLB(t *testing.T) {
+	clusterSpecManifest := "cluster_tinkerbell_single_node_skip_lb.yaml"
+	mockCtrl := gomock.NewController(t)
+	docker := stackmocks.NewMockDocker(mockCtrl)
+	helm := stackmocks.NewMockHelm(mockCtrl)
+	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	stackInstaller := stackmocks.NewMockStackInstaller(mockCtrl)
+	writer := filewritermocks.NewMockFileWriter(mockCtrl)
+	cluster := &types.Cluster{Name: "test"}
+	forceCleanup := false
+
+	clusterSpec := givenClusterSpec(t, clusterSpecManifest)
+	datacenterConfig := givenDatacenterConfig(t, clusterSpecManifest)
+	machineConfigs := givenMachineConfigs(t, clusterSpecManifest)
+	ctx := context.Background()
+
+	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl, forceCleanup)
+	provider.stackInstaller = stackInstaller
+
+	stackInstaller.EXPECT().CleanupLocalBoots(ctx, forceCleanup)
+
+	if err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec); err != nil {
+		t.Fatalf("failed to setup and validate: %v", err)
+	}
+
+	cp, md, err := provider.GenerateCAPISpecForCreate(context.Background(), cluster, clusterSpec)
+	if err != nil {
+		t.Fatalf("failed to generate cluster api spec contents: %v", err)
+	}
+
+	if len(md) != 0 {
+		t.Fatalf("expect nothing to be generated for worker node")
+	}
+	test.AssertContentToFile(t, string(cp), "testdata/expected_results_cluster_tinkerbell_cp_single_node_skip_lb.yaml")
+}


### PR DESCRIPTION
*Issue #, if available:* Services can be exposed as LoadBalancer type supported by kube-vip. But in single-node cluster, kube-vip daemonset cannot be deployed correctly as it has to run in controlplane nodes. So we need this adjustment, to let the kube-vip daemonset of cp nodes to handle LoadBalancer services.

*Description of changes:*

*Testing (if applicable):* 
1. Unit test
2. Manual tested SkipLoadBalancerDeployment on single-node cluster, when the field is set to false/true

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

