### PR TITLE
Remove snow machine objects exist check in controller

### DIFF
--- a/pkg/providers/snow/reconciler/reconciler.go
+++ b/pkg/providers/snow/reconciler/reconciler.go
@@ -72,13 +72,6 @@ func (r *Reconciler) ValidateMachineConfigs(ctx context.Context, log logr.Logger
 		}
 	}
 
-	if err := cluster.ValidateSnowMachineRefExists(clusterSpec.Config); err != nil {
-		log.Error(err, "Invalid SnowMachineConfig")
-		failureMessage := err.Error()
-		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
-		return controller.Result{}, err
-	}
-
 	return controller.Result{}, nil
 }
 

--- a/pkg/providers/snow/reconciler/reconciler_test.go
+++ b/pkg/providers/snow/reconciler/reconciler_test.go
@@ -87,20 +87,6 @@ func TestReconcilerValidateMachineConfigsInvalidControlPlaneMachineConfig(t *tes
 	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("Something wrong"))
 }
 
-func TestReconcilerValidateMachineConfigsSnowMachineRefNotExists(t *testing.T) {
-	tt := newReconcilerTest(t)
-	tt.withFakeClient()
-
-	spec := tt.buildSpec()
-	spec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "cp-machine-not-exists"
-
-	_, err := tt.reconciler().ValidateMachineConfigs(tt.ctx, test.NewNullLogger(), spec)
-
-	tt.Expect(err).To(MatchError(ContainSubstring("unable to find SnowMachineConfig cp-machine-not-exists")))
-	tt.Expect(tt.cluster.Status.FailureMessage).ToNot(BeZero())
-	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("unable to find SnowMachineConfig cp-machine-not-exists"))
-}
-
 func TestReconcilerReconcileWorkers(t *testing.T) {
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()


### PR DESCRIPTION
*Issue #, if available:*

Change #3795 

*Description of changes:*

We already check the machine config existence in controller here: https://github.com/aws/eks-anywhere/blob/main/pkg/cluster/snow.go#L157-L160.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

