### PR TITLE
Enable cron job if credentials

### DIFF
--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -100,6 +100,9 @@ func (pc *PackageControllerClient) EnableCuratedPackages(ctx context.Context) er
 		noProxy := fmt.Sprintf("proxy.NO_PROXY=%s", strings.Join(pc.noProxy, "\\,"))
 		values = append(values, httpProxy, httpsProxy, noProxy)
 	}
+	if pc.eksaSecretAccessKey == "" {
+		values = append(values, "cronjob.suspend=true")
+	}
 
 	err := pc.chartInstaller.InstallChart(ctx, pc.chartName, ociUri, pc.chartVersion, pc.kubeConfig, "", values)
 	if err != nil {
@@ -122,6 +125,9 @@ func (pc *PackageControllerClient) EnableCuratedPackages(ctx context.Context) er
 func (pc *PackageControllerClient) CreateCredentials(ctx context.Context) error {
 	if err := pc.ApplySecret(ctx); err != nil {
 		return errors.New("environment variables EKSA_AWS_SECRET_ACCESS_KEY and EKSA_AWS_ACCESS_KEY_ID not provided")
+	}
+	if pc.eksaSecretAccessKey == "" {
+		return nil
 	}
 
 	if err := pc.CreateCronJob(ctx); err != nil {

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -100,7 +100,7 @@ func (pc *PackageControllerClient) EnableCuratedPackages(ctx context.Context) er
 		noProxy := fmt.Sprintf("proxy.NO_PROXY=%s", strings.Join(pc.noProxy, "\\,"))
 		values = append(values, httpProxy, httpsProxy, noProxy)
 	}
-	if pc.eksaSecretAccessKey == "" {
+	if pc.eksaSecretAccessKey == "" || pc.eksaAccessKeyId == "" {
 		values = append(values, "cronjob.suspend=true")
 	}
 
@@ -125,9 +125,6 @@ func (pc *PackageControllerClient) EnableCuratedPackages(ctx context.Context) er
 func (pc *PackageControllerClient) CreateCredentials(ctx context.Context) error {
 	if err := pc.ApplySecret(ctx); err != nil {
 		return errors.New("environment variables EKSA_AWS_SECRET_ACCESS_KEY and EKSA_AWS_ACCESS_KEY_ID not provided")
-	}
-	if pc.eksaSecretAccessKey == "" {
-		return nil
 	}
 
 	if err := pc.CreateCronJob(ctx); err != nil {

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -123,7 +123,7 @@ func TestEnableCuratedPackagesNoCronjob(t *testing.T) {
 	params := []string{"create", "-f", "-", "--kubeconfig", tt.kubeConfig}
 	dat, err := os.ReadFile("testdata/awssecret_test_empty.yaml")
 	tt.Expect(err).NotTo(HaveOccurred())
-	tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, dat, params).Return(bytes.Buffer{}, nil)
+	tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, dat, params).Return(bytes.Buffer{}, fmt.Errorf("boom"))
 	registry := curatedpackages.GetRegistry(tt.ociUri)
 	sourceRegistry := fmt.Sprintf("sourceRegistry=%s", registry)
 	clusterName := fmt.Sprintf("clusterName=%s", "billy")

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -111,6 +111,36 @@ func TestEnableCuratedPackagesSuccess(t *testing.T) {
 	}
 }
 
+func TestEnableCuratedPackagesNoCronjob(t *testing.T) {
+	tt := newPackageControllerTest(t)
+	tt.command = curatedpackages.NewPackageControllerClient(
+		tt.chartInstaller, tt.kubectl, tt.clusterName, tt.kubeConfig, tt.ociUri, tt.chartName, tt.chartVersion,
+		curatedpackages.WithEksaSecretAccessKey(""),
+		curatedpackages.WithEksaRegion(tt.eksaRegion),
+		curatedpackages.WithEksaAccessKeyId(""),
+		curatedpackages.WithManagementClusterName(tt.clusterName),
+	)
+	params := []string{"create", "-f", "-", "--kubeconfig", tt.kubeConfig}
+	dat, err := os.ReadFile("testdata/awssecret_test_empty.yaml")
+	tt.Expect(err).NotTo(HaveOccurred())
+	tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, dat, params).Return(bytes.Buffer{}, nil)
+	registry := curatedpackages.GetRegistry(tt.ociUri)
+	sourceRegistry := fmt.Sprintf("sourceRegistry=%s", registry)
+	clusterName := fmt.Sprintf("clusterName=%s", "billy")
+	values := []string{sourceRegistry, clusterName, "cronjob.suspend=true"}
+	tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chartName, "oci://"+tt.ociUri, tt.chartVersion, tt.kubeConfig, "", values).Return(nil)
+	any := gomock.Any()
+	tt.kubectl.EXPECT().
+		GetObject(any, any, any, any, any, any).
+		DoAndReturn(getPBCSuccess(t)).
+		AnyTimes()
+
+	err = tt.command.EnableCuratedPackages(tt.ctx)
+	if err != nil {
+		t.Errorf("Install Controller Should succeed when installation passes")
+	}
+}
+
 func TestEnableCuratedPackagesSucceedInWorkloadCluster(t *testing.T) {
 	tt := newPackageControllerTest(t)
 	tt.command = curatedpackages.NewPackageControllerClient(

--- a/pkg/curatedpackages/testdata/awssecret_test_empty.yaml
+++ b/pkg/curatedpackages/testdata/awssecret_test_empty.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+stringData:
+  ID: 
+  SECRET: 
+  REGION: test-region
+kind: Secret
+metadata:
+  name: aws-secret
+  namespace: eksa-packages
+type: Opaque


### PR DESCRIPTION
If the AWS secret key is NOT set, do not enable the cron job or run the one-off job. 

