### PR TITLE
docs: add us-west-2 region to the "aws ecr get-login-password" command in curated packages docs

### DIFF
--- a/docs/content/en/docs/tasks/packages/_index.md
+++ b/docs/content/en/docs/tasks/packages/_index.md
@@ -58,7 +58,7 @@ aws sts get-caller-identity
 Login to docker
 
 ```bash
-aws ecr get-login-password |docker login --username AWS --password-stdin 783794618700.dkr.ecr.us-west-2.amazonaws.com
+aws ecr get-login-password --region us-west-2 |docker login --username AWS --password-stdin 783794618700.dkr.ecr.us-west-2.amazonaws.com
 ```
 
 Verify you can pull an image


### PR DESCRIPTION
*Description of changes:*
Following the example on how to login to ECR with docker does not work:
```
# aws ecr get-login-password

You must specify a region. You can also configure your region by running "aws configure".
```

It is also important to use the proper region:
```
# aws ecr get-login-password --region eu-central-1 |docker login --username AWS --password-stdin 783794618700.dkr.ecr.us-west-2.amazonaws.com
Error response from daemon: login attempt to https://783794618700.dkr.ecr.us-west-2.amazonaws.com/v2/ failed with status: 400 Bad Request
```

The solution is to use the same region where the registry resides:
```
# aws ecr get-login-password --region us-west-2 |docker login --username AWS --password-stdin 783794618700.dkr.ecr.us-west-2.amazonaws.com
WARNING! Your password will be stored unencrypted in /root/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
```

The proposed PR adds this to the documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

