### PR TITLE
Add target to build controller for custom bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -617,6 +617,10 @@ conformance-tests: eks-a-e2e integration-test-binary ## Build e2e conformance te
 eksa-components-override:
 	scripts/eksa_components_override.sh $(BUNDLE_MANIFEST_URL) $(CLUSTER_CONTROLLER_IMAGE)
 
+.PHONY: bundles-override-local-e2e-tests
+bundles-override-local-e2e-tests: docker-build docker-push eksa-components-override
+	echo "Don't forget to export T_BUNDLES_OVERRIDE=true before running the tests"
+
 .PHONY: help
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[%\/0-9A-Za-z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -642,15 +646,6 @@ generate-core-manifests: $(CONTROLLER_GEN) ## Generate manifests for the core pr
 		output:webhook:dir=./config/webhook \
 		webhook
 
-REGISTRY ?= public.ecr.aws/a2k4d8v8
-IMAGE_NAME ?= eksa-cluster-controller
-CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-
-TAG ?= dev
-ARCH ?= amd64
-
-CONTROLLER_IMG_TAGGED ?= $(CONTROLLER_IMG)-$(ARCH):$(TAG)
-
 LDFLAGS := $(shell hack/version.sh)
 
 .PHONY: docker-build
@@ -664,11 +659,11 @@ docker-build-core: ## Build the docker image for controller-manager
 	--build-arg TARGETARCH=$(GO_ARCH) \
 	--build-arg TARGETOS=$(GO_OS) \
 	--build-arg BASE_IMAGE=$(CLUSTER_CONTROLLER_BASE_IMAGE) \
-    . -t $(CONTROLLER_IMG_TAGGED) -f $(DOCKERFILE_FOLDER)/Dockerfile
+    . -t $(CLUSTER_CONTROLLER_IMAGE) -f $(DOCKERFILE_FOLDER)/Dockerfile
 
 .PHONY: docker-push
 docker-push: ## Push the docker image
-	docker push $(CONTROLLER_IMG_TAGGED)
+	docker push $(CLUSTER_CONTROLLER_IMAGE)
 
 ## TODO update release folder
 RELEASE_DIR := config/manifest


### PR DESCRIPTION
## Description of changes
Allows to
```sh
make bundles-override-local-e2e-tests IMAGE_REPO=public.ecr.aws/xxx
```

This will:
1. Build the controller image
2. Push it to your registry
3. Reference that image in a custom bundle in local disk

The bundle will be in `bin/local-bundle-release.yaml` and the custom eksa manifest in `bin/local-eksa-components.yaml`. This is compatible with the e2e test suite, you just need to `export T_BUNDLES_OVERRIDE=true`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

