### PR TITLE
Move tagging of images to registry.go

### DIFF
--- a/pkg/docker/registry.go
+++ b/pkg/docker/registry.go
@@ -107,6 +107,9 @@ func getUpdatedEndpoint(originalEndpoint, image string) string {
 
 // Replace original registries with the new endpoint from the registry mirror configuration.
 func getLocalImage(endpoint string, image string) string {
+	// Performing a string replacement instead of url replacement because the url parsing
+	// has an issue distinguishing between / and %2f when parsing the url
+	// Issue can be found here: https://github.com/golang/go/issues/10887.
 	replacer := strings.NewReplacer(defaultRegistry, endpoint, packageProdDomain, endpoint, packageDevDomain, endpoint)
 	localImage := replacer.Replace(image)
 	return removeDigestReference(localImage)

--- a/pkg/docker/registry.go
+++ b/pkg/docker/registry.go
@@ -105,7 +105,7 @@ func getUpdatedEndpoint(originalEndpoint, image string) string {
 	return originalEndpoint
 }
 
-// Replace original registries with the new endpoint from the registry mirror configuration
+// Replace original registries with the new endpoint from the registry mirror configuration.
 func getLocalImage(endpoint string, image string) string {
 	replacer := strings.NewReplacer(defaultRegistry, endpoint, packageProdDomain, endpoint, packageDevDomain, endpoint)
 	localImage := replacer.Replace(image)

--- a/pkg/docker/registry.go
+++ b/pkg/docker/registry.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/utils/urls"
 )
 
 // These constants are temporary since currently there is a limitation on harbor
@@ -107,11 +108,8 @@ func getUpdatedEndpoint(originalEndpoint, image string) string {
 
 // Replace original registries with the new endpoint from the registry mirror configuration.
 func getLocalImage(endpoint string, image string) string {
-	// Performing a string replacement instead of url replacement because the url parsing
-	// has an issue distinguishing between / and %2f when parsing the url
-	// Issue can be found here: https://github.com/golang/go/issues/10887.
-	replacer := strings.NewReplacer(defaultRegistry, endpoint, packageProdDomain, endpoint, packageDevDomain, endpoint)
-	localImage := replacer.Replace(image)
+	localImage := urls.ReplaceHost(image, endpoint)
+	// Some images contain digest reference on them.
 	return removeDigestReference(localImage)
 }
 

--- a/pkg/docker/registry_test.go
+++ b/pkg/docker/registry_test.go
@@ -19,12 +19,13 @@ func TestNewRegistryDestination(t *testing.T) {
 	client := mocks.NewMockImageTaggerPusher(ctrl)
 
 	registry := "https://registry"
-	images := []string{"image1:1", "image2:2"}
+	images := []string{"public.ecr.aws/image1:1", "public.ecr.aws/image2:2"}
+	localImages := []string{"https://registry/image1:1", "https://registry/image2:2"}
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
-	for _, i := range images {
-		client.EXPECT().TagImage(test.AContext(), i, registry)
-		client.EXPECT().PushImage(test.AContext(), i, registry)
+	for index, i := range images {
+		client.EXPECT().TagImage(test.AContext(), i, localImages[index])
+		client.EXPECT().PushImage(test.AContext(), i, localImages[index])
 	}
 
 	g.Expect(dstLoader.Write(ctx, images...)).To(Succeed())
@@ -36,12 +37,12 @@ func TestNewRegistryDestinationWhenDigestSpecified(t *testing.T) {
 	client := mocks.NewMockImageTaggerPusher(ctrl)
 
 	registry := "https://registry"
-	image := "image1@sha256:v1"
-	expectedImage := "image1:v1"
+	image := "public.ecr.aws/image1@sha256:v1"
+	expectedImage := "https://registry/image1:v1"
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
-	client.EXPECT().TagImage(test.AContext(), expectedImage, registry)
-	client.EXPECT().PushImage(test.AContext(), expectedImage, registry)
+	client.EXPECT().TagImage(test.AContext(), image, expectedImage)
+	client.EXPECT().PushImage(test.AContext(), image, expectedImage)
 
 	g.Expect(dstLoader.Write(ctx, image)).To(Succeed())
 }
@@ -52,12 +53,12 @@ func TestNewRegistryDestinationWhenPackagesDevProvided(t *testing.T) {
 	client := mocks.NewMockImageTaggerPusher(ctrl)
 
 	registry := "https://registry"
-	expectedRegistry := "https://registry/l0g8r8j6"
-	image := "857151390494.dkr.ecr.us-west-2.amazonaws.com:v1"
+	image := "857151390494.dkr.ecr.us-west-2.amazonaws.com/image1:v1"
+	expectedImage := "https://registry/l0g8r8j6/image1:v1"
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
-	client.EXPECT().TagImage(test.AContext(), image, expectedRegistry)
-	client.EXPECT().PushImage(test.AContext(), image, expectedRegistry)
+	client.EXPECT().TagImage(test.AContext(), image, expectedImage)
+	client.EXPECT().PushImage(test.AContext(), image, expectedImage)
 
 	g.Expect(dstLoader.Write(ctx, image)).To(Succeed())
 }
@@ -68,12 +69,12 @@ func TestNewRegistryDestinationWhenPackagesProdProvided(t *testing.T) {
 	client := mocks.NewMockImageTaggerPusher(ctrl)
 
 	registry := "https://registry"
-	expectedRegistry := "https://registry/eks-anywhere"
-	image := "783794618700.dkr.ecr.us-west-2.amazonaws.com:v1"
+	image := "783794618700.dkr.ecr.us-west-2.amazonaws.com/image1:v1"
+	expectedImage := "https://registry/eks-anywhere/image1:v1"
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
-	client.EXPECT().TagImage(test.AContext(), image, expectedRegistry)
-	client.EXPECT().PushImage(test.AContext(), image, expectedRegistry)
+	client.EXPECT().TagImage(test.AContext(), image, expectedImage)
+	client.EXPECT().PushImage(test.AContext(), image, expectedImage)
 
 	g.Expect(dstLoader.Write(ctx, image)).To(Succeed())
 }
@@ -84,12 +85,13 @@ func TestNewRegistryDestinationErrorTag(t *testing.T) {
 	client := mocks.NewMockImageTaggerPusher(ctrl)
 
 	registry := "https://registry"
-	images := []string{"image1:1", "image2:2"}
+	images := []string{"public.ecr.aws/image1:1", "public.ecr.aws/image2:2"}
+	localImages := []string{"https://registry/image1:1", "https://registry/image2:2"}
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
-	client.EXPECT().TagImage(test.AContext(), images[0], registry).Return(errors.New("error tagging"))
-	client.EXPECT().TagImage(test.AContext(), images[1], registry).MaxTimes(1)
-	client.EXPECT().PushImage(test.AContext(), images[1], registry).MaxTimes(1)
+	client.EXPECT().TagImage(test.AContext(), images[0], localImages[0]).Return(errors.New("error tagging"))
+	client.EXPECT().TagImage(test.AContext(), images[1], localImages[1]).MaxTimes(1)
+	client.EXPECT().PushImage(test.AContext(), images[1], localImages[1]).MaxTimes(1)
 
 	g.Expect(dstLoader.Write(ctx, images...)).To(MatchError(ContainSubstring("error tagging")))
 }
@@ -100,13 +102,14 @@ func TestNewRegistryDestinationErrorPush(t *testing.T) {
 	client := mocks.NewMockImageTaggerPusher(ctrl)
 
 	registry := "https://registry"
-	images := []string{"image1:1", "image2:2"}
+	images := []string{"public.ecr.aws/image1:1", "public.ecr.aws/image2:2"}
+	localImages := []string{"https://registry/image1:1", "https://registry/image2:2"}
 	ctx := context.Background()
 	dstLoader := docker.NewRegistryDestination(client, registry)
-	client.EXPECT().TagImage(test.AContext(), images[0], registry)
-	client.EXPECT().PushImage(test.AContext(), images[0], registry).Return(errors.New("error pushing"))
-	client.EXPECT().TagImage(test.AContext(), images[1], registry).MaxTimes(1)
-	client.EXPECT().PushImage(test.AContext(), images[1], registry).MaxTimes(1)
+	client.EXPECT().TagImage(test.AContext(), images[0], localImages[0])
+	client.EXPECT().PushImage(test.AContext(), images[0], localImages[0]).Return(errors.New("error pushing"))
+	client.EXPECT().TagImage(test.AContext(), images[1], localImages[1]).MaxTimes(1)
+	client.EXPECT().PushImage(test.AContext(), images[1], localImages[1]).MaxTimes(1)
 
 	g.Expect(dstLoader.Write(ctx, images...)).To(MatchError(ContainSubstring("error pushing")))
 }

--- a/pkg/executables/docker.go
+++ b/pkg/executables/docker.go
@@ -12,10 +12,7 @@ import (
 // Temporary: Curated packages dev and prod accounts are currently hard coded
 // This is because there is no mechanism to extract these values as of now.
 const (
-	dockerPath        = "docker"
-	defaultRegistry   = "public.ecr.aws"
-	packageProdDomain = "783794618700.dkr.ecr.us-west-2.amazonaws.com"
-	packageDevDomain  = "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+	dockerPath = "docker"
 )
 
 type Docker struct {
@@ -83,9 +80,7 @@ func (d *Docker) CgroupVersion(ctx context.Context) (int, error) {
 	return version, nil
 }
 
-func (d *Docker) TagImage(ctx context.Context, image string, endpoint string) error {
-	replacer := strings.NewReplacer(defaultRegistry, endpoint, packageProdDomain, endpoint, packageDevDomain, endpoint)
-	localImage := replacer.Replace(image)
+func (d *Docker) TagImage(ctx context.Context, image string, localImage string) error {
 	logger.Info("Tagging image", "image", image, "local image", localImage)
 	if _, err := d.Execute(ctx, "tag", image, localImage); err != nil {
 		return err
@@ -93,9 +88,7 @@ func (d *Docker) TagImage(ctx context.Context, image string, endpoint string) er
 	return nil
 }
 
-func (d *Docker) PushImage(ctx context.Context, image string, endpoint string) error {
-	replacer := strings.NewReplacer(defaultRegistry, endpoint, packageProdDomain, endpoint, packageDevDomain, endpoint)
-	localImage := replacer.Replace(image)
+func (d *Docker) PushImage(ctx context.Context, image string, localImage string) error {
 	logger.Info("Pushing", "image", localImage)
 	if _, err := d.Execute(ctx, "push", localImage); err != nil {
 		return err

--- a/pkg/executables/docker.go
+++ b/pkg/executables/docker.go
@@ -80,6 +80,7 @@ func (d *Docker) CgroupVersion(ctx context.Context) (int, error) {
 	return version, nil
 }
 
+// TagImage tags an image with the new localImage.
 func (d *Docker) TagImage(ctx context.Context, image string, localImage string) error {
 	logger.Info("Tagging image", "image", image, "local image", localImage)
 	if _, err := d.Execute(ctx, "tag", image, localImage); err != nil {
@@ -88,6 +89,7 @@ func (d *Docker) TagImage(ctx context.Context, image string, localImage string) 
 	return nil
 }
 
+// PushImage pushes an image to the local registry.
 func (d *Docker) PushImage(ctx context.Context, image string, localImage string) error {
 	logger.Info("Pushing", "image", localImage)
 	if _, err := d.Execute(ctx, "push", localImage); err != nil {


### PR DESCRIPTION
*Description of changes:*
- Currently Replacement of default registry and curated packages prod/dev registries occur in docker.go. Ideally we should move this replacement to the registry.go.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

