### PR TITLE
Use dynamic affinity group and remove symlinks from test-etcd CloudStackMachineConfig

### DIFF
--- a/pkg/providers/cloudstack/testdata/cluster_main.yaml
+++ b/pkg/providers/cloudstack/testdata/cluster_main.yaml
@@ -74,8 +74,8 @@ spec:
     label: "data_disk"
   symlinks:
     /var/log/kubernetes: /data-small/var/log/kubernetes
-  affinityGroupIds:
-  - control-plane-anti-affinity
+  affinity:
+  - pro
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: CloudStackMachineConfig
@@ -100,8 +100,8 @@ spec:
   symlinks:
     /var/log/pods: /data-small/var/log/pods
     /var/log/containers: /data-small/var/log/containers
-  affinityGroupIds:
-  - worker-affinity
+  affinity:
+  - anti
   userCustomDetails:
     foo: bar
 ---
@@ -125,9 +125,5 @@ spec:
     device: "/dev/vdb"
     filesystem: "ext4"
     label: "data_disk"
-  symlinks:
-    /var/lib/: /data-small/var/lib
-  affinityGroupIds:
-  - etcd-affinity
 
 ---


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
- affinityGroupIds isn't working with multi-endpoint feature.  
- symlinks doesn't allow a trailing / and having one for a system folder such as /var/lib is dangerous

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

