### PR TITLE
fix orphaned machines left after timeout of a tinkerbell upgrade test

### DIFF
--- a/test/e2e/awsiam_test.go
+++ b/test/e2e/awsiam_test.go
@@ -35,7 +35,7 @@ func runTinkerbellAWSIamAuthFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.GenerateHardwareConfig()
 	test.PowerOffHardware()
-	test.CreateCluster(framework.WithForce())
+	test.CreateCluster(framework.WithForce(), framework.WithControlPlaneWaitTimeout("20m"))
 	test.ValidateAWSIamAuth()
 	test.StopIfFailed()
 	test.DeleteCluster()

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -24,7 +24,7 @@ func runTinkerbellConformanceFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.GenerateHardwareConfig()
 	test.PowerOffHardware()
-	test.CreateCluster()
+	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
 	test.RunConformanceTests()
 	test.StopIfFailed()
 	test.DeleteCluster()

--- a/test/e2e/registry_mirror_test.go
+++ b/test/e2e/registry_mirror_test.go
@@ -26,7 +26,7 @@ func runTinkerbellRegistryMirrorFlow(test *framework.ClusterE2ETest) {
 	test.ImportImages()
 	test.GenerateHardwareConfig()
 	test.PowerOffHardware()
-	test.CreateCluster(framework.WithForce())
+	test.CreateCluster(framework.WithForce(), framework.WithControlPlaneWaitTimeout("20m"))
 	test.StopIfFailed()
 	test.DeleteCluster()
 	test.ValidateHardwareDecommissioned()

--- a/test/e2e/single_node_test.go
+++ b/test/e2e/single_node_test.go
@@ -14,7 +14,7 @@ import (
 func runTinkerbellSingleNodeFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.GenerateHardwareConfig()
-	test.PowerOnHardware()
+	test.PowerOffHardware()
 	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneNoTaints, framework.ValidateControlPlaneLabels)
 	test.DeleteCluster()

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -30,6 +30,7 @@ func TestTinkerbellKubernetes122WithNodesPoweredOn(t *testing.T) {
 
 	test.GenerateClusterConfig()
 	test.GenerateHardwareConfig()
+	test.PowerOffHardware()
 	test.PowerOnHardware()
 	test.CreateCluster(framework.WithForce(), framework.WithControlPlaneWaitTimeout("20m"))
 	test.DeleteCluster()

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -50,7 +50,8 @@ func runUpgradeFlowWithCheckpoint(test *framework.ClusterE2ETest, updateVersion 
 func runSimpleUpgradeFlowForBareMetal(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.GenerateClusterConfig()
 	test.GenerateHardwareConfig()
-	test.CreateCluster()
+	test.PowerOffHardware()
+	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
 	test.UpgradeCluster(clusterOpts)
 	test.ValidateCluster(updateVersion)
 	test.StopIfFailed()


### PR DESCRIPTION
Add cp timeout on all tinkerbell tests and ensure all tests power off hardware prior to test. This guards against orphaned machines from previous test run that timeout and were left in provisioned state.
