### PR TITLE
Fix registry-auth validation

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -103,6 +103,10 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		return err
 	}
 
+	if err := validations.ValidateAuthenticationForRegistryMirror(clusterSpec); err != nil {
+		return err
+	}
+
 	cliConfig := buildCliConfig(clusterSpec)
 	dirs, err := cc.directoriesToMount(clusterSpec, cliConfig, cc.installPackages)
 	if err != nil {

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -2299,52 +2298,10 @@ func TestValidateMirrorConfig(t *testing.T) {
 				},
 			},
 		},
-		{
-			name:    "authenticate but username not set",
-			wantErr: "please set REGISTRY_USERNAME env var",
-			cluster: &Cluster{
-				Spec: ClusterSpec{
-					RegistryMirrorConfiguration: &RegistryMirrorConfiguration{
-						Endpoint:     "1.2.3.4",
-						Port:         "443",
-						Authenticate: true,
-					},
-					DatacenterRef: Ref{
-						Kind: VSphereDatacenterKind,
-					},
-				},
-			},
-		},
-		{
-			name:    "authenticate but not vsphere",
-			wantErr: "authenticated registry mirror is only supported for vSphere provider currently",
-			cluster: &Cluster{
-				Spec: ClusterSpec{
-					RegistryMirrorConfiguration: &RegistryMirrorConfiguration{
-						Endpoint:     "1.2.3.4",
-						Port:         "443",
-						Authenticate: true,
-					},
-					DatacenterRef: Ref{
-						Kind: TinkerbellDatacenterKind,
-					},
-				},
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			if tt.cluster.Spec.RegistryMirrorConfiguration != nil {
-				if tt.cluster.Spec.RegistryMirrorConfiguration.Authenticate {
-					if err := os.Unsetenv("REGISTRY_USERNAME"); err != nil {
-						t.Fatalf(err.Error())
-					}
-					if err := os.Unsetenv("REGISTRY_PASSWORD"); err != nil {
-						t.Fatalf(err.Error())
-					}
-				}
-			}
 			err := validateMirrorConfig(tt.cluster)
 			if tt.wantErr == "" {
 				g.Expect(err).To(BeNil())

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -272,7 +272,7 @@ func (f *Factory) WithExecutableBuilder() *Factory {
 		if f.executablesConfig.builder != nil {
 			return nil
 		}
-		
+
 		if f.registryMirror != nil && f.registryMirror.auth {
 			f.WithDockerLogin()
 		}

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -266,14 +266,15 @@ func (f *Factory) WithDockerLogin() *Factory {
 func (f *Factory) WithExecutableBuilder() *Factory {
 	if f.executablesConfig.useDockerContainer {
 		f.WithExecutableImage().WithDocker()
-		if f.registryMirror != nil && f.registryMirror.auth {
-			f.WithDockerLogin()
-		}
 	}
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.executablesConfig.builder != nil {
 			return nil
+		}
+		
+		if f.registryMirror != nil && f.registryMirror.auth {
+			f.WithDockerLogin()
 		}
 
 		if f.executablesConfig.useDockerContainer {

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 )
@@ -40,6 +41,19 @@ func ValidateCertForRegistryMirror(clusterSpec *cluster.Spec, tlsValidator TlsVa
 		}
 	}
 
+	return nil
+}
+
+func ValidateAuthenticationForRegistryMirror(clusterSpec *cluster.Spec) error {
+	cluster := clusterSpec.Cluster
+	if cluster.Spec.RegistryMirrorConfiguration != nil {
+		if cluster.Spec.RegistryMirrorConfiguration.Authenticate {
+			_, _, err := config.ReadCredentials()
+			if err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -47,12 +47,10 @@ func ValidateCertForRegistryMirror(clusterSpec *cluster.Spec, tlsValidator TlsVa
 // ValidateAuthenticationForRegistryMirror checks if REGISTRY_USERNAME and REGISTRY_PASSWORD is set if authenticated registry mirrors are used.
 func ValidateAuthenticationForRegistryMirror(clusterSpec *cluster.Spec) error {
 	cluster := clusterSpec.Cluster
-	if cluster.Spec.RegistryMirrorConfiguration != nil {
-		if cluster.Spec.RegistryMirrorConfiguration.Authenticate {
-			_, _, err := config.ReadCredentials()
-			if err != nil {
-				return err
-			}
+	if cluster.Spec.RegistryMirrorConfiguration != nil && cluster.Spec.RegistryMirrorConfiguration.Authenticate {
+		_, _, err := config.ReadCredentials()
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -44,6 +44,7 @@ func ValidateCertForRegistryMirror(clusterSpec *cluster.Spec, tlsValidator TlsVa
 	return nil
 }
 
+// ValidateAuthenticationForRegistryMirror checks if REGISTRY_USERNAME and REGISTRY_PASSWORD is set if authenticated registry mirrors are used.
 func ValidateAuthenticationForRegistryMirror(clusterSpec *cluster.Spec) error {
 	cluster := clusterSpec.Cluster
 	if cluster.Spec.RegistryMirrorConfiguration != nil {

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -127,12 +127,8 @@ func TestValidateAuthenticationForRegistryMirrorAuthInvalid(t *testing.T) {
 func TestValidateAuthenticationForRegistryMirrorAuthValid(t *testing.T) {
 	tt := newTlsTest(t)
 	tt.clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Authenticate = true
-	if err := os.Setenv("REGISTRY_USERNAME", "username"); err != nil {
-		t.Fatalf(err.Error())
-	}
-	if err := os.Setenv("REGISTRY_PASSWORD", "password"); err != nil {
-		t.Fatalf(err.Error())
-	}
+	t.Setenv("REGISTRY_USERNAME", "username")
+	t.Setenv("REGISTRY_PASSWORD", "password")
 
 	tt.Expect(validations.ValidateAuthenticationForRegistryMirror(tt.clusterSpec)).To(Succeed())
 }


### PR DESCRIPTION
*Description of changes:*
Moved registry validation from api/v1alpha1/cluster.go to createcluster.go

*Testing (if applicable):*
Tested manually to check that it works

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


