### PR TITLE
Added note on RHEL to bare metal docs

### DIFF
--- a/docs/content/en/docs/reference/baremetal/bare-preparation.md
+++ b/docs/content/en/docs/reference/baremetal/bare-preparation.md
@@ -16,7 +16,7 @@ Once the hardware is in place, you need to:
 * Obtain the gateway address for your network to reach the Internet.
 * Obtain the IP address for your DNS servers.
 * Make sure the following settings are in place:
-  * UEFI is enabled on all target cluster machines, unless you are provisioning RHEL systems. In that case, enable legacy BIOS.
+  * UEFI is enabled on all target cluster machines, unless you are provisioning RHEL systems. Enable legacy BIOS on any RHEL machines.
   * PXE boot is enabled for the NIC on each machine for which you provided the MAC address. This is the interface on which the operating system will be provisioned.
   * PXE is set as the first device in each machine's boot order
   * IPMI over LAN is enabled on the IPMI interfaces

--- a/docs/content/en/docs/reference/baremetal/bare-preparation.md
+++ b/docs/content/en/docs/reference/baremetal/bare-preparation.md
@@ -16,7 +16,7 @@ Once the hardware is in place, you need to:
 * Obtain the gateway address for your network to reach the Internet.
 * Obtain the IP address for your DNS servers.
 * Make sure the following settings are in place:
-  * UEFI is enabled on all target cluster machines
+  * UEFI is enabled on all target cluster machines, unless you are provisioning RHEL systems. In that case, enable legacy BIOS.
   * PXE boot is enabled for the NIC on each machine for which you provided the MAC address. This is the interface on which the operating system will be provisioned.
   * PXE is set as the first device in each machine's boot order
   * IPMI over LAN is enabled on the IPMI interfaces


### PR DESCRIPTION
*Description of changes:*

Using RHEL images for EKS-A bare metal clusters requires that legacy bios be enabled on those machines. This PR adds a note about that to the docs.
