### PR TITLE
Add client processor for docker datacenter config

### DIFF
--- a/pkg/cluster/build.go
+++ b/pkg/cluster/build.go
@@ -4,6 +4,7 @@ package cluster
 // default processors to build a Config.
 func NewDefaultConfigClientBuilder() *ConfigClientBuilder {
 	return NewConfigClientBuilder().Register(
+		getDockerDatacenter,
 		getVSphereDatacenter,
 		getVSphereMachineConfigs,
 		getSnowDatacenter,

--- a/pkg/cluster/docker.go
+++ b/pkg/cluster/docker.go
@@ -1,6 +1,10 @@
 package cluster
 
-import anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+import (
+	"context"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
 
 func dockerEntry() *ConfigManagerEntry {
 	return &ConfigManagerEntry{
@@ -38,4 +42,18 @@ func processDockerDatacenter(c *Config, objects ObjectLookup) {
 			c.DockerDatacenter = datacenter.(*anywherev1.DockerDatacenterConfig)
 		}
 	}
+}
+
+func getDockerDatacenter(ctx context.Context, client Client, c *Config) error {
+	if c.Cluster.Spec.DatacenterRef.Kind != anywherev1.DockerDatacenterKind {
+		return nil
+	}
+
+	datacenter := &anywherev1.DockerDatacenterConfig{}
+	if err := client.Get(ctx, c.Cluster.Spec.DatacenterRef.Name, c.Cluster.Namespace, datacenter); err != nil {
+		return err
+	}
+
+	c.DockerDatacenter = datacenter
+	return nil
 }

--- a/pkg/cluster/docker_test.go
+++ b/pkg/cluster/docker_test.go
@@ -1,11 +1,17 @@
 package cluster_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/cluster/mocks"
 )
 
 func TestParseConfigMissingDockerDatacenter(t *testing.T) {
@@ -14,4 +20,53 @@ func TestParseConfigMissingDockerDatacenter(t *testing.T) {
 
 	g.Expect(err).To(Not(HaveOccurred()))
 	g.Expect(got.DockerDatacenter).To(BeNil())
+}
+
+func TestDefaultConfigClientBuilderDockerCluster(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	b := cluster.NewDefaultConfigClientBuilder()
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockClient(ctrl)
+	cluster := &anywherev1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: "default",
+		},
+		Spec: anywherev1.ClusterSpec{
+			DatacenterRef: anywherev1.Ref{
+				Kind: anywherev1.DockerDatacenterKind,
+				Name: "datacenter",
+			},
+			ControlPlaneConfiguration: anywherev1.ControlPlaneConfiguration{
+				Count: 1,
+			},
+			WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Name: "md-0",
+				},
+			},
+		},
+	}
+	datacenter := &anywherev1.DockerDatacenterConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datacenter",
+			Namespace: "default",
+		},
+	}
+
+	client.EXPECT().Get(ctx, "datacenter", "default", &anywherev1.DockerDatacenterConfig{}).Return(nil).DoAndReturn(
+		func(ctx context.Context, name, namespace string, obj runtime.Object) error {
+			d := obj.(*anywherev1.DockerDatacenterConfig)
+			d.ObjectMeta = datacenter.ObjectMeta
+			d.Spec = datacenter.Spec
+			return nil
+		},
+	)
+
+	config, err := b.Build(ctx, client, cluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(config).NotTo(BeNil())
+	g.Expect(config.Cluster).To(Equal(cluster))
+	g.Expect(config.DockerDatacenter).To(Equal(datacenter))
 }

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -462,7 +462,7 @@ func eksdRelease() *eksdv1.Release {
 							Image: &eksdv1.AssetImage{},
 						},
 						{
-							Name:  "kube-apiserver-image",
+							Name: "kube-apiserver-image",
 							Image: &eksdv1.AssetImage{
 								URI: "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.19.8",
 							},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add client processor for docker datacenter config and register it in the default Config Client Builder.

*Testing (if applicable):*
- unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

