### PR TITLE
Improve E2E vSphere template selection logic

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -15,6 +15,7 @@ env:
     TEST_RUNNER_GOVC_LIBRARY: "eks-a-templates"
     TEST_RUNNER_GOVC_TEMPLATE: "eks-a-admin-ci"
     INTEGRATION_TEST_INFRA_CONFIG: "/tmp/test-infra.yml"
+    T_VSPHERE_TEMPLATES_FOLDER: "/SDDC-Datacenter/vm/Templates"
     T_VSPHERE_TEMPLATE_UBUNTU_KUBERNETES_1_20_EKS_20: "/SDDC-Datacenter/vm/Templates/kubernetes-1-20-eks-20-ubuntu"
     T_VSPHERE_TEMPLATE_UBUNTU_KUBERNETES_1_20_EKS_21: "/SDDC-Datacenter/vm/Templates/kubernetes-1-20-eks-21-ubuntu"
     T_VSPHERE_TEMPLATE_UBUNTU_KUBERNETES_1_20_EKS_22: "/SDDC-Datacenter/vm/Templates/ubuntu-kube-v1-20"

--- a/pkg/executables/govc_test.go
+++ b/pkg/executables/govc_test.go
@@ -182,35 +182,34 @@ func (dt *deployTemplateTest) assertDeployOptsMatches(t *testing.T) {
 
 func TestSearchTemplateItExists(t *testing.T) {
 	ctx := context.Background()
+	template := "my-template"
 	datacenter := "SDDC-Datacenter"
 
 	_, g, executable, env := setup(t)
-	machineConfig := newMachineConfig(t)
-	machineConfig.Spec.Template = "/SDDC Datacenter/vm/Templates/ubuntu 2004-kube-v1.19.6"
-	executable.EXPECT().ExecuteWithEnv(ctx, env, "find", "-json", "/"+datacenter, "-type", "VirtualMachine", "-name", filepath.Base(machineConfig.Spec.Template)).Return(*bytes.NewBufferString("[\"/SDDC Datacenter/vm/Templates/ubuntu 2004-kube-v1.19.6\"]"), nil)
+	executable.EXPECT().ExecuteWithEnv(ctx, env, "find", "-json", "/"+datacenter, "-type", "VirtualMachine", "-name", filepath.Base(template)).Return(*bytes.NewBufferString("[\"/SDDC Datacenter/vm/Templates/ubuntu 2004-kube-v1.19.6\"]"), nil)
 
-	_, err := g.SearchTemplate(ctx, datacenter, machineConfig)
+	_, err := g.SearchTemplate(ctx, datacenter, template)
 	if err != nil {
 		t.Fatalf("Govc.SearchTemplate() exists = false, want true %v", err)
 	}
 }
 
 func TestSearchTemplateItDoesNotExists(t *testing.T) {
-	machineConfig := newMachineConfig(t)
+	template := "my-template"
 	ctx := context.Background()
 	datacenter := "SDDC-Datacenter"
 
 	_, g, executable, env := setup(t)
-	executable.EXPECT().ExecuteWithEnv(ctx, env, "find", "-json", "/"+datacenter, "-type", "VirtualMachine", "-name", filepath.Base(machineConfig.Spec.Template)).Return(*bytes.NewBufferString(""), nil)
+	executable.EXPECT().ExecuteWithEnv(ctx, env, "find", "-json", "/"+datacenter, "-type", "VirtualMachine", "-name", filepath.Base(template)).Return(*bytes.NewBufferString(""), nil)
 
-	templateFullPath, err := g.SearchTemplate(ctx, datacenter, machineConfig)
+	templateFullPath, err := g.SearchTemplate(ctx, datacenter, template)
 	if err == nil && len(templateFullPath) > 0 {
 		t.Fatalf("Govc.SearchTemplate() exists = true, want false %v", err)
 	}
 }
 
 func TestSearchTemplateError(t *testing.T) {
-	machineConfig := newMachineConfig(t)
+	template := "my-template"
 	ctx := context.Background()
 	datacenter := "SDDC-Datacenter"
 
@@ -218,7 +217,7 @@ func TestSearchTemplateError(t *testing.T) {
 	g.Retrier = retrier.NewWithMaxRetries(5, 0)
 	executable.EXPECT().ExecuteWithEnv(ctx, env, gomock.Any()).Return(bytes.Buffer{}, errors.New("error from execute with env")).Times(5)
 
-	_, err := g.SearchTemplate(ctx, datacenter, machineConfig)
+	_, err := g.SearchTemplate(ctx, datacenter, template)
 	if err == nil {
 		t.Fatal("Govc.SearchTemplate() err = nil, want err not nil")
 	}

--- a/pkg/providers/vsphere/defaults.go
+++ b/pkg/providers/vsphere/defaults.go
@@ -123,7 +123,7 @@ func (d *Defaulter) setTemplateFullPath(ctx context.Context,
 	datacenterConfig *anywherev1.VSphereDatacenterConfig,
 	machine *anywherev1.VSphereMachineConfig,
 ) error {
-	templateFullPath, err := d.govc.SearchTemplate(ctx, datacenterConfig.Spec.Datacenter, machine)
+	templateFullPath, err := d.govc.SearchTemplate(ctx, datacenterConfig.Spec.Datacenter, machine.Spec.Template)
 	if err != nil {
 		return fmt.Errorf("setting template full path: %v", err)
 	}

--- a/pkg/providers/vsphere/internal/templates/factory.go
+++ b/pkg/providers/vsphere/internal/templates/factory.go
@@ -29,7 +29,7 @@ type Factory struct {
 type GovcClient interface {
 	CreateLibrary(ctx context.Context, datastore, library string) error
 	DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, datacenter, datastore, network, resourcePool string, resizeBRDisk bool) error
-	SearchTemplate(ctx context.Context, datacenter string, machineConfig *v1alpha1.VSphereMachineConfig) (string, error)
+	SearchTemplate(ctx context.Context, datacenter, template string) (string, error)
 	ImportTemplate(ctx context.Context, library, ovaURL, name string) error
 	LibraryElementExists(ctx context.Context, library string) (bool, error)
 	GetLibraryElementContentVersion(ctx context.Context, element string) (string, error)
@@ -62,7 +62,7 @@ func NewFactory(client GovcClient, datacenter, datastore, network, resourcePool,
 }
 
 func (f *Factory) CreateIfMissing(ctx context.Context, datacenter string, machineConfig *v1alpha1.VSphereMachineConfig, ovaURL string, tagsByCategory map[string][]string) error {
-	templateFullPath, err := f.client.SearchTemplate(ctx, datacenter, machineConfig)
+	templateFullPath, err := f.client.SearchTemplate(ctx, datacenter, machineConfig.Spec.Template)
 	if err != nil {
 		return fmt.Errorf("checking for template: %v", err)
 	}

--- a/pkg/providers/vsphere/internal/templates/factory_test.go
+++ b/pkg/providers/vsphere/internal/templates/factory_test.go
@@ -119,20 +119,20 @@ func (ct *createTest) assertSuccessFromCreateIfMissing() {
 
 func TestFactoryCreateIfMissingSearchTemplate(t *testing.T) {
 	ct := newCreateTest(t)
-	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig).Return(ct.machineConfig.Spec.Template, nil)
+	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig.Spec.Template).Return(ct.machineConfig.Spec.Template, nil)
 	ct.assertSuccessFromCreateIfMissing()
 }
 
 func TestFactoryCreateIfMissingErrorSearchTemplate(t *testing.T) {
 	ct := newCreateTest(t)
-	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig).Return("", ct.dummyError) // error getting template
+	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig.Spec.Template).Return("", ct.dummyError) // error getting template
 
 	ct.assertErrorFromCreateIfMissing()
 }
 
 func TestFactoryCreateIfMissingErrorLibraryElementExists(t *testing.T) {
 	ct := newCreateTest(t)
-	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig).Return("", nil) // template not present
+	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig.Spec.Template).Return("", nil) // template not present
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateLibrary).Return(false, ct.dummyError)
 
 	ct.assertErrorFromCreateIfMissing()
@@ -140,7 +140,7 @@ func TestFactoryCreateIfMissingErrorLibraryElementExists(t *testing.T) {
 
 func TestFactoryCreateIfMissingErrorCreateLibrary(t *testing.T) {
 	ct := newCreateTest(t)
-	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig).Return("", nil) // template not present
+	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig.Spec.Template).Return("", nil) // template not present
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateLibrary).Return(false, nil)
 	ct.govc.EXPECT().CreateLibrary(ct.ctx, ct.datastore, ct.templateLibrary).Return(ct.dummyError)
 
