### PR TITLE
Skip installing curated packages when no license info is provided.

### DIFF
--- a/pkg/curatedpackages/mocks/packageinstaller.go
+++ b/pkg/curatedpackages/mocks/packageinstaller.go
@@ -34,6 +34,20 @@ func (m *MockPackageController) EXPECT() *MockPackageControllerMockRecorder {
 	return m.recorder
 }
 
+// CanCuratedPackagesEnabled mocks base method.
+func (m *MockPackageController) CanCuratedPackagesEnabled(ctx context.Context) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CanCuratedPackagesEnabled", ctx)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CanCuratedPackagesEnabled indicates an expected call of CanCuratedPackagesEnabled.
+func (mr *MockPackageControllerMockRecorder) CanCuratedPackagesEnabled(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanCuratedPackagesEnabled", reflect.TypeOf((*MockPackageController)(nil).CanCuratedPackagesEnabled), ctx)
+}
+
 // EnableCuratedPackages mocks base method.
 func (m *MockPackageController) EnableCuratedPackages(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -68,6 +68,11 @@ func NewPackageControllerClient(chartInstaller ChartInstaller, kubectl KubectlRu
 	return pcc
 }
 
+// CanCuratedPackagesEnabled checks if curated packages can be enabled in a cluster
+func (pc *PackageControllerClient) CanCuratedPackagesEnabled(ctx context.Context) bool {
+	return pc.eksaAccessKeyId != "" && pc.eksaSecretAccessKey != "" && pc.eksaRegion != ""
+}
+
 // EnableCuratedPackages enables curated packages in a cluster
 // In case the cluster is management cluster, it performs the following actions:
 //   - Installation of Package Controller through helm chart installation

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -8,6 +8,7 @@ import (
 )
 
 type PackageController interface {
+	CanCuratedPackagesEnabled(ctx context.Context) bool
 	EnableCuratedPackages(ctx context.Context) error
 	IsInstalled(ctx context.Context) bool
 }
@@ -38,6 +39,11 @@ func NewInstaller(runner KubectlRunner, pc PackageHandler, pcc PackageController
 }
 
 func (pi *Installer) InstallCuratedPackages(ctx context.Context) error {
+	if !pi.packageController.CanCuratedPackagesEnabled(ctx) {
+		logger.MarkWarning("Installing curated packages is skipped")
+		return nil
+	}
+
 	PrintLicense()
 	err := pi.installPackagesController(ctx)
 	if err != nil {

--- a/pkg/curatedpackages/packageinstaller_test.go
+++ b/pkg/curatedpackages/packageinstaller_test.go
@@ -72,8 +72,17 @@ func TestPackageInstallerSuccess(t *testing.T) {
 	tt := newPackageInstallerTest(t)
 
 	tt.packageClient.EXPECT().CreatePackages(tt.ctx, tt.packagePath, tt.kubeConfigPath).Return(nil)
+	tt.packageControllerClient.EXPECT().CanCuratedPackagesEnabled(tt.ctx).Return(true)
 	tt.packageControllerClient.EXPECT().EnableCuratedPackages(tt.ctx).Return(nil)
 
+	err := tt.command.InstallCuratedPackages(tt.ctx)
+	tt.Expect(err).To(BeNil())
+}
+
+func TestPackageInstallerSkipped(t *testing.T) {
+	tt := newPackageInstallerTest(t)
+
+	tt.packageControllerClient.EXPECT().CanCuratedPackagesEnabled(tt.ctx).Return(false)
 	err := tt.command.InstallCuratedPackages(tt.ctx)
 	tt.Expect(err).To(BeNil())
 }
@@ -81,6 +90,7 @@ func TestPackageInstallerSuccess(t *testing.T) {
 func TestPackageInstallerFailWhenControllerFails(t *testing.T) {
 	tt := newPackageInstallerTest(t)
 
+	tt.packageControllerClient.EXPECT().CanCuratedPackagesEnabled(tt.ctx).Return(true)
 	tt.packageControllerClient.EXPECT().EnableCuratedPackages(tt.ctx).Return(errors.New("controller installation failed"))
 
 	err := tt.command.InstallCuratedPackages(tt.ctx)
@@ -91,6 +101,7 @@ func TestPackageInstallerFailWhenPackageFails(t *testing.T) {
 	tt := newPackageInstallerTest(t)
 
 	tt.packageClient.EXPECT().CreatePackages(tt.ctx, tt.packagePath, tt.kubeConfigPath).Return(errors.New("path doesn't exist"))
+	tt.packageControllerClient.EXPECT().CanCuratedPackagesEnabled(tt.ctx).Return(true)
 	tt.packageControllerClient.EXPECT().EnableCuratedPackages(tt.ctx).Return(nil)
 
 	err := tt.command.InstallCuratedPackages(tt.ctx)


### PR DESCRIPTION
*Issue #, if available:* #3829

*Description of changes:*
Skip installing the curated packages when no license info is provided

*Testing (if applicable):*
Unit testing and e2e testing

```
2022-10-28T20:51:06.431-0500    V0      🎉 Cluster created!
2022-10-28T20:51:06.431-0500    V4      Task finished   {"task_name": "delete-kind-cluster", "duration": "12.581401292s"}
2022-10-28T20:51:06.431-0500    V4      ----------------------------------
2022-10-28T20:51:06.432-0500    V4      Task start      {"task_name": "install-curated-packages"}
2022-10-28T20:51:06.432-0500    V0      ⚠️Installing curated packages is skipped
2022-10-28T20:51:06.432-0500    V4      Task finished   {"task_name": "install-curated-packages", "duration": "258.949µs"}
2022-10-28T20:51:06.432-0500    V4      ----------------------------------
2022-10-28T20:51:06.432-0500    V4      Tasks completed {"duration": "10m2.688560109s"}
2022-10-28T20:51:06.464-0500    V3      Cleaning up long running container      {"name": "eksa_1667007645532228000"}
2022-10-28T20:51:06.466-0500    V6      Executing command       {"cmd": "/usr/local/bin/docker rm -f -v eksa_1667007645532228000"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

