### PR TITLE
Add missing ContentLibrary permission to GlobalRole

### DIFF
--- a/docs/content/en/docs/reference/vsphere/vsphere-preparation.md
+++ b/docs/content/en/docs/reference/vsphere/vsphere-preparation.md
@@ -66,6 +66,7 @@ Three roles are needed to be able to create the EKS Anywhere cluster:
    * Check in a template
    * Check out a template
    * Create local library
+   * Update files
    > vSphere Tagging
    * Assign or Unassign vSphere Tag
    * Assign or Unassign vSphere Tag on Object

--- a/pkg/config/static/globalPrivs.json
+++ b/pkg/config/static/globalPrivs.json
@@ -3,6 +3,7 @@
   "ContentLibrary.CheckInTemplate",
   "ContentLibrary.CheckOutTemplate",
   "ContentLibrary.CreateLocalLibrary",
+  "ContentLibrary.UpdateSession",
   "InventoryService.Tagging.AttachTag",
   "InventoryService.Tagging.CreateCategory",
   "InventoryService.Tagging.CreateTag",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/3692

*Description of changes:*
Adds a missing ContentLibrary permission.

This permission is required to automatically import a template.

*Testing (if applicable):*
Verified that my user could successfully import images when this permission was added to the globalRole.


<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->