@@ -149,7 +149,7 @@ func TestFactoryCreateIfMissingErrorCreateLibrary(t *testing.T) {
 
 func TestFactoryCreateIfMissingErrorTemplateExistsInLibrary(t *testing.T) {
 	ct := newCreateTest(t)
-	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig).Return("", nil) // template not present
+	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig.Spec.Template).Return("", nil) // template not present
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateLibrary).Return(false, nil)
 	ct.govc.EXPECT().CreateLibrary(ct.ctx, ct.datastore, ct.templateLibrary).Return(nil)
 	ct.govc.EXPECT().GetLibraryElementContentVersion(ct.ctx, ct.templateInLibrary).Return("", ct.dummyError)
@@ -159,7 +159,7 @@ func TestFactoryCreateIfMissingErrorTemplateExistsInLibrary(t *testing.T) {
 
 func TestFactoryCreateIfMissingErrorImport(t *testing.T) {
 	ct := newCreateTest(t)
-	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig).Return("", nil) // template not present
+	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig.Spec.Template).Return("", nil) // template not present
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateLibrary).Return(false, nil)
 	ct.govc.EXPECT().CreateLibrary(ct.ctx, ct.datastore, ct.templateLibrary).Return(nil)
 	ct.govc.EXPECT().GetLibraryElementContentVersion(ct.ctx, ct.templateInLibrary).Return(ct.libraryContentDoesNotExist, nil)
@@ -170,7 +170,7 @@ func TestFactoryCreateIfMissingErrorImport(t *testing.T) {
 
 func TestFactoryCreateIfMissingErrorDeploy(t *testing.T) {
 	ct := newCreateTest(t)
-	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig).Return("", nil) // template not present
+	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig.Spec.Template).Return("", nil) // template not present
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateLibrary).Return(false, nil)
 	ct.govc.EXPECT().CreateLibrary(ct.ctx, ct.datastore, ct.templateLibrary).Return(nil)
 	ct.govc.EXPECT().GetLibraryElementContentVersion(ct.ctx, ct.templateInLibrary).Return(ct.libraryContentDoesNotExist, nil)
@@ -184,7 +184,7 @@ func TestFactoryCreateIfMissingErrorDeploy(t *testing.T) {
 
 func TestFactoryCreateIfMissingErrorFromTagFactory(t *testing.T) {
 	ct := newCreateTest(t)
-	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig).Return("", nil) // template not present
+	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig.Spec.Template).Return("", nil) // template not present
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateLibrary).Return(false, nil)
 	ct.govc.EXPECT().CreateLibrary(ct.ctx, ct.datastore, ct.templateLibrary).Return(nil)
 	ct.govc.EXPECT().GetLibraryElementContentVersion(ct.ctx, ct.templateInLibrary).Return(ct.libraryContentDoesNotExist, nil)
@@ -201,7 +201,7 @@ func TestFactoryCreateIfMissingErrorFromTagFactory(t *testing.T) {
 
 func TestFactoryCreateIfMissingSuccessLibraryDoesNotExist(t *testing.T) {
 	ct := newCreateTest(t)
-	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig).Return("", nil) // template not present
+	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig.Spec.Template).Return("", nil) // template not present
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateLibrary).Return(false, nil)
 	ct.govc.EXPECT().CreateLibrary(ct.ctx, ct.datastore, ct.templateLibrary).Return(nil)
 	ct.govc.EXPECT().GetLibraryElementContentVersion(ct.ctx, ct.templateInLibrary).Return(ct.libraryContentDoesNotExist, nil)
@@ -219,7 +219,7 @@ func TestFactoryCreateIfMissingSuccessLibraryDoesNotExist(t *testing.T) {
 
 func TestFactoryCreateIfMissingSuccessLibraryExists(t *testing.T) {
 	ct := newCreateTest(t)
-	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig).Return("", nil) // template not present
+	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig.Spec.Template).Return("", nil) // template not present
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateLibrary).Return(true, nil)
 	ct.govc.EXPECT().GetLibraryElementContentVersion(ct.ctx, ct.templateInLibrary).Return(ct.libraryContentDoesNotExist, nil)
 	ct.govc.EXPECT().ImportTemplate(ct.ctx, ct.templateLibrary, ct.ovaURL, ct.templateName).Return(nil)
