### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/controllers/resource/reconciler_test.go
+++ b/controllers/resource/reconciler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/golang/mock/gomock"
 	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -1169,8 +1167,7 @@ func TestClusterReconcilerReconcileCloudStack(t *testing.T) {
 }
 
 func TestClusterReconcilerReconcileNutanix(t *testing.T) {
-	err := os.Setenv(features.NutanixProviderEnvVar, "true")
-	require.NoError(t, err)
+	t.Setenv(features.NutanixProviderEnvVar, "true")
 	assert.True(t, features.NutanixProvider().IsActive())
 
 	type args struct {

--- a/pkg/api/v1alpha1/fluxconfig_test.go
+++ b/pkg/api/v1alpha1/fluxconfig_test.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 
@@ -14,41 +13,6 @@ const (
 	EksaGitPrivateKeyTokenEnv = "EKSA_GIT_PRIVATE_KEY"
 	EksaGitKnownHostsFileEnv  = "EKSA_GIT_KNOWN_HOSTS"
 )
-
-type testContext struct {
-	privateKeyFile         string
-	isprivateKeyFileSet    bool
-	gitKnownHostsFile      string
-	isGitKnownHostsFileSet bool
-}
-
-func (tctx *testContext) SaveContext() {
-	tctx.privateKeyFile, tctx.isprivateKeyFileSet = os.LookupEnv(EksaGitPrivateKeyTokenEnv)
-	tctx.gitKnownHostsFile, tctx.isGitKnownHostsFileSet = os.LookupEnv(EksaGitKnownHostsFileEnv)
-	os.Setenv(EksaGitPrivateKeyTokenEnv, "my/private/key")
-	os.Setenv(EksaGitKnownHostsFileEnv, "my/known/hosts")
-}
-
-func (tctx *testContext) RestoreContext() {
-	if tctx.isprivateKeyFileSet {
-		os.Setenv(EksaGitPrivateKeyTokenEnv, tctx.privateKeyFile)
-	} else {
-		os.Unsetenv(EksaGitPrivateKeyTokenEnv)
-	}
-	if tctx.isGitKnownHostsFileSet {
-		os.Setenv(EksaGitKnownHostsFileEnv, tctx.gitKnownHostsFile)
-	} else {
-		os.Unsetenv(EksaGitKnownHostsFileEnv)
-	}
-}
-
-func setupContext(t *testing.T) {
-	var tctx testContext
-	tctx.SaveContext()
-	t.Cleanup(func() {
-		tctx.RestoreContext()
-	})
-}
 
 func TestValidateFluxConfig(t *testing.T) {
 	tests := []struct {
@@ -229,7 +193,8 @@ func TestValidateFluxConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			if tt.gitProvider {
-				setupContext(t)
+				t.Setenv(EksaGitPrivateKeyTokenEnv, "my/private/key")
+				t.Setenv(EksaGitKnownHostsFileEnv, "my/known/hosts")
 			}
 			err := tt.fluxConfig.Validate()
 			if (err != nil) != tt.wantErr {

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_webhook_test.go
@@ -1,7 +1,6 @@
 package v1alpha1_test
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -146,12 +145,11 @@ func vsphereDatacenterConfig() v1alpha1.VSphereDatacenterConfig {
 }
 
 func TestVSphereDatacenterValidateCreateFullManagementCycleOn(t *testing.T) {
-	os.Setenv("FULL_LIFECYCLE_API", "true")
+	t.Setenv("FULL_LIFECYCLE_API", "true")
 	dataCenterConfig := vsphereDatacenterConfig()
 
 	g := NewWithT(t)
 	g.Expect(dataCenterConfig.ValidateCreate()).To(Succeed())
-	os.Unsetenv("FULL_LIFECYCLE_API")
 }
 
 func TestVSphereDatacenterValidateCreate(t *testing.T) {

--- a/pkg/aws/creds_test.go
+++ b/pkg/aws/creds_test.go
@@ -16,27 +16,18 @@ const (
 )
 
 func setupContext(t *testing.T, key, val string) {
-	originVal, isSet := os.LookupEnv(key)
-	os.Setenv(key, val)
-	t.Cleanup(func() {
-		if isSet {
-			os.Setenv(key, originVal)
-		} else {
-			os.Unsetenv(key)
-		}
-	})
+	t.Setenv(key, val)
 }
 
 func TestAwsCredentialsFile(t *testing.T) {
 	tt := newAwsTest(t)
-	setupContext(t, aws.EksaAwsCredentialsFileKey, credentialsFile)
+	t.Setenv(aws.EksaAwsCredentialsFileKey, credentialsFile)
 	_, err := aws.AwsCredentialsFile()
 	tt.Expect(err).To(Succeed())
 }
 
 func TestAwsCredentialsFileEnvNotSet(t *testing.T) {
 	tt := newAwsTest(t)
-	setupContext(t, aws.EksaAwsCredentialsFileKey, credentialsFile)
 	os.Unsetenv(aws.EksaAwsCredentialsFileKey)
 	_, err := aws.AwsCredentialsFile()
 	tt.Expect(err).To((MatchError(ContainSubstring("env 'EKSA_AWS_CREDENTIALS_FILE' is not set or is empty"))))
@@ -44,21 +35,20 @@ func TestAwsCredentialsFileEnvNotSet(t *testing.T) {
 
 func TestAwsCredentialsFileNotExists(t *testing.T) {
 	tt := newAwsTest(t)
-	setupContext(t, aws.EksaAwsCredentialsFileKey, "testdata/not_exists_credentials")
+	t.Setenv(aws.EksaAwsCredentialsFileKey, "testdata/not_exists_credentials")
 	_, err := aws.AwsCredentialsFile()
 	tt.Expect(err).To((MatchError(ContainSubstring("file 'testdata/not_exists_credentials' does not exist"))))
 }
 
 func TestAwsCABundlesFile(t *testing.T) {
 	tt := newAwsTest(t)
-	setupContext(t, aws.EksaAwsCABundlesFileKey, certificatesFile)
+	t.Setenv(aws.EksaAwsCABundlesFileKey, certificatesFile)
 	_, err := aws.AwsCABundlesFile()
 	tt.Expect(err).To(Succeed())
 }
 
 func TestAwsCABundlesFileEnvNotSet(t *testing.T) {
 	tt := newAwsTest(t)
-	setupContext(t, aws.EksaAwsCABundlesFileKey, certificatesFile)
 	os.Unsetenv(aws.EksaAwsCABundlesFileKey)
 	_, err := aws.AwsCABundlesFile()
 	tt.Expect(err).To((MatchError(ContainSubstring("env 'EKSA_AWS_CA_BUNDLES_FILE' is not set or is empty"))))
@@ -66,14 +56,14 @@ func TestAwsCABundlesFileEnvNotSet(t *testing.T) {
 
 func TestAwsCABundlesFileNotExists(t *testing.T) {
 	tt := newAwsTest(t)
-	setupContext(t, aws.EksaAwsCABundlesFileKey, "testdata/not_exists_certificates")
+	t.Setenv(aws.EksaAwsCABundlesFileKey, "testdata/not_exists_certificates")
 	_, err := aws.AwsCABundlesFile()
 	tt.Expect(err).To((MatchError(ContainSubstring("file 'testdata/not_exists_certificates' does not exist"))))
 }
 
 func TestEncodeFileFromEnv(t *testing.T) {
 	tt := newAwsTest(t)
-	setupContext(t, aws.EksaAwsCredentialsFileKey, credentialsFile)
+	t.Setenv(aws.EksaAwsCredentialsFileKey, credentialsFile)
 	strB64, err := aws.EncodeFileFromEnv(aws.EksaAwsCredentialsFileKey)
 	tt.Expect(err).To(Succeed())
 	tt.Expect(strB64).To(Equal("WzEuMi4zLjRdCmF3c19hY2Nlc3Nfa2V5X2lkID0gQUJDREVGR0hJSktMTU5PUFFSMlQKYXdzX3NlY3JldF9hY2Nlc3Nfa2V5ID0gQWZTRDdzWXovVEJadHprUmVCbDZQdXVJU3pKMld0TmtlZVB3K25OekoKcmVnaW9uID0gc25vdwoKWzEuMi4zLjVdCmF3c19hY2Nlc3Nfa2V5X2lkID0gQUJDREVGR0hJSktMTU5PUFFSMlQKYXdzX3NlY3JldF9hY2Nlc3Nfa2V5ID0gQWZTRDdzWXovVEJadHprUmVCbDZQdXVJU3pKMld0TmtlZVB3K25OekoKcmVnaW9uID0gc25vdw=="))

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -107,10 +106,8 @@ func TestFactoryBuildWithProviderNutanix(t *testing.T) {
 		},
 	}
 
-	os.Setenv("NUTANIX_USER", "test")
-	defer os.Unsetenv("NUTANIX_USER")
-	os.Setenv("NUTANIX_PASSWORD", "test")
-	defer os.Unsetenv("NUTANIX_PASSWORD")
+	t.Setenv("NUTANIX_USER", "test")
+	t.Setenv("NUTANIX_PASSWORD", "test")
 	for _, tc := range tests {
 		tt := newTest(t, nutanix)
 		tt.clusterConfigFile = tc.clusterConfigFile

--- a/pkg/eksctl/eksctl_test.go
+++ b/pkg/eksctl/eksctl_test.go
@@ -1,19 +1,17 @@
 package eksctl_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/aws/eks-anywhere/pkg/eksctl"
 )
 
 func TestValidateVersionSuccess(t *testing.T) {
-	os.Setenv(eksctl.VersionEnvVar, "dev")
+	t.Setenv(eksctl.VersionEnvVar, "dev")
 	err := eksctl.ValidateVersion()
 	if err != nil {
 		t.Fatalf("ValidateVersion() error = %v, wantErr <nil>", err)
 	}
-	os.Unsetenv(eksctl.VersionEnvVar)
 }
 
 func TestValidateVersionError(t *testing.T) {

--- a/pkg/executables/cmk_test.go
+++ b/pkg/executables/cmk_test.go
@@ -257,9 +257,7 @@ func TestCmkCleanupVms(t *testing.T) {
 			ctx := context.Background()
 			mockCtrl := gomock.NewController(t)
 
-			var tctx testContext
-			tctx.SaveContext()
-			defer tctx.RestoreContext()
+			setupContext(t)
 
 			executable := mockexecutables.NewMockExecutable(mockCtrl)
 			for _, argsList := range tt.argumentsExecCalls {
@@ -974,9 +972,7 @@ func TestCmkListOperations(t *testing.T) {
 			ctx := context.Background()
 			mockCtrl := gomock.NewController(t)
 
-			var tctx testContext
-			tctx.SaveContext()
-			defer tctx.RestoreContext()
+			setupContext(t)
 
 			executable := mockexecutables.NewMockExecutable(mockCtrl)
 			if tt.argumentsExecCall != nil {
@@ -998,9 +994,7 @@ func TestCmkGetManagementApiEndpoint(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	tt := NewWithT(t)
 
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	executable := mockexecutables.NewMockExecutable(mockCtrl)
 	cmk := executables.NewCmk(executable, writer, execConfigWithMultipleProfiles.Profiles)

--- a/pkg/executables/flux_test.go
+++ b/pkg/executables/flux_test.go
@@ -26,31 +26,15 @@ const (
 	validGitKnownHostsFilePath = "testdata/known_hosts"
 )
 
-type testFluxContext struct {
-	oldGithubToken   string
-	isGithubTokenSet bool
-}
-
-func (tctx *testFluxContext) SaveContext() {
-	tctx.oldGithubToken, tctx.isGithubTokenSet = os.LookupEnv(eksaGithubTokenEnv)
-	os.Setenv(eksaGithubTokenEnv, validPATValue)
-	os.Setenv(githubToken, os.Getenv(eksaGithubTokenEnv))
-}
-
-func (tctx *testFluxContext) RestoreContext() {
-	if tctx.isGithubTokenSet {
-		os.Setenv(eksaGithubTokenEnv, tctx.oldGithubToken)
-	} else {
-		os.Unsetenv(eksaGithubTokenEnv)
-	}
+func setupFluxContext(t *testing.T) {
+	t.Setenv(eksaGithubTokenEnv, validPATValue)
+	t.Setenv(githubToken, os.Getenv(eksaGithubTokenEnv))
 }
 
 func TestFluxInstallGithubToolkitsSuccess(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 
-	var tctx testFluxContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupFluxContext(t)
 
 	owner := "janedoe"
 	repo := "gitops-fleet"
@@ -168,9 +152,7 @@ func TestFluxInstallGithubToolkitsSuccess(t *testing.T) {
 func TestFluxUninstallGitOpsToolkitsComponents(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 
-	var tctx testFluxContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupFluxContext(t)
 
 	tests := []struct {
 		testName     string
@@ -231,9 +213,7 @@ func TestFluxUninstallGitOpsToolkitsComponents(t *testing.T) {
 func TestFluxPauseKustomization(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 
-	var tctx testFluxContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupFluxContext(t)
 
 	tests := []struct {
 		testName     string
@@ -304,9 +284,7 @@ func TestFluxPauseKustomization(t *testing.T) {
 func TestFluxResumeKustomization(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 
-	var tctx testFluxContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupFluxContext(t)
 
 	tests := []struct {
 		testName     string
@@ -378,9 +356,7 @@ func TestFluxResumeKustomization(t *testing.T) {
 func TestFluxReconcile(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 
-	var tctx testFluxContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupFluxContext(t)
 
 	tests := []struct {
 		testName     string

--- a/pkg/executables/govc_test.go
+++ b/pkg/executables/govc_test.go
@@ -46,61 +46,15 @@ var govcEnvironment = map[string]string{
 	govcInsecure:   "false",
 }
 
-type testContext struct {
-	oldUsername     string
-	isUsernameSet   bool
-	oldPassword     string
-	isPasswordSet   bool
-	oldServer       string
-	isServerSet     bool
-	oldDatacenter   string
-	isDatacenterSet bool
-}
-
-func (tctx *testContext) SaveContext() {
-	tctx.oldUsername, tctx.isUsernameSet = os.LookupEnv(vSphereUsername)
-	tctx.oldPassword, tctx.isPasswordSet = os.LookupEnv(vSpherePassword)
-	tctx.oldServer, tctx.isServerSet = os.LookupEnv(vSphereServer)
-	tctx.oldDatacenter, tctx.isDatacenterSet = os.LookupEnv(govcDatacenter)
-	os.Setenv(vSphereUsername, "vsphere_username")
-	os.Setenv(vSpherePassword, "vsphere_password")
-	os.Setenv(vSphereServer, "vsphere_server")
-	os.Setenv(govcUsername, os.Getenv(vSphereUsername))
-	os.Setenv(govcPassword, os.Getenv(vSpherePassword))
-	os.Setenv(govcURL, os.Getenv(vSphereServer))
-	os.Setenv(govcInsecure, "false")
-	os.Setenv(govcDatacenter, "vsphere_datacenter")
-}
-
-func (tctx *testContext) RestoreContext() {
-	if tctx.isUsernameSet {
-		os.Setenv(vSphereUsername, tctx.oldUsername)
-	} else {
-		os.Unsetenv(vSphereUsername)
-	}
-	if tctx.isPasswordSet {
-		os.Setenv(vSpherePassword, tctx.oldPassword)
-	} else {
-		os.Unsetenv(vSpherePassword)
-	}
-	if tctx.isServerSet {
-		os.Setenv(vSphereServer, tctx.oldServer)
-	} else {
-		os.Unsetenv(vSphereServer)
-	}
-	if tctx.isDatacenterSet {
-		os.Setenv(govcDatacenter, tctx.oldDatacenter)
-	} else {
-		os.Unsetenv(govcDatacenter)
-	}
-}
-
 func setupContext(t *testing.T) {
-	var tctx testContext
-	tctx.SaveContext()
-	t.Cleanup(func() {
-		tctx.RestoreContext()
-	})
+	t.Setenv(vSphereUsername, "vsphere_username")
+	t.Setenv(vSpherePassword, "vsphere_password")
+	t.Setenv(vSphereServer, "vsphere_server")
+	t.Setenv(govcUsername, os.Getenv(vSphereUsername))
+	t.Setenv(govcPassword, os.Getenv(vSpherePassword))
+	t.Setenv(govcURL, os.Getenv(vSphereServer))
+	t.Setenv(govcInsecure, "false")
+	t.Setenv(govcDatacenter, "vsphere_datacenter")
 }
 
 func setup(t *testing.T, opts ...executables.GovcOpt) (dir string, govc *executables.Govc, mockExecutable *mockexecutables.MockExecutable, env map[string]string) {
@@ -378,9 +332,7 @@ func TestGovcTemplateHasSnapshot(t *testing.T) {
 	ctx := context.Background()
 	mockCtrl := gomock.NewController(t)
 
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	executable := mockexecutables.NewMockExecutable(mockCtrl)
 	params := []string{"snapshot.tree", "-vm", template}
@@ -418,9 +370,7 @@ func TestGovcGetWorkloadAvailableSpace(t *testing.T) {
 			ctx := context.Background()
 			mockCtrl := gomock.NewController(t)
 
-			var tctx testContext
-			tctx.SaveContext()
-			defer tctx.RestoreContext()
+			setupContext(t)
 
 			executable := mockexecutables.NewMockExecutable(mockCtrl)
 			params := []string{"datastore.info", "-json=true", datastore}
@@ -497,9 +447,7 @@ func TestGovcValidateVCenterSetupMachineConfig(t *testing.T) {
 	_, writer := test.NewWriter(t)
 	selfSigned := true
 
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	executable := mockexecutables.NewMockExecutable(mockCtrl)
 
@@ -545,9 +493,7 @@ func TestGovcCleanupVms(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	_, writer := test.NewWriter(t)
 
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	executable := mockexecutables.NewMockExecutable(mockCtrl)
 
@@ -1033,7 +979,7 @@ func TestGovcValidateVCenterAuthenticationErrorNoDatacenter(t *testing.T) {
 	ctx := context.Background()
 	_, g, _, _ := setup(t)
 
-	os.Setenv(govcDatacenter, "")
+	t.Setenv(govcDatacenter, "")
 
 	if err := g.ValidateVCenterAuthentication(ctx); err == nil {
 		t.Fatal("Govc.ValidateVCenterAuthentication() err = nil, want err not nil")

--- a/pkg/executables/kind_test.go
+++ b/pkg/executables/kind_test.go
@@ -218,12 +218,8 @@ func TestKindCreateBootstrapClusterSuccessWithRegistryMirror(t *testing.T) {
 			image = kindImage
 
 			if spec.Cluster.Spec.RegistryMirrorConfiguration.Authenticate {
-				if err := os.Setenv("REGISTRY_USERNAME", "username"); err != nil {
-					t.Fatalf(err.Error())
-				}
-				if err := os.Setenv("REGISTRY_PASSWORD", "password"); err != nil {
-					t.Fatalf(err.Error())
-				}
+				t.Setenv("REGISTRY_USERNAME", "username")
+				t.Setenv("REGISTRY_PASSWORD", "password")
 			}
 
 			executable.EXPECT().ExecuteWithEnv(

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -29,16 +29,10 @@ func fakeFeatureWithGate() Feature {
 }
 
 func setupContext(t *testing.T) {
-	envVarOrgValue, set := os.LookupEnv(fakeFeatureEnvVar)
 	t.Cleanup(func() {
 		// cleanup cache
 		globalFeatures.cache = newMutexMap()
 		globalFeatures.initGates = sync.Once{}
-		if set {
-			os.Setenv(fakeFeatureEnvVar, envVarOrgValue)
-		} else {
-			os.Unsetenv(fakeFeatureEnvVar)
-		}
 	})
 }
 
@@ -54,7 +48,7 @@ func TestIsActiveEnvVarSetFalse(t *testing.T) {
 	g := NewWithT(t)
 	setupContext(t)
 
-	os.Setenv(fakeFeatureEnvVar, "false")
+	t.Setenv(fakeFeatureEnvVar, "false")
 	g.Expect(IsActive(fakeFeature())).To(BeFalse())
 }
 
@@ -62,7 +56,7 @@ func TestIsActiveEnvVarSetTrue(t *testing.T) {
 	g := NewWithT(t)
 	setupContext(t)
 
-	g.Expect(os.Setenv(fakeFeatureEnvVar, "true")).To(Succeed())
+	t.Setenv(fakeFeatureEnvVar, "true")
 	g.Expect(IsActive(fakeFeature())).To(BeTrue())
 }
 
@@ -80,7 +74,7 @@ func TestWithNutanixFeatureFlag(t *testing.T) {
 	g := NewWithT(t)
 	setupContext(t)
 
-	g.Expect(os.Setenv(NutanixProviderEnvVar, "true")).To(Succeed())
+	t.Setenv(NutanixProviderEnvVar, "true")
 	g.Expect(IsActive(NutanixProvider())).To(BeTrue())
 }
 
@@ -88,6 +82,6 @@ func TestWithK8s124FeatureFlag(t *testing.T) {
 	g := NewWithT(t)
 	setupContext(t)
 
-	g.Expect(os.Setenv(K8s124SupportEnvVar, "true")).To(Succeed())
+	t.Setenv(K8s124SupportEnvVar, "true")
 	g.Expect(IsActive(K8s124Support())).To(BeTrue())
 }

--- a/pkg/git/factory/gitfactory_test.go
+++ b/pkg/git/factory/gitfactory_test.go
@@ -2,7 +2,6 @@ package gitfactory_test
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,9 +35,7 @@ func TestGitFactoryHappyPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
-			var tctx testContext
-			tctx.SaveContext(validPATValue)
-			defer tctx.RestoreContext()
+			setupContext(t)
 
 			gitProviderConfig := v1alpha1.GithubProviderConfig{
 				Owner:      "Jeff",
@@ -68,21 +65,7 @@ func TestGitFactoryHappyPath(t *testing.T) {
 	}
 }
 
-type testContext struct {
-	oldGithubToken   string
-	isGithubTokenSet bool
-}
-
-func (tctx *testContext) SaveContext(token string) {
-	tctx.oldGithubToken, tctx.isGithubTokenSet = os.LookupEnv(github.EksaGithubTokenEnv)
-	os.Setenv(github.EksaGithubTokenEnv, validPATValue)
-	os.Setenv(github.GithubTokenEnv, validPATValue)
-}
-
-func (tctx *testContext) RestoreContext() {
-	if tctx.isGithubTokenSet {
-		os.Setenv(github.EksaGithubTokenEnv, tctx.oldGithubToken)
-	} else {
-		os.Unsetenv(github.EksaGithubTokenEnv)
-	}
+func setupContext(t *testing.T) {
+	t.Setenv(github.EksaGithubTokenEnv, validPATValue)
+	t.Setenv(github.GithubTokenEnv, validPATValue)
 }

--- a/pkg/git/providers/github/github_test.go
+++ b/pkg/git/providers/github/github_test.go
@@ -3,7 +3,6 @@ package github_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 
@@ -107,29 +106,13 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-type testContext struct {
-	oldGithubToken   string
-	isGithubTokenSet bool
-}
-
-func (tctx *testContext) SaveContext(token string) {
-	tctx.oldGithubToken, tctx.isGithubTokenSet = os.LookupEnv(github.EksaGithubTokenEnv)
-	os.Setenv(github.EksaGithubTokenEnv, token)
-	os.Setenv(github.GithubTokenEnv, token)
-}
-
-func (tctx *testContext) RestoreContext() {
-	if tctx.isGithubTokenSet {
-		os.Setenv(github.EksaGithubTokenEnv, tctx.oldGithubToken)
-	} else {
-		os.Unsetenv(github.EksaGithubTokenEnv)
-	}
+func setupContext(t *testing.T) {
+	t.Setenv(github.EksaGithubTokenEnv, validPATValue)
+	t.Setenv(github.GithubTokenEnv, validPATValue)
 }
 
 func TestIsGithubAccessTokenValidWithEnv(t *testing.T) {
-	var tctx testContext
-	tctx.SaveContext(validPATValue)
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	tests := []struct {
 		testName string

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -398,8 +398,8 @@ func TestTemplaterGenerateManifestForRegistryAuth(t *testing.T) {
 	_, err := tt.t.GenerateManifest(tt.ctx, tt.spec)
 	tt.Expect(err).To(HaveOccurred(), "templater.GenerateManifest() should fail")
 
-	os.Setenv("REGISTRY_USERNAME", "username")
-	os.Setenv("REGISTRY_PASSWORD", "password")
+	t.Setenv("REGISTRY_USERNAME", "username")
+	t.Setenv("REGISTRY_PASSWORD", "password")
 
 	tt.h.EXPECT().
 		RegistryLogin(gomock.Any(), "1.2.3.4:443", "username", "password").

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -294,7 +294,7 @@ func TestProviderSetupAndValidateCreateClusterFailureOnInvalidUrl(t *testing.T) 
 		t.Fatalf("provider object is nil")
 	}
 
-	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, cloudStackCloudConfigWithInvalidUrl)
+	t.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, cloudStackCloudConfigWithInvalidUrl)
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	tt.Expect(err).NotTo(BeNil())
 }
@@ -316,7 +316,7 @@ func TestProviderSetupAndValidateUpgradeClusterFailureOnInvalidUrl(t *testing.T)
 		t.Fatalf("provider object is nil")
 	}
 
-	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, cloudStackCloudConfigWithInvalidUrl)
+	t.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, cloudStackCloudConfigWithInvalidUrl)
 	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec, clusterSpec)
 	tt.Expect(err).NotTo(BeNil())
 }
@@ -338,7 +338,7 @@ func TestProviderSetupAndValidateDeleteClusterFailureOnInvalidUrl(t *testing.T) 
 		t.Fatalf("provider object is nil")
 	}
 
-	os.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, cloudStackCloudConfigWithInvalidUrl)
+	t.Setenv(decoder.EksacloudStackCloudConfigB64SecretKey, cloudStackCloudConfigWithInvalidUrl)
 	err := provider.SetupAndValidateDeleteCluster(ctx, cluster, nil)
 	tt.Expect(err).NotTo(BeNil())
 }

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -256,25 +256,8 @@ func newProvider(ctx context.Context, t *testing.T, kubeUnAuthClient snow.KubeUn
 }
 
 func setupContext(t *testing.T) {
-	credsFileOrgVal, isSet := os.LookupEnv(credsFileEnvVar)
-	os.Setenv(credsFileEnvVar, credsFilePath)
-	t.Cleanup(func() {
-		if isSet {
-			os.Setenv(credsFileEnvVar, credsFileOrgVal)
-		} else {
-			os.Unsetenv(credsFileEnvVar)
-		}
-	})
-
-	certsFileOrgVal, isSet := os.LookupEnv(certsFileEnvVar)
-	os.Setenv(certsFileEnvVar, certsFilePath)
-	t.Cleanup(func() {
-		if isSet {
-			os.Setenv(certsFileEnvVar, certsFileOrgVal)
-		} else {
-			os.Unsetenv(certsFileEnvVar)
-		}
-	})
+	t.Setenv(credsFileEnvVar, credsFilePath)
+	t.Setenv(certsFileEnvVar, certsFilePath)
 }
 
 func TestName(t *testing.T) {

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -260,17 +260,6 @@ func givenProvider(t *testing.T) *vsphereProvider {
 	return provider
 }
 
-type testContext struct {
-	oldUsername                string
-	isUsernameSet              bool
-	oldPassword                string
-	isPasswordSet              bool
-	oldServername              string
-	isServernameSet            bool
-	oldExpClusterResourceSet   string
-	isExpClusterResourceSetSet bool
-}
-
 func workerNodeGroup1MachineDeployment() *clusterv1.MachineDeployment {
 	return &clusterv1.MachineDeployment{
 		Spec: clusterv1.MachineDeploymentSpec{
@@ -303,38 +292,13 @@ func workerNodeGroup2MachineDeployment() *clusterv1.MachineDeployment {
 	}
 }
 
-func (tctx *testContext) SaveContext() {
-	tctx.oldUsername, tctx.isUsernameSet = os.LookupEnv(config.EksavSphereUsernameKey)
-	tctx.oldPassword, tctx.isPasswordSet = os.LookupEnv(config.EksavSpherePasswordKey)
-	tctx.oldServername, tctx.isServernameSet = os.LookupEnv(vSpherePasswordKey)
-	tctx.oldExpClusterResourceSet, tctx.isExpClusterResourceSetSet = os.LookupEnv(vSpherePasswordKey)
-	os.Setenv(config.EksavSphereUsernameKey, expectedVSphereUsername)
-	os.Setenv(vSphereUsernameKey, os.Getenv(config.EksavSphereUsernameKey))
-	os.Setenv(config.EksavSpherePasswordKey, expectedVSpherePassword)
-	os.Setenv(vSpherePasswordKey, os.Getenv(config.EksavSpherePasswordKey))
-	os.Setenv(vSphereServerKey, expectedVSphereServer)
-	os.Setenv(expClusterResourceSetKey, expectedExpClusterResourceSet)
-}
-
-func (tctx *testContext) RestoreContext() {
-	if tctx.isUsernameSet {
-		os.Setenv(config.EksavSphereUsernameKey, tctx.oldUsername)
-	} else {
-		os.Unsetenv(config.EksavSphereUsernameKey)
-	}
-	if tctx.isPasswordSet {
-		os.Setenv(config.EksavSpherePasswordKey, tctx.oldPassword)
-	} else {
-		os.Unsetenv(config.EksavSpherePasswordKey)
-	}
-}
-
 func setupContext(t *testing.T) {
-	var tctx testContext
-	tctx.SaveContext()
-	t.Cleanup(func() {
-		tctx.RestoreContext()
-	})
+	t.Setenv(config.EksavSphereUsernameKey, expectedVSphereUsername)
+	t.Setenv(vSphereUsernameKey, os.Getenv(config.EksavSphereUsernameKey))
+	t.Setenv(config.EksavSpherePasswordKey, expectedVSpherePassword)
+	t.Setenv(vSpherePasswordKey, os.Getenv(config.EksavSpherePasswordKey))
+	t.Setenv(vSphereServerKey, expectedVSphereServer)
+	t.Setenv(expClusterResourceSetKey, expectedExpClusterResourceSet)
 }
 
 type providerTest struct {
@@ -576,9 +540,7 @@ func TestProviderGenerateCAPISpecForUpgradeUpdateMachineTemplate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			var tctx testContext
-			tctx.SaveContext()
-			defer tctx.RestoreContext()
+			setupContext(t)
 			ctx := context.Background()
 			kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 			cluster := &types.Cluster{
@@ -656,9 +618,7 @@ func TestProviderGenerateCAPISpecForUpgradeCP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			var tctx testContext
-			tctx.SaveContext()
-			defer tctx.RestoreContext()
+			setupContext(t)
 			ctx := context.Background()
 			kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 			cluster := &types.Cluster{
@@ -724,9 +684,7 @@ func TestProviderGenerateCAPISpecForUpgradeMultipleWorkerNodeGroups(t *testing.T
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			var tctx testContext
-			tctx.SaveContext()
-			defer tctx.RestoreContext()
+			setupContext(t)
 			ctx := context.Background()
 			kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 			cluster := &types.Cluster{
@@ -819,9 +777,7 @@ func TestProviderGenerateCAPISpecForUpgradeUpdateMachineTemplateExternalEtcd(t *
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			var tctx testContext
-			tctx.SaveContext()
-			defer tctx.RestoreContext()
+			setupContext(t)
 			ctx := context.Background()
 			kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 			cluster := &types.Cluster{
@@ -877,9 +833,7 @@ func TestProviderGenerateCAPISpecForUpgradeUpdateMachineTemplateExternalEtcd(t *
 
 func TestProviderGenerateCAPISpecForUpgradeNotUpdateMachineTemplate(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 	ctx := context.Background()
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	cluster := &types.Cluster{
@@ -958,9 +912,7 @@ func TestProviderGenerateCAPISpecForUpgradeNotUpdateMachineTemplate(t *testing.T
 
 func TestProviderGenerateCAPISpecForCreate(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 	ctx := context.Background()
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	cluster := &types.Cluster{
@@ -990,9 +942,7 @@ func TestProviderGenerateCAPISpecForCreate(t *testing.T) {
 
 func TestProviderGenerateCAPISpecForCreateWithMultipleWorkerNodeGroups(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 	ctx := context.Background()
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	cluster := &types.Cluster{
@@ -1276,9 +1226,7 @@ func TestSetupAndValidateCreateCluster(t *testing.T) {
 	provider := givenProvider(t)
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -1310,9 +1258,7 @@ func TestSetupAndValidateCreateClusterNoUsername(t *testing.T) {
 	ctx := context.Background()
 	clusterSpec := givenEmptyClusterSpec()
 	provider := givenProvider(t)
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 	os.Unsetenv(config.EksavSphereUsernameKey)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
@@ -1324,9 +1270,7 @@ func TestSetupAndValidateCreateClusterNoPassword(t *testing.T) {
 	ctx := context.Background()
 	clusterSpec := givenEmptyClusterSpec()
 	provider := givenProvider(t)
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 	os.Unsetenv(config.EksavSpherePasswordKey)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
@@ -1339,9 +1283,7 @@ func TestSetupAndValidateCreateWorkloadClusterSuccess(t *testing.T) {
 	provider := givenProvider(t)
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	datacenterConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
 	newMachineConfigs := givenMachineConfigs(t, testClusterConfigMainFilename)
@@ -1373,9 +1315,7 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfMachineExists(t *testing.T)
 	provider := givenProvider(t)
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	newMachineConfigs := givenMachineConfigs(t, testClusterConfigMainFilename)
 
@@ -1412,9 +1352,7 @@ func TestSetupAndValidateSelfManagedClusterSkipMachineNameValidateSuccess(t *tes
 	provider := givenProvider(t)
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
@@ -1440,9 +1378,7 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfDatacenterExists(t *testing
 	provider := givenProvider(t)
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	datacenterConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
 	newMachineConfigs := givenMachineConfigs(t, testClusterConfigMainFilename)
@@ -1473,9 +1409,7 @@ func TestSetupAndValidateSelfManagedClusterSkipDatacenterNameValidateSuccess(t *
 	provider := givenProvider(t)
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
@@ -1500,9 +1434,7 @@ func TestSetupAndValidateSelfManagedClusterSkipDatacenterNameValidateSuccess(t *
 func TestSetupAndValidateDeleteCluster(t *testing.T) {
 	ctx := context.Background()
 	provider := givenProvider(t)
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateDeleteCluster(ctx, nil, nil)
 	if err != nil {
@@ -1513,9 +1445,7 @@ func TestSetupAndValidateDeleteCluster(t *testing.T) {
 func TestSetupAndValidateDeleteClusterNoPassword(t *testing.T) {
 	ctx := context.Background()
 	provider := givenProvider(t)
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 	os.Unsetenv(config.EksavSpherePasswordKey)
 
 	err := provider.SetupAndValidateDeleteCluster(ctx, nil, nil)
@@ -1532,9 +1462,7 @@ func TestSetupAndValidateUpgradeCluster(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	provider.providerKubectlClient = kubectl
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil)
 	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec, clusterSpec)
@@ -1547,9 +1475,7 @@ func TestSetupAndValidateUpgradeClusterNoUsername(t *testing.T) {
 	ctx := context.Background()
 	clusterSpec := givenEmptyClusterSpec()
 	provider := givenProvider(t)
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 	os.Unsetenv(config.EksavSphereUsernameKey)
 
 	cluster := &types.Cluster{}
@@ -1562,9 +1488,7 @@ func TestSetupAndValidateUpgradeClusterNoPassword(t *testing.T) {
 	ctx := context.Background()
 	clusterSpec := givenEmptyClusterSpec()
 	provider := givenProvider(t)
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 	os.Unsetenv(config.EksavSpherePasswordKey)
 
 	cluster := &types.Cluster{}
@@ -1580,8 +1504,7 @@ func TestSetupAndValidateUpgradeClusterCPSshNotExists(t *testing.T) {
 	provider := givenProvider(t)
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
@@ -1602,8 +1525,7 @@ func TestSetupAndValidateUpgradeClusterWorkerSshNotExists(t *testing.T) {
 	provider := givenProvider(t)
 	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
@@ -1625,8 +1547,7 @@ func TestSetupAndValidateUpgradeClusterEtcdSshNotExists(t *testing.T) {
 	provider := givenProvider(t)
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
@@ -1646,9 +1567,7 @@ func TestVersion(t *testing.T) {
 	provider := givenProvider(t)
 	clusterSpec := givenEmptyClusterSpec()
 	clusterSpec.VersionsBundle.VSphere.Version = vSphereProviderVersion
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	result := provider.Version(clusterSpec)
 	if result != vSphereProviderVersion {
@@ -1682,9 +1601,7 @@ func TestProviderBootstrapSetup(t *testing.T) {
 		"eksaLicense":               "",
 	}
 
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	tpl, err := template.New("test").Funcs(sprig.TxtFuncMap()).Parse(defaultSecretObject)
 	if err != nil {
@@ -1725,9 +1642,7 @@ func TestProviderUpdateSecretSuccess(t *testing.T) {
 		"eksaSystemNamespace":       constants.EksaSystemNamespace,
 	}
 
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	kubectl.EXPECT().ApplyKubeSpecFromBytes(ctx, gomock.Any(), gomock.Any())
 
@@ -1751,8 +1666,7 @@ func TestSetupAndValidateCreateClusterNoServer(t *testing.T) {
 	clusterSpec := givenEmptyClusterSpec()
 	provider := givenProvider(t)
 	provider.datacenterConfig.Spec.Server = ""
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 
@@ -1765,8 +1679,7 @@ func TestSetupAndValidateCreateClusterInsecure(t *testing.T) {
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
 	provider.datacenterConfig.Spec.Insecure = true
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -1783,8 +1696,7 @@ func TestSetupAndValidateCreateClusterNoDatacenter(t *testing.T) {
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
 	provider.datacenterConfig.Spec.Datacenter = ""
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 
@@ -1797,8 +1709,7 @@ func TestSetupAndValidateCreateClusterNoNetwork(t *testing.T) {
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
 	provider.datacenterConfig.Spec.Network = ""
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 
@@ -1812,8 +1723,7 @@ func TestSetupAndValidateCreateClusterNotControlPlaneVMsMemoryMiB(t *testing.T) 
 	provider := givenProvider(t)
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.MemoryMiB = 0
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -1831,8 +1741,7 @@ func TestSetupAndValidateCreateClusterNotControlPlaneVMsNumCPUs(t *testing.T) {
 	provider := givenProvider(t)
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.NumCPUs = 0
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -1850,8 +1759,7 @@ func TestSetupAndValidateCreateClusterNotWorkloadVMsMemoryMiB(t *testing.T) {
 	provider := givenProvider(t)
 	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.MemoryMiB = 0
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -1869,8 +1777,7 @@ func TestSetupAndValidateCreateClusterNotWorkloadVMsNumCPUs(t *testing.T) {
 	provider := givenProvider(t)
 	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.NumCPUs = 0
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -1888,8 +1795,7 @@ func TestSetupAndValidateCreateClusterNotEtcdVMsMemoryMiB(t *testing.T) {
 	provider := givenProvider(t)
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.MemoryMiB = 0
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -1907,8 +1813,7 @@ func TestSetupAndValidateCreateClusterNotEtcdVMsNumCPUs(t *testing.T) {
 	provider := givenProvider(t)
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.NumCPUs = 0
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -1925,8 +1830,7 @@ func TestSetupAndValidateCreateClusterBogusIp(t *testing.T) {
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
 	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host = "bogus"
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 
@@ -1939,8 +1843,7 @@ func TestSetupAndValidateCreateClusterUsedIp(t *testing.T) {
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
 	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host = "255.255.255.255"
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 
@@ -1955,8 +1858,7 @@ func TestSetupAndValidateForCreateSSHAuthorizedKeyInvalidCP(t *testing.T) {
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	thenErrorExpected(t, "failed setup and validations: ssh: no key found", err)
@@ -1970,8 +1872,7 @@ func TestSetupAndValidateForCreateSSHAuthorizedKeyInvalidWorker(t *testing.T) {
 	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	thenErrorExpected(t, "failed setup and validations: ssh: no key found", err)
@@ -1985,8 +1886,7 @@ func TestSetupAndValidateForCreateSSHAuthorizedKeyInvalidEtcd(t *testing.T) {
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	thenErrorExpected(t, "failed setup and validations: ssh: no key found", err)
@@ -2000,8 +1900,7 @@ func TestSetupAndValidateForUpgradeSSHAuthorizedKeyInvalidCP(t *testing.T) {
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	cluster := &types.Cluster{}
 	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec, clusterSpec)
@@ -2016,8 +1915,7 @@ func TestSetupAndValidateForUpgradeSSHAuthorizedKeyInvalidWorker(t *testing.T) {
 	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	cluster := &types.Cluster{}
 	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec, clusterSpec)
@@ -2032,8 +1930,7 @@ func TestSetupAndValidateForUpgradeSSHAuthorizedKeyInvalidEtcd(t *testing.T) {
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	tempKey := "ssh-rsa AAAA    B3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = tempKey
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	cluster := &types.Cluster{}
 	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec, clusterSpec)
@@ -2051,8 +1948,7 @@ func TestSetupAndValidateSSHAuthorizedKeyEmptyCP(t *testing.T) {
 	provider := givenProvider(t)
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -2074,8 +1970,7 @@ func TestSetupAndValidateSSHAuthorizedKeyEmptyWorker(t *testing.T) {
 	provider := givenProvider(t)
 	workerNodeMachineConfigName := clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -2097,8 +1992,7 @@ func TestSetupAndValidateSSHAuthorizedKeyEmptyEtcd(t *testing.T) {
 	provider := givenProvider(t)
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -2125,8 +2019,7 @@ func TestSetupAndValidateSSHAuthorizedKeyEmptyAllMachineConfigs(t *testing.T) {
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys[0] = ""
 
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -2164,8 +2057,7 @@ func TestSetupAndValidateUsersNil(t *testing.T) {
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users = nil
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users = nil
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -2188,8 +2080,7 @@ func TestSetupAndValidateSshAuthorizedKeysNil(t *testing.T) {
 	provider.machineConfigs[workerNodeMachineConfigName].Spec.Users[0].SshAuthorizedKeys = nil
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].SshAuthorizedKeys = nil
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -2203,8 +2094,7 @@ func TestSetupAndValidateCreateClusterCPMachineGroupRefNonexistent(t *testing.T)
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
 	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "nonexistent"
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -2218,8 +2108,7 @@ func TestSetupAndValidateCreateClusterWorkerMachineGroupRefNonexistent(t *testin
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
 	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name = "nonexistent"
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -2233,8 +2122,7 @@ func TestSetupAndValidateCreateClusterEtcdMachineGroupRefNonexistent(t *testing.
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
 	provider := givenProvider(t)
 	clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name = "nonexistent"
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -2250,8 +2138,7 @@ func TestSetupAndValidateCreateClusterOsFamilyDifferent(t *testing.T) {
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.OSFamily = "bottlerocket"
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Users[0].Name = "ec2-user"
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -2267,8 +2154,7 @@ func TestSetupAndValidateCreateClusterOsFamilyDifferentForEtcd(t *testing.T) {
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.OSFamily = "bottlerocket"
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].Name = "ec2-user"
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -2296,8 +2182,7 @@ func TestSetupAndValidateCreateClusterOsFamilyEmpty(t *testing.T) {
 	etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[etcdMachineConfigName].Spec.OSFamily = ""
 	provider.machineConfigs[etcdMachineConfigName].Spec.Users[0].Name = ""
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -2321,8 +2206,7 @@ func TestSetupAndValidateCreateClusterTemplateDifferent(t *testing.T) {
 	provider := givenProvider(t)
 	controlPlaneMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	provider.machineConfigs[controlPlaneMachineConfigName].Spec.Template = "test"
-	var tctx testContext
-	tctx.SaveContext()
+	setupContext(t)
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
 	if err != nil {
@@ -2503,6 +2387,7 @@ func TestGetDatacenterConfig(t *testing.T) {
 func TestValidateNewSpecSuccess(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	clusterConfig := givenClusterConfig(t, testClusterConfigMainFilename)
+	setupContext(t)
 
 	provider := givenProvider(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
@@ -2539,6 +2424,7 @@ func TestValidateNewSpecSuccess(t *testing.T) {
 func TestValidateNewSpecMutableFields(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	clusterConfig := givenClusterConfig(t, testClusterConfigMainFilename)
+	setupContext(t)
 
 	provider := givenProvider(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
@@ -2854,9 +2740,7 @@ func TestProviderUpgradeNeeded(t *testing.T) {
 
 func TestProviderGenerateCAPISpecForCreateWithPodIAMConfig(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 	ctx := context.Background()
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	cluster := &types.Cluster{
@@ -2886,9 +2770,7 @@ func TestProviderGenerateCAPISpecForCreateWithPodIAMConfig(t *testing.T) {
 
 func TestProviderGenerateCAPISpecForCreateWithCustomResolvConf(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 	ctx := context.Background()
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	cluster := &types.Cluster{
@@ -2918,9 +2800,7 @@ func TestProviderGenerateCAPISpecForCreateWithCustomResolvConf(t *testing.T) {
 
 func TestProviderGenerateCAPISpecForCreateVersion121(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 	ctx := context.Background()
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	cluster := &types.Cluster{
@@ -2950,9 +2830,7 @@ func TestProviderGenerateCAPISpecForCreateVersion121(t *testing.T) {
 
 func TestProviderGenerateCAPISpecForCreateVersion121Controller(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 	ctx := context.Background()
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	cluster := &types.Cluster{
@@ -2986,9 +2864,7 @@ func TestSetupAndValidateCreateManagementDoesNotCheckIfMachineAndDataCenterExist
 	provider := givenProvider(t)
 	clusterSpec := givenEmptyClusterSpec()
 	fillClusterSpecWithClusterConfig(clusterSpec, givenClusterConfig(t, testClusterConfigMainFilename))
-	var tctx testContext
-	tctx.SaveContext()
-	defer tctx.RestoreContext()
+	setupContext(t)
 
 	datacenterConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
 	newMachineConfigs := givenMachineConfigs(t, testClusterConfigMainFilename)
@@ -3121,9 +2997,7 @@ func TestProviderGenerateCAPISpecForCreateMultipleCredentials(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			var tctx testContext
-			tctx.SaveContext()
-			defer tctx.RestoreContext()
+			setupContext(t)
 
 			previousValues := map[string]string{}
 			for k, v := range tt.envMap {

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -2,7 +2,6 @@ package validations_test
 
 import (
 	"errors"
-	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -107,6 +106,6 @@ func TestValidateK8s124SupportActive(t *testing.T) {
 	tt := newTlsTest(t)
 	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube124
 	features.ClearCache()
-	os.Setenv(features.K8s124SupportEnvVar, "true")
+	t.Setenv(features.K8s124SupportEnvVar, "true")
 	tt.Expect(validations.ValidateK8s124Support(tt.clusterSpec)).To(Succeed())
 }

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -62,18 +61,8 @@ func newUpgradeTest(t *testing.T) *upgradeTestSetup {
 	workflow := workflows.NewUpgrade(bootstrapper, provider, capiUpgrader, clusterManager, gitOpsManager, writer, eksdUpgrader, eksdInstaller)
 
 	for _, e := range featureEnvVars {
-		if err := os.Setenv(e, "true"); err != nil {
-			t.Fatal(err)
-		}
+		t.Setenv(e, "true")
 	}
-
-	t.Cleanup(func() {
-		for _, e := range featureEnvVars {
-			if err := os.Unsetenv(e); err != nil {
-				t.Fatal(err)
-			}
-		}
-	})
 
 	return &upgradeTestSetup{
 		t:                t,


### PR DESCRIPTION
*Description of changes:*

A testing cleanup.

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)
	
	if err := os.Setenv(key, "new value"); err != nil {
		t.Fatal(err)
	}
	defer func() {
		if err := os.Setenv(key, originalEnv); err != nil {
			t.Logf("failed to set env %s back to original value: %v", key, err)
		}
	}()
	
	// after
	t.Setenv(key, "new value")
}
```

*Testing (if applicable):*

