### PR TITLE
Clarify ResourcePool Documentation

### DIFF
--- a/docs/content/en/docs/reference/vsphere/vsphere-preparation.md
+++ b/docs/content/en/docs/reference/vsphere/vsphere-preparation.md
@@ -53,12 +53,14 @@ spec:
     datastores:
       - !!str "/MyDatacenter/datastore/MyDatastore2"
     resourcePools:
-      - !!str "/MyDatacenter/host/Cluster-03/MyResourcePool"
+      - !!str "/MyDatacenter/host/Cluster-03/MyResourcePool" # NOTE: see below if you do not want to use a resource pool
     folders:
       - !!str "/MyDatacenter/vm/OrgDirectory/MyVMs"
     templates:
       - !!str "/MyDatacenter/vm/Templates/MyTemplates"
 ```
+
+*NOTE: if you do not want to create a resource pool, you can instead specify the cluster directly as /MyDatacenter/host/Cluster-03 in user.yaml, where Cluster-03 is your cluster name. In your cluster spec, you will need to specify `/MyDatacenter/host/Cluster-03/Resources` for the resourcePool field.*
 
 Set the admin credentials as environment variables:
 ```bash
@@ -118,6 +120,8 @@ govc permissions.set -group=false -principal "$EKSA_USER"  -role "$USER_ROLE" "$
 
 govc permissions.set -group=false -principal "$EKSA_USER"  -role "$USER_ROLE" "$RESOURCE_POOL"
 ```
+
+*NOTE: if you do not want to create a resource pool, you can instead specify the cluster directly as /MyDatacenter/host/Cluster-03 in user.yaml, where Cluster-03 is your cluster name. In your cluster spec, you will need to specify `/MyDatacenter/host/Cluster-03/Resources` for the resourcePool field.*
 
 Please note that there is one more manual step to configure global permissions [here](#manually-set-global-permissions-role-in-global-permissions-ui).
 


### PR DESCRIPTION
*Description of changes:*
Clients can specify `Cluster/Resources` for the cluster config file, but for some reason govc will not assign permissions on this object.
Instead, for user.yaml, users need to just specify `Cluster`.

*Testing (if applicable):*
Manually validated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->