### PR TITLE
Fix broken links in docs and add HTML test

### DIFF
--- a/docs/.htmltest.yml
+++ b/docs/.htmltest.yml
@@ -1,0 +1,4 @@
+IgnoreInternalEmptyHash: true
+IgnoreDirs:
+- "_print"
+IgnoreAltMissing: true

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,14 +1,18 @@
+DOCS_FOLDER=$(shell git rev-parse --show-toplevel)/docs
 IMAGE_REGISTRY ?= public.ecr.aws/eks-distro-build-tooling
 CONTAINER_IMAGE   = $(IMAGE_REGISTRY)/eks-a-hugo
 CONTAINER_RUN     = docker run --rm --interactive --tty --volume $(CURDIR)/../:/src
 DOCS_ARCHIVE      = public.zip
+HTMLTEST_VERSION?=v0.16.0
 
 .PHONY: help build release submodule zip deploy serve server container-build container-serve container-server clean
 
 help: ## Show this help. Requires locally installed npm and hugo.
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-build: submodule ## Generate the static site into the /public folder
+build: build-docs htmltest
+
+build-docs: submodule ## Generate the static site into the /public folder
 	npm install
 	hugo --environment production --cleanDestinationDir
 
@@ -17,6 +21,12 @@ release: build
 submodule: ## initialize the docsy theme submodule
 	git submodule update --init --recursive
 	cd themes/docsy; git am ../../patches/0001-Make-docsy-js-files-static.patch; cd ../..
+
+htmltest: install-htmltest
+	bin/htmltest -c $(DOCS_FOLDER)/.htmltest.yml -s $(DOCS_FOLDER)/public
+
+install-htmltest:
+	curl https://htmltest.wjdp.uk | bash -s $(HTMLTEST_VERSION)
 
 submodule-reset: ## reset submodules to tracked commit
 	rm -rf themes/docsy

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -178,4 +178,4 @@ enable = false
 fullversion = "v0.12"
 version = "v0.12"
 docsbranch = "main"
-url = "/docs"
+url = "/docs/"

--- a/docs/content/en/docs/community/_index.md
+++ b/docs/content/en/docs/community/_index.md
@@ -7,7 +7,7 @@ description: >
 
 We work hard to provide a high-quality Kubernetes installer for EKS,
 and we greatly value feedback and contributions from our community. Please
