### PR TITLE
Fix install package controller for workload clusters

### DIFF
--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -63,7 +63,7 @@ func installPackageController(ctx context.Context) error {
 
 	ctrlClient := deps.PackageControllerClient
 
-	if ctrlClient.IsInstalled(ctx) {
+	if clusterSpec.Cluster.IsSelfManaged() && ctrlClient.IsInstalled(ctx) {
 		return errors.New("curated Packages controller exists in the current cluster")
 	}
 

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -225,12 +225,6 @@ func NewSpecFromClusterConfig(clusterConfigPath string, cliVersion version.Info,
 		s.TinkerbellTemplateConfigs = templateConfigs
 	}
 
-	if s.ManagementCluster != nil {
-		s.Cluster.SetManagedBy(s.ManagementCluster.Name)
-	} else {
-		s.Cluster.SetSelfManaged()
-	}
-
 	return s, nil
 }
 


### PR DESCRIPTION
*Description of changes:*
- Remove redundant code from cluster spec
- Check whether controller is installed or not only on self managed clusters.
*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

