### PR TITLE
Fix yq command in Github release script

### DIFF
--- a/release/scripts/github-bundle-release.sh
+++ b/release/scripts/github-bundle-release.sh
@@ -38,11 +38,11 @@ for releasetype in bundle eks-a; do
 done
 
 for os in darwin linux; do
-    EKSA_CLI_URI=yq e ".spec.releases[0].eksABinary.$os.uri" $ARTIFACTS_DIR/$DATE_YYYYMMDD-eks-a-release.yaml
+    EKSA_CLI_URI=$(yq e ".spec.releases[0].eksABinary.$os.uri" $ARTIFACTS_DIR/$DATE_YYYYMMDD-eks-a-release.yaml)
     wget $EKSA_CLI_URI -O $ARTIFACTS_DIR/$(basename $EKSA_CLI_URI)
 done
 
-IMAGE_BUILDER_CLI_URI=$(yq e ".spec.versionsBundles[0].eksD.imagebuilder.uri" $ARTIFACTS_DIR/$DATE_YYYYMMDD-eks-a-release.yaml)
+IMAGE_BUILDER_CLI_URI=$(yq e ".spec.versionsBundles[0].eksD.imagebuilder.uri" $ARTIFACTS_DIR/$DATE_YYYYMMDD-bundle-release.yaml)
 wget $IMAGE_BUILDER_CLI_URI -O $ARTIFACTS_DIR/$(basename $IMAGE_BUILDER_CLI_URI)
 
 # Publish the asset as a Github pre-release on main branch with a new dated tag


### PR DESCRIPTION
* Actually invoke yq command to get EKS-A CLI tarball URI.
* Fix source manifest for imagebuilder CLI tarball URI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