-review the [contribution guidelines](contributing) before
+review the [contribution guidelines](contributing/) before
 submitting any [issues](https://github.com/aws/eks-anywhere/issues) or
 [pull requests](https://github.com/aws/eks-anywhere/pulls) to ensure we have
 all the necessary information to respond to your bug report or contribution 

--- a/docs/content/en/docs/concepts/clusterworkflow.md
+++ b/docs/content/en/docs/concepts/clusterworkflow.md
@@ -54,7 +54,7 @@ With your Administrative machine in place, you need to prepare your [Bare Metal]
 The following sections describe how to create a Bare Metal or vSphere cluster.
 
 ## Creating a Bare Metal cluster
-The following diagram illustrates what happens when you start the cluster creation process for a Bare Metal provider, as described in the [Bare Metal Getting started]({{< relref "../getting-started/production-environment/baremetal-getstarted#create-an-initial-cluster" >}}) guide.
+The following diagram illustrates what happens when you start the cluster creation process for a Bare Metal provider, as described in the [Bare Metal Getting started]({{< relref "../getting-started/production-environment/baremetal-getstarted#create-the-cluster" >}}) guide.
 
 ### Start creating a Bare Metal cluster
 

--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -4,7 +4,7 @@ weight: 10
 ---
 
 EKS Anywhere will create and manage Kubernetes clusters on multiple providers.
-Currently we support creating development clusters locally using Docker and production clusters from providers listed on the [Create production cluster](../production-environment/) page.
+Currently we support creating development clusters locally using Docker and production clusters from providers listed on the [Create production cluster]({{< relref "/docs/getting-started/production-environment" >}}) page.
 
 Creating an EKS Anywhere cluster begins with setting up an Administrative machine where you will run Docker and add some binaries.
 From there, you create the cluster for your chosen provider.
@@ -90,5 +90,5 @@ eksctl anywhere version
 
 Once you have the tools installed you can deploy a local cluster or production cluster in the next steps.
 
-* [Create local cluster](../local-environment/)
-* [Create production cluster](../production-environment/)
+* [Create local cluster]({{< relref "/docs/getting-started/local-environment" >}})
+* [Create production cluster]({{< relref "/docs/getting-started/production-environment" >}})

--- a/docs/content/en/docs/reference/changelog.md
+++ b/docs/content/en/docs/reference/changelog.md
@@ -76,7 +76,7 @@ weight: 35
 ## [v0.11.0](https://github.com/aws/eks-anywhere/releases/tag/v0.11.0)
 
 ### Breaking Changes
-- EKS Anywhere no longer distributes Ubuntu OVAs for use with EKS Anywhere clusters. Building your own Ubuntu-based nodes as described in [Building Ubuntu-based node images]({{< relref "./artifacts.md/#building-ubuntu-based-node-images" >}}) is the only supported way to get that functionality.
+- EKS Anywhere no longer distributes Ubuntu OVAs for use with EKS Anywhere clusters. Building your own Ubuntu-based nodes as described in [Building node images]({{< relref "./artifacts.md/#building-node-images" >}}) is the only supported way to get that functionality.
 
 ### Added
 - Add support for Kubernetes 1.23 [#2159](https://github.com/aws/eks-anywhere/issues/2159)

--- a/docs/content/en/docs/reference/cloudstack/cloudstack-preparation.md
+++ b/docs/content/en/docs/reference/cloudstack/cloudstack-preparation.md
@@ -36,7 +36,7 @@ From the apachecloudstack console:
 ## Import template
 You need to build at least one operating system image and import it as a template to use for your cluster nodes.
 Currently, only Red Hat Enterprise Linux 8 images are supported.
-To build a RHEL-based image to use with EKS Anywhere, see [Build CloudStack node images]({{< relref "../artifacts/#build-cloudstack-node-images/" >}}).
+To build a RHEL-based image to use with EKS Anywhere, see [Build node images]({{< relref "../artifacts/#building-node-images" >}}).
 
 1. Make your image accessible from you local machine or from a URL that is accessible to your CloudStack setup.
 

--- a/docs/content/en/docs/reference/clusterspec/optional/autoscaling.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/autoscaling.md
@@ -46,7 +46,7 @@ cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: <minCount>
 cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: <maxCount>
 ```
 
-After deploying the Kubernetes Cluster Autoscaler from upstream or as a [curated package](../../../tasks/packages/cluster-autoscaler), the deployment will pick up your MachineDeployment and scale the nodes as per your min and max count values.
+After deploying the Kubernetes Cluster Autoscaler from upstream or as a [curated package](../../../../tasks/packages/cluster-autoscaler/), the deployment will pick up your MachineDeployment and scale the nodes as per your min and max count values.
 
 ### Cluster Autoscaler Deployment Topologies
 
@@ -54,6 +54,6 @@ The Kubernetes Cluster Autoscaler can only scale a single cluster per deployment
 
 This means that each cluster you want to scale will need its own cluster autoscaler deployment.
 
-The most straightforward way of deploying cluster autoscaler is to deploy it to the management cluster as described [here](../../../tasks/packages/cluster-autoscaler/_index.md#install).
+The most straightforward way of deploying cluster autoscaler is to deploy it to the management cluster as described [here](../../../../tasks/packages/cluster-autoscaler/#install).
 
-If your deployment topology runs small management clusters though, it is also possible to deploy the cluster autoscaler to a [workload cluster](../../../tasks/packages/cluster-autoscaler/_index.md#installing-cluster-autoscaler-on-workload-cluster).
+If your deployment topology runs small management clusters though, it is also possible to deploy the cluster autoscaler to a [workload cluster](../../../../tasks/packages/cluster-autoscaler/#installing-cluster-autoscaler-on-workload-cluster).

--- a/docs/content/en/docs/reference/clusterspec/vsphere.md
+++ b/docs/content/en/docs/reference/clusterspec/vsphere.md
@@ -143,7 +143,7 @@ range that does not conflict with other VMs.
 
 >**_NOTE:_** This IP should be outside the network DHCP range as it is a floating IP that gets assigned to one of
 the control plane nodes for kube-apiserver loadbalancing. Suggestions on how to ensure this IP does not cause issues during cluster 
-creation process are [here]({{< relref "../vsphere/vsphere-prereq/#:~:text=Below%20are%20some,existent%20mac%20address." >}})
+creation process are [here]({{< relref "../vsphere/vsphere-prereq/#prepare-a-vmware-vsphere-environment" >}})
 
 ### controlPlaneConfiguration.taints
 A list of taints to apply to the control plane nodes of the cluster.

--- a/docs/content/en/docs/reference/eksctl/_index.md
+++ b/docs/content/en/docs/reference/eksctl/_index.md
@@ -53,7 +53,7 @@ export CLUSTER_NAME=docker01
 eksctl anywhere generate clusterconfig ${CLUSTER_NAME} -p docker > ${CLUSTER_NAME}.yaml
 ```
 Once you have generated the yaml configuration file, edit that file to add configuration information before you use the file to create your cluster.
-See [local](../../getting-started/local-environment) and [production](../../getting-started/production-environment) cluster creation procedures for details.
+See [local](../../getting-started/local-environment/) and [production](../../getting-started/production-environment/) cluster creation procedures for details.
 
 ### `eksctl anywhere generate support-bundle-config`
 
@@ -111,7 +111,7 @@ export CLUSTER_NAME=vsphere01
 eksctl anywhere create cluster -v 9 -f ${CLUSTER_NAME}.yaml
 ```
 
-See [local](../../getting-started/local-environment) and [production](../../getting-started/production-environment) cluster creation procedures for details.
+See [local](../../getting-started/local-environment/) and [production](../../getting-started/production-environment/) cluster creation procedures for details.
 
 ## `eksctl anywhere upgrade cluster`
 
@@ -123,7 +123,7 @@ export CLUSTER_NAME=vsphere01
 eksctl anywhere upgrade cluster -f ${CLUSTER_NAME}.yaml --force-cleanup -v9 \
    -w KUBECONFIG=${PWD}/${CLUSTER_NAME}/${CLUSTER_NAME}-eks-a-cluster.kubeconfig 
 ```
-For more information on this and other ways to upgrade a cluster, see [Upgrade cluster](../../tasks/cluster/cluster-upgrades).
+For more information on this and other ways to upgrade a cluster, see [Upgrade cluster](../../tasks/cluster/cluster-upgrades/).
 
 ## `eksctl anywhere delete cluster`
 
@@ -136,7 +136,7 @@ eksctl anywhere delete cluster -f ${CLUSTER_NAME}.yaml \
    --force-cleanup \
    -w KUBECONFIG=${PWD}/${CLUSTER_NAME}/${CLUSTER_NAME}-eks-a-cluster.kubeconfig 
 ```
-For more information on deleting a cluster, see [Delete cluster](../../tasks/cluster/cluster-delete).
+For more information on deleting a cluster, see [Delete cluster](../../tasks/cluster/cluster-delete/).
 
 ## `eksctl anywhere version`
 

--- a/docs/content/en/docs/reference/security/kube-bench.md
+++ b/docs/content/en/docs/reference/security/kube-bench.md
@@ -10,7 +10,7 @@ The CIS Benchmark self-assessment guide serves to help EKS Anywhere users evalua
 
 You can verify the security posture of your EKS Anywhere cluster by using a tool called [`kube-bench`](https://github.com/aquasecurity/kube-bench). The ideal way to run the benchmark tests on your EKS Anywhere cluster is to apply the [Kube-bench Job YAMLs](https://github.com/aws/eks-anywhere/blob/main/test/kube-bench/jobs) to the cluster. This runs the `kube-bench` tests on a Pod on the cluster, and the logs of the Pod provide the test results.
 
-Kube-bench currently does not support unstacked `etcd` topology (which is the default for EKS Anywhere), so the following checks are skipped in the default kube-bench Job YAML. If you created your EKS Anywhere cluster with stacked `etcd` configuration, you can apply the stacked `etcd` [Job YAML](jobs/controlplane/kube-bench-stacked-etcd.yaml) instead.
+Kube-bench currently does not support unstacked `etcd` topology (which is the default for EKS Anywhere), so the following checks are skipped in the default kube-bench Job YAML. If you created your EKS Anywhere cluster with stacked `etcd` configuration, you can apply the stacked `etcd` [Job YAML](https://github.com/aws/eks-anywhere/blob/main/test/kube-bench/jobs/controlplane/kube-bench-stacked-etcd.yaml) instead.
 
 | Check number | Check description |
 | :---: | :---: |

--- a/docs/content/en/docs/reference/support/support-scope.md
+++ b/docs/content/en/docs/reference/support/support-scope.md
@@ -24,7 +24,7 @@ See the [Artifacts]({{< relref "../artifacts" >}}) page for details.
 
 * **Ubuntu**: EKS Anywhere has been tested with Ubuntu-based nodes.
 Amazon will assist with troubleshooting and configuration guidance with Ubuntu-based nodes under the [EKS Anywhere Enterprise Subscription.](https://aws.amazon.com/eks/eks-anywhere/pricing/)
-To build your own Ubuntu-based EKS Anywhere node, see [Building Ubuntu-based node images.]({{< relref "../artifacts/#building-ubuntu-based-node-images" >}})
+To build your own Ubuntu-based EKS Anywhere node, see [Building node images.]({{< relref "../artifacts/#building-node-images" >}})
 For official Ubuntu support, see the Canonical [Support](https://ubuntu.com/support) page.
 
 * **Red Hat Enterprise Linux (RHEL)**: EKS Anywhere has been tested with RHEL-based nodes.

--- a/docs/content/en/docs/reference/vsphere/vsphere-ovas.md
+++ b/docs/content/en/docs/reference/vsphere/vsphere-ovas.md
@@ -128,7 +128,7 @@ environment variables to run `govc` GOVC_USERNAME, GOVC_PASSWORD and GOVC_URL.
    ![Import ova wizard](/images/ss10.jpg)
 1. Click *Assign* -> *Add Tag* to create a new tag and attach it
    ![Import ova wizard](/images/ss11.jpg)
-1. Name the tag *eksdRelease:{eksd release for the selected ova}*, for example *eksdRelease:kubernetes-1-23-eks-4* for the 1.23 ova. You can find the rest of eksd releases in the previous [section](#import-an-ovaovf-template-to-vsphere). If it's the first time you add an `eksdRelease` tag, you would need to create the category first. Click on "Create New Category" and name it `eksdRelease`.
+1. Name the tag *eksdRelease:{eksd release for the selected ova}*, for example *eksdRelease:kubernetes-1-23-eks-4* for the 1.23 ova. You can find the rest of eksd releases in the previous [section](../vsphere-preparation/#deploy-an-ova-template). If it's the first time you add an `eksdRelease` tag, you would need to create the category first. Click on "Create New Category" and name it `eksdRelease`.
    ![Import ova wizard](/images/ss13.png)
 
 ### Using govc
@@ -163,7 +163,7 @@ govc tags.ls <Template Path>
 ```
 govc tags.category.create -t VirtualMachine eksdRelease
 ```
-2. Create the proper eksd release Tag, depending on your template. You can find the eksd releases in the previous [section](#import-an-ovaovf-template-to-vsphere). For example *eksdRelease:kubernetes-1-23-eks-4* for the 1.23 template.
+2. Create the proper eksd release Tag, depending on your template. You can find the eksd releases in the previous [section](../vsphere-preparation/#deploy-an-ova-template). For example *eksdRelease:kubernetes-1-23-eks-4* for the 1.23 template.
 ```
 govc tags.create -c eksdRelease eksdRelease:kubernetes-1-23-eks-4
 ```

--- a/docs/content/en/docs/tasks/cluster/cluster-scale/baremetal-scale.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-scale/baremetal-scale.md
@@ -52,4 +52,4 @@ kubectl scale kubeadmcontrolplane -n eksa-system <controlPlaneName> --replicas <
 
 EKS Anywhere supports autoscaling of worker node groups using the [Kubernetes Cluster Autoscaler](https://github.com/kubernetes/autoscaler/) and as a [curated package](../../../../reference/packagespec/cluster-autoscaler/).
 
-See [here](../../../../reference/clusterspec/optional/autoscaling) for details on how to configure your cluster spec to autoscale worker node groups for autoscaling.
+See [here](../../../../reference/clusterspec/optional/autoscaling/) for details on how to configure your cluster spec to autoscale worker node groups for autoscaling.

--- a/docs/content/en/docs/tasks/cluster/cluster-scale/cloudstack-scale.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-scale/cloudstack-scale.md
@@ -11,4 +11,4 @@ description: >
 
 EKS Anywhere supports autoscaling of worker node groups using the [Kubernetes Cluster Autoscaler](https://github.com/kubernetes/autoscaler/) and as a [curated package](../../../../reference/packagespec/cluster-autoscaler/).
 
-See [here](../../../../reference/clusterspec/optional/autoscaling) for details on how to configure your cluster spec to autoscale worker node groups for autoscaling.
+See [here](../../../../reference/clusterspec/optional/autoscaling/) for details on how to configure your cluster spec to autoscale worker node groups for autoscaling.

--- a/docs/content/en/docs/tasks/cluster/cluster-scale/vsphere-scale.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-scale/vsphere-scale.md
@@ -70,4 +70,4 @@ To read more about making changes with the integrated Flux GitOps controller you
 
 EKS Anywhere supports autoscaling of worker node groups using the [Kubernetes Cluster Autoscaler](https://github.com/kubernetes/autoscaler/) and as a [curated package](../../../../reference/packagespec/cluster-autoscaler/).
 
-See [here](../../../../reference/clusterspec/optional/autoscaling) for details on how to configure your cluster spec to autoscale worker node groups for autoscaling.
+See [here](../../../../reference/clusterspec/optional/autoscaling/) for details on how to configure your cluster spec to autoscale worker node groups for autoscaling.

--- a/docs/content/en/docs/tasks/packages/cluster-autoscaler/_index.md
+++ b/docs/content/en/docs/tasks/packages/cluster-autoscaler/_index.md
@@ -13,7 +13,7 @@ Be sure to refer to the [troubleshooting guide]({{< relref "../../troubleshoot/p
 ## Install
 
 <!-- this content needs to be indented so the numbers are automatically incremented -->
-1. Ensure you have configured at least one WorkerNodeGroup in your cluster to support autoscaling as outlined [here](../../../reference/clusterspec/optional/autoscaling)
+1. Ensure you have configured at least one WorkerNodeGroup in your cluster to support autoscaling as outlined [here](../../../reference/clusterspec/optional/autoscaling/)
 
 1. Generate the package configuration
    ```bash


### PR DESCRIPTION
This PR fixes some of the broken links and references in the docs. It also adds a make target to run `htmltest` CLI to ensure that all the links, images, scripts references work.

Example output for htmltest:
```
docs/reference/changelog/index.html
hash does not exist --- docs/reference/changelog/index.html --> /docs/reference/artifacts/#building-ubuntu-based-node-images
target does not exist --- docs/workshops/provision/prerequistes/index.html --> ../production-environment/
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

