### PR TITLE
Worker count pointer dereference fix (#3852)

### DIFF
--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -158,7 +158,7 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupMachineSpec v1
 		"eksaSystemNamespace":    constants.EksaSystemNamespace,
 		"format":                 format,
 		"kubernetesVersion":      bundle.KubeDistro.Kubernetes.Tag,
-		"workerReplicas":         workerNodeGroupConfiguration.Count,
+		"workerReplicas":         *workerNodeGroupConfiguration.Count,
 		"workerPoolName":         "md-0",
 		"workerSshAuthorizedKey": workerNodeGroupMachineSpec.Users[0].SshAuthorizedKeys[0],
 		"workerSshUsername":      workerNodeGroupMachineSpec.Users[0].Name,

--- a/pkg/providers/tinkerbell/assert.go
+++ b/pkg/providers/tinkerbell/assert.go
@@ -250,7 +250,7 @@ func AssertionsForScaleUpDown(catalogue *hardware.Catalogue, currentSpec *cluste
 
 		for _, nodeGroupNewSpec := range spec.Cluster.Spec.WorkerNodeGroupConfigurations {
 			if workerNodeGrpOldSpec, ok := workerNodeGroupMap[nodeGroupNewSpec.Name]; ok {
-				if nodeGroupNewSpec.Count != workerNodeGrpOldSpec.Count {
+				if *nodeGroupNewSpec.Count != *workerNodeGrpOldSpec.Count {
 					if rollingUpgrade {
 						return fmt.Errorf("cannot perform scale up or down during rolling upgrades")
 					}

--- a/pkg/providers/tinkerbell/assert_test.go
+++ b/pkg/providers/tinkerbell/assert_test.go
@@ -401,6 +401,33 @@ func TestMinimumHardwareAvailableAssertionForCreate_InsufficientFailsWithoutExte
 	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }
 
+func TestAssertionsForScaleUpDown_Success(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+
+	assertion := tinkerbell.AssertionsForScaleUpDown(catalogue, clusterSpec.Spec, true)
+	newClusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	newClusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+	g.Expect(assertion(newClusterSpec)).To(gomega.Succeed())
+}
+
+func TestAssertionsForScaleUpDown_FailsScaleUpAndRollingError(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+
+	assertion := tinkerbell.AssertionsForScaleUpDown(catalogue, clusterSpec.Spec, true)
+	newClusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	newClusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+	newClusterSpec.WorkerNodeGroupConfigurations()[0].Count = ptr.Int(2)
+	g.Expect(assertion(newClusterSpec)).NotTo(gomega.Succeed())
+}
+
 func TestHardwareSatisfiesOnlyOneSelectorAssertion_MeetsOnlyOneSelector(t *testing.T) {
 	g := gomega.NewWithT(t)
 

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -287,7 +287,7 @@ func (p *Provider) isScaleUpDown(oldCluster *v1alpha1.Cluster, newCluster *v1alp
 
 	for _, nodeGroupNewSpec := range newCluster.Spec.WorkerNodeGroupConfigurations {
 		if workerNodeGrpOldSpec, ok := workerNodeGroupMap[nodeGroupNewSpec.Name]; ok {
-			if nodeGroupNewSpec.Count != workerNodeGrpOldSpec.Count {
+			if *nodeGroupNewSpec.Count != *workerNodeGrpOldSpec.Count {
 				return true
 			}
 		}


### PR DESCRIPTION
* Fixing worker node group count dereference error for tinkerbell

* Fixing worker node group count dereference for nutanix

(cherry picked from commit 91f1ae10d7ba93d91e315812799d38184087a8fe)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

