### PR TITLE
Rely on setup-go action for caching

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: "1.18"
           check-latest: true
           cache: true
       - name: golangci-lint
@@ -25,3 +25,5 @@ jobs:
         with:
           version: v1.50.0
           only-new-issues: true
+          # Disable package caching to avoid a double cache with setup-go.
+          skip-pkg-cache: true


### PR DESCRIPTION
Both setup-go and golangci-lint actions offer dependency caching capabilities. Using both results in redherring errors that obscure actual linting errors.

https://github.com/aws/eks-anywhere/issues/3897