### PR TITLE
Fail VSphereMachineConfig Create Webhook on Missing Template

### DIFF
--- a/pkg/api/v1alpha1/vspheremachineconfig.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig.go
@@ -140,3 +140,11 @@ func validateVSphereMachineConfig(config *VSphereMachineConfig) error {
 
 	return nil
 }
+
+func validateVSphereMachineConfigHasTemplate(config *VSphereMachineConfig) error {
+	if config.Spec.Template == "" {
+		return fmt.Errorf("template field is required")
+	}
+
+	return nil
+}

--- a/pkg/api/v1alpha1/vspheremachineconfig_types.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_types.go
@@ -123,6 +123,13 @@ func (c *VSphereMachineConfig) Validate() error {
 	return validateVSphereMachineConfig(c)
 }
 
+// ValidateHasTemplate verifies that a VSphereMachineConfig object has a template.
+// Specifying a template is required when submitting an object via webhook,
+// as we only support auto-importing templates when creating a cluster via CLI.
+func (c *VSphereMachineConfig) ValidateHasTemplate() error {
+	return validateVSphereMachineConfigHasTemplate(c)
+}
+
 // +kubebuilder:object:generate=false
 
 // Same as VSphereMachineConfig except stripped down for generation of yaml file during generate clusterconfig

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
@@ -41,8 +41,11 @@ var _ webhook.Validator = &VSphereMachineConfig{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *VSphereMachineConfig) ValidateCreate() error {
 	vspheremachineconfiglog.Info("validate create", "name", r.Name)
-
-	return r.Validate()
+	err := r.Validate()
+	if err != nil {
+		return err
+	}
+	return r.ValidateHasTemplate()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
@@ -690,6 +690,14 @@ func TestVSphereMachineConfigValidateCreateResourcePoolNotSet(t *testing.T) {
 	g.Expect(config.ValidateCreate()).To(MatchError(ContainSubstring("resourcePool is not set or is empty")))
 }
 
+func TestVSphereMachineConfigValidateCreateTemplateNotSet(t *testing.T) {
+	config := vsphereMachineConfig()
+	config.Spec.Template = ""
+
+	g := NewWithT(t)
+	g.Expect(config.ValidateCreate()).To(MatchError(ContainSubstring("template field is required")))
+}
+
 func TestVSphereMachineConfigSetDefaults(t *testing.T) {
 	g := NewWithT(t)
 
@@ -711,6 +719,7 @@ func vsphereMachineConfig() v1alpha1.VSphereMachineConfig {
 			ResourcePool: "my-resourcePool",
 			Datastore:    "my-datastore",
 			OSFamily:     "ubuntu",
+			Template:     "/Datacenter/vm/Templates/bottlerocket-v1.23.12-kubernetes-1-23-eks-7-amd64-d44065e",
 		},
 		Status: v1alpha1.VSphereMachineConfigStatus{},
 	}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/3856

*Description of changes:*
The current controller implementation already skips the codepath that auto-imports a template if it is not present and throws an error if the template cannot be found:
https://github.com/aws/eks-anywhere/blob/6e032751ae1a7b04e94de0c41b34ab275050e053/pkg/providers/vsphere/validator.go#L171-L171

This PR just fails the create webhook if the template field is empty so that the user does not end up in a confusing state.

*Testing (if applicable):*
Manually tested creating a workload cluster on a management cluster by kubectl apply-ing a workload cluster definition file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.