### PR TITLE
Make audit policy apiVersion dynamic based on k8s version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.3
+	k8s.io/apiserver v0.24.2
 	k8s.io/client-go v0.24.2
 	oras.land/oras-go v1.2.0
 	sigs.k8s.io/cluster-api v1.1.3

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -3,6 +3,7 @@ package cloudstack
 import (
 	"context"
 	"embed"
+	_ "embed"
 	"encoding/base64"
 	"errors"
 	"fmt"

--- a/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
@@ -186,7 +186,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -186,7 +186,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
@@ -185,7 +185,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
@@ -174,7 +174,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_minimal_cp.yaml
@@ -168,7 +168,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_minimal_proxy_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_minimal_proxy_cp.yaml
@@ -168,7 +168,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
@@ -172,7 +172,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -172,7 +172,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
@@ -186,7 +186,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/common/auditpolicy.go
+++ b/pkg/providers/common/auditpolicy.go
@@ -1,0 +1,314 @@
+package common
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/semver"
+)
+
+// GetAuditPolicy returns the audit policy either v1 or v1beta1 depending on kube version.
+func GetAuditPolicy(kubeVersion v1alpha1.KubernetesVersion) (string, error) {
+	// appending the ".0" as the patch version to have a valid semver string and use those semvers for comparison
+	kubeVersionSemver, err := semver.New(string(kubeVersion) + ".0")
+	if err != nil {
+		return "", fmt.Errorf("error converting kubeVersion %v to semver %v", kubeVersion, err)
+	}
+
+	kube124Semver, err := semver.New(string(v1alpha1.Kube124) + ".0")
+	if err != nil {
+		return "", fmt.Errorf("error converting kubeVersion %v to semver %v", kube124Semver, err)
+	}
+
+	if kubeVersionSemver.Compare(kube124Semver) != -1 {
+		auditPolicyv1, err := AuditPolicyV1Yaml()
+		if err != nil {
+			return "", err
+		}
+		return string(auditPolicyv1), nil
+	}
+	return auditPolicy, nil
+}
+
+// AuditPolicyV1Yaml returns the byte array for yaml created with v1 api version for audit policy.
+func AuditPolicyV1Yaml() ([]byte, error) {
+	auditPolicy := AuditPolicyV1()
+	return yaml.Marshal(auditPolicy)
+}
+
+// AuditPolicyV1 returns the v1 audit policy.
+func AuditPolicyV1() *auditv1.Policy {
+	return &auditv1.Policy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Policy",
+			APIVersion: "audit.k8s.io/v1",
+		},
+		Rules: []auditv1.PolicyRule{
+			{
+				Level: auditv1.Level("RequestResponse"),
+				Verbs: []string{
+					"update",
+					"patch",
+					"delete",
+				},
+				Resources: []auditv1.GroupResources{
+					{
+						Resources: []string{
+							"configmaps",
+						},
+						ResourceNames: []string{
+							"aws-auth",
+						},
+					},
+				},
+				OmitStages: []auditv1.Stage{
+					"RequestReceived",
+				},
+				Namespaces: []string{"kube-system"},
+			},
+			{
+				Level: auditv1.Level("None"),
+				Users: []string{"system:kube-proxy"},
+				Verbs: []string{"watch"},
+				Resources: []auditv1.GroupResources{
+					{
+						Resources: []string{
+							"endpoints",
+							"services",
+							"services/status",
+						},
+					},
+				},
+			},
+			{
+				Level: auditv1.Level("None"),
+				Users: []string{"kubelet"},
+				Verbs: []string{"get"},
+				Resources: []auditv1.GroupResources{
+					{
+						Resources: []string{
+							"nodes",
+							"nodes/status",
+						},
+					},
+				},
+			},
+			{
+				Level: auditv1.Level("None"),
+				Verbs: []string{"get"},
+				Resources: []auditv1.GroupResources{
+					{
+						Resources: []string{
+							"nodes",
+							"nodes/status",
+						},
+					},
+				},
+			},
+			{
+				Level: auditv1.Level("None"),
+				Users: []string{
+					"system:kube-controller-manager",
+					"system:kube-scheduler",
+					"system:serviceaccount:kube-system:endpoint-controller",
+				},
+				Verbs: []string{
+					"get",
+					"update",
+				},
+				Resources: []auditv1.GroupResources{
+					{
+						Resources: []string{"endpoints"},
+					},
+				},
+				Namespaces: []string{"kube-system"},
+			},
+			{
+				Level: auditv1.Level("None"),
+				Users: []string{"system:apiserver"},
+				Verbs: []string{"get"},
+				Resources: []auditv1.GroupResources{
+					{
+						Resources: []string{
+							"namespaces",
+							"namespaces/status",
+							"namespaces/finalize",
+						},
+					},
+				},
+			},
+			{
+				Level: auditv1.Level("None"),
+				Users: []string{"system:kube-controller-manager"},
+				Verbs: []string{
+					"get",
+					"list",
+				},
+				Resources: []auditv1.GroupResources{
+					{
+						Group: "metrics.k8s.io",
+					},
+				},
+			},
+			{
+				Level: auditv1.Level("None"),
+				NonResourceURLs: []string{
+					"/healthz*",
+					"/version",
+					"/swagger*",
+				},
+			},
+			{
+				Level: auditv1.Level("None"),
+				Resources: []auditv1.GroupResources{
+					{
+						Resources: []string{"events"},
+					},
+				},
+			},
+			{
+				Level: auditv1.Level("Request"),
+				Users: []string{
+					"kubelet",
+					"system:node-problem-detector",
+					"system:serviceaccount:kube-system:node-problem-detector",
+				},
+				Verbs: []string{
+					"update",
+					"patch",
+				},
+				Resources: []auditv1.GroupResources{
+					{
+						Resources: []string{
+							"nodes/status",
+							"pods/status",
+						},
+					},
+				},
+				OmitStages: []auditv1.Stage{
+					"RequestReceived",
+				},
+			},
+			{
+				Level: auditv1.Level("Request"),
+				Verbs: []string{
+					"update",
+					"patch",
+				},
+				Resources: []auditv1.GroupResources{
+					{
+						Resources: []string{
+							"nodes/status",
+							"pods/status",
+						},
+					},
+				},
+				OmitStages: []auditv1.Stage{
+					"RequestReceived",
+				},
+				UserGroups: []string{
+					"system:nodes",
+				},
+			},
+			{
+				Level: auditv1.Level("Request"),
+				Users: []string{"system:serviceaccount:kube-system:namespace-controller"},
+				Verbs: []string{"deletecollection"},
+				OmitStages: []auditv1.Stage{
+					"RequestReceived",
+				},
+			},
+			{
+				Level: auditv1.Level("Metadata"),
+				Resources: []auditv1.GroupResources{
+					{Resources: []string{
+						"secrets",
+						"configmaps",
+					}},
+					{
+						Group:     "authentication.k8s.io",
+						Resources: []string{"tokenreviews"},
+					},
+				},
+				OmitStages: []auditv1.Stage{
+					"RequestReceived",
+				},
+			},
+			{
+				Level: auditv1.Level("Request"),
+				Resources: []auditv1.GroupResources{
+					{
+						Resources: []string{"serviceaccounts/token"},
+					},
+				},
+			},
+			{
+				Level: auditv1.Level("Request"),
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+				Resources: []auditv1.GroupResources{
+					{Group: ""},
+					{Group: "admissionregistration.k8s.io"},
+					{Group: "apiextensions.k8s.io"},
+					{Group: "apiregistration.k8s.io"},
+					{Group: "apps"},
+					{Group: "authentication.k8s.io"},
+					{Group: "authorization.k8s.io"},
+					{Group: "autoscaling"},
+					{Group: "batch"},
+					{Group: "certificates.k8s.io"},
+					{Group: "extensions"},
+					{Group: "metrics.k8s.io"},
+					{Group: "networking.k8s.io"},
+					{Group: "policy"},
+					{Group: "rbac.authorization.k8s.io"},
+					{Group: "scheduling.k8s.io"},
+					{Group: "settings.k8s.io"},
+					{Group: "storage.k8s.io"},
+				},
+				OmitStages: []auditv1.Stage{
+					"RequestReceived",
+				},
+			},
+			{
+				Level: auditv1.Level("RequestResponse"),
+				Resources: []auditv1.GroupResources{
+					{Group: ""},
+					{Group: "admissionregistration.k8s.io"},
+					{Group: "apiextensions.k8s.io"},
+					{Group: "apiregistration.k8s.io"},
+					{Group: "apps"},
+					{Group: "authentication.k8s.io"},
+					{Group: "authorization.k8s.io"},
+					{Group: "autoscaling"},
+					{Group: "batch"},
+					{Group: "certificates.k8s.io"},
+					{Group: "extensions"},
+					{Group: "metrics.k8s.io"},
+					{Group: "networking.k8s.io"},
+					{Group: "policy"},
+					{Group: "rbac.authorization.k8s.io"},
+					{Group: "scheduling.k8s.io"},
+					{Group: "settings.k8s.io"},
+					{Group: "storage.k8s.io"},
+				},
+				OmitStages: []auditv1.Stage{
+					"RequestReceived",
+				},
+			},
+			{
+				Level: auditv1.Level("Metadata"),
+				OmitStages: []auditv1.Stage{
+					"RequestReceived",
+				},
+			},
+		},
+	}
+}

