### PR TITLE
Set eksa-system namespace in etcd cluster object ref

### DIFF
--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -118,6 +118,7 @@ func Cluster(clusterSpec *cluster.Spec, infrastructureObject, controlPlaneObject
 			APIVersion: etcdClusterAPIVersion,
 			Kind:       etcdadmClusterKind,
 			Name:       clusterName,
+			Namespace:  constants.EksaSystemNamespace,
 		}
 	}
 

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -24,6 +24,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: {{.clusterName}}-etcd
+    namespace: {{.eksaSystemNamespace}}
 {{- end }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/controlplane_test.go
+++ b/pkg/providers/vsphere/controlplane_test.go
@@ -220,6 +220,7 @@ func capiCluster() *clusterv1.Cluster {
 				Kind:       "EtcdadmCluster",
 				Name:       "test-etcd",
 				APIVersion: "etcdcluster.cluster.x-k8s.io/v1beta1",
+				Namespace:  "eksa-system",
 			},
 			InfrastructureRef: &corev1.ObjectReference{
 				Kind:       "VSphereCluster",

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -23,6 +23,7 @@ spec:
     apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
     kind: EtcdadmCluster
     name: test-etcd
+    namespace: eksa-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The controller needs the namespace ref to be set correctly to lookup the etcd cluster for reconciliation.

*Testing (if applicable):*
Manual. I can add a unit test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.