### PR TITLE
Pass Nutanix env var to test runners

### DIFF
--- a/internal/test/e2e/nutanix.go
+++ b/internal/test/e2e/nutanix.go
@@ -1,0 +1,32 @@
+package e2e
+
+import (
+	"os"
+	"regexp"
+
+	e2etests "github.com/aws/eks-anywhere/test/framework"
+)
+
+const (
+	nutanixFeatureGateEnvVar = "NUTANIX_PROVIDER"
+	nutanixRegex             = `^.*Nutanix.*$`
+)
+
+func (e *E2ESession) setupNutanixEnv(testRegex string) error {
+	re := regexp.MustCompile(nutanixRegex)
+	if !re.MatchString(testRegex) {
+		e.logger.V(2).Info("Not running Nutanix tests, skipping Env variable setup")
+		return nil
+	}
+
+	requiredEnvVars := e2etests.RequiredNutanixEnvVars()
+	for _, eVar := range requiredEnvVars {
+		if val, ok := os.LookupEnv(eVar); ok {
+			e.testEnvVars[eVar] = val
+		}
+	}
+
+	// Since Nutanix Provider is feature gated, manually enable the feature gate for all Nutanix tests.
+	e.testEnvVars[nutanixFeatureGateEnvVar] = "true"
+	return nil
+}

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -113,6 +113,11 @@ func (e *E2ESession) setup(regex string) error {
 		return err
 	}
 
+	err = e.setupNutanixEnv(regex)
+	if err != nil {
+		return err
+	}
+
 	err = e.setupFluxEnv(regex)
 	if err != nil {
 		return err

--- a/test/framework/nutanix.go
+++ b/test/framework/nutanix.go
@@ -35,6 +35,24 @@ const (
 	nutanixTemplateUbuntu123Var = "T_NUTANIX_TEMPLATE_UBUNTU_1_23"
 )
 
+var requiredNutanixEnvVars = []string{
+	nutanixFeatureGateEnvVar,
+	nutanixEndpoint,
+	nutanixPort,
+	nutanixAdditionalTrustBundle,
+	nutanixMachineBootType,
+	nutanixMachineMemorySize,
+	nutanixSystemDiskSize,
+	nutanixMachineVCPUsPerSocket,
+	nutanixMachineVCPUSocket,
+	nutanixMachineTemplateImageName,
+	nutanixPrismElementClusterName,
+	nutanixSSHAuthorizedKey,
+	nutanixSubnetName,
+	nutanixPodCidrVar,
+	nutanixServiceCidrVar,
+}
+
 type Nutanix struct {
 	t                      *testing.T
 	fillers                []api.NutanixFiller
@@ -48,23 +66,6 @@ type Nutanix struct {
 type NutanixOpt func(*Nutanix)
 
 func NewNutanix(t *testing.T, opts ...NutanixOpt) *Nutanix {
-	requiredNutanixEnvVars := []string{
-		nutanixFeatureGateEnvVar,
-		nutanixEndpoint,
-		nutanixPort,
-		nutanixAdditionalTrustBundle,
-		nutanixMachineBootType,
-		nutanixMachineMemorySize,
-		nutanixSystemDiskSize,
-		nutanixMachineVCPUsPerSocket,
-		nutanixMachineVCPUSocket,
-		nutanixMachineTemplateImageName,
-		nutanixPrismElementClusterName,
-		nutanixSSHAuthorizedKey,
-		nutanixSubnetName,
-		nutanixPodCidrVar,
-		nutanixServiceCidrVar,
-	}
 	checkRequiredEnvVars(t, requiredNutanixEnvVars)
 
 	nutanixProvider := &Nutanix{
@@ -94,6 +95,11 @@ func NewNutanix(t *testing.T, opts ...NutanixOpt) *Nutanix {
 	}
 
 	return nutanixProvider
+}
+
+// RequiredNutanixEnvVars returns a list of environment variables needed for Nutanix tests.
+func RequiredNutanixEnvVars() []string {
+	return requiredNutanixEnvVars
 }
 
 func (s *Nutanix) Name() string {


### PR DESCRIPTION
*Description of changes:*
Pass the required Nutanix env vars to the test runner instances 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

