### PR TITLE
Add vSphere workers CAPI spec generator

### DIFF
--- a/pkg/clusterapi/controlplane.go
+++ b/pkg/clusterapi/controlplane.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ControlPlane represents the provider-specific spec for a CAPI control plane using the kubeadm CP provider.
-type ControlPlane[C, M Object] struct {
+type ControlPlane[C Object[C], M Object[M]] struct {
 	Cluster *clusterv1.Cluster
 
 	// ProviderCluster is the provider-specific resource that holds the details

--- a/pkg/clusterapi/controlplane_test.go
+++ b/pkg/clusterapi/controlplane_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
@@ -25,7 +26,7 @@ func TestControlPlaneObjects(t *testing.T) {
 	tests := []struct {
 		name         string
 		controlPlane *dockerControlPlane
-		want         []clusterapi.Object
+		want         []kubernetes.Object
 	}{
 		{
 			name: "stacked etcd",
@@ -35,7 +36,7 @@ func TestControlPlaneObjects(t *testing.T) {
 				KubeadmControlPlane:         kubeadmControlPlane(),
 				ControlPlaneMachineTemplate: dockerMachineTemplate(),
 			},
-			want: []clusterapi.Object{
+			want: []kubernetes.Object{
 				capiCluster(),
 				dockerCluster(),
 				kubeadmControlPlane(),
@@ -52,7 +53,7 @@ func TestControlPlaneObjects(t *testing.T) {
 				EtcdCluster:                 etcdCluster(),
 				EtcdMachineTemplate:         dockerMachineTemplate(),
 			},
-			want: []clusterapi.Object{
+			want: []kubernetes.Object{
 				capiCluster(),
 				dockerCluster(),
 				kubeadmControlPlane(),

--- a/pkg/clusterapi/name.go
+++ b/pkg/clusterapi/name.go
@@ -18,18 +18,19 @@ import (
 var nameRegex = regexp.MustCompile(`(.*?)(-)(\d+)$`)
 
 // Object represents a kubernetes API object.
-type Object interface {
+type Object[O kubernetes.Object] interface {
 	kubernetes.Object
+	DeepCopy() O
 }
 
 // ObjectComparator returns true only if only both kubernetes Object's are identical
 // Most of the time, this only requires comparing the Spec field, but that can variate
 // from object to object.
-type ObjectComparator[O Object] func(current, new O) bool
+type ObjectComparator[O Object[O]] func(current, new O) bool
 
 // ObjectRetriever gets a kubernetes API object using the provided client
 // If the object doesn't exist, it returns a NotFound error.
-type ObjectRetriever[O Object] func(ctx context.Context, client kubernetes.Client, name, namespace string) (O, error)
+type ObjectRetriever[O Object[O]] func(ctx context.Context, client kubernetes.Client, name, namespace string) (O, error)
 
 // IncrementName takes an object name and increments the suffix number by one.
 // This method is used for updating objects (e.g. machinetemplate, kubeadmconfigtemplate) that are either immutable
@@ -106,7 +107,7 @@ func WorkerMachineHealthCheckName(clusterSpec *cluster.Spec, workerNodeGroupConf
 }
 
 // EnsureNewNameIfChanged updates an object's name if such object is different from its current state in the cluster.
-func EnsureNewNameIfChanged[M Object](ctx context.Context,
+func EnsureNewNameIfChanged[M Object[M]](ctx context.Context,
 	client kubernetes.Client,
 	retrieve ObjectRetriever[M],
 	equal ObjectComparator[M],

--- a/pkg/clusterapi/workers.go
+++ b/pkg/clusterapi/workers.go
@@ -13,7 +13,8 @@ import (
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 )
 
-type Workers[M Object] struct {
+// Workers represents the provider specific CAPI spec for an eks-a cluster's workers.
+type Workers[M Object[M]] struct {
 	Groups []WorkerGroup[M]
 }
 
@@ -35,7 +36,8 @@ func (w *Workers[M]) UpdateImmutableObjectNames(
 	return nil
 }
 
-type WorkerGroup[M Object] struct {
+// WorkerGroup represents the provider specific CAPI spec for an eks-a worker group.
+type WorkerGroup[M Object[M]] struct {
 	KubeadmConfigTemplate   *kubeadmv1.KubeadmConfigTemplate
 	MachineDeployment       *clusterv1.MachineDeployment
 	ProviderMachineTemplate M
@@ -45,7 +47,7 @@ type WorkerGroup[M Object] struct {
 // with the current state of the cluster. If they had, it generates a new name for them by increasing a monotonic number
 // at the end of the name.
 // This process is performed to the provider machine template and the kubeadmconfigtemplate.
-// The kubeadmconfigtemplate is not immutable at the API level but we treat is a such for consistency.
+// The kubeadmconfigtemplate is not immutable at the API level but we treat it as such for consistency.
 func (g *WorkerGroup[M]) UpdateImmutableObjectNames(
 	ctx context.Context,
 	client kubernetes.Client,
@@ -66,13 +68,24 @@ func (g *WorkerGroup[M]) UpdateImmutableObjectNames(
 	if err = EnsureNewNameIfChanged(ctx, client, machineTemplateRetriever, machineTemplateComparator, g.ProviderMachineTemplate); err != nil {
 		return err
 	}
+	g.MachineDeployment.Spec.Template.Spec.InfrastructureRef.Name = g.ProviderMachineTemplate.GetName()
 
 	g.KubeadmConfigTemplate.SetName(currentMachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef.Name)
 	if err = EnsureNewNameIfChanged(ctx, client, GetKubeadmConfigTemplate, KubeadmConfigTemplateEqual, g.KubeadmConfigTemplate); err != nil {
 		return err
 	}
+	g.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef.Name = g.KubeadmConfigTemplate.Name
 
 	return nil
+}
+
+// DeepCopy generates a new WorkerGroup copying the contexts of the receiver.
+func (g *WorkerGroup[M]) DeepCopy() *WorkerGroup[M] {
+	return &WorkerGroup[M]{
+		MachineDeployment:       g.MachineDeployment.DeepCopy(),
+		KubeadmConfigTemplate:   g.KubeadmConfigTemplate.DeepCopy(),
+		ProviderMachineTemplate: g.ProviderMachineTemplate.DeepCopy(),
+	}
 }
 
 // GetKubeadmConfigTemplate retrieves a KubeadmConfigTemplate using a client

--- a/pkg/clusterapi/workers_test.go
+++ b/pkg/clusterapi/workers_test.go
@@ -140,6 +140,8 @@ func TestWorkerGroupUpdateImmutableObjectNamesSuccess(t *testing.T) {
 	).To(Succeed())
 	g.Expect(group.KubeadmConfigTemplate.Name).To(Equal("template-2"))
 	g.Expect(group.ProviderMachineTemplate.Name).To(Equal("mt-2"))
+	g.Expect(group.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef.Name).To(Equal(group.KubeadmConfigTemplate.Name))
+	g.Expect(group.MachineDeployment.Spec.Template.Spec.InfrastructureRef.Name).To(Equal(group.ProviderMachineTemplate.Name))
 }
 
 func TestGetKubeadmConfigTemplateSuccess(t *testing.T) {
@@ -392,6 +394,17 @@ func TestKubeadmConfigTemplateEqual(t *testing.T) {
 			g.Expect(clusterapi.KubeadmConfigTemplateEqual(tt.new, tt.old)).To(Equal(tt.want))
 		})
 	}
+}
+
+func TestWorkerGroupDeepCopy(t *testing.T) {
+	g := NewWithT(t)
+	group := &dockerGroup{
+		MachineDeployment:       machineDeployment(),
+		KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+		ProviderMachineTemplate: dockerMachineTemplate(),
+	}
+
+	g.Expect(group.DeepCopy()).To(Equal(group))
 }
 
 func kubeadmConfigTemplate() *kubeadmv1.KubeadmConfigTemplate {

--- a/pkg/clusterapi/yaml/workers.go
+++ b/pkg/clusterapi/yaml/workers.go
@@ -14,11 +14,12 @@ const machineDeploymentKind = "MachineDeployment"
 
 // WorkersBuilder implements yamlutil.Builder
 // It's a wrapper around Workers to provide yaml parsing functionality.
-type WorkersBuilder[M clusterapi.Object] struct {
+type WorkersBuilder[M clusterapi.Object[M]] struct {
 	Workers *clusterapi.Workers[M]
 }
 
-func NewWorkersBuilder[M clusterapi.Object]() *WorkersBuilder[M] {
+// NewWorkersBuilder builds a WorkersBuilder.
+func NewWorkersBuilder[M clusterapi.Object[M]]() *WorkersBuilder[M] {
 	return &WorkersBuilder[M]{
 		Workers: new(clusterapi.Workers[M]),
 	}
@@ -35,7 +36,7 @@ func (cp *WorkersBuilder[M]) BuildFromParsed(lookup yamlutil.ObjectLookup) error
 // For worker specs that need to include more objects, wrap around the provider builder and
 // implement BuildFromParsed.
 // Any extra mappings will need to be registered manually in the Parser.
-func NewWorkersParserAndBuilder[M clusterapi.Object](
+func NewWorkersParserAndBuilder[M clusterapi.Object[M]](
 	logger logr.Logger,
 	machineTemplateMapping yamlutil.Mapping[M],
 ) (*yamlutil.Parser, *WorkersBuilder[M], error) {
@@ -77,7 +78,7 @@ func RegisterWorkerMappings(parser *yamlutil.Parser) error {
 }
 
 // ProcessWorkerObjects finds all necessary objects in the parsed objects and sets them in Workers.
-func ProcessWorkerObjects[M clusterapi.Object](w *clusterapi.Workers[M], lookup yamlutil.ObjectLookup) {
+func ProcessWorkerObjects[M clusterapi.Object[M]](w *clusterapi.Workers[M], lookup yamlutil.ObjectLookup) {
 	for _, obj := range lookup {
 		if obj.GetObjectKind().GroupVersionKind().Kind == machineDeploymentKind {
 			g := new(clusterapi.WorkerGroup[M])
@@ -91,7 +92,7 @@ func ProcessWorkerObjects[M clusterapi.Object](w *clusterapi.Workers[M], lookup 
 // ProcessWorkerGroupObjects looks in the parsed objects for the KubeadmConfigTemplate and
 // the provider machine template referenced in the MachineDeployment and sets them in the WorkerGroup.
 // MachineDeployment needs to be already set in the WorkerGroup.
-func ProcessWorkerGroupObjects[M clusterapi.Object](g *clusterapi.WorkerGroup[M], lookup yamlutil.ObjectLookup) {
+func ProcessWorkerGroupObjects[M clusterapi.Object[M]](g *clusterapi.WorkerGroup[M], lookup yamlutil.ObjectLookup) {
 	kubeadmConfigTemplate := lookup.GetFromRef(*g.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef)
 	if kubeadmConfigTemplate != nil {
 		g.KubeadmConfigTemplate = kubeadmConfigTemplate.(*kubeadmv1.KubeadmConfigTemplate)

--- a/pkg/providers/vsphere/controlplane_test.go
+++ b/pkg/providers/vsphere/controlplane_test.go
@@ -11,6 +11,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	yamlcapi "github.com/aws/eks-anywhere/pkg/clusterapi/yaml"
 	"github.com/aws/eks-anywhere/pkg/constants"
@@ -52,7 +53,7 @@ func TestControlPlaneObjects(t *testing.T) {
 	tests := []struct {
 		name         string
 		controlPlane *vsphere.ControlPlane
-		want         []clusterapi.Object
+		want         []kubernetes.Object
 	}{
 		{
 			name: "stacked etcd",
@@ -64,7 +65,7 @@ func TestControlPlaneObjects(t *testing.T) {
 					ControlPlaneMachineTemplate: vsphereMachineTemplate("cp-mt"),
 				},
 			},
-			want: []clusterapi.Object{
+			want: []kubernetes.Object{
 				capiCluster(),
 				vsphereCluster(),
 				kubeadmControlPlane(),
@@ -85,7 +86,7 @@ func TestControlPlaneObjects(t *testing.T) {
 				Secrets:    []*corev1.Secret{secret()},
 				ConfigMaps: []*corev1.ConfigMap{configMap()},
 			},
-			want: []clusterapi.Object{
+			want: []kubernetes.Object{
 				capiCluster(),
 				vsphereCluster(),
 				kubeadmControlPlane(),

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -665,6 +665,9 @@ func (p *vsphereProvider) generateCAPISpecForCreate(ctx context.Context, cluster
 		return nil, nil, err
 	}
 
+	// TODO(g-gaston): update this to use the new method CAPIWorkersSpecWithInitialNames.
+	// That implies moving to monotonically increasing names instead of based on timestamp.
+	// Upgrades should also be moved to that naming scheme for consistency. That requires bigger changes.
 	workloadTemplateNames := make(map[string]string, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
 	kubeadmconfigTemplateNames := make(map[string]string, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
 	for _, workerNodeGroupConfiguration := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {

--- a/pkg/providers/vsphere/workers.go
+++ b/pkg/providers/vsphere/workers.go
@@ -1,0 +1,86 @@
+package vsphere
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/equality"
+	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	capiyaml "github.com/aws/eks-anywhere/pkg/clusterapi/yaml"
+	"github.com/aws/eks-anywhere/pkg/yamlutil"
+)
+
+type (
+	// Workers represents the vSphere specific CAPI spec for worker nodes.
+	Workers        = clusterapi.Workers[*vspherev1.VSphereMachineTemplate]
+	workersBuilder = capiyaml.WorkersBuilder[*vspherev1.VSphereMachineTemplate]
+)
+
+// WorkersSpec generates a vSphere specific CAPI spec for an eks-a cluster worker nodes.
+// It talks to the cluster with a client to detect changes in immutable objects and generates new
+// names for them.
+func WorkersSpec(ctx context.Context, logger logr.Logger, client kubernetes.Client, spec *cluster.Spec) (*Workers, error) {
+	// TODO(g-gaston): refactor template builder so it doesn't behave differently for controller and CLI
+	// TODO(g-gaston): do we need time.Now if the names are not dependent on a timestamp anymore?
+	templateBuilder := NewVsphereTemplateBuilder(time.Now, false)
+	workersYaml, err := templateBuilder.CAPIWorkersSpecWithInitialNames(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	parser, builder, err := newWorkersParserAndBuilder(logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = parser.Parse(workersYaml, builder); err != nil {
+		return nil, errors.Wrap(err, "parsing vSphere CAPI workers yaml")
+	}
+
+	workers := builder.Workers
+	if err = workers.UpdateImmutableObjectNames(ctx, client, getMachineTemplate, machineTemplateEqual); err != nil {
+		return nil, errors.Wrap(err, "updating vSphere worker immutable object names")
+	}
+
+	return workers, nil
+}
+
+func newWorkersParserAndBuilder(logger logr.Logger) (*yamlutil.Parser, *workersBuilder, error) {
+	parser, builder, err := capiyaml.NewWorkersParserAndBuilder(
+		logger,
+		machineTemplateMapping(),
+	)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "building vSphere workers parser and builder")
+	}
+
+	return parser, builder, nil
+}
+
+func machineTemplateMapping() yamlutil.Mapping[*vspherev1.VSphereMachineTemplate] {
+	return yamlutil.NewMapping(
+		"VSphereMachineTemplate",
+		func() *vspherev1.VSphereMachineTemplate {
+			return &vspherev1.VSphereMachineTemplate{}
+		},
+	)
+}
+
+func getMachineTemplate(ctx context.Context, client kubernetes.Client, name, namespace string) (*vspherev1.VSphereMachineTemplate, error) {
+	m := &vspherev1.VSphereMachineTemplate{}
+	if err := client.Get(ctx, name, namespace, m); err != nil {
+		return nil, errors.Wrap(err, "reading vSphereMachineTemplate")
+	}
+
+	return m, nil
+}
+
+func machineTemplateEqual(new, old *vspherev1.VSphereMachineTemplate) bool {
+	return equality.Semantic.DeepDerivative(new, old)
+}

--- a/pkg/providers/vsphere/workers_test.go
+++ b/pkg/providers/vsphere/workers_test.go
@@ -1,0 +1,306 @@
+package vsphere_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	"github.com/aws/eks-anywhere/pkg/providers/vsphere"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
+)
+
+func TestWorkersSpecNewCluster(t *testing.T) {
+	g := NewWithT(t)
+	logger := test.NewNullLogger()
+	ctx := context.Background()
+	spec := test.NewFullClusterSpec(t, "testdata/cluster_main_multiple_worker_node_groups.yaml")
+	client := test.NewFakeKubeClient()
+
+	workers, err := vsphere.WorkersSpec(ctx, logger, client, spec)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(workers).NotTo(BeNil())
+	g.Expect(workers.Groups).To(HaveLen(2))
+	g.Expect(workers.Groups).To(ConsistOf(
+		clusterapi.WorkerGroup[*vspherev1.VSphereMachineTemplate]{
+			KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+			MachineDeployment:       machineDeployment(),
+			ProviderMachineTemplate: machineTemplate(),
+		},
+		clusterapi.WorkerGroup[*vspherev1.VSphereMachineTemplate]{
+			KubeadmConfigTemplate: kubeadmConfigTemplate(
+				func(kct *bootstrapv1.KubeadmConfigTemplate) {
+					kct.Name = "test-md-1-1"
+				},
+			),
+			MachineDeployment: machineDeployment(
+				func(md *clusterv1.MachineDeployment) {
+					md.Name = "test-md-1"
+					md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-1-1"
+					md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-1-1"
+					md.Spec.Replicas = ptr.Int32(2)
+				},
+			),
+			ProviderMachineTemplate: machineTemplate(
+				func(vmt *vspherev1.VSphereMachineTemplate) {
+					vmt.Name = "test-md-1-1"
+				},
+			),
+		},
+	))
+}
+
+func TestWorkersSpecUpgradeCluster(t *testing.T) {
+	g := NewWithT(t)
+	logger := test.NewNullLogger()
+	ctx := context.Background()
+	spec := test.NewFullClusterSpec(t, "testdata/cluster_main_multiple_worker_node_groups.yaml")
+	oldGroup1 := &clusterapi.WorkerGroup[*vspherev1.VSphereMachineTemplate]{
+		KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+		MachineDeployment:       machineDeployment(),
+		ProviderMachineTemplate: machineTemplate(),
+	}
+	oldGroup2 := &clusterapi.WorkerGroup[*vspherev1.VSphereMachineTemplate]{
+		KubeadmConfigTemplate: kubeadmConfigTemplate(
+			func(kct *bootstrapv1.KubeadmConfigTemplate) {
+				kct.Name = "test-md-1-1"
+			},
+		),
+		MachineDeployment: machineDeployment(
+			func(md *clusterv1.MachineDeployment) {
+				md.Name = "test-md-1"
+				md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-1-1"
+				md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-1-1"
+				md.Spec.Replicas = ptr.Int32(2)
+			},
+		),
+		ProviderMachineTemplate: machineTemplate(
+			func(vmt *vspherev1.VSphereMachineTemplate) {
+				vmt.Name = "test-md-1-1"
+			},
+		),
+	}
+
+	// Always make copies before passing to client since it does modifies the api objects
+	// Like for example, the ResourceVersion
+	expectedGroup1 := oldGroup1.DeepCopy()
+	expectedGroup2 := oldGroup2.DeepCopy()
+
+	client := test.NewFakeKubeClient(
+		oldGroup1.MachineDeployment,
+		oldGroup1.KubeadmConfigTemplate,
+		oldGroup1.ProviderMachineTemplate,
+		oldGroup2.MachineDeployment,
+		oldGroup2.KubeadmConfigTemplate,
+		oldGroup2.ProviderMachineTemplate,
+	)
+
+	// This will cause a change in the vsphere machine templates, which is immutable
+	spec.VSphereMachineConfigs["test-wn"].Spec.NumCPUs = 10
+
+	// This will cause a change in the kubeadmconfigtemplate which we also treat as immutable
+	spec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Taints = []corev1.Taint{}
+	spec.Cluster.Spec.WorkerNodeGroupConfigurations[1].Taints = []corev1.Taint{}
+
+	expectedGroup1.MachineDeployment.Spec.Template.Spec.InfrastructureRef.Name = "test-md-0-2"
+	expectedGroup1.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-0-2"
+	expectedGroup1.KubeadmConfigTemplate.Name = "test-md-0-2"
+	expectedGroup1.KubeadmConfigTemplate.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints = []corev1.Taint{}
+	expectedGroup1.ProviderMachineTemplate.Name = "test-md-0-2"
+	expectedGroup1.ProviderMachineTemplate.Spec.Template.Spec.NumCPUs = 10
+
+	expectedGroup2.MachineDeployment.Spec.Template.Spec.InfrastructureRef.Name = "test-md-1-2"
+	expectedGroup2.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-1-2"
+	expectedGroup2.KubeadmConfigTemplate.Name = "test-md-1-2"
+	expectedGroup2.KubeadmConfigTemplate.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints = []corev1.Taint{}
+	expectedGroup2.ProviderMachineTemplate.Name = "test-md-1-2"
+	expectedGroup2.ProviderMachineTemplate.Spec.Template.Spec.NumCPUs = 10
+
+	workers, err := vsphere.WorkersSpec(ctx, logger, client, spec)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(workers).NotTo(BeNil())
+	g.Expect(workers.Groups).To(HaveLen(2))
+	g.Expect(workers.Groups).To(ConsistOf(*expectedGroup1, *expectedGroup2))
+}
+
+func TestWorkersSpecErrorFromClient(t *testing.T) {
+	g := NewWithT(t)
+	logger := test.NewNullLogger()
+	ctx := context.Background()
+	spec := test.NewFullClusterSpec(t, "testdata/cluster_main_multiple_worker_node_groups.yaml")
+	client := test.NewFakeKubeClientAlwaysError()
+	_, err := vsphere.WorkersSpec(ctx, logger, client, spec)
+	g.Expect(err).To(MatchError(ContainSubstring("updating vSphere worker immutable object names")))
+}
+
+func TestWorkersSpecMachineTemplateNotFound(t *testing.T) {
+	g := NewWithT(t)
+	logger := test.NewNullLogger()
+	ctx := context.Background()
+	spec := test.NewFullClusterSpec(t, "testdata/cluster_main_multiple_worker_node_groups.yaml")
+	client := test.NewFakeKubeClient(machineDeployment())
+	_, err := vsphere.WorkersSpec(ctx, logger, client, spec)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func machineDeployment(opts ...func(*clusterv1.MachineDeployment)) *clusterv1.MachineDeployment {
+	o := &clusterv1.MachineDeployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MachineDeployment",
+			APIVersion: "cluster.x-k8s.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-md-0",
+			Namespace: "eksa-system",
+			Labels:    map[string]string{"cluster.x-k8s.io/cluster-name": "test"},
+		},
+		Spec: clusterv1.MachineDeploymentSpec{
+			ClusterName: "test",
+			Replicas:    ptr.Int32(3),
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{},
+			},
+			Template: clusterv1.MachineTemplateSpec{
+				ObjectMeta: clusterv1.ObjectMeta{
+					Labels: map[string]string{"cluster.x-k8s.io/cluster-name": "test"},
+				},
+				Spec: clusterv1.MachineSpec{
+					ClusterName: "test",
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{
+							Kind:       "KubeadmConfigTemplate",
+							Name:       "test-md-0-1",
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+						},
+					},
+					InfrastructureRef: corev1.ObjectReference{
+						Kind:       "VSphereMachineTemplate",
+						Name:       "test-md-0-1",
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+					},
+					Version: ptr.String("v1.19.8-eks-1-19-4"),
+				},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return o
+}
+
+func kubeadmConfigTemplate(opts ...func(*bootstrapv1.KubeadmConfigTemplate)) *bootstrapv1.KubeadmConfigTemplate {
+	o := &bootstrapv1.KubeadmConfigTemplate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeadmConfigTemplate",
+			APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-md-0-1",
+			Namespace: "eksa-system",
+		},
+		Spec: bootstrapv1.KubeadmConfigTemplateSpec{
+			Template: bootstrapv1.KubeadmConfigTemplateResource{
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					JoinConfiguration: &bootstrapv1.JoinConfiguration{
+						NodeRegistration: bootstrapv1.NodeRegistrationOptions{
+							Name:      "{{ ds.meta_data.hostname }}",
+							CRISocket: "/var/run/containerd/containerd.sock",
+							Taints: []corev1.Taint{
+								{
+									Key:       "key2",
+									Value:     "val2",
+									Effect:    "PreferNoSchedule",
+									TimeAdded: nil,
+								},
+							},
+							KubeletExtraArgs: map[string]string{
+								"anonymous-auth":    "false",
+								"cloud-provider":    "external",
+								"read-only-port":    "0",
+								"tls-cipher-suites": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+							},
+						},
+					},
+					PreKubeadmCommands: []string{
+						`hostname "{{ ds.meta_data.hostname }}"`,
+						`echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts`,
+						`echo "127.0.0.1   localhost" >>/etc/hosts`,
+						`echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts`,
+						`echo "{{ ds.meta_data.hostname }}" >/etc/hostname`,
+					},
+					Users: []bootstrapv1.User{
+						{
+							Name:              "capv",
+							Sudo:              ptr.String("ALL=(ALL) NOPASSWD:ALL"),
+							SSHAuthorizedKeys: []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=="},
+						},
+					},
+					Format: bootstrapv1.Format("cloud-config"),
+				},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return o
+}
+
+func machineTemplate(opts ...func(*vspherev1.VSphereMachineTemplate)) *vspherev1.VSphereMachineTemplate {
+	o := &vspherev1.VSphereMachineTemplate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VSphereMachineTemplate",
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-md-0-1",
+			Namespace: "eksa-system",
+		},
+		Spec: vspherev1.VSphereMachineTemplateSpec{
+			Template: vspherev1.VSphereMachineTemplateResource{
+				Spec: vspherev1.VSphereMachineSpec{
+					VirtualMachineCloneSpec: vspherev1.VirtualMachineCloneSpec{
+						Template:          "/SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6",
+						CloneMode:         vspherev1.CloneMode("linkedClone"),
+						Server:            "vsphere_server",
+						Thumbprint:        "ABCDEFG",
+						Datacenter:        "SDDC-Datacenter",
+						Folder:            "/SDDC-Datacenter/vm",
+						Datastore:         "/SDDC-Datacenter/datastore/WorkloadDatastore",
+						StoragePolicyName: "vSAN Default Storage Policy",
+						ResourcePool:      "*/Resources",
+						Network: vspherev1.NetworkSpec{
+							Devices: []vspherev1.NetworkDeviceSpec{
+								{
+									NetworkName: "/SDDC-Datacenter/network/sddc-cgw-network-1",
+									DHCP4:       true,
+								},
+							},
+						},
+						NumCPUs:   3,
+						MemoryMiB: 4096,
+						DiskGiB:   25,
+					},
+				},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return o
+}


### PR DESCRIPTION
## Description of changes
Part of the cluster lifecycle project. Generate CAPI spec in yaml with the vsphere template builder and parse it into api structs. Generate new immutable changes if a difference is detected (upgrades).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

