### PR TITLE
Download and import curated packages package bundle by default

### DIFF
--- a/cmd/eksctl-anywhere/cmd/downloadimages.go
+++ b/cmd/eksctl-anywhere/cmd/downloadimages.go
@@ -90,7 +90,7 @@ func (c downloadImagesCommand) Run(ctx context.Context) error {
 		TmpDowloadFolder:   downloadFolder,
 		DstFile:            c.outputFile,
 		Packager:           packagerForFile(c.outputFile),
-		ManifestDownloader: fetchManifestDownloader(downloadFolder, c.includePackages),
+		ManifestDownloader: oras.NewBundleDownloader(downloadFolder),
 	}
 
 	return downloadArtifacts.Run(ctx)
@@ -114,11 +114,4 @@ func fetchReader(reader *manifests.Reader, includePackages bool) artifacts.Reade
 		return curatedpackages.NewPackageReader(reader)
 	}
 	return reader
-}
-
-func fetchManifestDownloader(downloadFolder string, includePackages bool) artifacts.ManifestDownloader {
-	if includePackages {
-		return oras.NewBundleDownloader(downloadFolder)
-	}
-	return &artifacts.Noop{}
 }

--- a/cmd/eksctl-anywhere/cmd/import_images.go
+++ b/cmd/eksctl-anywhere/cmd/import_images.go
@@ -135,15 +135,8 @@ func (c ImportImagesCommand) Call(ctx context.Context) error {
 			password,
 		),
 		TmpArtifactsFolder: artifactsFolder,
-		FileImporter:       fetchFileRegistry(c.RegistryEndpoint, username, password, artifactsFolder, c.includePackages),
+		FileImporter:       oras.NewFileRegistryImporter(c.RegistryEndpoint, username, password, artifactsFolder),
 	}
 
 	return importArtifacts.Run(ctx)
-}
-
-func fetchFileRegistry(registryEndpoint, username, password, artifactsFolder string, includePackages bool) artifacts.FileImporter {
-	if includePackages {
-		return oras.NewFileRegistryImporter(registryEndpoint, username, password, artifactsFolder)
-	}
-	return &artifacts.Noop{}
 }

--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -222,6 +222,7 @@ func (vb *VersionsBundle) Charts() map[string]*Image {
 	return map[string]*Image{
 		"cilium":                &vb.Cilium.HelmChart,
 		"eks-anywhere-packages": &vb.PackageController.HelmChart,
+		"ecr-token-refresher":   &vb.PackageController.TokenRefresher,
 		"tinkerbell-chart":      &vb.Tinkerbell.TinkerbellStack.TinkebellChart,
 	}
 }

--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -222,7 +222,6 @@ func (vb *VersionsBundle) Charts() map[string]*Image {
 	return map[string]*Image{
 		"cilium":                &vb.Cilium.HelmChart,
 		"eks-anywhere-packages": &vb.PackageController.HelmChart,
-		"ecr-token-refresher":   &vb.PackageController.TokenRefresher,
 		"tinkerbell-chart":      &vb.Tinkerbell.TinkerbellStack.TinkebellChart,
 	}
 }


### PR DESCRIPTION
*Description of changes:*
- Fetch curated packages bundle by default since it is needed by package controller to function properly.
*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

