### PR TITLE
Split instances in chunks for termination

### DIFF
--- a/internal/pkg/ec2/terminate.go
+++ b/internal/pkg/ec2/terminate.go
@@ -7,16 +7,38 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
-func TerminateEc2Instances(session *session.Session, instances []*string) error {
-	service := ec2.New(session)
-	input := &ec2.TerminateInstancesInput{
-		InstanceIds: instances,
-	}
+const defaultInstanceIDBlockSize = 500
 
-	_, err := service.TerminateInstances(input)
-	if err != nil {
-		return fmt.Errorf("terminating EC2 instances: %v", err)
+// TerminateEc2Instances terminates EC2 instances by calling the AWS API.
+func TerminateEc2Instances(session *session.Session, instanceIDs []*string) error {
+	service := ec2.New(session)
+	for _, instanceIDChunk := range makeChunks(instanceIDs, defaultInstanceIDBlockSize) {
+		input := &ec2.TerminateInstancesInput{
+			InstanceIds: instanceIDChunk,
+		}
+
+		if _, err := service.TerminateInstances(input); err != nil {
+			return fmt.Errorf("terminating EC2 instances: %v", err)
+		}
 	}
 
 	return nil
+}
+
+func makeChunks[T any](elements []T, chunkSize int) [][]T {
+	elementsSize := len(elements)
+	if elementsSize == 0 {
+		return [][]T{}
+	}
+	chunksSize := (elementsSize + chunkSize - 1) / chunkSize
+	chunks := make([][]T, 0, chunksSize)
+	start := 0
+	for i := 0; i < chunksSize-1; i++ {
+		end := start + chunkSize
+		chunks = append(chunks, elements[start:end])
+		start = end
+	}
+	chunks = append(chunks, elements[start:elementsSize])
+
+	return chunks
 }

--- a/internal/pkg/ec2/terminate_test.go
+++ b/internal/pkg/ec2/terminate_test.go
@@ -1,0 +1,133 @@
+package ec2
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
+)
+
+func TestMakeChunks(t *testing.T) {
+	tests := []struct {
+		name      string
+		elements  []*int
+		chunkSize int
+		want      [][]*int
+	}{
+		{
+			name:      "empty elements",
+			elements:  []*int{},
+			chunkSize: 2,
+			want:      [][]*int{},
+		},
+		{
+			name:      "nil elements",
+			elements:  nil,
+			chunkSize: 2,
+			want:      [][]*int{},
+		},
+		{
+			name: "even length, exact division",
+			elements: []*int{
+				ptr.Int(1), ptr.Int(2),
+				ptr.Int(3), ptr.Int(4),
+				ptr.Int(5), ptr.Int(6),
+				ptr.Int(7), ptr.Int(8),
+			},
+			chunkSize: 2,
+			want: [][]*int{
+				{ptr.Int(1), ptr.Int(2)},
+				{ptr.Int(3), ptr.Int(4)},
+				{ptr.Int(5), ptr.Int(6)},
+				{ptr.Int(7), ptr.Int(8)},
+			},
+		},
+		{
+			name: "odd length, exact division",
+			elements: []*int{
+				ptr.Int(1), ptr.Int(2), ptr.Int(3),
+				ptr.Int(4), ptr.Int(5), ptr.Int(6),
+				ptr.Int(7), ptr.Int(8), ptr.Int(9),
+			},
+			chunkSize: 3,
+			want: [][]*int{
+				{ptr.Int(1), ptr.Int(2), ptr.Int(3)},
+				{ptr.Int(4), ptr.Int(5), ptr.Int(6)},
+				{ptr.Int(7), ptr.Int(8), ptr.Int(9)},
+			},
+		},
+		{
+			name: "even length, non exact division",
+			elements: []*int{
+				ptr.Int(1), ptr.Int(2),
+				ptr.Int(3), ptr.Int(4),
+				ptr.Int(5), ptr.Int(6),
+				ptr.Int(7),
+			},
+			chunkSize: 2,
+			want: [][]*int{
+				{ptr.Int(1), ptr.Int(2)},
+				{ptr.Int(3), ptr.Int(4)},
+				{ptr.Int(5), ptr.Int(6)},
+				{ptr.Int(7)},
+			},
+		},
+		{
+			name: "odd length, non exact division",
+			elements: []*int{
+				ptr.Int(1), ptr.Int(2), ptr.Int(3),
+				ptr.Int(4), ptr.Int(5), ptr.Int(6),
+				ptr.Int(7),
+			},
+			chunkSize: 3,
+			want: [][]*int{
+				{ptr.Int(1), ptr.Int(2), ptr.Int(3)},
+				{ptr.Int(4), ptr.Int(5), ptr.Int(6)},
+				{ptr.Int(7)},
+			},
+		},
+		{
+			name: "length same as chunk size",
+			elements: []*int{
+				ptr.Int(1), ptr.Int(2),
+				ptr.Int(3), ptr.Int(4),
+				ptr.Int(5), ptr.Int(6),
+				ptr.Int(7),
+			},
+			chunkSize: 7,
+			want: [][]*int{
+				{
+					ptr.Int(1), ptr.Int(2),
+					ptr.Int(3), ptr.Int(4),
+					ptr.Int(5), ptr.Int(6),
+					ptr.Int(7),
+				},
+			},
+		},
+		{
+			name: "length same smaller than chunk size",
+			elements: []*int{
+				ptr.Int(1), ptr.Int(2),
+				ptr.Int(3), ptr.Int(4),
+				ptr.Int(5), ptr.Int(6),
+				ptr.Int(7),
+			},
+			chunkSize: 17,
+			want: [][]*int{
+				{
+					ptr.Int(1), ptr.Int(2),
+					ptr.Int(3), ptr.Int(4),
+					ptr.Int(5), ptr.Int(6),
+					ptr.Int(7),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(makeChunks(tt.elements, tt.chunkSize)).To(Equal(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
*Description of changes:*
The AWS API has a limit of a 1000 instances per request. If the cleanup job fails to run a couple times, the accumulated instances number can exceed this limit. The API docs recommend to split this into even smaller chunks, so going with 500 for now.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

