### PR TITLE
Add license info for workload cluster docs

### DIFF
--- a/docs/content/en/docs/getting-started/production-environment/cloudstack-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/cloudstack-getstarted.md
@@ -92,7 +92,7 @@ Follow these steps to create an EKS Anywhere cluster that can be used either as 
 
 1. Set License Environment Variable
 
-   If you are creating a licensed cluster, set and export the license variable (see [License cluster]({{< relref "/docs/tasks/cluster/cluster-license" >}}) if you are licensing an existing cluster):
+   Add a license to any cluster for which you want to receive paid support. If you are creating a licensed cluster, set and export the license variable (see [License cluster]({{< relref "/docs/tasks/cluster/cluster-license" >}}) if you are licensing an existing cluster):
 
    ```bash
    export EKSA_LICENSE='my-license-here'
@@ -185,6 +185,14 @@ Follow these steps if you want to use your initial cluster to create and manage 
 
    * Ensure workload cluster object names (`Cluster`, `CloudDatacenterConfig`, `CloudStackMachineConfig`, etc.) are distinct from management cluster object names.
    * Be sure to set the `managementCluster` field to identify the name of the management cluster.
+
+1. Set License Environment Variable
+
+   Add a license to any cluster for which you want to receive paid support. If you are creating a licensed cluster, set and export the license variable (see [License cluster]({{< relref "/docs/tasks/cluster/cluster-license" >}}) if you are licensing an existing cluster):
+
+   ```bash
+   export EKSA_LICENSE='my-license-here'
+   ```
 
 1. Create a workload cluster
 

--- a/docs/content/en/docs/getting-started/production-environment/vsphere-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/vsphere-getstarted.md
@@ -74,7 +74,7 @@ Make sure you use single quotes around the values so that your shell does not in
 
 1. Set License Environment Variable
 
-   If you are creating a licensed cluster, set and export the license variable (see [License cluster]({{< relref "/docs/tasks/cluster/cluster-license" >}}) if you are licensing an existing cluster):
+   Add a license to any cluster for which you want to receive paid support. If you are creating a licensed cluster, set and export the license variable (see [License cluster]({{< relref "/docs/tasks/cluster/cluster-license" >}}) if you are licensing an existing cluster):
 
    ```bash
    export EKSA_LICENSE='my-license-here'
@@ -160,6 +160,14 @@ Follow these steps if you want to use your initial cluster to create and manage 
 
    Refer to the initial config described earlier for the required and optional settings.
    Ensure workload cluster object names (`Cluster`, `vSphereDatacenterConfig`, `vSphereMachineConfig`, etc.) are distinct from management cluster object names. Be sure to set the `managementCluster` field to identify the name of the management cluster.
+
+1. Set License Environment Variable
+
+   Add a license to any cluster for which you want to receive paid support. If you are creating a licensed cluster, set and export the license variable (see [License cluster]({{< relref "/docs/tasks/cluster/cluster-license" >}}) if you are licensing an existing cluster):
+
+   ```bash
+   export EKSA_LICENSE='my-license-here'
+   ```
 
 1. Create a workload cluster
 


### PR DESCRIPTION
*Issue #, if available:* [#3843](https://github.com/aws/eks-anywhere/issues/3843)

*Description of changes:*
Add step for assigning a support license for workload clusters on a vSphere or CloudStack EKS Anywhere provider.