@@ -236,7 +236,7 @@ func TestFactoryCreateIfMissingSuccessLibraryExists(t *testing.T) {
 
 func TestFactoryCreateIfMissingSuccessTemplateInLibraryExists(t *testing.T) {
 	ct := newCreateTest(t)
-	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig).Return("", nil) // template not present
+	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig.Spec.Template).Return("", nil) // template not present
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateLibrary).Return(true, nil)
 	ct.govc.EXPECT().GetLibraryElementContentVersion(ct.ctx, ct.templateInLibrary).Return(ct.libraryContentValid, nil)
 	ct.govc.EXPECT().DeployTemplateFromLibrary(
@@ -252,7 +252,7 @@ func TestFactoryCreateIfMissingSuccessTemplateInLibraryExists(t *testing.T) {
 
 func TestFactoryCreateIfMissingSuccessTemplateInLibraryCorrupted(t *testing.T) {
 	ct := newCreateTest(t)
-	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig).Return("", nil) // template not present
+	ct.govc.EXPECT().SearchTemplate(ct.ctx, ct.datacenter, ct.machineConfig.Spec.Template).Return("", nil) // template not present
 	ct.govc.EXPECT().LibraryElementExists(ct.ctx, ct.templateLibrary).Return(true, nil)
 	ct.govc.EXPECT().GetLibraryElementContentVersion(ct.ctx, ct.templateInLibrary).Return(ct.libraryContentCorrupted, nil)
 	ct.govc.EXPECT().DeleteLibraryElement(ct.ctx, ct.templateInLibrary).Return(nil)

--- a/pkg/providers/vsphere/internal/templates/mocks/govc.go
+++ b/pkg/providers/vsphere/internal/templates/mocks/govc.go
@@ -8,7 +8,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -280,18 +279,18 @@ func (mr *MockGovcClientMockRecorder) RoleExists(ctx, name interface{}) *gomock.
 }
 
 // SearchTemplate mocks base method.
-func (m *MockGovcClient) SearchTemplate(ctx context.Context, datacenter string, machineConfig *v1alpha1.VSphereMachineConfig) (string, error) {
+func (m *MockGovcClient) SearchTemplate(ctx context.Context, datacenter, template string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchTemplate", ctx, datacenter, machineConfig)
+	ret := m.ctrl.Call(m, "SearchTemplate", ctx, datacenter, template)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchTemplate indicates an expected call of SearchTemplate.
-func (mr *MockGovcClientMockRecorder) SearchTemplate(ctx, datacenter, machineConfig interface{}) *gomock.Call {
+func (mr *MockGovcClientMockRecorder) SearchTemplate(ctx, datacenter, template interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchTemplate", reflect.TypeOf((*MockGovcClient)(nil).SearchTemplate), ctx, datacenter, machineConfig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchTemplate", reflect.TypeOf((*MockGovcClient)(nil).SearchTemplate), ctx, datacenter, template)
 }
 
 // SetGroupRoleOnObject mocks base method.

--- a/pkg/providers/vsphere/mocks/client.go
+++ b/pkg/providers/vsphere/mocks/client.go
@@ -389,7 +389,7 @@ func (mr *MockProviderGovcClientMockRecorder) RoleExists(arg0, arg1 interface{})
 }
 
 // SearchTemplate mocks base method.
-func (m *MockProviderGovcClient) SearchTemplate(arg0 context.Context, arg1 string, arg2 *v1alpha1.VSphereMachineConfig) (string, error) {
+func (m *MockProviderGovcClient) SearchTemplate(arg0 context.Context, arg1, arg2 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SearchTemplate", arg0, arg1, arg2)
 	ret0, _ := ret[0].(string)

--- a/pkg/providers/vsphere/validator.go
+++ b/pkg/providers/vsphere/validator.go
@@ -162,7 +162,7 @@ func (v *Validator) validateTemplate(ctx context.Context, spec *Spec, machineCon
 }
 
 func (v *Validator) validateTemplatePresence(ctx context.Context, datacenter string, machineConfig *anywherev1.VSphereMachineConfig) error {
-	templateFullPath, err := v.govc.SearchTemplate(ctx, datacenter, machineConfig)
+	templateFullPath, err := v.govc.SearchTemplate(ctx, datacenter, machineConfig.Spec.Template)
 	if err != nil {
 		return fmt.Errorf("validating template: %v", err)
 	}

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -82,7 +82,7 @@ type vsphereProvider struct {
 }
 
 type ProviderGovcClient interface {
-	SearchTemplate(ctx context.Context, datacenter string, machineConfig *v1alpha1.VSphereMachineConfig) (string, error)
+	SearchTemplate(ctx context.Context, datacenter, template string) (string, error)
 	LibraryElementExists(ctx context.Context, library string) (bool, error)
 	GetLibraryElementContentVersion(ctx context.Context, element string) (string, error)
 	DeleteLibraryElement(ctx context.Context, element string) error

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -110,8 +110,8 @@ func (pc *DummyProviderGovcClient) ValidateVCenterSetupMachineConfig(ctx context
 	return nil
 }
 
-func (pc *DummyProviderGovcClient) SearchTemplate(ctx context.Context, datacenter string, machineConfig *v1alpha1.VSphereMachineConfig) (string, error) {
-	return machineConfig.Spec.Template, nil
+func (pc *DummyProviderGovcClient) SearchTemplate(ctx context.Context, datacenter, template string) (string, error) {
+	return template, nil
 }
 
 func (pc *DummyProviderGovcClient) LibraryElementExists(ctx context.Context, library string) (bool, error) {
@@ -2094,7 +2094,7 @@ func TestSetupAndValidateCreateClusterTemplateDoesNotExist(t *testing.T) {
 	tt.setExpectationForSetup()
 	tt.setExpectationForVCenterValidation()
 	for _, mc := range tt.machineConfigs {
-		tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, mc).Return("", nil).MaxTimes(1)
+		tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, mc.Spec.Template).Return("", nil).MaxTimes(1)
 	}
 
 	err := tt.provider.SetupAndValidateCreateCluster(tt.ctx, tt.clusterSpec)
@@ -2109,7 +2109,7 @@ func TestSetupAndValidateCreateClusterErrorCheckingTemplate(t *testing.T) {
 	tt.setExpectationForSetup()
 	tt.setExpectationForVCenterValidation()
 	for _, mc := range tt.machineConfigs {
-		tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, mc).Return("", errors.New(errorMessage)).MaxTimes(1)
+		tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, mc.Spec.Template).Return("", errors.New(errorMessage)).MaxTimes(1)
 	}
 
 	err := tt.provider.SetupAndValidateCreateCluster(tt.ctx, tt.clusterSpec)
@@ -2126,12 +2126,12 @@ func TestSetupAndValidateCreateClusterTemplateMissingTags(t *testing.T) {
 	tt.setExpectationsForMachineConfigsVCenterValidation()
 
 	for _, mc := range tt.machineConfigs {
-		tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, mc).Return(mc.Spec.Template, nil)
+		tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, mc.Spec.Template).Return(mc.Spec.Template, nil)
 	}
 	controlPlaneMachineConfigName := tt.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 	controlPlaneMachineConfig := tt.machineConfigs[controlPlaneMachineConfigName]
 
-	tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, controlPlaneMachineConfig).Return(controlPlaneMachineConfig.Spec.Template, nil)
+	tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, controlPlaneMachineConfig.Spec.Template).Return(controlPlaneMachineConfig.Spec.Template, nil)
 	tt.govc.EXPECT().GetTags(tt.ctx, controlPlaneMachineConfig.Spec.Template).Return(nil, nil)
 
 	err := tt.provider.SetupAndValidateCreateCluster(tt.ctx, tt.clusterSpec)
@@ -2151,9 +2151,9 @@ func TestSetupAndValidateCreateClusterErrorGettingTags(t *testing.T) {
 	tt.setExpectationForVCenterValidation()
 	tt.setExpectationsForMachineConfigsVCenterValidation()
 	for _, mc := range tt.machineConfigs {
-		tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, mc).Return(mc.Spec.Template, nil)
+		tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, mc.Spec.Template).Return(mc.Spec.Template, nil)
 	}
-	tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, controlPlaneMachineConfig).Return(controlPlaneMachineConfig.Spec.Template, nil)
+	tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, controlPlaneMachineConfig.Spec.Template).Return(controlPlaneMachineConfig.Spec.Template, nil)
 	tt.govc.EXPECT().GetTags(tt.ctx, controlPlaneMachineConfig.Spec.Template).Return(nil, errors.New(errorMessage))
 
 	err := tt.provider.SetupAndValidateCreateCluster(tt.ctx, tt.clusterSpec)

--- a/test/e2e/awsiam_test.go
+++ b/test/e2e/awsiam_test.go
@@ -203,7 +203,7 @@ func TestVSphereKubernetes123To124AWSIamAuthUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate124Var()),
+		provider.WithProviderUpgrade(provider.Ubuntu124Template()),
 		framework.WithEnvVar(features.K8s124SupportEnvVar, "true"),
 	)
 }

--- a/test/e2e/flux_test.go
+++ b/test/e2e/flux_test.go
@@ -269,7 +269,7 @@ func TestVSphereKubernetes123To124FluxUpgradeLegacy(t *testing.T) {
 		test,
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate124Var()),
+		provider.WithProviderUpgrade(provider.Ubuntu124Template()),
 		framework.WithEnvVar(features.K8s124SupportEnvVar, "true"),
 	)
 }
@@ -289,7 +289,7 @@ func TestVSphereKubernetes123To124GitFluxUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate124Var()),
+		provider.WithProviderUpgrade(provider.Ubuntu124Template()),
 		framework.WithEnvVar(features.K8s124SupportEnvVar, "true"),
 	)
 }

