### PR TITLE
Allow overriding date in Github bundle release

### DIFF
--- a/release/scripts/github-bundle-release.sh
+++ b/release/scripts/github-bundle-release.sh
@@ -23,7 +23,7 @@ WEEKLY_RELEASES_URL_PREFIX="${2?Specify second argument - weekly releases URL pr
 
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 RELEASE_NOTES_PATH="$SCRIPT_ROOT/github-bundle-release-notes"
-export DATE_YYYYMMDD=$(date "+%F")
+export DATE_YYYYMMDD="${DATE_YYYYMMDD:-$(date "+%F")}"
 RELEASE_TAG="weekly.$DATE_YYYYMMDD"
 
 # Filling in values for the GitHub Release notes template


### PR DESCRIPTION
Allow overriding of date in Github bundle release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

