### PR TITLE
Add control-plane toleration for aws iam auth for 1.24

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -1634,35 +1634,6 @@ spec:
                               description: URI points to the manifest yaml file
                               type: string
                           type: object
-                        kubeVip:
-                          properties:
-                            arch:
-                              description: Architectures of the asset
-                              items:
-                                type: string
-                              type: array
-                            description:
-                              type: string
-                            imageDigest:
-                              description: The SHA256 digest of the image manifest
-                              type: string
-                            name:
-                              description: The asset name
-                              type: string
-                            os:
-                              description: Operating system of the asset
-                              enum:
-                              - linux
-                              - darwin
-                              - windows
-                              type: string
-                            osName:
-                              description: Name of the OS like ubuntu, bottlerocket
-                              type: string
-                            uri:
-                              description: The image repository, name, and tag
-                              type: string
-                          type: object
                         metadata:
                           properties:
                             uri:
@@ -1675,7 +1646,6 @@ spec:
                       - clusterAPIController
                       - clusterTemplate
                       - components
-                      - kubeVip
                       - metadata
                       - version
                       type: object
@@ -2190,6 +2160,35 @@ spec:
                                   description: The image repository, name, and tag
                                   type: string
                               type: object
+                            cfssl:
+                              properties:
+                                arch:
+                                  description: Architectures of the asset
+                                  items:
+                                    type: string
+                                  type: array
+                                description:
+                                  type: string
+                                imageDigest:
+                                  description: The SHA256 digest of the image manifest
+                                  type: string
+                                name:
+                                  description: The asset name
+                                  type: string
+                                os:
+                                  description: Operating system of the asset
+                                  enum:
+                                  - linux
+                                  - darwin
+                                  - windows
+                                  type: string
+                                osName:
+                                  description: Name of the OS like ubuntu, bottlerocket
+                                  type: string
+                                uri:
+                                  description: The image repository, name, and tag
+                                  type: string
+                              type: object
                             hegel:
                               properties:
                                 arch:
@@ -2639,6 +2638,7 @@ spec:
                           required:
                           - actions
                           - boots
+                          - cfssl
                           - hegel
                           - hook
                           - rufio

--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -172,23 +172,6 @@ spec:
                       - key
                       type: object
                     type: array
-                  upgradeRolloutStrategy:
-                    description: UpgradeRolloutStrategy determines the rollout strategy
-                      to use for rolling upgrades and related parameters/knobs
-                    properties:
-                      rollingUpdate:
-                        properties:
-                          maxSurge:
-                            type: integer
-                          maxUnavailable:
-                            type: integer
-                        required:
-                        - maxSurge
-                        - maxUnavailable
-                        type: object
-                      type:
-                        type: string
-                    type: object
                 type: object
               datacenterRef:
                 properties:
@@ -258,9 +241,6 @@ spec:
                 description: RegistryMirrorConfiguration defines the settings for
                   image registry mirror
                 properties:
-                  authenticate:
-                    description: Authenticate defines if registry requires authentication
-                    type: boolean
                   caCertContent:
                     description: CACertContent defines the contents registry mirror
                       CA certificate
@@ -347,23 +327,6 @@ spec:
                         - key
                         type: object
                       type: array
-                    upgradeRolloutStrategy:
-                      description: UpgradeRolloutStrategy determines the rollout strategy
-                        to use for rolling upgrades and related parameters/knobs
-                      properties:
-                        rollingUpdate:
-                          properties:
-                            maxSurge:
-                              type: integer
-                            maxUnavailable:
-                              type: integer
-                          required:
-                          - maxSurge
-                          - maxUnavailable
-                          type: object
-                        type:
-                          type: string
-                      type: object
                   type: object
                 type: array
             type: object

--- a/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbelldatacenterconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbelldatacenterconfigs.yaml
@@ -35,26 +35,21 @@ spec:
           metadata:
             type: object
           spec:
-            description: TinkerbellDatacenterConfigSpec defines the desired state
-              of TinkerbellDatacenterConfig
+            description: "TinkerbellDatacenterConfigSpec defines the desired state
+              of TinkerbellDatacenterConfig \n Important: Run \"make generate\" to
+              regenerate code after modifying this file"
             properties:
               hookImagesURLPath:
                 description: HookImagesURLPath can be used to override the default
-                  Hook images path to pull from a local server.
+                  Hook images path to pull from a local server
                 type: string
               osImageURL:
                 description: OSImageURL can be used to override the default OS image
-                  path to pull from a local server.
+                  path to pull from a local server
                 type: string
