### PR TITLE
Perform Helm logout after pulling and pushing

### DIFF
--- a/release/pkg/operations/upload.go
+++ b/release/pkg/operations/upload.go
@@ -92,13 +92,13 @@ func UploadArtifacts(r *releasetypes.ReleaseConfig, eksArtifacts map[string][]re
 					if err != nil {
 						return fmt.Errorf("creating helm client: %v", err)
 					}
-					
+
 					fmt.Printf("Modifying helm chart for %s\n", trimmedAsset)
 					helmDest, err := helm.GetHelmDest(helmDriver, r, artifact.Image.SourceImageURI, trimmedAsset)
 					if err != nil {
 						return fmt.Errorf("getting Helm destination: %v", err)
 					}
-					
+
 					fmt.Printf("Pulled helm chart locally to %s\n", helmDest)
 					err = helm.ModifyAndPushChartYaml(*artifact.Image, r, helmDriver, helmDest)
 					if err != nil {


### PR DESCRIPTION
The Helm credentials of the source are still present at the time of logging into the destination registry. This causes 403 errors when pushing to the destination. Hence we perform logout from the appropriate registry after pull/push.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

