### PR TITLE
Expose maxSurge and maxUnavailable knobs for rolling update strategy

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -172,6 +172,23 @@ spec:
                       - key
                       type: object
                     type: array
+                  upgradeRolloutStrategy:
+                    description: UpgradeRolloutStrategy determines the rollout strategy
+                      to use for rolling upgrades and related parameters/knobs
+                    properties:
+                      rollingUpdate:
+                        properties:
+                          maxSurge:
+                            type: integer
+                          maxUnavailable:
+                            type: integer
+                        required:
+                        - maxSurge
+                        - maxUnavailable
+                        type: object
+                      type:
+                        type: string
+                    type: object
                 type: object
               datacenterRef:
                 properties:
@@ -330,6 +347,23 @@ spec:
                         - key
                         type: object
                       type: array
+                    upgradeRolloutStrategy:
+                      description: UpgradeRolloutStrategy determines the rollout strategy
+                        to use for rolling upgrades and related parameters/knobs
+                      properties:
+                        rollingUpdate:
+                          properties:
+                            maxSurge:
+                              type: integer
+                            maxUnavailable:
+                              type: integer
+                          required:
+                          - maxSurge
+                          - maxUnavailable
+                          type: object
+                        type:
+                          type: string
+                      type: object
                   type: object
                 type: array
             type: object

--- a/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbellmachineconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbellmachineconfigs.yaml
@@ -53,18 +53,6 @@ spec:
                   name:
                     type: string
                 type: object
-              upgradeRolloutStrategy:
-                properties:
-                  rollingUpdateParams:
-                    properties:
-                      maxSurge:
-                        type: integer
-                      maxUnavailable:
-                        type: integer
-                    type: object
-                  type:
-                    type: string
-                type: object
               users:
                 items:
                   description: UserConfiguration defines the configuration of the

--- a/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbellmachineconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbellmachineconfigs.yaml
@@ -53,6 +53,18 @@ spec:
                   name:
                     type: string
                 type: object
+              upgradeRolloutStrategy:
+                properties:
+                  rollingUpdateParams:
+                    properties:
+                      maxSurge:
+                        type: integer
+                      maxUnavailable:
+                        type: integer
+                    type: object
+                  type:
+                    type: string
+                type: object
               users:
                 items:
                   description: UserConfiguration defines the configuration of the

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4891,6 +4891,18 @@ spec:
                   name:
                     type: string
                 type: object
+              upgradeRolloutStrategy:
+                properties:
+                  rollingUpdateParams:
+                    properties:
+                      maxSurge:
+                        type: integer
+                      maxUnavailable:
+                        type: integer
+                    type: object
+                  type:
+                    type: string
+                type: object
               users:
                 items:
                   description: UserConfiguration defines the configuration of the

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -3649,6 +3649,23 @@ spec:
                       - key
                       type: object
                     type: array
+                  upgradeRolloutStrategy:
+                    description: UpgradeRolloutStrategy determines the rollout strategy
+                      to use for rolling upgrades and related parameters/knobs
+                    properties:
+                      rollingUpdate:
+                        properties:
+                          maxSurge:
+                            type: integer
+                          maxUnavailable:
+                            type: integer
+                        required:
+                        - maxSurge
+                        - maxUnavailable
+                        type: object
+                      type:
+                        type: string
+                    type: object
                 type: object
               datacenterRef:
                 properties:
@@ -3807,6 +3824,23 @@ spec:
                         - key
                         type: object
                       type: array
+                    upgradeRolloutStrategy:
+                      description: UpgradeRolloutStrategy determines the rollout strategy
+                        to use for rolling upgrades and related parameters/knobs
+                      properties:
+                        rollingUpdate:
+                          properties:
+                            maxSurge:
+                              type: integer
+                            maxUnavailable:
+                              type: integer
+                          required:
+                          - maxSurge
+                          - maxUnavailable
+                          type: object
+                        type:
+                          type: string
+                      type: object
                   type: object
                 type: array
             type: object
@@ -4889,18 +4923,6 @@ spec:
                   kind:
                     type: string
                   name:
-                    type: string
-                type: object
-              upgradeRolloutStrategy:
-                properties:
-                  rollingUpdateParams:
-                    properties:
-                      maxSurge:
-                        type: integer
-                      maxUnavailable:
-                        type: integer
-                    type: object
-                  type:
                     type: string
                 type: object
               users:

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -2630,6 +2630,222 @@ func TestValidateControlPlaneEndpoint(t *testing.T) {
 	}
 }
 
