### PR TITLE
Plumbing validation error back to user

### DIFF
--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
@@ -107,7 +107,7 @@ func (r *CloudStackResourceDiskOffering) IsEmpty() bool {
 func (r *CloudStackResourceDiskOffering) Validate() (err error, field string, value string) {
 	if r != nil && (len(r.Id) > 0 || len(r.Name) > 0) {
 		if len(r.MountPath) < 2 || !strings.HasPrefix(r.MountPath, "/") {
-			return errors.New("must be non-empty and starts with /"), "mountPath", r.MountPath
+			return errors.New("must be non-empty and start with /"), "mountPath", r.MountPath
 		}
 		if len(r.Filesystem) < 1 {
 			return errors.New("empty filesystem"), "filesystem", r.Filesystem

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types_test.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types_test.go
@@ -258,7 +258,7 @@ func TestCloudStackMachineConfigDiskOfferingInValidMountPathRoot(t *testing.T) {
 	g.Expect(err != nil).To(BeTrue())
 	g.Expect(fieldName == "mountPath").To(BeTrue())
 	g.Expect(fieldValue == "/").To(BeTrue())
-	g.Expect(err.Error() == "must be non-empty and starts with /").To(BeTrue())
+	g.Expect(err.Error() == "must be non-empty and start with /").To(BeTrue())
 }
 
 func TestCloudStackMachineConfigDiskOfferingInValidMountPathRelative(t *testing.T) {
@@ -276,7 +276,7 @@ func TestCloudStackMachineConfigDiskOfferingInValidMountPathRelative(t *testing.
 	g.Expect(err != nil).To(BeTrue())
 	g.Expect(fieldName == "mountPath").To(BeTrue())
 	g.Expect(fieldValue == "data").To(BeTrue())
-	g.Expect(err.Error() == "must be non-empty and starts with /").To(BeTrue())
+	g.Expect(err.Error() == "must be non-empty and start with /").To(BeTrue())
 }
 
 func TestCloudStackMachineConfigDiskOfferingValid(t *testing.T) {

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_webhook.go
@@ -32,10 +32,10 @@ func (r *CloudStackMachineConfig) ValidateCreate() error {
 	cloudstackmachineconfiglog.Info("validate create", "name", r.Name)
 
 	if err, fieldName, fieldValue := r.Spec.DiskOffering.Validate(); err != nil {
-		return apierrors.NewBadRequest(fmt.Sprintf("disk offering %s:%v, preventing CloudStackMachineConfig resource creation", fieldName, fieldValue))
+		return apierrors.NewBadRequest(fmt.Sprintf("disk offering %s:%v, preventing CloudStackMachineConfig resource creation: %v", fieldName, fieldValue, err))
 	}
 	if err, fieldName, fieldValue := r.Spec.Symlinks.Validate(); err != nil {
-		return apierrors.NewBadRequest(fmt.Sprintf("symlinks %s:%v, preventing CloudStackMachineConfig resource creation", fieldName, fieldValue))
+		return apierrors.NewBadRequest(fmt.Sprintf("symlinks %s:%v, preventing CloudStackMachineConfig resource creation: %v", fieldName, fieldValue, err))
 	}
 
 	return nil

--- a/pkg/providers/cloudstack/validator_test.go
+++ b/pkg/providers/cloudstack/validator_test.go
@@ -438,7 +438,7 @@ func TestSetupAndValidateInValidDiskOfferingBadMountPath(t *testing.T) {
 	cmk.EXPECT().ValidateAffinityGroupsPresent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 	err = validator.ValidateClusterMachineConfigs(ctx, cloudStackClusterSpec)
-	wantErrMsg := "machine config test validation failed: mountPath: / invalid, must be non-empty and starts with /"
+	wantErrMsg := "machine config test validation failed: mountPath: / invalid, must be non-empty and start with /"
 	assert.Contains(t, err.Error(), wantErrMsg, "expected error containing %q, got %v", wantErrMsg, err)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When attempting to create a cluster with some symlinks, we observed failures such as 

```
error when creating \"STDIN\": admission webhook \"validation.cloudstackmachineconfig.anywhere.amazonaws.com\" denied the request: symlinks symlinks:/var/lib/, preventing CloudStackMachineConfig resource creation\n", "retries": 30}
```

which were unclear and confusing. The issue turned out to be that symlinks cannot end with a `/` character

*Testing (if applicable):*
Debugged unit test to observe extended error message

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

