### PR TITLE
Add custom logic to reconcile a CAPI control plane

### DIFF
--- a/internal/test/envtest/client.go
+++ b/internal/test/envtest/client.go
@@ -150,6 +150,22 @@ func (a *APIExpecter) ShouldEventuallyExist(ctx context.Context, obj client.Obje
 	}, a.timeout).Should(gomega.Succeed(), "object %s should eventually exist", obj.GetName())
 }
 
+// ShouldEventuallyMatch defines an eventual expectation that succeeds if the provided object
+// becomes readable by the client and matches the provider expectation before the timeout expires.
+func (a *APIExpecter) ShouldEventuallyMatch(ctx context.Context, obj client.Object, match func(g gomega.Gomega)) {
+	a.t.Helper()
+	key := client.ObjectKeyFromObject(obj)
+	a.g.Eventually(func(g gomega.Gomega) error {
+		if err := a.client.Get(ctx, key, obj); err != nil {
+			return err
+		}
+
+		match(g)
+
+		return nil
+	}, a.timeout).Should(gomega.Succeed(), "object %s should eventually match", obj.GetName())
+}
+
 // ShouldEventuallyNotExist defines an eventual expectation that succeeds if the provided object
 // becomes not found by the client before the timeout expires.
 func (a *APIExpecter) ShouldEventuallyNotExist(ctx context.Context, obj client.Object) {

--- a/internal/test/envtest/crd.go
+++ b/internal/test/envtest/crd.go
@@ -33,6 +33,12 @@ func withAdditionalCustomCRDPath(customCRDPath string) moduleOpt {
 	}
 }
 
+func withMainCustomCRDPath(customCRDPath string) moduleOpt {
+	return func(m *moduleWithCRD) {
+		m.crdPaths[0] = customCRDPath
+	}
+}
+
 type moduleOpt func(*moduleWithCRD)
 
 func buildModuleWithCRD(pkg string, opts ...moduleOpt) (*moduleWithCRD, error) {

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -37,8 +37,10 @@ import (
 )
 
 const (
-	capiPackage = "sigs.k8s.io/cluster-api"
-	capvPackage = "sigs.k8s.io/cluster-api-provider-vsphere"
+	capiPackage         = "sigs.k8s.io/cluster-api"
+	capdPackage         = "sigs.k8s.io/cluster-api/test"
+	capvPackage         = "sigs.k8s.io/cluster-api-provider-vsphere"
+	etcdProviderPackage = "github.com/mrajashree/etcdadm-controller"
 )
 
 func init() {
@@ -66,6 +68,10 @@ var packages = []moduleWithCRD{
 		withAdditionalCustomCRDPath("controlplane/kubeadm/config/crd/bases"),
 	),
 	mustBuildModuleWithCRDs(capvPackage),
+	mustBuildModuleWithCRDs(capdPackage,
+		withMainCustomCRDPath("infrastructure/docker/config/crd/bases"),
+	),
+	mustBuildModuleWithCRDs(etcdProviderPackage),
 }
 
 type Environment struct {

--- a/pkg/controller/clientutil/annotations.go
+++ b/pkg/controller/clientutil/annotations.go
@@ -1,0 +1,14 @@
+package clientutil
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+// AddAnnotation adds an annotation to the given object.
+// If the annotation already exists, it overwrites its value.
+func AddAnnotation(o client.Object, key, value string) {
+	a := o.GetAnnotations()
+	if a == nil {
+		a = make(map[string]string, 1)
+	}
+	a[key] = value
+	o.SetAnnotations(a)
+}

--- a/pkg/controller/clientutil/annotations_test.go
+++ b/pkg/controller/clientutil/annotations_test.go
@@ -1,0 +1,70 @@
+package clientutil_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
+)
+
+func TestAddAnnotation(t *testing.T) {
+	tests := []struct {
+		name       string
+		obj        client.Object
+		key, value string
+	}{
+		{
+			name:  "empty annotations",
+			obj:   &corev1.ConfigMap{},
+			key:   "my-annotation",
+			value: "my-value",
+		},
+		{
+			name: "non empty annotations",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"a": "b",
+					},
+				},
+			},
+			key:   "my-annotation",
+			value: "my-value",
+		},
+		{
+			name: "annotation present same value",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"my-annotation": "my-value",
+					},
+				},
+			},
+			key:   "my-annotation",
+			value: "my-value",
+		},
+		{
+			name: "annotation present diff value",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"my-annotation": "other-value",
+					},
+				},
+			},
+			key:   "my-annotation",
+			value: "my-value",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			clientutil.AddAnnotation(tt.obj, tt.key, tt.value)
+			g.Expect(tt.obj.GetAnnotations()).To(HaveKeyWithValue(tt.key, tt.value))
+		})
+	}
+}