--- a/test/e2e/oidc_test.go
+++ b/test/e2e/oidc_test.go
@@ -210,7 +210,7 @@ func TestVSphereKubernetes123To124OIDCUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate124Var()),
+		provider.WithProviderUpgrade(provider.Ubuntu124Template()),
 		framework.WithEnvVar(features.K8s124SupportEnvVar, "true"),
 	)
 }

--- a/test/e2e/upgrade_from_latest_test.go
+++ b/test/e2e/upgrade_from_latest_test.go
@@ -69,7 +69,7 @@ func TestVSphereKubernetes120BottlerocketUpgradeFromLatestMinorRelease(t *testin
 		release,
 		anywherev1.Kube120,
 		provider.WithProviderUpgrade(
-			framework.UpdateBottlerocketTemplate120(), // Set the template so it doesn't get autoimported
+			provider.Bottlerocket120Template(), // Set the template so it doesn't get autoimported
 		),
 	)
 }
@@ -114,7 +114,7 @@ func TestVSphereKubernetes121BottlerocketUpgradeFromLatestMinorRelease(t *testin
 		release,
 		anywherev1.Kube121,
 		provider.WithProviderUpgrade(
-			framework.UpdateBottlerocketTemplate121(), // Set the template so it doesn't get autoimported
+			provider.Bottlerocket121Template(), // Set the template so it doesn't get autoimported
 		),
 	)
 }
@@ -140,7 +140,7 @@ func TestVSphereKubernetes120UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
 		release,
 		anywherev1.Kube120,
 		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate120Var(), // Set the template so it doesn't get autoimported
+			provider.Ubuntu120Template(), // Set the template so it doesn't get autoimported
 		),
 	)
 }
@@ -166,7 +166,7 @@ func TestVSphereKubernetes121UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
 		release,
 		anywherev1.Kube121,
 		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate121Var(), // Set the template so it doesn't get autoimported
+			provider.Ubuntu121Template(), // Set the template so it doesn't get autoimported
 		),
 	)
 }
@@ -193,7 +193,7 @@ func TestVSphereKubernetes121UbuntuUpgradeFromLatestMinorReleaseAlwaysNetworkPol
 		anywherev1.Kube121,
 		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(anywherev1.CiliumPolicyModeAlways)),
 		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate121Var(), // Set the template so it doesn't get autoimported
+			provider.Ubuntu121Template(), // Set the template so it doesn't get autoimported
 		),
 	)
 }
@@ -237,7 +237,7 @@ func TestVSphereKubernetes121To122UbuntuUpgradeFromLatestMinorRelease(t *testing
 		release,
 		anywherev1.Kube122,
 		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate122Var(), // Set the template so it doesn't get autoimported
+			provider.Ubuntu122Template(), // Set the template so it doesn't get autoimported
 		),
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(anywherev1.Kube122)),
 	)
@@ -264,7 +264,7 @@ func TestVSphereKubernetes122To123UbuntuUpgradeFromLatestMinorRelease(t *testing
 		release,
 		anywherev1.Kube123,
 		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate123Var(), // Set the template so it doesn't get autoimported
+			provider.Ubuntu123Template(), // Set the template so it doesn't get autoimported
 		),
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(anywherev1.Kube123)),
 	)
@@ -292,7 +292,7 @@ func TestVSphereKubernetes123To124UbuntuUpgradeFromLatestMinorRelease(t *testing
 		release,
 		anywherev1.Kube124,
 		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate124Var(), // Set the template so it doesn't get autoimported
+			provider.Ubuntu124Template(), // Set the template so it doesn't get autoimported
 		),
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(anywherev1.Kube124)),
 		framework.WithEnvVar(features.K8s124SupportEnvVar, "true"),

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -70,7 +70,7 @@ func TestVSphereKubernetes120UbuntuTo121Upgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube121,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate121Var()),
+		provider.WithProviderUpgrade(provider.Ubuntu121Template()),
 	)
 }
 
@@ -85,7 +85,7 @@ func TestVSphereKubernetes121UbuntuTo122Upgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube122,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var()),
+		provider.WithProviderUpgrade(provider.Ubuntu122Template()),
 	)
 }
 
@@ -100,7 +100,7 @@ func TestVSphereKubernetes122UbuntuTo123Upgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube123,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube123)),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate123Var()),
+		provider.WithProviderUpgrade(provider.Ubuntu123Template()),
 	)
 }
 
@@ -116,7 +116,7 @@ func TestVSphereKubernetes123UbuntuTo124Upgrade(t *testing.T) {
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
 		framework.WithEnvVar(features.K8s124SupportEnvVar, "true"),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate124Var()),
+		provider.WithProviderUpgrade(provider.Ubuntu124Template()),
 	)
 }
 
@@ -136,7 +136,7 @@ func TestVSphereKubernetes123UbuntuTo124UpgradeCiliumPolicyEnforcementMode(t *te
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
 		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate124Var()),
+		provider.WithProviderUpgrade(provider.Ubuntu124Template()),
 		framework.WithEnvVar(features.K8s124SupportEnvVar, "true"),
 	)
 }
@@ -154,7 +154,7 @@ func TestVSphereKubernetes123UbuntuTo124MultipleFieldsUpgrade(t *testing.T) {
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
 		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate124Var(),
+			provider.Ubuntu124Template(),
 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
 			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
 			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
@@ -185,7 +185,7 @@ func TestVSphereKubernetes123UbuntuTo124WithFluxLegacyUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate124Var()),
+		provider.WithProviderUpgrade(provider.Ubuntu124Template()),
 		framework.WithEnvVar(features.K8s124SupportEnvVar, "true"),
 	)
 }
@@ -208,7 +208,7 @@ func TestVSphereKubernetes123UbuntuTo124DifferentNamespaceWithFluxLegacyUpgrade(
 		test,
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate124Var()),
+		provider.WithProviderUpgrade(provider.Ubuntu124Template()),
 		framework.WithEnvVar(features.K8s124SupportEnvVar, "true"),
 	)
 }
@@ -261,7 +261,7 @@ func TestVSphereKubernetes123BottlerocketTo124Upgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
-		provider.WithProviderUpgrade(framework.UpdateBottlerocketTemplate124()),
+		provider.WithProviderUpgrade(provider.Bottlerocket124Template()),
 		framework.WithEnvVar(features.K8s124SupportEnvVar, "true"),
 	)
 }
@@ -279,7 +279,7 @@ func TestVSphereKubernetes123BottlerocketTo124MultipleFieldsUpgrade(t *testing.T
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
 		provider.WithProviderUpgrade(
-			framework.UpdateBottlerocketTemplate124(),
+			provider.Bottlerocket124Template(),
 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
 			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
 			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
@@ -310,7 +310,7 @@ func TestVSphereKubernetes123BottlerocketTo124WithFluxLegacyUpgrade(t *testing.T
 		test,
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
-		provider.WithProviderUpgrade(framework.UpdateBottlerocketTemplate124()),
+		provider.WithProviderUpgrade(provider.Bottlerocket124Template()),
 		framework.WithEnvVar(features.K8s124SupportEnvVar, "true"),
 	)
 }
@@ -332,7 +332,7 @@ func TestVSphereKubernetes123BottlerocketTo124DifferentNamespaceWithFluxLegacyUp
 		test,
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
-		provider.WithProviderUpgrade(framework.UpdateBottlerocketTemplate124()),
+		provider.WithProviderUpgrade(provider.Bottlerocket124Template()),
 		framework.WithEnvVar(features.K8s124SupportEnvVar, "true"),
 	)
 }
@@ -405,7 +405,7 @@ func TestVSphereKubernetes123UbuntuTo124StackedEtcdUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate124Var()),
+		provider.WithProviderUpgrade(provider.Ubuntu124Template()),
 		framework.WithEnvVar(features.K8s124SupportEnvVar, "true"),
 	)
 }
