### PR TITLE
Skip failing curated packages test.

### DIFF
--- a/pkg/curatedpackages/packagereader_test.go
+++ b/pkg/curatedpackages/packagereader_test.go
@@ -35,6 +35,7 @@ func newPackageReaderTest(t *testing.T) *packageReaderTest {
 }
 
 func TestPackageReaderReadImagesFromBundlesSuccess(t *testing.T) {
+	t.Skip("Test consistently fails locally as it attempts to download unreachable artifacts (https://github.com/aws/eks-anywhere/issues/3881)")
 	tt := newPackageReaderTest(t)
 	bundles := &releasev1.Bundles{
 		Spec: releasev1.BundlesSpec{
@@ -110,6 +111,7 @@ func TestPackageReaderReadImagesFromBundlesFailWhenWrongBundle(t *testing.T) {
 }
 
 func TestPackageReaderReadChartsFromBundlesSuccess(t *testing.T) {
+	t.Skip("Test consistently fails locally as it attempts to download unreachable artifacts (https://github.com/aws/eks-anywhere/issues/3881)")
 	tt := newPackageReaderTest(t)
 	bundles := &releasev1.Bundles{
 		Spec: releasev1.BundlesSpec{

--- a/pkg/curatedpackages/reader.go
+++ b/pkg/curatedpackages/reader.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Temporary: Curated packages dev and prod accounts are currently hard coded
-// This is because there is no mechanism to extract these values as of now
+// This is because there is no mechanism to extract these values as of now.
 const (
 	publicProdECR     = "public.ecr.aws/eks-anywhere"
 	packageProdDomain = "783794618700.dkr.ecr.us-west-2.amazonaws.com"


### PR DESCRIPTION
See https://github.com/aws/eks-anywhere/issues/3881