### PR TITLE
Fix customize ubuntu docs to clean the vm properly

### DIFF
--- a/docs/content/en/docs/reference/vsphere/customize-ovas.md
+++ b/docs/content/en/docs/reference/vsphere/customize-ovas.md
@@ -132,14 +132,29 @@ Restart containerd service with the `sudo systemctl restart containerd` command.
 
 After you have customized the VM, you need to convert it to a template.
 
-### Reset the machine-id and power off the VM
+### Cleanup the machine and power off the VM
 
 This step is needed because of a [known issue in Ubuntu](https://kb.vmware.com/s/article/82229) which results in the clone VMs getting the same DHCP IP
 
 ```
+sudo su
 echo -n > /etc/machine-id
 rm /var/lib/dbus/machine-id
 ln -s /etc/machine-id /var/lib/dbus/machine-id
+cloud-init clean -l --machine-id
+```
+
+Delete the hostname from file
+```
+/etc/hostname
+```
+Delete the networking config file
+```
+rm -rf /etc/netplan/50-cloud-init.yaml
+```
+Edit the cloud init config to turn `preserve_hostname` to false
+```
+vi /etc/cloud/cloud.cfg
 ```
 
 Power the VM down


### PR DESCRIPTION
*Issue #, if available:*  #3840

*Description of changes:*
Without these changes the hostname would get preserved. Etcd nodes while coming up would not take in the proper names from postkubeadm commands that would result in etcd not coming up properly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

