### PR TITLE
Added workload cluster upgrade functionality for tinkerbell

### DIFF
--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -134,7 +134,23 @@ func (p *Provider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *
 		return err
 	}
 
-	return p.validateAvailableHardwareForUpgrade(ctx, currentClusterSpec, clusterSpec)
+	if err := p.validateAvailableHardwareForUpgrade(ctx, currentClusterSpec, clusterSpec); err != nil {
+		return err
+	}
+
+	if p.clusterConfig.IsManaged() {
+		if err := p.applyHardwareUpgrade(ctx, clusterSpec.ManagementCluster); err != nil {
+			return err
+		}
+		if len(p.catalogue.AllBMCs()) > 0 {
+			err = p.providerKubectlClient.WaitForBaseboardManagements(ctx, cluster, "5m", "Contactable", constants.EksaSystemNamespace)
+			if err != nil {
+				return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (p *Provider) validateAvailableHardwareForUpgrade(ctx context.Context, currentSpec, newClusterSpec *cluster.Spec) (err error) {
@@ -167,11 +183,15 @@ func (p *Provider) PostBootstrapDeleteForUpgrade(ctx context.Context) error {
 }
 
 func (p *Provider) PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error {
+	return p.applyHardwareUpgrade(ctx, cluster)
+}
+
+// ApplyHardwareToCluster adds all the hardwares to the cluster.
+func (p *Provider) applyHardwareUpgrade(ctx context.Context, cluster *types.Cluster) error {
 	allHardware := p.catalogue.AllHardware()
 	if len(allHardware) == 0 {
 		return nil
 	}
-
 	hardwareSpec, err := hardware.MarshalCatalogue(p.catalogue)
 	if err != nil {
 		return fmt.Errorf("failed marshalling resources for hardware spec: %v", err)
@@ -180,7 +200,7 @@ func (p *Provider) PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig 
 	if err != nil {
 		return fmt.Errorf("applying hardware yaml: %v", err)
 	}
-
+	
 	return nil
 }
 

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -142,7 +142,7 @@ func (p *Provider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *
 		if err := p.applyHardwareUpgrade(ctx, clusterSpec.ManagementCluster); err != nil {
 			return err
 		}
-		if len(p.catalogue.AllBMCs()) > 0 {
+		if p.catalogue.TotalHardware() > 0 && p.catalogue.AllHardware()[0].Spec.BMCRef != nil {
 			err = p.providerKubectlClient.WaitForBaseboardManagements(ctx, cluster, "5m", "Contactable", constants.EksaSystemNamespace)
 			if err != nil {
 				return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -200,7 +200,7 @@ func (p *Provider) applyHardwareUpgrade(ctx context.Context, cluster *types.Clus
 	if err != nil {
 		return fmt.Errorf("applying hardware yaml: %v", err)
 	}
-	
+
 	return nil
 }
 

--- a/test/e2e/workload_clusters_test.go
+++ b/test/e2e/workload_clusters_test.go
@@ -29,14 +29,12 @@ func runTinkerbellWorkloadClusterFlow(test *framework.MulticlusterE2ETest) {
 	test.CreateTinkerbellManagementCluster()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
 		w.GenerateClusterConfig()
-		w.GenerateHardwareConfig()
 		w.PowerOffHardware()
 		w.CreateCluster(framework.WithForce(), framework.WithControlPlaneWaitTimeout("20m"))
 		w.StopIfFailed()
 		w.DeleteCluster()
 		w.ValidateHardwareDecommissioned()
 	})
-	time.Sleep(5 * time.Minute)
 	test.DeleteTinkerbellManagementCluster()
 }
 
@@ -44,16 +42,16 @@ func runSimpleWorkloadUpgradeFlowForBareMetal(test *framework.MulticlusterE2ETes
 	test.CreateTinkerbellManagementCluster()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
 		w.GenerateClusterConfig()
-		w.GenerateHardwareConfig()
 		w.PowerOffHardware()
 		w.CreateCluster(framework.WithForce(), framework.WithControlPlaneWaitTimeout("20m"))
+		time.Sleep(2 * time.Minute)
 		w.UpgradeCluster(clusterOpts)
+		time.Sleep(2 * time.Minute)
 		w.ValidateCluster(updateVersion)
 		w.StopIfFailed()
 		w.DeleteCluster()
 		w.ValidateHardwareDecommissioned()
 	})
-	time.Sleep(5 * time.Minute)
 	test.DeleteManagementCluster()
 }
 
@@ -393,63 +391,60 @@ func TestCloudStackKubernetes121ManagementClusterUpgradeFromLatest(t *testing.T)
 }
 
 func TestTinkerbellKubernetes122UbuntuWorkloadCluster(t *testing.T) {
+	provider := framework.NewTinkerbell(t, framework.WithUbuntu122Tinkerbell())
 	test := framework.NewMulticlusterE2ETest(
 		t,
 		framework.NewClusterE2ETest(
 			t,
-			framework.NewTinkerbell(t, framework.WithUbuntu122Tinkerbell()),
+			provider,
 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-			framework.WithControlPlaneHardware(1),
-			framework.WithWorkerHardware(1),
+			framework.WithControlPlaneHardware(2),
+			framework.WithWorkerHardware(2),
 		),
 		framework.NewClusterE2ETest(
 			t,
-			framework.NewTinkerbell(t, framework.WithUbuntu122Tinkerbell()),
+			provider,
 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-			framework.WithControlPlaneHardware(1),
-			framework.WithWorkerHardware(1),
 		),
 	)
 	runTinkerbellWorkloadClusterFlow(test)
 }
 
 func TestTinkerbellKubernetes122BottlerocketWorkloadCluster(t *testing.T) {
+	provider := framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell())
 	test := framework.NewMulticlusterE2ETest(
 		t,
 		framework.NewClusterE2ETest(
 			t,
-			framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell()),
+			provider,
 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-			framework.WithControlPlaneHardware(1),
-			framework.WithWorkerHardware(1),
+			framework.WithControlPlaneHardware(2),
+			framework.WithWorkerHardware(2),
 		),
 		framework.NewClusterE2ETest(
 			t,
-			framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell()),
+			provider,
 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-			framework.WithControlPlaneHardware(1),
-			framework.WithWorkerHardware(1),
 		),
 	)
 	runTinkerbellWorkloadClusterFlow(test)
 }
 
-func TestTinkerbellUpgradeMulticlusterWorkloadCluster(t *testing.T) {
+func TestTinkerbellUpgradeMulticlusterWorkloadClusterWorkerScaleup(t *testing.T) {
+	provider := framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell())
 	test := framework.NewMulticlusterE2ETest(
 		t,
 		framework.NewClusterE2ETest(
 			t,
-			framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell()),
+			provider,
 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-			framework.WithControlPlaneHardware(1),
-			framework.WithWorkerHardware(1),
+			framework.WithControlPlaneHardware(2),
+			framework.WithWorkerHardware(3),
 		),
 		framework.NewClusterE2ETest(
 			t,
-			framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell()),
+			provider,
 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
-			framework.WithControlPlaneHardware(1),
-			framework.WithWorkerHardware(1),
 		),
 	)
 	runSimpleWorkloadUpgradeFlowForBareMetal(
@@ -459,5 +454,85 @@ func TestTinkerbellUpgradeMulticlusterWorkloadCluster(t *testing.T) {
 			api.WithKubernetesVersion(v1alpha1.Kube122),
 			api.WithWorkerNodeCount(2),
 		),
+	)
+}
+
+func TestTinkerbellUpgradeMulticlusterWorkloadClusterCPScaleup(t *testing.T) {
+	provider := framework.NewTinkerbell(t, framework.WithUbuntu122Tinkerbell())
+	test := framework.NewMulticlusterE2ETest(
+		t,
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
+			framework.WithControlPlaneHardware(4),
+			framework.WithWorkerHardware(1),
+		),
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
+		),
+	)
+	runSimpleWorkloadUpgradeFlowForBareMetal(
+		test,
+		v1alpha1.Kube122,
+		framework.WithClusterUpgrade(
+			api.WithKubernetesVersion(v1alpha1.Kube122),
+			api.WithControlPlaneCount(3),
+		),
+	)
+}
+
+func TestTinkerbellUpgradeMulticlusterWorkloadClusterWorkerScaleDown(t *testing.T) {
+	provider := framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell())
+	test := framework.NewMulticlusterE2ETest(
+		t,
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
+			framework.WithControlPlaneHardware(1),
+			framework.WithWorkerHardware(2),
+		),
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
+			framework.WithClusterFiller(api.WithWorkerNodeCount(2)),
+		),
+	)
+	runSimpleWorkloadUpgradeFlowForBareMetal(
+		test,
+		v1alpha1.Kube122,
+		framework.WithClusterUpgrade(
+			api.WithKubernetesVersion(v1alpha1.Kube122),
+			api.WithWorkerNodeCount(1),
+		),
+	)
+}
+
+func TestTinkerbellUpgradeMulticlusterWorkloadClusterK8sUpgrade(t *testing.T) {
+	provider := framework.NewTinkerbell(t, framework.WithUbuntu122Tinkerbell())
+	test := framework.NewMulticlusterE2ETest(
+		t,
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
+			framework.WithControlPlaneHardware(3),
+			framework.WithWorkerHardware(3),
+		),
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
+		),
+	)
+	runSimpleWorkloadUpgradeFlowForBareMetal(
+		test,
+		v1alpha1.Kube123,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube123)),
+		provider.WithProviderUpgrade(framework.UpdateTinkerbellUbuntuTemplate123Var()),
 	)
 }

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -407,6 +407,7 @@ func (e *ClusterE2ETest) ValidateHardwareDecommissioned() {
 }
 
 func (e *ClusterE2ETest) GenerateHardwareConfig(opts ...CommandOpt) {
+	fmt.Println("---------------here inside GenerateHardwareConfig------------------")
 	e.generateHardwareConfig(opts...)
 }
 

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -407,7 +407,6 @@ func (e *ClusterE2ETest) ValidateHardwareDecommissioned() {
 }
 
 func (e *ClusterE2ETest) GenerateHardwareConfig(opts ...CommandOpt) {
-	fmt.Println("---------------here inside GenerateHardwareConfig------------------")
 	e.generateHardwareConfig(opts...)
 }
 

