### PR TITLE
Use CAPI machine name for node name and add validation on failuredoma…

### DIFF
--- a/controllers/resource/testdata/cloudstackKubeadmconfigTemplateSpec.yaml
+++ b/controllers/resource/testdata/cloudstackKubeadmconfigTemplateSpec.yaml
@@ -15,15 +15,15 @@ spec:
             provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
             read-only-port: "0"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
           taints: []
       preKubeadmCommands:
         - swapoff -a
-        - hostname "{{ ds.meta_data.local_hostname }}"
+        - hostname "{{ ds.meta_data.hostname }}"
         - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
         - echo "127.0.0.1   localhost" >>/etc/hosts
-        - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-        - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+        - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+        - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       diskSetup:
         filesystems:
           - device: /dev/vdb1

--- a/controllers/resource/testdata/cloudstackKubeadmcontrolplane.yaml
+++ b/controllers/resource/testdata/cloudstackKubeadmcontrolplane.yaml
@@ -80,7 +80,7 @@ spec:
           anonymous-auth: "false"
           provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
           read-only-port: "0"
-        name: '{{ ds.meta_data.hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -88,7 +88,7 @@ spec:
           anonymous-auth: "false"
           provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
           read-only-port: "0"
-        name: '{{ ds.meta_data.hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     preKubeadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/api/v1alpha1/cloudstackdatacenterconfig_test.go
+++ b/pkg/api/v1alpha1/cloudstackdatacenterconfig_test.go
@@ -291,30 +291,52 @@ func TestCloudStackDatacenterConfigSetDefaults(t *testing.T) {
 func TestCloudStackDatacenterConfigValidate(t *testing.T) {
 	g := NewWithT(t)
 	cloudStackDatacenterConfig := CloudStackDatacenterConfig{
-		Spec: *cloudStackDatacenterConfigSpec1.DeepCopy(),
+		Spec: *cloudStackDatacenterConfigSpecAzs.DeepCopy(),
 	}
 
-	// Spec.Accout validation
+	// Spec validation
 	err := cloudStackDatacenterConfig.Validate()
+	g.Expect(err).To(BeNil())
+
+	// Spec.Accout validation
+	cloudStackDatacenterConfig.Spec.Account = "admin"
+	err = cloudStackDatacenterConfig.Validate()
 	g.Expect(err).NotTo(BeNil())
 
 	// Spec.Domain validation
-	cloudStackDatacenterConfig.Spec.Account = ""
+	cloudStackDatacenterConfig.Spec = *cloudStackDatacenterConfigSpecAzs.DeepCopy()
+	cloudStackDatacenterConfig.Spec.Domain = "root"
 	err = cloudStackDatacenterConfig.Validate()
 	g.Expect(err).NotTo(BeNil())
 
 	// Spec.ManagementApiEndpoint validation
-	cloudStackDatacenterConfig.Spec.Domain = ""
+	cloudStackDatacenterConfig.Spec = *cloudStackDatacenterConfigSpecAzs.DeepCopy()
+	cloudStackDatacenterConfig.Spec.ManagementApiEndpoint = "http://192.168.1.141:8080/client"
 	err = cloudStackDatacenterConfig.Validate()
 	g.Expect(err).NotTo(BeNil())
 
 	// Spec.Zones validation
-	cloudStackDatacenterConfig.Spec.ManagementApiEndpoint = ""
+	cloudStackDatacenterConfig.Spec = *cloudStackDatacenterConfigSpecAzs.DeepCopy()
+	cloudStackDatacenterConfig.Spec.Zones = []CloudStackZone{
+		{
+			Name: "zone1",
+			Network: CloudStackResourceIdentifier{
+				Name: "net1",
+			},
+		},
+	}
 	err = cloudStackDatacenterConfig.Validate()
 	g.Expect(err).NotTo(BeNil())
 
 	// Spec.AvailabilityZones validation #1 (Length)
-	cloudStackDatacenterConfig.Spec.Zones = []CloudStackZone{}
+	cloudStackDatacenterConfig.Spec = *cloudStackDatacenterConfigSpecAzs.DeepCopy()
+	cloudStackDatacenterConfig.Spec.AvailabilityZones = []CloudStackAvailabilityZone{}
+	err = cloudStackDatacenterConfig.Validate()
+	g.Expect(err).NotTo(BeNil())
+
+	// Spec.AvailabilityZones validation #2 (Name)
+	cloudStackDatacenterConfig.Spec = *cloudStackDatacenterConfigSpecAzs.DeepCopy()
+	cloudStackDatacenterConfig.Spec.AvailabilityZones[0].Name = "_az-1"
 	err = cloudStackDatacenterConfig.Validate()
 	g.Expect(err).NotTo(BeNil())
 }

--- a/pkg/api/v1alpha1/cloudstackdatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackdatacenterconfig_types.go
@@ -16,9 +16,11 @@ package v1alpha1
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -197,6 +199,11 @@ func (v *CloudStackDatacenterConfig) Validate() error {
 	}
 	azSet := make(map[string]bool)
 	for _, az := range v.Spec.AvailabilityZones {
+		errorMessages := validation.IsValidLabelValue(az.Name)
+		if len(errorMessages) > 0 {
+			return fmt.Errorf("availabilityZone names must be a valid label value since it is used to label nodes: %s",
+				strings.Join(errorMessages, ";"))
+		}
 		if exists := azSet[az.Name]; exists {
 			return fmt.Errorf("availabilityZone names must be unique. Duplicate name: %s", az.Name)
 		}

--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -333,7 +333,7 @@ spec:
 {{- if .kubeletExtraArgs }}
 {{ .kubeletExtraArgs.ToYaml | indent 10 }}
 {{- end }}
-        name: '{{`{{ ds.meta_data.local_hostname }}`}}'
+        name: "{{`{{ ds.meta_data.hostname }}`}}"
 {{- if .controlPlaneTaints }}
         taints:
 {{- range .controlPlaneTaints}}
@@ -355,7 +355,7 @@ spec:
 {{- if .kubeletExtraArgs }}
 {{ .kubeletExtraArgs.ToYaml | indent 10 }}
 {{- end }}
-        name: '{{`{{ ds.meta_data.local_hostname }}`}}'
+        name: "{{`{{ ds.meta_data.hostname }}`}}"
 {{- if .controlPlaneTaints }}
         taints:
 {{- range .controlPlaneTaints}}
@@ -376,11 +376,11 @@ spec:
     - sudo systemctl daemon-reload
     - sudo systemctl restart containerd
 {{- end }}
-    - hostname "{{`{{ ds.meta_data.local_hostname }}`}}"
+    - hostname "{{`{{ ds.meta_data.hostname }}`}}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{`{{ ds.meta_data.local_hostname }}`}}" >>/etc/hosts
-    - echo "{{`{{ ds.meta_data.local_hostname }}`}}" >/etc/hostname
+    - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
+    - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
 {{- range $dir, $target := .cloudstackControlPlaneSymlinks}}
     - >-
       if [ ! -L {{$dir}} ] ;
@@ -440,11 +440,11 @@ spec:
       - echo https://github.com/mrajashree/etcdadm-bootstrap-provider/issues/13
     preEtcdadmCommands:
     - swapoff -a
-    - hostname "{{`{{ ds.meta_data.local_hostname }}`}}"
+    - hostname "{{`{{ ds.meta_data.hostname }}`}}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{`{{ ds.meta_data.local_hostname }}`}}" >>/etc/hosts
-    - echo "{{`{{ ds.meta_data.local_hostname }}`}}" >/etc/hostname
+    - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
+    - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
 {{- if .cloudstackEtcdDiskOfferingProvided }}
     - >-
       echo "type=83" | sfdisk {{ .cloudstackEtcdDiskOfferingDevice }} &&

--- a/pkg/providers/cloudstack/config/template-md.yaml
+++ b/pkg/providers/cloudstack/config/template-md.yaml
@@ -28,7 +28,7 @@ spec:
 {{- if .kubeletExtraArgs }}
 {{ .kubeletExtraArgs.ToYaml | indent 12 }}
 {{- end }}
-          name: '{{`{{ ds.meta_data.local_hostname }}`}}'
+          name: "{{`{{ ds.meta_data.hostname }}`}}"
 {{- if or .proxyConfig .registryMirrorConfiguration }}
       files:
 {{- end }}
@@ -68,11 +68,11 @@ spec:
       - sudo systemctl daemon-reload
       - sudo systemctl restart containerd
 {{- end }}
-      - hostname "{{`{{ ds.meta_data.local_hostname }}`}}"
+      - hostname "{{`{{ ds.meta_data.hostname }}`}}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{`{{ ds.meta_data.local_hostname }}`}}" >>/etc/hosts
-      - echo "{{`{{ ds.meta_data.local_hostname }}`}}" >/etc/hostname
+      - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
+      - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
 {{- range $dir, $target := .cloudstackSymlinks}}
       - >-
         if [ ! -L {{$dir}} ] ;

--- a/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
@@ -338,7 +338,7 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -347,14 +347,14 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     preKubeadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     useExperimentalRetryJoin: true
     users:
     - name: mySshUsername
@@ -385,11 +385,11 @@ spec:
       - echo https://github.com/mrajashree/etcdadm-bootstrap-provider/issues/13
     preEtcdadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
     - name: mySshUsername

--- a/pkg/providers/cloudstack/testdata/expected_results_affinity_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_affinity_md.yaml
@@ -15,14 +15,14 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       preKubeadmCommands:
       - swapoff -a
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
       - name: mySshUsername
         sshAuthorizedKeys:

--- a/pkg/providers/cloudstack/testdata/expected_results_availability_zones_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_availability_zones_cp.yaml
@@ -345,7 +345,7 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -354,14 +354,14 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     preKubeadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     useExperimentalRetryJoin: true
     users:
     - name: mySshUsername
@@ -392,11 +392,11 @@ spec:
       - echo https://github.com/mrajashree/etcdadm-bootstrap-provider/issues/13
     preEtcdadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
     - name: mySshUsername

--- a/pkg/providers/cloudstack/testdata/expected_results_availability_zones_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_availability_zones_md.yaml
@@ -15,14 +15,14 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       preKubeadmCommands:
       - swapoff -a
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
       - name: mySshUsername
         sshAuthorizedKeys: # The key below was manually generated and not used in any production systems

--- a/pkg/providers/cloudstack/testdata/expected_results_main_autoscaling_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_autoscaling_md.yaml
@@ -15,14 +15,14 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       preKubeadmCommands:
       - swapoff -a
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       - >-
         if [ ! -L /var/log/containers ] ;
           then

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
@@ -351,7 +351,7 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -360,14 +360,14 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     preKubeadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     - >-
       if [ ! -L /var/log/kubernetes ] ;
         then
@@ -422,11 +422,11 @@ spec:
       - echo https://github.com/mrajashree/etcdadm-bootstrap-provider/issues/13
     preEtcdadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     - >-
       echo "type=83" | sfdisk /dev/vdb &&
       mkfs -t ext4 /dev/vdb1 &&

--- a/pkg/providers/cloudstack/testdata/expected_results_main_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_md.yaml
@@ -15,14 +15,14 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       preKubeadmCommands:
       - swapoff -a
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       - >-
         if [ ! -L /var/log/containers ] ;
           then

--- a/pkg/providers/cloudstack/testdata/expected_results_main_multiple_worker_node_groups.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_multiple_worker_node_groups.yaml
@@ -18,14 +18,14 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       preKubeadmCommands:
       - swapoff -a
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
       - name: mySshUsername
         sshAuthorizedKeys:
@@ -100,14 +100,14 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       preKubeadmCommands:
       - swapoff -a
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
       - name: mySshUsername
         sshAuthorizedKeys:

--- a/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -351,7 +351,7 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -360,14 +360,14 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     preKubeadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     - >-
       if [ ! -L /var/log/kubernetes ] ;
         then
@@ -422,11 +422,11 @@ spec:
       - echo https://github.com/mrajashree/etcdadm-bootstrap-provider/issues/13
     preEtcdadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     - >-
       echo "type=83" | sfdisk /dev/vdb &&
       mkfs -t ext4 /dev/vdb1 &&

--- a/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_md.yaml
@@ -15,14 +15,14 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       preKubeadmCommands:
       - swapoff -a
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       - >-
         if [ ! -L /var/log/containers ] ;
           then

--- a/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
@@ -351,7 +351,7 @@ spec:
           anonymous-auth: "false"
           node-labels: label1=foo,label2=bar
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -361,14 +361,14 @@ spec:
           anonymous-auth: "false"
           node-labels: label1=foo,label2=bar
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     preKubeadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     diskSetup:
       filesystems:
         - device: /dev/vdb1
@@ -416,11 +416,11 @@ spec:
       - echo https://github.com/mrajashree/etcdadm-bootstrap-provider/issues/13
     preEtcdadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     - >-
       echo "type=83" | sfdisk /dev/vdb &&
       mkfs -t ext4 /dev/vdb1 &&

--- a/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_md.yaml
@@ -16,14 +16,14 @@ spec:
             anonymous-auth: "false"
             node-labels: label1=foo,label2=bar
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       preKubeadmCommands:
       - swapoff -a
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       diskSetup:
         filesystems:
           - device: /dev/vdb1

--- a/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
@@ -339,7 +339,7 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
         taints:
         - key: key1
           value: val1
@@ -358,7 +358,7 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
         taints:
         - key: key1
           value: val1
@@ -371,11 +371,11 @@ spec:
           effect: NoExecute
     preKubeadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     useExperimentalRetryJoin: true
     users:
     - name: mySshUsername
@@ -406,11 +406,11 @@ spec:
       - echo https://github.com/mrajashree/etcdadm-bootstrap-provider/issues/13
     preEtcdadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
     - name: mySshUsername

--- a/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_md.yaml
@@ -18,14 +18,14 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       preKubeadmCommands:
       - swapoff -a
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
       - name: mySshUsername
         sshAuthorizedKeys:

--- a/pkg/providers/cloudstack/testdata/expected_results_minimal_add_worker_node_group.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_minimal_add_worker_node_group.yaml
@@ -18,14 +18,14 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       preKubeadmCommands:
       - swapoff -a
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
       - name: mySshUsername
         sshAuthorizedKeys:
@@ -100,14 +100,14 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       preKubeadmCommands:
       - swapoff -a
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
       - name: mySshUsername
         sshAuthorizedKeys:
@@ -179,14 +179,14 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       preKubeadmCommands:
       - swapoff -a
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
       - name: mySshUsername
         sshAuthorizedKeys:

--- a/pkg/providers/cloudstack/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_minimal_cp.yaml
@@ -333,7 +333,7 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -342,14 +342,14 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     preKubeadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     useExperimentalRetryJoin: true
     users:
     - name: mySshUsername

--- a/pkg/providers/cloudstack/testdata/expected_results_minimal_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_minimal_md.yaml
@@ -15,14 +15,14 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       preKubeadmCommands:
       - swapoff -a
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
       - name: mySshUsername
         sshAuthorizedKeys:

--- a/pkg/providers/cloudstack/testdata/expected_results_minimal_proxy_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_minimal_proxy_cp.yaml
@@ -340,7 +340,7 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -349,16 +349,16 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     preKubeadmCommands:
     - swapoff -a
     - sudo systemctl daemon-reload
     - sudo systemctl restart containerd
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     useExperimentalRetryJoin: true
     users:
     - name: mySshUsername

--- a/pkg/providers/cloudstack/testdata/expected_results_minimal_proxy_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_minimal_proxy_md.yaml
@@ -15,7 +15,7 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       files:
       - content: |
           [Service]
@@ -28,11 +28,11 @@ spec:
       - swapoff -a
       - sudo systemctl daemon-reload
       - sudo systemctl restart containerd
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
       - name: mySshUsername
         sshAuthorizedKeys:

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
@@ -343,7 +343,7 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -352,17 +352,17 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     preKubeadmCommands:
     - swapoff -a
     - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
     - sudo systemctl daemon-reload
     - sudo systemctl restart containerd
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     useExperimentalRetryJoin: true
     users:
     - name: mySshUsername
@@ -393,11 +393,11 @@ spec:
       - echo https://github.com/mrajashree/etcdadm-bootstrap-provider/issues/13
     preEtcdadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
     - name: mySshUsername

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_md.yaml
@@ -15,7 +15,7 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       files:
       - content: |
           [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
@@ -28,11 +28,11 @@ spec:
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
       - sudo systemctl daemon-reload
       - sudo systemctl restart containerd
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
       - name: mySshUsername
         sshAuthorizedKeys:

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -365,7 +365,7 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -374,17 +374,17 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     preKubeadmCommands:
     - swapoff -a
     - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
     - sudo systemctl daemon-reload
     - sudo systemctl restart containerd
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     useExperimentalRetryJoin: true
     users:
     - name: mySshUsername
@@ -415,11 +415,11 @@ spec:
       - echo https://github.com/mrajashree/etcdadm-bootstrap-provider/issues/13
     preEtcdadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
     - name: mySshUsername

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_md.yaml
@@ -15,7 +15,7 @@ spec:
             read-only-port: "0"
             anonymous-auth: "false"
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: "{{ ds.meta_data.hostname }}"
       files:
       - content: |
           -----BEGIN CERTIFICATE-----
@@ -50,11 +50,11 @@ spec:
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
       - sudo systemctl daemon-reload
       - sudo systemctl restart containerd
-      - hostname "{{ ds.meta_data.local_hostname }}"
+      - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
       users:
       - name: mySshUsername
         sshAuthorizedKeys:

--- a/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
@@ -351,7 +351,7 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -360,14 +360,14 @@ spec:
           read-only-port: "0"
           anonymous-auth: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: "{{ ds.meta_data.hostname }}"
     preKubeadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     - >-
       if [ ! -L /var/log/kubernetes ] ;
         then
@@ -422,11 +422,11 @@ spec:
       - echo https://github.com/mrajashree/etcdadm-bootstrap-provider/issues/13
     preEtcdadmCommands:
     - swapoff -a
-    - hostname "{{ ds.meta_data.local_hostname }}"
+    - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
     - echo "127.0.0.1   localhost" >>/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.local_hostname }}" >>/etc/hosts
-    - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
     - >-
       echo "type=83" | sfdisk /dev/vdb &&
       mkfs -t ext4 /dev/vdb1 &&


### PR DESCRIPTION
…in name (#3566)

* add label failure-domain to node by setting kubelet args

* remove accidently committed file

* replace local_hostname with hostname and availability_zone with failuredomains

* update test data to use hostname and failuredomain

* use built-in label support

* update unit testing

* add back removed newline at file end.

* Add extra comment for WorkerNodeGroup and CP Configuration label field.

To support label cluster.x-k8s.io/failure-domain in control plane and worker nodes created in CloudStack cluster, a pre-determined string between CloudStack provider CAPC and EKS-A 'ds.meta_data.failuredomain' is used as label value.

For example:
labels:
      cluster.x-k8s.io/failure-domain: ds.meta_data.failuredomain

CPAC will replace ds.meta_data.failure with proper failuredomain name before passing to CloudStack API.

* remove label comments for CAPC and order import

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

