### PR TITLE
Validate kube version when creating cluster without worker nodes

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -493,6 +493,10 @@ func validateWorkerNodeGroups(clusterConfig *Cluster) error {
 		return errors.New("cannot taint control plane when there is no worker node")
 	}
 
+	if len(workerNodeGroupConfigs) == 0 && clusterConfig.Spec.KubernetesVersion <= Kube121 {
+		return errors.New("Empty workerNodeGroupConfigs is not supported for kube version <= 1.21")
+	}
+
 	return nil
 }
 

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -869,6 +869,12 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			testName:    "tinkerbell 1.21 cluster without worker nodes",
+			fileName:    "testdata/tinkerbell_121cluster_without_worker_nodes.yaml",
+			wantCluster: nil,
+			wantErr:     true,
+		},
+		{
 			testName:    "nontinkerbell datacenter without worker nodes",
 			fileName:    "testdata/vsphere_cluster_without_worker_nodes.yaml",
 			wantCluster: nil,

--- a/pkg/api/v1alpha1/testdata/tinkerbell_121cluster_without_worker_nodes.yaml
+++ b/pkg/api/v1alpha1/testdata/tinkerbell_121cluster_without_worker_nodes.yaml
@@ -1,0 +1,44 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: single-node
+spec:
+  clusterNetwork:
+    cniConfig:
+      cilium: {}
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+    endpoint:
+      host: "10.80.8.90"
+    machineGroupRef:
+      kind: TinkerbellMachineConfig
+      name: single-node-cp
+  datacenterRef:
+    kind: TinkerbellDatacenterConfig
+    name: single-node
+  kubernetesVersion: "1.21"
+  managementCluster:
+    name: single-node
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellDatacenterConfig
+metadata:
+  name: single-node
+spec:
+  tinkerbellIP: "10.80.8.91"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellMachineConfig
+metadata:
+  name: single-node-cp
+spec:
+  hardwareSelector:
+    type: cp
+  osFamily: bottlerocket
+  templateRef: {}


### PR DESCRIPTION
*Issue #, if available:* Empty worker nodes doesn't work with kube version <= 1.21, due to the limitation of cluster-api

*Description of changes:* Add kube version check when worker nodes is empty

*Testing (if applicable):* unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

