### PR TITLE
Update CP infra machine template names if changes

### DIFF
--- a/pkg/clusterapi/controlplane.go
+++ b/pkg/clusterapi/controlplane.go
@@ -68,6 +68,7 @@ func (cp *ControlPlane[C, M]) UpdateImmutableObjectNames(
 	if err = EnsureNewNameIfChanged(ctx, client, machineTemplateRetriever, machineTemplateComparator, cp.ControlPlaneMachineTemplate); err != nil {
 		return err
 	}
+	cp.KubeadmControlPlane.Spec.MachineTemplate.InfrastructureRef.Name = cp.ControlPlaneMachineTemplate.GetName()
 
 	if cp.EtcdCluster == nil {
 		return nil
@@ -87,6 +88,7 @@ func (cp *ControlPlane[C, M]) UpdateImmutableObjectNames(
 	if err = EnsureNewNameIfChanged(ctx, client, machineTemplateRetriever, machineTemplateComparator, cp.EtcdMachineTemplate); err != nil {
 		return err
 	}
+	cp.EtcdCluster.Spec.InfrastructureTemplate.Name = cp.EtcdMachineTemplate.GetName()
 
 	return nil
 }


### PR DESCRIPTION
## Description of changes

When changes are detected in the provider machine templates for the control plane or etcdadm cluster, we generate a new name because these objects are immutable. If that happens, we also need to update their corresponding references in the KubeadmControlPlane and EtcdadmCluster or new machines will be never be rolled out. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