--- a/pkg/providers/common/common.go
+++ b/pkg/providers/common/common.go
@@ -26,10 +26,6 @@ const (
 	publicKeyFileName  = "eks-a-id_rsa.pub"
 )
 
-func GetAuditPolicy() string {
-	return auditPolicy
-}
-
 func BootstrapClusterOpts(clusterConfig *v1alpha1.Cluster, serverEndpoints ...string) ([]bootstrapper.BootstrapClusterOption, error) {
 	env := map[string]string{}
 	if clusterConfig.Spec.ProxyConfiguration != nil {

--- a/pkg/providers/common/config/audit-policy.yaml
+++ b/pkg/providers/common/config/audit-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: audit.k8s.io/v1
+apiVersion: audit.k8s.io/v1beta1
 kind: Policy
 rules:
 # Log aws-auth configmap changes

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -151,7 +151,10 @@ type DockerTemplateBuilder struct {
 }
 
 func (d *DockerTemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spec, buildOptions ...providers.BuildMapOption) (content []byte, err error) {
-	values := buildTemplateMapCP(clusterSpec)
+	values, err := buildTemplateMapCP(clusterSpec)
+	if err != nil {
+		return nil, fmt.Errorf("error building template map from CP %v", err)
+	}
 	for _, buildOption := range buildOptions {
 		buildOption(values)
 	}
@@ -181,7 +184,7 @@ func (d *DockerTemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spe
 	return templater.AppendYamlResources(workerSpecs...), nil
 }
 
-func buildTemplateMapCP(clusterSpec *cluster.Spec) map[string]interface{} {
+func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, error) {
 	bundle := clusterSpec.VersionsBundle
 	etcdExtraArgs := clusterapi.SecureEtcdTlsCipherSuitesExtraArgs()
 	sharedExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs()
@@ -213,7 +216,6 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) map[string]interface{} {
 		"kubeletExtraArgs":           kubeletExtraArgs.ToPartialYaml(),
 		"externalEtcdVersion":        bundle.KubeDistro.EtcdVersion,
 		"eksaSystemNamespace":        constants.EksaSystemNamespace,
-		"auditPolicy":                common.GetAuditPolicy(),
 		"podCidrs":                   clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks,
 		"serviceCidrs":               clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks,
 		"haproxyImageRepository":     getHAProxyImageRepo(bundle.Haproxy.Image),
@@ -230,7 +232,13 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) map[string]interface{} {
 
 	values["controlPlaneTaints"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints
 
-	return values
+	auditPolicy, err := common.GetAuditPolicy(clusterSpec.Cluster.Spec.KubernetesVersion)
+	if err != nil {
+		return nil, err
+	}
+	values["auditPolicy"] = auditPolicy
+
+	return values, nil
 }
 
 func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration) map[string]interface{} {

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
@@ -114,7 +114,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
@@ -109,7 +109,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/no_machinetemplate_update_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/no_machinetemplate_update_cp_expected.yaml
@@ -102,7 +102,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
@@ -107,7 +107,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
@@ -108,7 +108,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/valid_deployment_cp_stacked_etcd_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_stacked_etcd_expected.yaml
@@ -102,7 +102,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
@@ -107,7 +107,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
@@ -107,7 +107,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
@@ -107,7 +107,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/validator/validate.go
+++ b/pkg/providers/validator/validate.go
@@ -20,7 +20,6 @@ func ValidateControlPlaneIpUniqueness(cluster *v1alpha1.Cluster, netClient netwo
 }
 
 func ValidateSupportedProviderCreate(provider providers.Provider) error {
-
 	if !features.IsActive(features.SnowProvider()) && provider.Name() == constants.SnowProviderName {
 		return fmt.Errorf("provider snow is not supported in this release")
 	}

--- a/pkg/providers/vsphere/template_test.go
+++ b/pkg/providers/vsphere/template_test.go
@@ -1,0 +1,110 @@
+package vsphere
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
+)
+
+func TestVsphereTemplateBuilderGenerateCAPISpecControlPlane(t *testing.T) {
+	type fields struct {
+		datacenterSpec          *v1alpha1.VSphereDatacenterConfigSpec
+		controlPlaneMachineSpec *v1alpha1.VSphereMachineConfigSpec
+	}
+
+	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Cluster.Name = "test-cluster"
+		s.Cluster.Spec.ControlPlaneConfiguration = v1alpha1.ControlPlaneConfiguration{
+			Count: 3,
+			Endpoint: &v1alpha1.Endpoint{
+				Host: "test-ip",
+			},
+			MachineGroupRef: &v1alpha1.Ref{
+				Kind: v1alpha1.VSphereMachineConfigKind,
+				Name: "eksa-unit-test",
+			},
+		}
+		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{
+			Name:  "md-0",
+			Count: ptr.Int(3),
+			MachineGroupRef: &v1alpha1.Ref{
+				Kind: v1alpha1.VSphereMachineConfigKind,
+				Name: "eksa-unit-test",
+			},
+		}}
+		s.Cluster.Spec.ClusterNetwork = v1alpha1.ClusterNetwork{
+			CNIConfig: &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{}},
+			Pods: v1alpha1.Pods{
+				CidrBlocks: []string{"192.168.0.0/16"},
+			},
+			Services: v1alpha1.Services{
+				CidrBlocks: []string{"10.96.0.0/12"},
+			},
+		}
+		s.Cluster.Spec.DatacenterRef = v1alpha1.Ref{
+			Kind: v1alpha1.VSphereDatacenterKind,
+			Name: "eksa-unit-test",
+		}
+		s.VSphereDatacenter = &v1alpha1.VSphereDatacenterConfig{
+			Spec: v1alpha1.VSphereDatacenterConfigSpec{
+				Datacenter: "test",
+				Network:    "test",
+				Server:     "test",
+			},
+		}
+		s.Cluster.Spec.DatacenterRef = v1alpha1.Ref{
+			Kind: v1alpha1.VSphereDatacenterKind,
+			Name: "vsphere test",
+		}
+	})
+
+	vsphereMachineConfig := &v1alpha1.VSphereMachineConfigSpec{
+		Users: []v1alpha1.UserConfiguration{
+			{
+				Name:              "capv",
+				SshAuthorizedKeys: []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=="},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		fields      fields
+		wantContent []byte
+		wantErr     error
+	}{
+		{
+			name: "kube version not specified",
+			fields: fields{
+				datacenterSpec:          &clusterSpec.VSphereDatacenter.Spec,
+				controlPlaneMachineSpec: vsphereMachineConfig,
+			},
+			wantErr: fmt.Errorf("error building template map from CP"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			vs := &VsphereTemplateBuilder{
+				datacenterSpec:          tt.fields.datacenterSpec,
+				controlPlaneMachineSpec: tt.fields.controlPlaneMachineSpec,
+			}
+			gotContent, err := vs.GenerateCAPISpecControlPlane(clusterSpec)
+			if err != tt.wantErr && !assert.Contains(t, err.Error(), tt.wantErr.Error()) {
+				t.Errorf("Got VsphereTemplateBuilder.GenerateCAPISpecControlPlane() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err == nil {
+				g.Expect(gotContent).NotTo(BeEmpty())
+			}
+		})
+	}
+}

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
@@ -199,7 +199,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
@@ -194,7 +194,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -212,7 +212,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
@@ -176,7 +176,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
@@ -168,7 +168,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_disable_csi_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_disable_csi_cp.yaml
@@ -168,7 +168,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
@@ -171,7 +171,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -173,7 +173,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -174,7 +174,7 @@ spec:
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
     - content: |
-        apiVersion: audit.k8s.io/v1
+        apiVersion: audit.k8s.io/v1beta1
         kind: Policy
         rules:
         # Log aws-auth configmap changes


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make audit policy apiVersion dynamic based on k8s version


In this PR we are keeping the previous yaml for audit policy with `v1beta1` policy for all versions before 1.24. for all the versions from 1.24 onwards (including 1.24) we will be using the go struct to use `v1` audit policy.

A WIP PR, all changes are not yet a part of this PR.
*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