--- a/test/framework/multicluster.go
+++ b/test/framework/multicluster.go
@@ -50,6 +50,19 @@ func (m *MulticlusterE2ETest) CreateManagementCluster(opts ...CommandOpt) {
 	m.ManagementCluster.CreateCluster(opts...)
 }
 
+func (m *MulticlusterE2ETest) CreateTinkerbellManagementCluster(opts ...CommandOpt) {
+	m.ManagementCluster.GenerateClusterConfig()
+	m.ManagementCluster.GenerateHardwareConfig()
+	m.ManagementCluster.PowerOffHardware()
+	m.ManagementCluster.CreateCluster(opts...)
+}
+
 func (m *MulticlusterE2ETest) DeleteManagementCluster() {
 	m.ManagementCluster.DeleteCluster()
+}
+
+func (m *MulticlusterE2ETest) DeleteTinkerbellManagementCluster() {
+	m.ManagementCluster.StopIfFailed()
+	m.ManagementCluster.DeleteCluster()
+	m.ManagementCluster.ValidateHardwareDecommissioned()
 }

--- a/test/framework/multicluster.go
+++ b/test/framework/multicluster.go
@@ -50,6 +50,7 @@ func (m *MulticlusterE2ETest) CreateManagementCluster(opts ...CommandOpt) {
 	m.ManagementCluster.CreateCluster(opts...)
 }
 
