### PR TITLE
Removing initial slow cloudmonkey call to verify connection to cloudstack

### DIFF
--- a/pkg/executables/cmk.go
+++ b/pkg/executables/cmk.go
@@ -362,17 +362,6 @@ func (c *Cmk) GetManagementApiEndpoint(profile string) (string, error) {
 	return "", fmt.Errorf("profile %s does not exist", profile)
 }
 
-// ValidateCloudStackConnection Calls `cmk sync` to ensure that the endpoint and credentials + domain are valid.
-func (c *Cmk) ValidateCloudStackConnection(ctx context.Context, profile string) error {
-	command := newCmkCommand("sync")
-	buffer, err := c.exec(ctx, profile, command...)
-	if err != nil {
-		return fmt.Errorf("validating cloudstack connection for cmk: %s: %v", buffer.String(), err)
-	}
-	logger.MarkPass("Connected to CloudStack server")
-	return nil
-}
-
 func (c *Cmk) CleanupVms(ctx context.Context, profile string, clusterName string, dryRun bool) error {
 	command := newCmkCommand("list virtualmachines")
 	applyCmkArgs(&command, withCloudStackKeyword(clusterName), appendArgs("listall=true"))

--- a/pkg/executables/cmk_test.go
+++ b/pkg/executables/cmk_test.go
@@ -21,7 +21,6 @@ import (
 
 const (
 	cmkConfigFileName  = "cmk_test_name.ini"
-	cmkConfigFileName2 = "cmk_test_name_2.ini"
 	accountName        = "account1"
 	rootDomain         = "ROOT"
 	rootDomainId       = "5300cdac-74d5-11ec-8696-c81f66d3e965"
@@ -101,62 +100,6 @@ var diskOfferingCustomSizeInGB = v1alpha1.CloudStackResourceDiskOffering{
 	Device:     "/dev/vdb",
 	Filesystem: "ext4",
 	Label:      "data_disk",
-}
-
-func TestValidateCloudStackConnectionSuccess(t *testing.T) {
-	_, writer := test.NewWriter(t)
-	ctx := context.Background()
-	mockCtrl := gomock.NewController(t)
-
-	executable := mockexecutables.NewMockExecutable(mockCtrl)
-	configFilePath, _ := filepath.Abs(filepath.Join(writer.Dir(), "generated", cmkConfigFileName))
-	expectedArgs := []string{"-c", configFilePath, "sync"}
-	executable.EXPECT().Execute(ctx, expectedArgs).Return(bytes.Buffer{}, nil)
-	c, _ := executables.NewCmk(executable, writer, execConfig)
-	err := c.ValidateCloudStackConnection(ctx, execConfig.Profiles[0].Name)
-	if err != nil {
-		t.Fatalf("Cmk.ValidateCloudStackConnection() error = %v, want nil", err)
-	}
-}
-
-func TestValidateMultipleCloudStackProfiles(t *testing.T) {
-	_, writer := test.NewWriter(t)
-	ctx := context.Background()
-	mockCtrl := gomock.NewController(t)
-
-	executable := mockexecutables.NewMockExecutable(mockCtrl)
-	configFilePath, _ := filepath.Abs(filepath.Join(writer.Dir(), "generated", cmkConfigFileName))
-	expectedArgs := []string{"-c", configFilePath, "sync"}
-	executable.EXPECT().Execute(ctx, expectedArgs).Return(bytes.Buffer{}, nil)
-	configFilePath2, _ := filepath.Abs(filepath.Join(writer.Dir(), "generated", cmkConfigFileName2))
-	expectedArgs2 := []string{"-c", configFilePath2, "sync"}
-	executable.EXPECT().Execute(ctx, expectedArgs2).Return(bytes.Buffer{}, nil)
-
-	c, _ := executables.NewCmk(executable, writer, execConfigWithMultipleProfiles)
-	err := c.ValidateCloudStackConnection(ctx, execConfigWithMultipleProfiles.Profiles[0].Name)
-	if err != nil {
-		t.Fatalf("Cmk.ValidateCloudStackConnection() error = %v, want nil", err)
-	}
-	err = c.ValidateCloudStackConnection(ctx, execConfigWithMultipleProfiles.Profiles[1].Name)
-	if err != nil {
-		t.Fatalf("Cmk.ValidateCloudStackConnection() error = %v, want nil", err)
-	}
-}
-
-func TestValidateCloudStackConnectionError(t *testing.T) {
-	_, writer := test.NewWriter(t)
-	ctx := context.Background()
-	mockCtrl := gomock.NewController(t)
-
-	executable := mockexecutables.NewMockExecutable(mockCtrl)
-	configFilePath, _ := filepath.Abs(filepath.Join(writer.Dir(), "generated", cmkConfigFileName))
-	expectedArgs := []string{"-c", configFilePath, "sync"}
-	executable.EXPECT().Execute(ctx, expectedArgs).Return(bytes.Buffer{}, errors.New("cmk test error"))
-	c, _ := executables.NewCmk(executable, writer, execConfig)
-	err := c.ValidateCloudStackConnection(ctx, execConfig.Profiles[0].Name)
-	if err == nil {
-		t.Fatalf("Cmk.ValidateCloudStackConnection() didn't throw expected error")
-	}
 }
 
 func TestCmkCleanupVms(t *testing.T) {

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -431,9 +431,6 @@ func secretDifferentFromProfile(secret *corev1.Secret, profile decoder.CloudStac
 }
 
 func (p *cloudstackProvider) validateClusterSpec(ctx context.Context, clusterSpec *cluster.Spec) (err error) {
-	if err := p.validator.ValidateCloudStackAccess(ctx, clusterSpec.CloudStackDatacenter); err != nil {
-		return err
-	}
 	if err := p.validator.ValidateCloudStackDatacenterConfig(ctx, clusterSpec.CloudStackDatacenter); err != nil {
 		return err
 	}

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -78,7 +78,6 @@ func givenWildcardValidator(mockCtrl *gomock.Controller, clusterSpec *cluster.Sp
 	setClusterSpecDefaultHostPort(cloudstackSpec)
 	validator.EXPECT().ValidateClusterMachineConfigs(gomock.Any(), gomock.Any()).SetArg(1, *cloudstackSpec).AnyTimes()
 	validator.EXPECT().ValidateCloudStackDatacenterConfig(gomock.Any(), clusterSpec.CloudStackDatacenter).AnyTimes()
-	validator.EXPECT().ValidateCloudStackAccess(gomock.Any(), clusterSpec.CloudStackDatacenter).AnyTimes()
 	validator.EXPECT().ValidateControlPlaneEndpointUniqueness(gomock.Any()).AnyTimes()
 	return validator
 }

--- a/pkg/providers/cloudstack/mocks/client.go
+++ b/pkg/providers/cloudstack/mocks/client.go
@@ -84,20 +84,6 @@ func (mr *MockProviderCmkClientMockRecorder) ValidateAffinityGroupsPresent(arg0,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAffinityGroupsPresent", reflect.TypeOf((*MockProviderCmkClient)(nil).ValidateAffinityGroupsPresent), arg0, arg1, arg2, arg3, arg4)
 }
 
-// ValidateCloudStackConnection mocks base method.
-func (m *MockProviderCmkClient) ValidateCloudStackConnection(arg0 context.Context, arg1 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateCloudStackConnection", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ValidateCloudStackConnection indicates an expected call of ValidateCloudStackConnection.
-func (mr *MockProviderCmkClientMockRecorder) ValidateCloudStackConnection(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateCloudStackConnection", reflect.TypeOf((*MockProviderCmkClient)(nil).ValidateCloudStackConnection), arg0, arg1)
-}
-
 // ValidateDiskOfferingPresent mocks base method.
 func (m *MockProviderCmkClient) ValidateDiskOfferingPresent(arg0 context.Context, arg1, arg2 string, arg3 v1alpha1.CloudStackResourceDiskOffering) error {
 	m.ctrl.T.Helper()

--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -10,7 +10,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
-	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 )
 
 type Validator struct {
@@ -48,7 +47,6 @@ type localAvailabilityZone struct {
 // ProviderCmkClient defines the methods used by Cmk as a separate interface to be mockable when injected into other objects.
 type ProviderCmkClient interface {
 	GetManagementApiEndpoint(profile string) (string, error)
-	ValidateCloudStackConnection(ctx context.Context, profile string) error
 	ValidateServiceOfferingPresent(ctx context.Context, profile string, zoneId string, serviceOffering anywherev1.CloudStackResourceIdentifier) error
 	ValidateDiskOfferingPresent(ctx context.Context, profile string, zoneId string, diskOffering anywherev1.CloudStackResourceDiskOffering) error
 	ValidateTemplatePresent(ctx context.Context, profile string, domainId string, zoneId string, account string, template anywherev1.CloudStackResourceIdentifier) error
@@ -57,26 +55,6 @@ type ProviderCmkClient interface {
 	ValidateNetworkPresent(ctx context.Context, profile string, domainId string, network anywherev1.CloudStackResourceIdentifier, zoneId string, account string) error
 	ValidateDomainAndGetId(ctx context.Context, profile string, domain string) (string, error)
 	ValidateAccountPresent(ctx context.Context, profile string, account string, domainId string) error
-}
-
-// ValidateCloudStackAccess is used as a preflight check to ensure we can connect to all the Cloudstack endpoints used by a cluster.
-func (v *Validator) ValidateCloudStackAccess(ctx context.Context, datacenterConfig *anywherev1.CloudStackDatacenterConfig) error {
-	refNamesToCheck := []string{}
-	if len(datacenterConfig.Spec.Domain) > 0 {
-		refNamesToCheck = append(refNamesToCheck, decoder.CloudStackGlobalAZ)
-	}
-	for _, az := range datacenterConfig.Spec.AvailabilityZones {
-		refNamesToCheck = append(refNamesToCheck, az.CredentialsRef)
-	}
-
-	for _, refName := range refNamesToCheck {
-		if err := v.cmk.ValidateCloudStackConnection(ctx, refName); err != nil {
-			return fmt.Errorf("validating connection to cloudstack %s: %v", refName, err)
-		}
-	}
-
-	logger.MarkPass(fmt.Sprintf("Connected to servers: %s", strings.Join(refNamesToCheck, ", ")))
-	return nil
 }
 
 func (v *Validator) ValidateCloudStackDatacenterConfig(ctx context.Context, datacenterConfig *anywherev1.CloudStackDatacenterConfig) error {

--- a/pkg/providers/cloudstack/validator_mocks.go
+++ b/pkg/providers/cloudstack/validator_mocks.go
@@ -35,20 +35,6 @@ func (m *MockProviderValidator) EXPECT() *MockProviderValidatorMockRecorder {
 	return m.recorder
 }
 
-// ValidateCloudStackAccess mocks base method.
-func (m *MockProviderValidator) ValidateCloudStackAccess(arg0 context.Context, arg1 *v1alpha1.CloudStackDatacenterConfig) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateCloudStackAccess", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ValidateCloudStackAccess indicates an expected call of ValidateCloudStackAccess.
-func (mr *MockProviderValidatorMockRecorder) ValidateCloudStackAccess(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateCloudStackAccess", reflect.TypeOf((*MockProviderValidator)(nil).ValidateCloudStackAccess), arg0, arg1)
-}
-
 // ValidateCloudStackDatacenterConfig mocks base method.
 func (m *MockProviderValidator) ValidateCloudStackDatacenterConfig(arg0 context.Context, arg1 *v1alpha1.CloudStackDatacenterConfig) error {
 	m.ctrl.T.Helper()

--- a/pkg/providers/cloudstack/validator_registry.go
+++ b/pkg/providers/cloudstack/validator_registry.go
@@ -32,7 +32,6 @@ type ProviderValidator interface {
 	ValidateCloudStackDatacenterConfig(ctx context.Context, datacenterConfig *anywherev1.CloudStackDatacenterConfig) error
 	ValidateClusterMachineConfigs(ctx context.Context, cloudStackClusterSpec *Spec) error
 	ValidateControlPlaneEndpointUniqueness(endpoint string) error
-	ValidateCloudStackAccess(ctx context.Context, datacenterConfig *anywherev1.CloudStackDatacenterConfig) error
 }
 
 // NewValidatorFactory initializes a factory for the CloudStack provider validator.

--- a/pkg/providers/cloudstack/validator_test.go
+++ b/pkg/providers/cloudstack/validator_test.go
@@ -89,35 +89,6 @@ func TestValidateCloudStackDatacenterConfigWithAZ(t *testing.T) {
 	}
 }
 
-func TestValidateCloudStackConnection(t *testing.T) {
-	ctx := context.Background()
-	cmk := mocks.NewMockProviderCmkClient(gomock.NewController(t))
-	validator := NewValidator(cmk, &DummyNetClient{}, true)
-	datacenterConfig, err := v1alpha1.GetCloudStackDatacenterConfig(path.Join(testDataDir, testClusterConfigMainFilename))
-	if err != nil {
-		t.Fatalf("unable to get datacenter config from file")
-	}
-
-	cmk.EXPECT().ValidateCloudStackConnection(ctx, "global").Return(nil)
-	if err := validator.ValidateCloudStackAccess(ctx, datacenterConfig); err != nil {
-		t.Fatalf("failed to validate CloudStackDataCenterConfig: %v", err)
-	}
-}
-
-func TestValidateCloudStackConnectionFailure(t *testing.T) {
-	ctx := context.Background()
-	cmk := mocks.NewMockProviderCmkClient(gomock.NewController(t))
-	validator := NewValidator(cmk, &DummyNetClient{}, true)
-	datacenterConfig, err := v1alpha1.GetCloudStackDatacenterConfig(path.Join(testDataDir, testClusterConfigMainFilename))
-	if err != nil {
-		t.Fatalf("unable to get datacenter config from file")
-	}
-
-	cmk.EXPECT().ValidateCloudStackConnection(ctx, "global").Return(errors.New("exception"))
-	err = validator.ValidateCloudStackAccess(ctx, datacenterConfig)
-	thenErrorExpected(t, "validating connection to cloudstack global: exception", err)
-}
-
 func TestValidateSkipControlPlaneIpCheck(t *testing.T) {
 	cmk := mocks.NewMockProviderCmkClient(gomock.NewController(t))
 	validator := NewValidator(cmk, &DummyNetClient{}, true)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
E2e tests fail with slow call to `cmk sync`. From the [cmk docs](https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+cloudmonkey+CLI): 
> The sync command in cloudmonkey pull a list of apis which are accessible to your user role, along with help docs etc. and stores the cache in ~/.cloudmonkey/cache

We do not need this functionality in EKS-A since we are not using cloudmonkey interactively in a CLI. It also pulls an enormous amount of data and tends to be slow. Lastly, the data we get from this call in case of failure is the same as we would get from any other cloudmonkey query failure, so it's not explicitly needed. It was also recently removed in CAPC due to enormous resource consumption

*Testing (if applicable):*
E2E test running locally avoids failing at this `sync` step. Unit tests pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

