### PR TITLE
redacting the nutanix user and password from log stmts

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -50,6 +50,8 @@ const (
 	GovcPasswordKey    = "GOVC_PASSWORD"
 	SnowCredentialsKey = "AWS_B64ENCODED_CREDENTIALS"
 	SnowCertsKey       = "AWS_B64ENCODED_CA_BUNDLES"
+	NutanixUsernameKey = "NUTANIX_USER"
+	NutanixPasswordKey = "NUTANIX_PASSWORD"
 )
 
 type Operation int

--- a/pkg/executables/executables.go
+++ b/pkg/executables/executables.go
@@ -33,6 +33,8 @@ var redactedEnvKeys = []string{
 	config.AwsSecretAccessKeyEnv,
 	constants.SnowCredentialsKey,
 	constants.SnowCertsKey,
+	constants.NutanixUsernameKey,
+	constants.NutanixPasswordKey,
 }
 
 type executable struct {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Now it will show following instead of actual data
<pre>
NUTANIX_USER=***** -e NUTANIX_PASSWORD=*****
</pre>

*Testing (if applicable):*
ran create cluster and observed above

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

