### PR TITLE
Fix Permissions Doc Typo

### DIFF
--- a/docs/content/en/docs/reference/vsphere/vsphere-preparation.md
+++ b/docs/content/en/docs/reference/vsphere/vsphere-preparation.md
@@ -66,7 +66,7 @@ export EKSA_VSPHERE_USERNAME=<ADMIN_VSPHERE_USERNAME>
 export EKSA_VSPHERE_PASSWORD=<ADMIN_VSPHERE_PASSWORD>
 ```
 
-If the user does not already exist, you can create the user and all the specified group and role objects by runing:
+If the user does not already exist, you can create the user and all the specified group and role objects by running:
 ```bash
 eksctl anywhere exp vsphere setup user -f user.yaml --password '<NewUserPassword>'
 ```


### PR DESCRIPTION
*Description of changes:*
Fixes a typo in permissions docs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->