### PR TITLE
Stop reconciliation if child objects are invalid

### DIFF
--- a/pkg/providers/vsphere/reconciler/reconciler.go
+++ b/pkg/providers/vsphere/reconciler/reconciler.go
@@ -128,14 +128,15 @@ func (r *Reconciler) ValidateDatacenterConfig(ctx context.Context, log logr.Logg
 	dataCenterConfig := clusterSpec.VSphereDatacenter
 
 	if !dataCenterConfig.Status.SpecValid {
-		var failureMessage string
 		if dataCenterConfig.Status.FailureMessage != nil {
-			failureMessage = *dataCenterConfig.Status.FailureMessage
+			failureMessage := fmt.Sprintf("Invalid %s VSphereDatacenterConfig: %s", dataCenterConfig.Name, *dataCenterConfig.Status.FailureMessage)
+			clusterSpec.Cluster.Status.FailureMessage = &failureMessage
+			log.Error(errors.New(*dataCenterConfig.Status.FailureMessage), "Invalid VSphereDatacenterConfig", "datacenterConfig", klog.KObj(dataCenterConfig))
+		} else {
+			log.Info("VSphereDatacenterConfig hasn't been validated yet", klog.KObj(dataCenterConfig))
 		}
 
-		log.Error(errors.New(failureMessage), "Invalid VSphereDatacenterConfig", "datacenterConfig", klog.KObj(dataCenterConfig))
-		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
-		return controller.Result{}, nil
+		return controller.ResultWithReturn(), nil
 	}
 	return controller.Result{}, nil
 }
@@ -157,7 +158,7 @@ func (r *Reconciler) ValidateMachineConfigs(ctx context.Context, log logr.Logger
 		log.Error(err, "Invalid VSphereMachineConfig")
 		failureMessage := err.Error()
 		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
-		return controller.Result{}, err
+		return controller.ResultWithReturn(), nil
 	}
 	return controller.Result{}, nil
 }


### PR DESCRIPTION
## Description of changes

If datacenter or machine configs are invalid for a cluster, reconciliation should stop to prevent any further changes.

When the failure message is not set, it's safe for us to assume the object hasn't been validated yet but still might be valid. In this case, we shouldn't bubble an error to the cluster status and just return and wait for the object to updated, either to be valid or to have a failure message.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