--- a/pkg/controller/clusters/controlplane.go
+++ b/pkg/controller/clusters/controlplane.go
@@ -1,0 +1,100 @@
+package clusters
+
+import (
+	"context"
+
+	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/eks-anywhere/pkg/controller"
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
+	"github.com/aws/eks-anywhere/pkg/controller/serverside"
+)
+
+// ControlPlane represents a CAPI spec for a kubernetes cluster.
+type ControlPlane struct {
+	Cluster *clusterv1.Cluster
+
+	// ProviderCluster is the provider-specific resource that holds the details
+	// for provisioning the infrastructure, referenced in Cluster.Spec.InfrastructureRef
+	ProviderCluster client.Object
+
+	KubeadmControlPlane *controlplanev1.KubeadmControlPlane
+
+	// ControlPlaneMachineTemplate is the provider-specific machine template referenced
+	// in KubeadmControlPlane.Spec.MachineTemplate.InfrastructureRef
+	ControlPlaneMachineTemplate client.Object
+
+	EtcdCluster *etcdv1.EtcdadmCluster
+
+	// EtcdMachineTemplate is the provider-specific machine template referenced
+	// in EtcdCluster.Spec.InfrastructureTemplate
+	EtcdMachineTemplate client.Object
+
+	// Other includes any other provider-specific objects that need to be reconciled
+	// as part of the control plane.
+	Other []client.Object
+}
+
+// AllObjects returns all the control plane objects.
+func (cp *ControlPlane) AllObjects() []client.Object {
+	objs := make([]client.Object, 0, 6+len(cp.Other))
+	objs = append(objs, cp.Cluster, cp.ProviderCluster, cp.KubeadmControlPlane, cp.ControlPlaneMachineTemplate)
+	if cp.EtcdCluster != nil {
+		objs = append(objs, cp.EtcdCluster, cp.EtcdMachineTemplate)
+	}
+	objs = append(objs, cp.Other...)
+
+	return objs
+}
+
+// ReconcileControlPlane orchestrates the ControlPlane reconciliation logic.
+func ReconcileControlPlane(ctx context.Context, c client.Client, cp *ControlPlane) (controller.Result, error) {
+	if cp.EtcdCluster == nil {
+		// For stacked etcd, we don't need orchestration, apply directly
+		return controller.Result{}, applyAllControlPlaneObjects(ctx, c, cp)
+	}
+
+	cluster := &clusterv1.Cluster{}
+	err := c.Get(ctx, client.ObjectKeyFromObject(cp.Cluster), cluster)
+	if apierrors.IsNotFound(err) {
+		// If the CAPI cluster doesn't exist, this is a new cluster, create all objects
+		return controller.Result{}, applyAllControlPlaneObjects(ctx, c, cp)
+	}
+	if err != nil {
+		return controller.Result{}, errors.Wrap(err, "reading CAPI cluster")
+	}
+
+	etcdadmCluster := &etcdv1.EtcdadmCluster{}
+	key := client.ObjectKey{
+		Name:      cluster.Spec.ManagedExternalEtcdRef.Name,
+		Namespace: cluster.Spec.ManagedExternalEtcdRef.Namespace,
+	}
+	if err = c.Get(ctx, key, etcdadmCluster); err != nil {
+		return controller.Result{}, errors.Wrap(err, "reading etcdadm cluster")
+	}
+
+	if !equality.Semantic.DeepDerivative(cp.EtcdCluster.Spec, etcdadmCluster.Spec) {
+		// If the etcdadm cluster has changes, this will require a rolling upgrade
+		// Mark the etcdadm cluster as upgrading and pause the kcp reconciliation
+		// The CAPI cluster and etcdadm cluster controller will take care of removing
+		// these annotation at the right time to orchestrate the kcp upgrade
+		clientutil.AddAnnotation(cp.EtcdCluster, etcdv1.UpgradeInProgressAnnotation, "true")
+		clientutil.AddAnnotation(cp.KubeadmControlPlane, clusterv1.PausedAnnotation, "true")
+	}
+
+	return controller.Result{}, applyAllControlPlaneObjects(ctx, c, cp)
+}
+
+func applyAllControlPlaneObjects(ctx context.Context, c client.Client, cp *ControlPlane) error {
+	if err := serverside.ReconcileObjects(ctx, c, cp.AllObjects()); err != nil {
+		return errors.Wrap(err, "applying control plane objects")
+	}
+
+	return nil
+}