-              skipLoadBalancerDeployment:
-                description: SkipLoadBalancerDeployment when set to "true" can be
-                  used to skip deploying a load balancer to expose Tinkerbell stack.
-                  Users will need to deploy and configure a load balancer manually
-                  after the cluster is created.
-                type: boolean
               tinkerbellIP:
                 description: TinkerbellIP is used to configure a VIP for hosting the
-                  Tinkerbell services.
+                  Tinkerbell servies.
                 type: string
             required:
             - tinkerbellIP

--- a/config/crd/bases/anywhere.eks.amazonaws.com_vspheredatacenterconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_vspheredatacenterconfigs.yaml
@@ -40,8 +40,6 @@ spec:
             properties:
               datacenter:
                 type: string
-              disableCSI:
-                type: boolean
               insecure:
                 type: boolean
               network:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -1802,35 +1802,6 @@ spec:
                               description: URI points to the manifest yaml file
                               type: string
                           type: object
-                        kubeVip:
-                          properties:
-                            arch:
-                              description: Architectures of the asset
-                              items:
-                                type: string
-                              type: array
-                            description:
-                              type: string
-                            imageDigest:
-                              description: The SHA256 digest of the image manifest
-                              type: string
-                            name:
-                              description: The asset name
-                              type: string
-                            os:
-                              description: Operating system of the asset
-                              enum:
-                              - linux
-                              - darwin
-                              - windows
-                              type: string
-                            osName:
-                              description: Name of the OS like ubuntu, bottlerocket
-                              type: string
-                            uri:
-                              description: The image repository, name, and tag
-                              type: string
-                          type: object
                         metadata:
                           properties:
                             uri:
@@ -1843,7 +1814,6 @@ spec:
                       - clusterAPIController
                       - clusterTemplate
                       - components
-                      - kubeVip
                       - metadata
                       - version
                       type: object
@@ -2358,6 +2328,35 @@ spec:
                                   description: The image repository, name, and tag
                                   type: string
                               type: object
+                            cfssl:
+                              properties:
+                                arch:
+                                  description: Architectures of the asset
+                                  items:
+                                    type: string
+                                  type: array
+                                description:
+                                  type: string
+                                imageDigest:
+                                  description: The SHA256 digest of the image manifest
+                                  type: string
+                                name:
+                                  description: The asset name
+                                  type: string
+                                os:
+                                  description: Operating system of the asset
+                                  enum:
+                                  - linux
+                                  - darwin
+                                  - windows
+                                  type: string
+                                osName:
+                                  description: Name of the OS like ubuntu, bottlerocket
+                                  type: string
+                                uri:
+                                  description: The image repository, name, and tag
+                                  type: string
+                              type: object
                             hegel:
                               properties:
                                 arch:
@@ -2807,6 +2806,7 @@ spec:
                           required:
                           - actions
                           - boots
+                          - cfssl
                           - hegel
                           - hook
                           - rufio
@@ -3649,23 +3649,6 @@ spec:
                       - key
                       type: object
                     type: array
-                  upgradeRolloutStrategy:
-                    description: UpgradeRolloutStrategy determines the rollout strategy
-                      to use for rolling upgrades and related parameters/knobs
-                    properties:
-                      rollingUpdate:
-                        properties:
-                          maxSurge:
-                            type: integer
-                          maxUnavailable:
-                            type: integer
-                        required:
-                        - maxSurge
-                        - maxUnavailable
-                        type: object
-                      type:
-                        type: string
-                    type: object
                 type: object
               datacenterRef:
                 properties:
@@ -3735,9 +3718,6 @@ spec:
                 description: RegistryMirrorConfiguration defines the settings for
                   image registry mirror
                 properties:
-                  authenticate:
-                    description: Authenticate defines if registry requires authentication
-                    type: boolean
                   caCertContent:
                     description: CACertContent defines the contents registry mirror
                       CA certificate
@@ -3824,23 +3804,6 @@ spec:
                         - key
                         type: object
                       type: array
-                    upgradeRolloutStrategy:
-                      description: UpgradeRolloutStrategy determines the rollout strategy
-                        to use for rolling upgrades and related parameters/knobs
-                      properties:
-                        rollingUpdate:
-                          properties:
-                            maxSurge:
-                              type: integer
-                            maxUnavailable:
-                              type: integer
-                          required:
-                          - maxSurge
-                          - maxUnavailable
-                          type: object
-                        type:
-                          type: string
-                      type: object
                   type: object
                 type: array
             type: object
@@ -4831,26 +4794,21 @@ spec:
           metadata:
             type: object
           spec:
