### PR TITLE
Add docs for `skipLoadBalancerDeployment` for Tinkerbell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ hardware-manifests/
 support-bundle*
 /.ignore
 coverage.out
+docs/.hugo_build.lock

--- a/docs/content/en/docs/reference/clusterspec/baremetal.md
+++ b/docs/content/en/docs/reference/clusterspec/baremetal.md
@@ -220,7 +220,7 @@ my-web-server
 ### skipLoadBalancerDeployment
 Optional field to skip deploying the default load balancer for Tinkerbell stack.
 
-EKS Anywhere for bare-metal uses `kube-vip` load balancer by default to expose the Tinkerbell stack externally.
+EKS Anywhere for Bare Metal uses `kube-vip` load balancer by default to expose the Tinkerbell stack externally.
 You can disable this feature by setting this field to `true`.
 >**_NOTE:_** If you skip load balancer deployment, you will have to ensure that the Tinkerbell stack is available at [tinkerbellIP]({{< relref "#tinkerbellip" >}}) once the cluster creation is finished. One way to achieve this is by using the [MetalLB]({{< relref "../../tasks/packages/metallb" >}}) package. 
 

--- a/docs/content/en/docs/reference/clusterspec/baremetal.md
+++ b/docs/content/en/docs/reference/clusterspec/baremetal.md
@@ -217,6 +217,13 @@ my-web-server
 └── ubuntu-v1.23.7-eks-a-12-amd64.gz
 ```
 
+### skipLoadBalancerDeployment
+Optional field to skip deploying the default load balancer for Tinkerbell stack.
+
+EKS Anywhere for bare-metal uses `kube-vip` load balancer by default to expose the Tinkerbell stack externally.
+You can disable this feature by setting this field to `true`.
+>**_NOTE:_** If you skip load balancer deployment, you will have to ensure that the Tinkerbell stack is available at [tinkerbellIP]({{< relref "#tinkerbellip" >}}) once the cluster creation is finished. One way to achieve this is by using the [MetalLB]({{< relref "../../tasks/packages/metallb" >}}) package. 
+
 ## TinkerbellMachineConfig Fields
 In the example, there are `TinkerbellMachineConfig` sections for control plane (`my-cluster-name-cp`) and worker (`my-cluster-name`) machine groups.
 The following fields identify information needed to configure the nodes in each of those groups.


### PR DESCRIPTION
*Description of changes:*
Adding docs for `skipLoadBalancerDeployment` changes from this PR https://github.com/aws/eks-anywhere/pull/3608

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