--- a/pkg/controller/clusters/controlplane_test.go
+++ b/pkg/controller/clusters/controlplane_test.go
@@ -1,0 +1,264 @@
+package clusters_test
+
+import (
+	"context"
+	"testing"
+
+	etcdv1 "github.com/mrajashree/etcdadm-controller/api/v1beta1"
+	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/eks-anywhere/internal/test/envtest"
+	"github.com/aws/eks-anywhere/pkg/controller"
+	"github.com/aws/eks-anywhere/pkg/controller/clusters"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
+)
+
+func TestReconcileControlPlaneStackedEtcd(t *testing.T) {
+	g := NewWithT(t)
+	c := env.Client()
+	api := envtest.NewAPIExpecter(t, c)
+	ctx := context.Background()
+	ns := env.CreateNamespaceForTest(ctx, t)
+	cp := controlPlaneStackedEtcd(ns)
+
+	g.Expect(clusters.ReconcileControlPlane(ctx, c, cp)).To(Equal(controller.Result{}))
+	api.ShouldEventuallyExist(ctx, cp.Cluster)
+	api.ShouldEventuallyExist(ctx, cp.KubeadmControlPlane)
+	api.ShouldEventuallyExist(ctx, cp.ControlPlaneMachineTemplate)
+	api.ShouldEventuallyExist(ctx, cp.ProviderCluster)
+}
+
+func TestReconcileControlPlaneExternalEtcdNewCluster(t *testing.T) {
+	g := NewWithT(t)
+	c := env.Client()
+	api := envtest.NewAPIExpecter(t, c)
+	ctx := context.Background()
+	ns := env.CreateNamespaceForTest(ctx, t)
+	cp := controlPlaneExternalEtcd(ns)
+
+	g.Expect(clusters.ReconcileControlPlane(ctx, c, cp)).To(Equal(controller.Result{}))
+	api.ShouldEventuallyExist(ctx, cp.Cluster)
+	api.ShouldEventuallyExist(ctx, cp.KubeadmControlPlane)
+	api.ShouldEventuallyExist(ctx, cp.ControlPlaneMachineTemplate)
+	api.ShouldEventuallyExist(ctx, cp.ProviderCluster)
+	api.ShouldEventuallyExist(ctx, cp.EtcdCluster)
+	api.ShouldEventuallyExist(ctx, cp.EtcdMachineTemplate)
+}
+
+func TestReconcileControlPlaneExternalEtcdUpgradeWithDiff(t *testing.T) {
+	g := NewWithT(t)
+	c := env.Client()
+	api := envtest.NewAPIExpecter(t, c)
+	ctx := context.Background()
+	ns := env.CreateNamespaceForTest(ctx, t)
+	cp := controlPlaneExternalEtcd(ns)
+	envtest.CreateObjs(ctx, t, c, cp.AllObjects()...)
+
+	cp.EtcdCluster.Spec.Replicas = ptr.Int32(5)
+
+	g.Expect(clusters.ReconcileControlPlane(ctx, c, cp)).To(Equal(controller.Result{}))
+	api.ShouldEventuallyExist(ctx, cp.Cluster)
+	api.ShouldEventuallyExist(ctx, cp.KubeadmControlPlane)
+	api.ShouldEventuallyExist(ctx, cp.ControlPlaneMachineTemplate)
+	api.ShouldEventuallyExist(ctx, cp.ProviderCluster)
+	api.ShouldEventuallyExist(ctx, cp.EtcdCluster)
+	api.ShouldEventuallyExist(ctx, cp.EtcdMachineTemplate)
+
+	etcdadmCluster := &etcdv1.EtcdadmCluster{ObjectMeta: cp.EtcdCluster.ObjectMeta}
+	api.ShouldEventuallyMatch(
+		ctx,
+		etcdadmCluster,
+		func(g gomega.Gomega) {
+			g.Expect(etcdadmCluster.Spec.Replicas).To(HaveValue(BeEquivalentTo(5)), "etcdadm replicas should have been updated")
+			g.Expect(etcdadmCluster.Annotations).To(
+				HaveKeyWithValue(etcdv1.UpgradeInProgressAnnotation, "true"),
+				"etcdadm upgrading annotation should have been added",
+			)
+		},
+	)
+	kcp := &etcdv1.EtcdadmCluster{ObjectMeta: cp.KubeadmControlPlane.ObjectMeta}
+	api.ShouldEventuallyMatch(
+		ctx,
+		etcdadmCluster,
+		func(g gomega.Gomega) {
+			g.Expect(kcp.Annotations).To(
+				HaveKeyWithValue(clusterv1.PausedAnnotation, "true"),
+				"kcp paused annotation should have been added",
+			)
+		},
+	)
+}
+
+func TestReconcileControlPlaneExternalEtcdUpgradeWithNoDiff(t *testing.T) {
+	g := NewWithT(t)
+	c := env.Client()
+	api := envtest.NewAPIExpecter(t, c)
+	ctx := context.Background()
+	ns := env.CreateNamespaceForTest(ctx, t)
+	cp := controlPlaneExternalEtcd(ns)
+	envtest.CreateObjs(ctx, t, c, cp.AllObjects()...)
+
+	g.Expect(clusters.ReconcileControlPlane(ctx, c, cp)).To(Equal(controller.Result{}))
+	api.ShouldEventuallyExist(ctx, cp.Cluster)
+	api.ShouldEventuallyExist(ctx, cp.KubeadmControlPlane)
+	api.ShouldEventuallyExist(ctx, cp.ControlPlaneMachineTemplate)
+	api.ShouldEventuallyExist(ctx, cp.ProviderCluster)
+	api.ShouldEventuallyExist(ctx, cp.EtcdCluster)
+	api.ShouldEventuallyExist(ctx, cp.EtcdMachineTemplate)
+}
+
+func controlPlaneStackedEtcd(namespace string) *clusters.ControlPlane {
+	return &clusters.ControlPlane{
+		Cluster: &clusterv1.Cluster{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "cluster.x-k8s.io/v1beta1",
+				Kind:       "Cluster",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-cluster",
+				Namespace: namespace,
+			},
+		},
+		KubeadmControlPlane: &controlplanev1.KubeadmControlPlane{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+				Kind:       "KubeadmControlPlane",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-cluster",
+				Namespace: namespace,
+			},
+		},
+		ProviderCluster: &dockerv1.DockerCluster{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "DockerCluster",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-cluster",
+				Namespace: namespace,
+			},
+		},
+		ControlPlaneMachineTemplate: &dockerv1.DockerMachineTemplate{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "DockerMachineTemplate",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "my-cluster-cp",
+			},
+		},
+	}
+}
+
+func controlPlaneExternalEtcd(namespace string) *clusters.ControlPlane {
+	cp := controlPlaneStackedEtcd(namespace)
+	cp.EtcdCluster = &etcdv1.EtcdadmCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "etcdcluster.cluster.x-k8s.io/v1beta1",
+			Kind:       "EtcdadmCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: namespace,
+		},
+	}
+	cp.Cluster.Spec.ManagedExternalEtcdRef = &corev1.ObjectReference{
+		Name:      cp.EtcdCluster.Name,
+		Namespace: cp.EtcdCluster.Namespace,
+	}
+
+	cp.EtcdMachineTemplate = &dockerv1.DockerMachineTemplate{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			Kind:       "DockerMachineTemplate",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "my-cluster-etcd",
+		},
+	}
+
+	return cp
+}
+
+func TestControlPlaneAllObjects(t *testing.T) {
+	stackedCP := controlPlaneStackedEtcd("my-ns")
+	withOtherCP := controlPlaneStackedEtcd("my-ns")
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "s",
+			Namespace: "eksa-system",
+		},
+	}
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm",
+			Namespace: "eksa-system",
+		},
+	}
+	withOtherCP.Other = append(withOtherCP.Other, secret, cm)
+	externalCP := controlPlaneExternalEtcd("my-ns")
+	tests := []struct {
+		name string
+		cp   *clusters.ControlPlane
+		want []client.Object
+	}{
+		{
+			name: "stacked etcd",
+			cp:   stackedCP,
+			want: []client.Object{
+				stackedCP.Cluster,
+				stackedCP.KubeadmControlPlane,
+				stackedCP.ProviderCluster,
+				stackedCP.ControlPlaneMachineTemplate,
+			},
+		},
+		{
+			name: "external etcd",
+			cp:   externalCP,
+			want: []client.Object{
+				externalCP.Cluster,
+				externalCP.KubeadmControlPlane,
+				externalCP.ProviderCluster,
+				externalCP.ControlPlaneMachineTemplate,
+				externalCP.EtcdCluster,
+				externalCP.EtcdMachineTemplate,
+			},
+		},
+		{
+			name: "stacked etcd with other",
+			cp:   withOtherCP,
+			want: []client.Object{
+				stackedCP.Cluster,
+				stackedCP.KubeadmControlPlane,
+				stackedCP.ProviderCluster,
+				stackedCP.ControlPlaneMachineTemplate,
+				secret,
+				cm,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.cp.AllObjects()).To(ConsistOf(tt.want))
+		})
+	}
+}

