### PR TITLE
fixed the test build failure

### DIFF
--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -311,7 +311,7 @@ func TestSnowKubernetes121ThreeWorkersConformanceFlow(t *testing.T) {
 		framework.NewSnow(t, framework.WithSnowUbuntu121()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(SnowProviderEnvVar, "true"),
+		framework.WithEnvVar(features.SnowProviderEnvVar, "true"),
 		framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
 	)
 	runConformanceFlow(test)
@@ -323,7 +323,7 @@ func TestSnowKubernetes122ThreeWorkersConformanceFlow(t *testing.T) {
 		framework.NewSnow(t, framework.WithSnowUbuntu122()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(SnowProviderEnvVar, "true"),
+		framework.WithEnvVar(features.SnowProviderEnvVar, "true"),
 		framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
 	)
 	runConformanceFlow(test)
@@ -335,7 +335,7 @@ func TestSnowKubernetes123ThreeWorkersConformanceFlow(t *testing.T) {
 		framework.NewSnow(t, framework.WithSnowUbuntu123()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube123)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(SnowProviderEnvVar, "true"),
+		framework.WithEnvVar(features.SnowProviderEnvVar, "true"),
 		framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
 	)
 	runConformanceFlow(test)


### PR DESCRIPTION
Output: before fix
<pre>
Using standard BUNDLE_MANIFEST_URL https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/bundle-release.yaml and RELEASE_MANIFEST_URL https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/eks-a-release.yaml fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/Library/Developer/CommandLineTools/usr/bin/make e2e-tests-binary E2E_TAGS=conformance_e2e Using standard BUNDLE_MANIFEST_URL https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/bundle-release.yaml and RELEASE_MANIFEST_URL https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/eks-a-release.yaml fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
GOOS=darwin GOARCH=amd64 /usr/local/bin/go test ./test/e2e -c -o bin/e2e.test -tags "conformance_e2e" -ldflags "-X github.com/aws/eks-anywhere/pkg/version.gitVersion=v0.0.0-dev -X github.com/aws/eks-anywhere/pkg/cluster.releasesManifestURL=https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/eks-a-release.yaml -X github.com/aws/eks-anywhere/pkg/manifests/releases.manifestURL=https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/eks-a-release.yaml" 
test/e2e/conformance_test.go:314:24: undefined: SnowProviderEnvVar 
test/e2e/conformance_test.go:326:24: undefined: SnowProviderEnvVar 
test/e2e/conformance_test.go:338:24: undefined: SnowProviderEnvVar 
make[1]: *** [e2e-tests-binary] Error 2
make: *** [conformance] Error 2
</pre>

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

