### PR TITLE
Commiting the fix for validating ec2 username and key passed by user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ endif
 CUSTOM_GIT_VERSION:=v0.0.0-custom
 
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
+AWS_ACCOUNT_NAME?=$(shell aws sts get-caller-identity --query UserId --output text)
+EXPORT_ACCOUNT_NAME=$(shell echo $EKSA_AWS_ACCESS_KEY_ID)
+GET_USER_SECRET_KEY=$(shell aws secretsmanager get-secret-value --secret-id "$SECRET_ID" --query "SecretString" --output text)
+EXPORT_SECRET_KEY=$(shell echo $EKSA_AWS_SECRET_ACCESS_KEY)
 AWS_REGION=us-west-2
 
 BIN_DIR := bin

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -178,6 +178,7 @@ var clusterConfigValidations = []func(*Cluster) error{
 	validateMirrorConfig,
 	validatePodIAMConfig,
 	validateControlPlaneLabels,
+	validateUsernameAndSecretKey,
 }
 
 // GetClusterConfig parses a Cluster object from a multiobject yaml file in disk
@@ -717,6 +718,16 @@ func validatePodIAMConfig(clusterConfig *Cluster) error {
 	}
 	if clusterConfig.Spec.PodIAMConfig.ServiceAccountIssuer == "" {
 		return errors.New("ServiceAccount Issuer can't be empty while configuring IAM roles for pods")
+	}
+	return nil
+}
+
+func validateUsernameAndSecretKey() error {
+	if AWS_ACCOUNT_NAME!=EXPORT_ACCOUNT_NAME {
+		return errors.New("User account is not same as provided")
+	}
+	if GET_USER_SECRET_KEY!=EXPORT_SECRET_KEY {
+		return errors.New("User secret key is not same as provided")
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Parit Mehta <paritmehta3382@gmail.com>

Addressing Issue 3289
Bottlerocket only supports one user with the name ec2-user and one key that the user can provide. EKS-A should properly validate the inputs from the user on cluster spec and error if any other username or multiple keys are provided.

Description of Fix
This PR addresses the issue associated with id 3298 and had updated the MakeFile and cluster.go file.


