### PR TITLE
Reconcile control plane in vsphere

### DIFF
--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -24,6 +24,7 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,6 +57,7 @@ func init() {
 	utilruntime.Must(anywherev1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(eksdv1alpha1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(snowv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(addonsv1.AddToScheme(scheme.Scheme))
 }
 
 var packages = []moduleWithCRD{

--- a/manager/main.go
+++ b/manager/main.go
@@ -19,6 +19,7 @@ import (
 	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -57,6 +58,7 @@ func init() {
 	utilruntime.Must(kubeadmv1.AddToScheme(scheme))
 	utilruntime.Must(eksdv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(snowv1.AddToScheme(scheme))
+	utilruntime.Must(addonsv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/pkg/providers/vsphere/controlplane.go
+++ b/pkg/providers/vsphere/controlplane.go
@@ -2,6 +2,7 @@ package vsphere
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -61,6 +62,9 @@ func (b *ControlPlaneBuilder) BuildFromParsed(lookup yamlutil.ObjectLookup) erro
 func ControlPlaneSpec(ctx context.Context, logger logr.Logger, client kubernetes.Client, spec *cluster.Spec) (*ControlPlane, error) {
 	templateBuilder := NewVsphereTemplateBuilder(time.Now)
 
+	if spec == nil {
+		return nil, fmt.Errorf("control plane spec can't be nil")
+	}
 	controlPlaneYaml, err := templateBuilder.GenerateCAPISpecControlPlane(
 		spec,
 		func(values map[string]interface{}) {

--- a/pkg/providers/vsphere/controlplane.go
+++ b/pkg/providers/vsphere/controlplane.go
@@ -2,7 +2,6 @@ package vsphere
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -62,9 +61,6 @@ func (b *ControlPlaneBuilder) BuildFromParsed(lookup yamlutil.ObjectLookup) erro
 func ControlPlaneSpec(ctx context.Context, logger logr.Logger, client kubernetes.Client, spec *cluster.Spec) (*ControlPlane, error) {
 	templateBuilder := NewVsphereTemplateBuilder(time.Now)
 
-	if spec == nil {
-		return nil, fmt.Errorf("control plane spec can't be nil")
-	}
 	controlPlaneYaml, err := templateBuilder.GenerateCAPISpecControlPlane(
 		spec,
 		func(values map[string]interface{}) {

--- a/pkg/providers/vsphere/reconciler/reconciler.go
+++ b/pkg/providers/vsphere/reconciler/reconciler.go
@@ -166,8 +166,14 @@ func (r *Reconciler) ValidateMachineConfigs(ctx context.Context, log logr.Logger
 func (r *Reconciler) ReconcileControlPlane(ctx context.Context, log logr.Logger, clusterSpec *c.Spec) (controller.Result, error) {
 	log = log.WithValues("phase", "reconcileControlPlane")
 	log.Info("Applying control plane CAPI objects")
-	// TODO: implement CP reconciliation phase
-	return controller.Result{}, nil
+
+	return r.Apply(ctx, func() ([]kubernetes.Object, error) {
+		cp, err := vsphere.ControlPlaneSpec(ctx, log, clientutil.NewKubeClient(r.client), clusterSpec)
+		if err != nil {
+			return nil, err
+		}
+		return cp.Objects(), nil
+	})
 }
 
 // CheckControlPlaneReady checks whether the control plane for an eks-a cluster is ready or not.

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -256,8 +256,10 @@ func TestReconcilerReconcileControlPlaneSuccess(t *testing.T) {
 func TestReconcilerReconcileControlPlaneFailure(t *testing.T) {
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
+	spec := tt.buildSpec()
+	spec.Cluster.Spec.KubernetesVersion = ""
 
-	_, err := tt.reconciler().ReconcileControlPlane(tt.ctx, test.NewNullLogger(), nil)
+	_, err := tt.reconciler().ReconcileControlPlane(tt.ctx, test.NewNullLogger(), spec)
 
 	tt.Expect(err).To(HaveOccurred())
 }

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -253,6 +253,15 @@ func TestReconcilerReconcileControlPlaneSuccess(t *testing.T) {
 	}).Should(Succeed(), "\"object %s should eventually exist", obj.GetName())
 }
 
+func TestReconcilerReconcileControlPlaneFailure(t *testing.T) {
+	tt := newReconcilerTest(t)
+	tt.createAllObjs()
+
+	_, err := tt.reconciler().ReconcileControlPlane(tt.ctx, test.NewNullLogger(), nil)
+
+	tt.Expect(err).To(HaveOccurred())
+}
+
 type reconcilerTest struct {
 	t testing.TB
 	*WithT


### PR DESCRIPTION
*Issue #, if available:*
Issue #3917 

*Description of changes:*
Implement the ProviderClusterReconciler interface: ControlPlane reconciliation

*Testing (if applicable):*
unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

