### PR TITLE
Fix fetch logs for Tinkerbell failed tests

### DIFF
--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/filewriter/writer.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/filewriter/writer.go
@@ -26,6 +26,10 @@ func NewWriter(dir string) (FileWriter, error) {
 }
 
 func (t *writer) Write(fileName string, content []byte, f ...FileOptionsFunc) (string, error) {
+	if strings.Contains(fileName, "|") {
+		count := strings.Count(fileName, "|") - 1
+		fileName = fmt.Sprintf("%s+%dTests", fileName[:strings.Index(fileName, "|")], count)
+	}
 	op := defaultFileOptions() // Default file options. -->> temporary file with default permissions
 	for _, optionFunc := range f {
 		optionFunc(op)


### PR DESCRIPTION
*Description of changes:*
The test log fetcher tool currently doesn't fetch Tinkerbell logs because the filename is too big.

This change clips the filename so the logs can be fetched properly for failed Tinkerbell tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

