### PR TITLE
Pull the prerequisites out of each package task

### DIFF
--- a/docs/content/en/docs/tasks/packages/adot/_index.md
+++ b/docs/content/en/docs/tasks/packages/adot/_index.md
@@ -7,8 +7,8 @@ description: >
   Install/upgrade/uninstall ADOT
 ---
 
-{{< content "../prereq.md" >}}
-
+If you have not already done so, make sure your cluster meets the [package prerequisites.]({{< relref "../prereq" >}})
+Be sure to refer to the [troubleshooting guide]({{< relref "../../troubleshoot/packages" >}}) in the event of a problem.
 
 ## Install
 

--- a/docs/content/en/docs/tasks/packages/cert-manager/_index.md
+++ b/docs/content/en/docs/tasks/packages/cert-manager/_index.md
@@ -7,8 +7,8 @@ description: >
    Install/update/upgrade/uninstall Cert-Manager
 ---
 
-{{< content "../prereq.md" >}}
-
+If you have not already done so, make sure your cluster meets the [package prerequisites.]({{< relref "../prereq" >}})
+Be sure to refer to the [troubleshooting guide]({{< relref "../../troubleshoot/packages" >}}) in the event of a problem.
 
 ## Install on workload cluster
 

--- a/docs/content/en/docs/tasks/packages/cluster-autoscaler/_index.md
+++ b/docs/content/en/docs/tasks/packages/cluster-autoscaler/_index.md
@@ -7,8 +7,8 @@ description: >
   Install/upgrade/uninstall Cluster Autoscaler
 ---
 
-{{< content "../prereq.md" >}}
-
+If you have not already done so, make sure your cluster meets the [package prerequisites.]({{< relref "../prereq" >}})
+Be sure to refer to the [troubleshooting guide]({{< relref "../../troubleshoot/packages" >}}) in the event of a problem.
 
 ## Install
 

--- a/docs/content/en/docs/tasks/packages/emissary/_index.md
+++ b/docs/content/en/docs/tasks/packages/emissary/_index.md
@@ -7,8 +7,8 @@ description: >
   Install/upgrade/uninstall Emissary Ingress
 ---
 
-{{< content "../prereq.md" >}}
-
+If you have not already done so, make sure your cluster meets the [package prerequisites.]({{< relref "../prereq" >}})
+Be sure to refer to the [troubleshooting guide]({{< relref "../../troubleshoot/packages" >}}) in the event of a problem.
 
 ## Install
 

--- a/docs/content/en/docs/tasks/packages/harbor/_index.md
+++ b/docs/content/en/docs/tasks/packages/harbor/_index.md
@@ -7,7 +7,8 @@ description: >
   Install/upgrade/uninstall Harbor
 ---
 
-{{< content "../prereq.md" >}}
+If you have not already done so, make sure your cluster meets the [package prerequisites.]({{< relref "../prereq" >}})
+Be sure to refer to the [troubleshooting guide]({{< relref "../../troubleshoot/packages" >}}) in the event of a problem.
 
 ## Install
 

--- a/docs/content/en/docs/tasks/packages/metallb/_index.md
+++ b/docs/content/en/docs/tasks/packages/metallb/_index.md
@@ -7,8 +7,8 @@ description: >
   Install/upgrade/uninstall MetalLB
 ---
 
-{{< content "../prereq.md" >}}
-
+If you have not already done so, make sure your cluster meets the [package prerequisites.]({{< relref "../prereq" >}})
+Be sure to refer to the [troubleshooting guide]({{< relref "../../troubleshoot/packages" >}}) in the event of a problem.
 
 ## Install
 

--- a/docs/content/en/docs/tasks/packages/metrics-server/_index.md
+++ b/docs/content/en/docs/tasks/packages/metrics-server/_index.md
@@ -7,8 +7,8 @@ description: >
   Install/upgrade/uninstall Metrics Server
 ---
 
-{{< content "../prereq.md" >}}
-
+If you have not already done so, make sure your cluster meets the [package prerequisites.]({{< relref "../prereq" >}})
+Be sure to refer to the [troubleshooting guide]({{< relref "../../troubleshoot/packages" >}}) in the event of a problem.
 
 ## Install
 

--- a/docs/content/en/docs/tasks/packages/prereq.md
+++ b/docs/content/en/docs/tasks/packages/prereq.md
@@ -9,7 +9,7 @@ description: >
 ## Prerequisites
 Before installing any curated packages for EKS Anywhere, do the following:
 
-* Check that the cluster `Kubernetes` version is `v1.21` or above.
+* Check that the cluster `Kubernetes` version is `v1.21` or above. For example, you could run `kubectl get cluster -o yaml <cluster-name> | grep -i kubernetesVersion`
 * Check that the version of `eksctl anywhere` is `v0.11.0` or above with the `eksctl anywhere version` command.
 * It is recommended that the package controller is only installed on the management cluster.
 * Check the existence of package controller:


### PR DESCRIPTION
I found the prereqs on every package I bit long winded, so this makes it so the user doesn't have to scroll past as much
