### PR TITLE
Add control-plane toleration for aws iam auth for 1.24

### DIFF
--- a/pkg/awsiamauth/config/aws-iam-authenticator.yaml
+++ b/pkg/awsiamauth/config/aws-iam-authenticator.yaml
@@ -94,12 +94,20 @@ spec:
 
       # run on each master node
       nodeSelector:
+{{- if .kubeVersion124 }}
+        node-role.kubernetes.io/control-plane: ""
+{{- else }}
         node-role.kubernetes.io/master: ""
+{{- end }}
       tolerations:
       - effect: NoSchedule 
         key: node-role.kubernetes.io/master
       - key: CriticalAddonsOnly
         operator: Exists
+{{- if .kubeVersion124 }}
+      - effect: NoSchedule 
+        key: node-role.kubernetes.io/control-plane
+{{- end }}
 {{- if .controlPlaneTaints }}
 {{- range .controlPlaneTaints }}
       - key: {{ .Key }}

--- a/pkg/awsiamauth/template.go
+++ b/pkg/awsiamauth/template.go
@@ -32,6 +32,7 @@ func (t *TemplateBuilder) GenerateManifest(clusterSpec *cluster.Spec, clusterID 
 		"clusterID":          clusterIDValue,
 		"backendMode":        strings.Join(clusterSpec.AWSIamConfig.Spec.BackendMode, ","),
 		"partition":          clusterSpec.AWSIamConfig.Spec.Partition,
+		"kubeVersion124":     clusterSpec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube124,
 	}
 
 	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since 1.24 Kubernetes added the control-plane taint to the control plane nodes along with the master taint, so added the toleration accordingly for aws iam auth daemonsets.


*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

