### PR TITLE
Patch cmd comments to satisfy godot requirements

### DIFF
--- a/cmd/eksctl-anywhere/cmd/downloadimages.go
+++ b/cmd/eksctl-anywhere/cmd/downloadimages.go
@@ -20,7 +20,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/version"
 )
 
-// imagesCmd represents the images command
+// imagesCmd represents the images command.
 var downloadImagesCmd = &cobra.Command{
 	Use:   "images",
 	Short: "Download all eks-a images to disk",

--- a/cmd/eksctl-anywhere/cmd/import.go
+++ b/cmd/eksctl-anywhere/cmd/import.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// importCmd represents the import command
+// importCmd represents the import command.
 var importCmd = &cobra.Command{
 	Use:   "import",
 	Short: "Import resources",

--- a/cmd/eksctl-anywhere/cmd/import_images.go
+++ b/cmd/eksctl-anywhere/cmd/import_images.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
 )
 
-// imagesCmd represents the images command
+// imagesCmd represents the images command.
 var importImagesCmd = &cobra.Command{
 	Use:   "images",
 	Short: "Import images and charts to a registry from a tarball",


### PR DESCRIPTION
Godot was recently turned on as part of our linting. Some sources in the `/cmd` directory violate it with IDEs auto-correcting the mishaps. This commits those auto-corrections.