-            description: TinkerbellDatacenterConfigSpec defines the desired state
-              of TinkerbellDatacenterConfig
+            description: "TinkerbellDatacenterConfigSpec defines the desired state
+              of TinkerbellDatacenterConfig \n Important: Run \"make generate\" to
+              regenerate code after modifying this file"
             properties:
               hookImagesURLPath:
                 description: HookImagesURLPath can be used to override the default
-                  Hook images path to pull from a local server.
+                  Hook images path to pull from a local server
                 type: string
               osImageURL:
                 description: OSImageURL can be used to override the default OS image
-                  path to pull from a local server.
+                  path to pull from a local server
                 type: string
-              skipLoadBalancerDeployment:
-                description: SkipLoadBalancerDeployment when set to "true" can be
-                  used to skip deploying a load balancer to expose Tinkerbell stack.
-                  Users will need to deploy and configure a load balancer manually
-                  after the cluster is created.
-                type: boolean
               tinkerbellIP:
                 description: TinkerbellIP is used to configure a VIP for hosting the
-                  Tinkerbell services.
+                  Tinkerbell servies.
                 type: string
             required:
             - tinkerbellIP
@@ -5140,8 +5098,6 @@ spec:
             properties:
               datacenter:
                 type: string
-              disableCSI:
-                type: boolean
               insecure:
                 type: boolean
               network:
@@ -5341,8 +5297,6 @@ rules:
   - cloudstackmachineconfigs
   - clusters
   - dockerdatacenterconfigs
-  - nutanixdatacenterconfigs
-  - nutanixmachineconfigs
   - snowmachineconfigs
   - vspheredatacenterconfigs
   - vspheremachineconfigs
@@ -5849,27 +5803,6 @@ webhooks:
     - UPDATE
     resources:
     - snowmachineconfigs
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: eksa-webhook-service
-      namespace: eksa-system
-      path: /mutate-anywhere-eks-amazonaws-com-v1alpha1-vspheredatacenterconfig
-  failurePolicy: Fail
-  name: mutation.vspheredatacenterconfig.anywhere.amazonaws.com
-  rules:
-  - apiGroups:
-    - anywhere.eks.amazonaws.com
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - vspheredatacenterconfigs
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -15,8 +15,6 @@ rules:
   - cloudstackmachineconfigs
   - clusters
   - dockerdatacenterconfigs
-  - nutanixdatacenterconfigs
-  - nutanixmachineconfigs
   - snowmachineconfigs
   - vspheredatacenterconfigs
   - vspheremachineconfigs

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -76,27 +76,6 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-anywhere-eks-amazonaws-com-v1alpha1-vspheredatacenterconfig
-  failurePolicy: Fail
-  name: mutation.vspheredatacenterconfig.anywhere.amazonaws.com
-  rules:
-  - apiGroups:
-    - anywhere.eks.amazonaws.com
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - vspheredatacenterconfigs
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
       path: /mutate-anywhere-eks-amazonaws-com-v1alpha1-vspheremachineconfig
   failurePolicy: Fail
   name: mutation.vspheremachineconfig.anywhere.amazonaws.com

--- a/pkg/awsiamauth/config/aws-iam-authenticator.yaml
+++ b/pkg/awsiamauth/config/aws-iam-authenticator.yaml
@@ -94,12 +94,20 @@ spec:
 
       # run on each master node
       nodeSelector:
+{{- if .kubeVersion124 }}
+        node-role.kubernetes.io/control-plane: ""
+{{- else }}
         node-role.kubernetes.io/master: ""
+{{- end }}
       tolerations:
       - effect: NoSchedule 
         key: node-role.kubernetes.io/master
       - key: CriticalAddonsOnly
         operator: Exists
+{{- if .kubeVersion124 }}
+      - effect: NoSchedule 
+        key: node-role.kubernetes.io/control-plane
+{{- end }}
 {{- if .controlPlaneTaints }}
 {{- range .controlPlaneTaints }}
       - key: {{ .Key }}

--- a/pkg/awsiamauth/template.go
+++ b/pkg/awsiamauth/template.go
@@ -32,6 +32,7 @@ func (t *TemplateBuilder) GenerateManifest(clusterSpec *cluster.Spec, clusterID 
 		"clusterID":          clusterIDValue,
 		"backendMode":        strings.Join(clusterSpec.AWSIamConfig.Spec.BackendMode, ","),
 		"partition":          clusterSpec.AWSIamConfig.Spec.Partition,
+		"kubeVersion124":     clusterSpec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube124,
 	}
 
 	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since 1.24 Kubernetes added the `control-plane` taint to the control plane nodes along with the `master`  taint, so added the toleration accordingly for aws iam auth daemonsets.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

