### PR TITLE
now collecting capx logs in support-bundle

### DIFF
--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -393,7 +393,7 @@ func (c *collectorFactory) nutanixCrdCollectors() []*Collect {
 		"nutanixmachines.infrastructure.cluster.x-k8s.io",
 		"nutanixmachinetemplates.infrastructure.cluster.x-k8s.io",
 	}
-	return c.generateCrdCollectors(capvCrds)
+	return c.generateCrdCollectors(capxCrds)
 }
 
 func (c *collectorFactory) generateCrdCollectors(crds []string) []*Collect {

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -74,9 +74,23 @@ func (c *collectorFactory) DataCenterConfigCollectors(datacenter v1alpha1.Ref, s
 		return c.eksaTinkerbellCollectors()
 	case v1alpha1.SnowDatacenterKind:
 		return c.eksaSnowCollectors()
+	case v1alpha1.NutanixDatacenterKind:
+		return c.eksaNutanixCollectors()
 	default:
 		return nil
 	}
+}
+
+func (c *collectorFactory) eksaNutanixCollectors() []*Collect {
+	nutanixLogs := []*Collect{
+		{
+			Logs: &logs{
+				Namespace: constants.CapxSystemNamespace,
+				Name:      logpath(constants.CapxSystemNamespace),
+			},
+		},
+	}
+	return append(nutanixLogs, c.nutanixCrdCollectors()...)
 }
 
 func (c *collectorFactory) eksaSnowCollectors() []*Collect {
@@ -369,6 +383,17 @@ func (c *collectorFactory) packagesCrdCollectors() []*Collect {
 		"packages.packages.eks.amazonaws.com",
 	}
 	return c.generateCrdCollectors(packageCrds)
+}
+
+func (c *collectorFactory) nutanixCrdCollectors() []*Collect {
+	capvCrds := []string{
+		"nutanixclusters.infrastructure.cluster.x-k8s.io",
+		"nutanixdatacenterconfigs.anywhere.eks.amazonaws.com",
+		"nutanixmachineconfigs.anywhere.eks.amazonaws.com",
+		"nutanixmachines.infrastructure.cluster.x-k8s.io",
+		"nutanixmachinetemplates.infrastructure.cluster.x-k8s.io",
+	}
+	return c.generateCrdCollectors(capvCrds)
 }
 
 func (c *collectorFactory) generateCrdCollectors(crds []string) []*Collect {

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -386,7 +386,7 @@ func (c *collectorFactory) packagesCrdCollectors() []*Collect {
 }
 
 func (c *collectorFactory) nutanixCrdCollectors() []*Collect {
-	capvCrds := []string{
+	capxCrds := []string{
 		"nutanixclusters.infrastructure.cluster.x-k8s.io",
 		"nutanixdatacenterconfigs.anywhere.eks.amazonaws.com",
 		"nutanixmachineconfigs.anywhere.eks.amazonaws.com",

--- a/pkg/diagnostics/collectors_test.go
+++ b/pkg/diagnostics/collectors_test.go
@@ -108,3 +108,18 @@ func TestSnowCollectors(t *testing.T) {
 		g.Expect("eksa-diagnostics").To(Equal(collector.RunPod.Namespace))
 	}
 }
+
+func TestNutanixCollectors(t *testing.T) {
+	g := NewGomegaWithT(t)
+	spec := test.NewClusterSpec(func(s *cluster.Spec) {})
+	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.NutanixDatacenterKind}
+	factory := diagnostics.NewDefaultCollectorFactory()
+	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
+	g.Expect(collectors).To(HaveLen(6), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
+	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapxSystemNamespace))
+	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CapxSystemNamespace)))
+	for _, collector := range collectors[1:] {
+		g.Expect([]string{"kubectl"}).To(Equal(collector.RunPod.PodSpec.Containers[0].Command))
+		g.Expect("eksa-diagnostics").To(Equal(collector.RunPod.Namespace))
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*
<pre>
bin/eksctl-anywhere generate support-bundle-config -f nutanix-dev-cluster.yaml
</pre>
show output with following contents 
<pre>
  collectors:
  - logs:
      name: logs/capx-system
      namespace: capx-system
      selector: null
  - runPod:
      collectorName: nutanixclusters.infrastructure.cluster.x-k8s.io
      name: crds/nutanixclusters.infrastructure.cluster.x-k8s.io
      namespace: eksa-diagnostics
      podSpec:
        containers:
        - args:
          - get
          - nutanixclusters.infrastructure.cluster.x-k8s.io
          - -o
          - json
          - --all-namespaces
          command:
          - kubectl
          image: public.ecr.aws/l0g8r8j6/eks-anywhere-diagnostic-collector:v0.12.0-eks-a-v0.0.0-dev-build.4603
          name: crds/nutanixclusters.infrastructure.cluster.x-k8s.io
          resources: {}
        hostNetwork: true
        tolerations:
        - effect: NoSchedule
          key: node.kubernetes.io
          value: not-ready
      timeout: 30s
  - runPod:
      collectorName: nutanixdatacenterconfigs.anywhere.eks.amazonaws.com
      name: crds/nutanixdatacenterconfigs.anywhere.eks.amazonaws.com
      namespace: eksa-diagnostics
      podSpec:
        containers:
        - args:
          - get
          - nutanixdatacenterconfigs.anywhere.eks.amazonaws.com
          - -o
          - json
          - --all-namespaces
          command:
          - kubectl
          image: public.ecr.aws/l0g8r8j6/eks-anywhere-diagnostic-collector:v0.12.0-eks-a-v0.0.0-dev-build.4603
          name: crds/nutanixdatacenterconfigs.anywhere.eks.amazonaws.com
          resources: {}
        hostNetwork: true
        tolerations:
        - effect: NoSchedule
          key: node.kubernetes.io
          value: not-ready
      timeout: 30s
  - runPod:
      collectorName: nutanixmachineconfigs.anywhere.eks.amazonaws.com
      name: crds/nutanixmachineconfigs.anywhere.eks.amazonaws.com
      namespace: eksa-diagnostics
      podSpec:
        containers:
        - args:
          - get
          - nutanixmachineconfigs.anywhere.eks.amazonaws.com
          - -o
          - json
          - --all-namespaces
          command:
          - kubectl
          image: public.ecr.aws/l0g8r8j6/eks-anywhere-diagnostic-collector:v0.12.0-eks-a-v0.0.0-dev-build.4603
          name: crds/nutanixmachineconfigs.anywhere.eks.amazonaws.com
          resources: {}
        hostNetwork: true
        tolerations:
        - effect: NoSchedule
          key: node.kubernetes.io
          value: not-ready
      timeout: 30s
  - runPod:
      collectorName: nutanixmachines.infrastructure.cluster.x-k8s.io
      name: crds/nutanixmachines.infrastructure.cluster.x-k8s.io
      namespace: eksa-diagnostics
      podSpec:
        containers:
        - args:
          - get
          - nutanixmachines.infrastructure.cluster.x-k8s.io
          - -o
          - json
          - --all-namespaces
          command:
          - kubectl
          image: public.ecr.aws/l0g8r8j6/eks-anywhere-diagnostic-collector:v0.12.0-eks-a-v0.0.0-dev-build.4603
          name: crds/nutanixmachines.infrastructure.cluster.x-k8s.io
          resources: {}
        hostNetwork: true
        tolerations:
        - effect: NoSchedule
          key: node.kubernetes.io
          value: not-ready
      timeout: 30s
  - runPod:
      collectorName: nutanixmachinetemplates.infrastructure.cluster.x-k8s.io
      name: crds/nutanixmachinetemplates.infrastructure.cluster.x-k8s.io
      namespace: eksa-diagnostics
      podSpec:
        containers:
        - args:
          - get
          - nutanixmachinetemplates.infrastructure.cluster.x-k8s.io
          - -o
          - json
          - --all-namespaces
          command:
          - kubectl
          image: public.ecr.aws/l0g8r8j6/eks-anywhere-diagnostic-collector:v0.12.0-eks-a-v0.0.0-dev-build.4603
          name: crds/nutanixmachinetemplates.infrastructure.cluster.x-k8s.io
          resources: {}
        hostNetwork: true
        tolerations:
        - effect: NoSchedule
          key: node.kubernetes.io
          value: not-ready
      timeout: 30s
</pre>

<pre>
bin/eksctl-anywhere generate support-bundle -f nutanix-dev-cluster.yaml                               
⏳ Collecting support bundle from cluster, this can take a while	{"cluster": "nutanix-dev-cluster", "bundle": "nutanix-dev-cluster/generated/nutanix-dev-cluster-2022-10-28T16:01:24-07:00-bundle.yaml", "since": -6795364578871345152, "kubeconfig": "nutanix-dev-cluster/nutanix-dev-cluster-eks-a-cluster.kubeconfig"}
Support bundle archive created	{"path": "support-bundle-2022-10-28T23_01_26.tar.gz"}
Analyzing support bundle	{"bundle": "nutanix-dev-cluster/generated/nutanix-dev-cluster-2022-10-28T16:01:24-07:00-bundle.yaml", "archive": "support-bundle-2022-10-28T23_01_26.tar.gz"}
Analysis output generated	{"path": "nutanix-dev-cluster/generated/nutanix-dev-cluster-2022-10-28T16:03:11-07:00-analysis.yaml"}
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: cert-manager-webhook is running.
  title: cert-manager-webhook Status
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: cert-manager-cainjector is running.
  title: cert-manager-cainjector Status
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: cert-manager is running.
  title: cert-manager Status
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: capi-controller-manager is running.
  title: capi-controller-manager Status
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: capi-kubeadm-control-plane-controller-manager is running.
  title: capi-kubeadm-control-plane-controller-manager Status
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: capi-kubeadm-control-plane-controller-manager is running.
  title: capi-kubeadm-control-plane-controller-manager Status
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: capi-kubeadm-bootstrap-controller-manager is running.
  title: capi-kubeadm-bootstrap-controller-manager Status
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: clusters.anywhere.eks.amazonaws.com is present on the cluster
  title: clusters.anywhere.eks.amazonaws.com
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: bundles.anywhere.eks.amazonaws.com is present on the cluster
  title: bundles.anywhere.eks.amazonaws.com
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: coredns is running.
  title: coredns Status
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: eks-anywhere-packages is running.
  title: eks-anywhere-packages Status
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: packagebundlecontrollers.packages.eks.amazonaws.com is present on the cluster
  title: packagebundlecontrollers.packages.eks.amazonaws.com
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: packagebundles.packages.eks.amazonaws.com is present on the cluster
  title: packagebundles.packages.eks.amazonaws.com
- URI: ""
  isFail: true
  isPass: false
  isWarn: false
  message: packagecontrollers.packages.eks.amazonaws.com is not present on cluster
  title: packagecontrollers.packages.eks.amazonaws.com
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: packages.packages.eks.amazonaws.com is present on the cluster
  title: packages.packages.eks.amazonaws.com
- URI: ""
  isFail: false
  isPass: true
  isWarn: false
  message: API server pods launched correctly
  title: 'log analysis:: API server pod missing. Log: logs/capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-controller-manager-*.log'
</pre>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

