### PR TITLE
Rename e2e env var to pass it to test instances

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -15,7 +15,7 @@ env:
     TEST_RUNNER_GOVC_LIBRARY: "eks-a-templates"
     TEST_RUNNER_GOVC_TEMPLATE: "eks-a-admin-ci"
     INTEGRATION_TEST_INFRA_CONFIG: "/tmp/test-infra.yml"
-    T_VSPHERE_TEMPLATES_FOLDER: "/SDDC-Datacenter/vm/Templates"
+    T_VSPHERE_TEMPLATE_FOLDER: "/SDDC-Datacenter/vm/Templates"
     T_VSPHERE_TEMPLATE_UBUNTU_1_20: "/SDDC-Datacenter/vm/Templates/ubuntu-kube-v1-20"
     T_VSPHERE_TEMPLATE_UBUNTU_1_21: "/SDDC-Datacenter/vm/Templates/ubuntu-kube-v1-21"
     T_VSPHERE_TEMPLATE_UBUNTU_1_22: "/SDDC-Datacenter/vm/Templates/ubuntu-kube-v1-22"

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -38,7 +38,7 @@ const (
 	govcInsecureVar             = "GOVC_INSECURE"
 	govcDatacenterVar           = "GOVC_DATACENTER"
 	vsphereTemplateEnvVarPrefix = "T_VSPHERE_TEMPLATE_"
-	vsphereTemplatesFolder      = "T_VSPHERE_TEMPLATES_FOLDER"
+	vsphereTemplatesFolder      = "T_VSPHERE_TEMPLATE_FOLDER"
 )
 
 var requiredEnvVars = []string{


### PR DESCRIPTION
*Description of changes:*

The new name fits the prefix for templates, so it will get passed to the test instances if it's present in the host running the test runner binary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

