### PR TITLE
Reserve IP pool for Nutanix tests

### DIFF
--- a/internal/test/e2e/nutanix.go
+++ b/internal/test/e2e/nutanix.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	nutanixFeatureGateEnvVar = "NUTANIX_PROVIDER"
+	nutanixCidrVar           = "T_NUTANIX_CONTROL_PLANE_CIDR"
 	nutanixRegex             = `^.*Nutanix.*$`
 )
 

--- a/internal/test/e2e/vsphere.go
+++ b/internal/test/e2e/vsphere.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	cidrVar               = "T_VSPHERE_CIDR"
-	privateNetworkCidrVar = "T_VSPHERE_PRIVATE_NETWORK_CIDR"
-	vsphereRegex          = `^.*VSphere.*$`
+	vsphereCidrVar               = "T_VSPHERE_CIDR"
+	vspherePrivateNetworkCidrVar = "T_VSPHERE_PRIVATE_NETWORK_CIDR"
+	vsphereRegex                 = `^.*VSphere.*$`
 )
 
 func (e *E2ESession) setupVSphereEnv(testRegex string) error {

--- a/test/framework/network.go
+++ b/test/framework/network.go
@@ -48,13 +48,13 @@ func GetIP(cidr, ipEnvVar string) (string, error) {
 			logger.V(2).Info("WARN: failed to pop ip from environment, attempting to generate unique ip")
 			ip, err = GenerateUniqueIp(cidr)
 			if err != nil {
-				return "", fmt.Errorf("failed to generate ip for vsphere cidr %s: %v", cidr, err)
+				return "", fmt.Errorf("failed to generate ip for cidr %s: %v", cidr, err)
 			}
 		}
 	} else {
 		ip, err = GenerateUniqueIp(cidr)
 		if err != nil {
-			return "", fmt.Errorf("failed to generate ip for vsphere cidr %s: %v", cidr, err)
+			return "", fmt.Errorf("failed to generate ip for cidr %s: %v", cidr, err)
 		}
 	}
 	return ip, nil


### PR DESCRIPTION
*Description of changes:*
Nutanix tests are currently failing because it doesn't have an IP pool 
This PR reserves the IP pool for Nutanix tests

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

