### PR TITLE
Coverage view fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -446,7 +446,7 @@ coverage-view-patch: GO_PKGS ?= $(shell ./scripts/go-packages-in-patch.sh)
 coverage-view-patch: $(SETUP_ENVTEST)
 coverage-view-patch: KUBEBUILDER_ASSETS ?= $(shell $(SETUP_ENVTEST) use --use-env -p path --arch $(GO_ARCH) $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))
 coverage-view-patch:
-	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" $(GO_TEST) -coverprofile=$(COVER_PROFILE) -covermode=atomic $(GO_PKGS)
+	-$(MAKE) unit-test-patch GO_TEST_FLAGS="-coverprofile=$(COVER_PROFILE) -covermode=atomic"
 	$(GO) tool cover -html=$(COVER_PROFILE)
 	@echo Reminder: $@ is not a substitute for make unit-test
 

--- a/scripts/go-packages-in-patch.sh
+++ b/scripts/go-packages-in-patch.sh
@@ -21,7 +21,7 @@ ref="$(awsRemote)/main"
     set +e
     git diff --stat --name-only "$ref...HEAD"
     git status --untracked-files=normal --short | awk '{ print $NF }'
-} | grep ._test\.go \
+} | grep .\.go\$ \
     | xargs -r -n1 dirname \
     | sort \
     | uniq \


### PR DESCRIPTION
One quick fix and one quick "feature" for the patch-based Makefile targets I recently added.

The fix is for changes that modify package source files without modifying a _test.go file in the same package---those packages would have been ignored.

The new "feature" is to continue running the Make recipe when there's a test failure, so that the coverage report will still open.