### PR TITLE
Remove cgroup driver arg for docker 1.24 onwards

### DIFF
--- a/pkg/clusterapi/extraargs.go
+++ b/pkg/clusterapi/extraargs.go
@@ -102,6 +102,13 @@ func ControlPlaneNodeLabelsExtraArgs(cpc v1alpha1.ControlPlaneConfiguration) Ext
 	return nodeLabelsExtraArgs(cpc.Labels)
 }
 
+// CgroupDriverExtraArgs args added for kube versions below 1.24.
+func CgroupDriverExtraArgs() ExtraArgs {
+	args := ExtraArgs{}
+	args.AddIfNotEmpty("cgroup-driver", "cgroupfs")
+	return args
+}
+
 func nodeLabelsExtraArgs(labels map[string]string) ExtraArgs {
 	args := ExtraArgs{}
 	args.AddIfNotEmpty("node-labels", labelsMapToArg(labels))

--- a/pkg/clusterapi/extraargs_test.go
+++ b/pkg/clusterapi/extraargs_test.go
@@ -310,6 +310,28 @@ func TestSecureEtcdTlsCipherSuitesExtraArgs(t *testing.T) {
 	}
 }
 
+func TestCgroupDriverExtraArgs(t *testing.T) {
+	tests := []struct {
+		testName string
+		want     clusterapi.ExtraArgs
+	}{
+		{
+			testName: "default",
+			want: clusterapi.ExtraArgs{
+				"cgroup-driver": "cgroupfs",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			if got := clusterapi.CgroupDriverExtraArgs(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CgroupDriverExtraArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNodeLabelsExtraArgs(t *testing.T) {
 	tests := []struct {
 		testName string

--- a/pkg/providers/common/auditpolicy.go
+++ b/pkg/providers/common/auditpolicy.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
@@ -29,7 +30,7 @@ func GetAuditPolicy(kubeVersion v1alpha1.KubernetesVersion) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return string(auditPolicyv1), nil
+		return strings.TrimSpace(string(auditPolicyv1)), nil
 	}
 	return auditPolicy, nil
 }

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -179,7 +179,6 @@ spec:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
 {{- if .kubeletExtraArgs }}
 {{ .kubeletExtraArgs.ToYaml | indent 10 }}
@@ -198,7 +197,6 @@ spec:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
 {{- if .kubeletExtraArgs }}
 {{ .kubeletExtraArgs.ToYaml | indent 10 }}

--- a/pkg/providers/docker/config/template-md.yaml
+++ b/pkg/providers/docker/config/template-md.yaml
@@ -22,7 +22,6 @@ spec:
           taints: []
 {{- end }}
           kubeletExtraArgs:
-            cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
 {{- if .kubeletExtraArgs }}
 {{ .kubeletExtraArgs.ToYaml | indent 12 }}

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/providers/common"
+	"github.com/aws/eks-anywhere/pkg/semver"
 	"github.com/aws/eks-anywhere/pkg/templater"
 	"github.com/aws/eks-anywhere/pkg/types"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -153,7 +154,7 @@ type DockerTemplateBuilder struct {
 func (d *DockerTemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spec, buildOptions ...providers.BuildMapOption) (content []byte, err error) {
 	values, err := buildTemplateMapCP(clusterSpec)
 	if err != nil {
-		return nil, fmt.Errorf("error building template map from CP %v", err)
+		return nil, fmt.Errorf("error building template map for CP %v", err)
 	}
 	for _, buildOption := range buildOptions {
 		buildOption(values)
@@ -170,7 +171,10 @@ func (d *DockerTemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluste
 func (d *DockerTemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, workloadTemplateNames, kubeadmconfigTemplateNames map[string]string) (content []byte, err error) {
 	workerSpecs := make([][]byte, 0, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
 	for _, workerNodeGroupConfiguration := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
-		values := buildTemplateMapMD(clusterSpec, workerNodeGroupConfiguration)
+		values, err := buildTemplateMapMD(clusterSpec, workerNodeGroupConfiguration)
+		if err != nil {
+			return nil, fmt.Errorf("error building template map for MD %v", err)
+		}
 		values["workloadTemplateName"] = workloadTemplateNames[workerNodeGroupConfiguration.Name]
 		values["workloadkubeadmconfigTemplateName"] = kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name]
 
@@ -184,6 +188,22 @@ func (d *DockerTemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spe
 	return templater.AppendYamlResources(workerSpecs...), nil
 }
 
+func kubeletCgroupDriverExtraArgs(kubeVersion v1alpha1.KubernetesVersion) (clusterapi.ExtraArgs, error) {
+	clusterKubeVersionSemver, err := semver.KubeVersionToValidSemver(kubeVersion)
+	if err != nil {
+		return nil, fmt.Errorf("converting kubeVersion %v to semver %v", kubeVersion, err)
+	}
+	kube124Semver, err := semver.KubeVersionToValidSemver(v1alpha1.Kube124)
+	if err != nil {
+		return nil, fmt.Errorf("error converting kubeVersion %v to semver %v", v1alpha1.Kube124, err)
+	}
+	if clusterKubeVersionSemver.Compare(kube124Semver) != -1 {
+		return nil, nil
+	}
+
+	return clusterapi.CgroupDriverExtraArgs(), nil
+}
+
 func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, error) {
 	bundle := clusterSpec.VersionsBundle
 	etcdExtraArgs := clusterapi.SecureEtcdTlsCipherSuitesExtraArgs()
@@ -191,6 +211,15 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
 		Append(clusterapi.ResolvConfExtraArgs(clusterSpec.Cluster.Spec.ClusterNetwork.DNS.ResolvConf)).
 		Append(clusterapi.ControlPlaneNodeLabelsExtraArgs(clusterSpec.Cluster.Spec.ControlPlaneConfiguration))
+
+	cgroupDriverArgs, err := kubeletCgroupDriverExtraArgs(clusterSpec.Cluster.Spec.KubernetesVersion)
+	if err != nil {
+		return nil, err
+	}
+	if cgroupDriverArgs != nil {
+		kubeletExtraArgs.Append(cgroupDriverArgs)
+	}
+
 	apiServerExtraArgs := clusterapi.OIDCToExtraArgs(clusterSpec.OIDCConfig).
 		Append(clusterapi.AwsIamAuthExtraArgs(clusterSpec.AWSIamConfig)).
 		Append(clusterapi.PodIAMAuthExtraArgs(clusterSpec.Cluster.Spec.PodIAMConfig)).
@@ -241,12 +270,19 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 	return values, nil
 }
 
-func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration) map[string]interface{} {
+func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration) (map[string]interface{}, error) {
 	bundle := clusterSpec.VersionsBundle
 	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
 		Append(clusterapi.WorkerNodeLabelsExtraArgs(workerNodeGroupConfiguration)).
 		Append(clusterapi.ResolvConfExtraArgs(clusterSpec.Cluster.Spec.ClusterNetwork.DNS.ResolvConf))
 
+	cgroupDriverArgs, err := kubeletCgroupDriverExtraArgs(clusterSpec.Cluster.Spec.KubernetesVersion)
+	if err != nil {
+		return nil, err
+	}
+	if cgroupDriverArgs != nil {
+		kubeletExtraArgs.Append(cgroupDriverArgs)
+	}
 	values := map[string]interface{}{
 		"clusterName":           clusterSpec.Cluster.Name,
 		"kubernetesVersion":     bundle.KubeDistro.Kubernetes.Tag,
@@ -259,7 +295,7 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration 
 		"autoscalingConfig":     workerNodeGroupConfiguration.AutoScalingConfiguration,
 	}
 
-	return values
+	return values, nil
 }
 
 func NeedsNewControlPlaneTemplate(oldSpec, newSpec *cluster.Spec) bool {

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
@@ -275,15 +275,15 @@ spec:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   replicas: 3
   version: v1.19.6-eks-1-19-2

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_md_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_md_expected.yaml
@@ -11,8 +11,8 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           taints: []
           kubeletExtraArgs:
-            cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cgroup-driver: cgroupfs
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
@@ -270,15 +270,15 @@ spec:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   replicas: 3
   version: v1.19.6-eks-1-19-2

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_md_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_md_expected.yaml
@@ -11,8 +11,8 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           taints: []
           kubeletExtraArgs:
-            cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cgroup-driver: cgroupfs
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/no_machinetemplate_update_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/no_machinetemplate_update_cp_expected.yaml
@@ -263,15 +263,15 @@ spec:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   replicas: 0
   version: 

--- a/pkg/providers/docker/testdata/no_machinetemplate_update_md_expected.yaml
+++ b/pkg/providers/docker/testdata/no_machinetemplate_update_md_expected.yaml
@@ -11,8 +11,8 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           taints: []
           kubeletExtraArgs:
-            cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cgroup-driver: cgroupfs
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_autoscaler_deployment_md_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_autoscaler_deployment_md_expected.yaml
@@ -11,8 +11,8 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           taints: []
           kubeletExtraArgs:
-            cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cgroup-driver: cgroupfs
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
@@ -268,15 +268,15 @@ spec:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   replicas: 3
   version: v1.19.6-eks-1-19-2

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected_124onwards.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected_124onwards.yaml
@@ -107,161 +107,189 @@ spec:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     files:
     - content: |
-        apiVersion: audit.k8s.io/v1beta1
+        apiVersion: audit.k8s.io/v1
         kind: Policy
+        metadata:
+          creationTimestamp: null
         rules:
-        # Log aws-auth configmap changes
         - level: RequestResponse
-          namespaces: ["kube-system"]
-          verbs: ["update", "patch", "delete"]
-          resources:
-          - group: "" # core
-            resources: ["configmaps"]
-            resourceNames: ["aws-auth"]
+          namespaces:
+          - kube-system
           omitStages:
-          - "RequestReceived"
-        # The following requests were manually identified as high-volume and low-risk,
-        # so drop them.
-        - level: None
-          users: ["system:kube-proxy"]
-          verbs: ["watch"]
+          - RequestReceived
           resources:
-          - group: "" # core
-            resources: ["endpoints", "services", "services/status"]
+          - resourceNames:
+            - aws-auth
+            resources:
+            - configmaps
+          verbs:
+          - update
+          - patch
+          - delete
         - level: None
-          users: ["kubelet"] # legacy kubelet identity
-          verbs: ["get"]
           resources:
-          - group: "" # core
-            resources: ["nodes", "nodes/status"]
+          - resources:
+            - endpoints
+            - services
+            - services/status
+          users:
+          - system:kube-proxy
+          verbs:
+          - watch
         - level: None
-          userGroups: ["system:nodes"]
-          verbs: ["get"]
           resources:
-          - group: "" # core
-            resources: ["nodes", "nodes/status"]
+          - resources:
+            - nodes
+            - nodes/status
+          users:
+          - kubelet
+          verbs:
+          - get
         - level: None
+          resources:
+          - resources:
+            - nodes
+            - nodes/status
+          verbs:
+          - get
+        - level: None
+          namespaces:
+          - kube-system
+          resources:
+          - resources:
+            - endpoints
           users:
           - system:kube-controller-manager
           - system:kube-scheduler
           - system:serviceaccount:kube-system:endpoint-controller
-          verbs: ["get", "update"]
-          namespaces: ["kube-system"]
-          resources:
-          - group: "" # core
-            resources: ["endpoints"]
+          verbs:
+          - get
+          - update
         - level: None
-          users: ["system:apiserver"]
-          verbs: ["get"]
           resources:
-          - group: "" # core
-            resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
-        # Don't log HPA fetching metrics.
+          - resources:
+            - namespaces
+            - namespaces/status
+            - namespaces/finalize
+          users:
+          - system:apiserver
+          verbs:
+          - get
         - level: None
+          resources:
+          - group: metrics.k8s.io
           users:
           - system:kube-controller-manager
-          verbs: ["get", "list"]
-          resources:
-          - group: "metrics.k8s.io"
-        # Don't log these read-only URLs.
+          verbs:
+          - get
+          - list
         - level: None
           nonResourceURLs:
           - /healthz*
           - /version
           - /swagger*
-        # Don't log events requests.
         - level: None
           resources:
-          - group: "" # core
-            resources: ["events"]
-        # node and pod status calls from nodes are high-volume and can be large, don't log responses for expected updates from nodes
+          - resources:
+            - events
         - level: Request
-          users: ["kubelet", "system:node-problem-detector", "system:serviceaccount:kube-system:node-problem-detector"]
-          verbs: ["update","patch"]
+          omitStages:
+          - RequestReceived
           resources:
-          - group: "" # core
-            resources: ["nodes/status", "pods/status"]
-          omitStages:
-          - "RequestReceived"
+          - resources:
+            - nodes/status
+            - pods/status
+          users:
+          - kubelet
+          - system:node-problem-detector
+          - system:serviceaccount:kube-system:node-problem-detector
+          verbs:
+          - update
+          - patch
         - level: Request
-          userGroups: ["system:nodes"]
-          verbs: ["update","patch"]
+          omitStages:
+          - RequestReceived
           resources:
-          - group: "" # core
-            resources: ["nodes/status", "pods/status"]
-          omitStages:
-          - "RequestReceived"
-        # deletecollection calls can be large, don't log responses for expected namespace deletions
+          - resources:
+            - nodes/status
+            - pods/status
+          userGroups:
+          - system:nodes
+          verbs:
+          - update
+          - patch
         - level: Request
-          users: ["system:serviceaccount:kube-system:namespace-controller"]
-          verbs: ["deletecollection"]
           omitStages:
-          - "RequestReceived"
-        # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
-        # so only log at the Metadata level.
+          - RequestReceived
+          users:
+          - system:serviceaccount:kube-system:namespace-controller
+          verbs:
+          - deletecollection
         - level: Metadata
+          omitStages:
+          - RequestReceived
           resources:
-          - group: "" # core
-            resources: ["secrets", "configmaps"]
+          - resources:
+            - secrets
+            - configmaps
           - group: authentication.k8s.io
-            resources: ["tokenreviews"]
-          omitStages:
-            - "RequestReceived"
+            resources:
+            - tokenreviews
         - level: Request
           resources:
-          - group: ""
-            resources: ["serviceaccounts/token"]
-        # Get repsonses can be large; skip them.
+          - resources:
+            - serviceaccounts/token
         - level: Request
-          verbs: ["get", "list", "watch"]
-          resources:
-          - group: "" # core
-          - group: "admissionregistration.k8s.io"
-          - group: "apiextensions.k8s.io"
-          - group: "apiregistration.k8s.io"
-          - group: "apps"
-          - group: "authentication.k8s.io"
-          - group: "authorization.k8s.io"
-          - group: "autoscaling"
-          - group: "batch"
-          - group: "certificates.k8s.io"
-          - group: "extensions"
-          - group: "metrics.k8s.io"
-          - group: "networking.k8s.io"
-          - group: "policy"
-          - group: "rbac.authorization.k8s.io"
-          - group: "scheduling.k8s.io"
-          - group: "settings.k8s.io"
-          - group: "storage.k8s.io"
           omitStages:
-          - "RequestReceived"
-        # Default level for known APIs
+          - RequestReceived
+          resources:
+          - {}
+          - group: admissionregistration.k8s.io
+          - group: apiextensions.k8s.io
+          - group: apiregistration.k8s.io
+          - group: apps
+          - group: authentication.k8s.io
+          - group: authorization.k8s.io
+          - group: autoscaling
+          - group: batch
+          - group: certificates.k8s.io
+          - group: extensions
+          - group: metrics.k8s.io
+          - group: networking.k8s.io
+          - group: policy
+          - group: rbac.authorization.k8s.io
+          - group: scheduling.k8s.io
+          - group: settings.k8s.io
+          - group: storage.k8s.io
+          verbs:
+          - get
+          - list
+          - watch
         - level: RequestResponse
-          resources:
-          - group: "" # core
-          - group: "admissionregistration.k8s.io"
-          - group: "apiextensions.k8s.io"
-          - group: "apiregistration.k8s.io"
-          - group: "apps"
-          - group: "authentication.k8s.io"
-          - group: "authorization.k8s.io"
-          - group: "autoscaling"
-          - group: "batch"
-          - group: "certificates.k8s.io"
-          - group: "extensions"
-          - group: "metrics.k8s.io"
-          - group: "networking.k8s.io"
-          - group: "policy"
-          - group: "rbac.authorization.k8s.io"
-          - group: "scheduling.k8s.io"
-          - group: "settings.k8s.io"
-          - group: "storage.k8s.io"
           omitStages:
-          - "RequestReceived"
-        # Default level for all other requests.
+          - RequestReceived
+          resources:
+          - {}
+          - group: admissionregistration.k8s.io
+          - group: apiextensions.k8s.io
+          - group: apiregistration.k8s.io
+          - group: apps
+          - group: authentication.k8s.io
+          - group: authorization.k8s.io
+          - group: autoscaling
+          - group: batch
+          - group: certificates.k8s.io
+          - group: extensions
+          - group: metrics.k8s.io
+          - group: networking.k8s.io
+          - group: policy
+          - group: rbac.authorization.k8s.io
+          - group: scheduling.k8s.io
+          - group: settings.k8s.io
+          - group: storage.k8s.io
         - level: Metadata
           omitStages:
-          - "RequestReceived"
+          - RequestReceived
       owner: root:root
       path: /etc/kubernetes/audit-policy.yaml
     initConfiguration:
@@ -269,35 +297,13 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-          cgroup-driver: cgroupfs
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        taints: 
-          - key: key1
-            value: val1
-            effect: NoSchedule
-          - key: key2
-            value: val2
-            effect: PreferNoSchedule
-          - key: key3
-            value: val3
-            effect: NoExecute
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-          cgroup-driver: cgroupfs
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        taints: 
-          - key: key1
-            value: val1
-            effect: NoSchedule
-          - key: key2
-            value: val2
-            effect: PreferNoSchedule
-          - key: key3
-            value: val3
-            effect: NoExecute
   replicas: 3
   version: v1.19.6-eks-1-19-2
 ---

--- a/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
@@ -269,15 +269,15 @@ spec:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   replicas: 1
   version: v1.19.6-eks-1-19-2

--- a/pkg/providers/docker/testdata/valid_deployment_cp_stacked_etcd_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_stacked_etcd_expected.yaml
@@ -263,15 +263,15 @@ spec:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   replicas: 1
   version: v1.19.6-eks-1-19-2

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
@@ -268,16 +268,16 @@ spec:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           resolv-conf: /etc/my-custom-resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           resolv-conf: /etc/my-custom-resolv.conf
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   replicas: 3

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_md_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_md_expected.yaml
@@ -11,8 +11,8 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           taints: []
           kubeletExtraArgs:
-            cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cgroup-driver: cgroupfs
             resolv-conf: /etc/my-custom-resolv.conf
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---

--- a/pkg/providers/docker/testdata/valid_deployment_md_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_md_expected.yaml
@@ -11,8 +11,8 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           taints: []
           kubeletExtraArgs:
-            cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cgroup-driver: cgroupfs
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_md_expected_124onwards.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_md_expected_124onwards.yaml
@@ -12,8 +12,6 @@ spec:
           taints: []
           kubeletExtraArgs:
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-            cgroup-driver: cgroupfs
-            node-labels: label1=foo,label2=bar
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_md_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_md_taints_expected.yaml
@@ -14,8 +14,8 @@ spec:
               value: val2
               effect: PreferNoSchedule
           kubeletExtraArgs:
-            cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cgroup-driver: cgroupfs
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_multiple_md_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_multiple_md_taints_expected.yaml
@@ -14,8 +14,8 @@ spec:
               value: val2
               effect: PreferNoSchedule
           kubeletExtraArgs:
-            cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cgroup-driver: cgroupfs
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -74,8 +74,8 @@ spec:
               value: true
               effect: PreferNoSchedule
           kubeletExtraArgs:
-            cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cgroup-driver: cgroupfs
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
@@ -268,16 +268,16 @@ spec:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           node-labels: label1=foo,label2=bar
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: cgroupfs
           node-labels: label1=foo,label2=bar
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   replicas: 3

--- a/pkg/semver/utils.go
+++ b/pkg/semver/utils.go
@@ -1,0 +1,11 @@
+package semver
+
+import (
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+// KubeVersionToValidSemver converts kube version to semver for comparisons.
+func KubeVersionToValidSemver(kubeVersion v1alpha1.KubernetesVersion) (*Version, error) {
+	// appending the ".0" as the patch version to have a valid semver string and use those semvers for comparison
+	return New(string(kubeVersion) + ".0")
+}

--- a/pkg/semver/utils_test.go
+++ b/pkg/semver/utils_test.go
@@ -1,0 +1,46 @@
+package semver_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/semver"
+)
+
+func TestKubeVersionToValidSemver(t *testing.T) {
+	type args struct {
+		kubeVersion v1alpha1.KubernetesVersion
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *semver.Version
+		wantErr error
+	}{
+		{
+			name: "convert kube 1.22",
+			args: args{
+				kubeVersion: v1alpha1.Kube122,
+			},
+			want: &semver.Version{
+				Major: 1,
+				Minor: 22,
+				Patch: 0,
+			},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := semver.KubeVersionToValidSemver(tt.args.kubeVersion)
+			if err != tt.wantErr {
+				t.Errorf("KubeVersionToValidSemver() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("KubeVersionToValidSemver() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove cgroup driver arg for docker 1.24 onwards

[Extra reference
](https://github.com/kubernetes-sigs/cluster-api/blob/69ab7870322d4e69eeb5c616299564ba78655ae0/test/e2e/data/infrastructure-docker/v1beta1/v1.2/clusterclass-quick-start.yaml#L92)*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