@@ -425,7 +425,7 @@ func TestVSphereKubernetes123BottlerocketTo124StackedEtcdUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
-		provider.WithProviderUpgrade(framework.UpdateBottlerocketTemplate124()),
+		provider.WithProviderUpgrade(provider.Bottlerocket124Template()),
 		framework.WithEnvVar(features.K8s124SupportEnvVar, "true"),
 	)
 }
@@ -589,12 +589,12 @@ func TestVSphereKubernetes121UbuntuTo122UpgradeWithCheckpoint(t *testing.T) {
 	)
 
 	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)), framework.ExpectFailure(true),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var(), api.WithResourcePoolForAllMachines(vsphereInvalidResourcePoolUpdateVar)), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupVmsVar, "false"))
+		provider.WithProviderUpgrade(provider.Ubuntu122Template(), api.WithResourcePoolForAllMachines(vsphereInvalidResourcePoolUpdateVar)), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupVmsVar, "false"))
 
 	commandOpts := []framework.CommandOpt{framework.WithExternalEtcdWaitTimeout("10m")}
 
 	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)), framework.ExpectFailure(false),
-		provider.WithProviderUpgrade(framework.UpdateUbuntuTemplate122Var(), api.WithResourcePoolForAllMachines(os.Getenv(vsphereResourcePoolVar))), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupVmsVar, "true"))
+		provider.WithProviderUpgrade(provider.Ubuntu122Template(), api.WithResourcePoolForAllMachines(os.Getenv(vsphereResourcePoolVar))), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupVmsVar, "true"))
 
 	runUpgradeFlowWithCheckpoint(
 		test,

--- a/test/e2e/workload_clusters_test.go
+++ b/test/e2e/workload_clusters_test.go
@@ -143,7 +143,7 @@ func TestVSphereUpgradeMulticlusterWorkloadClusterWithFluxLegacy(t *testing.T) {
 			api.WithWorkerNodeCount(3),
 		),
 		provider.WithProviderUpgradeGit(
-			framework.UpdateUbuntuTemplate121Var(),
+			provider.Ubuntu121Template(),
 		),
 	)
 }