--- a/pkg/controller/clusters/main_test.go
+++ b/pkg/controller/clusters/main_test.go
@@ -1,0 +1,14 @@
+package clusters_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/aws/eks-anywhere/internal/test/envtest"
+)
+
+var env *envtest.Environment
+
+func TestMain(m *testing.M) {
+	os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+}

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -243,14 +243,14 @@ func TestReconcilerReconcileControlPlaneSuccess(t *testing.T) {
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 
-	obj := &addonsv1.ClusterResourceSet{ObjectMeta: metav1.ObjectMeta{
-		Name:      "workload-cluster-crs-0",
-		Namespace: "eksa-system",
-	}}
-	key := client.ObjectKeyFromObject(obj)
-	tt.Eventually(func() error {
-		return tt.client.Get(tt.ctx, key, obj)
-	}).Should(Succeed(), "\"object %s should eventually exist", obj.GetName())
+	tt.ShouldEventuallyExist(tt.ctx,
+		&addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "workload-cluster-crs-0",
+				Namespace: "eksa-system",
+			},
+		},
+	)
 }
 
 func TestReconcilerReconcileControlPlaneFailure(t *testing.T) {


### PR DESCRIPTION
## Description of changes

When using a control plane with external etcd, upgrades can't be done by just applying al changes, and depending on the changes, it needs to be orchestrated through annotations.

Marking the etcdadm cluster as upgrading, signals the kcp to not react
to changes in the etcd endpoints until the annotation is removed. This
will be done by the etcdadm cluster controller once the rolling upgrade
is finished.

Pausing the kcp reconciliation avoids having a unnecessary rolling
upgrade of the control plane when there are both cp and etcd changes
(for example, a k8s version upgrade). The CAPI cluster controller will
remove the pause annotation once the etcdadm cluster becomes ready.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

