### PR TITLE
[release-0.12] Removing initial slow cloudmonkey call to verify connection to cloudstack

### DIFF
--- a/pkg/executables/cmk_test.go
+++ b/pkg/executables/cmk_test.go
@@ -103,62 +103,6 @@ var diskOfferingCustomSizeInGB = v1alpha1.CloudStackResourceDiskOffering{
 	Label:      "data_disk",
 }
 
-func TestValidateCloudStackConnectionSuccess(t *testing.T) {
-	_, writer := test.NewWriter(t)
-	ctx := context.Background()
-	mockCtrl := gomock.NewController(t)
-
-	executable := mockexecutables.NewMockExecutable(mockCtrl)
-	configFilePath, _ := filepath.Abs(filepath.Join(writer.Dir(), "generated", cmkConfigFileName))
-	expectedArgs := []string{"-c", configFilePath, "sync"}
-	executable.EXPECT().Execute(ctx, expectedArgs).Return(bytes.Buffer{}, nil)
-	c := executables.NewCmk(executable, writer, execConfig.Profiles)
-	err := c.ValidateCloudStackConnection(ctx, execConfig.Profiles[0].Name)
-	if err != nil {
-		t.Fatalf("Cmk.ValidateCloudStackConnection() error = %v, want nil", err)
-	}
-}
-
-func TestValidateMultipleCloudStackProfiles(t *testing.T) {
-	_, writer := test.NewWriter(t)
-	ctx := context.Background()
-	mockCtrl := gomock.NewController(t)
-
-	executable := mockexecutables.NewMockExecutable(mockCtrl)
-	configFilePath, _ := filepath.Abs(filepath.Join(writer.Dir(), "generated", cmkConfigFileName))
-	expectedArgs := []string{"-c", configFilePath, "sync"}
-	executable.EXPECT().Execute(ctx, expectedArgs).Return(bytes.Buffer{}, nil)
-	configFilePath2, _ := filepath.Abs(filepath.Join(writer.Dir(), "generated", cmkConfigFileName2))
-	expectedArgs2 := []string{"-c", configFilePath2, "sync"}
-	executable.EXPECT().Execute(ctx, expectedArgs2).Return(bytes.Buffer{}, nil)
-
-	c := executables.NewCmk(executable, writer, execConfigWithMultipleProfiles.Profiles)
-	err := c.ValidateCloudStackConnection(ctx, execConfigWithMultipleProfiles.Profiles[0].Name)
-	if err != nil {
-		t.Fatalf("Cmk.ValidateCloudStackConnection() error = %v, want nil", err)
-	}
-	err = c.ValidateCloudStackConnection(ctx, execConfigWithMultipleProfiles.Profiles[1].Name)
-	if err != nil {
-		t.Fatalf("Cmk.ValidateCloudStackConnection() error = %v, want nil", err)
-	}
-}
-
-func TestValidateCloudStackConnectionError(t *testing.T) {
-	_, writer := test.NewWriter(t)
-	ctx := context.Background()
-	mockCtrl := gomock.NewController(t)
-
-	executable := mockexecutables.NewMockExecutable(mockCtrl)
-	configFilePath, _ := filepath.Abs(filepath.Join(writer.Dir(), "generated", cmkConfigFileName))
-	expectedArgs := []string{"-c", configFilePath, "sync"}
-	executable.EXPECT().Execute(ctx, expectedArgs).Return(bytes.Buffer{}, errors.New("cmk test error"))
-	c := executables.NewCmk(executable, writer, execConfig.Profiles)
-	err := c.ValidateCloudStackConnection(ctx, execConfig.Profiles[0].Name)
-	if err == nil {
-		t.Fatalf("Cmk.ValidateCloudStackConnection() didn't throw expected error")
-	}
-}
-
 func TestCmkCleanupVms(t *testing.T) {
 	_, writer := test.NewWriter(t)
 	configFilePath, _ := filepath.Abs(filepath.Join(writer.Dir(), "generated", cmkConfigFileName))

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -429,9 +429,6 @@ func secretDifferentFromProfile(secret *corev1.Secret, profile decoder.CloudStac
 }
 
 func (p *cloudstackProvider) validateClusterSpec(ctx context.Context, clusterSpec *cluster.Spec) (err error) {
-	if err := p.validator.validateCloudStackAccess(ctx, clusterSpec.CloudStackDatacenter); err != nil {
-		return err
-	}
 	if err := p.validator.ValidateCloudStackDatacenterConfig(ctx, clusterSpec.CloudStackDatacenter); err != nil {
 		return err
 	}

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -78,7 +78,6 @@ func givenWildcardCmk(mockCtrl *gomock.Controller) ProviderCmkClient {
 	cmk.EXPECT().ValidateDiskOfferingPresent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	cmk.EXPECT().ValidateZoneAndGetId(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	cmk.EXPECT().ValidateAffinityGroupsPresent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	cmk.EXPECT().ValidateCloudStackConnection(gomock.Any(), gomock.Any()).AnyTimes()
 	cmk.EXPECT().ValidateDomainAndGetId(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	cmk.EXPECT().ValidateAccountPresent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	cmk.EXPECT().ValidateNetworkPresent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()

--- a/pkg/providers/cloudstack/mocks/client.go
+++ b/pkg/providers/cloudstack/mocks/client.go
@@ -84,20 +84,6 @@ func (mr *MockProviderCmkClientMockRecorder) ValidateAffinityGroupsPresent(arg0,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAffinityGroupsPresent", reflect.TypeOf((*MockProviderCmkClient)(nil).ValidateAffinityGroupsPresent), arg0, arg1, arg2, arg3, arg4)
 }
 
-// ValidateCloudStackConnection mocks base method.
-func (m *MockProviderCmkClient) ValidateCloudStackConnection(arg0 context.Context, arg1 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateCloudStackConnection", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ValidateCloudStackConnection indicates an expected call of ValidateCloudStackConnection.
-func (mr *MockProviderCmkClientMockRecorder) ValidateCloudStackConnection(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateCloudStackConnection", reflect.TypeOf((*MockProviderCmkClient)(nil).ValidateCloudStackConnection), arg0, arg1)
-}
-
 // ValidateDiskOfferingPresent mocks base method.
 func (m *MockProviderCmkClient) ValidateDiskOfferingPresent(arg0 context.Context, arg1, arg2 string, arg3 v1alpha1.CloudStackResourceDiskOffering) error {
 	m.ctrl.T.Helper()

--- a/pkg/providers/cloudstack/validator_test.go
+++ b/pkg/providers/cloudstack/validator_test.go
@@ -89,35 +89,6 @@ func TestValidateCloudStackDatacenterConfigWithAZ(t *testing.T) {
 	}
 }
 
-func TestValidateCloudStackConnection(t *testing.T) {
-	ctx := context.Background()
-	cmk := mocks.NewMockProviderCmkClient(gomock.NewController(t))
-	validator := NewValidator(cmk, &DummyNetClient{}, true)
-	datacenterConfig, err := v1alpha1.GetCloudStackDatacenterConfig(path.Join(testDataDir, testClusterConfigMainFilename))
-	if err != nil {
-		t.Fatalf("unable to get datacenter config from file")
-	}
-
-	cmk.EXPECT().ValidateCloudStackConnection(ctx, "global").Return(nil)
-	if err := validator.validateCloudStackAccess(ctx, datacenterConfig); err != nil {
-		t.Fatalf("failed to validate CloudStackDataCenterConfig: %v", err)
-	}
-}
-
-func TestValidateCloudStackConnectionFailure(t *testing.T) {
-	ctx := context.Background()
-	cmk := mocks.NewMockProviderCmkClient(gomock.NewController(t))
-	validator := NewValidator(cmk, &DummyNetClient{}, true)
-	datacenterConfig, err := v1alpha1.GetCloudStackDatacenterConfig(path.Join(testDataDir, testClusterConfigMainFilename))
-	if err != nil {
-		t.Fatalf("unable to get datacenter config from file")
-	}
-
-	cmk.EXPECT().ValidateCloudStackConnection(ctx, "global").Return(errors.New("exception"))
-	err = validator.validateCloudStackAccess(ctx, datacenterConfig)
-	thenErrorExpected(t, "validating connection to cloudstack global: exception", err)
-}
-
 func TestValidateSkipControlPlaneIpCheck(t *testing.T) {
 	cmk := mocks.NewMockProviderCmkClient(gomock.NewController(t))
 	validator := NewValidator(cmk, &DummyNetClient{}, true)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Manually cherrypick changes from #4016 into release branch to unblock e2e tests

*Testing (if applicable):*
Unit tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