+// CreateTinkerbellManagementCluster runs tinkerbell related steps for cluster creation.
 func (m *MulticlusterE2ETest) CreateTinkerbellManagementCluster(opts ...CommandOpt) {
 	m.ManagementCluster.GenerateClusterConfig()
 	m.ManagementCluster.GenerateHardwareConfig()
@@ -61,6 +62,7 @@ func (m *MulticlusterE2ETest) DeleteManagementCluster() {
 	m.ManagementCluster.DeleteCluster()
 }
 
+// DeleteTinkerbellManagementCluster runs tinkerbell related steps for cluster deletion.
 func (m *MulticlusterE2ETest) DeleteTinkerbellManagementCluster() {
 	m.ManagementCluster.StopIfFailed()
 	m.ManagementCluster.DeleteCluster()


### PR DESCRIPTION
*Description of changes:*
Added workload cluster upgrade functionality for Tinkerbell. Added e2e tests for workload cluster create and upgrade functionality.

*Testing (if applicable):*

--- PASS: TestTinkerbellKubernetes122BottlerocketWorkloadCluster
--- PASS: TestTinkerbellKubernetes122UbuntuWorkloadCluster
--- PASS: TestTinkerbellUpgradeMulticlusterWorkloadClusterWorkerScaleup
--- PASS: TestTinkerbellUpgradeMulticlusterWorkloadClusterK8sUpgrade

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

