### PR TITLE
Fix bug in controller vsphere template generator

### DIFF
--- a/controllers/resource/template.go
+++ b/controllers/resource/template.go
@@ -164,8 +164,6 @@ func (r *VsphereTemplate) TemplateResources(ctx context.Context, eksaCluster *an
 
 	cpOpt := func(values map[string]interface{}) {
 		values["controlPlaneTemplateName"] = controlPlaneTemplateName
-		values["vsphereControlPlaneSshAuthorizedKey"] = sshAuthorizedKey(cpVmc.Spec.Users)
-		values["vsphereEtcdSshAuthorizedKey"] = sshAuthorizedKey(etcdVmc.Spec.Users)
 		values["etcdTemplateName"] = etcdTemplateName
 		for k, v := range credValues {
 			values[k] = v


### PR DESCRIPTION
## Description of changes

Avoid overwriting ssh keys for CP and etcd machines since the vsphere template builder is already capable of doing it and runs more robust logic. This was causing new machine rollouts when the specified ssh key had a comment due a difference in kubeadm control plane, etcdadm cluster and vsphere machine templates. The CLI strips them out before creating the vsphere capi objects because it uses the template builder logic.

This was causing some e2e tests to fail due to cluster instability: the controller kept rolling out new machines so the cluster didn't become ready fast enough and the delete operation timed out waiting for it. 

## Testing
Unit tests and manual e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

