### PR TITLE
Fix nil pointer when fetching snowmachineconfig that does not exist

### DIFF
--- a/pkg/cluster/snow.go
+++ b/pkg/cluster/snow.go
@@ -70,6 +70,9 @@ func snowEntry() *ConfigManagerEntry {
 				}
 				return nil
 			},
+			func(c *Config) error {
+				return ValidateSnowMachineRefExists(c)
+			},
 		},
 	}
 }
@@ -191,4 +194,15 @@ func SetSnowDatacenterIndentityRefDefault(s *anywherev1.SnowDatacenterConfig) {
 			Name: fmt.Sprintf("%s-snow-credentials", s.GetName()),
 		}
 	}
+}
+
+// ValidateSnowMachineRefExists checks the cluster spec machine refs and makes sure
+// the snowmachineconfig object exists for each ref with kind == snowmachineconfig.
+func ValidateSnowMachineRefExists(c *Config) error {
+	for _, machineRef := range c.Cluster.MachineConfigRefs() {
+		if machineRef.Kind == anywherev1.SnowMachineConfigKind && c.SnowMachineConfig(machineRef.Name) == nil {
+			return fmt.Errorf("unable to find SnowMachineConfig %s", machineRef.Name)
+		}
+	}
+	return nil
 }

--- a/pkg/cluster/snow_test.go
+++ b/pkg/cluster/snow_test.go
@@ -311,3 +311,39 @@ func TestSetSnowDatacenterIndentityRefDefault(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSnowMachineRefExistsError(t *testing.T) {
+	g := NewWithT(t)
+	c := &cluster.Config{
+		Cluster: &anywherev1.Cluster{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       anywherev1.ClusterKind,
+				APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "eksa-unit-test",
+				Namespace: "ns-1",
+			},
+			Spec: anywherev1.ClusterSpec{
+				WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						MachineGroupRef: &anywherev1.Ref{
+							Name: "worker-not-exists",
+							Kind: "SnowMachineConfig",
+						},
+					},
+				},
+			},
+		},
+		SnowMachineConfigs: map[string]*anywherev1.SnowMachineConfig{
+			"worker-1": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker-1",
+				},
+			},
+		},
+	}
+	g.Expect(cluster.ValidateConfig(c)).To(
+		MatchError(ContainSubstring("unable to find SnowMachineConfig worker-not-exists")),
+	)
+}

--- a/pkg/providers/snow/reconciler/reconciler.go
+++ b/pkg/providers/snow/reconciler/reconciler.go
@@ -72,6 +72,13 @@ func (r *Reconciler) ValidateMachineConfigs(ctx context.Context, log logr.Logger
 		}
 	}
 
+	if err := cluster.ValidateSnowMachineRefExists(clusterSpec.Config); err != nil {
+		log.Error(err, "Invalid SnowMachineConfig")
+		failureMessage := err.Error()
+		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
+		return controller.Result{}, err
+	}
+
 	return controller.Result{}, nil
 }
 

--- a/pkg/providers/snow/reconciler/reconciler_test.go
+++ b/pkg/providers/snow/reconciler/reconciler_test.go
@@ -87,6 +87,20 @@ func TestReconcilerValidateMachineConfigsInvalidControlPlaneMachineConfig(t *tes
 	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("Something wrong"))
 }
 
+func TestReconcilerValidateMachineConfigsSnowMachineRefNotExists(t *testing.T) {
+	tt := newReconcilerTest(t)
+	tt.withFakeClient()
+
+	spec := tt.buildSpec()
+	spec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "cp-machine-not-exists"
+
+	_, err := tt.reconciler().ValidateMachineConfigs(tt.ctx, test.NewNullLogger(), spec)
+
+	tt.Expect(err).To(MatchError(ContainSubstring("unable to find SnowMachineConfig cp-machine-not-exists")))
+	tt.Expect(tt.cluster.Status.FailureMessage).ToNot(BeZero())
+	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("unable to find SnowMachineConfig cp-machine-not-exists"))
+}
+
 func TestReconcilerReconcileWorkers(t *testing.T) {
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()


### PR DESCRIPTION
*Issue #, if available:*

GA AppSec review finding: Potential Memory Violation / NULL Pointer Dereference when specifying a machineRef that does not exist in cluster spec.

*Description of changes:*

Add validation to check all the machine refs point to objs that exist. For controller we requeue and wait till the snow machine config object exists in the cluster.

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

