### PR TITLE
Invalid hardware.csv message

### DIFF
--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -185,12 +185,7 @@ func (p *Provider) readCSVToCatalogue() error {
 		return err
 	}
 
-	csvErr := hardware.TranslateAll(machines, writer, machineValidator)
-	if csvErr != nil {
-		return fmt.Errorf("hardware.csv is not correct: %v", csvErr)
-	}
-
-	return csvErr
+	return hardware.TranslateAll(machines, writer, machineValidator)
 }
 
 // selectorsFromMachineConfigs extracts all selectors from TinkerbellMachineConfigs returning them

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -185,7 +185,12 @@ func (p *Provider) readCSVToCatalogue() error {
 		return err
 	}
 
-	return hardware.TranslateAll(machines, writer, machineValidator)
+	csvErr := hardware.TranslateAll(machines, writer, machineValidator)
+	if csvErr != nil {
+		return fmt.Errorf("hardware.csv is not correct: %v", csvErr)
+	}
+
+	return csvErr
 }
 
 // selectorsFromMachineConfigs extracts all selectors from TinkerbellMachineConfigs returning them

--- a/pkg/providers/tinkerbell/hardware/translate.go
+++ b/pkg/providers/tinkerbell/hardware/translate.go
@@ -45,7 +45,7 @@ func Translate(reader MachineReader, writer MachineWriter, validator MachineVali
 	}
 
 	if err != nil {
-		return fmt.Errorf("read: %v", err)
+		return fmt.Errorf("hardware.csv is not correct: read: %v", err)
 	}
 
 	if err := validator.Validate(machine); err != nil {

--- a/pkg/providers/tinkerbell/hardware/translate.go
+++ b/pkg/providers/tinkerbell/hardware/translate.go
@@ -45,7 +45,7 @@ func Translate(reader MachineReader, writer MachineWriter, validator MachineVali
 	}
 
 	if err != nil {
-		return fmt.Errorf("hardware.csv is not correct: read: %v", err)
+		return fmt.Errorf("read: invalid hardware: %v", err)
 	}
 
 	if err := validator.Validate(machine); err != nil {


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:*
When running `eksctl anywhere create cluster --hardware-csv hardware.csv -f eksa-single-node-cluster.yaml -v` and there is an issue with hardware.csv, it will now tell you that "hardware.csv is not correct" along with the specific problem whereas before it would just say the problem.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

