### PR TITLE
Surface errors emitted by Helm push operation

### DIFF
--- a/release/pkg/assets/images/images_test.go
+++ b/release/pkg/assets/images/images_test.go
@@ -69,7 +69,7 @@ func TestGenerateImageAssets(t *testing.T) {
 			eksDReleaseChannel:  "1-21",
 			eksDReleaseNumber:   "8",
 			kubeVersion:         "1.21.9",
-			assetConfig: &assettypes.AssetConfig{},
+			assetConfig:         &assettypes.AssetConfig{},
 			image: &assettypes.Image{
 				RepoName: "bar",
 			},
@@ -95,7 +95,7 @@ func TestGenerateImageAssets(t *testing.T) {
 			eksDReleaseChannel:  "1-22",
 			eksDReleaseNumber:   "5",
 			kubeVersion:         "1.22.4",
-			assetConfig: &assettypes.AssetConfig{},
+			assetConfig:         &assettypes.AssetConfig{},
 			image: &assettypes.Image{
 				RepoName: "bar",
 			},
@@ -120,7 +120,7 @@ func TestGenerateImageAssets(t *testing.T) {
 			eksDReleaseChannel:  "1-21",
 			eksDReleaseNumber:   "8",
 			kubeVersion:         "1.21.9",
-			assetConfig: &assettypes.AssetConfig{},
+			assetConfig:         &assettypes.AssetConfig{},
 			image: &assettypes.Image{
 				RepoName:  "bar",
 				AssetName: "lorem-ipsum",
@@ -147,7 +147,7 @@ func TestGenerateImageAssets(t *testing.T) {
 			eksDReleaseChannel:  "1-21",
 			eksDReleaseNumber:   "8",
 			kubeVersion:         "1.21.9",
-			assetConfig: &assettypes.AssetConfig{},
+			assetConfig:         &assettypes.AssetConfig{},
 			image: &assettypes.Image{
 				RepoName:  "bar",
 				AssetName: "custom-bar",
@@ -178,7 +178,7 @@ func TestGenerateImageAssets(t *testing.T) {
 			eksDReleaseChannel:  "1-21",
 			eksDReleaseNumber:   "8",
 			kubeVersion:         "1.21.9",
-			assetConfig: &assettypes.AssetConfig{},
+			assetConfig:         &assettypes.AssetConfig{},
 			image: &assettypes.Image{
 				RepoName: "bar",
 			},

--- a/release/pkg/helm/helm.go
+++ b/release/pkg/helm/helm.go
@@ -151,7 +151,7 @@ func (d *helmDriver) PushHelmChart(packaged, URI string) error {
 	}
 	_, err := p.Run(packaged, URI)
 	if err != nil {
-		return fmt.Errorf("empty input for PushHelmChart, check flags")
+		return fmt.Errorf("running Helm push command on URI %s: %w", URI, err)
 	}
 	return nil
 }
@@ -208,7 +208,7 @@ func HasRequires(helmdir string) (string, error) {
 		return "", err
 	}
 	if info.IsDir() {
-		return "", fmt.Errorf("Found Dir, not requires.yaml file")
+		return "", fmt.Errorf("found Dir, not requires.yaml file")
 	}
 	return requires, nil
 }
@@ -253,7 +253,7 @@ func validateHelmRequiresName(helmrequires *Requires) error {
 func (helmrequires *Requires) validateHelmRequiresNotEmpty() error {
 	// Check if Projects are listed
 	if len(helmrequires.Spec.Images) < 1 {
-		return fmt.Errorf("Should use non-empty list of images for requires")
+		return fmt.Errorf("should use non-empty list of images for requires")
 	}
 	return nil
 }
@@ -274,7 +274,7 @@ func parseHelmRequires(fileName string, helmrequires *Requires) error {
 		}
 		return nil
 	}
-	return fmt.Errorf("Requires.yaml file [%s] is invalid or does not contain kind %v", fileName, helmrequires)
+	return fmt.Errorf("requires.yaml file [%s] is invalid or does not contain kind %v", fileName, helmrequires)
 }
 
 // Chart yaml functions
@@ -287,7 +287,7 @@ func HasChart(helmdir string) (string, error) {
 		return "", err
 	}
 	if info.IsDir() {
-		return "", fmt.Errorf("Found Dir, not Chart.yaml file")
+		return "", fmt.Errorf("found Dir, not Chart.yaml file")
 	}
 	return requires, nil
 }


### PR DESCRIPTION
We were dropping the errors from the Helm pusher's `Run` command, which shouldn't have been the case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

