### PR TITLE
Fixing e2e tests artifacts download

### DIFF
--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/artifacts/artifactFetcher.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/artifacts/artifactFetcher.go
@@ -162,11 +162,13 @@ func (l *testArtifactFetcher) FetchArtifacts(opts ...FetchArtifactsOpt) error {
 func excludedKey(key string) bool {
 	excludedKeys := []string{
 		"/.git/",
+		"/oidc/",
 	}
 
 	excludedSuffixes := []string{
 		"/e2e.test",
 		"/eksctl-anywhere",
+		".csv",
 	}
 
 	for _, s := range excludedKeys {


### PR DESCRIPTION
*Description of changes:*
Fixing the e2e tests fetch artifacts. Was failing with an index error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

