### PR TITLE
Remove vsphere provider dependency on api structs

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -339,14 +339,8 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 				return fmt.Errorf("unable to get datacenter config from file %s: %v", clusterConfigFile, err)
 			}
 
-			machineConfigs, err := v1alpha1.GetVSphereMachineConfigs(clusterConfigFile)
-			if err != nil {
-				return fmt.Errorf("unable to get machine config from file %s: %v", clusterConfigFile, err)
-			}
-
 			f.dependencies.Provider = vsphere.NewProvider(
 				datacenterConfig,
-				machineConfigs,
 				clusterConfig,
 				f.dependencies.Govc,
 				f.dependencies.Kubectl,


### PR DESCRIPTION
## Description of changes

It makes the code easier to follow, given the cluster spec is passed to most methods as an argument. This reduces api structs copies to one, removing ambiguity around which one contains the most updated data. It also avoids bugs where updates are only performed in one place but not the other.

If needed, a stateful version of the provider can be implemented by composing on top of this one.

This also fixes a bug where the controller rolled out new machines immediately after the cluster was created. It was detecting a change in machine configs due to a default not being applied in the cluster spec machine configs. I could have patched that alone and the change would have been smaller, but I decided to do this and avoid these kinds of bugs all together.

## Testing
* Unit tests
* Upgrade e2e test run manually


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

