### PR TITLE
Revert "Adding new test for detecting workload cluster rollingupgrade"

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -291,10 +291,6 @@ func (k *Kubectl) WaitForManagedExternalEtcdNotReady(ctx context.Context, cluste
 	return k.Wait(ctx, cluster.KubeconfigFile, timeout, "ManagedEtcdReady=false", fmt.Sprintf("clusters.%s/%s", clusterv1.GroupVersion.Group, newClusterName), constants.EksaSystemNamespace)
 }
 
-func (k *Kubectl) WaitForMachineDeploymentReady(ctx context.Context, cluster *types.Cluster, timeout string, machineDeploymentName string) error {
-	return k.Wait(ctx, cluster.KubeconfigFile, timeout, "Ready=true", fmt.Sprintf("machinedeployments.%s/%s", clusterv1.GroupVersion.Group, machineDeploymentName), constants.EksaSystemNamespace)
-}
-
 // WaitForService blocks until an IP address is assigned.
 //
 // Until more generic status matching comes around (possibly in 1.23), poll

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -606,9 +606,6 @@ func TestKubectlGetMachines(t *testing.T) {
 			jsonResponseFile: "testdata/kubectl_machines_no_node_ref_no_labels.json",
 			wantMachines: []types.Machine{
 				{
-					Metadata: types.MachineMetadata{
-						Name: "eksa-test-capd-control-plane-5nfdg",
-					},
 					Status: types.MachineStatus{
 						Conditions: types.Conditions{
 							{
@@ -651,9 +648,6 @@ func TestKubectlGetMachines(t *testing.T) {
 					},
 				},
 				{
-					Metadata: types.MachineMetadata{
-						Name: "eksa-test-capd-md-0-bb7885f6f-gkb85",
-					},
 					Status: types.MachineStatus{
 						Conditions: types.Conditions{
 							{
@@ -687,7 +681,6 @@ func TestKubectlGetMachines(t *testing.T) {
 							"cluster.x-k8s.io/cluster-name":  "eksa-test-capd",
 							"cluster.x-k8s.io/control-plane": "",
 						},
-						Name: "eksa-test-capd-control-plane-5nfdg",
 					},
 					Status: types.MachineStatus{
 						NodeRef: &types.ResourceRef{
@@ -704,7 +697,6 @@ func TestKubectlGetMachines(t *testing.T) {
 							"cluster.x-k8s.io/deployment-name": "eksa-test-capd-md-0",
 							"machine-template-hash":            "663441929",
 						},
-						Name: "eksa-test-capd-md-0-bb7885f6f-gkb85",
 					},
 					Status: types.MachineStatus{
 						NodeRef: &types.ResourceRef{
@@ -726,7 +718,6 @@ func TestKubectlGetMachines(t *testing.T) {
 							"cluster.x-k8s.io/cluster-name":  "eksa-test-capd",
 							"cluster.x-k8s.io/control-plane": "",
 						},
-						Name: "eksa-test-capd-control-plane-5nfdg",
 					},
 					Status: types.MachineStatus{
 						NodeRef: &types.ResourceRef{
@@ -781,7 +772,6 @@ func TestKubectlGetMachines(t *testing.T) {
 							"cluster.x-k8s.io/deployment-name": "eksa-test-capd-md-0",
 							"machine-template-hash":            "663441929",
 						},
-						Name: "eksa-test-capd-md-0-bb7885f6f-gkb85",
 					},
 					Status: types.MachineStatus{
 						NodeRef: &types.ResourceRef{
@@ -821,7 +811,6 @@ func TestKubectlGetMachines(t *testing.T) {
 							"cluster.x-k8s.io/cluster-name": "eksa-test-capd",
 							"cluster.x-k8s.io/etcd-cluster": "",
 						},
-						Name: "eksa-test-capd-control-plane-5nfdg",
 					},
 					Status: types.MachineStatus{
 						Conditions: types.Conditions{
@@ -2430,19 +2419,6 @@ func TestKubectlWaitForManagedExternalEtcdNotReady(t *testing.T) {
 	).Return(bytes.Buffer{}, nil)
 
 	tt.Expect(tt.k.WaitForManagedExternalEtcdNotReady(tt.ctx, tt.cluster, timeout, "test")).To(Succeed())
-}
-
-func TestKubectlWaitForMachineDeploymentReady(t *testing.T) {
-	tt := newKubectlTest(t)
-	timeout := "5m"
-	expectedTimeout := "300.00s"
-
-	tt.e.EXPECT().Execute(
-		tt.ctx,
-		"wait", "--timeout", expectedTimeout, "--for=condition=Ready=true", "machinedeployments.cluster.x-k8s.io/test", "--kubeconfig", tt.cluster.KubeconfigFile, "-n", "eksa-system",
-	).Return(bytes.Buffer{}, nil)
-
-	tt.Expect(tt.k.WaitForMachineDeploymentReady(tt.ctx, tt.cluster, timeout, "test")).To(Succeed())
 }
 
 func TestKubectlWaitForClusterReady(t *testing.T) {

--- a/pkg/types/resources.go
+++ b/pkg/types/resources.go
@@ -28,7 +28,6 @@ type MachineStatus struct {
 }
 
 type MachineMetadata struct {
-	Name   string            `json:"name,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/test/e2e/workload_clusters_test.go
+++ b/test/e2e/workload_clusters_test.go
@@ -4,13 +4,11 @@
 package e2e
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -36,48 +34,6 @@ func runWorkloadClusterFlowWithGitOps(test *framework.MulticlusterE2ETest, clust
 	})
 	time.Sleep(5 * time.Minute)
 	test.DeleteManagementCluster()
-}
-
-func runWorkloadClusterUpgradeFlowCheckWorkloadRollingUpgrade(test *framework.MulticlusterE2ETest, clusterOpts ...framework.ClusterE2ETestOpt) {
-	latest := latestMinorRelease(test.T)
-	test.CreateManagementClusterForVersion(latest.Version, framework.ExecuteWithEksaRelease(latest))
-	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
-		w.GenerateClusterConfigForVersion(latest.Version)
-		w.CreateCluster(framework.ExecuteWithEksaRelease(latest))
-	})
-	preUpgradeMachines := make(map[string]map[string]types.Machine, 0)
-	for key, workloadCluster := range test.WorkloadClusters {
-		test.T.Logf("Capturing CAPI machines for cluster %v", workloadCluster)
-		mdName := fmt.Sprintf("%s-%s", workloadCluster.ClusterName, "md-0")
-		test.ManagementCluster.WaitForMachineDeploymentReady(mdName)
-		preUpgradeMachines[key] = test.ManagementCluster.GetCapiMachinesForCluster(workloadCluster.ClusterName)
-	}
-	test.ManagementCluster.UpgradeCluster(clusterOpts)
-	test.T.Logf("Waiting for EKS-A controller to reconcile clusters")
-	time.Sleep(2 * time.Minute) // Time for new eks-a controller to kick in and potentially trigger rolling upgrade
-	for key, workloadCluster := range test.WorkloadClusters {
-		test.T.Logf("Capturing CAPI machines for cluster %v", workloadCluster)
-		postUpgradeMachines := test.ManagementCluster.GetCapiMachinesForCluster(workloadCluster.ClusterName)
-		if anyMachinesChanged(preUpgradeMachines[key], postUpgradeMachines) {
-			test.T.Fatalf("Found CAPI machines of workload cluster were changed after upgrading management cluster")
-		}
-	}
-	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
-		w.DeleteCluster()
-	})
-	test.DeleteManagementCluster()
-}
-
-func anyMachinesChanged(machineMap1 map[string]types.Machine, machineMap2 map[string]types.Machine) bool {
-	if len(machineMap1) != len(machineMap2) {
-		return true
-	}
-	for machineName := range machineMap1 {
-		if _, found := machineMap2[machineName]; !found {
-			return true
-		}
-	}
-	return false
 }
 
 func TestVSphereKubernetes121MulticlusterWorkloadCluster(t *testing.T) {
@@ -330,32 +286,4 @@ func TestCloudStackUpgradeMulticlusterWorkloadClusterWithFluxLegacy(t *testing.T
 			framework.UpdateRedhatTemplate121Var(),
 		),
 	)
-}
-
-func TestCloudStackKubernetes121ManagementClusterUpgradeFromLatest(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat121())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube121),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithEtcdCountIfExternal(1),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube121),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithEtcdCountIfExternal(1),
-			),
-		),
-	)
-	runWorkloadClusterUpgradeFlowCheckWorkloadRollingUpgrade(test)
 }

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -536,28 +536,6 @@ func (e *ClusterE2ETest) ValidateCluster(kubeVersion v1alpha1.KubernetesVersion)
 	}
 }
 
-func (e *ClusterE2ETest) WaitForMachineDeploymentReady(machineDeploymentName string) {
-	ctx := context.Background()
-	e.T.Logf("Waiting for machine deployment %s to be ready for cluster %s", machineDeploymentName, e.ClusterName)
-	err := e.KubectlClient.WaitForMachineDeploymentReady(ctx, e.cluster(), "5m", machineDeploymentName)
-	if err != nil {
-		e.T.Fatal(err)
-	}
-}
-
-func (e *ClusterE2ETest) GetCapiMachinesForCluster(clusterName string) map[string]types.Machine {
-	ctx := context.Background()
-	capiMachines, err := e.KubectlClient.GetMachines(ctx, e.cluster(), clusterName)
-	if err != nil {
-		e.T.Fatal(err)
-	}
-	machinesMap := make(map[string]types.Machine, 0)
-	for _, machine := range capiMachines {
-		machinesMap[machine.Metadata.Name] = machine
-	}
-	return machinesMap
-}
-
 func WithClusterUpgrade(fillers ...api.ClusterFiller) ClusterE2ETestOpt {
 	return func(e *ClusterE2ETest) {
 		e.ClusterConfigB = e.customizeClusterConfig(e.ClusterConfigLocation, fillers...)

--- a/test/framework/multicluster.go
+++ b/test/framework/multicluster.go
@@ -40,14 +40,9 @@ func (m *MulticlusterE2ETest) RunInWorkloadClusters(flow func(*WorkloadCluster))
 	}
 }
 
-func (m *MulticlusterE2ETest) CreateManagementClusterForVersion(eksaVersion string, opts ...CommandOpt) {
-	m.ManagementCluster.GenerateClusterConfigForVersion(eksaVersion)
-	m.ManagementCluster.CreateCluster(opts...)
-}
-
-func (m *MulticlusterE2ETest) CreateManagementCluster(opts ...CommandOpt) {
+func (m *MulticlusterE2ETest) CreateManagementCluster() {
 	m.ManagementCluster.GenerateClusterConfig()
-	m.ManagementCluster.CreateCluster(opts...)
+	m.ManagementCluster.CreateCluster()
 }
 
 func (m *MulticlusterE2ETest) DeleteManagementCluster() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This reverts commit 26480c33d215237199b3aa9814995a778f5f1a41.

The commit was causing the build to fail with error
```
# github.com/aws/eks-anywhere/test/e2e [github.com/aws/eks-anywhere/test/e2e.test]
test/e2e/workload_clusters_test.go:42:12: undefined: latestMinorRelease
make[1]: *** [e2e-tests-binary] Error 2
```

presumably due to a missing prerequisite change which introduced the `latestMinorRelease` function. This test itself is not necessary for this release branch and can be excluded from the branch.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

