### PR TITLE
added upgradeclusterplan support for nutanix provider capx

### DIFF
--- a/pkg/providers/nutanix/provider.go
+++ b/pkg/providers/nutanix/provider.go
@@ -535,8 +535,15 @@ func (p *Provider) ValidateNewSpec(_ context.Context, _ *types.Cluster, _ *clust
 }
 
 func (p *Provider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	// TODO(nutanix): figure out if we need something else here
-	return nil
+	if currentSpec.VersionsBundle.Nutanix.Version == newSpec.VersionsBundle.Nutanix.Version {
+		return nil
+	}
+
+	return &types.ComponentChangeDiff{
+		ComponentName: constants.NutanixProviderName,
+		NewVersion:    newSpec.VersionsBundle.Nutanix.Version,
+		OldVersion:    currentSpec.VersionsBundle.Nutanix.Version,
+	}
 }
 
 func (p *Provider) RunPostControlPlaneUpgrade(ctx context.Context, oldClusterSpec *cluster.Spec, clusterSpec *cluster.Spec, workloadCluster *types.Cluster, managementCluster *types.Cluster) error {

--- a/pkg/providers/nutanix/provider_test.go
+++ b/pkg/providers/nutanix/provider_test.go
@@ -621,6 +621,21 @@ func TestNutanixProviderChangeDiff(t *testing.T) {
 	assert.Nil(t, cd)
 }
 
+func TestNutanixProviderChangeDiffWithChange(t *testing.T) {
+	provider := testDefaultNutanixProvider(t)
+	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
+	newClusterSpec := clusterSpec.DeepCopy()
+	clusterSpec.VersionsBundle.Nutanix.Version = "v0.5.2"
+	newClusterSpec.VersionsBundle.Nutanix.Version = "v1.0.0"
+	want := &types.ComponentChangeDiff{
+		ComponentName: "nutanix",
+		NewVersion:    "v1.0.0",
+		OldVersion:    "v0.5.2",
+	}
+	cd := provider.ChangeDiff(clusterSpec, newClusterSpec)
+	assert.Equal(t, cd, want)
+}
+
 func TestNutanixProviderRunPostControlPlaneUpgrade(t *testing.T) {
 	provider := testDefaultNutanixProvider(t)
 	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR returns appropriate ChangeDiff to help decide if upgrade is required for CAPX

*Testing (if applicable):*
<pre>
bin/eksctl-anywhere upgrade plan cluster -f nutanix-dev-cluster.yaml
Checking new release availability...
NAME      CURRENT VERSION                 NEXT VERSION
EKS-A     v0.0.0-dev+build.4610+08d8345   v0.0.0-dev+build.4615+bf67b82
</pre>
TODO for testing, yet to figure out how to have the new spec deployed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

