### PR TITLE
Setting minimum wait time for nodes and machinedeployments

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -12,6 +12,7 @@ import (
 
 	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
+	"k8s.io/utils/integer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/yaml"
 
@@ -704,7 +705,7 @@ func (c *ClusterManager) waitForControlPlaneReplicasReady(ctx context.Context, m
 func (c *ClusterManager) waitForMachineDeploymentReplicasReady(ctx context.Context, managementCluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	ready, total := 0, 0
 	policy := func(_ int, _ error) (bool, time.Duration) {
-		return true, c.machineBackoff * time.Duration(total-ready)
+		return true, c.machineBackoff * time.Duration(integer.IntMax(1, total-ready))
 	}
 
 	var machineDeploymentReplicasCount int
@@ -739,7 +740,7 @@ func (c *ClusterManager) waitForMachineDeploymentReplicasReady(ctx context.Conte
 func (c *ClusterManager) waitForNodesReady(ctx context.Context, managementCluster *types.Cluster, clusterName string, labels []string, checkers ...types.NodeReadyChecker) error {
 	readyNodes, totalNodes := 0, 0
 	policy := func(_ int, _ error) (bool, time.Duration) {
-		return true, c.machineBackoff * time.Duration(totalNodes-readyNodes)
+		return true, c.machineBackoff * time.Duration(integer.IntMax(1, totalNodes-readyNodes))
 	}
 
 	areNodesReady := func() error {


### PR DESCRIPTION
*Issue #, if available:*
Resolves https://github.com/aws/eks-anywhere/issues/3822

*Description of changes:*
As described in the issue above, we're seeing 0-second retries with the current implementation. We're multiplying the retry time by 0 in some instances. This PR changes the retry policy to have a minimum threshold for the retry wait policy

*Testing (if applicable):*
Unit tests succeed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

