### PR TITLE
minor rework for eks-a-test-tool

### DIFF
--- a/test/e2e/tools/eks-anywhere-test-tool/cmd/fetchartifacts.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/cmd/fetchartifacts.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -14,6 +13,7 @@ import (
 	"github.com/aws/eks-anywhere-test-tool/pkg/cloudwatch"
 	"github.com/aws/eks-anywhere-test-tool/pkg/codebuild"
 	"github.com/aws/eks-anywhere-test-tool/pkg/constants"
+	"github.com/aws/eks-anywhere-test-tool/pkg/fileutils"
 	"github.com/aws/eks-anywhere-test-tool/pkg/filewriter"
 	"github.com/aws/eks-anywhere-test-tool/pkg/s3"
 	"github.com/aws/eks-anywhere/pkg/logger"
@@ -44,8 +44,8 @@ var e2eFetchArtifactsCommand = &cobra.Command{
 			return fmt.Errorf("creating s3 client: %v", err)
 		}
 
-		now := time.Now().Format(time.RFC3339 + "-artifacts")
-		writer, err := filewriter.NewWriter(now)
+		dir := fileutils.GenOutputDirName("artifacts")
+		writer := filewriter.NewWriter(dir)
 		if err != nil {
 			return fmt.Errorf("setting up writer: %v", err)
 		}

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/fileutils/fileutils.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/fileutils/fileutils.go
@@ -1,0 +1,14 @@
+package fileutils
+
+import (
+	"strings"
+	"time"
+)
+
+func GenOutputDirName(suffix string) string {
+	now := time.Now().Format(time.RFC3339)
+	// Replace : characters with _ for easier double-click selection in a
+	// terminal.
+	prefix := strings.ReplaceAll(now, ":", "_")
+	return prefix + "-" + suffix
+}

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/filewriter/writer.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/filewriter/writer.go
@@ -14,15 +14,8 @@ type writer struct {
 	dir string
 }
 
-func NewWriter(dir string) (FileWriter, error) {
-	newFolder := filepath.Join(dir, DefaultTmpFolder)
-	if _, err := os.Stat(newFolder); errors.Is(err, os.ErrNotExist) {
-		err := os.MkdirAll(newFolder, os.ModePerm)
-		if err != nil {
-			return nil, fmt.Errorf("creating directory [%s]: %v", dir, err)
-		}
-	}
-	return &writer{dir: dir}, nil
+func NewWriter(dir string) FileWriter {
+	return &writer{dir: dir}
 }
 
 func (t *writer) Write(fileName string, content []byte, f ...FileOptionsFunc) (string, error) {
@@ -30,6 +23,14 @@ func (t *writer) Write(fileName string, content []byte, f ...FileOptionsFunc) (s
 		count := strings.Count(fileName, "|") - 1
 		fileName = fmt.Sprintf("%s+%dTests", fileName[:strings.Index(fileName, "|")], count)
 	}
+	newFolder := filepath.Join(t.dir, DefaultTmpFolder)
+	if _, err := os.Stat(newFolder); errors.Is(err, os.ErrNotExist) {
+		err := os.MkdirAll(newFolder, os.ModePerm)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	op := defaultFileOptions() // Default file options. -->> temporary file with default permissions
 	for _, optionFunc := range f {
 		optionFunc(op)
@@ -50,7 +51,7 @@ func (t *writer) Write(fileName string, content []byte, f ...FileOptionsFunc) (s
 }
 
 func (w *writer) WithDir(dir string) (FileWriter, error) {
-	return NewWriter(filepath.Join(w.dir, dir))
+	return NewWriter(filepath.Join(w.dir, dir)), nil
 }
 
 func (t *writer) Dir() string {

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/logfetcher/logfetcher.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/logfetcher/logfetcher.go
@@ -3,7 +3,6 @@ package logfetcher
 import (
 	"bytes"
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	awscodebuild "github.com/aws/aws-sdk-go/service/codebuild"
@@ -11,6 +10,7 @@ import (
 	"github.com/aws/eks-anywhere-test-tool/pkg/cloudwatch"
 	"github.com/aws/eks-anywhere-test-tool/pkg/codebuild"
 	"github.com/aws/eks-anywhere-test-tool/pkg/constants"
+	"github.com/aws/eks-anywhere-test-tool/pkg/fileutils"
 	"github.com/aws/eks-anywhere-test-tool/pkg/testResults"
 	"github.com/aws/eks-anywhere/pkg/logger"
 )
@@ -83,24 +83,24 @@ func New(buildAccountCwClient *cloudwatch.Cloudwatch, testAccountCwClient *cloud
 		o(l)
 	}
 
-	defultOutputFolder := time.Now().Format(time.RFC3339 + "-logs")
+	defaultOutputFolder := fileutils.GenOutputDirName("logs")
 
 	if l.filterTests == nil {
 		l.filterTests = testResults.GetFailedTests
 	}
 
 	if l.processCodebuild == nil {
-		_ = l.ensureWriter(defultOutputFolder)
+		_ = l.ensureWriter(defaultOutputFolder)
 		l.processCodebuild = l.writer.writeCodeBuild
 	}
 
 	if l.processMessages == nil {
-		_ = l.ensureWriter(defultOutputFolder)
+		_ = l.ensureWriter(defaultOutputFolder)
 		l.processMessages = l.writer.writeMessages
 	}
 
 	if l.processTest == nil {
-		_ = l.ensureWriter(defultOutputFolder)
+		_ = l.ensureWriter(defaultOutputFolder)
 		l.processTest = l.writer.writeTest
 	}
 

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/logfetcher/testswriter.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/logfetcher/testswriter.go
@@ -16,11 +16,7 @@ type testsWriter struct {
 }
 
 func newTestsWriter(folderPath string) (*testsWriter, error) {
-	writer, err := filewriter.NewWriter(folderPath)
-	if err != nil {
-		return nil, fmt.Errorf("setting up tests writer: %v", err)
-	}
-
+	writer := filewriter.NewWriter(folderPath)
 	return &testsWriter{FileWriter: writer}, nil
 }
 

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/providerProxy/logFetcher.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/providerProxy/logFetcher.go
@@ -2,13 +2,13 @@ package providerProxy
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 
 	"github.com/aws/eks-anywhere-test-tool/pkg/cloudwatch"
 	"github.com/aws/eks-anywhere-test-tool/pkg/codebuild"
 	"github.com/aws/eks-anywhere-test-tool/pkg/constants"
+	"github.com/aws/eks-anywhere-test-tool/pkg/fileutils"
 	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
@@ -67,7 +67,7 @@ func New(buildAccountCwClient *cloudwatch.Cloudwatch, testAccountCwClient *cloud
 		o(l)
 	}
 
-	defaultOutputFolder := fmt.Sprintf("provider-proxy-logs-%s", time.Now().Format(time.RFC3339))
+	defaultOutputFolder := fileutils.GenOutputDirName("provider-proxy-logs")
 
 	if l.filterRequests == nil {
 		l.filterRequests = noFilter

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/providerProxy/requestWriter.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/providerProxy/requestWriter.go
@@ -2,7 +2,6 @@ package providerProxy
 
 import (
 	"bytes"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 
@@ -14,11 +13,7 @@ type requestWriter struct {
 }
 
 func newRequestWriter(folderPath string) (*requestWriter, error) {
-	writer, err := filewriter.NewWriter(folderPath)
-	if err != nil {
-		return nil, fmt.Errorf("setting up tests writer: %v", err)
-	}
-
+	writer := filewriter.NewWriter(folderPath)
 	return &requestWriter{FileWriter: writer}, nil
 }
 


### PR DESCRIPTION
- Don't make output directories until a file is written

  This prevents useless and empty directories from being created when there's a usage error or something.

- Change colons to underscores in directory names

  Just a small quality of life improvement. Most terminals, by default, will recognize a colon as a word-stop, and so double-clicking will select to the colon but no further. Changing to underscore lets a nice double-click select the whole directory.

https://user-images.githubusercontent.com/169516/201174235-0a39a057-6c8a-43c6-ba3a-89d74fc174f8.mp4