@@ -259,7 +259,7 @@ func TestVSphereUpgradeMulticlusterWorkloadClusterWithGithubFlux(t *testing.T) {
 			api.WithWorkerNodeCount(3),
 		),
 		provider.WithProviderUpgradeGit(
-			framework.UpdateUbuntuTemplate122Var(),
+			provider.Ubuntu122Template(),
 		),
 	)
 }

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -27,22 +28,6 @@ const (
 	vsphereServerVar            = "T_VSPHERE_SERVER"
 	vsphereSshAuthorizedKeyVar  = "T_VSPHERE_SSH_AUTHORIZED_KEY"
 	vsphereStoragePolicyNameVar = "T_VSPHERE_STORAGE_POLICY_NAME"
-	vsphereTemplateUbuntu118Var = "T_VSPHERE_TEMPLATE_UBUNTU_1_18"
-	vsphereTemplateUbuntu119Var = "T_VSPHERE_TEMPLATE_UBUNTU_1_19"
-	vsphereTemplateUbuntu120Var = "T_VSPHERE_TEMPLATE_UBUNTU_1_20"
-	vsphereTemplateUbuntu121Var = "T_VSPHERE_TEMPLATE_UBUNTU_1_21"
-	vsphereTemplateUbuntu122Var = "T_VSPHERE_TEMPLATE_UBUNTU_1_22"
-	vsphereTemplateUbuntu123Var = "T_VSPHERE_TEMPLATE_UBUNTU_1_23"
-	vsphereTemplateUbuntu124Var = "T_VSPHERE_TEMPLATE_UBUNTU_1_24"
-	vsphereTemplateRedhat120Var = "T_VSPHERE_TEMPLATE_REDHAT_1_20"
-	vsphereTemplateRedhat121Var = "T_VSPHERE_TEMPLATE_REDHAT_1_21"
-	vsphereTemplateRedhat122Var = "T_VSPHERE_TEMPLATE_REDHAT_1_22"
-	vsphereTemplateRedhat123Var = "T_VSPHERE_TEMPLATE_REDHAT_1_23"
-	vsphereTemplateBR120Var     = "T_VSPHERE_TEMPLATE_BR_1_20"
-	vsphereTemplateBR121Var     = "T_VSPHERE_TEMPLATE_BR_1_21"
-	vsphereTemplateBR122Var     = "T_VSPHERE_TEMPLATE_BR_1_22"
-	vsphereTemplateBR123Var     = "T_VSPHERE_TEMPLATE_BR_1_23"
-	vsphereTemplateBR124Var     = "T_VSPHERE_TEMPLATE_BR_1_24"
 	vsphereTlsInsecureVar       = "T_VSPHERE_TLS_INSECURE"
 	vsphereTlsThumbprintVar     = "T_VSPHERE_TLS_THUMBPRINT"
 	vsphereUsernameVar          = "EKSA_VSPHERE_USERNAME"
@@ -53,6 +38,7 @@ const (
 	govcInsecureVar             = "GOVC_INSECURE"
 	govcDatacenterVar           = "GOVC_DATACENTER"
 	vsphereTemplateEnvVarPrefix = "T_VSPHERE_TEMPLATE_"
+	vsphereTemplatesFolder      = "T_VSPHERE_TEMPLATES_FOLDER"
 )
 
 var requiredEnvVars = []string{
@@ -64,22 +50,6 @@ var requiredEnvVars = []string{
 	vsphereResourcePoolVar,
 	vsphereServerVar,
 	vsphereSshAuthorizedKeyVar,
-	vsphereTemplateUbuntu118Var,
-	vsphereTemplateUbuntu119Var,
-	vsphereTemplateUbuntu120Var,
-	vsphereTemplateUbuntu121Var,
-	vsphereTemplateUbuntu122Var,
-	vsphereTemplateUbuntu123Var,
-	vsphereTemplateUbuntu124Var,
-	vsphereTemplateRedhat120Var,
-	vsphereTemplateRedhat121Var,
-	vsphereTemplateRedhat122Var,
-	vsphereTemplateRedhat123Var,
-	vsphereTemplateBR120Var,
-	vsphereTemplateBR121Var,
-	vsphereTemplateBR122Var,
-	vsphereTemplateBR123Var,
-	vsphereTemplateBR124Var,
 	vsphereTlsInsecureVar,
 	vsphereTlsThumbprintVar,
 	vsphereUsernameVar,
@@ -93,77 +63,56 @@ var requiredEnvVars = []string{
 
 type VSphere struct {
 	t              *testing.T
+	testsConfig    vsphereConfig
 	fillers        []api.VSphereFiller
 	clusterFillers []api.ClusterFiller
 	cidr           string
 	GovcClient     *executables.Govc
+	devRelease     *releasev1.EksARelease
+	templatesCache map[string]string
 }
 
+type vsphereConfig struct {
+	Datacenter        string
+	Datastore         string
+	Folder            string
+	Network           string
+	ResourcePool      string
+	Server            string
+	SSHAuthorizedKey  string
+	StoragePolicyName string
+	TLSInsecure       bool
+	TLSThumbprint     string
+	TemplatesFolder   string
+}
+
+// VSphereOpt is construction option for the E2E vSphere provider.
 type VSphereOpt func(*VSphere)
-
-func UpdateUbuntuTemplate119Var() api.VSphereFiller {
-	return api.WithVSphereStringFromEnvVar(vsphereTemplateUbuntu119Var, api.WithTemplateForAllMachines)
-}
-
-func UpdateUbuntuTemplate120Var() api.VSphereFiller {
-	return api.WithVSphereStringFromEnvVar(vsphereTemplateUbuntu120Var, api.WithTemplateForAllMachines)
-}
-
-func UpdateUbuntuTemplate121Var() api.VSphereFiller {
-	return api.WithVSphereStringFromEnvVar(vsphereTemplateUbuntu121Var, api.WithTemplateForAllMachines)
-}
-
-func UpdateUbuntuTemplate122Var() api.VSphereFiller {
-	return api.WithVSphereStringFromEnvVar(vsphereTemplateUbuntu122Var, api.WithTemplateForAllMachines)
-}
-
-func UpdateUbuntuTemplate123Var() api.VSphereFiller {
-	return api.WithVSphereStringFromEnvVar(vsphereTemplateUbuntu123Var, api.WithTemplateForAllMachines)
-}
-
-func UpdateUbuntuTemplate124Var() api.VSphereFiller {
-	return api.WithVSphereStringFromEnvVar(vsphereTemplateUbuntu124Var, api.WithTemplateForAllMachines)
-}
-
-func UpdateBottlerocketTemplate121() api.VSphereFiller {
-	return api.WithVSphereStringFromEnvVar(vsphereTemplateBR121Var, api.WithTemplateForAllMachines)
-}
-
-func UpdateBottlerocketTemplate122() api.VSphereFiller {
-	return api.WithVSphereStringFromEnvVar(vsphereTemplateBR122Var, api.WithTemplateForAllMachines)
-}
-
-func UpdateBottlerocketTemplate123() api.VSphereFiller {
-	return api.WithVSphereStringFromEnvVar(vsphereTemplateBR123Var, api.WithTemplateForAllMachines)
-}
-
-// UpdateBottlerocketTemplate124 retusns vsphere filler for 1.24 BR.
-func UpdateBottlerocketTemplate124() api.VSphereFiller {
-	return api.WithVSphereStringFromEnvVar(vsphereTemplateBR124Var, api.WithTemplateForAllMachines)
-}
-
-func UpdateBottlerocketTemplate120() api.VSphereFiller {
-	return api.WithVSphereStringFromEnvVar(vsphereTemplateBR120Var, api.WithTemplateForAllMachines)
-}
 
 func NewVSphere(t *testing.T, opts ...VSphereOpt) *VSphere {
 	checkRequiredEnvVars(t, requiredEnvVars)
 	c := buildGovc(t)
+	config, err := readVSphereConfig()
+	if err != nil {
+		t.Fatalf("Failed reading vSphere tests config: %v", err)
+	}
 	v := &VSphere{
-		t:          t,
-		GovcClient: c,
+		t:           t,
+		GovcClient:  c,
+		testsConfig: config,
 		fillers: []api.VSphereFiller{
-			api.WithVSphereStringFromEnvVar(vsphereDatacenterVar, api.WithDatacenter),
-			api.WithVSphereStringFromEnvVar(vsphereDatastoreVar, api.WithDatastoreForAllMachines),
-			api.WithVSphereStringFromEnvVar(vsphereFolderVar, api.WithFolderForAllMachines),
-			api.WithVSphereStringFromEnvVar(vsphereNetworkVar, api.WithNetwork),
-			api.WithVSphereStringFromEnvVar(vsphereResourcePoolVar, api.WithResourcePoolForAllMachines),
-			api.WithVSphereStringFromEnvVar(vsphereServerVar, api.WithServer),
-			api.WithVSphereStringFromEnvVar(vsphereSshAuthorizedKeyVar, api.WithSSHAuthorizedKeyForAllMachines),
-			api.WithVSphereStringFromEnvVar(vsphereStoragePolicyNameVar, api.WithStoragePolicyNameForAllMachines),
-			api.WithVSphereBoolFromEnvVar(vsphereTlsInsecureVar, api.WithTLSInsecure),
-			api.WithVSphereStringFromEnvVar(vsphereTlsThumbprintVar, api.WithTLSThumbprint),
+			api.WithDatacenter(config.Datacenter),
+			api.WithDatastoreForAllMachines(config.Datastore),
+			api.WithFolderForAllMachines(config.Folder),
+			api.WithNetwork(config.Network),
+			api.WithResourcePoolForAllMachines(config.ResourcePool),
+			api.WithServer(config.Server),
+			api.WithSSHAuthorizedKeyForAllMachines(config.SSHAuthorizedKey),
+			api.WithStoragePolicyNameForAllMachines(config.StoragePolicyName),
+			api.WithTLSInsecure(config.TLSInsecure),
+			api.WithTLSThumbprint(config.TLSThumbprint),
 		},
+		templatesCache: make(map[string]string),
 	}
 
 	v.cidr = os.Getenv(cidrVar)
@@ -175,20 +124,11 @@ func NewVSphere(t *testing.T, opts ...VSphereOpt) *VSphere {
 	return v
 }
 
-func WithUbuntu124() VSphereOpt {
-	return func(v *VSphere) {
-		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateUbuntu124Var, api.WithTemplateForAllMachines),
-			api.WithOsFamilyForAllMachines(anywherev1.Ubuntu),
-		)
-	}
-}
-
 // WithRedHat120VSphere vsphere test with redhat 1.20.
 func WithRedHat120VSphere() VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateRedhat120Var, api.WithTemplateForAllMachines),
+			api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.RedHat, anywherev1.Kube120)),
 			api.WithOsFamilyForAllMachines(anywherev1.RedHat),
 		)
 	}
@@ -198,7 +138,7 @@ func WithRedHat120VSphere() VSphereOpt {
 func WithRedHat121VSphere() VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateRedhat121Var, api.WithTemplateForAllMachines),
+			api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.RedHat, anywherev1.Kube121)),
 			api.WithOsFamilyForAllMachines(anywherev1.RedHat),
 		)
 	}
@@ -208,7 +148,7 @@ func WithRedHat121VSphere() VSphereOpt {
 func WithRedHat122VSphere() VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateRedhat122Var, api.WithTemplateForAllMachines),
+			api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.RedHat, anywherev1.Kube122)),
 			api.WithOsFamilyForAllMachines(anywherev1.RedHat),
 		)
 	}
@@ -218,52 +158,62 @@ func WithRedHat122VSphere() VSphereOpt {
 func WithRedHat123VSphere() VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateRedhat123Var, api.WithTemplateForAllMachines),
+			api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.RedHat, anywherev1.Kube123)),
 			api.WithOsFamilyForAllMachines(anywherev1.RedHat),
 		)
 	}
 }
 
+// WithUbuntu124 returns a VSphereOpt that adds API fillers to use a Ubuntu vSphere template for k8s 1.24
+// and the "ubuntu" osFamily in all machine configs.
+func WithUbuntu124() VSphereOpt {
+	return func(v *VSphere) {
+		v.fillers = append(v.fillers,
+			api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Ubuntu, anywherev1.Kube124)),
+			api.WithOsFamilyForAllMachines(anywherev1.Ubuntu),
+		)
+	}
+}
+
+// WithUbuntu123 returns a VSphereOpt that adds API fillers to use a Ubuntu vSphere template for k8s 1.23
+// and the "ubuntu" osFamily in all machine configs.
 func WithUbuntu123() VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateUbuntu123Var, api.WithTemplateForAllMachines),
+			api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Ubuntu, anywherev1.Kube123)),
 			api.WithOsFamilyForAllMachines(anywherev1.Ubuntu),
 		)
 	}
 }
 
