### PR TITLE
Fix godot linting errors

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -31,7 +31,7 @@ const (
 	clusterFinalizerName = "clusters.anywhere.eks.amazonaws.com/finalizer"
 )
 
-// ClusterReconciler reconciles a Cluster object
+// ClusterReconciler reconciles a Cluster object.
 type ClusterReconciler struct {
 	client                     client.Client
 	log                        logr.Logger

--- a/controllers/cluster_controller_legacy.go
+++ b/controllers/cluster_controller_legacy.go
@@ -18,7 +18,7 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
-// ClusterReconcilerLegacy reconciles a Cluster object
+// ClusterReconcilerLegacy reconciles a Cluster object.
 type ClusterReconcilerLegacy struct {
 	client.Client
 	Log             logr.Logger

--- a/controllers/resource/fetcher.go
+++ b/controllers/resource/fetcher.go
@@ -544,7 +544,7 @@ func (r *CapiResourceFetcher) ExistingKubeVersion(ctx context.Context, cs *anywh
 	return existingControlPlane.Spec.Version, nil
 }
 
-// Control plane and external etcd are configured to use the same node image, so pulling it from control plane
+// Control plane and external etcd are configured to use the same node image, so pulling it from control plane.
 func (r *CapiResourceFetcher) ExistingControlPlaneKindNodeImage(ctx context.Context, cs *anywherev1.Cluster) (string, error) {
 	existingDockerMachineTemplate, err := r.DockerControlPlaneMachineTemplate(ctx, cs)
 	if err != nil {

--- a/controllers/resource/template.go
+++ b/controllers/resource/template.go
@@ -57,7 +57,7 @@ type TinkerbellTemplate struct {
 	now anywhereTypes.NowFunc
 }
 
-// NutanixTemplate is a struct that implements the TemplateResources method for Nutanix Provider
+// NutanixTemplate is a struct that implements the TemplateResources method for Nutanix Provider.
 type NutanixTemplate struct {
 	ResourceFetcher
 	now anywhereTypes.NowFunc
@@ -310,7 +310,7 @@ func (r *CloudStackTemplate) getWorkloadTemplateNames(ctx context.Context, eksaC
 	return workloadTemplateNames, nil
 }
 
-// TODO(pokearu): This method is currently not used. Need to add logic in reconciler for TinkerbellDatacenterKind
+// TODO(pokearu): This method is currently not used. Need to add logic in reconciler for TinkerbellDatacenterKind.
 func (r *TinkerbellTemplate) TemplateResources(ctx context.Context, eksaCluster *anywherev1.Cluster, clusterSpec *cluster.Spec, tdc anywherev1.TinkerbellDatacenterConfig, cpTmc, etcdTmc anywherev1.TinkerbellMachineConfig, workerTmc map[string]anywherev1.TinkerbellMachineConfig) ([]*unstructured.Unstructured, error) {
 	workerNodeGroupMachineSpecs := make(map[string]anywherev1.TinkerbellMachineConfigSpec, len(workerTmc))
 	for _, wnConfig := range workerTmc {
@@ -491,7 +491,7 @@ func (r *AWSIamConfigTemplate) TemplateResources(ctx context.Context, clusterSpe
 }
 
 // TemplateResources generates the templated resources for the nutanix cluster
-// TODO(nutanix): This is currently a placeholder for the actual implementation
+// TODO(nutanix): This is currently a placeholder for the actual implementation.
 func (r *NutanixTemplate) TemplateResources(
 	ctx context.Context,
 	cluster *anywherev1.Cluster,

--- a/controllers/snow_machineconfig_controller.go
+++ b/controllers/snow_machineconfig_controller.go
@@ -18,7 +18,7 @@ type Validator interface {
 	ValidateEC2ImageExistsOnDevice(ctx context.Context, m *anywherev1.SnowMachineConfig) error
 }
 
-// SnowMachineConfigReconciler reconciles a SnowMachineConfig object
+// SnowMachineConfigReconciler reconciles a SnowMachineConfig object.
 type SnowMachineConfigReconciler struct {
 	client    client.Client
 	log       logr.Logger
@@ -40,7 +40,7 @@ func (r *SnowMachineConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// TODO: add here kubebuilder permissions as needed
+// TODO: add here kubebuilder permissions as needed.
 func (r *SnowMachineConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	log := r.log.WithValues("snowMachineConfig", req.NamespacedName)
 

--- a/controllers/vsphere_datacenter_controller.go
+++ b/controllers/vsphere_datacenter_controller.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers/vsphere/reconciler"
 )
 
-// VSphereDatacenterReconciler reconciles a VSphereDatacenterConfig object
+// VSphereDatacenterReconciler reconciles a VSphereDatacenterConfig object.
 type VSphereDatacenterReconciler struct {
 	log       logr.Logger
 	client    client.Client
@@ -39,7 +39,7 @@ func (r *VSphereDatacenterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// TODO: add here kubebuilder permissions as neeeded
+// TODO: add here kubebuilder permissions as neeeded.
 func (r *VSphereDatacenterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	log := r.log.WithValues("vsphereDatacenter", req.NamespacedName)
 

--- a/internal/aws-sdk-go-v2/internal/configsources/config.go
+++ b/internal/aws-sdk-go-v2/internal/configsources/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 // EnableEndpointDiscoveryProvider is an interface for retrieving external configuration value
-// for Enable Endpoint Discovery
+// for Enable Endpoint Discovery.
 type EnableEndpointDiscoveryProvider interface {
 	GetEnableEndpointDiscovery(ctx context.Context) (value aws.EndpointDiscoveryEnableState, found bool, err error)
 }
@@ -27,7 +27,7 @@ func ResolveEnableEndpointDiscovery(ctx context.Context, configs []interface{}) 
 	return
 }
 
-// UseDualStackEndpointProvider is an interface for retrieving external configuration values for UseDualStackEndpoint
+// UseDualStackEndpointProvider is an interface for retrieving external configuration values for UseDualStackEndpoint.
 type UseDualStackEndpointProvider interface {
 	GetUseDualStackEndpoint(context.Context) (value aws.DualStackEndpointState, found bool, err error)
 }
@@ -46,7 +46,7 @@ func ResolveUseDualStackEndpoint(ctx context.Context, configs []interface{}) (va
 	return
 }
 
-// UseFIPSEndpointProvider is an interface for retrieving external configuration values for UseFIPSEndpoint
+// UseFIPSEndpointProvider is an interface for retrieving external configuration values for UseFIPSEndpoint.
 type UseFIPSEndpointProvider interface {
 	GetUseFIPSEndpoint(context.Context) (value aws.FIPSEndpointState, found bool, err error)
 }

--- a/internal/aws-sdk-go-v2/internal/configsources/configtesting/config_test.go
+++ b/internal/aws-sdk-go-v2/internal/configsources/configtesting/config_test.go
@@ -5,26 +5,26 @@ import (
 	internalConfig "github.com/aws/aws-sdk-go-v2/internal/configsources"
 )
 
-// EnableEndpointDiscoveryProvider Assertions
+// EnableEndpointDiscoveryProvider Assertions.
 var (
 	_ internalConfig.EnableEndpointDiscoveryProvider = &config.EnvConfig{}
 	_ internalConfig.EnableEndpointDiscoveryProvider = &config.SharedConfig{}
 )
 
-// EnableEndpointDiscoveryProvider Assertions
+// EnableEndpointDiscoveryProvider Assertions.
 var (
 	_ internalConfig.EnableEndpointDiscoveryProvider = &config.EnvConfig{}
 	_ internalConfig.EnableEndpointDiscoveryProvider = &config.SharedConfig{}
 )
 
-// UseDualStackEndpointProvider Assertions
+// UseDualStackEndpointProvider Assertions.
 var (
 	_ internalConfig.UseDualStackEndpointProvider = &config.EnvConfig{}
 	_ internalConfig.UseDualStackEndpointProvider = &config.SharedConfig{}
 	_ internalConfig.UseDualStackEndpointProvider = &config.LoadOptions{}
 )
 
-// UseDualStackEndpointProvider Assertions
+// UseDualStackEndpointProvider Assertions.
 var (
 	_ internalConfig.UseFIPSEndpointProvider = &config.EnvConfig{}
 	_ internalConfig.UseFIPSEndpointProvider = &config.SharedConfig{}

--- a/internal/aws-sdk-go-v2/internal/configsources/configtesting/go_module_metadata.go
+++ b/internal/aws-sdk-go-v2/internal/configsources/configtesting/go_module_metadata.go
@@ -2,5 +2,5 @@
 
 package configtesting
 
-// goModuleVersion is the tagged release for this module
+// goModuleVersion is the tagged release for this module.
 const goModuleVersion = "tip"

--- a/internal/aws-sdk-go-v2/internal/configsources/go_module_metadata.go
+++ b/internal/aws-sdk-go-v2/internal/configsources/go_module_metadata.go
@@ -2,5 +2,5 @@
 
 package configsources
 
-// goModuleVersion is the tagged release for this module
+// goModuleVersion is the tagged release for this module.
 const goModuleVersion = "1.1.21"

--- a/internal/aws-sdk-go-v2/internal/endpoints/endpoints.go
+++ b/internal/aws-sdk-go-v2/internal/endpoints/endpoints.go
@@ -24,7 +24,7 @@ type Options struct {
 	DisableHTTPS bool
 }
 
-// Partitions is a slice of partition
+// Partitions is a slice of partition.
 type Partitions []Partition
 
 // ResolveEndpoint resolves a service endpoint for the given region and options.
@@ -85,16 +85,16 @@ func (p Partition) endpointForRegion(region string) (Endpoint, bool) {
 	return Endpoint{}, false
 }
 
-// Endpoints is a map of service config regions to endpoints
+// Endpoints is a map of service config regions to endpoints.
 type Endpoints map[string]Endpoint
 
-// CredentialScope is the credential scope of a region and service
+// CredentialScope is the credential scope of a region and service.
 type CredentialScope struct {
 	Region  string
 	Service string
 }
 
-// Endpoint is a service endpoint description
+// Endpoint is a service endpoint description.
 type Endpoint struct {
 	// True if the endpoint cannot be resolved for this partition/region/service
 	Unresolveable aws.Ternary

--- a/internal/aws-sdk-go-v2/internal/endpoints/v2/endpoints.go
+++ b/internal/aws-sdk-go-v2/internal/endpoints/v2/endpoints.go
@@ -85,7 +85,7 @@ func (o Options) GetEndpointVariant() (v EndpointVariant) {
 	return v
 }
 
-// Partitions is a slice of partition
+// Partitions is a slice of partition.
 type Partitions []Partition
 
 // ResolveEndpoint resolves a service endpoint for the given region and options.
@@ -174,16 +174,16 @@ func (p Partition) endpointForRegion(region string, variant EndpointVariant, ser
 	return Endpoint{}
 }
 
-// Endpoints is a map of service config regions to endpoints
+// Endpoints is a map of service config regions to endpoints.
 type Endpoints map[EndpointKey]Endpoint
 
-// CredentialScope is the credential scope of a region and service
+// CredentialScope is the credential scope of a region and service.
 type CredentialScope struct {
 	Region  string
 	Service string
 }
 
-// Endpoint is a service endpoint description
+// Endpoint is a service endpoint description.
 type Endpoint struct {
 	// True if the endpoint cannot be resolved for this partition/region/service
 	Unresolveable aws.Ternary

--- a/internal/aws-sdk-go-v2/internal/endpoints/v2/go_module_metadata.go
+++ b/internal/aws-sdk-go-v2/internal/endpoints/v2/go_module_metadata.go
@@ -2,5 +2,5 @@
 
 package endpoints
 
-// goModuleVersion is the tagged release for this module
+// goModuleVersion is the tagged release for this module.
 const goModuleVersion = "2.4.15"

--- a/internal/aws-sdk-go-v2/service/snowballdevice/api_client.go
+++ b/internal/aws-sdk-go-v2/service/snowballdevice/api_client.go
@@ -385,7 +385,7 @@ func addRetryMiddlewares(stack *middleware.Stack, o Options) error {
 	return retry.AddRetryMiddlewares(stack, mo)
 }
 
-// resolves dual-stack endpoint configuration
+// resolves dual-stack endpoint configuration.
 func resolveUseDualStackEndpoint(cfg aws.Config, o *Options) error {
 	if len(cfg.ConfigSources) == 0 {
 		return nil
@@ -400,7 +400,7 @@ func resolveUseDualStackEndpoint(cfg aws.Config, o *Options) error {
 	return nil
 }
 
-// resolves FIPS endpoint configuration
+// resolves FIPS endpoint configuration.
 func resolveUseFIPSEndpoint(cfg aws.Config, o *Options) error {
 	if len(cfg.ConfigSources) == 0 {
 		return nil

--- a/internal/aws-sdk-go-v2/service/snowballdevice/api_op_DescribeAutoStartConfigurations.go
+++ b/internal/aws-sdk-go-v2/service/snowballdevice/api_op_DescribeAutoStartConfigurations.go
@@ -113,7 +113,7 @@ type DescribeAutoStartConfigurationsAPIClient interface {
 var _ DescribeAutoStartConfigurationsAPIClient = (*Client)(nil)
 
 // DescribeAutoStartConfigurationsPaginatorOptions is the paginator options for
-// DescribeAutoStartConfigurations
+// DescribeAutoStartConfigurations.
 type DescribeAutoStartConfigurationsPaginatorOptions struct {
 	// Set to true if pagination should stop if the service returns a pagination token
 	// that matches the most recent token provided to the service.
@@ -121,7 +121,7 @@ type DescribeAutoStartConfigurationsPaginatorOptions struct {
 }
 
 // DescribeAutoStartConfigurationsPaginator is a paginator for
-// DescribeAutoStartConfigurations
+// DescribeAutoStartConfigurations.
 type DescribeAutoStartConfigurationsPaginator struct {
 	options   DescribeAutoStartConfigurationsPaginatorOptions
 	client    DescribeAutoStartConfigurationsAPIClient
@@ -131,7 +131,7 @@ type DescribeAutoStartConfigurationsPaginator struct {
 }
 
 // NewDescribeAutoStartConfigurationsPaginator returns a new
-// DescribeAutoStartConfigurationsPaginator
+// DescribeAutoStartConfigurationsPaginator.
 func NewDescribeAutoStartConfigurationsPaginator(client DescribeAutoStartConfigurationsAPIClient, params *DescribeAutoStartConfigurationsInput, optFns ...func(*DescribeAutoStartConfigurationsPaginatorOptions)) *DescribeAutoStartConfigurationsPaginator {
 	if params == nil {
 		params = &DescribeAutoStartConfigurationsInput{}
@@ -152,7 +152,7 @@ func NewDescribeAutoStartConfigurationsPaginator(client DescribeAutoStartConfigu
 	}
 }
 
-// HasMorePages returns a boolean indicating whether more pages are available
+// HasMorePages returns a boolean indicating whether more pages are available.
 func (p *DescribeAutoStartConfigurationsPaginator) HasMorePages() bool {
 	return p.firstPage || (p.nextToken != nil && len(*p.nextToken) != 0)
 }

--- a/internal/aws-sdk-go-v2/service/snowballdevice/api_op_DescribeAutoUpdateStrategies.go
+++ b/internal/aws-sdk-go-v2/service/snowballdevice/api_op_DescribeAutoUpdateStrategies.go
@@ -113,7 +113,7 @@ type DescribeAutoUpdateStrategiesAPIClient interface {
 var _ DescribeAutoUpdateStrategiesAPIClient = (*Client)(nil)
 
 // DescribeAutoUpdateStrategiesPaginatorOptions is the paginator options for
-// DescribeAutoUpdateStrategies
+// DescribeAutoUpdateStrategies.
 type DescribeAutoUpdateStrategiesPaginatorOptions struct {
 	// Set to true if pagination should stop if the service returns a pagination token
 	// that matches the most recent token provided to the service.
@@ -121,7 +121,7 @@ type DescribeAutoUpdateStrategiesPaginatorOptions struct {
 }
 
 // DescribeAutoUpdateStrategiesPaginator is a paginator for
-// DescribeAutoUpdateStrategies
+// DescribeAutoUpdateStrategies.
 type DescribeAutoUpdateStrategiesPaginator struct {
 	options   DescribeAutoUpdateStrategiesPaginatorOptions
 	client    DescribeAutoUpdateStrategiesAPIClient
@@ -131,7 +131,7 @@ type DescribeAutoUpdateStrategiesPaginator struct {
 }
 
 // NewDescribeAutoUpdateStrategiesPaginator returns a new
-// DescribeAutoUpdateStrategiesPaginator
+// DescribeAutoUpdateStrategiesPaginator.
 func NewDescribeAutoUpdateStrategiesPaginator(client DescribeAutoUpdateStrategiesAPIClient, params *DescribeAutoUpdateStrategiesInput, optFns ...func(*DescribeAutoUpdateStrategiesPaginatorOptions)) *DescribeAutoUpdateStrategiesPaginator {
 	if params == nil {
 		params = &DescribeAutoUpdateStrategiesInput{}
@@ -152,7 +152,7 @@ func NewDescribeAutoUpdateStrategiesPaginator(client DescribeAutoUpdateStrategie
 	}
 }
 
-// HasMorePages returns a boolean indicating whether more pages are available
+// HasMorePages returns a boolean indicating whether more pages are available.
 func (p *DescribeAutoUpdateStrategiesPaginator) HasMorePages() bool {
 	return p.firstPage || (p.nextToken != nil && len(*p.nextToken) != 0)
 }

--- a/internal/aws-sdk-go-v2/service/snowballdevice/api_op_DescribePhysicalNetworkInterfaces.go
+++ b/internal/aws-sdk-go-v2/service/snowballdevice/api_op_DescribePhysicalNetworkInterfaces.go
@@ -115,7 +115,7 @@ type DescribePhysicalNetworkInterfacesAPIClient interface {
 var _ DescribePhysicalNetworkInterfacesAPIClient = (*Client)(nil)
 
 // DescribePhysicalNetworkInterfacesPaginatorOptions is the paginator options for
-// DescribePhysicalNetworkInterfaces
+// DescribePhysicalNetworkInterfaces.
 type DescribePhysicalNetworkInterfacesPaginatorOptions struct {
 	// Set to true if pagination should stop if the service returns a pagination token
 	// that matches the most recent token provided to the service.
@@ -123,7 +123,7 @@ type DescribePhysicalNetworkInterfacesPaginatorOptions struct {
 }
 
 // DescribePhysicalNetworkInterfacesPaginator is a paginator for
-// DescribePhysicalNetworkInterfaces
+// DescribePhysicalNetworkInterfaces.
 type DescribePhysicalNetworkInterfacesPaginator struct {
 	options   DescribePhysicalNetworkInterfacesPaginatorOptions
 	client    DescribePhysicalNetworkInterfacesAPIClient
@@ -133,7 +133,7 @@ type DescribePhysicalNetworkInterfacesPaginator struct {
 }
 
 // NewDescribePhysicalNetworkInterfacesPaginator returns a new
-// DescribePhysicalNetworkInterfacesPaginator
+// DescribePhysicalNetworkInterfacesPaginator.
 func NewDescribePhysicalNetworkInterfacesPaginator(client DescribePhysicalNetworkInterfacesAPIClient, params *DescribePhysicalNetworkInterfacesInput, optFns ...func(*DescribePhysicalNetworkInterfacesPaginatorOptions)) *DescribePhysicalNetworkInterfacesPaginator {
 	if params == nil {
 		params = &DescribePhysicalNetworkInterfacesInput{}
@@ -154,7 +154,7 @@ func NewDescribePhysicalNetworkInterfacesPaginator(client DescribePhysicalNetwor
 	}
 }
 
-// HasMorePages returns a boolean indicating whether more pages are available
+// HasMorePages returns a boolean indicating whether more pages are available.
 func (p *DescribePhysicalNetworkInterfacesPaginator) HasMorePages() bool {
 	return p.firstPage || (p.nextToken != nil && len(*p.nextToken) != 0)
 }

--- a/internal/aws-sdk-go-v2/service/snowballdevice/api_op_DescribeTags.go
+++ b/internal/aws-sdk-go-v2/service/snowballdevice/api_op_DescribeTags.go
@@ -111,14 +111,14 @@ type DescribeTagsAPIClient interface {
 
 var _ DescribeTagsAPIClient = (*Client)(nil)
 
-// DescribeTagsPaginatorOptions is the paginator options for DescribeTags
+// DescribeTagsPaginatorOptions is the paginator options for DescribeTags.
 type DescribeTagsPaginatorOptions struct {
 	// Set to true if pagination should stop if the service returns a pagination token
 	// that matches the most recent token provided to the service.
 	StopOnDuplicateToken bool
 }
 
-// DescribeTagsPaginator is a paginator for DescribeTags
+// DescribeTagsPaginator is a paginator for DescribeTags.
 type DescribeTagsPaginator struct {
 	options   DescribeTagsPaginatorOptions
 	client    DescribeTagsAPIClient
@@ -127,7 +127,7 @@ type DescribeTagsPaginator struct {
 	firstPage bool
 }
 
-// NewDescribeTagsPaginator returns a new DescribeTagsPaginator
+// NewDescribeTagsPaginator returns a new DescribeTagsPaginator.
 func NewDescribeTagsPaginator(client DescribeTagsAPIClient, params *DescribeTagsInput, optFns ...func(*DescribeTagsPaginatorOptions)) *DescribeTagsPaginator {
 	if params == nil {
 		params = &DescribeTagsInput{}
@@ -148,7 +148,7 @@ func NewDescribeTagsPaginator(client DescribeTagsAPIClient, params *DescribeTags
 	}
 }
 
-// HasMorePages returns a boolean indicating whether more pages are available
+// HasMorePages returns a boolean indicating whether more pages are available.
 func (p *DescribeTagsPaginator) HasMorePages() bool {
 	return p.firstPage || (p.nextToken != nil && len(*p.nextToken) != 0)
 }

--- a/internal/aws-sdk-go-v2/service/snowballdevice/api_op_DescribeVirtualNetworkInterfaces.go
+++ b/internal/aws-sdk-go-v2/service/snowballdevice/api_op_DescribeVirtualNetworkInterfaces.go
@@ -115,7 +115,7 @@ type DescribeVirtualNetworkInterfacesAPIClient interface {
 var _ DescribeVirtualNetworkInterfacesAPIClient = (*Client)(nil)
 
 // DescribeVirtualNetworkInterfacesPaginatorOptions is the paginator options for
-// DescribeVirtualNetworkInterfaces
+// DescribeVirtualNetworkInterfaces.
 type DescribeVirtualNetworkInterfacesPaginatorOptions struct {
 	// Set to true if pagination should stop if the service returns a pagination token
 	// that matches the most recent token provided to the service.
@@ -123,7 +123,7 @@ type DescribeVirtualNetworkInterfacesPaginatorOptions struct {
 }
 
 // DescribeVirtualNetworkInterfacesPaginator is a paginator for
-// DescribeVirtualNetworkInterfaces
+// DescribeVirtualNetworkInterfaces.
 type DescribeVirtualNetworkInterfacesPaginator struct {
 	options   DescribeVirtualNetworkInterfacesPaginatorOptions
 	client    DescribeVirtualNetworkInterfacesAPIClient
@@ -133,7 +133,7 @@ type DescribeVirtualNetworkInterfacesPaginator struct {
 }
 
 // NewDescribeVirtualNetworkInterfacesPaginator returns a new
-// DescribeVirtualNetworkInterfacesPaginator
+// DescribeVirtualNetworkInterfacesPaginator.
 func NewDescribeVirtualNetworkInterfacesPaginator(client DescribeVirtualNetworkInterfacesAPIClient, params *DescribeVirtualNetworkInterfacesInput, optFns ...func(*DescribeVirtualNetworkInterfacesPaginatorOptions)) *DescribeVirtualNetworkInterfacesPaginator {
 	if params == nil {
 		params = &DescribeVirtualNetworkInterfacesInput{}
@@ -154,7 +154,7 @@ func NewDescribeVirtualNetworkInterfacesPaginator(client DescribeVirtualNetworkI
 	}
 }
 
-// HasMorePages returns a boolean indicating whether more pages are available
+// HasMorePages returns a boolean indicating whether more pages are available.
 func (p *DescribeVirtualNetworkInterfacesPaginator) HasMorePages() bool {
 	return p.firstPage || (p.nextToken != nil && len(*p.nextToken) != 0)
 }

--- a/internal/aws-sdk-go-v2/service/snowballdevice/endpoints.go
+++ b/internal/aws-sdk-go-v2/service/snowballdevice/endpoints.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-// EndpointResolverOptions is the service endpoint resolver options
+// EndpointResolverOptions is the service endpoint resolver options.
 type EndpointResolverOptions = internalendpoints.Options
 
 // EndpointResolver interface for resolving service endpoints.
@@ -25,7 +25,7 @@ type EndpointResolver interface {
 
 var _ EndpointResolver = &internalendpoints.Resolver{}
 
-// NewDefaultEndpointResolver constructs a new service endpoint resolver
+// NewDefaultEndpointResolver constructs a new service endpoint resolver.
 func NewDefaultEndpointResolver() *internalendpoints.Resolver {
 	return internalendpoints.New()
 }
@@ -164,7 +164,7 @@ var _ aws.EndpointResolverWithOptions = awsEndpointResolverAdaptor(nil)
 // If awsResolver returns aws.EndpointNotFoundError error, the resolver will use the the provided
 // fallbackResolver for resolution.
 //
-// fallbackResolver must not be nil
+// fallbackResolver must not be nil.
 func withEndpointResolver(awsResolver aws.EndpointResolver, awsResolverWithOptions aws.EndpointResolverWithOptions, fallbackResolver EndpointResolver) EndpointResolver {
 	var resolver aws.EndpointResolverWithOptions
 

--- a/internal/aws-sdk-go-v2/service/snowballdevice/go_module_metadata.go
+++ b/internal/aws-sdk-go-v2/service/snowballdevice/go_module_metadata.go
@@ -2,5 +2,5 @@
 
 package snowballdevice
 
-// goModuleVersion is the tagged release for this module
+// goModuleVersion is the tagged release for this module.
 const goModuleVersion = "tip"

--- a/internal/aws-sdk-go-v2/service/snowballdevice/internal/endpoints/endpoints.go
+++ b/internal/aws-sdk-go-v2/service/snowballdevice/internal/endpoints/endpoints.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 )
 
-// Options is the endpoint resolver configuration options
+// Options is the endpoint resolver configuration options.
 type Options struct {
 	// Logger is a logging implementation that log events should be sent to.
 	Logger logging.Logger
@@ -62,12 +62,12 @@ func transformToSharedOptions(options Options) endpoints.Options {
 	}
 }
 
-// Resolver Snowball Device endpoint resolver
+// Resolver Snowball Device endpoint resolver.
 type Resolver struct {
 	partitions endpoints.Partitions
 }
 
-// ResolveEndpoint resolves the service endpoint for the given region and options
+// ResolveEndpoint resolves the service endpoint for the given region and options.
 func (r *Resolver) ResolveEndpoint(region string, options Options) (endpoint aws.Endpoint, err error) {
 	if len(region) == 0 {
 		return endpoint, &aws.MissingRegionError{}
@@ -77,7 +77,7 @@ func (r *Resolver) ResolveEndpoint(region string, options Options) (endpoint aws
 	return r.partitions.ResolveEndpoint(region, opt)
 }
 
-// New returns a new Resolver
+// New returns a new Resolver.
 func New() *Resolver {
 	return &Resolver{
 		partitions: defaultPartitions,

--- a/internal/aws-sdk-go-v2/service/snowballdevice/types/enums.go
+++ b/internal/aws-sdk-go-v2/service/snowballdevice/types/enums.go
@@ -4,7 +4,7 @@ package types
 
 type ClusterAssociationState string
 
-// Enum values for ClusterAssociationState
+// Enum values for ClusterAssociationState.
 const (
 	ClusterAssociationStateAssociated     ClusterAssociationState = "ASSOCIATED"
 	ClusterAssociationStateAssociating    ClusterAssociationState = "ASSOCIATING"
@@ -26,7 +26,7 @@ func (ClusterAssociationState) Values() []ClusterAssociationState {
 
 type DirectNetworkDriver string
 
-// Enum values for DirectNetworkDriver
+// Enum values for DirectNetworkDriver.
 const (
 	DirectNetworkDriverIxgbevf  DirectNetworkDriver = "ixgbevf"
 	DirectNetworkDriverMlx5Core DirectNetworkDriver = "mlx5_core"
@@ -44,7 +44,7 @@ func (DirectNetworkDriver) Values() []DirectNetworkDriver {
 
 type InstallState string
 
-// Enum values for InstallState
+// Enum values for InstallState.
 const (
 	InstallStateNa             InstallState = "NA"
 	InstallStateDecrypting     InstallState = "DECRYPTING"
@@ -76,7 +76,7 @@ func (InstallState) Values() []InstallState {
 
 type IpAddressAssignment string
 
-// Enum values for IpAddressAssignment
+// Enum values for IpAddressAssignment.
 const (
 	IpAddressAssignmentDhcp   IpAddressAssignment = "DHCP"
 	IpAddressAssignmentStatic IpAddressAssignment = "STATIC"
@@ -94,7 +94,7 @@ func (IpAddressAssignment) Values() []IpAddressAssignment {
 
 type NetworkReachabilityState string
 
-// Enum values for NetworkReachabilityState
+// Enum values for NetworkReachabilityState.
 const (
 	NetworkReachabilityStateReachable   NetworkReachabilityState = "REACHABLE"
 	NetworkReachabilityStateUnreachable NetworkReachabilityState = "UNREACHABLE"
@@ -112,7 +112,7 @@ func (NetworkReachabilityState) Values() []NetworkReachabilityState {
 
 type PhysicalConnectorType string
 
-// Enum values for PhysicalConnectorType
+// Enum values for PhysicalConnectorType.
 const (
 	PhysicalConnectorTypeRj45    PhysicalConnectorType = "RJ45"
 	PhysicalConnectorTypeRj452   PhysicalConnectorType = "RJ45_2"
@@ -136,7 +136,7 @@ func (PhysicalConnectorType) Values() []PhysicalConnectorType {
 
 type RemoteManagementState string
 
-// Enum values for RemoteManagementState
+// Enum values for RemoteManagementState.
 const (
 	RemoteManagementStateInstalledAutostart RemoteManagementState = "INSTALLED_AUTOSTART"
 	RemoteManagementStateInstalledOnly      RemoteManagementState = "INSTALLED_ONLY"
@@ -154,7 +154,7 @@ func (RemoteManagementState) Values() []RemoteManagementState {
 
 type ServiceStatusState string
 
-// Enum values for ServiceStatusState
+// Enum values for ServiceStatusState.
 const (
 	ServiceStatusStateInactive     ServiceStatusState = "INACTIVE"
 	ServiceStatusStateDeactivating ServiceStatusState = "DEACTIVATING"
@@ -178,7 +178,7 @@ func (ServiceStatusState) Values() []ServiceStatusState {
 
 type ShippingLabelUpdateStatus string
 
-// Enum values for ShippingLabelUpdateStatus
+// Enum values for ShippingLabelUpdateStatus.
 const (
 	ShippingLabelUpdateStatusLabelStateUnavailable ShippingLabelUpdateStatus = "LABEL_STATE_UNAVAILABLE"
 	ShippingLabelUpdateStatusLabelFound            ShippingLabelUpdateStatus = "LABEL_FOUND"
@@ -216,7 +216,7 @@ func (ShippingLabelUpdateStatus) Values() []ShippingLabelUpdateStatus {
 
 type TimeSourceState string
 
-// Enum values for TimeSourceState
+// Enum values for TimeSourceState.
 const (
 	TimeSourceStateCurrent      TimeSourceState = "CURRENT"
 	TimeSourceStateCombined     TimeSourceState = "COMBINED"
@@ -240,7 +240,7 @@ func (TimeSourceState) Values() []TimeSourceState {
 
 type TimeSourceType string
 
-// Enum values for TimeSourceType
+// Enum values for TimeSourceType.
 const (
 	TimeSourceTypeServer TimeSourceType = "SERVER"
 	TimeSourceTypePeer   TimeSourceType = "PEER"
@@ -258,7 +258,7 @@ func (TimeSourceType) Values() []TimeSourceType {
 
 type UnlockStatusState string
 
-// Enum values for UnlockStatusState
+// Enum values for UnlockStatusState.
 const (
 	UnlockStatusStateLocked    UnlockStatusState = "LOCKED"
 	UnlockStatusStateUnlocked  UnlockStatusState = "UNLOCKED"

--- a/internal/pkg/api/hardware.go
+++ b/internal/pkg/api/hardware.go
@@ -51,7 +51,7 @@ func NewHardwareMapFromFile(file string) (map[string]*Hardware, error) {
 	return HardwareSliceToMap(slice), nil
 }
 
-// converts a hardware slice to a map. The first instance of the slice is used in case slice contains duplicates
+// converts a hardware slice to a map. The first instance of the slice is used in case slice contains duplicates.
 func HardwareSliceToMap(slice []*Hardware) map[string]*Hardware {
 	hardwareMap := make(map[string]*Hardware)
 

--- a/internal/pkg/files/files.go
+++ b/internal/pkg/files/files.go
@@ -13,7 +13,7 @@ import (
 	untar "github.com/aws/eks-anywhere/pkg/tar"
 )
 
-// GzipFileDownloadExtract downloads and extracts a specific file to destination
+// GzipFileDownloadExtract downloads and extracts a specific file to destination.
 func GzipFileDownloadExtract(uri, fileToExtract, destination string) error {
 	targetFile := filepath.Join(destination, fileToExtract)
 	if _, err := os.Stat(targetFile); err == nil {

--- a/internal/test/envtest/client.go
+++ b/internal/test/envtest/client.go
@@ -14,7 +14,7 @@ import (
 type Object client.Object
 
 // CreateObjs creates Objects using the provided kube client and waits until its cache
-// has been updated with those objects
+// has been updated with those objects.
 func CreateObjs(ctx context.Context, t testing.TB, c client.Client, objs ...Object) {
 	t.Helper()
 	for _, o := range objs {

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -86,7 +86,7 @@ func WithAssignment(envRef **Environment) EnvironmentOpt {
 
 // RunWithEnvironment runs a suite of tests with an envtest that is shared across all tests
 // We use testing.M as the input to avoid having this called directly from a test
-// This ensures the envtest setup is always run from a TestMain
+// This ensures the envtest setup is always run from a TestMain.
 func RunWithEnvironment(m *testing.M, opts ...EnvironmentOpt) int {
 	ctx := ctrl.SetupSignalHandler()
 	env, err := newEnvironment(ctx)
@@ -181,12 +181,12 @@ func (e *Environment) Client() client.Client {
 	return e.client
 }
 
-// APIReader returns a non cached reader client
+// APIReader returns a non cached reader client.
 func (e *Environment) APIReader() client.Reader {
 	return e.apiReader
 }
 
-// Manager returns a Manager for the test environment
+// Manager returns a Manager for the test environment.
 func (e *Environment) Manager() manager.Manager {
 	return e.manager
 }

--- a/internal/test/kubernetes.go
+++ b/internal/test/kubernetes.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 )
 
-// KubeClient implements kubernetes.Client by using client.Client
+// KubeClient implements kubernetes.Client by using client.Client.
 type KubeClient struct {
 	client client.Client
 }
@@ -27,14 +27,14 @@ func (c *KubeClient) Get(ctx context.Context, name, namespace string, obj kubern
 	return c.client.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj)
 }
 
-// NewFakeKubeClient returns a KubeClient that uses a fake client.Client under the hood
+// NewFakeKubeClient returns a KubeClient that uses a fake client.Client under the hood.
 func NewFakeKubeClient(objs ...client.Object) *KubeClient {
 	return NewKubeClient(fake.NewClientBuilder().WithObjects(objs...).Build())
 }
 
 // NewFakeKubeClientAlwaysError returns a KubeClient that will always fail in any operation
 // This is achieved by injecting an empty Scheme, which will make the underlying client.Client
-// incapable of determining the resource type for a particular client.Object
+// incapable of determining the resource type for a particular client.Object.
 func NewFakeKubeClientAlwaysError(objs ...client.Object) *KubeClient {
 	return NewKubeClient(
 		fake.NewClientBuilder().WithScheme(runtime.NewScheme()).WithObjects(objs...).Build(),

--- a/internal/test/matchers.go
+++ b/internal/test/matchers.go
@@ -22,7 +22,7 @@ func (o *ofType) String() string {
 }
 
 // AContext returns a gomock matchers that evaluates if the receive value can
-// fullfills the context.Context interface
+// fullfills the context.Context interface.
 func AContext() gomock.Matcher {
 	ctxInterface := reflect.TypeOf((*context.Context)(nil)).Elem()
 	return gomock.AssignableToTypeOf(ctxInterface)

--- a/internal/test/reader.go
+++ b/internal/test/reader.go
@@ -2,7 +2,7 @@ package test
 
 // Reader is a commonly used interface in multiple packages
 // We are replicating here just to create a single mock we can
-// use in multiple test packages
+// use in multiple test packages.
 type Reader interface {
 	ReadFile(url string) ([]byte, error)
 }

--- a/pkg/api/v1alpha1/awsdatacenterconfig.go
+++ b/pkg/api/v1alpha1/awsdatacenterconfig.go
@@ -6,7 +6,7 @@ import (
 
 const AWSDatacenterKind = "AWSDatacenterConfig"
 
-// Used for generating yaml for generate clusterconfig command
+// Used for generating yaml for generate clusterconfig command.
 func NewAWSDatacenterConfigGenerate(clusterName string) *AWSDatacenterConfigGenerate {
 	return &AWSDatacenterConfigGenerate{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/api/v1alpha1/awsdatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/awsdatacenterconfig_types.go
@@ -6,7 +6,7 @@ import (
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// AWSDatacenterConfigSpec defines the desired state of AWSDatacenterConfig
+// AWSDatacenterConfigSpec defines the desired state of AWSDatacenterConfig.
 type AWSDatacenterConfigSpec struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
 
@@ -14,14 +14,14 @@ type AWSDatacenterConfigSpec struct {
 	AmiID  string `json:"amiID"`
 }
 
-// AWSDatacenterConfigStatus defines the observed state of AWSDatacenterConfig
+// AWSDatacenterConfigStatus defines the observed state of AWSDatacenterConfig.
 type AWSDatacenterConfigStatus struct { // Important: Run "make generate" to regenerate code after modifying this file
 }
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// AWSDatacenterConfig is the Schema for the AWSDatacenterConfigs API
+// AWSDatacenterConfig is the Schema for the AWSDatacenterConfigs API.
 type AWSDatacenterConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -71,7 +71,7 @@ func (a *AWSDatacenterConfig) ConvertConfigToConfigGenerateStruct() *AWSDatacent
 
 // +kubebuilder:object:generate=false
 
-// Same as AWSDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig
+// Same as AWSDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig.
 type AWSDatacenterConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -81,7 +81,7 @@ type AWSDatacenterConfigGenerate struct {
 
 //+kubebuilder:object:root=true
 
-// AWSDatacenterConfigList contains a list of AWSDatacenterConfig
+// AWSDatacenterConfigList contains a list of AWSDatacenterConfig.
 type AWSDatacenterConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/awsiamconfig_types.go
+++ b/pkg/api/v1alpha1/awsiamconfig_types.go
@@ -5,7 +5,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 // AWSIamConfig defines configuration options for AWS IAM Authenticator server
 
-// AWSIamConfigSpec defines the desired state of AWSIamConfig
+// AWSIamConfigSpec defines the desired state of AWSIamConfig.
 type AWSIamConfigSpec struct {
 	// AWSRegion defines a region in an AWS partition
 	AWSRegion string `json:"awsRegion"`
@@ -22,14 +22,14 @@ type AWSIamConfigSpec struct {
 	Partition string `json:"partition,omitempty"`
 }
 
-// MapRoles defines IAM role to a username and set of groups mapping using EKSConfigMap BackendMode
+// MapRoles defines IAM role to a username and set of groups mapping using EKSConfigMap BackendMode.
 type MapRoles struct {
 	RoleARN  string   `yaml:"rolearn" json:"roleARN"`
 	Username string   `json:"username"`
 	Groups   []string `json:"groups,omitempty"`
 }
 
-// MapUsers defines IAM role to a username and set of groups mapping using EKSConfigMap BackendMode
+// MapUsers defines IAM role to a username and set of groups mapping using EKSConfigMap BackendMode.
 type MapUsers struct {
 	UserARN  string   `yaml:"userarn" json:"userARN"`
 	Username string   `json:"username"`
@@ -52,13 +52,13 @@ func (e *AWSIamConfigSpec) Equal(n *AWSIamConfigSpec) bool {
 	return SliceEqual(e.BackendMode, n.BackendMode)
 }
 
-// AWSIamConfigStatus defines the observed state of AWSIamConfig
+// AWSIamConfigStatus defines the observed state of AWSIamConfig.
 type AWSIamConfigStatus struct{}
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// AWSIamConfig is the Schema for the awsiamconfigs API
+// AWSIamConfig is the Schema for the awsiamconfigs API.
 type AWSIamConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -68,7 +68,7 @@ type AWSIamConfig struct {
 }
 
 // +kubebuilder:object:generate=false
-// Same as AWSIamConfig except stripped down for generation of yaml file while writing to github repo when flux is enabled
+// Same as AWSIamConfig except stripped down for generation of yaml file while writing to github repo when flux is enabled.
 type AWSIamConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -78,7 +78,7 @@ type AWSIamConfigGenerate struct {
 
 //+kubebuilder:object:root=true
 
-// AWSIamConfigList contains a list of AWSIamConfig
+// AWSIamConfigList contains a list of AWSIamConfig.
 type AWSIamConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/awsiamconfig_webhook.go
+++ b/pkg/api/v1alpha1/awsiamconfig_webhook.go
@@ -24,7 +24,7 @@ func (r *AWSIamConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.Defaulter = &AWSIamConfig{}
 
-// Default implements webhook.Defaulter so a webhook will be registered for the type
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (r *AWSIamConfig) Default() {
 	awsiamconfiglog.Info("Setting up AWSIamConfig defaults for", "name", r.Name)
 	r.SetDefaults()
@@ -35,14 +35,14 @@ func (r *AWSIamConfig) Default() {
 
 var _ webhook.Validator = &AWSIamConfig{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AWSIamConfig) ValidateCreate() error {
 	awsiamconfiglog.Info("validate create", "name", r.Name)
 
 	return r.Validate()
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AWSIamConfig) ValidateUpdate(old runtime.Object) error {
 	awsiamconfiglog.Info("validate update", "name", r.Name)
 
@@ -65,7 +65,7 @@ func (r *AWSIamConfig) ValidateUpdate(old runtime.Object) error {
 	return apierrors.NewInvalid(GroupVersion.WithKind(AWSIamConfigKind).GroupKind(), r.Name, allErrs)
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *AWSIamConfig) ValidateDelete() error {
 	awsiamconfiglog.Info("validate delete", "name", r.Name)
 

--- a/pkg/api/v1alpha1/cloudstackdatacenterconfig.go
+++ b/pkg/api/v1alpha1/cloudstackdatacenterconfig.go
@@ -6,7 +6,7 @@ import (
 
 const CloudStackDatacenterKind = "CloudStackDatacenterConfig"
 
-// Used for generating yaml for generate clusterconfig command
+// Used for generating yaml for generate clusterconfig command.
 func NewCloudStackDatacenterConfigGenerate(clusterName string) *CloudStackDatacenterConfigGenerate {
 	return &CloudStackDatacenterConfigGenerate{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/api/v1alpha1/cloudstackdatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackdatacenterconfig_types.go
@@ -28,7 +28,7 @@ import (
 
 const DefaultCloudStackAZPrefix = "default-az"
 
-// CloudStackDatacenterConfigSpec defines the desired state of CloudStackDatacenterConfig
+// CloudStackDatacenterConfigSpec defines the desired state of CloudStackDatacenterConfig.
 type CloudStackDatacenterConfigSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -77,7 +77,7 @@ func (r *CloudStackResourceIdentifier) Equal(o *CloudStackResourceIdentifier) bo
 	return r.Id == "" && o.Id == "" && r.Name == o.Name
 }
 
-// CloudStackZone is an organizational construct typically used to represent a single datacenter, and all its physical and virtual resources exist inside that zone. It can either be specified as a UUID or name
+// CloudStackZone is an organizational construct typically used to represent a single datacenter, and all its physical and virtual resources exist inside that zone. It can either be specified as a UUID or name.
 type CloudStackZone struct {
 	// Zone is the name or UUID of the CloudStack zone in which clusters should be created. Zones should be managed by a single CloudStack Management endpoint.
 	Id   string `json:"id,omitempty"`
@@ -87,7 +87,7 @@ type CloudStackZone struct {
 	Network CloudStackResourceIdentifier `json:"network"`
 }
 
-// CloudStackAvailabilityZone maps to a CAPI failure domain to distribute machines across Cloudstack infrastructure
+// CloudStackAvailabilityZone maps to a CAPI failure domain to distribute machines across Cloudstack infrastructure.
 type CloudStackAvailabilityZone struct {
 	// Name is used as a unique identifier for each availability zone
 	Name string `json:"name"`
@@ -105,7 +105,7 @@ type CloudStackAvailabilityZone struct {
 	ManagementApiEndpoint string `json:"managementApiEndpoint"`
 }
 
-// CloudStackDatacenterConfigStatus defines the observed state of CloudStackDatacenterConfig
+// CloudStackDatacenterConfigStatus defines the observed state of CloudStackDatacenterConfig.
 type CloudStackDatacenterConfigStatus struct { // INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// SpecValid is set to true if cloudstackdatacenterconfig is validated.
 	SpecValid bool `json:"specValid,omitempty"`
@@ -122,7 +122,7 @@ type CloudStackDatacenterConfigStatus struct { // INSERT ADDITIONAL STATUS FIELD
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// CloudStackDatacenterConfig is the Schema for the cloudstackdatacenterconfigs API
+// CloudStackDatacenterConfig is the Schema for the cloudstackdatacenterconfigs API.
 type CloudStackDatacenterConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -300,7 +300,7 @@ func (az *CloudStackAvailabilityZone) Equal(o *CloudStackAvailabilityZone) bool 
 
 // +kubebuilder:object:generate=false
 
-// Same as CloudStackDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig
+// Same as CloudStackDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig.
 type CloudStackDatacenterConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -310,7 +310,7 @@ type CloudStackDatacenterConfigGenerate struct {
 
 //+kubebuilder:object:root=true
 
-// CloudStackDatacenterConfigList contains a list of CloudStackDatacenterConfig
+// CloudStackDatacenterConfigList contains a list of CloudStackDatacenterConfig.
 type CloudStackDatacenterConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/cloudstackdatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/cloudstackdatacenterconfig_webhook.go
@@ -45,7 +45,7 @@ func (r *CloudStackDatacenterConfig) SetupWebhookWithManager(mgr ctrl.Manager) e
 
 var _ webhook.Validator = &CloudStackDatacenterConfig{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *CloudStackDatacenterConfig) ValidateCreate() error {
 	cloudstackdatacenterconfiglog.Info("validate create", "name", r.Name)
 	if r.IsReconcilePaused() {
@@ -58,7 +58,7 @@ func (r *CloudStackDatacenterConfig) ValidateCreate() error {
 	return nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *CloudStackDatacenterConfig) ValidateUpdate(old runtime.Object) error {
 	cloudstackdatacenterconfiglog.Info("validate update", "name", r.Name)
 
@@ -140,7 +140,7 @@ func validateImmutableFieldsCloudStackCluster(new, old *CloudStackDatacenterConf
 	return allErrs
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *CloudStackDatacenterConfig) ValidateDelete() error {
 	cloudstackdatacenterconfiglog.Info("validate delete", "name", r.Name)
 

--- a/pkg/api/v1alpha1/cloudstackmachineconfig.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig.go
@@ -11,7 +11,7 @@ import (
 
 const CloudStackMachineConfigKind = "CloudStackMachineConfig"
 
-// Used for generating yaml for generate clusterconfig command
+// Used for generating yaml for generate clusterconfig command.
 func NewCloudStackMachineConfigGenerate(name string) *CloudStackMachineConfigGenerate {
 	return &CloudStackMachineConfigGenerate{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
@@ -25,7 +25,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// CloudStackMachineConfigSpec defines the desired state of CloudStackMachineConfig
+// CloudStackMachineConfigSpec defines the desired state of CloudStackMachineConfig.
 type CloudStackMachineConfigSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -206,7 +206,7 @@ func (c *CloudStackMachineConfig) Validate() error {
 	return nil
 }
 
-// CloudStackMachineConfigStatus defines the observed state of CloudStackMachineConfig
+// CloudStackMachineConfigStatus defines the observed state of CloudStackMachineConfig.
 type CloudStackMachineConfigStatus struct { // INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
@@ -222,7 +222,7 @@ type CloudStackMachineConfigStatus struct { // INSERT ADDITIONAL STATUS FIELD - 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// CloudStackMachineConfig is the Schema for the cloudstackmachineconfigs API
+// CloudStackMachineConfig is the Schema for the cloudstackmachineconfigs API.
 type CloudStackMachineConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -300,7 +300,7 @@ func (c *CloudStackMachineConfig) Marshallable() Marshallable {
 
 // +kubebuilder:object:generate=false
 
-// Same as CloudStackMachineConfig except stripped down for generation of yaml file during generate clusterconfig
+// Same as CloudStackMachineConfig except stripped down for generation of yaml file during generate clusterconfig.
 type CloudStackMachineConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -310,7 +310,7 @@ type CloudStackMachineConfigGenerate struct {
 
 //+kubebuilder:object:root=true
 
-// CloudStackMachineConfigList contains a list of CloudStackMachineConfig
+// CloudStackMachineConfigList contains a list of CloudStackMachineConfig.
 type CloudStackMachineConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_webhook.go
@@ -27,7 +27,7 @@ func (r *CloudStackMachineConfig) SetupWebhookWithManager(mgr ctrl.Manager) erro
 
 var _ webhook.Validator = &CloudStackMachineConfig{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *CloudStackMachineConfig) ValidateCreate() error {
 	cloudstackmachineconfiglog.Info("validate create", "name", r.Name)
 
@@ -41,7 +41,7 @@ func (r *CloudStackMachineConfig) ValidateCreate() error {
 	return nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *CloudStackMachineConfig) ValidateUpdate(old runtime.Object) error {
 	cloudstackmachineconfiglog.Info("validate update", "name", r.Name)
 
@@ -114,7 +114,7 @@ func validateImmutableFieldsCloudStackMachineConfig(new, old *CloudStackMachineC
 	return allErrs
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *CloudStackMachineConfig) ValidateDelete() error {
 	cloudstackmachineconfiglog.Info("validate delete", "name", r.Name)
 

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -32,7 +32,7 @@ const (
 // +kubebuilder:object:generate=false
 type ClusterGenerateOpt func(config *ClusterGenerate)
 
-// Used for generating yaml for generate clusterconfig command
+// Used for generating yaml for generate clusterconfig command.
 func NewClusterGenerate(clusterName string, opts ...ClusterGenerateOpt) *ClusterGenerate {
 	clusterConfig := &ClusterGenerate{
 		TypeMeta: metav1.TypeMeta{
@@ -200,7 +200,7 @@ var clusterConfigValidations = []func(*Cluster) error{
 }
 
 // GetClusterConfig parses a Cluster object from a multiobject yaml file in disk
-// and sets defaults if necessary
+// and sets defaults if necessary.
 func GetClusterConfig(fileName string) (*Cluster, error) {
 	clusterConfig := &Cluster{}
 	err := ParseClusterConfig(fileName, clusterConfig)
@@ -213,7 +213,7 @@ func GetClusterConfig(fileName string) (*Cluster, error) {
 	return clusterConfig, nil
 }
 
-// GetClusterConfigFromContent parses a Cluster object from a multiobject yaml content
+// GetClusterConfigFromContent parses a Cluster object from a multiobject yaml content.
 func GetClusterConfigFromContent(content []byte) (*Cluster, error) {
 	clusterConfig := &Cluster{}
 	err := ParseClusterConfigFromContent(content, clusterConfig)
@@ -224,7 +224,7 @@ func GetClusterConfigFromContent(content []byte) (*Cluster, error) {
 }
 
 // GetClusterConfig parses a Cluster object from a multiobject yaml file in disk
-// sets defaults if necessary and validates the Cluster
+// sets defaults if necessary and validates the Cluster.
 func GetAndValidateClusterConfig(fileName string) (*Cluster, error) {
 	clusterConfig, err := GetClusterConfig(fileName)
 	if err != nil {
@@ -238,13 +238,13 @@ func GetAndValidateClusterConfig(fileName string) (*Cluster, error) {
 	return clusterConfig, nil
 }
 
-// GetClusterDefaultKubernetesVersion returns the default kubernetes version for a Cluster
+// GetClusterDefaultKubernetesVersion returns the default kubernetes version for a Cluster.
 func GetClusterDefaultKubernetesVersion() KubernetesVersion {
 	return Kube123
 }
 
 // ValidateClusterConfigContent validates a Cluster object without modifying it
-// Some of the validations are a bit heavy and need a network connection
+// Some of the validations are a bit heavy and need a network connection.
 func ValidateClusterConfigContent(clusterConfig *Cluster) error {
 	for _, v := range clusterConfigValidations {
 		if err := v(clusterConfig); err != nil {
@@ -255,7 +255,7 @@ func ValidateClusterConfigContent(clusterConfig *Cluster) error {
 }
 
 // ParseClusterConfig unmarshalls an API object implementing the KindAccessor interface
-// from a multiobject yaml file in disk. It doesn't set defaults nor validates the object
+// from a multiobject yaml file in disk. It doesn't set defaults nor validates the object.
 func ParseClusterConfig(fileName string, clusterConfig KindAccessor) error {
 	content, err := ioutil.ReadFile(fileName)
 	if err != nil {
@@ -274,7 +274,7 @@ type kindObject struct {
 }
 
 // ParseClusterConfigFromContent unmarshalls an API object implementing the KindAccessor interface
-// from a multiobject yaml content. It doesn't set defaults nor validates the object
+// from a multiobject yaml content. It doesn't set defaults nor validates the object.
 func ParseClusterConfigFromContent(content []byte, clusterConfig KindAccessor) error {
 	for _, c := range strings.Split(string(content), YamlSeparator) {
 		k := &kindObject{}

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -21,11 +21,11 @@ const (
 
 	clusterResourceType = "clusters.anywhere.eks.amazonaws.com"
 
-	// etcdAnnotation can be applied to EKS-A machineconfig CR for etcd, to prevent controller from making changes to it
+	// etcdAnnotation can be applied to EKS-A machineconfig CR for etcd, to prevent controller from making changes to it.
 	etcdAnnotation = "anywhere.eks.amazonaws.com/etcd"
 
 	// managementAnnotation points to the name of a management cluster
-	// cluster object
+	// cluster object.
 	managementAnnotation = "anywhere.eks.amazonaws.com/managed-by"
 
 	// defaultEksaNamespace is the default namespace for EKS-A resources when not specified.
@@ -34,7 +34,7 @@ const (
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// ClusterSpec defines the desired state of Cluster
+// ClusterSpec defines the desired state of Cluster.
 type ClusterSpec struct {
 	KubernetesVersion             KubernetesVersion              `json:"kubernetesVersion,omitempty"`
 	ControlPlaneConfiguration     ControlPlaneConfiguration      `json:"controlPlaneConfiguration,omitempty"`
@@ -128,7 +128,7 @@ func (n *ProxyConfiguration) Equal(o *ProxyConfiguration) bool {
 	return n.HttpProxy == o.HttpProxy && n.HttpsProxy == o.HttpsProxy && SliceEqual(n.NoProxy, o.NoProxy)
 }
 
-// RegistryMirrorConfiguration defines the settings for image registry mirror
+// RegistryMirrorConfiguration defines the settings for image registry mirror.
 type RegistryMirrorConfiguration struct {
 	// Endpoint defines the registry mirror endpoint to use for pulling images
 	Endpoint string `json:"endpoint,omitempty"`
@@ -614,7 +614,7 @@ var validCiliumPolicyEnforcementModes = map[CiliumPolicyEnforcementMode]bool{
 	CiliumPolicyModeNever:   true,
 }
 
-// ClusterStatus defines the observed state of Cluster
+// ClusterStatus defines the observed state of Cluster.
 type ClusterStatus struct {
 	// Descriptive message about a fatal problem while reconciling a cluster
 	// +optional
@@ -669,20 +669,20 @@ func (n *Ref) Equal(o *Ref) bool {
 }
 
 // +kubebuilder:object:generate=false
-// Interface for getting DatacenterRef fields for Cluster type
+// Interface for getting DatacenterRef fields for Cluster type.
 type ProviderRefAccessor interface {
 	Kind() string
 	Name() string
 }
 
 // +kubebuilder:object:generate=false
-// Interface for getting Kind field for Cluster type
+// Interface for getting Kind field for Cluster type.
 type KindAccessor interface {
 	Kind() string
 	ExpectedKind() string
 }
 
-// ExternalEtcdConfiguration defines the configuration options for using unstacked etcd topology
+// ExternalEtcdConfiguration defines the configuration options for using unstacked etcd topology.
 type ExternalEtcdConfiguration struct {
 	Count int `json:"count,omitempty"`
 	// MachineGroupRef defines the machine group configuration for the etcd machines.
@@ -721,7 +721,7 @@ func (n *PodIAMConfig) Equal(o *PodIAMConfig) bool {
 	return n.ServiceAccountIssuer == o.ServiceAccountIssuer
 }
 
-// AutoScalingConfiguration defines the configuration for the node autoscaling feature
+// AutoScalingConfiguration defines the configuration for the node autoscaling feature.
 type AutoScalingConfiguration struct {
 	// MinCount defines the minimum number of nodes for the associated resource group.
 	// +optional
@@ -757,7 +757,7 @@ type WorkerNodesRollingUpdateParams struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// Cluster is the Schema for the clusters API
+// Cluster is the Schema for the clusters API.
 type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -775,7 +775,7 @@ func (c *Cluster) SetConditions(conditions clusterv1.Conditions) {
 }
 
 // +kubebuilder:object:generate=false
-// Same as Cluster except stripped down for generation of yaml file during generate clusterconfig
+// Same as Cluster except stripped down for generation of yaml file during generate clusterconfig.
 type ClusterGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -903,7 +903,7 @@ func (c *Cluster) ManagedBy() string {
 }
 
 // +kubebuilder:object:root=true
-// ClusterList contains a list of Cluster
+// ClusterList contains a list of Cluster.
 type ClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -40,7 +40,7 @@ func (r *Cluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.Defaulter = &Cluster{}
 
-// Default implements webhook.Defaulter so a webhook will be registered for the type
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (r *Cluster) Default() {
 	clusterlog.Info("Setting up Cluster defaults", "name", r.Name, "namespace", r.Namespace)
 	r.SetDefaults()
@@ -51,7 +51,7 @@ func (r *Cluster) Default() {
 
 var _ webhook.Validator = &Cluster{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *Cluster) ValidateCreate() error {
 	clusterlog.Info("validate create", "name", r.Name)
 
@@ -76,7 +76,7 @@ func (r *Cluster) ValidateCreate() error {
 	return nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *Cluster) ValidateUpdate(old runtime.Object) error {
 	clusterlog.Info("validate update", "name", r.Name)
 	oldCluster, ok := old.(*Cluster)
@@ -231,7 +231,7 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 	return allErrs
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *Cluster) ValidateDelete() error {
 	clusterlog.Info("validate delete", "name", r.Name)
 

--- a/pkg/api/v1alpha1/dockerdatacenterconfig.go
+++ b/pkg/api/v1alpha1/dockerdatacenterconfig.go
@@ -6,7 +6,7 @@ import (
 
 const DockerDatacenterKind = "DockerDatacenterConfig"
 
-// Used for generating yaml for generate clusterconfig command
+// Used for generating yaml for generate clusterconfig command.
 func NewDockerDatacenterConfigGenerate(clusterName string) *DockerDatacenterConfigGenerate {
 	return &DockerDatacenterConfigGenerate{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/api/v1alpha1/dockerdatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/dockerdatacenterconfig_types.go
@@ -6,20 +6,20 @@ import (
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// DockerDatacenterConfigSpec defines the desired state of DockerDatacenterConfig
+// DockerDatacenterConfigSpec defines the desired state of DockerDatacenterConfig.
 type DockerDatacenterConfigSpec struct { // Important: Run "make generate" to regenerate code after modifying this file
 	// Foo is an example field of DockerDatacenterConfig. Edit DockerDatacenter_types.go to remove/update
 	// Foo string `json:"foo,omitempty"`
 }
 
-// DockerDatacenterConfigStatus defines the observed state of DockerDatacenterConfig
+// DockerDatacenterConfigStatus defines the observed state of DockerDatacenterConfig.
 type DockerDatacenterConfigStatus struct { // Important: Run "make generate" to regenerate code after modifying this file
 }
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// DockerDatacenterConfig is the Schema for the DockerDatacenterConfigs API
+// DockerDatacenterConfig is the Schema for the DockerDatacenterConfigs API.
 type DockerDatacenterConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -77,7 +77,7 @@ func (d *DockerDatacenterConfig) Validate() error {
 
 // +kubebuilder:object:generate=false
 
-// Same as DockerDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig
+// Same as DockerDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig.
 type DockerDatacenterConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -87,7 +87,7 @@ type DockerDatacenterConfigGenerate struct {
 
 //+kubebuilder:object:root=true
 
-// DockerDatacenterConfigList contains a list of DockerDatacenterConfig
+// DockerDatacenterConfigList contains a list of DockerDatacenterConfig.
 type DockerDatacenterConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/fluxconfig_types.go
+++ b/pkg/api/v1alpha1/fluxconfig_types.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// FluxConfigSpec defines the desired state of FluxConfig
+// FluxConfigSpec defines the desired state of FluxConfig.
 type FluxConfigSpec struct {
 	// SystemNamespace scope for this operation. Defaults to flux-system
 	SystemNamespace string `json:"systemNamespace,omitempty"`
@@ -56,7 +56,7 @@ type GitProviderConfig struct {
 	SshKeyAlgorithm string `json:"sshKeyAlgorithm,omitempty"`
 }
 
-// FluxConfigStatus defines the observed state of FluxConfig
+// FluxConfigStatus defines the observed state of FluxConfig.
 type FluxConfigStatus struct{}
 
 //+kubebuilder:object:root=true
@@ -73,7 +73,7 @@ type FluxConfig struct {
 }
 
 // +kubebuilder:object:generate=false
-// Same as FluxConfig except stripped down for generation of yaml file while writing to github repo when flux is enabled
+// Same as FluxConfig except stripped down for generation of yaml file while writing to github repo when flux is enabled.
 type FluxConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -122,7 +122,7 @@ func (e *GitProviderConfig) Equal(n *GitProviderConfig) bool {
 
 //+kubebuilder:object:root=true
 
-// FluxConfigList contains a list of FluxConfig
+// FluxConfigList contains a list of FluxConfig.
 type FluxConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/fluxconfig_webhook.go
+++ b/pkg/api/v1alpha1/fluxconfig_webhook.go
@@ -39,7 +39,7 @@ func (r *FluxConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.Validator = &FluxConfig{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *FluxConfig) ValidateCreate() error {
 	fluxconfiglog.Info("validate create", "name", r.Name)
 
@@ -53,7 +53,7 @@ func (r *FluxConfig) ValidateCreate() error {
 	return nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *FluxConfig) ValidateUpdate(old runtime.Object) error {
 	fluxconfiglog.Info("validate update", "name", r.Name)
 
@@ -77,7 +77,7 @@ func (r *FluxConfig) ValidateUpdate(old runtime.Object) error {
 	return apierrors.NewInvalid(GroupVersion.WithKind(FluxConfigKind).GroupKind(), r.Name, allErrs)
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *FluxConfig) ValidateDelete() error {
 	fluxconfiglog.Info("validate delete", "name", r.Name)
 

--- a/pkg/api/v1alpha1/gitopsconfig_types.go
+++ b/pkg/api/v1alpha1/gitopsconfig_types.go
@@ -9,7 +9,7 @@ type GitOpsConfigSpec struct {
 	Flux Flux `json:"flux,omitempty"`
 }
 
-// Flux defines the Git repository options for Flux v2
+// Flux defines the Git repository options for Flux v2.
 type Flux struct {
 	// github is the name of the Git Provider to host the Git repo.
 	Github Github `json:"github,omitempty"`
@@ -36,7 +36,7 @@ type Github struct {
 	Personal bool `json:"personal,omitempty"`
 }
 
-// GitOpsConfigStatus defines the observed state of GitOpsConfig
+// GitOpsConfigStatus defines the observed state of GitOpsConfig.
 type GitOpsConfigStatus struct{}
 
 //+kubebuilder:object:root=true
@@ -51,7 +51,7 @@ type GitOpsConfig struct {
 }
 
 // +kubebuilder:object:generate=false
-// Same as GitOpsConfig except stripped down for generation of yaml file while writing to github repo when flux is enabled
+// Same as GitOpsConfig except stripped down for generation of yaml file while writing to github repo when flux is enabled.
 type GitOpsConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -71,7 +71,7 @@ func (e *GitOpsConfigSpec) Equal(n *GitOpsConfigSpec) bool {
 
 //+kubebuilder:object:root=true
 
-// GitOpsConfigList contains a list of GitOpsConfig
+// GitOpsConfigList contains a list of GitOpsConfig.
 type GitOpsConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/gitopsconfig_webhook.go
+++ b/pkg/api/v1alpha1/gitopsconfig_webhook.go
@@ -25,14 +25,14 @@ func (r *GitOpsConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.Validator = &GitOpsConfig{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *GitOpsConfig) ValidateCreate() error {
 	gitopsconfiglog.Info("validate create", "name", r.Name)
 
 	return nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *GitOpsConfig) ValidateUpdate(old runtime.Object) error {
 	gitopsconfiglog.Info("validate update", "name", r.Name)
 
@@ -52,7 +52,7 @@ func (r *GitOpsConfig) ValidateUpdate(old runtime.Object) error {
 	return apierrors.NewInvalid(GroupVersion.WithKind(GitOpsConfigKind).GroupKind(), r.Name, allErrs)
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *GitOpsConfig) ValidateDelete() error {
 	gitopsconfiglog.Info("validate delete", "name", r.Name)
 

--- a/pkg/api/v1alpha1/groupversion_info.go
+++ b/pkg/api/v1alpha1/groupversion_info.go
@@ -9,10 +9,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "anywhere.eks.amazonaws.com", Version: "v1alpha1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/pkg/api/v1alpha1/machine_types.go
+++ b/pkg/api/v1alpha1/machine_types.go
@@ -8,7 +8,7 @@ const (
 	RedHat       OSFamily = "redhat"
 )
 
-// UserConfiguration defines the configuration of the user to be added to the VM
+// UserConfiguration defines the configuration of the user to be added to the VM.
 type UserConfiguration struct {
 	Name              string   `json:"name"`
 	SshAuthorizedKeys []string `json:"sshAuthorizedKeys"`

--- a/pkg/api/v1alpha1/nutanixdatacenterconfig.go
+++ b/pkg/api/v1alpha1/nutanixdatacenterconfig.go
@@ -6,7 +6,7 @@ import (
 
 const NutanixDatacenterKind = "NutanixDatacenterConfig"
 
-// NewNutanixDatacenterConfigGenerate is used for generating yaml for generate clusterconfig command
+// NewNutanixDatacenterConfigGenerate is used for generating yaml for generate clusterconfig command.
 func NewNutanixDatacenterConfigGenerate(clusterName string) *NutanixDatacenterConfigGenerate {
 	return &NutanixDatacenterConfigGenerate{
 		TypeMeta: metav1.TypeMeta{
@@ -32,7 +32,7 @@ func (c *NutanixDatacenterConfigGenerate) Name() string {
 	return c.ObjectMeta.Name
 }
 
-// GetNutanixDatacenterConfig parses config in a yaml file and returns a NutanixDatacenterConfig object
+// GetNutanixDatacenterConfig parses config in a yaml file and returns a NutanixDatacenterConfig object.
 func GetNutanixDatacenterConfig(fileName string) (*NutanixDatacenterConfig, error) {
 	var clusterConfig NutanixDatacenterConfig
 	err := ParseClusterConfig(fileName, &clusterConfig)

--- a/pkg/api/v1alpha1/nutanixdatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/nutanixdatacenterconfig_types.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NutanixDatacenterConfigSpec defines the desired state of NutanixDatacenterConfig
+// NutanixDatacenterConfigSpec defines the desired state of NutanixDatacenterConfig.
 type NutanixDatacenterConfigSpec struct {
 	// Endpoint is the Endpoint of Nutanix Prism Central
 	// +kubebuilder:validation:Required
@@ -28,7 +28,7 @@ type NutanixDatacenterConfigSpec struct {
 	AdditionalTrustBundle string `json:"additionalTrustBundle,omitempty"`
 }
 
-// NutanixDatacenterConfigStatus defines the observed state of NutanixDatacenterConfig
+// NutanixDatacenterConfigStatus defines the observed state of NutanixDatacenterConfig.
 type NutanixDatacenterConfigStatus struct{}
 
 // NutanixDatacenterConfig is the Schema for the NutanixDatacenterConfigs API

--- a/pkg/api/v1alpha1/nutanixmachineconfig.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig.go
@@ -14,7 +14,7 @@ import (
 type NutanixIdentifierType string
 
 const (
-	// NutanixMachineConfigKind is the kind for a NutanixMachineConfig
+	// NutanixMachineConfigKind is the kind for a NutanixMachineConfig.
 	NutanixMachineConfigKind = "NutanixMachineConfig"
 
 	// NutanixIdentifierUUID is a resource identifier identifying the object by UUID.
@@ -32,7 +32,7 @@ const (
 
 // NutanixResourceIdentifier holds the identity of a Nutanix Prism resource (cluster, image, subnet, etc.)
 //
-// +union
+// +union.
 type NutanixResourceIdentifier struct {
 	// Type is the identifier type to use for this resource.
 	// +kubebuilder:validation:Required
@@ -55,7 +55,7 @@ type NutanixResourceIdentifier struct {
 type NutanixMachineConfigGenerateOpt func(config *NutanixMachineConfigGenerate)
 
 // NewNutanixMachineConfigGenerate returns a new instance of NutanixMachineConfigGenerate
-// used for generating yaml for generate clusterconfig command
+// used for generating yaml for generate clusterconfig command.
 func NewNutanixMachineConfigGenerate(name string, opts ...NutanixMachineConfigGenerateOpt) *NutanixMachineConfigGenerate {
 	emptyString := ""
 	machineConfig := &NutanixMachineConfigGenerate{

--- a/pkg/api/v1alpha1/nutanixmachineconfig_types.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_types.go
@@ -10,7 +10,7 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-// NutanixMachineConfigSpec defines the desired state of NutanixMachineConfig
+// NutanixMachineConfigSpec defines the desired state of NutanixMachineConfig.
 type NutanixMachineConfigSpec struct {
 	OSFamily OSFamily            `json:"osFamily"`
 	Users    []UserConfiguration `json:"users,omitempty"`
@@ -108,7 +108,7 @@ func (in *NutanixMachineConfig) GetName() string {
 	return in.Name
 }
 
-// NutanixMachineConfigStatus defines the observed state of NutanixMachineConfig
+// NutanixMachineConfigStatus defines the observed state of NutanixMachineConfig.
 type NutanixMachineConfigStatus struct {
 	// Ready is true when the provider resource is ready.
 	// +optional

--- a/pkg/api/v1alpha1/oidcconfig_types.go
+++ b/pkg/api/v1alpha1/oidcconfig_types.go
@@ -8,7 +8,7 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 // OIDCConfig defines an OpenID Connect (OIDCConfigSpec) identity provider configuration
 
-// OIDCConfigSpec defines the desired state of OIDCConfig
+// OIDCConfigSpec defines the desired state of OIDCConfig.
 type OIDCConfigSpec struct {
 	// ClientId defines the client ID for the OpenID Connect client
 	ClientId string `json:"clientId,omitempty"`
@@ -80,7 +80,7 @@ func RequiredClaimsSliceEqual(a, b []OIDCConfigRequiredClaim) bool {
 	return len(m) == 0
 }
 
-// IsManaged returns true if the oidcconfig is associated with a workload cluster
+// IsManaged returns true if the oidcconfig is associated with a workload cluster.
 func (c *OIDCConfig) IsManaged() bool {
 	if s, ok := c.Annotations[managementAnnotation]; ok {
 		return s != ""
@@ -100,13 +100,13 @@ type OIDCConfigRequiredClaim struct {
 	Value string `json:"value,omitempty"`
 }
 
-// OIDCConfigStatus defines the observed state of OIDCConfig
+// OIDCConfigStatus defines the observed state of OIDCConfig.
 type OIDCConfigStatus struct{}
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// OIDCConfig is the Schema for the oidcconfigs API
+// OIDCConfig is the Schema for the oidcconfigs API.
 type OIDCConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -116,7 +116,7 @@ type OIDCConfig struct {
 }
 
 // +kubebuilder:object:generate=false
-// Same as OIDCConfig except stripped down for generation of yaml file while writing to github repo when flux is enabled
+// Same as OIDCConfig except stripped down for generation of yaml file while writing to github repo when flux is enabled.
 type OIDCConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -126,7 +126,7 @@ type OIDCConfigGenerate struct {
 
 //+kubebuilder:object:root=true
 
-// OIDCConfigList contains a list of OIDCConfig
+// OIDCConfigList contains a list of OIDCConfig.
 type OIDCConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/oidcconfig_webhook.go
+++ b/pkg/api/v1alpha1/oidcconfig_webhook.go
@@ -25,7 +25,7 @@ func (r *OIDCConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.Validator = &OIDCConfig{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *OIDCConfig) ValidateCreate() error {
 	oidcconfiglog.Info("validate create", "name", r.Name)
 
@@ -38,7 +38,7 @@ func (r *OIDCConfig) ValidateCreate() error {
 	return apierrors.NewInvalid(GroupVersion.WithKind(OIDCConfigKind).GroupKind(), r.Name, allErrs)
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *OIDCConfig) ValidateUpdate(old runtime.Object) error {
 	oidcconfiglog.Info("validate update", "name", r.Name)
 
@@ -65,7 +65,7 @@ func (r *OIDCConfig) ValidateUpdate(old runtime.Object) error {
 	return apierrors.NewInvalid(GroupVersion.WithKind(OIDCConfigKind).GroupKind(), r.Name, allErrs)
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *OIDCConfig) ValidateDelete() error {
 	oidcconfiglog.Info("validate delete", "name", r.Name)
 

--- a/pkg/api/v1alpha1/snowdatacenterconfig.go
+++ b/pkg/api/v1alpha1/snowdatacenterconfig.go
@@ -6,7 +6,7 @@ import (
 
 const SnowDatacenterKind = "SnowDatacenterConfig"
 
-// Used for generating yaml for generate clusterconfig command
+// Used for generating yaml for generate clusterconfig command.
 func NewSnowDatacenterConfigGenerate(clusterName string) *SnowDatacenterConfigGenerate {
 	return &SnowDatacenterConfigGenerate{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/api/v1alpha1/snowdatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/snowdatacenterconfig_types.go
@@ -14,20 +14,20 @@ const (
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// SnowDatacenterConfigSpec defines the desired state of SnowDatacenterConfig
+// SnowDatacenterConfigSpec defines the desired state of SnowDatacenterConfig.
 type SnowDatacenterConfigSpec struct { // Important: Run "make generate" to regenerate code after modifying this file
 
 	// IdentityRef is a reference to an identity for the Snow API to be used when reconciling this cluster
 	IdentityRef Ref `json:"identityRef,omitempty"`
 }
 
-// SnowDatacenterConfigStatus defines the observed state of SnowDatacenterConfig
+// SnowDatacenterConfigStatus defines the observed state of SnowDatacenterConfig.
 type SnowDatacenterConfigStatus struct{}
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// SnowDatacenterConfig is the Schema for the SnowDatacenterConfigs API
+// SnowDatacenterConfig is the Schema for the SnowDatacenterConfigs API.
 type SnowDatacenterConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -96,7 +96,7 @@ func (s *SnowDatacenterConfig) Marshallable() Marshallable {
 
 // +kubebuilder:object:generate=false
 
-// Same as SnowDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig
+// Same as SnowDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig.
 type SnowDatacenterConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -106,7 +106,7 @@ type SnowDatacenterConfigGenerate struct {
 
 //+kubebuilder:object:root=true
 
-// SnowDatacenterConfigList contains a list of SnowDatacenterConfig
+// SnowDatacenterConfigList contains a list of SnowDatacenterConfig.
 type SnowDatacenterConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/snowdatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/snowdatacenterconfig_webhook.go
@@ -35,21 +35,21 @@ func (r *SnowDatacenterConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.Validator = &SnowDatacenterConfig{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *SnowDatacenterConfig) ValidateCreate() error {
 	snowdatacenterconfiglog.Info("validate create", "name", r.Name)
 
 	return r.Validate()
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *SnowDatacenterConfig) ValidateUpdate(old runtime.Object) error {
 	snowdatacenterconfiglog.Info("validate update", "name", r.Name)
 
 	return r.Validate()
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *SnowDatacenterConfig) ValidateDelete() error {
 	snowdatacenterconfiglog.Info("validate delete", "name", r.Name)
 

--- a/pkg/api/v1alpha1/snowmachineconfig.go
+++ b/pkg/api/v1alpha1/snowmachineconfig.go
@@ -17,7 +17,7 @@ const (
 	MinimumContainerVolumeSize              = 8
 )
 
-// Used for generating yaml for generate clusterconfig command
+// Used for generating yaml for generate clusterconfig command.
 func NewSnowMachineConfigGenerate(name string) *SnowMachineConfigGenerate {
 	return &SnowMachineConfigGenerate{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/api/v1alpha1/snowmachineconfig_types.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_types.go
@@ -23,7 +23,7 @@ type SnowInstanceType string
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 // Important: Run "make generate" to regenerate code after modifying this file
 
-// SnowMachineConfigSpec defines the desired state of SnowMachineConfigSpec
+// SnowMachineConfigSpec defines the desired state of SnowMachineConfigSpec.
 type SnowMachineConfigSpec struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
 
@@ -59,7 +59,7 @@ func (s *SnowMachineConfig) OSFamily() OSFamily {
 	return ""
 }
 
-// SnowMachineConfigStatus defines the observed state of SnowMachineConfig
+// SnowMachineConfigStatus defines the observed state of SnowMachineConfig.
 type SnowMachineConfigStatus struct {
 	// SpecValid is set to true if vspheredatacenterconfig is validated.
 	SpecValid bool `json:"specValid,omitempty"`
@@ -73,7 +73,7 @@ type SnowMachineConfigStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// SnowMachineConfig is the Schema for the SnowMachineConfigs API
+// SnowMachineConfig is the Schema for the SnowMachineConfigs API.
 type SnowMachineConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -108,7 +108,7 @@ func (s *SnowMachineConfig) SetEtcdAnnotation() {
 
 // +kubebuilder:object:generate=false
 
-// Same as SnowMachineConfig except stripped down for generation of yaml file during generate clusterconfig
+// Same as SnowMachineConfig except stripped down for generation of yaml file during generate clusterconfig.
 type SnowMachineConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -140,7 +140,7 @@ func (s *SnowMachineConfig) Marshallable() Marshallable {
 
 //+kubebuilder:object:root=true
 
-// SnowMachineConfigList contains a list of SnowMachineConfig
+// SnowMachineConfigList contains a list of SnowMachineConfig.
 type SnowMachineConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/snowmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_webhook.go
@@ -34,7 +34,7 @@ func (r *SnowMachineConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.Defaulter = &SnowMachineConfig{}
 
-// Default implements webhook.Defaulter so a webhook will be registered for the type
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (r *SnowMachineConfig) Default() {
 	snowmachineconfiglog.Info("Setting up Snow Machine Config defaults for", "name", r.Name)
 	r.SetDefaults()
@@ -45,21 +45,21 @@ func (r *SnowMachineConfig) Default() {
 
 var _ webhook.Validator = &SnowMachineConfig{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *SnowMachineConfig) ValidateCreate() error {
 	snowmachineconfiglog.Info("validate create", "name", r.Name)
 
 	return r.Validate()
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *SnowMachineConfig) ValidateUpdate(old runtime.Object) error {
 	snowmachineconfiglog.Info("validate update", "name", r.Name)
 
 	return r.Validate()
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *SnowMachineConfig) ValidateDelete() error {
 	snowmachineconfiglog.Info("validate delete", "name", r.Name)
 

--- a/pkg/api/v1alpha1/snowmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_webhook_test.go
@@ -72,7 +72,7 @@ func TestSnowMachineConfigValidateUpdateNoDevices(t *testing.T) {
 	g.Expect(sNew.ValidateUpdate(&sOld)).NotTo(Succeed())
 }
 
-// Unit test to pass the code coverage job
+// Unit test to pass the code coverage job.
 func TestSnowMachineConfigValidateDelete(t *testing.T) {
 	g := NewWithT(t)
 	sOld := snowMachineConfig()

--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig.go
@@ -6,7 +6,7 @@ import (
 
 const TinkerbellDatacenterKind = "TinkerbellDatacenterConfig"
 
-// Used for generating yaml for generate clusterconfig command
+// Used for generating yaml for generate clusterconfig command.
 func NewTinkerbellDatacenterConfigGenerate(clusterName string) *TinkerbellDatacenterConfigGenerate {
 	return &TinkerbellDatacenterConfigGenerate{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig_types.go
@@ -7,7 +7,7 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 // Important: Run "make generate" to regenerate code after modifying this file
 
-// TinkerbellDatacenterConfigSpec defines the desired state of TinkerbellDatacenterConfig
+// TinkerbellDatacenterConfigSpec defines the desired state of TinkerbellDatacenterConfig.
 type TinkerbellDatacenterConfigSpec struct {
 	// TinkerbellIP is used to configure a VIP for hosting the Tinkerbell services.
 	TinkerbellIP string `json:"tinkerbellIP"`
@@ -22,13 +22,13 @@ type TinkerbellDatacenterConfigSpec struct {
 
 // TinkerbellDatacenterConfigStatus defines the observed state of TinkerbellDatacenterConfig
 //
-// Important: Run "make generate" to regenerate code after modifying this file
+// Important: Run "make generate" to regenerate code after modifying this file.
 type TinkerbellDatacenterConfigStatus struct{}
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// TinkerbellDatacenterConfig is the Schema for the TinkerbellDatacenterConfigs API
+// TinkerbellDatacenterConfig is the Schema for the TinkerbellDatacenterConfigs API.
 type TinkerbellDatacenterConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -89,7 +89,7 @@ func (t *TinkerbellDatacenterConfig) Marshallable() Marshallable {
 
 // +kubebuilder:object:generate=false
 
-// Same as TinkerbellDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig
+// Same as TinkerbellDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig.
 type TinkerbellDatacenterConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -99,7 +99,7 @@ type TinkerbellDatacenterConfigGenerate struct {
 
 //+kubebuilder:object:root=true
 
-// TinkerbellDatacenterConfigList contains a list of TinkerbellDatacenterConfig
+// TinkerbellDatacenterConfigList contains a list of TinkerbellDatacenterConfig.
 type TinkerbellDatacenterConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig.go
@@ -14,7 +14,7 @@ const TinkerbellMachineConfigKind = "TinkerbellMachineConfig"
 // +kubebuilder:object:generate=false
 type TinkerbellMachineConfigGenerateOpt func(config *TinkerbellMachineConfigGenerate)
 
-// Used for generating yaml for generate clusterconfig command
+// Used for generating yaml for generate clusterconfig command.
 func NewTinkerbellMachineConfigGenerate(name string, opts ...TinkerbellMachineConfigGenerateOpt) *TinkerbellMachineConfigGenerate {
 	machineConfig := &TinkerbellMachineConfigGenerate{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
@@ -8,7 +8,7 @@ import (
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// TinkerbellMachineConfigSpec defines the desired state of TinkerbellMachineConfig
+// TinkerbellMachineConfigSpec defines the desired state of TinkerbellMachineConfig.
 type TinkerbellMachineConfigSpec struct {
 	HardwareSelector HardwareSelector    `json:"hardwareSelector"`
 	TemplateRef      Ref                 `json:"templateRef,omitempty"`
@@ -91,13 +91,13 @@ func (c *TinkerbellMachineConfig) GetName() string {
 	return c.Name
 }
 
-// TinkerbellMachineConfigStatus defines the observed state of TinkerbellMachineConfig
+// TinkerbellMachineConfigStatus defines the observed state of TinkerbellMachineConfig.
 type TinkerbellMachineConfigStatus struct{}
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// TinkerbellMachineConfig is the Schema for the tinkerbellmachineconfigs API
+// TinkerbellMachineConfig is the Schema for the tinkerbellmachineconfigs API.
 type TinkerbellMachineConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -130,7 +130,7 @@ func (c *TinkerbellMachineConfig) Marshallable() Marshallable {
 
 // +kubebuilder:object:generate=false
 
-// Same as TinkerbellMachineConfig except stripped down for generation of yaml file during generate clusterconfig
+// Same as TinkerbellMachineConfig except stripped down for generation of yaml file during generate clusterconfig.
 type TinkerbellMachineConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -140,7 +140,7 @@ type TinkerbellMachineConfigGenerate struct {
 
 //+kubebuilder:object:root=true
 
-// TinkerbellMachineConfigList contains a list of TinkerbellMachineConfig
+// TinkerbellMachineConfigList contains a list of TinkerbellMachineConfig.
 type TinkerbellMachineConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig.go
@@ -17,7 +17,7 @@ const TinkerbellTemplateConfigKind = "TinkerbellTemplateConfig"
 // +kubebuilder:object:generate=false
 type ActionOpt func(action *[]tinkerbell.Action)
 
-// NewDefaultTinkerbellTemplateConfigCreate returns a default TinkerbellTemplateConfig with the required Tasks and Actions
+// NewDefaultTinkerbellTemplateConfigCreate returns a default TinkerbellTemplateConfig with the required Tasks and Actions.
 func NewDefaultTinkerbellTemplateConfigCreate(name string, versionBundle v1alpha1.VersionsBundle, disk string, osImageOverride, tinkerbellLocalIp, tinkerbellLBIp string, osFamily OSFamily) *TinkerbellTemplateConfig {
 	config := &TinkerbellTemplateConfig{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_types.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_types.go
@@ -12,19 +12,19 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 // Important: Run "make generate" to regenerate code after modifying this file
 
-// TinkerbellTemplateConfigSpec defines the desired state of TinkerbellTemplateConfig
+// TinkerbellTemplateConfigSpec defines the desired state of TinkerbellTemplateConfig.
 type TinkerbellTemplateConfigSpec struct {
 	// Template defines a Tinkerbell workflow template with specific tasks and actions.
 	Template tinkerbell.Workflow `json:"template"`
 }
 
-// TinkerbellTemplateConfigStatus defines the observed state of TinkerbellTemplateConfig
+// TinkerbellTemplateConfigStatus defines the observed state of TinkerbellTemplateConfig.
 type TinkerbellTemplateConfigStatus struct{}
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// TinkerbellTemplateConfig is the Schema for the TinkerbellTemplateConfigs API
+// TinkerbellTemplateConfig is the Schema for the TinkerbellTemplateConfigs API.
 type TinkerbellTemplateConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -69,7 +69,7 @@ func (c *TinkerbellTemplateConfig) ConvertConfigToConfigGenerateStruct() *Tinker
 
 // +kubebuilder:object:generate=false
 
-// Same as TinkerbellTemplateConfig except stripped down for generation of yaml file during generate clusterconfig
+// Same as TinkerbellTemplateConfig except stripped down for generation of yaml file during generate clusterconfig.
 type TinkerbellTemplateConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -79,7 +79,7 @@ type TinkerbellTemplateConfigGenerate struct {
 
 //+kubebuilder:object:root=true
 
-// TinkerbellTemplateConfigList contains a list of TinkerbellTemplateConfig
+// TinkerbellTemplateConfigList contains a list of TinkerbellTemplateConfig.
 type TinkerbellTemplateConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/vspheredatacenterconfig.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig.go
@@ -18,7 +18,7 @@ const (
 	networkFolderType folderType = "network"
 )
 
-// Used for generating yaml for generate clusterconfig command
+// Used for generating yaml for generate clusterconfig command.
 func NewVSphereDatacenterConfigGenerate(clusterName string) *VSphereDatacenterConfigGenerate {
 	return &VSphereDatacenterConfigGenerate{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_types.go
@@ -10,7 +10,7 @@ import (
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// VSphereDatacenterConfigSpec defines the desired state of VSphereDatacenterConfig
+// VSphereDatacenterConfigSpec defines the desired state of VSphereDatacenterConfig.
 type VSphereDatacenterConfigSpec struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
 
@@ -22,7 +22,7 @@ type VSphereDatacenterConfigSpec struct {
 	Insecure   bool   `json:"insecure"`
 }
 
-// VSphereDatacenterConfigStatus defines the observed state of VSphereDatacenterConfig
+// VSphereDatacenterConfigStatus defines the observed state of VSphereDatacenterConfig.
 type VSphereDatacenterConfigStatus struct { // Important: Run "make generate" to regenerate code after modifying this file
 	// SpecValid is set to true if vspheredatacenterconfig is validated.
 	SpecValid bool `json:"specValid,omitempty"`
@@ -38,7 +38,7 @@ type VSphereDatacenterConfigStatus struct { // Important: Run "make generate" to
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// VSphereDatacenterConfig is the Schema for the VSphereDatacenterConfigs API
+// VSphereDatacenterConfig is the Schema for the VSphereDatacenterConfigs API.
 type VSphereDatacenterConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -128,7 +128,7 @@ func (v *VSphereDatacenterConfig) Marshallable() Marshallable {
 
 // +kubebuilder:object:generate=false
 
-// Same as VSphereDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig
+// Same as VSphereDatacenterConfig except stripped down for generation of yaml file during generate clusterconfig.
 type VSphereDatacenterConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -138,7 +138,7 @@ type VSphereDatacenterConfigGenerate struct {
 
 //+kubebuilder:object:root=true
 
-// VSphereDatacenterConfigList contains a list of VSphereDatacenterConfig
+// VSphereDatacenterConfigList contains a list of VSphereDatacenterConfig.
 type VSphereDatacenterConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_webhook.go
@@ -42,7 +42,7 @@ func (r *VSphereDatacenterConfig) SetupWebhookWithManager(mgr ctrl.Manager) erro
 
 var _ webhook.Defaulter = &VSphereDatacenterConfig{}
 
-// Default implements webhook.Defaulter so a webhook will be registered for the type
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (r *VSphereDatacenterConfig) Default() {
 	vspheredatacenterconfiglog.Info("Setting up VSphere Datacenter Config defaults for", "name", r.Name)
 	r.SetDefaults()
@@ -53,7 +53,7 @@ func (r *VSphereDatacenterConfig) Default() {
 
 var _ webhook.Validator = &VSphereDatacenterConfig{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *VSphereDatacenterConfig) ValidateCreate() error {
 	vspheredatacenterconfiglog.Info("validate create", "name", r.Name)
 
@@ -78,7 +78,7 @@ func (r *VSphereDatacenterConfig) ValidateCreate() error {
 	return nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *VSphereDatacenterConfig) ValidateUpdate(old runtime.Object) error {
 	vspheredatacenterconfiglog.Info("validate update", "name", r.Name)
 
@@ -160,7 +160,7 @@ func validateImmutableFieldsVSphereCluster(new, old *VSphereDatacenterConfig) fi
 	return allErrs
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *VSphereDatacenterConfig) ValidateDelete() error {
 	vspheredatacenterconfiglog.Info("validate delete", "name", r.Name)
 

--- a/pkg/api/v1alpha1/vspheremachineconfig.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig.go
@@ -21,7 +21,7 @@ const (
 	ubuntuDefaultUser        = "capv"
 )
 
-// Used for generating yaml for generate clusterconfig command
+// Used for generating yaml for generate clusterconfig command.
 func NewVSphereMachineConfigGenerate(name string) *VSphereMachineConfigGenerate {
 	return &VSphereMachineConfigGenerate{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/api/v1alpha1/vspheremachineconfig_types.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_types.go
@@ -4,7 +4,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// VSphereMachineConfigSpec defines the desired state of VSphereMachineConfig
+// VSphereMachineConfigSpec defines the desired state of VSphereMachineConfig.
 type VSphereMachineConfigSpec struct {
 	DiskGiB           int                 `json:"diskGiB,omitempty"`
 	Datastore         string              `json:"datastore"`
@@ -58,7 +58,7 @@ func (c *VSphereMachineConfig) SetManagedBy(clusterName string) {
 	c.Annotations[managementAnnotation] = clusterName
 }
 
-// IsManaged returns true if the vspheremachineconfig is associated with a workload cluster
+// IsManaged returns true if the vspheremachineconfig is associated with a workload cluster.
 func (c *VSphereMachineConfig) IsManaged() bool {
 	if s, ok := c.Annotations[managementAnnotation]; ok {
 		return s != ""
@@ -78,13 +78,13 @@ func (c *VSphereMachineConfig) GetName() string {
 	return c.Name
 }
 
-// VSphereMachineConfigStatus defines the observed state of VSphereMachineConfig
+// VSphereMachineConfigStatus defines the observed state of VSphereMachineConfig.
 type VSphereMachineConfigStatus struct{}
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// VSphereMachineConfig is the Schema for the vspheremachineconfigs API
+// VSphereMachineConfig is the Schema for the vspheremachineconfigs API.
 type VSphereMachineConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -132,7 +132,7 @@ func (c *VSphereMachineConfig) ValidateHasTemplate() error {
 
 // +kubebuilder:object:generate=false
 
-// Same as VSphereMachineConfig except stripped down for generation of yaml file during generate clusterconfig
+// Same as VSphereMachineConfig except stripped down for generation of yaml file during generate clusterconfig.
 type VSphereMachineConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
@@ -142,7 +142,7 @@ type VSphereMachineConfigGenerate struct {
 
 //+kubebuilder:object:root=true
 
-// VSphereMachineConfigList contains a list of VSphereMachineConfig
+// VSphereMachineConfigList contains a list of VSphereMachineConfig.
 type VSphereMachineConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
@@ -27,7 +27,7 @@ func (r *VSphereMachineConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.Defaulter = &VSphereMachineConfig{}
 
-// Default implements webhook.Defaulter so a webhook will be registered for the type
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (r *VSphereMachineConfig) Default() {
 	vspheremachineconfiglog.Info("Setting up VSphere Machine Config defaults for", "name", r.Name)
 	r.SetDefaults()
@@ -38,7 +38,7 @@ func (r *VSphereMachineConfig) Default() {
 
 var _ webhook.Validator = &VSphereMachineConfig{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *VSphereMachineConfig) ValidateCreate() error {
 	vspheremachineconfiglog.Info("validate create", "name", r.Name)
 	err := r.Validate()
@@ -48,7 +48,7 @@ func (r *VSphereMachineConfig) ValidateCreate() error {
 	return r.ValidateHasTemplate()
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *VSphereMachineConfig) ValidateUpdate(old runtime.Object) error {
 	vspheremachineconfiglog.Info("validate update", "name", r.Name)
 
@@ -170,7 +170,7 @@ func validateImmutableFieldsVSphereMachineConfig(new, old *VSphereMachineConfig)
 	return allErrs
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *VSphereMachineConfig) ValidateDelete() error {
 	vspheremachineconfiglog.Info("validate delete", "name", r.Name)
 

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -8,13 +8,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 )
 
-// Client provides the single API client to make operations call to aws services
+// Client provides the single API client to make operations call to aws services.
 type Client struct {
 	ec2            EC2Client
 	snowballDevice SnowballDeviceClient
 }
 
-// Clients are a map between aws profile and its aws client
+// Clients are a map between aws profile and its aws client.
 type Clients map[string]*Client
 
 type ServiceEndpoint struct {
@@ -60,14 +60,14 @@ func NewClient(ctx context.Context, cfg aws.Config) *Client {
 	}
 }
 
-// NewClientFromEC2 is mainly used for EC2 related unit tests
+// NewClientFromEC2 is mainly used for EC2 related unit tests.
 func NewClientFromEC2(ec2 EC2Client) *Client {
 	return &Client{
 		ec2: ec2,
 	}
 }
 
-// NewClientFromSnowball is mainly used for Snowballdevice related unit tests
+// NewClientFromSnowball is mainly used for Snowballdevice related unit tests.
 func NewClientFromSnowball(snowballdevice SnowballDeviceClient) *Client {
 	return &Client{
 		snowballDevice: snowballdevice,

--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -74,7 +74,7 @@ func (b *Bootstrapper) CreateBootstrapCluster(ctx context.Context, clusterSpec *
 
 type BootstrapperOpt func(*Bootstrapper)
 
-// WithRetrier implemented primarily for unit testing optimization purposes
+// WithRetrier implemented primarily for unit testing optimization purposes.
 func WithRetrier(retrier *retrier.Retrier) BootstrapperOpt {
 	return func(c *Bootstrapper) {
 		c.clusterClient.Retrier = retrier

--- a/pkg/clients/kubernetes/kubeconfig.go
+++ b/pkg/clients/kubernetes/kubeconfig.go
@@ -15,7 +15,7 @@ type Object client.Object
 type ObjectList client.ObjectList
 
 // KubeconfigClient is an authenticated kubernetes API client
-// it authenticates using the credentials of a kubeconfig file
+// it authenticates using the credentials of a kubeconfig file.
 type KubeconfigClient struct {
 	client     *UnAuthClient
 	kubeconfig string
@@ -29,7 +29,7 @@ func NewKubeconfigClient(client *UnAuthClient, kubeconfig string) *KubeconfigCli
 }
 
 // Get performs a GET call to the kube API server
-// and unmarshalls the response into the provided Object
+// and unmarshalls the response into the provided Object.
 func (c *KubeconfigClient) Get(ctx context.Context, name, namespace string, obj Object) error {
 	return c.client.Get(ctx, name, namespace, c.kubeconfig, obj)
 }

--- a/pkg/clients/kubernetes/unauth.go
+++ b/pkg/clients/kubernetes/unauth.go
@@ -16,7 +16,7 @@ type KubectlGetter interface {
 }
 
 // UnAuthClient is a generic kubernetes API client that takes a kubeconfig
-// file on every call in order to authenticate
+// file on every call in order to authenticate.
 type UnAuthClient struct {
 	kubectl KubectlGetter
 	scheme  *runtime.Scheme
@@ -31,13 +31,13 @@ func NewUnAuthClient(kubectl KubectlGetter) *UnAuthClient {
 
 // Init initializes the client internal API scheme
 // It has always be invoked at least once before making any API call
-// It is not thread safe
+// It is not thread safe.
 func (c *UnAuthClient) Init() error {
 	return addToScheme(c.scheme, schemeAdders...)
 }
 
 // Get performs a GET call to the kube API server authenticating with a kubeconfig file
-// and unmarshalls the response into the provdied Object
+// and unmarshalls the response into the provdied Object.
 func (c *UnAuthClient) Get(ctx context.Context, name, namespace, kubeconfig string, obj runtime.Object) error {
 	resourceType, err := c.resourceTypeForObj(obj)
 	if err != nil {
@@ -47,12 +47,12 @@ func (c *UnAuthClient) Get(ctx context.Context, name, namespace, kubeconfig stri
 	return c.kubectl.GetObject(ctx, resourceType, name, namespace, kubeconfig, obj)
 }
 
-// KubeconfigClient returns an equivalent authenticated client
+// KubeconfigClient returns an equivalent authenticated client.
 func (c *UnAuthClient) KubeconfigClient(kubeconfig string) Client {
 	return NewKubeconfigClient(c, kubeconfig)
 }
 
-// Delete performs a DELETE call to the kube API server authenticating with a kubeconfig file
+// Delete performs a DELETE call to the kube API server authenticating with a kubeconfig file.
 func (c *UnAuthClient) Delete(ctx context.Context, name, namespace, kubeconfig string, obj runtime.Object) error {
 	resourceType, err := c.resourceTypeForObj(obj)
 	if err != nil {

--- a/pkg/cluster/apiobject.go
+++ b/pkg/cluster/apiobject.go
@@ -8,7 +8,7 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
-// APIObject represents a kubernetes API object
+// APIObject represents a kubernetes API object.
 type APIObject interface {
 	runtime.Object
 	GetName() string
@@ -16,7 +16,7 @@ type APIObject interface {
 
 type ObjectLookup map[string]APIObject
 
-// GetFromRef searches in a ObjectLookup for an APIObject referenced by a anywherev1.Ref
+// GetFromRef searches in a ObjectLookup for an APIObject referenced by a anywherev1.Ref.
 func (o ObjectLookup) GetFromRef(apiVersion string, ref anywherev1.Ref) APIObject {
 	return o[keyForRef(apiVersion, ref)]
 }

--- a/pkg/cluster/build.go
+++ b/pkg/cluster/build.go
@@ -1,7 +1,7 @@
 package cluster
 
 // NewDefaultConfigClientBuilder returns a ConfigClientBuilder with the
-// default processors to build a Config
+// default processors to build a Config.
 func NewDefaultConfigClientBuilder() *ConfigClientBuilder {
 	return NewConfigClientBuilder().Register(
 		getVSphereDatacenter,

--- a/pkg/cluster/client_builder.go
+++ b/pkg/cluster/client_builder.go
@@ -8,34 +8,34 @@ import (
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 )
 
-// Client is a kubernetes API client
+// Client is a kubernetes API client.
 type Client interface {
 	Get(ctx context.Context, name, namespace string, obj kubernetes.Object) error
 }
 
 // ConfigClientProcessor updates a Config retrieving objects from
-// the API server through a client
+// the API server through a client.
 type ConfigClientProcessor func(ctx context.Context, client Client, c *Config) error
 
 // ConfigClientBuilder allows to register processors to build a Config
-// using a cluster client, retrieving the api objects from the API server
+// using a cluster client, retrieving the api objects from the API server.
 type ConfigClientBuilder struct {
 	processors []ConfigClientProcessor
 }
 
 // NewConfigClientBuilder builds a new ConfigClientBuilder with
-// no processors registered
+// no processors registered.
 func NewConfigClientBuilder() *ConfigClientBuilder {
 	return &ConfigClientBuilder{}
 }
 
-// Register stores processors to be used during Build
+// Register stores processors to be used during Build.
 func (b *ConfigClientBuilder) Register(processors ...ConfigClientProcessor) *ConfigClientBuilder {
 	b.processors = append(b.processors, processors...)
 	return b
 }
 
-// Build constructs a Config for a cluster using the registered processors
+// Build constructs a Config for a cluster using the registered processors.
 func (b *ConfigClientBuilder) Build(ctx context.Context, client Client, cluster *anywherev1.Cluster) (*Config, error) {
 	c := &Config{
 		Cluster: cluster,

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -109,7 +109,7 @@ func (c *Config) DeepCopy() *Config {
 	return c2
 }
 
-// ChildObjects returns all API objects in Config except the Cluster
+// ChildObjects returns all API objects in Config except the Cluster.
 func (c *Config) ChildObjects() []kubernetes.Object {
 	objs := make(
 		[]kubernetes.Object,

--- a/pkg/cluster/config_manager.go
+++ b/pkg/cluster/config_manager.go
@@ -15,12 +15,12 @@ import (
 )
 
 // ConfigManager allows to parse from yaml, set defaults and validate a Cluster struct
-// It allows to dynamically register configuration for all those operations
+// It allows to dynamically register configuration for all those operations.
 type ConfigManager struct { // TODO: find a better name
 	entry *ConfigManagerEntry
 }
 
-// NewConfigManager builds a ConfigManager with empty configuration
+// NewConfigManager builds a ConfigManager with empty configuration.
 func NewConfigManager() *ConfigManager {
 	return &ConfigManager{
 		entry: NewConfigManagerEntry(),
@@ -28,32 +28,32 @@ func NewConfigManager() *ConfigManager {
 }
 
 // Register records the configuration defined in a ConfigManagerEntry into the ConfigManager
-// This is equivalent to the individual register methods
+// This is equivalent to the individual register methods.
 func (c *ConfigManager) Register(entries ...*ConfigManagerEntry) error {
 	return c.entry.Merge(entries...)
 }
 
-// RegisterMapping records the mapping between a kubernetes Kind and an API concrete type
+// RegisterMapping records the mapping between a kubernetes Kind and an API concrete type.
 func (c *ConfigManager) RegisterMapping(kind string, generator APIObjectGenerator) error {
 	return c.entry.RegisterMapping(kind, generator)
 }
 
-// RegisterProcessors records setters to fill the Config struct from the parsed API objects
+// RegisterProcessors records setters to fill the Config struct from the parsed API objects.
 func (c *ConfigManager) RegisterProcessors(processors ...ParsedProcessor) {
 	c.entry.RegisterProcessors(processors...)
 }
 
-// RegisterValidations records validations for a Config struct
+// RegisterValidations records validations for a Config struct.
 func (c *ConfigManager) RegisterValidations(validations ...Validation) {
 	c.entry.RegisterValidations(validations...)
 }
 
-// RegisterDefaulters records defaults for a Config struct
+// RegisterDefaulters records defaults for a Config struct.
 func (c *ConfigManager) RegisterDefaulters(defaulters ...Defaulter) {
 	c.entry.RegisterDefaulters(defaulters...)
 }
 
-// Parse reads yaml manifest with at least one cluster object and generates the corresponding Config
+// Parse reads yaml manifest with at least one cluster object and generates the corresponding Config.
 func (c *ConfigManager) Parse(yamlManifest []byte) (*Config, error) {
 	parsed, err := c.unmarshal(yamlManifest)
 	if err != nil {
@@ -63,7 +63,7 @@ func (c *ConfigManager) Parse(yamlManifest []byte) (*Config, error) {
 	return c.buildConfigFromParsed(parsed)
 }
 
-// Parse set the registered defaults in a Config struct
+// Parse set the registered defaults in a Config struct.
 func (c *ConfigManager) SetDefaults(config *Config) error {
 	var allErrs []error
 
@@ -81,7 +81,7 @@ func (c *ConfigManager) SetDefaults(config *Config) error {
 	return nil
 }
 
-// Validate performs the registered validations in a Config struct
+// Validate performs the registered validations in a Config struct.
 func (c *ConfigManager) Validate(config *Config) error {
 	var allErrs []error
 
@@ -175,7 +175,7 @@ func (c *ConfigManager) buildConfigFromParsed(p *parsed) (*Config, error) {
 	return config, nil
 }
 
-// machineConfigsProcessor is a helper to generate a ParsedProcessor for all machine configs in a Cluster
+// machineConfigsProcessor is a helper to generate a ParsedProcessor for all machine configs in a Cluster.
 func machineConfigsProcessor(processMachineRef func(c *Config, o ObjectLookup, machineRef *anywherev1.Ref)) ParsedProcessor {
 	return func(c *Config, o ObjectLookup) {
 		for _, m := range c.Cluster.MachineConfigRefs() {

--- a/pkg/cluster/fetch.go
+++ b/pkg/cluster/fetch.go
@@ -26,7 +26,7 @@ type AWSIamConfigFetch func(ctx context.Context, name, namespace string) (*v1alp
 
 // BuildSpec constructs a cluster.Spec for an eks-a cluster by retrieving all
 // necessary objects using fetch methods
-// This is deprecated in favour of BuildSpec
+// This is deprecated in favour of BuildSpec.
 func BuildSpecForCluster(ctx context.Context, cluster *v1alpha1.Cluster, bundlesFetch BundlesFetch, eksdReleaseFetch EksdReleaseFetch, gitOpsFetch GitOpsFetch, fluxConfigFetch FluxConfigFetch, oidcFetch OIDCFetch, awsIamConfigFetch AWSIamConfigFetch) (*Spec, error) {
 	bundles, err := GetBundlesForCluster(ctx, cluster, bundlesFetch)
 	if err != nil {
@@ -178,7 +178,7 @@ func GetAWSIamConfigForCluster(ctx context.Context, cluster *v1alpha1.Cluster, f
 }
 
 // BuildSpec constructs a cluster.Spec for an eks-a cluster by retrieving all
-// necessary objects from the cluster using a kubernetes client
+// necessary objects from the cluster using a kubernetes client.
 func BuildSpec(ctx context.Context, client Client, cluster *v1alpha1.Cluster) (*Spec, error) {
 	configBuilder := NewDefaultConfigClientBuilder()
 	config, err := configBuilder.Build(ctx, client, cluster)

--- a/pkg/cluster/manager_entry.go
+++ b/pkg/cluster/manager_entry.go
@@ -3,13 +3,13 @@ package cluster
 import "fmt"
 
 type (
-	// APIObjectGenerator returns an implementor of the APIObject interface
+	// APIObjectGenerator returns an implementor of the APIObject interface.
 	APIObjectGenerator func() APIObject
-	// ParsedProcessor fills the Config struct from the parsed API objects in ObjectLookup
+	// ParsedProcessor fills the Config struct from the parsed API objects in ObjectLookup.
 	ParsedProcessor func(*Config, ObjectLookup)
-	// Validation performs a validation over the Config object
+	// Validation performs a validation over the Config object.
 	Validation func(*Config) error
-	// Defaulter sets defaults in a Config object
+	// Defaulter sets defaults in a Config object.
 	Defaulter func(*Config) error
 )
 
@@ -24,14 +24,14 @@ type ConfigManagerEntry struct {
 	Defaulters       []Defaulter
 }
 
-// NewConfigManagerEntry builds a ConfigManagerEntry with empty configuration
+// NewConfigManagerEntry builds a ConfigManagerEntry with empty configuration.
 func NewConfigManagerEntry() *ConfigManagerEntry {
 	return &ConfigManagerEntry{
 		APIObjectMapping: map[string]APIObjectGenerator{},
 	}
 }
 
-// Merge combines the configuration declared in multiple ConfigManagerEntry
+// Merge combines the configuration declared in multiple ConfigManagerEntry.
 func (c *ConfigManagerEntry) Merge(entries ...*ConfigManagerEntry) error {
 	for _, config := range entries {
 		for k, v := range config.APIObjectMapping {
@@ -48,7 +48,7 @@ func (c *ConfigManagerEntry) Merge(entries ...*ConfigManagerEntry) error {
 	return nil
 }
 
-// RegisterMapping records the mapping between a kubernetes Kind and an API concrete type
+// RegisterMapping records the mapping between a kubernetes Kind and an API concrete type.
 func (c *ConfigManagerEntry) RegisterMapping(kind string, generator APIObjectGenerator) error {
 	if _, ok := c.APIObjectMapping[kind]; ok {
 		return fmt.Errorf("mapping for api object %s already registered", kind)
@@ -58,17 +58,17 @@ func (c *ConfigManagerEntry) RegisterMapping(kind string, generator APIObjectGen
 	return nil
 }
 
-// RegisterProcessors records setters to fill the Config struct from the parsed API objects
+// RegisterProcessors records setters to fill the Config struct from the parsed API objects.
 func (c *ConfigManagerEntry) RegisterProcessors(processors ...ParsedProcessor) {
 	c.Processors = append(c.Processors, processors...)
 }
 
-// RegisterValidations records validations for a Config struct
+// RegisterValidations records validations for a Config struct.
 func (c *ConfigManagerEntry) RegisterValidations(validations ...Validation) {
 	c.Validations = append(c.Validations, validations...)
 }
 
-// RegisterDefaulters records defaults for a Config struct
+// RegisterDefaulters records defaults for a Config struct.
 func (c *ConfigManagerEntry) RegisterDefaulters(defaulters ...Defaulter) {
 	c.Defaulters = append(c.Defaulters, defaulters...)
 }

--- a/pkg/cluster/parse.go
+++ b/pkg/cluster/parse.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ParseConfig reads yaml file with at least one Cluster object and generates the corresponding Config
-// using the default package config manager
+// using the default package config manager.
 func ParseConfigFromFile(path string) (*Config, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -17,7 +17,7 @@ func ParseConfigFromFile(path string) (*Config, error) {
 }
 
 // ParseConfig reads yaml manifest with at least one Cluster object and generates the corresponding Config
-// using the default package config manager
+// using the default package config manager.
 func ParseConfig(yamlManifest []byte) (*Config, error) {
 	return manager().Parse(yamlManifest)
 }

--- a/pkg/cluster/snow.go
+++ b/pkg/cluster/snow.go
@@ -186,7 +186,7 @@ func getSnowIdentitySecret(ctx context.Context, client Client, c *Config) error 
 
 // SetSnowDatacenterIndentityRefDefault sets a default secret as the identity reference
 // The secret will need to be created by the CLI flow as it's not provided by the user
-// This only runs in CLI. snowDatacenterConfig.SetDefaults() will run in both CLI and webhook
+// This only runs in CLI. snowDatacenterConfig.SetDefaults() will run in both CLI and webhook.
 func SetSnowDatacenterIndentityRefDefault(s *anywherev1.SnowDatacenterConfig) {
 	if len(s.Spec.IdentityRef.Kind) == 0 && len(s.Spec.IdentityRef.Name) == 0 {
 		s.Spec.IdentityRef = anywherev1.Ref{

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -228,7 +228,7 @@ func NewSpecFromClusterConfig(clusterConfigPath string, cliVersion version.Info,
 	return s, nil
 }
 
-// init does the basic initialization with the provided necessary api objects
+// init does the basic initialization with the provided necessary api objects.
 func (s *Spec) init(config *Config, bundles *v1alpha1.Bundles, versionsBundle *v1alpha1.VersionsBundle, eksdRelease *eksdv1alpha1.Release) error {
 	kubeDistro, err := buildKubeDistro(eksdRelease)
 	if err != nil {

--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -74,7 +74,7 @@ func mergeLabels(labels ...map[string]string) map[string]string {
 	return merged
 }
 
-// ClusterName generates the CAPI cluster name for an EKSA Cluster
+// ClusterName generates the CAPI cluster name for an EKSA Cluster.
 func ClusterName(cluster *anywherev1.Cluster) string {
 	return cluster.Name
 }

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -162,7 +162,7 @@ func newApiBuilerTest(t *testing.T) apiBuilerTest {
 	}
 }
 
-// TODO: add unstacked etcd test
+// TODO: add unstacked etcd test.
 func TestCluster(t *testing.T) {
 	tt := newApiBuilerTest(t)
 	got := clusterapi.Cluster(tt.clusterSpec, tt.providerCluster, tt.controlPlane)
@@ -297,7 +297,7 @@ func wantKubeadmControlPlane() *controlplanev1.KubeadmControlPlane {
 	}
 }
 
-// TODO: add unstacked etcd test
+// TODO: add unstacked etcd test.
 func TestKubeadmControlPlane(t *testing.T) {
 	tt := newApiBuilerTest(t)
 	got, err := clusterapi.KubeadmControlPlane(tt.clusterSpec, tt.providerMachineTemplate)

--- a/pkg/clusterapi/controlplane.go
+++ b/pkg/clusterapi/controlplane.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 )
 
-// ControlPlane represents the provider-specific spec for a CAPI control plane using the kubeadm CP provider
+// ControlPlane represents the provider-specific spec for a CAPI control plane using the kubeadm CP provider.
 type ControlPlane[C, M Object] struct {
 	Cluster *clusterv1.Cluster
 
@@ -33,7 +33,7 @@ type ControlPlane[C, M Object] struct {
 	EtcdMachineTemplate M
 }
 
-// Objects returns all API objects that form a concrete provider-specific control plane
+// Objects returns all API objects that form a concrete provider-specific control plane.
 func (cp *ControlPlane[C, M]) Objects() []kubernetes.Object {
 	objs := make([]kubernetes.Object, 0, 4)
 	objs = append(objs, cp.Cluster, cp.KubeadmControlPlane, cp.ProviderCluster, cp.ControlPlaneMachineTemplate)
@@ -47,7 +47,7 @@ func (cp *ControlPlane[C, M]) Objects() []kubernetes.Object {
 // UpdateImmutableObjectNames checks if any control plane immutable objects have changed by comparing the new definition
 // with the current state of the cluster. If they had, it generates a new name for them by increasing a monotonic number
 // at the end of the name
-// This is applied to all provider machine templates
+// This is applied to all provider machine templates.
 func (cp *ControlPlane[C, M]) UpdateImmutableObjectNames(
 	ctx context.Context,
 	client kubernetes.Client,

--- a/pkg/clusterapi/extraargs.go
+++ b/pkg/clusterapi/extraargs.go
@@ -44,7 +44,7 @@ func AwsIamAuthExtraArgs(awsiam *v1alpha1.AWSIamConfig) ExtraArgs {
 }
 
 // FeatureGatesExtraArgs takes a list of features with the value and returns it in the proper format
-// Example FeatureGatesExtraArgs("ServiceLoadBalancerClass=true")
+// Example FeatureGatesExtraArgs("ServiceLoadBalancerClass=true").
 func FeatureGatesExtraArgs(features ...string) ExtraArgs {
 	if len(features) == 0 {
 		return nil
@@ -81,7 +81,7 @@ func ResolvConfExtraArgs(resolvConf *v1alpha1.ResolvConf) ExtraArgs {
 	return args
 }
 
-// We don't need to add these once the Kubernetes components default to using the secure cipher suites
+// We don't need to add these once the Kubernetes components default to using the secure cipher suites.
 func SecureTlsCipherSuitesExtraArgs() ExtraArgs {
 	args := ExtraArgs{}
 	args.AddIfNotEmpty("tls-cipher-suites", crypto.SecureCipherSuitesString())

--- a/pkg/clusterapi/fetch.go
+++ b/pkg/clusterapi/fetch.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/constants"
 )
 
-// KubeClient is a kubernetes API client
+// KubeClient is a kubernetes API client.
 type KubeClient interface {
 	Get(ctx context.Context, name, namespace string, obj kubernetes.Object) error
 }

--- a/pkg/clusterapi/name.go
+++ b/pkg/clusterapi/name.go
@@ -17,18 +17,18 @@ import (
 
 var nameRegex = regexp.MustCompile(`(.*?)(-)(\d+)$`)
 
-// Object represents a kubernetes API object
+// Object represents a kubernetes API object.
 type Object interface {
 	kubernetes.Object
 }
 
 // ObjectComparator returns true only if only both kubernetes Object's are identical
 // Most of the time, this only requires comparing the Spec field, but that can variate
-// from object to object
+// from object to object.
 type ObjectComparator[O Object] func(current, new O) bool
 
 // ObjectRetriever gets a kubernetes API object using the provided client
-// If the object doesn't exist, it returns a NotFound error
+// If the object doesn't exist, it returns a NotFound error.
 type ObjectRetriever[O Object] func(ctx context.Context, client kubernetes.Client, name, namespace string) (O, error)
 
 // IncrementName takes an object name and increments the suffix number by one.
@@ -105,7 +105,7 @@ func WorkerMachineHealthCheckName(clusterSpec *cluster.Spec, workerNodeGroupConf
 	return fmt.Sprintf("%s-worker-unhealthy", MachineDeploymentName(clusterSpec, workerNodeGroupConfig))
 }
 
-// EnsureNewNameIfChanged updates an object's name if such object is different from its current state in the cluster
+// EnsureNewNameIfChanged updates an object's name if such object is different from its current state in the cluster.
 func EnsureNewNameIfChanged[M Object](ctx context.Context,
 	client kubernetes.Client,
 	retrieve ObjectRetriever[M],

--- a/pkg/clusterapi/providers.go
+++ b/pkg/clusterapi/providers.go
@@ -11,7 +11,7 @@ type KubeLister interface {
 	List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
 }
 
-// GetProviders lists all installed CAPI providers across all namespaces from the kube-api server
+// GetProviders lists all installed CAPI providers across all namespaces from the kube-api server.
 func GetProviders(ctx context.Context, client KubeLister) ([]clusterctlv1.Provider, error) {
 	providersList := &clusterctlv1.ProviderList{}
 	err := client.List(ctx, providersList)

--- a/pkg/clusterapi/resourceset_manager.go
+++ b/pkg/clusterapi/resourceset_manager.go
@@ -13,7 +13,7 @@ import (
 
 // ResourceSetManager helps managing capi ClusterResourceSet's
 // It doesn't implement the complete ClusterResourceSet specification so there might be some
-// configurations that are not supported. JsonLists as content in resources are not supported
+// configurations that are not supported. JsonLists as content in resources are not supported.
 type ResourceSetManager struct {
 	client Client
 }

--- a/pkg/clusterapi/workers.go
+++ b/pkg/clusterapi/workers.go
@@ -45,7 +45,7 @@ type WorkerGroup[M Object] struct {
 // with the current state of the cluster. If they had, it generates a new name for them by increasing a monotonic number
 // at the end of the name.
 // This process is performed to the provider machine template and the kubeadmconfigtemplate.
-// The kubeadmconfigtemplate is not immutable at the API level but we treat is a such for consistency
+// The kubeadmconfigtemplate is not immutable at the API level but we treat is a such for consistency.
 func (g *WorkerGroup[M]) UpdateImmutableObjectNames(
 	ctx context.Context,
 	client kubernetes.Client,
@@ -76,7 +76,7 @@ func (g *WorkerGroup[M]) UpdateImmutableObjectNames(
 }
 
 // GetKubeadmConfigTemplate retrieves a KubeadmConfigTemplate using a client
-// Implements ObjectRetriever
+// Implements ObjectRetriever.
 func GetKubeadmConfigTemplate(ctx context.Context, client kubernetes.Client, name, namespace string) (*kubeadmv1.KubeadmConfigTemplate, error) {
 	k := &kubeadmv1.KubeadmConfigTemplate{}
 	if err := client.Get(ctx, name, namespace, k); err != nil {
@@ -88,7 +88,7 @@ func GetKubeadmConfigTemplate(ctx context.Context, client kubernetes.Client, nam
 
 // KubeadmConfigTemplateEqual returns true only if the new version of a KubeadmConfigTemplate
 // involves changes with respect6 to the old one when applied to the cluster
-// Implements ObjectComparator
+// Implements ObjectComparator.
 func KubeadmConfigTemplateEqual(new, old *kubeadmv1.KubeadmConfigTemplate) bool {
 	// DeepDerivative treats empty map (length == 0) as unset field. We need to manually compare certain fields
 	// such as taints, so that setting it to empty will trigger machine recreate

--- a/pkg/clusterapi/yaml/controlplane.go
+++ b/pkg/clusterapi/yaml/controlplane.go
@@ -14,7 +14,7 @@ import (
 // NewControlPlaneParserAndBuilder builds a Parser and a Builder for a particular provider ControlPlane
 // It registers the basic shared mappings plus another two for the provider cluster and machine template
 // For ControlPlane that need to include more objects, wrap around the provider builder and implement BuildFromParsed
-// Any extra mappings will need to be registered manually in the Parser
+// Any extra mappings will need to be registered manually in the Parser.
 func NewControlPlaneParserAndBuilder[C, M clusterapi.Object](logger logr.Logger, clusterMapping yamlutil.Mapping[C], machineTemplateMapping yamlutil.Mapping[M]) (*yamlutil.Parser, *ControlPlaneBuilder[C, M], error) {
 	parser := yamlutil.NewParser(logger)
 	if err := RegisterControlPlaneMappings(parser); err != nil {
@@ -33,7 +33,7 @@ func NewControlPlaneParserAndBuilder[C, M clusterapi.Object](logger logr.Logger,
 }
 
 // RegisterControlPlaneMappings records the basic mappings for CAPI cluster, kubeadmcontrolplane
-// and etcdadm cluster in a Parser
+// and etcdadm cluster in a Parser.
 func RegisterControlPlaneMappings(parser *yamlutil.Parser) error {
 	err := parser.RegisterMappings(
 		yamlutil.NewMapping(
@@ -60,7 +60,7 @@ func RegisterControlPlaneMappings(parser *yamlutil.Parser) error {
 }
 
 // ControlPlaneBuilder implements yamlutil.Builder
-// It's a wrapper around ControlPlane to provide yaml parsing functionality
+// It's a wrapper around ControlPlane to provide yaml parsing functionality.
 type ControlPlaneBuilder[C, M clusterapi.Object] struct {
 	ControlPlane *clusterapi.ControlPlane[C, M]
 }
@@ -71,13 +71,13 @@ func NewControlPlaneBuilder[C, M clusterapi.Object]() *ControlPlaneBuilder[C, M]
 	}
 }
 
-// BuildFromParsed reads parsed objects in ObjectLookup and sets them in the ControlPlane
+// BuildFromParsed reads parsed objects in ObjectLookup and sets them in the ControlPlane.
 func (cp *ControlPlaneBuilder[C, M]) BuildFromParsed(lookup yamlutil.ObjectLookup) error {
 	ProcessControlPlaneObjects(cp.ControlPlane, lookup)
 	return nil
 }
 
-// ProcessControlPlaneObjects finds all necessary objects in the parsed objects and sets them in the ControlPlane
+// ProcessControlPlaneObjects finds all necessary objects in the parsed objects and sets them in the ControlPlane.
 func ProcessControlPlaneObjects[C, M clusterapi.Object](cp *clusterapi.ControlPlane[C, M], lookup yamlutil.ObjectLookup) {
 	ProcessCluster(cp, lookup)
 	if cp.Cluster == nil {
@@ -89,7 +89,7 @@ func ProcessControlPlaneObjects[C, M clusterapi.Object](cp *clusterapi.ControlPl
 	ProcessEtcdCluster(cp, lookup)
 }
 
-// ProcessCluster finds the CAPI cluster in the parsed objects and sets it in ControlPlane
+// ProcessCluster finds the CAPI cluster in the parsed objects and sets it in ControlPlane.
 func ProcessCluster[C, M clusterapi.Object](cp *clusterapi.ControlPlane[C, M], lookup yamlutil.ObjectLookup) {
 	for _, obj := range lookup {
 		if obj.GetObjectKind().GroupVersionKind().Kind == "Cluster" {
@@ -99,7 +99,7 @@ func ProcessCluster[C, M clusterapi.Object](cp *clusterapi.ControlPlane[C, M], l
 	}
 }
 
-// ProcessCluster finds the provider cluster in the parsed objects and sets it in ControlPlane
+// ProcessCluster finds the provider cluster in the parsed objects and sets it in ControlPlane.
 func ProcessProviderCluster[C, M clusterapi.Object](cp *clusterapi.ControlPlane[C, M], lookup yamlutil.ObjectLookup) {
 	providerCluster := lookup.GetFromRef(*cp.Cluster.Spec.InfrastructureRef)
 	if providerCluster == nil {
@@ -110,7 +110,7 @@ func ProcessProviderCluster[C, M clusterapi.Object](cp *clusterapi.ControlPlane[
 }
 
 // ProcessKubeadmControlPlane finds the CAPI kubeadm control plane and the kubeadm control plane machine template
-// in the parsed objects and sets it in ControlPlane
+// in the parsed objects and sets it in ControlPlane.
 func ProcessKubeadmControlPlane[C, M clusterapi.Object](cp *clusterapi.ControlPlane[C, M], lookup yamlutil.ObjectLookup) {
 	kcp := lookup.GetFromRef(*cp.Cluster.Spec.ControlPlaneRef)
 	if kcp == nil {
@@ -127,7 +127,7 @@ func ProcessKubeadmControlPlane[C, M clusterapi.Object](cp *clusterapi.ControlPl
 	cp.ControlPlaneMachineTemplate = machineTemplate.(M)
 }
 
-// ProcessEtcdCluster finds the CAPI etcdadm cluster (for unstacked clusters) in the parsed objects and sets it in ControlPlane
+// ProcessEtcdCluster finds the CAPI etcdadm cluster (for unstacked clusters) in the parsed objects and sets it in ControlPlane.
 func ProcessEtcdCluster[C, M clusterapi.Object](cp *clusterapi.ControlPlane[C, M], lookup yamlutil.ObjectLookup) {
 	if cp.Cluster.Spec.ManagedExternalEtcdRef == nil {
 		return

--- a/pkg/clusterapi/yaml/workers.go
+++ b/pkg/clusterapi/yaml/workers.go
@@ -13,7 +13,7 @@ import (
 const machineDeploymentKind = "MachineDeployment"
 
 // WorkersBuilder implements yamlutil.Builder
-// It's a wrapper around Workers to provide yaml parsing functionality
+// It's a wrapper around Workers to provide yaml parsing functionality.
 type WorkersBuilder[M clusterapi.Object] struct {
 	Workers *clusterapi.Workers[M]
 }
@@ -24,7 +24,7 @@ func NewWorkersBuilder[M clusterapi.Object]() *WorkersBuilder[M] {
 	}
 }
 
-// BuildFromParsed reads parsed objects in ObjectLookup and sets them in the Workers
+// BuildFromParsed reads parsed objects in ObjectLookup and sets them in the Workers.
 func (cp *WorkersBuilder[M]) BuildFromParsed(lookup yamlutil.ObjectLookup) error {
 	ProcessWorkerObjects(cp.Workers, lookup)
 	return nil
@@ -34,7 +34,7 @@ func (cp *WorkersBuilder[M]) BuildFromParsed(lookup yamlutil.ObjectLookup) error
 // It registers the basic shared mappings plus another one for the provider machine template
 // For worker specs that need to include more objects, wrap around the provider builder and
 // implement BuildFromParsed.
-// Any extra mappings will need to be registered manually in the Parser
+// Any extra mappings will need to be registered manually in the Parser.
 func NewWorkersParserAndBuilder[M clusterapi.Object](
 	logger logr.Logger,
 	machineTemplateMapping yamlutil.Mapping[M],
@@ -55,7 +55,7 @@ func NewWorkersParserAndBuilder[M clusterapi.Object](
 }
 
 // RegisterWorkerMappings records the basic mappings for CAPI MachineDeployment
-// and KubeadmConfigTemplate in a Parser
+// and KubeadmConfigTemplate in a Parser.
 func RegisterWorkerMappings(parser *yamlutil.Parser) error {
 	err := parser.RegisterMappings(
 		yamlutil.NewMapping(
@@ -76,7 +76,7 @@ func RegisterWorkerMappings(parser *yamlutil.Parser) error {
 	return nil
 }
 
-// ProcessWorkerObjects finds all necessary objects in the parsed objects and sets them in Workers
+// ProcessWorkerObjects finds all necessary objects in the parsed objects and sets them in Workers.
 func ProcessWorkerObjects[M clusterapi.Object](w *clusterapi.Workers[M], lookup yamlutil.ObjectLookup) {
 	for _, obj := range lookup {
 		if obj.GetObjectKind().GroupVersionKind().Kind == machineDeploymentKind {
@@ -90,7 +90,7 @@ func ProcessWorkerObjects[M clusterapi.Object](w *clusterapi.Workers[M], lookup 
 
 // ProcessWorkerGroupObjects looks in the parsed objects for the KubeadmConfigTemplate and
 // the provider machine template referenced in the MachineDeployment and sets them in the WorkerGroup.
-// MachineDeployment needs to be already set in the WorkerGroup
+// MachineDeployment needs to be already set in the WorkerGroup.
 func ProcessWorkerGroupObjects[M clusterapi.Object](g *clusterapi.WorkerGroup[M], lookup yamlutil.ObjectLookup) {
 	kubeadmConfigTemplate := lookup.GetFromRef(*g.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef)
 	if kubeadmConfigTemplate != nil {

--- a/pkg/controller/clientutil/kubernetes.go
+++ b/pkg/controller/clientutil/kubernetes.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Kubeclient implements kubernetes.Client interface using a
-// client.Client as the underlying implementation
+// client.Client as the underlying implementation.
 type KubeClient struct {
 	client client.Client
 }

--- a/pkg/controller/clusterapi.go
+++ b/pkg/controller/clusterapi.go
@@ -14,7 +14,7 @@ import (
 )
 
 // GetCAPICluster reads a cluster-api Cluster for an eks-a cluster using a kube client
-// If the CAPI cluster is not found, the method returns (nil, nil)
+// If the CAPI cluster is not found, the method returns (nil, nil).
 func GetCAPICluster(ctx context.Context, client client.Client, cluster *anywherev1.Cluster) (*clusterv1.Cluster, error) {
 	capiClusterName := clusterapi.ClusterName(cluster)
 
@@ -33,7 +33,7 @@ func GetCAPICluster(ctx context.Context, client client.Client, cluster *anywhere
 }
 
 // CapiClusterObjectKey generates an ObjectKey for the CAPI cluster owned by
-// the provided eks-a cluster
+// the provided eks-a cluster.
 func CapiClusterObjectKey(cluster *anywherev1.Cluster) client.ObjectKey {
 	// TODO: we should consider storing a reference to the CAPI cluster in the eksa cluster status
 	return client.ObjectKey{

--- a/pkg/controller/clusters/clusterapi.go
+++ b/pkg/controller/clusters/clusterapi.go
@@ -16,7 +16,7 @@ import (
 // CheckControlPlaneReady is a controller helper to check whether a CAPI cluster CP for
 // an eks-a cluster is ready or not. This is intended to be used from cluster reconcilers
 // due its signature and that it returns controller results with appropriate wait times whenever
-// the cluster is not ready
+// the cluster is not ready.
 func CheckControlPlaneReady(ctx context.Context, client client.Client, log logr.Logger, cluster *anywherev1.Cluster) (controller.Result, error) {
 	capiCluster, err := controller.GetCAPICluster(ctx, client, cluster)
 	if err != nil {

--- a/pkg/controller/clusters/registry.go
+++ b/pkg/controller/clusters/registry.go
@@ -14,7 +14,7 @@ type ProviderClusterReconciler interface {
 }
 
 // ProviderClusterReconcilerRegistry holds a collection of cluster provider reconcilers
-// and ties them to different provider Datacenter kinds
+// and ties them to different provider Datacenter kinds.
 type ProviderClusterReconcilerRegistry struct {
 	reconcilers map[string]ProviderClusterReconciler
 }
@@ -29,30 +29,30 @@ func (r *ProviderClusterReconcilerRegistry) add(datacenterKind string, reconcile
 	r.reconcilers[datacenterKind] = reconciler
 }
 
-// Get returns ProviderClusterReconciler for a particular Datacenter kind
+// Get returns ProviderClusterReconciler for a particular Datacenter kind.
 func (r *ProviderClusterReconcilerRegistry) Get(datacenterKind string) ProviderClusterReconciler {
 	return r.reconcilers[datacenterKind]
 }
 
-// ProviderClusterReconcilerRegistryBuilder builds ProviderClusterReconcilerRegistry's
+// ProviderClusterReconcilerRegistryBuilder builds ProviderClusterReconcilerRegistry's.
 type ProviderClusterReconcilerRegistryBuilder struct {
 	reconciler ProviderClusterReconcilerRegistry
 }
 
-// NewProviderClusterReconcilerRegistryBuilder returns a new empty ProviderClusterReconcilerRegistryBuilder
+// NewProviderClusterReconcilerRegistryBuilder returns a new empty ProviderClusterReconcilerRegistryBuilder.
 func NewProviderClusterReconcilerRegistryBuilder() *ProviderClusterReconcilerRegistryBuilder {
 	return &ProviderClusterReconcilerRegistryBuilder{
 		reconciler: newClusterReconcilerRegistry(),
 	}
 }
 
-// Add accumulates a pair of datacenter kind a reconciler to be included in the final registry
+// Add accumulates a pair of datacenter kind a reconciler to be included in the final registry.
 func (b *ProviderClusterReconcilerRegistryBuilder) Add(datacenterKind string, reconciler ProviderClusterReconciler) *ProviderClusterReconcilerRegistryBuilder {
 	b.reconciler.add(datacenterKind, reconciler)
 	return b
 }
 
-// Build returns a registry with all the previously added reconcilers
+// Build returns a registry with all the previously added reconcilers.
 func (b *ProviderClusterReconcilerRegistryBuilder) Build() ProviderClusterReconcilerRegistry {
 	r := b.reconciler
 	b.reconciler = newClusterReconcilerRegistry()

--- a/pkg/controller/handlers/capiobjects.go
+++ b/pkg/controller/handlers/capiobjects.go
@@ -13,7 +13,7 @@ import (
 )
 
 // CAPIObjectToCluster returns a request handler that enqueues an EKS-A Cluster
-// reconcile request for CAPI objects that contain the cluster name and namespace labels
+// reconcile request for CAPI objects that contain the cluster name and namespace labels.
 func CAPIObjectToCluster(log logr.Logger) handler.MapFunc {
 	return func(o client.Object) []reconcile.Request {
 		labels := o.GetLabels()

--- a/pkg/controller/result.go
+++ b/pkg/controller/result.go
@@ -8,12 +8,12 @@ import (
 
 // Result represents the result of a reconciliation
 // It allows to express intent for a reconciliation interruption
-// without necessarily requeueing the request
+// without necessarily requeueing the request.
 type Result struct {
 	Result *ctrl.Result
 }
 
-// ToCtrlResult converts Result to a controller-runtime result
+// ToCtrlResult converts Result to a controller-runtime result.
 func (r Result) ToCtrlResult() ctrl.Result {
 	if r.Result == nil {
 		return ctrl.Result{}
@@ -23,19 +23,19 @@ func (r Result) ToCtrlResult() ctrl.Result {
 }
 
 // Return evaluates the intent of a Result to interrupt the reconciliation
-// process or not
+// process or not.
 func (r *Result) Return() bool {
 	return r.Result != nil
 }
 
 // ResultWithReturn creates a new Result that interrupts the reconciliation
-// without requeueing
+// without requeueing.
 func ResultWithReturn() Result {
 	return Result{Result: &ctrl.Result{}}
 }
 
 // ResultWithReturn creates a new Result that requeues the request after
-// the provided duration
+// the provided duration.
 func ResultWithRequeue(after time.Duration) Result {
 	return Result{Result: &ctrl.Result{RequeueAfter: after}}
 }

--- a/pkg/controller/runner.go
+++ b/pkg/controller/runner.go
@@ -8,27 +8,27 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 )
 
-// Phase represents a generic reconciliation phase for a cluster spec
+// Phase represents a generic reconciliation phase for a cluster spec.
 type Phase func(ctx context.Context, log logr.Logger, clusterSpec *cluster.Spec) (Result, error)
 
-// PhaseRunner allows to execute Phases in order
+// PhaseRunner allows to execute Phases in order.
 type PhaseRunner struct {
 	phases []Phase
 }
 
-// NewPhaseRunner creates a new PhaseRunner without any Phases
+// NewPhaseRunner creates a new PhaseRunner without any Phases.
 func NewPhaseRunner() PhaseRunner {
 	return PhaseRunner{}
 }
 
-// Register adds a phase to the runnner
+// Register adds a phase to the runnner.
 func (r PhaseRunner) Register(phases ...Phase) PhaseRunner {
 	r.phases = append(r.phases, phases...)
 	return r
 }
 
 // Run will execute phases in the order they were registered until a phase
-// returns an error or a Result that requests to an interruption
+// returns an error or a Result that requests to an interruption.
 func (r PhaseRunner) Run(ctx context.Context, log logr.Logger, clusterSpec *cluster.Spec) (Result, error) {
 	for _, p := range r.phases {
 		if r, err := p(ctx, log, clusterSpec); r.Return() {

--- a/pkg/controller/serverside/applier.go
+++ b/pkg/controller/serverside/applier.go
@@ -12,12 +12,12 @@ import (
 
 type ObjectGenerator func() ([]kubernetes.Object, error)
 
-// ObjectApplier helps reconcile kubernetes object using server side apply
+// ObjectApplier helps reconcile kubernetes object using server side apply.
 type ObjectApplier struct {
 	client client.Client
 }
 
-// NewObjectApplier builds a ObjectApplier
+// NewObjectApplier builds a ObjectApplier.
 func NewObjectApplier(client client.Client) *ObjectApplier {
 	return &ObjectApplier{
 		client: client,
@@ -27,7 +27,7 @@ func NewObjectApplier(client client.Client) *ObjectApplier {
 // Apply uses server side apply to reconcile kubernetes objects returned by a generator
 // Useful in reconcilers because it simplifies the reconciliation when generating API
 // objects from another package, like a provider
-// This is mostly a helper for generate objects + serverside apply
+// This is mostly a helper for generate objects + serverside apply.
 func (a *ObjectApplier) Apply(ctx context.Context, generateObjects ObjectGenerator) (controller.Result, error) {
 	return controller.Result{}, reconcileKubernetesObjects(ctx, a.client, generateObjects)
 }

--- a/pkg/crypto/validator.go
+++ b/pkg/crypto/validator.go
@@ -35,7 +35,7 @@ func (tv *DefaultTlsValidator) IsSignedByUnknownAuthority(host, port string) (bo
 	return false, nil
 }
 
-// ValidateCert parses the cert, ensures that the cert format is valid and verifies that the cert is valid for the url
+// ValidateCert parses the cert, ensures that the cert format is valid and verifies that the cert is valid for the url.
 func (tv *DefaultTlsValidator) ValidateCert(host, port, caCertContent string) error {
 	// Validates that the cert format is valid
 	block, _ := pem.Decode([]byte(caCertContent))

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -209,7 +209,7 @@ func (f *Factory) UseExecutableImage(image string) *Factory {
 // from the Bundle and using the first VersionsBundle
 // This is just the default for when there is not an specific kubernetes version available
 // For commands that receive a cluster config file or a kubernetes version directly as input,
-// use UseExecutableImage to specify the image directly
+// use UseExecutableImage to specify the image directly.
 func (f *Factory) WithExecutableImage() *Factory {
 	f.WithManifestReader()
 
@@ -242,7 +242,7 @@ func (f *Factory) WithLocalExecutables() *Factory {
 
 // UseExecutablesDockerClient forces a specific DockerClient to build
 // Executables as opposed to follow the normal building flow
-// This is only for testing
+// This is only for testing.
 func (f *Factory) UseExecutablesDockerClient(client executables.DockerClient) *Factory {
 	f.executablesConfig.dockerClient = client
 	return f

--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -214,7 +214,7 @@ func (a *analyzerFactory) eksaDockerAnalyzers() []*Analyze {
 }
 
 // EksaLogTextAnalyzers given a slice of Collectors will check which namespaced log collectors are present
-// and return the log analyzers associated with the namespace in the namespaceLogTextAnalyzersMap
+// and return the log analyzers associated with the namespace in the namespaceLogTextAnalyzersMap.
 func (a *analyzerFactory) EksaLogTextAnalyzers(collectors []*Collect) []*Analyze {
 	var analyzers []*Analyze
 	analyzersMap := a.namespaceLogTextAnalyzersMap()
@@ -335,13 +335,13 @@ func (a *analyzerFactory) crdAnalyzer(crdName string) *Analyze {
 	}
 }
 
-// vsphereDiagnosticAnalyzers will return diagnostic analyzers to analyze the condition of vSphere cluster
+// vsphereDiagnosticAnalyzers will return diagnostic analyzers to analyze the condition of vSphere cluster.
 func (a *analyzerFactory) vsphereDiagnosticAnalyzers() []*Analyze {
 	return []*Analyze{a.validControlPlaneIPAnalyzer(), a.vcenterSessionValidatePermissionAnalyzer()}
 }
 
 // validControlPlaneIPAnalyzer analyzes whether a valid control plane IP is used to connect
-// to API server
+// to API server.
 func (a *analyzerFactory) validControlPlaneIPAnalyzer() *Analyze {
 	runPingPod := "ping-host-ip"
 	runPingPodLog := fmt.Sprintf("%s.log", runPingPod)
@@ -373,7 +373,7 @@ func (a *analyzerFactory) validControlPlaneIPAnalyzer() *Analyze {
 }
 
 // vcenterSessionValidateAnalyzer analyzes whether the vcenter user has Session validate permissions for CAPV
-// to be able to look up existing valid sessions to reuse them instead of having to create new ones
+// to be able to look up existing valid sessions to reuse them instead of having to create new ones.
 func (a *analyzerFactory) vcenterSessionValidatePermissionAnalyzer() *Analyze {
 	capvManagerPod := "capv-controller-manager-*"
 	capvManagerContainerLogFile := capvManagerPod + ".log"

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -412,7 +412,7 @@ func (c *collectorFactory) crdCollector(crdType string) *Collect {
 	}
 }
 
-// apiServerCollectors collect connection info when running a pod on an existing cluster
+// apiServerCollectors collect connection info when running a pod on an existing cluster.
 func (c *collectorFactory) apiServerCollectors(controlPlaneIP string) []*Collect {
 	var collectors []*Collect
 	collectors = append(collectors, c.controlPlaneNetworkPathCollector(controlPlaneIP)...)
@@ -470,7 +470,7 @@ func (c *collectorFactory) pingHostCollector(hostIP string) *Collect {
 }
 
 // vmsAccessCollector will connect to API server first, then collect vsphere-cloud-controller-manager logs
-// on control plane node
+// on control plane node.
 func (c *collectorFactory) vmsAccessCollector(controlPlaneConfiguration v1alpha1.ControlPlaneConfiguration) *Collect {
 	controlPlaneEndpointHost := controlPlaneConfiguration.Endpoint.Host
 	taints := controlPlaneConfiguration.Taints

--- a/pkg/diagnostics/diagnostic_bundle.go
+++ b/pkg/diagnostics/diagnostic_bundle.go
@@ -306,7 +306,7 @@ func (e *EksaDiagnosticBundle) WithLogTextAnalyzers() *EksaDiagnosticBundle {
 // createDiagnosticNamespace attempts to create the namespace eksa-diagnostics and associated RBAC objects.
 // collector pods, for example host log collectors or run command collectors, will be launched in this namespace with the default service account.
 // this method intentionally does not return an error
-// a cluster in need of diagnosis may be unable to create new API objects and we should not stop our collection/analysis just because the namespace fails to create
+// a cluster in need of diagnosis may be unable to create new API objects and we should not stop our collection/analysis just because the namespace fails to create.
 func (e *EksaDiagnosticBundle) createDiagnosticNamespaceAndRoles(ctx context.Context) {
 	targetCluster := &types.Cluster{
 		KubeconfigFile: e.kubeconfig,

--- a/pkg/docker/file.go
+++ b/pkg/docker/file.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ImageDiskSource implements the ImageSource interface, loading images and tags from
-// a tarbal into the local docker cache
+// a tarbal into the local docker cache.
 type ImageDiskSource struct {
 	client ImageDiskLoader
 	file   string
@@ -20,14 +20,14 @@ func NewDiskSource(client ImageDiskLoader, file string) *ImageDiskSource {
 	}
 }
 
-// Load reads images and tags from a tarbal into the local docker cache
+// Load reads images and tags from a tarbal into the local docker cache.
 func (s *ImageDiskSource) Load(ctx context.Context, images ...string) error {
 	logger.Info("Loading images from disk")
 	return s.client.LoadFromFile(ctx, s.file)
 }
 
 // ImageDiskDestination implements the ImageDestination interface, writing images and tags from
-// from the local docker cache into a tarbal
+// from the local docker cache into a tarbal.
 type ImageDiskDestination struct {
 	client ImageDiskWriter
 	file   string
@@ -40,7 +40,7 @@ func NewDiskDestination(client ImageDiskWriter, file string) *ImageDiskDestinati
 	}
 }
 
-// Write creates a tarball including images and tags from the the local docker cache
+// Write creates a tarball including images and tags from the the local docker cache.
 func (s *ImageDiskDestination) Write(ctx context.Context, images ...string) error {
 	logger.Info("Writing images to disk")
 	return s.client.SaveToFile(ctx, s.file, images...)

--- a/pkg/docker/mover.go
+++ b/pkg/docker/mover.go
@@ -32,18 +32,18 @@ type DockerClient interface {
 }
 
 // ImageSource represents a generic source for container images that can be loaded
-// into the local docker cache
+// into the local docker cache.
 type ImageSource interface {
 	Load(ctx context.Context, images ...string) error
 }
 
 // ImageDestination represents a generic destination for container images that
-// can be written from the local docker cache
+// can be written from the local docker cache.
 type ImageDestination interface {
 	Write(ctx context.Context, images ...string) error
 }
 
-// ImageMover orchestrates loading images from a source and writing them to a destination
+// ImageMover orchestrates loading images from a source and writing them to a destination.
 type ImageMover struct {
 	source      ImageSource
 	destination ImageDestination
@@ -56,7 +56,7 @@ func NewImageMover(source ImageSource, destination ImageDestination) *ImageMover
 	}
 }
 
-// Move loads images from source and writes them to the destination
+// Move loads images from source and writes them to the destination.
 func (m *ImageMover) Move(ctx context.Context, images ...string) error {
 	uniqueImages := removesDuplicates(images)
 

--- a/pkg/docker/registry.go
+++ b/pkg/docker/registry.go
@@ -11,7 +11,7 @@ import (
 
 // These constants are temporary since currently there is a limitation on harbor
 // Harbor requires root level projects but curated packages private account currently
-// doesn't have support for root level
+// doesn't have support for root level.
 const (
 	packageProdDomain = "783794618700.dkr.ecr.us-west-2.amazonaws.com"
 	packageDevDomain  = "857151390494.dkr.ecr.us-west-2.amazonaws.com"
@@ -20,7 +20,7 @@ const (
 )
 
 // ImageRegistryDestination implements the ImageDestination interface, writing images and tags from
-// from the local docker cache to an external registry
+// from the local docker cache to an external registry.
 type ImageRegistryDestination struct {
 	client    ImageTaggerPusher
 	endpoint  string
@@ -35,7 +35,7 @@ func NewRegistryDestination(client ImageTaggerPusher, registryEndpoint string) *
 	}
 }
 
-// Write pushes images and tags from from the local docker cache to an external registry
+// Write pushes images and tags from from the local docker cache to an external registry.
 func (d *ImageRegistryDestination) Write(ctx context.Context, images ...string) error {
 	logger.Info("Writing images to registry")
 	logger.V(3).Info("Starting registry write", "numberOfImages", len(images))
@@ -60,7 +60,7 @@ func (d *ImageRegistryDestination) Write(ctx context.Context, images ...string) 
 }
 
 // ImageOriginalRegistrySource implements the ImageSource interface, pulling images and tags from
-// their original registry into the local docker cache
+// their original registry into the local docker cache.
 type ImageOriginalRegistrySource struct {
 	client    ImagePuller
 	processor *ConcurrentImageProcessor
@@ -73,7 +73,7 @@ func NewOriginalRegistrySource(client ImagePuller) *ImageOriginalRegistrySource 
 	}
 }
 
-// Load pulls images and tags from their original registry into the local docker cache
+// Load pulls images and tags from their original registry into the local docker cache.
 func (s *ImageOriginalRegistrySource) Load(ctx context.Context, images ...string) error {
 	logger.Info("Pulling images from origin, this might take a while")
 	logger.V(3).Info("Starting pull", "numberOfImages", len(images))
@@ -93,7 +93,7 @@ func (s *ImageOriginalRegistrySource) Load(ctx context.Context, images ...string
 }
 
 // Currently private curated packages don't have a root level project
-// This method adds a root level projectName to the endpoint
+// This method adds a root level projectName to the endpoint.
 func getUpdatedEndpoint(originalEndpoint, image string) string {
 	if strings.Contains(image, packageDevDomain) {
 		return originalEndpoint + "/" + publicDevECRName
@@ -106,7 +106,7 @@ func getUpdatedEndpoint(originalEndpoint, image string) string {
 
 // Curated packages are currently referenced by digest
 // Docker doesn't support tagging images with digest
-// This method extracts any @ in the image tag
+// This method extracts any @ in the image tag.
 func removeDigestReference(image string) string {
 	imageSplit := strings.Split(image, "@")
 	if len(imageSplit) < 2 {

--- a/pkg/eksd/installer.go
+++ b/pkg/eksd/installer.go
@@ -69,7 +69,7 @@ func (i *Installer) InstallEksdCRDs(ctx context.Context, clusterSpec *cluster.Sp
 }
 
 // SetRetrier allows to modify the internal retrier
-// For unit testing purposes only. It is not thread safe
+// For unit testing purposes only. It is not thread safe.
 func (i *Installer) SetRetrier(retrier *retrier.Retrier) {
 	i.retrier = retrier
 }

--- a/pkg/executables/builder.go
+++ b/pkg/executables/builder.go
@@ -70,7 +70,7 @@ func (b *ExecutablesBuilder) BuildHelmExecutable(opts ...HelmOpt) *Helm {
 
 // Init initializes the executable builder and returns a Closer
 // that needs to be called once the executables are not in used anymore
-// The closer will cleanup and free all internal resources
+// The closer will cleanup and free all internal resources.
 func (b *ExecutablesBuilder) Init(ctx context.Context) (Closer, error) {
 	return b.executableBuilder.Init(ctx)
 }
@@ -89,7 +89,7 @@ func BuildDockerExecutable() *Docker {
 
 // RunExecutablesInDocker determines if binary executables should be ran
 // from a docker container or native binaries from the host path
-// It reads MR_TOOLS_DISABLE variable
+// It reads MR_TOOLS_DISABLE variable.
 func ExecutablesInDocker() bool {
 	if env, ok := os.LookupEnv("MR_TOOLS_DISABLE"); ok && strings.EqualFold(env, "true") {
 		logger.Info("Warning: eks-a tools image disabled, using client's executables")
@@ -99,7 +99,7 @@ func ExecutablesInDocker() bool {
 }
 
 // InitInDockerExecutablesBuilder builds and inits a default ExecutablesBuilder to run executables in a docker container
-// that will make use of a long running docker container
+// that will make use of a long running docker container.
 func InitInDockerExecutablesBuilder(ctx context.Context, image string, mountDirs ...string) (*ExecutablesBuilder, Closer, error) {
 	b, err := NewInDockerExecutablesBuilder(BuildDockerExecutable(), image, mountDirs...)
 	if err != nil {
@@ -114,7 +114,7 @@ func InitInDockerExecutablesBuilder(ctx context.Context, image string, mountDirs
 	return b, closer, nil
 }
 
-// NewInDockerExecutablesBuilder builds an executables builder for docker
+// NewInDockerExecutablesBuilder builds an executables builder for docker.
 func NewInDockerExecutablesBuilder(dockerClient DockerClient, image string, mountDirs ...string) (*ExecutablesBuilder, error) {
 	currentDir, err := os.Getwd()
 	if err != nil {
@@ -138,13 +138,13 @@ func DefaultEksaImage() string {
 
 type Closer func(ctx context.Context) error
 
-// Close implements interface types.Closer
+// Close implements interface types.Closer.
 func (c Closer) Close(ctx context.Context) error {
 	return c(ctx)
 }
 
 // CheckErr just calls the closer and logs an error if present
-// It's mostly a helper for defering the close in a oneliner without ignoring the error
+// It's mostly a helper for defering the close in a oneliner without ignoring the error.
 func (c Closer) CheckErr(ctx context.Context) {
 	if err := c(ctx); err != nil {
 		logger.Error(err, "Failed closing container for executables")

--- a/pkg/executables/cmk.go
+++ b/pkg/executables/cmk.go
@@ -30,7 +30,7 @@ const (
 	domainDelimiter                   = "/"
 )
 
-// Cmk this struct wraps around the CloudMonkey executable CLI to perform operations against a CloudStack endpoint
+// Cmk this struct wraps around the CloudMonkey executable CLI to perform operations against a CloudStack endpoint.
 type Cmk struct {
 	writer     filewriter.FileWriter
 	executable Executable
@@ -359,7 +359,7 @@ func (c *Cmk) GetManagementApiEndpoint(profile string) (string, error) {
 	return "", fmt.Errorf("profile %s does not exist", profile)
 }
 
-// ValidateCloudStackConnection Calls `cmk sync` to ensure that the endpoint and credentials + domain are valid
+// ValidateCloudStackConnection Calls `cmk sync` to ensure that the endpoint and credentials + domain are valid.
 func (c *Cmk) ValidateCloudStackConnection(ctx context.Context, profile string) error {
 	command := newCmkCommand("sync")
 	buffer, err := c.exec(ctx, profile, command...)

--- a/pkg/executables/docker.go
+++ b/pkg/executables/docker.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Temporary: Curated packages dev and prod accounts are currently hard coded
-// This is because there is no mechanism to extract these values as of now
+// This is because there is no mechanism to extract these values as of now.
 const (
 	dockerPath        = "docker"
 	defaultRegistry   = "public.ecr.aws"
@@ -152,7 +152,7 @@ func (d *Docker) ForceRemove(ctx context.Context, name string) error {
 }
 
 // CheckContainerExistence checks whether a Docker container with the provided name exists
-// It returns true if a container with the name exists, false if it doesn't and an error if it encounters some other error
+// It returns true if a container with the name exists, false if it doesn't and an error if it encounters some other error.
 func (d *Docker) CheckContainerExistence(ctx context.Context, name string) (bool, error) {
 	params := []string{"container", "inspect", name}
 

--- a/pkg/executables/dockerlinux.go
+++ b/pkg/executables/dockerlinux.go
@@ -14,7 +14,7 @@ type linuxDockerExecutable struct {
 }
 
 // This currently returns a linuxDockerExecutable, but if we support other types of docker executables we can change
-// the name of this constructor
+// the name of this constructor.
 func NewDockerExecutable(cli string, containerName string) Executable {
 	return &linuxDockerExecutable{
 		cli:           cli,

--- a/pkg/executables/executables.go
+++ b/pkg/executables/executables.go
@@ -49,7 +49,7 @@ type Executable interface {
 	Run(cmd *Command) (stdout bytes.Buffer, err error)
 }
 
-// this should only be called through the executables.builder
+// this should only be called through the executables.builder.
 func NewExecutable(cli string) Executable {
 	return &executable{
 		cli: cli,

--- a/pkg/executables/helm.go
+++ b/pkg/executables/helm.go
@@ -37,7 +37,7 @@ func WithInsecure() HelmOpt {
 	}
 }
 
-// join the default and the provided maps together
+// join the default and the provided maps together.
 func WithEnv(env map[string]string) HelmOpt {
 	return func(h *Helm) {
 		for k, v := range env {
@@ -138,7 +138,7 @@ func (h *Helm) InstallChart(ctx context.Context, chart, ociURI, version, kubecon
 }
 
 // InstallChartWithValuesFile installs a helm chart with the provided values file and waits for the chart deployment to be ready
-// The default timeout for the chart to reach ready state is 5m
+// The default timeout for the chart to reach ready state is 5m.
 func (h *Helm) InstallChartWithValuesFile(ctx context.Context, chart, ociURI, version, kubeconfigFilePath, valuesFilePath string) error {
 	params := []string{"install", chart, ociURI, "--version", version, "--values", valuesFilePath, "--kubeconfig", kubeconfigFilePath, "--wait"}
 	params = h.addInsecureFlagIfProvided(params)

--- a/pkg/executables/kind.go
+++ b/pkg/executables/kind.go
@@ -36,7 +36,7 @@ type Kind struct {
 
 // kindExecConfig contains transient information for the execution of kind commands
 // It's used by BootstrapClusterClientOption's to store/change information prior to a command execution
-// It must be cleaned after each execution to prevent side effects from past executions options
+// It must be cleaned after each execution to prevent side effects from past executions options.
 type kindExecConfig struct {
 	env                    map[string]string
 	ConfigFile             string

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -1658,7 +1658,7 @@ func (k *Kubectl) HasResource(ctx context.Context, resourceType string, name str
 
 // GetObject performs a GET call to the kube API server authenticating with a kubeconfig file
 // and unmarshalls the response into the provided Object
-// If the object is not found, it returns an error implementing apimachinery errors.APIStatus
+// If the object is not found, it returns an error implementing apimachinery errors.APIStatus.
 func (k *Kubectl) GetObject(ctx context.Context, resourceType, name, namespace, kubeconfig string, obj runtime.Object) error {
 	return k.get(ctx, resourceType, kubeconfig, obj, withGetResourceName(name), withGetNamespace(namespace))
 }
@@ -1778,7 +1778,7 @@ func (k *Kubectl) ExecuteCommand(ctx context.Context, opts ...string) (bytes.Buf
 	return k.Execute(ctx, opts...)
 }
 
-// Delete performs a DELETE call to the kube API server authenticating with a kubeconfig file
+// Delete performs a DELETE call to the kube API server authenticating with a kubeconfig file.
 func (k *Kubectl) Delete(ctx context.Context, resourceType, name, namespace, kubeconfig string) error {
 	if _, err := k.Execute(ctx, "delete", resourceType, name, "--namespace", namespace, "--kubeconfig", kubeconfig); err != nil {
 		return fmt.Errorf("deleting %s %s in namespace %s: %v", name, resourceType, namespace, err)

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -24,7 +24,7 @@ func IsActive(feature Feature) bool {
 	return feature.IsActive()
 }
 
-// ClearCache is mainly used for unit tests as of now
+// ClearCache is mainly used for unit tests as of now.
 func ClearCache() {
 	globalFeatures.clearCache()
 }
@@ -64,7 +64,7 @@ func CheckpointEnabled() Feature {
 	}
 }
 
-// NutanixProvider returns a feature that is active if the NUTANIX_PROVIDER environment variable is true
+// NutanixProvider returns a feature that is active if the NUTANIX_PROVIDER environment variable is true.
 func NutanixProvider() Feature {
 	return Feature{
 		Name:     "Nutanix provider support",

--- a/pkg/git/gogithub/gogithub.go
+++ b/pkg/git/gogithub/gogithub.go
@@ -194,7 +194,7 @@ func (g *GoGithub) Organization(ctx context.Context, org string) (*goGithub.Orga
 }
 
 // PathExists checks if a path exists in the remote repository. If the owner, repository or branch doesn't exist,
-// it returns false and no error
+// it returns false and no error.
 func (g *GoGithub) PathExists(ctx context.Context, owner, repo, branch, path string) (bool, error) {
 	_, _, _, err := g.Client.GetContents(
 		ctx,

--- a/pkg/git/providers/github/github.go
+++ b/pkg/git/providers/github/github.go
@@ -85,7 +85,7 @@ func (g *githubProvider) AddDeployKeyToRepo(ctx context.Context, opts git.AddDep
 	return g.githubProviderClient.AddDeployKeyToRepo(ctx, opts)
 }
 
-// validates the github setup and access
+// validates the github setup and access.
 func (g *githubProvider) Validate(ctx context.Context) error {
 	user, err := g.githubProviderClient.AuthenticatedUser(ctx)
 	if err != nil {

--- a/pkg/gitops/flux/cluster.go
+++ b/pkg/gitops/flux/cluster.go
@@ -149,7 +149,7 @@ func (fc *fluxForCluster) clone(ctx context.Context) error {
 	return fc.gitClient.Branch(fc.branch())
 }
 
-// createRemoteRepository will create a repository in the remote git provider with the user-provided configuration
+// createRemoteRepository will create a repository in the remote git provider with the user-provided configuration.
 func (fc *fluxForCluster) createRemoteRepository(ctx context.Context) error {
 	logger.V(3).Info("Remote Github repo does not exist; will create and initialize", "repo", fc.repository(), "owner", fc.owner())
 
@@ -170,7 +170,7 @@ func (fc *fluxForCluster) createRemoteRepository(ctx context.Context) error {
 }
 
 // initializeLocalRepository will git init the local repository directory, initialize a git repository.
-// it will then change branches to the branch specified in the GitOps configuration
+// it will then change branches to the branch specified in the GitOps configuration.
 func (fc *fluxForCluster) initializeLocalRepository() error {
 	if err := fc.gitClient.Init(); err != nil {
 		return fmt.Errorf("initializing repository: %v", err)

--- a/pkg/gitops/flux/files.go
+++ b/pkg/gitops/flux/files.go
@@ -45,7 +45,7 @@ func NewFileGenerator() *FileGenerator {
 }
 
 // NewFileGeneratorWithWriterTemplater takes flux and eksa writer and templater interface to build the generator.
-// This is only for testing
+// This is only for testing.
 func NewFileGeneratorWithWriterTemplater(fluxWriter, eksaWriter filewriter.FileWriter, fluxTemplater, eksaTemplater Templater) *FileGenerator {
 	return &FileGenerator{
 		fluxWriter:    fluxWriter,

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
 
-// FromClusterFormat defines the format of the kubeconfig of the
+// FromClusterFormat defines the format of the kubeconfig of the.
 const FromClusterFormat = "%s-eks-a-cluster.kubeconfig"
 
 // EnvName is the standard KubeConfig environment variable name.
@@ -21,7 +21,7 @@ const EnvName = "KUBECONFIG"
 
 // FromClusterName formats an expected Kubeconfig path for EKS-A clusters. This includes a subdirecftory
 // named after the cluster name. For example, if the clusterName is 'sandbox' the generated path would be
-// sandbox/sandbox-eks-a-cluster.kubeconfig
+// sandbox/sandbox-eks-a-cluster.kubeconfig.
 func FromClusterName(clusterName string) string {
 	return filepath.Join(clusterName, fmt.Sprintf(FromClusterFormat, clusterName))
 }

--- a/pkg/logger/zap.go
+++ b/pkg/logger/zap.go
@@ -13,7 +13,7 @@ import (
 // and sets it as the package logger.
 // 0 is the least verbose and 10 the most verbose.
 // The package logger can only be init once, so subsequent calls to this method
-// won't have any effect
+// won't have any effect.
 func InitZap(level int, opts ...LoggerOpt) error {
 	cfg := zap.NewDevelopmentConfig()
 	cfg.Level = zap.NewAtomicLevelAt(zapcore.Level(-1 * level))
@@ -45,10 +45,10 @@ func InitZap(level int, opts ...LoggerOpt) error {
 	return nil
 }
 
-// VLevelEncoder serializes a Level to V + v-level number,
+// VLevelEncoder serializes a Level to V + v-level number,.
 func VLevelEncoder(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
 	enc.AppendString(fmt.Sprintf("V%d", -1*int(l)))
 }
 
-// NullTimeEncoder skips time serialization
+// NullTimeEncoder skips time serialization.
 func NullTimeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {}

--- a/pkg/manifests/releases/read.go
+++ b/pkg/manifests/releases/read.go
@@ -11,7 +11,7 @@ import (
 )
 
 // manifestURL holds the url to the eksa releases manifest
-// this is injected at build time, this is just a sane default for development
+// this is injected at build time, this is just a sane default for development.
 var manifestURL = "https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/eks-a-release.yaml"
 
 func ManifestURL() string {

--- a/pkg/networking/cilium/installation.go
+++ b/pkg/networking/cilium/installation.go
@@ -2,13 +2,13 @@ package cilium
 
 import appsv1 "k8s.io/api/apps/v1"
 
-// Installation represents the Cilium components installed in a cluster
+// Installation represents the Cilium components installed in a cluster.
 type Installation struct {
 	DaemonSet *appsv1.DaemonSet
 	Operator  *appsv1.Deployment
 }
 
-// Installed determines if all Cilium components are present
+// Installed determines if all Cilium components are present.
 func (i Installation) Installed() bool {
 	return i.DaemonSet != nil && i.Operator != nil
 }

--- a/pkg/networking/cilium/reconciler/reconciler.go
+++ b/pkg/networking/cilium/reconciler/reconciler.go
@@ -26,7 +26,7 @@ type Templater interface {
 	GenerateManifest(ctx context.Context, spec *cluster.Spec, opts ...cilium.ManifestOpt) ([]byte, error)
 }
 
-// Reconciler allows to reconcile a Cilium CNI
+// Reconciler allows to reconcile a Cilium CNI.
 type Reconciler struct {
 	templater Templater
 }
@@ -39,7 +39,7 @@ func New(templater Templater) *Reconciler {
 
 // Reconcile takes the Cilium CNI in a cluster to the desired state defined in a cluster Spec
 // It uses a controller.Result to indicate when requeues are needed
-// Intended to be used in a kubernetes controller
+// Intended to be used in a kubernetes controller.
 func (r *Reconciler) Reconcile(ctx context.Context, logger logr.Logger, client client.Client, spec *cluster.Spec) (controller.Result, error) {
 	installation, err := getInstallation(ctx, client)
 	if err != nil {

--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -61,7 +61,7 @@ func (t *Templater) GenerateUpgradePreflightManifest(ctx context.Context, spec *
 	return manifest, nil
 }
 
-// ManifestOpt allows to modify options for a cilium manifest
+// ManifestOpt allows to modify options for a cilium manifest.
 type ManifestOpt func(*ManifestConfig)
 
 type ManifestConfig struct {
@@ -73,14 +73,14 @@ type ManifestConfig struct {
 
 // WithKubeVersion allows to generate the Cilium manifest for a different kubernetes version
 // than the one specified in the cluster spec. Useful for upgrades scenarios where Cilium is upgraded before
-// the kubernetes components
+// the kubernetes components.
 func WithKubeVersion(kubeVersion string) ManifestOpt {
 	return func(c *ManifestConfig) {
 		c.kubeVersion = kubeVersion
 	}
 }
 
-// WithRetrier introduced for optimizing unit tests
+// WithRetrier introduced for optimizing unit tests.
 func WithRetrier(retrier *retrier.Retrier) ManifestOpt {
 	return func(c *ManifestConfig) {
 		c.retrier = retrier
@@ -88,7 +88,7 @@ func WithRetrier(retrier *retrier.Retrier) ManifestOpt {
 }
 
 // WithUpgradeFromVersion allows to specify the compatibility Cilium version to use in the manifest.
-// This is necessary for Cilium upgrades
+// This is necessary for Cilium upgrades.
 func WithUpgradeFromVersion(version semver.Version) ManifestOpt {
 	return func(c *ManifestConfig) {
 		c.values.set(fmt.Sprintf("%d.%d", version.Major, version.Minor), "upgradeCompatibility")
@@ -96,7 +96,7 @@ func WithUpgradeFromVersion(version semver.Version) ManifestOpt {
 }
 
 // WithPolicyAllowedNamespaces allows to specify which namespaces traffic should be allowed when using
-// and "Always" policy enforcement mode
+// and "Always" policy enforcement mode.
 func WithPolicyAllowedNamespaces(namespaces []string) ManifestOpt {
 	return func(c *ManifestConfig) {
 		c.namespaces = namespaces

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -71,7 +71,7 @@ func eqMap(m map[string]interface{}) gomock.Matcher {
 }
 
 // mapMacher implements a gomock matcher for maps
-// transforms any map or struct into a map[string]interface{} and uses DeepEqual to compare
+// transforms any map or struct into a map[string]interface{} and uses DeepEqual to compare.
 type mapMatcher struct {
 	m map[string]interface{}
 }

--- a/pkg/networking/cilium/upgrade_plan.go
+++ b/pkg/networking/cilium/upgrade_plan.go
@@ -10,21 +10,21 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 )
 
-// UpgradePlan contains information about a Cilium installation upgrade
+// UpgradePlan contains information about a Cilium installation upgrade.
 type UpgradePlan struct {
 	DaemonSet ComponentUpgradePlan
 	Operator  ComponentUpgradePlan
 }
 
 // Needed determines if an upgrade is needed or not
-// Returns true if any of the installation components needs an upgrade
+// Returns true if any of the installation components needs an upgrade.
 func (c UpgradePlan) Needed() bool {
 	return c.DaemonSet.Needed() || c.Operator.Needed()
 }
 
 // Reason returns the reason why an upgrade might be needed
 // If no upgrade needed, returns empty string
-// For multiple components with needed upgrades, it composes their reasons into one
+// For multiple components with needed upgrades, it composes their reasons into one.
 func (c UpgradePlan) Reason() string {
 	if !c.Needed() {
 		return ""
@@ -41,20 +41,20 @@ func (c UpgradePlan) Reason() string {
 	return strings.Join(s, " - ")
 }
 
-// ComponentUpgradePlan contains upgrade information for a Cilium component
+// ComponentUpgradePlan contains upgrade information for a Cilium component.
 type ComponentUpgradePlan struct {
 	UpgradeReason string
 	OldImage      string
 	NewImage      string
 }
 
-// Needed determines if an upgrade is needed or not
+// Needed determines if an upgrade is needed or not.
 func (c ComponentUpgradePlan) Needed() bool {
 	return c.UpgradeReason != ""
 }
 
 // BuildUpgradePlan generates the upgrade plan information for a cilium installation by comparing it
-// with a desired cluster Spec
+// with a desired cluster Spec.
 func BuildUpgradePlan(installation *Installation, clusterSpec *cluster.Spec) UpgradePlan {
 	return UpgradePlan{
 		DaemonSet: daemonSetUpgradePlan(installation.DaemonSet, clusterSpec),

--- a/pkg/networking/reconciler/reconciler.go
+++ b/pkg/networking/reconciler/reconciler.go
@@ -28,7 +28,7 @@ func New(ciliumReconciler CiliumReconciler) *Reconciler {
 // Reconcile takes the specified CNI in a cluster to the desired state defined in a cluster Spec
 // It uses a controller.Result to indicate when requeues are needed
 // Intended to be used in a kubernetes controller
-// Only Cilium CNI is supported for now
+// Only Cilium CNI is supported for now.
 func (r *Reconciler) Reconcile(ctx context.Context, logger logr.Logger, client client.Client, spec *cluster.Spec) (controller.Result, error) {
 	if spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium != nil {
 		return r.ciliumReconciler.Reconcile(ctx, logger, client, spec)

--- a/pkg/networkutils/ipgenerator.go
+++ b/pkg/networkutils/ipgenerator.go
@@ -37,7 +37,7 @@ func (ipgen IPGenerator) GenerateUniqueIP(cidrBlock string) (string, error) {
 	return uniqueIp.String(), nil
 }
 
-// generates a random ip within the specified cidr block
+// generates a random ip within the specified cidr block.
 func (ipgen IPGenerator) randIp(cidr *net.IPNet) (net.IP, error) {
 	newIp := *new(net.IP)
 	for i := 0; i < 4; i++ {

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -403,7 +403,7 @@ func (p *cloudstackProvider) validateEnv(ctx context.Context) error {
 	return nil
 }
 
-// TODO: Consider to move this functionality to validator.go
+// TODO: Consider to move this functionality to validator.go.
 func (p *cloudstackProvider) validateSecretsUnchanged(ctx context.Context, cluster *types.Cluster) error {
 	for _, profile := range p.execConfig.Profiles {
 		secret, err := p.providerKubectlClient.GetSecretFromNamespace(ctx, cluster.KubeconfigFile, profile.Name, constants.EksaSystemNamespace)
@@ -579,7 +579,7 @@ func (p *cloudstackProvider) needsNewKubeadmConfigTemplate(workerNodeGroupConfig
 
 // AnyImmutableFieldChanged Used by EKS-A controller and CLI upgrade workflow to compare generated CSDC/CSMC's from
 // CAPC resources in fetcher.go with those already on the cluster when deciding whether or not to generate and apply
-// new CloudStackMachineTemplates
+// new CloudStackMachineTemplates.
 func AnyImmutableFieldChanged(generatedCsdc, actualCsdc *v1alpha1.CloudStackDatacenterConfig, generatedCsmc, actualCsmc *v1alpha1.CloudStackMachineConfig, log logr.Logger) bool {
 	if len(generatedCsdc.Spec.AvailabilityZones) != len(actualCsdc.Spec.AvailabilityZones) {
 		log.V(4).Info("Generated and actual CloudStackDatacenterConfigs do not match", "generatedAvailabilityZones", generatedCsdc.Spec.AvailabilityZones,

--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -20,7 +20,7 @@ type Validator struct {
 }
 
 // Taken from https://github.com/shapeblue/cloudstack/blob/08bb4ad9fea7e422c3d3ac6d52f4670b1e89eed7/api/src/main/java/com/cloud/vm/VmDetailConstants.java
-// These fields should be modeled separately in eks-a and not used by the additionalDetails cloudstack VM field
+// These fields should be modeled separately in eks-a and not used by the additionalDetails cloudstack VM field.
 var restrictedUserCustomDetails = [...]string{
 	"keyboard", "cpu.corespersocket", "rootdisksize", "boot.mode", "nameonhypervisor",
 	"nicAdapter", "rootDiskController", "dataDiskController", "svga.vramSize", "nestedVirtualizationFlag", "ramReservation",
@@ -143,7 +143,7 @@ func generateLocalAvailabilityZones(ctx context.Context, datacenterConfig *anywh
 	return localAvailabilityZones, nil
 }
 
-// TODO: dry out machine configs validations
+// TODO: dry out machine configs validations.
 func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, cloudStackClusterSpec *Spec) error {
 	if len(cloudStackClusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host) <= 0 {
 		return fmt.Errorf("cluster controlPlaneConfiguration.Endpoint.Host is not set or is empty")

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -482,7 +482,7 @@ func (p *provider) UpdateKubeConfig(content *[]byte, clusterName string) error {
 	}
 }
 
-// this is required for docker provider
+// this is required for docker provider.
 func getUpdatedKubeConfigContent(content *[]byte, dockerLbPort string) {
 	mc := regexp.MustCompile("server:.*")
 	updatedConfig := mc.ReplaceAllString(string(*content), fmt.Sprintf("server: https://127.0.0.1:%s", dockerLbPort))

--- a/pkg/providers/nutanix/provider.go
+++ b/pkg/providers/nutanix/provider.go
@@ -40,7 +40,7 @@ var (
 	requiredEnvs                      = []string{nutanixEndpointKey, constants.NutanixUsernameKey, constants.NutanixPasswordKey}
 )
 
-// Provider implements the Nutanix Provider
+// Provider implements the Nutanix Provider.
 type Provider struct {
 	clusterConfig    *v1alpha1.Cluster
 	datacenterConfig *v1alpha1.NutanixDatacenterConfig
@@ -53,7 +53,7 @@ type Provider struct {
 
 var _ providers.Provider = &Provider{}
 
-// NewProvider returns a new nutanix provider
+// NewProvider returns a new nutanix provider.
 func NewProvider(
 	datacenterConfig *v1alpha1.NutanixDatacenterConfig,
 	machineConfigs map[string]*v1alpha1.NutanixMachineConfig,

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -18,7 +18,7 @@ import (
 
 var jsonMarshal = json.Marshal
 
-// TemplateBuilder builds templates for nutanix
+// TemplateBuilder builds templates for nutanix.
 type TemplateBuilder struct {
 	datacenterSpec              *v1alpha1.NutanixDatacenterConfigSpec
 	controlPlaneMachineSpec     *v1alpha1.NutanixMachineConfigSpec

--- a/pkg/providers/snow/api/v1beta1/awssnowcluster_types.go
+++ b/pkg/providers/snow/api/v1beta1/awssnowcluster_types.go
@@ -30,7 +30,7 @@ const (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// AWSSnowClusterSpec defines the desired state of AWSSnowCluster
+// AWSSnowClusterSpec defines the desired state of AWSSnowCluster.
 type AWSSnowClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -109,7 +109,7 @@ type AWSSnowIdentityReference struct {
 	Kind AWSSnowIdentityKind `json:"kind"`
 }
 
-// AWSSnowClusterStatus defines the observed state of AWSSnowCluster
+// AWSSnowClusterStatus defines the observed state of AWSSnowCluster.
 type AWSSnowClusterStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -125,7 +125,7 @@ type AWSSnowClusterStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// AWSSnowCluster is the Schema for the awssnowclusters API
+// AWSSnowCluster is the Schema for the awssnowclusters API.
 type AWSSnowCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -136,7 +136,7 @@ type AWSSnowCluster struct {
 
 //+kubebuilder:object:root=true
 
-// AWSSnowClusterList contains a list of AWSSnowCluster
+// AWSSnowClusterList contains a list of AWSSnowCluster.
 type AWSSnowClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/providers/snow/api/v1beta1/awssnowmachine_types.go
+++ b/pkg/providers/snow/api/v1beta1/awssnowmachine_types.go
@@ -195,7 +195,7 @@ type CloudInit struct {
 	// SecureSecretsBackend SecretBackend `json:"secureSecretsBackend,omitempty"`
 }
 
-// AWSSnowMachineStatus defines the observed state of AWSSnowMachine
+// AWSSnowMachineStatus defines the observed state of AWSSnowMachine.
 type AWSSnowMachineStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -257,7 +257,7 @@ type AWSSnowMachineStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// AWSSnowMachine is the Schema for the awssnowmachines API
+// AWSSnowMachine is the Schema for the awssnowmachines API.
 type AWSSnowMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -269,7 +269,7 @@ type AWSSnowMachine struct {
 
 //+kubebuilder:object:root=true
 
-// AWSSnowMachineList contains a list of AWSSnowMachine
+// AWSSnowMachineList contains a list of AWSSnowMachine.
 type AWSSnowMachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/providers/snow/api/v1beta1/awssnowmachinetemplate_types.go
+++ b/pkg/providers/snow/api/v1beta1/awssnowmachinetemplate_types.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// AWSSnowMachineTemplateSpec defines the desired state of AWSSnowMachineTemplate
+// AWSSnowMachineTemplateSpec defines the desired state of AWSSnowMachineTemplate.
 type AWSSnowMachineTemplateSpec struct {
 	Template AWSSnowMachineTemplateResource `json:"template"`
 }
@@ -29,7 +29,7 @@ type AWSSnowMachineTemplateSpec struct {
 // +kubebuilder:resource:path=awssnowmachinetemplates,scope=Namespaced,categories=cluster-api,shortName=awssmt
 // +kubebuilder:storageversion
 
-// AWSSnowMachineTemplate is the Schema for the awssnowmachinetemplates API
+// AWSSnowMachineTemplate is the Schema for the awssnowmachinetemplates API.
 type AWSSnowMachineTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/providers/snow/api/v1beta1/groupversion_info.go
+++ b/pkg/providers/snow/api/v1beta1/groupversion_info.go
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/pkg/providers/snow/api/v1beta1/tags.go
+++ b/pkg/providers/snow/api/v1beta1/tags.go
@@ -44,7 +44,7 @@ func (t Tags) HasAWSCloudProviderOwned(cluster string) bool {
 	return ok && ResourceLifecycle(value) == ResourceLifecycleOwned
 }
 
-// GetRole returns the Cluster API role for the tagged resource
+// GetRole returns the Cluster API role for the tagged resource.
 func (t Tags) GetRole() string {
 	return t[NameAWSClusterAPIRole]
 }
@@ -71,7 +71,7 @@ func (t Tags) Merge(other Tags) {
 	}
 }
 
-// ResourceLifecycle configures the lifecycle of a resource
+// ResourceLifecycle configures the lifecycle of a resource.
 type ResourceLifecycle string
 
 const (
@@ -90,17 +90,17 @@ const (
 	// to be permissive about state changes.
 	// logically independent clusters running in the same AZ.
 	// The tag key = NameKubernetesAWSCloudProviderPrefix + clusterID
-	// The tag value is an ownership value
+	// The tag value is an ownership value.
 	NameKubernetesAWSCloudProviderPrefix = "kubernetes.io/cluster/"
 
 	// NameAWSProviderPrefix is the tag prefix we use to differentiate
 	// cluster-api-provider-aws owned components from other tooling that
-	// uses NameKubernetesClusterPrefix
+	// uses NameKubernetesClusterPrefix.
 	NameAWSProviderPrefix = "sigs.k8s.io/cluster-api-provider-aws-snow/"
 
 	// NameAWSProviderOwned is the tag name we use to differentiate
 	// cluster-api-provider-aws owned components from other tooling that
-	// uses NameKubernetesClusterPrefix
+	// uses NameKubernetesClusterPrefix.
 	NameAWSProviderOwned = NameAWSProviderPrefix + "cluster/"
 
 	// NameAWSClusterAPIRole is the tag name we use to mark roles for resources
@@ -111,22 +111,22 @@ const (
 
 	SecondarySubnetTagValue = "secondary"
 
-	// APIServerRoleTagValue describes the value for the apiserver role
+	// APIServerRoleTagValue describes the value for the apiserver role.
 	APIServerRoleTagValue = "apiserver"
 
-	// BastionRoleTagValue describes the value for the bastion role
+	// BastionRoleTagValue describes the value for the bastion role.
 	BastionRoleTagValue = "bastion"
 
-	// CommonRoleTagValue describes the value for the common role
+	// CommonRoleTagValue describes the value for the common role.
 	CommonRoleTagValue = "common"
 
-	// PublicRoleTagValue describes the value for the public role
+	// PublicRoleTagValue describes the value for the public role.
 	PublicRoleTagValue = "public"
 
-	// PrivateRoleTagValue describes the value for the private role
+	// PrivateRoleTagValue describes the value for the private role.
 	PrivateRoleTagValue = "private"
 
-	// MachineNameTagKey is the key for machine name
+	// MachineNameTagKey is the key for machine name.
 	MachineNameTagKey = "MachineName"
 )
 
@@ -165,14 +165,14 @@ type BuildParams struct {
 }
 
 // WithMachineName tags the namespaced machine name
-// The machine name will be tagged with key "MachineName"
+// The machine name will be tagged with key "MachineName".
 func (b BuildParams) WithMachineName(m *clusterv1.Machine) BuildParams {
 	machineNamespacedName := types.NamespacedName{Namespace: m.Namespace, Name: m.Name}
 	b.Additional[MachineNameTagKey] = machineNamespacedName.String()
 	return b
 }
 
-// WithCloudProvider tags the cluster ownership for a resource
+// WithCloudProvider tags the cluster ownership for a resource.
 func (b BuildParams) WithCloudProvider(name string) BuildParams {
 	b.Additional[ClusterAWSCloudProviderTagKey(name)] = string(ResourceLifecycleOwned)
 	return b

--- a/pkg/providers/snow/api/v1beta1/types.go
+++ b/pkg/providers/snow/api/v1beta1/types.go
@@ -40,7 +40,7 @@ type AWSResourceReference struct {
 	Filters []Filter `json:"filters,omitempty"`
 }
 
-// Filter is a filter used to identify an AWS resource
+// Filter is a filter used to identify an AWS resource.
 type Filter struct {
 	// Name of the filter. Filter names are case-sensitive.
 	Name string `json:"name"`
@@ -157,35 +157,35 @@ type Volume struct {
 type InstanceState string
 
 var (
-	// InstanceStatePending is the string representing an instance in a pending state
+	// InstanceStatePending is the string representing an instance in a pending state.
 	InstanceStatePending = InstanceState("pending")
 
-	// InstanceStateRunning is the string representing an instance in a running state
+	// InstanceStateRunning is the string representing an instance in a running state.
 	InstanceStateRunning = InstanceState("running")
 
-	// InstanceStateShuttingDown is the string representing an instance shutting down
+	// InstanceStateShuttingDown is the string representing an instance shutting down.
 	InstanceStateShuttingDown = InstanceState("shutting-down")
 
-	// InstanceStateTerminated is the string representing an instance that has been terminated
+	// InstanceStateTerminated is the string representing an instance that has been terminated.
 	InstanceStateTerminated = InstanceState("terminated")
 
 	// InstanceStateStopping is the string representing an instance
-	// that is in the process of being stopped and can be restarted
+	// that is in the process of being stopped and can be restarted.
 	InstanceStateStopping = InstanceState("stopping")
 
 	// InstanceStateStopped is the string representing an instance
-	// that has been stopped and can be restarted
+	// that has been stopped and can be restarted.
 	InstanceStateStopped = InstanceState("stopped")
 
 	// InstanceRunningStates defines the set of states in which an EC2 instance is
-	// running or going to be running soon
+	// running or going to be running soon.
 	InstanceRunningStates = sets.NewString(
 		string(InstanceStatePending),
 		string(InstanceStateRunning),
 	)
 
 	// InstanceOperationalStates defines the set of states in which an EC2 instance is
-	// or can return to running, and supports all EC2 operations
+	// or can return to running, and supports all EC2 operations.
 	InstanceOperationalStates = InstanceRunningStates.Union(
 		sets.NewString(
 			string(InstanceStateStopping),
@@ -193,7 +193,7 @@ var (
 		),
 	)
 
-	// InstanceKnownStates represents all known EC2 instance states
+	// InstanceKnownStates represents all known EC2 instance states.
 	InstanceKnownStates = InstanceOperationalStates.Union(
 		sets.NewString(
 			string(InstanceStateShuttingDown),
@@ -202,7 +202,7 @@ var (
 	)
 )
 
-// AWSSnowMachineTemplateResource describes the data needed to create am AWSSnowMachine from a template
+// AWSSnowMachineTemplateResource describes the data needed to create am AWSSnowMachine from a template.
 type AWSSnowMachineTemplateResource struct {
 	// Spec is the specification of the desired behavior of the machine.
 	Spec AWSSnowMachineSpec `json:"spec"`

--- a/pkg/providers/snow/objects.go
+++ b/pkg/providers/snow/objects.go
@@ -183,7 +183,7 @@ func recreateKubeadmConfigTemplateNeeded(new, old *bootstrapv1.KubeadmConfigTemp
 
 // credentialsSecret generates the credentials secret(s) used for provisioning a snow cluster.
 // - eks-a credentials secret: user managed secret referred from snowdatacenterconfig identityRef
-// - snow credentials secret: eks-a creates, updates and deletes in eksa-system namespace. this secret is fully managed by eks-a. User shall treat it as a "read-only" object
+// - snow credentials secret: eks-a creates, updates and deletes in eksa-system namespace. this secret is fully managed by eks-a. User shall treat it as a "read-only" object.
 func capasCredentialsSecret(clusterSpec *cluster.Spec) (*v1.Secret, error) {
 	if clusterSpec.SnowCredentialsSecret == nil {
 		return nil, errors.New("snowCredentialsSecret in clusterSpec shall not be nil")

--- a/pkg/providers/tinkerbell/assert.go
+++ b/pkg/providers/tinkerbell/assert.go
@@ -73,7 +73,7 @@ func AssertWorkerNodeGroupMachineRefsExists(spec *ClusterSpec) error {
 	return nil
 }
 
-// AssertK8SVersionNot120 ensures Kubernetes version is not set to v1.20
+// AssertK8SVersionNot120 ensures Kubernetes version is not set to v1.20.
 func AssertK8SVersionNot120(spec *ClusterSpec) error {
 	if spec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube120 {
 		return errors.New("kubernetes version v1.20 is not supported for Bare Metal")
@@ -98,7 +98,7 @@ func NewIPNotInUseAssertion(client networkutils.NetClient) ClusterSpecAssertion 
 	}
 }
 
-// AssertTinkerbellIPNotInUse ensures tinkerbell ip isn't in use
+// AssertTinkerbellIPNotInUse ensures tinkerbell ip isn't in use.
 func AssertTinkerbellIPNotInUse(client networkutils.NetClient) ClusterSpecAssertion {
 	return func(spec *ClusterSpec) error {
 		ip := spec.DatacenterConfig.Spec.TinkerbellIP
@@ -109,7 +109,7 @@ func AssertTinkerbellIPNotInUse(client networkutils.NetClient) ClusterSpecAssert
 	}
 }
 
-// AssertTinkerbellIPAndControlPlaneIPNotSame ensures tinkerbell ip and controlplane ip are not the same
+// AssertTinkerbellIPAndControlPlaneIPNotSame ensures tinkerbell ip and controlplane ip are not the same.
 func AssertTinkerbellIPAndControlPlaneIPNotSame(spec *ClusterSpec) error {
 	tinkerbellIP := spec.DatacenterConfig.Spec.TinkerbellIP
 	controlPlaneIP := spec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host
@@ -119,7 +119,7 @@ func AssertTinkerbellIPAndControlPlaneIPNotSame(spec *ClusterSpec) error {
 	return nil
 }
 
-// AssertPortsNotInUse ensures that ports 80, 42113, and 50061 are available
+// AssertPortsNotInUse ensures that ports 80, 42113, and 50061 are available.
 func AssertPortsNotInUse(client networkutils.NetClient) ClusterSpecAssertion {
 	return func(spec *ClusterSpec) error {
 		host := "0.0.0.0"

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/constants"
 )
 
-// DiskExtractor represents a hardware labels and map it with the appropriate disk given in the hardware csv file
+// DiskExtractor represents a hardware labels and map it with the appropriate disk given in the hardware csv file.
 type DiskExtractor struct {
 	selector                 map[string]eksav1alpha1.HardwareSelector
 	disks                    map[string]string

--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -70,28 +70,28 @@ type StackInstaller interface {
 	UninstallLocal(ctx context.Context) error
 }
 
-// WithNamespaceCreate is an InstallOption is lets you specify whether to create the namespace needed for Tinkerbell stack
+// WithNamespaceCreate is an InstallOption is lets you specify whether to create the namespace needed for Tinkerbell stack.
 func WithNamespaceCreate(create bool) InstallOption {
 	return func(s *Installer) {
 		s.createNamespace = create
 	}
 }
 
-// WithBootsOnDocker is an InstallOption to run Boots as a Docker container
+// WithBootsOnDocker is an InstallOption to run Boots as a Docker container.
 func WithBootsOnDocker() InstallOption {
 	return func(s *Installer) {
 		s.bootsOnDocker = true
 	}
 }
 
-// WithBootsOnKubernetes is an InstallOption to run Boots as a Kubernetes deployment
+// WithBootsOnKubernetes is an InstallOption to run Boots as a Kubernetes deployment.
 func WithBootsOnKubernetes() InstallOption {
 	return func(s *Installer) {
 		s.bootsOnDocker = false
 	}
 }
 
-// WithHostPortEnabled is an InstallOption that allows you to enable/disable host port for Tinkerbell deployments
+// WithHostPortEnabled is an InstallOption that allows you to enable/disable host port for Tinkerbell deployments.
 func WithHostPortEnabled(enabled bool) InstallOption {
 	return func(s *Installer) {
 		s.hostPort = enabled
@@ -104,14 +104,14 @@ func WithEnvoyEnabled(enabled bool) InstallOption {
 	}
 }
 
-// WithLoadBalancer is an InstallOption that allows you to setup a LoadBalancer to expose hegel and tink-server
+// WithLoadBalancer is an InstallOption that allows you to setup a LoadBalancer to expose hegel and tink-server.
 func WithLoadBalancerEnabled(enabled bool) InstallOption {
 	return func(s *Installer) {
 		s.loadBalancer = enabled
 	}
 }
 
-// NewInstaller returns a Tinkerbell StackInstaller which can be used to install or uninstall the Tinkerbell stack
+// NewInstaller returns a Tinkerbell StackInstaller which can be used to install or uninstall the Tinkerbell stack.
 func NewInstaller(docker Docker, filewriter filewriter.FileWriter, helm Helm, namespace string, podCidrRange string, registryMirror *v1alpha1.RegistryMirrorConfiguration) StackInstaller {
 	return &Installer{
 		docker:         docker,
@@ -123,7 +123,7 @@ func NewInstaller(docker Docker, filewriter filewriter.FileWriter, helm Helm, na
 	}
 }
 
-// Install installs the Tinkerbell stack on a target cluster using a helm chart and providing the necessary values overrides
+// Install installs the Tinkerbell stack on a target cluster using a helm chart and providing the necessary values overrides.
 func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.TinkerbellBundle, tinkerbellIP, kubeconfig, hookOverride string, opts ...InstallOption) error {
 	logger.V(6).Info("Installing Tinkerbell helm chart")
 
@@ -283,7 +283,7 @@ func (s *Installer) getBootsEnv(bundle releasev1alpha1.TinkerbellStackBundle, ti
 	}
 }
 
-// UninstallLocal currently removes local docker container running Boots
+// UninstallLocal currently removes local docker container running Boots.
 func (s *Installer) UninstallLocal(ctx context.Context) error {
 	return s.uninstallBootsFromDocker(ctx)
 }
@@ -306,7 +306,7 @@ func getURIDir(uri string) (string, error) {
 }
 
 // CleanupLocalBoots determines whether Boots is already running locally
-// and either cleans it up or errors out depending on the `remove` flag
+// and either cleans it up or errors out depending on the `remove` flag.
 func (s *Installer) CleanupLocalBoots(ctx context.Context, remove bool) error {
 	exists, err := s.docker.CheckContainerExistence(ctx, boots)
 	// return error if the docker call failed

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -98,7 +98,7 @@ func processUpdate(t *testing.T, goldenFilePath, generatedFilePath string) {
 
 // Note: This test contains generated files
 // To automatically update the generated files, run the following
-// go test -timeout 30s -run ^TestTinkerbellStackInstallWithDifferentOptions$ github.com/aws/eks-anywhere/pkg/providers/tinkerbell/stack -update -count=1 -v
+// go test -timeout 30s -run ^TestTinkerbellStackInstallWithDifferentOptions$ github.com/aws/eks-anywhere/pkg/providers/tinkerbell/stack -update -count=1 -v.
 func TestTinkerbellStackInstallWithDifferentOptions(t *testing.T) {
 	stackTests := []struct {
 		name              string

--- a/pkg/providers/validator/validate.go
+++ b/pkg/providers/validator/validate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers"
 )
 
-// TODO: update vsphere, cloudstack, tinkerbell validators to use this common validation method
+// TODO: update vsphere, cloudstack, tinkerbell validators to use this common validation method.
 func ValidateControlPlaneIpUniqueness(cluster *v1alpha1.Cluster, netClient networkutils.NetClient) error {
 	ip := cluster.Spec.ControlPlaneConfiguration.Endpoint.Host
 	if networkutils.IsIPInUse(netClient, ip) {

--- a/pkg/providers/vsphere/validator.go
+++ b/pkg/providers/vsphere/validator.go
@@ -90,7 +90,7 @@ func (v *Validator) ValidateVCenterConfig(ctx context.Context, datacenterConfig 
 	return nil
 }
 
-// TODO: dry out machine configs validations
+// TODO: dry out machine configs validations.
 func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, vsphereClusterSpec *Spec) error {
 	var etcdMachineConfig *anywherev1.VSphereMachineConfig
 
@@ -197,7 +197,7 @@ type datastoreUsage struct {
 }
 
 // TODO: cleanup this method signature
-// TODO: dry out implementation
+// TODO: dry out implementation.
 func (v *Validator) validateDatastoreUsage(ctx context.Context, vsphereClusterSpec *Spec, controlPlaneMachineConfig *anywherev1.VSphereMachineConfig, etcdMachineConfig *anywherev1.VSphereMachineConfig) error {
 	usage := make(map[string]*datastoreUsage)
 	controlPlaneAvailableSpace, err := v.govc.GetWorkloadAvailableSpace(ctx, controlPlaneMachineConfig.Spec.Datastore) // TODO: remove dependency on machineConfig

--- a/pkg/retrier/retrier.go
+++ b/pkg/retrier/retrier.go
@@ -15,13 +15,13 @@ type Retrier struct {
 
 type (
 	// RetryPolicy allows to customize the retrying logic. The boolean retry indicates if a new retry
-	// should be performed and the wait duration indicates the wait time before the next retry
+	// should be performed and the wait duration indicates the wait time before the next retry.
 	RetryPolicy func(totalRetries int, err error) (retry bool, wait time.Duration)
 	RetrierOpt  func(*Retrier)
 )
 
 // New creates a new retrier with a global timeout (max time allowed for the whole execution)
-// The default retry policy is to always retry with no wait time in between retries
+// The default retry policy is to always retry with no wait time in between retries.
 func New(timeout time.Duration, opts ...RetrierOpt) *Retrier {
 	r := &Retrier{
 		timeout:     timeout,
@@ -34,14 +34,14 @@ func New(timeout time.Duration, opts ...RetrierOpt) *Retrier {
 	return r
 }
 
-// NewWithMaxRetries creates a new retrier with no global timeout and a max retries policy
+// NewWithMaxRetries creates a new retrier with no global timeout and a max retries policy.
 func NewWithMaxRetries(maxRetries int, backOffPeriod time.Duration) *Retrier {
 	// this value is roughly 292 years, so in practice there is no timeout
 	return New(time.Duration(math.MaxInt64), WithMaxRetries(maxRetries, backOffPeriod))
 }
 
 // WithMaxRetries sets a retry policy that will retry up to maxRetries times
-// with a wait time between retries of backOffPeriod
+// with a wait time between retries of backOffPeriod.
 func WithMaxRetries(maxRetries int, backOffPeriod time.Duration) RetrierOpt {
 	return func(r *Retrier) {
 		r.retryPolicy = maxRetriesPolicy(maxRetries, backOffPeriod)
@@ -61,7 +61,7 @@ func WithRetryPolicy(policy RetryPolicy) RetrierOpt {
 }
 
 // Retry runs the fn function until it either successful completes (not error),
-// the set timeout reached or the retry policy aborts the execution
+// the set timeout reached or the retry policy aborts the execution.
 func (r *Retrier) Retry(fn func() error) error {
 	// While it seems aberrant to call a method with a nil receiver, several unit tests actually do.  With a previous
 	// version of this module (which didn't attempt to dereference the receiver until after the wrapped function failed)
@@ -110,7 +110,7 @@ func (r *Retrier) Retry(fn func() error) error {
 	return err
 }
 
-// Retry runs fn with a MaxRetriesPolicy
+// Retry runs fn with a MaxRetriesPolicy.
 func Retry(maxRetries int, backOffPeriod time.Duration, fn func() error) error {
 	r := NewWithMaxRetries(maxRetries, backOffPeriod)
 	return r.Retry(fn)

--- a/pkg/tar/router.go
+++ b/pkg/tar/router.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 )
 
-// Router instructs where to extract a file
+// Router instructs where to extract a file.
 type Router interface {
 	// ExtractPath instructs the path where a file should be extracted.
 	// Empty strings instructs to omit the file extraction

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/workflows/interfaces"
 )
 
-// Task is a logical unit of work - meant to be implemented by each Task
+// Task is a logical unit of work - meant to be implemented by each Task.
 type Task interface {
 	Run(ctx context.Context, commandContext *CommandContext) Task
 	Name() string
@@ -25,7 +25,7 @@ type Task interface {
 	Restore(ctx context.Context, commandContext *CommandContext, completedTask *CompletedTask) (Task, error)
 }
 
-// Command context maintains the mutable and shared entities
+// Command context maintains the mutable and shared entities.
 type CommandContext struct {
 	Bootstrapper       interfaces.Bootstrapper
 	Provider           providers.Provider
@@ -58,12 +58,12 @@ type Profiler struct {
 	starts  map[string]map[string]time.Time
 }
 
-// profiler for a Task
+// profiler for a Task.
 func (pp *Profiler) SetStartTask(taskName string) {
 	pp.SetStart(taskName, taskName)
 }
 
-// this can be used to profile sub tasks
+// this can be used to profile sub tasks.
 func (pp *Profiler) SetStart(taskName string, msg string) {
 	if _, ok := pp.starts[taskName]; !ok {
 		pp.starts[taskName] = map[string]time.Time{}
@@ -71,12 +71,12 @@ func (pp *Profiler) SetStart(taskName string, msg string) {
 	pp.starts[taskName][msg] = time.Now()
 }
 
-// needs to be called after setStart
+// needs to be called after setStart.
 func (pp *Profiler) MarkDoneTask(taskName string) {
 	pp.MarkDone(taskName, taskName)
 }
 
-// this can be used to profile sub tasks
+// this can be used to profile sub tasks.
 func (pp *Profiler) MarkDone(taskName string, msg string) {
 	if _, ok := pp.metrics[taskName]; !ok {
 		pp.metrics[taskName] = map[string]time.Duration{}
@@ -86,12 +86,12 @@ func (pp *Profiler) MarkDone(taskName string, msg string) {
 	}
 }
 
-// get Metrics
+// get Metrics.
 func (pp *Profiler) Metrics() map[string]map[string]time.Duration {
 	return pp.metrics
 }
 
-// debug logs for task metric
+// debug logs for task metric.
 func (pp *Profiler) logProfileSummary(taskName string) {
 	if durationMap, ok := pp.metrics[taskName]; ok {
 		for k, v := range durationMap {
@@ -106,7 +106,7 @@ func (pp *Profiler) logProfileSummary(taskName string) {
 	}
 }
 
-// Manages Task execution
+// Manages Task execution.
 type taskRunner struct {
 	task           Task
 	writer         filewriter.FileWriter

--- a/pkg/validations/createvalidations/gitops.go
+++ b/pkg/validations/createvalidations/gitops.go
@@ -31,7 +31,7 @@ func ValidateGitOps(ctx context.Context, k validations.KubectlClient, cluster *t
 	return nil
 }
 
-// validateGitOpsConfig method will be removed in a future release since gitOpsConfig is deprecated in favor of fluxConfig
+// validateGitOpsConfig method will be removed in a future release since gitOpsConfig is deprecated in favor of fluxConfig.
 func validateGitOpsConfig(ctx context.Context, k validations.KubectlClient, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	if clusterSpec.GitOpsConfig == nil {
 		return nil

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -299,7 +299,7 @@ func (s *CreateWorkloadClusterTask) Checkpoint() *task.CompletedTask {
 	return nil
 }
 
-// InstallResourcesOnManagement implementation
+// InstallResourcesOnManagement implementation.
 func (s *InstallResourcesOnManagementTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	if commandContext.BootstrapCluster.ExistingManagement {
 		return &MoveClusterManagementTask{}

--- a/pkg/yamlutil/apiobject.go
+++ b/pkg/yamlutil/apiobject.go
@@ -7,16 +7,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// APIObject represents a kubernetes API object
+// APIObject represents a kubernetes API object.
 type APIObject interface {
 	runtime.Object
 	GetName() string
 }
 
-// ObjectLookup allows to search APIObjects by a unique key composed of apiVersion, kind, and name
+// ObjectLookup allows to search APIObjects by a unique key composed of apiVersion, kind, and name.
 type ObjectLookup map[string]APIObject
 
-// GetFromRef searches in a ObjectLookup for an APIObject referenced by a corev1.ObjectReference
+// GetFromRef searches in a ObjectLookup for an APIObject referenced by a corev1.ObjectReference.
 func (o ObjectLookup) GetFromRef(ref corev1.ObjectReference) APIObject {
 	return o[keyForRef(ref)]
 }
@@ -31,12 +31,12 @@ func NewObjectLookupBuilder() *ObjectLookupBuilder {
 	}
 }
 
-// ObjectLookupBuilder allows to construct an ObjectLookup and add APIObjects to it
+// ObjectLookupBuilder allows to construct an ObjectLookup and add APIObjects to it.
 type ObjectLookupBuilder struct {
 	lookup ObjectLookup
 }
 
-// Add acumulates an API object that will be included in the built ObjectLookup
+// Add acumulates an API object that will be included in the built ObjectLookup.
 func (o *ObjectLookupBuilder) Add(objs ...APIObject) *ObjectLookupBuilder {
 	for _, obj := range objs {
 		o.lookup.add(obj)
@@ -46,7 +46,7 @@ func (o *ObjectLookupBuilder) Add(objs ...APIObject) *ObjectLookupBuilder {
 
 // Build constructs and returns an ObjectLookup
 // After this method is called, the builder is reset and loses track
-// of all previously added objects
+// of all previously added objects.
 func (o *ObjectLookupBuilder) Build() ObjectLookup {
 	l := o.lookup
 	o.lookup = ObjectLookup{}

--- a/pkg/yamlutil/parser.go
+++ b/pkg/yamlutil/parser.go
@@ -13,14 +13,14 @@ import (
 )
 
 type (
-	// APIObjectGenerator returns an implementor of the APIObject interface
+	// APIObjectGenerator returns an implementor of the APIObject interface.
 	APIObjectGenerator func() APIObject
-	// ParsedProcessor fills the struct of type T with the parsed API objects in ObjectLookup
+	// ParsedProcessor fills the struct of type T with the parsed API objects in ObjectLookup.
 	ParsedProcessor[T any] func(*T, ObjectLookup)
 
 	// Parser allows to parse from yaml with kubernetes style objects and
 	// store them in a type implementing Builder
-	// It allows to dynamically register configuration for mappings between kind and concrete types
+	// It allows to dynamically register configuration for mappings between kind and concrete types.
 	Parser struct {
 		apiObjectMapping map[string]APIObjectGenerator
 		logger           logr.Logger
@@ -34,7 +34,7 @@ func NewParser(logger logr.Logger) *Parser {
 	}
 }
 
-// RegisterMapping records the mapping between a kubernetes Kind and an API concrete type
+// RegisterMapping records the mapping between a kubernetes Kind and an API concrete type.
 func (c *Parser) RegisterMapping(kind string, generator APIObjectGenerator) error {
 	if _, ok := c.apiObjectMapping[kind]; ok {
 		return errors.Errorf("mapping for api object %s already registered", kind)
@@ -44,7 +44,7 @@ func (c *Parser) RegisterMapping(kind string, generator APIObjectGenerator) erro
 	return nil
 }
 
-// Mapping mapping between a kubernetes Kind and an API concrete type of type T
+// Mapping mapping between a kubernetes Kind and an API concrete type of type T.
 type Mapping[T APIObject] struct {
 	New  func() T
 	Kind string
@@ -59,7 +59,7 @@ func NewMapping[T APIObject](kind string, new func() T) Mapping[T] {
 
 // ToAPIObjectMapping is helper to convert from other concrete types of Mapping
 // to a APIObject Mapping
-// This is mostly to help pass Mappings to RegisterMappings
+// This is mostly to help pass Mappings to RegisterMappings.
 func (m Mapping[T]) ToAPIObjectMapping() Mapping[APIObject] {
 	return Mapping[APIObject]{
 		Kind: m.Kind,
@@ -69,7 +69,7 @@ func (m Mapping[T]) ToAPIObjectMapping() Mapping[APIObject] {
 	}
 }
 
-// RegisterMappings records a collection of mappings
+// RegisterMappings records a collection of mappings.
 func (c *Parser) RegisterMappings(mappings ...Mapping[APIObject]) error {
 	for _, m := range mappings {
 		if err := c.RegisterMapping(m.Kind, m.New); err != nil {
@@ -80,19 +80,19 @@ func (c *Parser) RegisterMappings(mappings ...Mapping[APIObject]) error {
 	return nil
 }
 
-// Builder processes the parsed API objects contained in a lookup
+// Builder processes the parsed API objects contained in a lookup.
 type Builder interface {
 	BuildFromParsed(ObjectLookup) error
 }
 
 // Parse reads yaml manifest content with the registered mappings and passes
-// the result to the Builder for further processing
+// the result to the Builder for further processing.
 func (p *Parser) Parse(yamlManifest []byte, b Builder) error {
 	return p.Read(bytes.NewReader(yamlManifest), b)
 }
 
 // Read reads yaml manifest content with the registered mappings and passes
-// the result to the Builder for further processing
+// the result to the Builder for further processing.
 func (p *Parser) Read(reader io.Reader, b Builder) error {
 	parsed, err := p.unmarshal(reader)
 	if err != nil {

--- a/release/api/v1alpha1/bundle_types.go
+++ b/release/api/v1alpha1/bundle_types.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// BundlesSpec defines the desired state of Bundles
+// BundlesSpec defines the desired state of Bundles.
 type BundlesSpec struct {
 	// Monotonically increasing release number
 	Number          int              `json:"number"`
@@ -27,13 +27,13 @@ type BundlesSpec struct {
 	VersionsBundles []VersionsBundle `json:"versionsBundles"`
 }
 
-// BundlesStatus defines the observed state of Bundles
+// BundlesStatus defines the observed state of Bundles.
 type BundlesStatus struct{}
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// Bundles is the Schema for the bundles API
+// Bundles is the Schema for the bundles API.
 type Bundles struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -48,7 +48,7 @@ func (b *Bundles) DefaultEksAToolsImage() Image {
 
 //+kubebuilder:object:root=true
 
-// BundlesList contains a list of Bundles
+// BundlesList contains a list of Bundles.
 type BundlesList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -277,7 +277,7 @@ type TinkerbellStackBundle struct {
 	Tink           TinkBundle    `json:"tink"`
 }
 
-// Tinkerbell Template Actions
+// Tinkerbell Template Actions.
 type ActionsBundle struct {
 	Cexec       Image `json:"cexec"`
 	Kexec       Image `json:"kexec"`
@@ -293,7 +293,7 @@ type TinkBundle struct {
 	TinkWorker     Image `json:"tinkWorker"`
 }
 
-// Tinkerbell hook OS
+// Tinkerbell hook OS.
 type HookBundle struct {
 	Bootkit   Image    `json:"bootkit"`
 	Docker    Image    `json:"docker"`

--- a/release/api/v1alpha1/groupversion_info.go
+++ b/release/api/v1alpha1/groupversion_info.go
@@ -23,10 +23,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "anywhere.eks.amazonaws.com", Version: "v1alpha1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/release/api/v1alpha1/release_types.go
+++ b/release/api/v1alpha1/release_types.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ReleaseSpec defines the desired state of Release
+// ReleaseSpec defines the desired state of Release.
 type ReleaseSpec struct {
 	// +kubebuilder:validation:Required
 	// EKS-A Latest Release version following semver
@@ -29,13 +29,13 @@ type ReleaseSpec struct {
 	Releases []EksARelease `json:"releases"`
 }
 
-// ReleaseStatus defines the observed state of Release
+// ReleaseStatus defines the observed state of Release.
 type ReleaseStatus struct{}
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// Release is the Schema for the releases API
+// Release is the Schema for the releases API.
 type Release struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -46,7 +46,7 @@ type Release struct {
 
 //+kubebuilder:object:root=true
 
-// ReleaseList contains a list of Release
+// ReleaseList contains a list of Release.
 type ReleaseList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -57,7 +57,7 @@ func init() {
 	SchemeBuilder.Register(&Release{}, &ReleaseList{})
 }
 
-// EksARelease defines each release of EKS-Anywhere
+// EksARelease defines each release of EKS-Anywhere.
 type EksARelease struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Type=string

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -43,7 +43,7 @@ var (
 	eksAReleaseManifestFile   = "/eks-a-release.yaml"
 )
 
-// releaseCmd represents the release command
+// releaseCmd represents the release command.
 var releaseCmd = &cobra.Command{
 	Use:   "release",
 	Short: "Cut an eks-anywhere release",

--- a/release/cmd/root.go
+++ b/release/cmd/root.go
@@ -25,7 +25,7 @@ import (
 
 var cfgFile string
 
-// rootCmd represents the base command when called without any subcommands
+// rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:   "eks-anywhere-release",
 	Short: "A release tool for EKS Anywhere",

--- a/release/pkg/bundles/bundles.go
+++ b/release/pkg/bundles/bundles.go
@@ -52,7 +52,7 @@ func NewBaseBundles(r *releasetypes.ReleaseConfig) *anywherev1alpha1.Bundles {
 }
 
 // GetVersionsBundles will build the entire bundle manifest from the
-// individual component bundles
+// individual component bundles.
 func GetVersionsBundles(r *releasetypes.ReleaseConfig, imageDigests map[string]string) ([]anywherev1alpha1.VersionsBundle, error) {
 	versionsBundles := []anywherev1alpha1.VersionsBundle{}
 

--- a/release/pkg/bundles/eksctl-anywhere.go
+++ b/release/pkg/bundles/eksctl-anywhere.go
@@ -28,7 +28,7 @@ import (
 	artifactutils "github.com/aws/eks-anywhere/release/pkg/util/artifacts"
 )
 
-// GetCliArtifacts returns the artifacts for eksctl-anywhere cli
+// GetCliArtifacts returns the artifacts for eksctl-anywhere cli.
 func GetEksACliArtifacts(r *releasetypes.ReleaseConfig) ([]releasetypes.Artifact, error) {
 	osList := []string{"linux", "darwin"}
 	arch := "amd64"

--- a/release/pkg/bundles/nutanix.go
+++ b/release/pkg/bundles/nutanix.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/eks-anywhere/release/pkg/version"
 )
 
-// GetNutanixBundle returns the bundle for Nutanix
+// GetNutanixBundle returns the bundle for Nutanix.
 func GetNutanixBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]string) (anywherev1alpha1.NutanixBundle, error) {
 	nutanixBundleArtifacts := map[string][]releasetypes.Artifact{
 		"cluster-api-provider-nutanix": r.BundleArtifactsTable["cluster-api-provider-nutanix"],

--- a/release/pkg/clients/clients.go
+++ b/release/pkg/clients/clients.go
@@ -60,7 +60,7 @@ type ReleaseECRPublicClient struct {
 	AuthConfig *docker.AuthConfiguration
 }
 
-// Function to create release clients for dev release
+// Function to create release clients for dev release.
 func CreateDevReleaseClients(dryRun bool) (*SourceClients, *ReleaseClients, error) {
 	fmt.Println("\n==========================================================")
 	fmt.Println("                 Dev Release Clients Creation")
@@ -130,7 +130,7 @@ func CreateDevReleaseClients(dryRun bool) (*SourceClients, *ReleaseClients, erro
 	return sourceClients, releaseClients, nil
 }
 
-// Function to create clients for staging release
+// Function to create clients for staging release.
 func CreateStagingReleaseClients() (*SourceClients, *ReleaseClients, error) {
 	fmt.Println("\n==========================================================")
 	fmt.Println("              Staging Release Clients Creation")
@@ -204,7 +204,7 @@ func CreateStagingReleaseClients() (*SourceClients, *ReleaseClients, error) {
 	return sourceClients, releaseClients, nil
 }
 
-// Function to create clients for production release
+// Function to create clients for production release.
 func CreateProdReleaseClients() (*SourceClients, *ReleaseClients, error) {
 	fmt.Println("\n==========================================================")
 	fmt.Println("             Production Release Clients Creation")

--- a/release/pkg/constants/constants.go
+++ b/release/pkg/constants/constants.go
@@ -15,7 +15,7 @@
 package constants
 
 const (
-	// Artifacts-related constants
+	// Artifacts-related constants.
 	ReleaseKind              = "Release"
 	BundlesKind              = "Bundles"
 	HexAlphabet              = "0123456789abcdef"
@@ -26,7 +26,7 @@ const (
 	EksDReleaseComponentsUrl = "https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml"
 	YamlSeparator            = "\n---\n"
 
-	// Project paths
+	// Project paths.
 	CapasProjectPath                    = "projects/aws/cluster-api-provider-aws-snow"
 	CapcProjectPath                     = "projects/kubernetes-sigs/cluster-api-provider-cloudstack"
 	CapiProjectPath                     = "projects/kubernetes-sigs/cluster-api"

--- a/release/pkg/helm/helm.go
+++ b/release/pkg/helm/helm.go
@@ -212,7 +212,7 @@ func (d *helmDriver) PullHelmChart(name, version string) (string, error) {
 	return chartPath, nil
 }
 
-// PushHelmChart will take in packaged helm chart and push to a remote URI
+// PushHelmChart will take in packaged helm chart and push to a remote URI.
 func (d *helmDriver) PushHelmChart(packaged, URI string) error {
 	config := action.WithPushConfig(d.cfg)
 	p := action.NewPushWithOpts(config)
@@ -226,7 +226,7 @@ func (d *helmDriver) PushHelmChart(packaged, URI string) error {
 	return nil
 }
 
-// PackageHelmChart will package a dir into a helm chart
+// PackageHelmChart will package a dir into a helm chart.
 func PackageHelmChart(dir string) (string, error) {
 	if dir == "" {
 		return "", fmt.Errorf("empty input for PackageHelmChart, check flags")
@@ -270,7 +270,7 @@ func UnTarHelmChart(chartRef, chartPath, dest string) error {
 	return chartutil.ExpandFile(dest, chartRef)
 }
 
-// HasRequires checks for the existance of the requires.yaml within the helm directory
+// HasRequires checks for the existance of the requires.yaml within the helm directory.
 func HasRequires(helmdir string) (string, error) {
 	requires := filepath.Join(helmdir, "requires.yaml")
 	info, err := os.Stat(requires)
@@ -283,7 +283,7 @@ func HasRequires(helmdir string) (string, error) {
 	return requires, nil
 }
 
-// ValidateHelmRequires runs the parse file into struct function, and validations
+// ValidateHelmRequires runs the parse file into struct function, and validations.
 func ValidateHelmRequires(fileName string) (*Requires, error) {
 	helmrequires := &Requires{}
 	err := parseHelmRequires(fileName, helmrequires)
@@ -297,7 +297,7 @@ func ValidateHelmRequires(fileName string) (*Requires, error) {
 	return helmrequires, err
 }
 
-// validateHelmRequiresContent loops over the validation tests
+// validateHelmRequiresContent loops over the validation tests.
 func validateHelmRequiresContent(helmrequires *Requires) error {
 	for _, v := range helmRequiresValidations {
 		if err := v(helmrequires); err != nil {
@@ -319,7 +319,7 @@ func validateHelmRequiresName(helmrequires *Requires) error {
 	return nil
 }
 
-// validateHelmRequiresNotEmpty checks that it has at least one image in the spec
+// validateHelmRequiresNotEmpty checks that it has at least one image in the spec.
 func (helmrequires *Requires) validateHelmRequiresNotEmpty() error {
 	// Check if Projects are listed
 	if len(helmrequires.Spec.Images) < 1 {
@@ -328,7 +328,7 @@ func (helmrequires *Requires) validateHelmRequiresNotEmpty() error {
 	return nil
 }
 
-// parseHelmRequires will attempt to unpack the requires.yaml into the Go struct `Requires`
+// parseHelmRequires will attempt to unpack the requires.yaml into the Go struct `Requires`.
 func parseHelmRequires(fileName string, helmrequires *Requires) error {
 	content, err := ioutil.ReadFile(fileName)
 	if err != nil {
@@ -349,7 +349,7 @@ func parseHelmRequires(fileName string, helmrequires *Requires) error {
 
 // Chart yaml functions
 
-// HasChart checks for the existance of the Chart.yaml within the helm directory
+// HasChart checks for the existance of the Chart.yaml within the helm directory.
 func HasChart(helmdir string) (string, error) {
 	requires := filepath.Join(helmdir, "Chart.yaml")
 	info, err := os.Stat(requires)
@@ -362,7 +362,7 @@ func HasChart(helmdir string) (string, error) {
 	return requires, nil
 }
 
-// ValidateHelmChart runs the parse file into struct function, and validations
+// ValidateHelmChart runs the parse file into struct function, and validations.
 func ValidateHelmChart(fileName string) (*chart.Metadata, error) {
 	helmChart := &chart.Metadata{}
 	err := parseHelmChart(fileName, helmChart)
@@ -372,7 +372,7 @@ func ValidateHelmChart(fileName string) (*chart.Metadata, error) {
 	return helmChart, err
 }
 
-// parseHelmChart will attempt to unpack the Chart.yaml into the Go struct `Chart`
+// parseHelmChart will attempt to unpack the Chart.yaml into the Go struct `Chart`.
 func parseHelmChart(fileName string, helmChart *chart.Metadata) error {
 	content, err := ioutil.ReadFile(fileName)
 	if err != nil {

--- a/release/pkg/retrier/retrier.go
+++ b/release/pkg/retrier/retrier.go
@@ -26,13 +26,13 @@ type Retrier struct {
 
 type (
 	// RetryPolicy allows to customize the retrying logic. The boolean retry indicates if a new retry
-	// should be performed and the wait duration indicates the wait time before the next retry
+	// should be performed and the wait duration indicates the wait time before the next retry.
 	RetryPolicy func(totalRetries int, err error) (retry bool, wait time.Duration)
 	RetrierOpt  func(*Retrier)
 )
 
 // NewRetrier creates a new retrier with a global timeout (max time allowed for the whole execution)
-// The default retry policy is to always retry with no wait time in between retries
+// The default retry policy is to always retry with no wait time in between retries.
 func NewRetrier(timeout time.Duration, opts ...RetrierOpt) *Retrier {
 	r := &Retrier{
 		timeout:     timeout,
@@ -52,7 +52,7 @@ func WithRetryPolicy(policy RetryPolicy) RetrierOpt {
 }
 
 // Retry runs the fn function until it either successful completes (not error),
-// the set timeout reached or the retry policy aborts the execution
+// the set timeout reached or the retry policy aborts the execution.
 func (r *Retrier) Retry(fn func() error) error {
 	start := time.Now()
 	retries := 0

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -50,7 +50,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-20-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-22-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -134,9 +134,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.8-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.8-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8-rc5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -156,8 +156,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8-rc5/metadata.yaml
-      version: v0.4.8-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8/metadata.yaml
+      version: v0.4.8+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
@@ -271,21 +271,21 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-20-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-22-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.20.15
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-20.yaml
-      name: kubernetes-1-20-eks-20
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-22.yaml
+      name: kubernetes-1-20-eks-22
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-20-20 release
-          name: bottlerocket-v1.20.15-eks-d-1-20-20-eks-a-v0.0.0-dev-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-20-22 release
+          name: bottlerocket-v1.20.15-eks-d-1-20-22-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-20/1-20-20/bottlerocket-v1.20.15-eks-d-1-20-20-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-20/1-20-22/bottlerocket-v1.20.15-eks-d-1-20-22-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket: {}
     eksa:
@@ -451,7 +451,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.14-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.15-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -460,7 +460,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.14-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.15-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -469,8 +469,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.14-eks-a-v0.0.0-dev-build.1
-      version: v0.2.14+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.15-eks-a-v0.0.0-dev-build.1
+      version: v0.2.15+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml
@@ -800,7 +800,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-18-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-20-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -884,9 +884,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.8-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.8-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8-rc5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -906,8 +906,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8-rc5/metadata.yaml
-      version: v0.4.8-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8/metadata.yaml
+      version: v0.4.8+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
@@ -1021,32 +1021,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.14-eks-d-1-21-20-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.21.14
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-18.yaml
-      name: kubernetes-1-21-eks-18
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-20.yaml
+      name: kubernetes-1-21-eks-20
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-21-18 release
-          name: bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-21-20 release
+          name: bottlerocket-v1.21.14-eks-d-1-21-20-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-21/1-21-18/bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-21/1-21-20/bottlerocket-v1.21.14-eks-d-1-21-20-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-21-18 release
-          name: bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-21-20 release
+          name: bottlerocket-v1.21.14-eks-d-1-21-20-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-21/1-21-18/bottlerocket-v1.21.14-eks-d-1-21-18-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-21/1-21-20/bottlerocket-v1.21.14-eks-d-1-21-20-eks-a-v0.0.0-dev-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -1210,7 +1210,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.14-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.15-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1219,7 +1219,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.14-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.15-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1228,8 +1228,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.14-eks-a-v0.0.0-dev-build.1
-      version: v0.2.14+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.15-eks-a-v0.0.0-dev-build.1
+      version: v0.2.15+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml
@@ -1559,7 +1559,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-11-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-12-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -1643,9 +1643,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.8-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.8-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8-rc5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -1665,8 +1665,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8-rc5/metadata.yaml
-      version: v0.4.8-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8/metadata.yaml
+      version: v0.4.8+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
@@ -1780,32 +1780,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.15-eks-d-1-22-11-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.15-eks-d-1-22-12-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.22.15
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-11.yaml
-      name: kubernetes-1-22-eks-11
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-12.yaml
+      name: kubernetes-1-22-eks-12
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-22-11 release
-          name: bottlerocket-v1.22.15-eks-d-1-22-11-eks-a-v0.0.0-dev-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-22-12 release
+          name: bottlerocket-v1.22.15-eks-d-1-22-12-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-22/1-22-11/bottlerocket-v1.22.15-eks-d-1-22-11-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-22/1-22-12/bottlerocket-v1.22.15-eks-d-1-22-12-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-22-11 release
-          name: bottlerocket-v1.22.15-eks-d-1-22-11-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-22-12 release
+          name: bottlerocket-v1.22.15-eks-d-1-22-12-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-22/1-22-11/bottlerocket-v1.22.15-eks-d-1-22-11-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-22/1-22-12/bottlerocket-v1.22.15-eks-d-1-22-12-eks-a-v0.0.0-dev-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -1969,7 +1969,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.14-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.15-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1978,7 +1978,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.14-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.15-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1987,8 +1987,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.14-eks-a-v0.0.0-dev-build.1
-      version: v0.2.14+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.15-eks-a-v0.0.0-dev-build.1
+      version: v0.2.15+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml
@@ -2318,7 +2318,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-7-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -2402,9 +2402,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.8-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.8-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8-rc5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -2424,8 +2424,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8-rc5/metadata.yaml
-      version: v0.4.8-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8/metadata.yaml
+      version: v0.4.8+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
@@ -2539,32 +2539,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.12-eks-d-1-23-6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.12-eks-d-1-23-7-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.23.12
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-6.yaml
-      name: kubernetes-1-23-eks-6
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-7.yaml
+      name: kubernetes-1-23-eks-7
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-23-6 release
-          name: bottlerocket-v1.23.12-eks-d-1-23-6-eks-a-v0.0.0-dev-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-23-7 release
+          name: bottlerocket-v1.23.12-eks-d-1-23-7-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-23/1-23-6/bottlerocket-v1.23.12-eks-d-1-23-6-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-23/1-23-7/bottlerocket-v1.23.12-eks-d-1-23-7-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-23-6 release
-          name: bottlerocket-v1.23.12-eks-d-1-23-6-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-23-7 release
+          name: bottlerocket-v1.23.12-eks-d-1-23-7-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-23/1-23-6/bottlerocket-v1.23.12-eks-d-1-23-6-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-23/1-23-7/bottlerocket-v1.23.12-eks-d-1-23-7-eks-a-v0.0.0-dev-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -2728,7 +2728,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.14-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.15-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -2737,7 +2737,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.14-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.15-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2746,8 +2746,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.14-eks-a-v0.0.0-dev-build.1
-      version: v0.2.14+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.15-eks-a-v0.0.0-dev-build.1
+      version: v0.2.15+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml
@@ -3077,7 +3077,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-24-1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-24-2-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -3161,9 +3161,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.8-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.8-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8-rc5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -3183,8 +3183,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8-rc5/metadata.yaml
-      version: v0.4.8-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.8/metadata.yaml
+      version: v0.4.8+abcdef1
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
@@ -3298,10 +3298,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.24.6-eks-d-1-24-1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.24.6-eks-d-1-24-2-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.24.6
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-24/kubernetes-1-24-eks-1.yaml
-      name: kubernetes-1-24-eks-1
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-24/kubernetes-1-24-eks-2.yaml
+      name: kubernetes-1-24-eks-2
       ova:
         bottlerocket: {}
       raw:
@@ -3469,7 +3469,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.14-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.15-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -3478,7 +3478,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.14-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.15-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -3487,8 +3487,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.14-eks-a-v0.0.0-dev-build.1
-      version: v0.2.14+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.15-eks-a-v0.0.0-dev-build.1
+      version: v0.2.15+abcdef1
     snow:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml

--- a/release/pkg/types/types.go
+++ b/release/pkg/types/types.go
@@ -20,7 +20,7 @@ import (
 	"github.com/aws/eks-anywhere/release/pkg/clients"
 )
 
-// ReleaseConfig contains metadata fields for a release
+// ReleaseConfig contains metadata fields for a release.
 type ReleaseConfig struct {
 	ReleaseVersion           string
 	DevReleaseUriVersion     string

--- a/release/pkg/util/artifacts/artifacts.go
+++ b/release/pkg/util/artifacts/artifacts.go
@@ -85,7 +85,7 @@ func GetLatestUploadDestination(sourcedFromBranch string) string {
 	}
 }
 
-// GetURI returns an full URL for the given path
+// GetURI returns an full URL for the given path.
 func GetURI(cdn, path string) (string, error) {
 	uri, err := url.Parse(cdn)
 	if err != nil {

--- a/test/e2e/curated_packages_test.go
+++ b/test/e2e/curated_packages_test.go
@@ -34,7 +34,7 @@ func NoErrorPredicate(_ string, err error) bool {
 	return err == nil
 }
 
-// TODO turn them into generics using comparable once 1.18 is allowed
+// TODO turn them into generics using comparable once 1.18 is allowed.
 func StringMatchPredicate(s string) resourcePredicate {
 	return func(in string, err error) bool {
 		return err == nil && strings.Compare(s, in) == 0

--- a/test/e2e/taints_test.go
+++ b/test/e2e/taints_test.go
@@ -31,7 +31,7 @@ func runTaintsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1
 // create a node with a taint
 // remove a taint from a node
 // add a taint to a node which already has another taint
-// add a taint to a node which had no taints
+// add a taint to a node which had no taints.
 func TestDockerKubernetes124Taints(t *testing.T) {
 	provider := framework.NewDocker(t)
 

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/filewriter/writer.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/filewriter/writer.go
@@ -53,7 +53,7 @@ func (t *writer) Dir() string {
 	return t.dir
 }
 
-// This method writes the e2e test artifacts from S3 to files in a directory named after the e2e test name
+// This method writes the e2e test artifacts from S3 to files in a directory named after the e2e test name.
 func (t *writer) WriteTestArtifactsS3ToFile(key string, data []byte) error {
 	i := strings.LastIndex(key, "/Test")
 	p := path.Join(t.dir, key[i:])

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -398,7 +398,7 @@ func RequiredVsphereEnvVars() []string {
 }
 
 // VSphereExtraEnvVarPrefixes returns prefixes for env vars that although not always required,
-// might be necessary for certain tests
+// might be necessary for certain tests.
 func VSphereExtraEnvVarPrefixes() []string {
 	return []string{
 		vsphereTemplateEnvVarPrefix,


### PR DESCRIPTION
We recently introduced the `godot` linter that barks when comments don't end in a period. This fixes all comments in the code base to end in a period.