### PR TITLE
Fix vsphere machine template equal compare

### DIFF
--- a/pkg/providers/vsphere/machinetemplate.go
+++ b/pkg/providers/vsphere/machinetemplate.go
@@ -20,5 +20,5 @@ func getMachineTemplate(ctx context.Context, client kubernetes.Client, name, nam
 }
 
 func machineTemplateEqual(new, old *vspherev1.VSphereMachineTemplate) bool {
-	return equality.Semantic.DeepDerivative(new, old)
+	return equality.Semantic.DeepDerivative(new.Spec, old.Spec)
 }


### PR DESCRIPTION
## Description of changes
When looking for changes in immutable objects, we only care about the spec field. Any other change is allowed and doesn't require a new name. If we don't do it, we create a new machine template on every single reconciliation loop, which trigger an infinite rollout of new machines.

## Testing
Unit tests and manual testing with tilt by @jonathanmeier5 and @mitalipaygude 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