+// WithUbuntu122 returns a VSphereOpt that adds API fillers to use a Ubuntu vSphere template for k8s 1.22
+// and the "ubuntu" osFamily in all machine configs.
 func WithUbuntu122() VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateUbuntu122Var, api.WithTemplateForAllMachines),
+			api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Ubuntu, anywherev1.Kube122)),
 			api.WithOsFamilyForAllMachines(anywherev1.Ubuntu),
 		)
 	}
 }
 
+// WithUbuntu121 returns a VSphereOpt that adds API fillers to use a Ubuntu vSphere template for k8s 1.21
+// and the "ubuntu" osFamily in all machine configs.
 func WithUbuntu121() VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateUbuntu121Var, api.WithTemplateForAllMachines),
+			api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Ubuntu, anywherev1.Kube121)),
 			api.WithOsFamilyForAllMachines(anywherev1.Ubuntu),
 		)
 	}
 }
 
+// WithUbuntu120 returns a VSphereOpt that adds API fillers to use a Ubuntu vSphere template for k8s 1.20
+// and the "ubuntu" osFamily in all machine configs.
 func WithUbuntu120() VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateUbuntu120Var, api.WithTemplateForAllMachines),
-			api.WithOsFamilyForAllMachines(anywherev1.Ubuntu),
-		)
-	}
-}
-
-func WithUbuntu118() VSphereOpt {
-	return func(v *VSphere) {
-		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateUbuntu118Var, api.WithTemplateForAllMachines),
+			api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Ubuntu, anywherev1.Kube120)),
 			api.WithOsFamilyForAllMachines(anywherev1.Ubuntu),
 		)
 	}
@@ -272,7 +222,7 @@ func WithUbuntu118() VSphereOpt {
 func WithBottleRocket120() VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateBR120Var, api.WithTemplateForAllMachines),
+			api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Bottlerocket, anywherev1.Kube120)),
 			api.WithOsFamilyForAllMachines(anywherev1.Bottlerocket),
 		)
 	}
@@ -281,7 +231,7 @@ func WithBottleRocket120() VSphereOpt {
 func WithBottleRocket121() VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateBR121Var, api.WithTemplateForAllMachines),
+			api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Bottlerocket, anywherev1.Kube121)),
 			api.WithOsFamilyForAllMachines(anywherev1.Bottlerocket),
 		)
 	}
@@ -290,7 +240,7 @@ func WithBottleRocket121() VSphereOpt {
 func WithBottleRocket122() VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateBR122Var, api.WithTemplateForAllMachines),
+			api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Bottlerocket, anywherev1.Kube122)),
 			api.WithOsFamilyForAllMachines(anywherev1.Bottlerocket),
 		)
 	}
@@ -299,7 +249,7 @@ func WithBottleRocket122() VSphereOpt {
 func WithBottleRocket123() VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateBR123Var, api.WithTemplateForAllMachines),
+			api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Bottlerocket, anywherev1.Kube123)),
 			api.WithOsFamilyForAllMachines(anywherev1.Bottlerocket),
 		)
 	}
@@ -309,7 +259,7 @@ func WithBottleRocket123() VSphereOpt {
 func WithBottleRocket124() VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithVSphereStringFromEnvVar(vsphereTemplateBR124Var, api.WithTemplateForAllMachines),
+			api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Bottlerocket, anywherev1.Kube124)),
 			api.WithOsFamilyForAllMachines(anywherev1.Bottlerocket),
 		)
 	}
@@ -384,6 +334,143 @@ func (v *VSphere) WithNewVSphereWorkerNodeGroup(name string, workerNodeGroup *Wo
 	}
 }
 
