### PR TITLE
Add worker reconciliation call and test

### DIFF
--- a/pkg/clusterapi/workers.go
+++ b/pkg/clusterapi/workers.go
@@ -18,6 +18,16 @@ type Workers[M Object[M]] struct {
 	Groups []WorkerGroup[M]
 }
 
+// WorkerObjects returns a list of API objects for concrete provider-specific collection of worker groups.
+func (w *Workers[M]) WorkerObjects() []kubernetes.Object {
+	objs := make([]kubernetes.Object, 0, len(w.Groups)*3)
+	for _, g := range w.Groups {
+		objs = append(objs, g.workerGroupObjects()...)
+	}
+
+	return objs
+}
+
 // UpdateImmutableObjectNames checks if any immutable objects have changed by comparing the new definition
 // with the current state of the cluster. If they had, it generates a new name for them by increasing a monotonic number
 // at the end of the name.
@@ -41,6 +51,14 @@ type WorkerGroup[M Object[M]] struct {
 	KubeadmConfigTemplate   *kubeadmv1.KubeadmConfigTemplate
 	MachineDeployment       *clusterv1.MachineDeployment
 	ProviderMachineTemplate M
+}
+
+func (g *WorkerGroup[M]) workerGroupObjects() []kubernetes.Object {
+	return []kubernetes.Object{
+		g.KubeadmConfigTemplate,
+		g.MachineDeployment,
+		g.ProviderMachineTemplate,
+	}
 }
 
 // UpdateImmutableObjectNames checks if any immutable objects have changed by comparing the new definition

--- a/pkg/clusterapi/workers_test.go
+++ b/pkg/clusterapi/workers_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/constants"
 )
@@ -60,6 +61,32 @@ func TestWorkersUpdateImmutableObjectNamesSuccess(t *testing.T) {
 	g.Expect(
 		workers.UpdateImmutableObjectNames(ctx, client, dummyRetriever, noChangesCompare),
 	).To(Succeed())
+}
+
+func TestWorkerObjects(t *testing.T) {
+	g := NewWithT(t)
+	group1 := dockerGroup{
+		MachineDeployment: machineDeployment(),
+	}
+	group2 := dockerGroup{
+		MachineDeployment: machineDeployment(),
+	}
+
+	workers := &dockerWorkers{
+		Groups: []dockerGroup{group1, group2},
+	}
+
+	objects := workers.WorkerObjects()
+	wantObjects := []kubernetes.Object{
+		group1.KubeadmConfigTemplate,
+		group1.MachineDeployment,
+		group1.ProviderMachineTemplate,
+		group2.KubeadmConfigTemplate,
+		group2.MachineDeployment,
+		group2.ProviderMachineTemplate,
+	}
+
+	g.Expect(objects).To(ConsistOf(wantObjects))
 }
 
 func TestWorkerGroupUpdateImmutableObjectNamesNoMachineDeployment(t *testing.T) {

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -86,6 +86,17 @@ func TestReconcilerFailToSetUpMachineConfigCP(t *testing.T) {
 	g.Expect(result).To(Equal(controller.Result{}))
 }
 
+func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
+	tt := newReconcilerTest(t)
+	tt.createAllObjs()
+
+	result, err := tt.reconciler().ReconcileWorkers(tt.ctx, test.NewNullLogger(), tt.buildSpec())
+
+	tt.Expect(err).NotTo(HaveOccurred())
+	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(result).To(Equal(controller.Result{}))
+}
+
 func TestReconcilerInvalidDatacenterConfig(t *testing.T) {
 	tt := newReconcilerTest(t)
 	logger := test.NewNullLogger()
@@ -452,7 +463,9 @@ func eksdRelease() *eksdv1.Release {
 						},
 						{
 							Name:  "kube-apiserver-image",
-							Image: &eksdv1.AssetImage{},
+							Image: &eksdv1.AssetImage{
+								URI: "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.19.8",
+							},
 						},
 					},
 				},
@@ -485,7 +498,7 @@ func machineConfig(opts ...vsphereMachineOpt) *anywherev1.VSphereMachineConfig {
 			Users: []anywherev1.UserConfiguration{
 				{
 					Name:              "user",
-					SshAuthorizedKeys: []string{"ABC"},
+					SshAuthorizedKeys: []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8ZEibIrz1AUBKDvmDiWLs9f5DnOerC4qPITiDtSOuPAsxgZbRMavBfVTxodMdAkYRYlXxK6PqNo0ve0qcOV2yvpxH1OogasMMetck6BlM/dIoo3vEY4ZoG9DuVRIf9Iry5gJKbpMDYWpx1IGZrDMOFcIM20ii2qLQQk5hfq9OqdqhToEJFixdgJt/y/zt6Koy3kix+XsnrVdAHgWAq4CZuwt1G6JUAqrpob3H8vPmL7aS+35ktf0pHBm6nYoxRhslnWMUb/7vpzWiq+fUBIm2LYqvrnm7t3fRqFx7p2sZqAm2jDNivyYXwRXkoQPR96zvGeMtuQ5BVGPpsDfVudSW21+pEXHI0GINtTbua7Ogz7wtpVywSvHraRgdFOeY9mkXPzvm2IhoqNrteck2GErwqSqb19mPz6LnHueK0u7i6WuQWJn0CUoCtyMGIrowXSviK8qgHXKrmfTWATmCkbtosnLskNdYuOw8bKxq5S4WgdQVhPps2TiMSZndjX5NTr8= ubuntu@ip-10-2-0-6"},
 				},
 			},
 		},


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/3916

*Description of changes:*
Makes API call to reconcile CAPI worker objects.

*Testing (if applicable):*
Unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->