### PR TITLE
Update taints e2e test to add control plane taint for 1.24

### DIFF
--- a/test/framework/taints.go
+++ b/test/framework/taints.go
@@ -17,7 +17,7 @@ func ValidateControlPlaneTaints(controlPlane v1alpha1.ControlPlaneConfiguration,
 	// if no taints are specified, kubeadm defaults it to a well-known control plane taint.
 	// so, we make sure to check for that well-known taint if no taints are provided in the spec.
 	if cpTaints == nil {
-		cpTaints = []corev1.Taint{ControlPlaneTaint()}
+		cpTaints = []corev1.Taint{ControlPlaneTaint(), MasterTaint()}
 	}
 
 	valid := v1alpha1.TaintsSliceEqual(cpTaints, node.Spec.Taints)
@@ -73,9 +73,18 @@ func PreferNoScheduleTaint() corev1.Taint {
 	}
 }
 
-func ControlPlaneTaint() corev1.Taint {
+// MasterTaint will be deprecated from kubernetes version 1.25 onwards.
+func MasterTaint() corev1.Taint {
 	return corev1.Taint{
 		Key:    "node-role.kubernetes.io/master",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+}
+
+// ControlPlaneTaint has been added from 1.24 onwards.
+func ControlPlaneTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    "node-role.kubernetes.io/control-plane",
 		Effect: corev1.TaintEffectNoSchedule,
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update taints e2e test to add control plane taint for 1.24

- Based on the [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#no-really-you-must-read-this-before-you-upgrade) from Kubernetes, kubeadm is going to move away from the master taint and only add the control plane taint. The `master` taint will be deprecated from 1.25.

*Testing (if applicable):*
- Run the e2e tests locally for docker

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

