### PR TITLE
Increase lint timeout from 5m to 10m

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,3 +27,4 @@ jobs:
           only-new-issues: true
           # Disable package caching to avoid a double cache with setup-go.
           skip-pkg-cache: true
+          args: --timeout 10m


### PR DESCRIPTION
The golangci-lint-action has a history of being slow. We've observed the tool timeout on several occasions now and its possibly due to a defecft in the action.

https://github.com/golangci/golangci-lint-action/issues/297