+// Ubuntu120Template returns vsphere filler for 1.20 Ubuntu.
+func (v *VSphere) Ubuntu120Template() api.VSphereFiller {
+	return api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Ubuntu, anywherev1.Kube120))
+}
+
+// Ubuntu121Template returns vsphere filler for 1.21 Ubuntu.
+func (v *VSphere) Ubuntu121Template() api.VSphereFiller {
+	return api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Ubuntu, anywherev1.Kube121))
+}
+
+// Ubuntu122Template returns vsphere filler for 1.22 Ubuntu.
+func (v *VSphere) Ubuntu122Template() api.VSphereFiller {
+	return api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Ubuntu, anywherev1.Kube122))
+}
+
+// Ubuntu123Template returns vsphere filler for 1.23 Ubuntu.
+func (v *VSphere) Ubuntu123Template() api.VSphereFiller {
+	return api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Ubuntu, anywherev1.Kube123))
+}
+
+// Ubuntu124Template returns vsphere filler for 1.24 Ubuntu.
+func (v *VSphere) Ubuntu124Template() api.VSphereFiller {
+	return api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Ubuntu, anywherev1.Kube124))
+}
+
+// Bottlerocket120Template returns vsphere filler for 1.20 BR.
+func (v *VSphere) Bottlerocket120Template() api.VSphereFiller {
+	return api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Bottlerocket, anywherev1.Kube120))
+}
+
+// Bottlerocket121Template returns vsphere filler for 1.21 BR.
+func (v *VSphere) Bottlerocket121Template() api.VSphereFiller {
+	return api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Bottlerocket, anywherev1.Kube121))
+}
+
+// Bottlerocket122Template returns vsphere filler for 1.22 BR.
+func (v *VSphere) Bottlerocket122Template() api.VSphereFiller {
+	return api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Bottlerocket, anywherev1.Kube122))
+}
+
+// Bottlerocket123Template returns vsphere filler for 1.23 BR.
+func (v *VSphere) Bottlerocket123Template() api.VSphereFiller {
+	return api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Bottlerocket, anywherev1.Kube123))
+}
+
+// Bottlerocket124Template returns vsphere filler for 1.24 BR.
+func (v *VSphere) Bottlerocket124Template() api.VSphereFiller {
+	return api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Bottlerocket, anywherev1.Kube124))
+}
+
+func (v *VSphere) getDevRelease() *releasev1.EksARelease {
+	v.t.Helper()
+	if v.devRelease == nil {
+		latestRelease, err := getLatestDevRelease()
+		if err != nil {
+			v.t.Fatal(err)
+		}
+		v.devRelease = latestRelease
+	}
+
+	return v.devRelease
+}
+
+func (v *VSphere) templateForDevRelease(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) string {
+	v.t.Helper()
+	return v.templateForRelease(osFamily, v.getDevRelease(), kubeVersion)
+}
+
+// templateForRelease tries to find a suitable template for a particular eks-a release, k8s version and OS family.
+// It follows these steps:
+//
+// 1. Look for explicit configuration through an env var: "T_VSPHERE_TEMPLATE_{osFamily}_{eks-d version}".
+// This should be used for explicit configuration, mostly in local development for overrides.
+//
+// 2. If not present, look for a template if the default templates folder: "/SDDC-Datacenter/vm/Templates/{eks-d version}-{osFamily}"
+// This is what should be used most of the time in CI, the explicit configuration is not present but the right template has already been
+// imported to vSphere.
+//
+// 3. If the template doesn't exist, default to the value of the default template env vars: eg. "T_VSPHERE_TEMPLATE_UBUNTU_1_20".
+// This is a catch all condition. Mostly for edge cases where the bundle has been updated with a new eks-d version, but the
+// the new template hasn't been imported yet. It also preserves backwards compatibility.
+func (v *VSphere) templateForRelease(osFamily anywherev1.OSFamily, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) string {
+	v.t.Helper()
+	osFamilyStr := string(osFamily)
+	versionsBundle := readVersionsBundles(v.t, release, kubeVersion)
+	eksDName := versionsBundle.EksD.Name
+
+	templateEnvVarName := envVarForVSphereTemplate(osFamilyStr, eksDName)
+	cacheKey := templateEnvVarName
+	if template, ok := v.templatesCache[cacheKey]; ok {
+		v.t.Logf("Template for release found in cache, using %s vSphere template.", template)
+		return template
+	}
+
+	template, ok := os.LookupEnv(templateEnvVarName)
+	if ok && template != "" {
+		v.t.Logf("Env var %s is set, using %s vSphere template", templateEnvVarName, template)
+		v.templatesCache[cacheKey] = template
+		return template
+	}
+	v.t.Logf("Env var %s not is set, trying default generated template name", templateEnvVarName)
+
+	// Env var is not set, try default template name
+	folder := v.testsConfig.TemplatesFolder
+	if folder == "" {
+		v.t.Log("vSphere templates folder is not configured, can't continue template search.")
+	} else {
+		template = defaultNameForVSphereTemplate(folder, osFamilyStr, eksDName)
+		foundTemplate, err := v.GovcClient.SearchTemplate(context.Background(), v.testsConfig.Datacenter, template)
+		if err != nil {
+			v.t.Fatalf("Failed checking if default template exists: %v", err)
+		}
+
+		if foundTemplate != "" {
+			v.t.Logf("Default template for release exists, using %s vSphere template.", template)
+			v.templatesCache[cacheKey] = template
+			return template
+		}
+		v.t.Logf("Default template %s for release doesn't exit.", template)
+	}
+
+	// Default template doesn't exist, try legacy generic env var
+	// It is not guaranteed that this template will work for the given release, if they don't match the
+	// same ekd-d release, the test will fail. This is just a catch all last try for cases where the new template
+	// hasn't been imported with its own name but the default one matches the same eks-d release.
+	templateEnvVarName = defaultEnvVarForTemplate(osFamilyStr, kubeVersion)
+	template, ok = os.LookupEnv(templateEnvVarName)
+	if !ok || template == "" {
+		v.t.Fatalf("Env var %s for default template is not set, can't determine which template to use", templateEnvVarName)
+	}
+
+	v.t.Logf("Env var %s is set, using %s vSphere template. There are no guarantees this template will be valid. Cluster validation might fail.", templateEnvVarName, template)
+
+	v.templatesCache[cacheKey] = template
+	return template
+}
+
 func (v *VSphere) ClusterConfigFillers() []api.ClusterFiller {
 	clusterIP, err := GetIP(v.cidr, ClusterIPPoolEnvVar)
 	if err != nil {
@@ -430,29 +517,35 @@ func buildVSphereWorkerNodeGroupClusterFiller(machineConfigName string, workerNo
 }
 
 func WithUbuntuForRelease(release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) VSphereOpt {
-	return optionToSetTemplateForRelease("ubuntu", release, kubeVersion)
+	return optionToSetTemplateForRelease(anywherev1.Ubuntu, release, kubeVersion)
 }
 
 func WithBottlerocketFromRelease(release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) VSphereOpt {
-	return optionToSetTemplateForRelease("bottlerocket", release, kubeVersion)
+	return optionToSetTemplateForRelease(anywherev1.Bottlerocket, release, kubeVersion)
 }
 
-func optionToSetTemplateForRelease(osFamily string, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) VSphereOpt {
+func optionToSetTemplateForRelease(osFamily anywherev1.OSFamily, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) VSphereOpt {
 	return func(v *VSphere) {
-		versionsBundle := readVersionsBundles(v.t, release, kubeVersion)
-		eksDName := versionsBundle.EksD.Name
-
-		templateEnvVarName := fmt.Sprintf("T_VSPHERE_TEMPLATE_%s_%s", strings.ToUpper(osFamily), strings.ToUpper(strings.ReplaceAll(eksDName, "-", "_")))
-
-		template, ok := os.LookupEnv(templateEnvVarName)
-		if !ok || template == "" {
-			v.t.Fatalf("%s env var not set or empty, required to run tests for release %s", templateEnvVarName, release.Version)
-		}
-
 		v.fillers = append(v.fillers,
-			api.WithTemplateForAllMachines(template),
+			api.WithTemplateForAllMachines(v.templateForRelease(osFamily, release, kubeVersion)),
 		)
 	}
+}
+
+func envVarForVSphereTemplate(osFamily, eksDName string) string {
+	return fmt.Sprintf("T_VSPHERE_TEMPLATE_%s_%s", strings.ToUpper(osFamily), strings.ToUpper(strings.ReplaceAll(eksDName, "-", "_")))
+}
+
+func defaultNameForVSphereTemplate(templatesFolder, osFamily, eksDName string) string {
+	return filepath.Join(templatesFolder, fmt.Sprintf("%s-%s", strings.ToLower(eksDName), strings.ToLower(osFamily)))
+}
+
+func defaultEnvVarForTemplate(osFamily string, kubeVersion anywherev1.KubernetesVersion) string {
+	if osFamily == "bottlerocket" {
+		// This is only to maintain backwards compatibility with old env var naming
+		osFamily = "br"
+	}
+	return fmt.Sprintf("T_VSPHERE_TEMPLATE_%s_%s", strings.ToUpper(osFamily), strings.ReplaceAll(string(kubeVersion), ".", "_"))
 }
 
 func readVersionsBundles(t testing.TB, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) *releasev1.VersionsBundle {
@@ -463,4 +556,20 @@ func readVersionsBundles(t testing.TB, release *releasev1.EksARelease, kubeVersi
 	}
 
 	return bundles.VersionsBundleForKubernetesVersion(b, string(kubeVersion))
+}
+
+func readVSphereConfig() (vsphereConfig, error) {
+	return vsphereConfig{
+		Datacenter:        os.Getenv(vsphereDatacenterVar),
+		Datastore:         os.Getenv(vsphereDatastoreVar),
+		Folder:            os.Getenv(vsphereFolderVar),
+		Network:           os.Getenv(vsphereNetworkVar),
+		ResourcePool:      os.Getenv(vsphereResourcePoolVar),
+		Server:            os.Getenv(vsphereServerVar),
+		SSHAuthorizedKey:  os.Getenv(vsphereSshAuthorizedKeyVar),
+		StoragePolicyName: os.Getenv(vsphereStoragePolicyNameVar),
+		TLSInsecure:       os.Getenv(vsphereTlsInsecureVar) == "true",
+		TLSThumbprint:     os.Getenv(vsphereTlsThumbprintVar),
+		TemplatesFolder:   os.Getenv(vsphereTemplatesFolder),
+	}, nil
 }


### PR DESCRIPTION
## Description of changes

Due to the the speed at which we bump eks-d versions, template config gets out of sync frequently. This makes the E2E tests fail. The solution is easy, updating the config with the new templates and importing if they are haven't been yet. However, due to the lenght of a full suite run, it takes up to a full day to get feedback on the fix.

This PRs introduces extra logic to try to select the right template even if the configuration is missing while still accepting explicit config to override the defaults. It follows these steps:

1. Look for explicit configuration through an env var: "T_VSPHERE_TEMPLATE_{osFamily}_{eks-d version}".
This should be used for explicit configuration, mostly in local development for overrides.
2. If not present, look for a template if the default templates folder: "/SDDC-Datacenter/vm/Templates/{eks-d version}-{osFamily}" This is what should be used most of the time in CI, the explicit configuration is not present but the right template has already been imported to vSphere.
3. If the template doesn't exist, default to the value of the default template env vars: eg. "T_VSPHERE_TEMPLATE_UBUNTU_1_20". This is a catch all condition. Mostly for edge cases where the bundle has been updated with a new eks-d version, but the the new template hasn't been imported yet. It also preserves backwards compatibility.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