+func TestValidateCPUpgradeRolloutStrategy(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr string
+		cluster *Cluster
+	}{
+		{
+			name:    "rolling upgrade strategy invalid",
+			wantErr: "ControlPlaneConfiguration: only 'RollingUpdate' supported for upgrade rollout strategy type",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						UpgradeRolloutStrategy: &ControlPlaneUpgradeRolloutStrategy{Type: "NotRollingUpdate"},
+					},
+				},
+			},
+		},
+		{
+			name:    "rolling upgrade knobs not specified",
+			wantErr: "",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						UpgradeRolloutStrategy: &ControlPlaneUpgradeRolloutStrategy{Type: "RollingUpdate"},
+					},
+				},
+			},
+		},
+		{
+			name:    "rolling upgrade invalid",
+			wantErr: "maxSurge for control plane must be 0 or 1",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						UpgradeRolloutStrategy: &ControlPlaneUpgradeRolloutStrategy{Type: "RollingUpdate", RollingUpdate: ControlPlaneRollingUpdateParams{MaxSurge: 2}},
+					},
+				},
+			},
+		},
+		{
+			name:    "rolling upgrade knobs valid value 0",
+			wantErr: "",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						UpgradeRolloutStrategy: &ControlPlaneUpgradeRolloutStrategy{Type: "RollingUpdate", RollingUpdate: ControlPlaneRollingUpdateParams{MaxSurge: 0}},
+					},
+				},
+			},
+		},
+		{
+			name:    "rolling upgrade knobs valid value 1",
+			wantErr: "",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						UpgradeRolloutStrategy: &ControlPlaneUpgradeRolloutStrategy{Type: "RollingUpdate", RollingUpdate: ControlPlaneRollingUpdateParams{MaxSurge: 1}},
+					},
+				},
+			},
+		},
+		{
+			name:    "rolling upgrade knobs invalid value -1",
+			wantErr: "ControlPlaneConfiguration: maxSurge for control plane cannot be a negative value",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						UpgradeRolloutStrategy: &ControlPlaneUpgradeRolloutStrategy{Type: "RollingUpdate", RollingUpdate: ControlPlaneRollingUpdateParams{MaxSurge: -1}},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := validateCPUpgradeRolloutStrategy(tt.cluster)
+			if tt.wantErr == "" {
+				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			}
+		})
+	}
+}
+
+func TestValidateMDUpgradeRolloutStrategy(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr string
+		cluster *Cluster
+	}{
+		{
+			name:    "rolling upgrade strategy invalid",
+			wantErr: "WorkerNodeGroupConfiguration: only 'RollingUpdate' supported for upgrade rollout strategy type",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						UpgradeRolloutStrategy: &WorkerNodesUpgradeRolloutStrategy{Type: "NotRollingUpdate"},
+					}},
+				},
+			},
+		},
+		{
+			name:    "rolling upgrade knobs not specified",
+			wantErr: "WorkerNodeGroupConfiguration: maxSurge and maxUnavailable not specified or are 0. maxSurge and maxUnavailable cannot both be 0",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						UpgradeRolloutStrategy: &WorkerNodesUpgradeRolloutStrategy{Type: "RollingUpdate"},
+					}},
+				},
+			},
+		},
+		{
+			name:    "rolling upgrade invalid",
+			wantErr: "WorkerNodeGroupConfiguration: maxSurge and maxUnavailable not specified or are 0. maxSurge and maxUnavailable cannot both be 0",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						UpgradeRolloutStrategy: &WorkerNodesUpgradeRolloutStrategy{Type: "RollingUpdate", RollingUpdate: WorkerNodesRollingUpdateParams{MaxSurge: 0, MaxUnavailable: 0}},
+					}},
+				},
+			},
+		},
+		{
+			name:    "rolling upgrade knobs valid value 0,1",
+			wantErr: "",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						UpgradeRolloutStrategy: &WorkerNodesUpgradeRolloutStrategy{Type: "RollingUpdate", RollingUpdate: WorkerNodesRollingUpdateParams{MaxSurge: 0, MaxUnavailable: 1}},
+					}},
+				},
+			},
+		},
+		{
+			name:    "rolling upgrade knobs valid value 1,0",
+			wantErr: "",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						UpgradeRolloutStrategy: &WorkerNodesUpgradeRolloutStrategy{Type: "RollingUpdate", RollingUpdate: WorkerNodesRollingUpdateParams{MaxSurge: 1, MaxUnavailable: 0}},
+					}},
+				},
+			},
+		},
+		{
+			name:    "rolling upgrade knobs valid value 5,0",
+			wantErr: "",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						UpgradeRolloutStrategy: &WorkerNodesUpgradeRolloutStrategy{Type: "RollingUpdate", RollingUpdate: WorkerNodesRollingUpdateParams{MaxSurge: 5, MaxUnavailable: 0}},
+					}},
+				},
+			},
+		},
+		{
+			name:    "rolling upgrade knobs valid value 3,1",
+			wantErr: "",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						UpgradeRolloutStrategy: &WorkerNodesUpgradeRolloutStrategy{Type: "RollingUpdate", RollingUpdate: WorkerNodesRollingUpdateParams{MaxSurge: 3, MaxUnavailable: 1}},
+					}},
+				},
+			},
+		},
+		{
+			name:    "rolling upgrade knobs invalid values 3,-1",
+			wantErr: "WorkerNodeGroupConfiguration: maxSurge and maxUnavailable values cannot be negative",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						UpgradeRolloutStrategy: &WorkerNodesUpgradeRolloutStrategy{Type: "RollingUpdate", RollingUpdate: WorkerNodesRollingUpdateParams{MaxSurge: 3, MaxUnavailable: -1}},
+					}},
+				},
+			},
+		},
+		{
+			name:    "rolling upgrade knobs invalid values -3,1",
+			wantErr: "WorkerNodeGroupConfiguration: maxSurge and maxUnavailable values cannot be negative",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						UpgradeRolloutStrategy: &WorkerNodesUpgradeRolloutStrategy{Type: "RollingUpdate", RollingUpdate: WorkerNodesRollingUpdateParams{MaxSurge: -3, MaxUnavailable: 1}},
+					}},
+				},
+			},
+		},
+		{
+			name:    "rolling upgrade knobs invalid values -3,-1",
+			wantErr: "WorkerNodeGroupConfiguration: maxSurge and maxUnavailable values cannot be negative",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						UpgradeRolloutStrategy: &WorkerNodesUpgradeRolloutStrategy{Type: "RollingUpdate", RollingUpdate: WorkerNodesRollingUpdateParams{MaxSurge: -3, MaxUnavailable: -1}},
+					}},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := validateMDUpgradeRolloutStrategy(&tt.cluster.Spec.WorkerNodeGroupConfigurations[0])
+			if tt.wantErr == "" {
+				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			}
+		})
+	}
+}
+
 func TestGetClusterDefaultKubernetesVersion(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(GetClusterDefaultKubernetesVersion()).To(Equal(Kube123))
@@ -2661,6 +2877,127 @@ func TestClusterWorkerNodeConfigCount(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cg := NewClusterGenerate("test-cluster", WorkerNodeConfigCount(5))
+			g := NewWithT(t)
+			g.Expect(cg.Spec.WorkerNodeGroupConfigurations).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestClusterCPUpgradeRolloutStrategyNil(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *Cluster
+		want    ControlPlaneConfiguration
+	}{
+		{
+			name: "with control plane rollout upgrade strategy nil",
+			cluster: &Cluster{
+				Spec: ClusterSpec{},
+			},
+			want: ControlPlaneConfiguration{
+				Endpoint:               nil,
+				Count:                  1,
+				MachineGroupRef:        nil,
+				Taints:                 nil,
+				Labels:                 nil,
+				UpgradeRolloutStrategy: nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cg := NewClusterGenerate("test-cluster", ControlPlaneConfigCount(1))
+			g := NewWithT(t)
+			g.Expect(cg.Spec.ControlPlaneConfiguration).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestClusterCPUpgradeRolloutStrategyNotNil(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *Cluster
+		want    ControlPlaneConfiguration
+	}{
+		{
+			name: "with control plane rollout upgrade strategy non-nil",
+			cluster: &Cluster{
+				Spec: ClusterSpec{},
+			},
+			want: ControlPlaneConfiguration{
+				Endpoint:               nil,
+				Count:                  1,
+				MachineGroupRef:        nil,
+				Taints:                 nil,
+				Labels:                 nil,
+				UpgradeRolloutStrategy: &ControlPlaneUpgradeRolloutStrategy{Type: "RollingUpdate", RollingUpdate: ControlPlaneRollingUpdateParams{MaxSurge: 5}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cg := NewClusterGenerate("test-cluster", ControlPlaneConfigCount(1), WithCPUpgradeRolloutStrategy(5, 2))
+			g := NewWithT(t)
+			g.Expect(cg.Spec.ControlPlaneConfiguration).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestClusterMDUpgradeRolloutStrategyNil(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *Cluster
+		want    []WorkerNodeGroupConfiguration
+	}{
+		{
+			name: "with md rollout upgrade strategy knobs not specified",
+			cluster: &Cluster{
+				Spec: ClusterSpec{},
+			},
+			want: []WorkerNodeGroupConfiguration{
+				{
+					Count:           ptr.Int(1),
+					MachineGroupRef: nil,
+					Taints:          nil,
+					Labels:          nil,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cg := NewClusterGenerate("test-cluster", WorkerNodeConfigCount(1))
+			g := NewWithT(t)
+			g.Expect(cg.Spec.WorkerNodeGroupConfigurations).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestClusterMDUpgradeRolloutStrategyNotNil(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *Cluster
+		want    []WorkerNodeGroupConfiguration
+	}{
+		{
+			name: "with md rollout upgrade strategy",
+			cluster: &Cluster{
+				Spec: ClusterSpec{},
+			},
+			want: []WorkerNodeGroupConfiguration{
+				{
+					Count:                  ptr.Int(1),
+					MachineGroupRef:        nil,
+					Taints:                 nil,
+					Labels:                 nil,
+					UpgradeRolloutStrategy: &WorkerNodesUpgradeRolloutStrategy{Type: "RollingUpdate", RollingUpdate: WorkerNodesRollingUpdateParams{MaxSurge: 5, MaxUnavailable: 2}},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cg := NewClusterGenerate("test-cluster", WorkerNodeConfigCount(1), WithWorkerMachineUpgradeRolloutStrategy(5, 2))
 			g := NewWithT(t)
 			g.Expect(cg.Spec.WorkerNodeGroupConfigurations).To(Equal(tt.want))
 		})

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -169,6 +169,9 @@ type ControlPlaneConfiguration struct {
 	Taints []corev1.Taint `json:"taints,omitempty"`
 	// Labels define the labels to assign to the node
 	Labels map[string]string `json:"labels,omitempty"`
+	// UpgradeRolloutStrategy determines the rollout strategy to use for rolling upgrades
+	// and related parameters/knobs
+	UpgradeRolloutStrategy *ControlPlaneUpgradeRolloutStrategy `json:"upgradeRolloutStrategy,omitempty"`
 }
 
 func TaintsSliceEqual(s1, s2 []corev1.Taint) bool {
@@ -243,6 +246,9 @@ type WorkerNodeGroupConfiguration struct {
 	Taints []corev1.Taint `json:"taints,omitempty"`
 	// Labels define the labels to assign to the node
 	Labels map[string]string `json:"labels,omitempty"`
+	// UpgradeRolloutStrategy determines the rollout strategy to use for rolling upgrades
+	// and related parameters/knobs
+	UpgradeRolloutStrategy *WorkerNodesUpgradeRolloutStrategy `json:"upgradeRolloutStrategy,omitempty"`
 }
 
 func generateWorkerNodeGroupKey(c WorkerNodeGroupConfiguration) (key string) {
@@ -724,6 +730,29 @@ type AutoScalingConfiguration struct {
 	// MaxCount defines the maximum number of nodes for the associated resource group.
 	// +optional
 	MaxCount int `json:"maxCount,omitempty"`
+}
+
+// ControlPlaneUpgradeRolloutStrategy indicates rollout strategy for cluster.
+type ControlPlaneUpgradeRolloutStrategy struct {
+	Type          string                          `json:"type,omitempty"`
+	RollingUpdate ControlPlaneRollingUpdateParams `json:"rollingUpdate,omitempty"`
+}
+
+// ControlPlaneRollingUpdateParams is API for rolling update strategy knobs.
+type ControlPlaneRollingUpdateParams struct {
+	MaxSurge int `json:"maxSurge"`
+}
+
+// WorkerNodesUpgradeRolloutStrategy indicates rollout strategy for cluster.
+type WorkerNodesUpgradeRolloutStrategy struct {
+	Type          string                         `json:"type,omitempty"`
+	RollingUpdate WorkerNodesRollingUpdateParams `json:"rollingUpdate,omitempty"`
+}
+
+// WorkerNodesRollingUpdateParams is API for rolling update strategy knobs.
+type WorkerNodesRollingUpdateParams struct {
+	MaxSurge       int `json:"maxSurge"`
+	MaxUnavailable int `json:"maxUnavailable"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/api/v1alpha1/machine_types.go
+++ b/pkg/api/v1alpha1/machine_types.go
@@ -13,3 +13,13 @@ type UserConfiguration struct {
 	Name              string   `json:"name"`
 	SshAuthorizedKeys []string `json:"sshAuthorizedKeys"`
 }
+
+type UpgradeRolloutStrategy struct {
+	Type			string		`json:"type,omitempty"`
+	RollingUpdateParams	*RollingUpdate	`json:"rollingUpdateParams,omitempty"`
+}
+
+type RollingUpdate struct {
+	MaxSurge	int	`json:"maxSurge,omitempty"`
+	MaxUnavailable	int	`json:"maxUnavailable,omitempty"`
+}

--- a/pkg/api/v1alpha1/machine_types.go
+++ b/pkg/api/v1alpha1/machine_types.go
@@ -13,13 +13,3 @@ type UserConfiguration struct {
 	Name              string   `json:"name"`
 	SshAuthorizedKeys []string `json:"sshAuthorizedKeys"`
 }
-
-type UpgradeRolloutStrategy struct {
-	Type			string		`json:"type,omitempty"`
-	RollingUpdateParams	*RollingUpdate	`json:"rollingUpdateParams,omitempty"`
-}
-
-type RollingUpdate struct {
-	MaxSurge	int	`json:"maxSurge,omitempty"`
-	MaxUnavailable	int	`json:"maxUnavailable,omitempty"`
-}

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig.go
@@ -33,6 +33,9 @@ func NewTinkerbellMachineConfigGenerate(name string, opts ...TinkerbellMachineCo
 					SshAuthorizedKeys: []string{"ssh-rsa AAAA..."},
 				},
 			},
+			UpgradeRolloutStrategy:	UpgradeRolloutStrategy{
+				Type:	"RollingUpdate",
+			},
 		},
 	}
 

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig.go
@@ -33,9 +33,6 @@ func NewTinkerbellMachineConfigGenerate(name string, opts ...TinkerbellMachineCo
 					SshAuthorizedKeys: []string{"ssh-rsa AAAA..."},
 				},
 			},
-			UpgradeRolloutStrategy:	UpgradeRolloutStrategy{
-				Type:	"RollingUpdate",
-			},
 		},
 	}
 

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
@@ -10,11 +10,10 @@ import (
 
 // TinkerbellMachineConfigSpec defines the desired state of TinkerbellMachineConfig
 type TinkerbellMachineConfigSpec struct {
-	HardwareSelector	HardwareSelector	`json:"hardwareSelector"`
-	TemplateRef		Ref			`json:"templateRef,omitempty"`
-	OSFamily		OSFamily		`json:"osFamily"`
-	Users			[]UserConfiguration	`json:"users,omitempty"`
-	UpgradeRolloutStrategy	UpgradeRolloutStrategy	`json:"upgradeRolloutStrategy,omitempty"`
+	HardwareSelector HardwareSelector    `json:"hardwareSelector"`
+	TemplateRef      Ref                 `json:"templateRef,omitempty"`
+	OSFamily         OSFamily            `json:"osFamily"`
+	Users            []UserConfiguration `json:"users,omitempty"`
 }
 
 // HardwareSelector models a simple key-value selector used in Tinkerbell provisioning.

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
@@ -10,10 +10,11 @@ import (
 
 // TinkerbellMachineConfigSpec defines the desired state of TinkerbellMachineConfig
 type TinkerbellMachineConfigSpec struct {
-	HardwareSelector HardwareSelector    `json:"hardwareSelector"`
-	TemplateRef      Ref                 `json:"templateRef,omitempty"`
-	OSFamily         OSFamily            `json:"osFamily"`
-	Users            []UserConfiguration `json:"users,omitempty"`
+	HardwareSelector	HardwareSelector	`json:"hardwareSelector"`
+	TemplateRef		Ref			`json:"templateRef,omitempty"`
+	OSFamily		OSFamily		`json:"osFamily"`
+	Users			[]UserConfiguration	`json:"users,omitempty"`
+	UpgradeRolloutStrategy	UpgradeRolloutStrategy	`json:"upgradeRolloutStrategy,omitempty"`
 }
 
 // HardwareSelector models a simple key-value selector used in Tinkerbell provisioning.

--- a/pkg/clustermanager/internal/deployments.go
+++ b/pkg/clustermanager/internal/deployments.go
@@ -1,6 +1,6 @@
 package internal
 
-// map where key = namespace and value is a capi deployment
+// CAPIDeployments is a map where key = namespace and value is a capi deployment.
 var CAPIDeployments = map[string][]string{
 	"capi-kubeadm-bootstrap-system":     {"capi-kubeadm-bootstrap-controller-manager"},
 	"capi-kubeadm-control-plane-system": {"capi-kubeadm-control-plane-controller-manager"},

--- a/pkg/config/vsphereuser.go
+++ b/pkg/config/vsphereuser.go
@@ -8,10 +8,11 @@ import (
 const (
 	EksavSphereUsernameKey = "EKSA_VSPHERE_USERNAME"
 	EksavSpherePasswordKey = "EKSA_VSPHERE_PASSWORD"
-	// Username and password for cloud provider
+	// EksavSphereCPUsernameKey holds Username for cloud provider.
 	EksavSphereCPUsernameKey = "EKSA_VSPHERE_CP_USERNAME"
+	// EksavSphereCPPasswordKey holds Password for cloud provider.
 	EksavSphereCPPasswordKey = "EKSA_VSPHERE_CP_PASSWORD"
-	// Username and password for the CSI driver
+	// EksavSphereCSIUsernameKey holds Username and password for the CSI driver.
 	EksavSphereCSIUsernameKey = "EKSA_VSPHERE_CSI_USERNAME"
 	EksavSphereCSIPasswordKey = "EKSA_VSPHERE_CSI_PASSWORD"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,6 +1,6 @@
 package constants
 
-// Namespace constants
+// Namespace constants.
 const (
 	EksaSystemNamespace                     = "eksa-system"
 	EksaDiagnosticsNamespace                = "eksa-diagnostics"
@@ -43,7 +43,7 @@ const (
 	DefaultRegistry            = "public.ecr.aws"
 	CloudstackAnnotationSuffix = "cloudstack.anywhere.eks.amazonaws.com/v1alpha1"
 
-	// provider specific env vars
+	// Provider specific env vars.
 	VSphereUsernameKey = "VSPHERE_USERNAME"
 	VSpherePasswordKey = "VSPHERE_PASSWORD"
 	GovcUsernameKey    = "GOVC_USERNAME"

--- a/pkg/providers/cloudstack/decoder/decoder.go
+++ b/pkg/providers/cloudstack/decoder/decoder.go
@@ -18,7 +18,7 @@ const (
 	CloudStackGlobalAZ                    = "global"
 )
 
-// ParseCloudStackSecret parses the input b64 string into the ini object to extract out the api key, secret key, and url
+// ParseCloudStackSecret parses the input b64 string into the ini object to extract out the api key, secret key, and url.
 func ParseCloudStackSecret() (*CloudStackExecConfig, error) {
 	cloudStackB64EncodedSecret, ok := os.LookupEnv(EksacloudStackCloudConfigB64SecretKey)
 	if !ok {

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -283,6 +283,10 @@ spec:
       kind: TinkerbellMachineTemplate
       name: {{.controlPlaneTemplateName}}
   replicas: {{.controlPlaneReplicas}}
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   version: {{.kubernetesVersion}}
 ---
 {{- if .externalEtcd }}

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -283,10 +283,11 @@ spec:
       kind: TinkerbellMachineTemplate
       name: {{.controlPlaneTemplateName}}
   replicas: {{.controlPlaneReplicas}}
+{{- if .upgradeRolloutStrategy }}
   rolloutStrategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: {{.maxSurge}} 
+{{- end }}
   version: {{.kubernetesVersion}}
 ---
 {{- if .externalEtcd }}

--- a/pkg/providers/tinkerbell/config/template-md.yaml
+++ b/pkg/providers/tinkerbell/config/template-md.yaml
@@ -33,6 +33,10 @@ spec:
         kind: TinkerbellMachineTemplate
         name: {{.workloadTemplateName}}
       version: {{.kubernetesVersion}}
+  upgradeRolloutStrategy:
+    rollingUpdate:
+      maxSurge: {{.maxSurge}}
+      maxUnavailable: {{.maxUnavailable}}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/config/template-md.yaml
+++ b/pkg/providers/tinkerbell/config/template-md.yaml
@@ -33,10 +33,12 @@ spec:
         kind: TinkerbellMachineTemplate
         name: {{.workloadTemplateName}}
       version: {{.kubernetesVersion}}
-  upgradeRolloutStrategy:
+{{- if .upgradeRolloutStrategy }}
+  strategy:
     rollingUpdate:
       maxSurge: {{.maxSurge}}
       maxUnavailable: {{.maxUnavailable}}
+{{- end }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -148,6 +148,12 @@ func (tb *TemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, wo
 		values["workloadkubeadmconfigTemplateName"] = kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name]
 		values["autoscalingConfig"] = workerNodeGroupConfiguration.AutoScalingConfiguration
 
+		if workerNodeGroupConfiguration.UpgradeRolloutStrategy != nil {
+			values["upgradeRolloutStrategy"] = true
+			values["maxSurge"] = workerNodeGroupConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxSurge
+			values["maxUnavailable"] = workerNodeGroupConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxUnavailable
+		}
+
 		bytes, err := templater.Execute(defaultClusterConfigMD, values)
 		if err != nil {
 			return nil, err
@@ -411,6 +417,11 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec, controlPlaneMachineSpec, etcd
 		"controlPlaneTaints":            clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints,
 		"workerNodeGroupConfigurations": clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations,
 		"skipLoadBalancerDeployment":    datacenterSpec.SkipLoadBalancerDeployment,
+	}
+
+	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy != nil {
+		values["upgradeRolloutStrategy"] = true
+		values["maxSurge"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxSurge
 	}
 
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_awsiam.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_awsiam.yaml
@@ -13,6 +13,11 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneConfiguration:
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     count: 1
     endpoint:
       host: 1.2.3.4
@@ -30,6 +35,11 @@ spec:
     name: test
   workerNodeGroupConfigurations:
     - count: 1
+      upgradeRolloutStrategy:
+        type: "RollingUpdate"
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
       machineGroupRef:
         name: test-md
         kind: TinkerbellMachineConfig

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_bottlerocket_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_bottlerocket_minimal_registry_mirror.yaml
@@ -19,6 +19,11 @@ spec:
     machineGroupRef:
       name: test-cp
       kind: TinkerbellMachineConfig
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
   datacenterRef:
     kind: TinkerbellDatacenterConfig
     name: test
@@ -27,6 +32,11 @@ spec:
     name: test
   workerNodeGroupConfigurations:
   - count: 1
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     machineGroupRef:
       name: test-md
       kind: TinkerbellMachineConfig

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_bottlerocket_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_bottlerocket_registry_mirror_with_cert.yaml
@@ -13,6 +13,11 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
   controlPlaneConfiguration:
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     count: 1
     endpoint:
       host: 1.2.3.4
@@ -27,6 +32,11 @@ spec:
     name: test
   workerNodeGroupConfigurations:
   - count: 1
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     machineGroupRef:
       name: test-md
       kind: TinkerbellMachineConfig

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_external_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_external_etcd.yaml
@@ -13,6 +13,11 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneConfiguration:
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     count: 1
     endpoint:
       host: 1.2.3.4
@@ -35,6 +40,11 @@ spec:
       machineGroupRef:
         name: test-md
         kind: TinkerbellMachineConfig
+      upgradeRolloutStrategy:
+        type: "RollingUpdate"
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
 
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_full_oidc.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_full_oidc.yaml
@@ -13,6 +13,11 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneConfiguration:
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     count: 1
     endpoint:
       host: 1.2.3.4
@@ -33,6 +38,11 @@ spec:
       machineGroupRef:
         name: test-md
         kind: TinkerbellMachineConfig
+      upgradeRolloutStrategy:
+        type: "RollingUpdate"
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
 
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_minimal_oidc.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_minimal_oidc.yaml
@@ -14,6 +14,11 @@ spec:
         - 10.96.0.0/12
   controlPlaneConfiguration:
     count: 1
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     endpoint:
       host: 1.2.3.4
     machineGroupRef:
@@ -33,6 +38,11 @@ spec:
       machineGroupRef:
         name: test-md
         kind: TinkerbellMachineConfig
+      upgradeRolloutStrategy:
+        type: "RollingUpdate"
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
 
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_minimal_registry_mirror.yaml
@@ -14,6 +14,11 @@ spec:
       - 10.96.0.0/12
   controlPlaneConfiguration:
     count: 1
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     endpoint:
       host: 1.2.3.4
     machineGroupRef:
@@ -30,6 +35,11 @@ spec:
     machineGroupRef:
       name: test-md
       kind: TinkerbellMachineConfig
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
   registryMirrorConfiguration:
     endpoint: 1.2.3.4
     port: 1234

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_missing_ssh_keys.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_missing_ssh_keys.yaml
@@ -13,6 +13,11 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneConfiguration:
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     count: 1
     endpoint:
       host: 1.2.3.4
@@ -27,6 +32,11 @@ spec:
     name: test
   workerNodeGroupConfigurations:
     - count: 1
+      upgradeRolloutStrategy:
+        type: "RollingUpdate"
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
       machineGroupRef:
         name: test-md
         kind: TinkerbellMachineConfig

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_multiple_node_groups.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_multiple_node_groups.yaml
@@ -13,6 +13,11 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneConfiguration:
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     count: 1
     endpoint:
       host: 1.2.3.4
@@ -30,11 +35,21 @@ spec:
       machineGroupRef:
         name: test-md
         kind: TinkerbellMachineConfig
+      upgradeRolloutStrategy:
+        type: "RollingUpdate"
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
       name: md-0
     - count: 1
       machineGroupRef:
         name: test-md
         kind: TinkerbellMachineConfig
+      upgradeRolloutStrategy:
+        type: "RollingUpdate"
+        rollingUpdate:
+          maxSurge: 5
+          maxUnavailable: 3
       name: md-1
 
 ---

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_node_labels.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_node_labels.yaml
@@ -13,6 +13,11 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
   controlPlaneConfiguration:
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     count: 1
     endpoint:
       host: 1.2.3.4
@@ -33,6 +38,11 @@ spec:
     machineGroupRef:
       name: test-md
       kind: TinkerbellMachineConfig
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     labels:
       key1-md: value1-md
       key2-md: value2-md

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_node_taints.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_node_taints.yaml
@@ -14,6 +14,11 @@ spec:
       - 10.96.0.0/12
   controlPlaneConfiguration:
     count: 1
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     endpoint:
       host: 1.2.3.4
     machineGroupRef:
@@ -40,6 +45,11 @@ spec:
     machineGroupRef:
       name: test-md
       kind: TinkerbellMachineConfig
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     taints:
     - key: key1
       value: val1

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_registry_mirror_with_cert.yaml
@@ -14,6 +14,11 @@ spec:
       - 10.96.0.0/12
   controlPlaneConfiguration:
     count: 1
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     endpoint:
       host: 1.2.3.4
     machineGroupRef:
@@ -30,6 +35,11 @@ spec:
     machineGroupRef:
       name: test-md
       kind: TinkerbellMachineConfig
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
   registryMirrorConfiguration:
     endpoint: 1.2.3.4
     port: 1234

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_single_node.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_single_node.yaml
@@ -14,6 +14,11 @@ spec:
       - 10.96.0.0/12
   controlPlaneConfiguration:
     count: 1
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     endpoint:
       host: 1.2.3.4
     machineGroupRef:

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_stacked_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_stacked_etcd.yaml
@@ -14,6 +14,11 @@ spec:
       - 10.96.0.0/12
   controlPlaneConfiguration:
     count: 1
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     endpoint:
       host: 1.2.3.4
     machineGroupRef:
@@ -30,6 +35,11 @@ spec:
     machineGroupRef:
       name: test-md
       kind: TinkerbellMachineConfig
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
 
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_autoscaler_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_autoscaler_md.yaml
@@ -31,6 +31,10 @@ spec:
         kind: TinkerbellMachineTemplate
         name: test-md-0-1234567890000
       version: v1.21.2-eks-1-21-4
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_minimal_registry_mirror.yaml
@@ -139,6 +139,9 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
   replicas: 1
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
   version: v1.21.2-eks-1-21-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_cert.yaml
@@ -157,6 +157,9 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
   replicas: 1
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
   version: v1.21.2-eks-1-21-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_minimal_registry_mirror.yaml
@@ -28,6 +28,10 @@ spec:
         kind: TinkerbellMachineTemplate
         name: test-md-0-1234567890000
       version: v1.21.2-eks-1-21-4
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_cert.yaml
@@ -28,6 +28,10 @@ spec:
         kind: TinkerbellMachineTemplate
         name: test-md-0-1234567890000
       version: v1.21.2-eks-1-21-4
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_awsiam.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_awsiam.yaml
@@ -170,6 +170,9 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
   replicas: 1
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
   version: v1.21.2-eks-1-21-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
@@ -125,6 +125,9 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
   replicas: 1
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
   version: v1.21.2-eks-1-21-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_full_oidc.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_full_oidc.yaml
@@ -132,6 +132,9 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
   replicas: 1
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
   version: v1.21.2-eks-1-21-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_oidc.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_oidc.yaml
@@ -127,6 +127,9 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
   replicas: 1
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
   version: v1.21.2-eks-1-21-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_registry_mirror.yaml
@@ -135,6 +135,9 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
   replicas: 1
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
   version: v1.21.2-eks-1-21-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_labels.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_labels.yaml
@@ -127,6 +127,9 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
   replicas: 1
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
   version: v1.21.2-eks-1-21-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_taints.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_taints.yaml
@@ -145,6 +145,9 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
   replicas: 1
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
   version: v1.21.2-eks-1-21-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_cert.yaml
@@ -157,6 +157,9 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
   replicas: 1
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
   version: v1.21.2-eks-1-21-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml
@@ -131,6 +131,9 @@ spec:
       kind: TinkerbellMachineTemplate
       name: single-node-control-plane-template-1234567890000
   replicas: 1
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
   version: v1.21.2-eks-1-21-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
@@ -125,6 +125,9 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
   replicas: 1
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
   version: v1.21.2-eks-1-21-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md.yaml
@@ -28,6 +28,10 @@ spec:
         kind: TinkerbellMachineTemplate
         name: test-md-0-1234567890000
       version: v1.21.2-eks-1-21-4
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_minimal_registry_mirror.yaml
@@ -28,6 +28,10 @@ spec:
         kind: TinkerbellMachineTemplate
         name: test-md-0-1234567890000
       version: v1.21.2-eks-1-21-4
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_labels.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_labels.yaml
@@ -28,6 +28,10 @@ spec:
         kind: TinkerbellMachineTemplate
         name: test-md-0-1234567890000
       version: v1.21.2-eks-1-21-4
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_taints.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_taints.yaml
@@ -28,6 +28,10 @@ spec:
         kind: TinkerbellMachineTemplate
         name: test-md-0-1234567890000
       version: v1.21.2-eks-1-21-4
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_cert.yaml
@@ -28,6 +28,10 @@ spec:
         kind: TinkerbellMachineTemplate
         name: test-md-0-1234567890000
       version: v1.21.2-eks-1-21-4
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
@@ -125,6 +125,9 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
   replicas: 1
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
   version: v1.21.2-eks-1-21-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_md_multiple_node_groups.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_md_multiple_node_groups.yaml
@@ -28,6 +28,10 @@ spec:
         kind: TinkerbellMachineTemplate
         name: test-md-0-1234567890000
       version: v1.21.2-eks-1-21-4
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: TinkerbellMachineTemplate
@@ -194,6 +198,10 @@ spec:
         kind: TinkerbellMachineTemplate
         name: test-md-1-1234567890000
       version: v1.21.2-eks-1-21-4
+  strategy:
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 3
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/validate.go
+++ b/pkg/providers/tinkerbell/validate.go
@@ -59,6 +59,17 @@ func validateMachineConfig(config *v1alpha1.TinkerbellMachineConfig) error {
 		)
 	}
 
+	if config.Spec.UpgradeRolloutStrategy.Type == "" {
+		return fmt.Errorf("TinkerbellMachineConfig: missing spec.upgradeRolloutStrategy.type: %v", config.Name)
+	}
+
+	if config.Spec.UpgradeRolloutStrategy.Type != "RollingUpdate" {
+		return fmt.Errorf(
+			"TinkerbellMachineConfig: unsupported spec.upgradeRolloutStrategy.type (%v); Please use RollingUpdate",
+			config.Spec.OSFamily,
+		)
+	}
+
 	return nil
 }
 

--- a/pkg/providers/tinkerbell/validate.go
+++ b/pkg/providers/tinkerbell/validate.go
@@ -59,17 +59,6 @@ func validateMachineConfig(config *v1alpha1.TinkerbellMachineConfig) error {
 		)
 	}
 
-	if config.Spec.UpgradeRolloutStrategy.Type == "" {
-		return fmt.Errorf("TinkerbellMachineConfig: missing spec.upgradeRolloutStrategy.type: %v", config.Name)
-	}
-
-	if config.Spec.UpgradeRolloutStrategy.Type != "RollingUpdate" {
-		return fmt.Errorf(
-			"TinkerbellMachineConfig: unsupported spec.upgradeRolloutStrategy.type (%v); Please use RollingUpdate",
-			config.Spec.OSFamily,
-		)
-	}
-
 	return nil
 }
 

--- a/pkg/utils/urls/replace.go
+++ b/pkg/utils/urls/replace.go
@@ -9,7 +9,7 @@ import (
 // It supports full URLs and container image URLs
 // If the provided original url is malformed, the are no guarantees
 // that the returned value will be valid
-// If host is empty, it will return the original URL
+// If host is empty, it will return the original URL.
 func ReplaceHost(orgURL, host string) string {
 	if host == "" {
 		return orgURL

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -46,7 +46,7 @@ func New(cfg Config) *Workflow {
 }
 
 // AppendTask appends t to the list of workflow tasks. Task names must be unique within a workflow.
-// Duplicate names will receive an ErrDuplicateTaskName
+// Duplicate names will receive an ErrDuplicateTaskName.
 func (w *Workflow) AppendTask(name TaskName, t Task) error {
 	if _, found := w.taskNames[name]; found {
 		return ErrDuplicateTaskName{name}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

