### PR TITLE
Remove unnecessary logging in e2e tests

### DIFF
--- a/internal/test/e2e/awsiam.go
+++ b/internal/test/e2e/awsiam.go
@@ -10,7 +10,6 @@ import (
 func (e *E2ESession) setupAwsIam(testRegex string) error {
 	re := regexp.MustCompile(`^.*AWSIamAuth.*$`)
 	if !re.MatchString(testRegex) {
-		e.logger.V(2).Info("Not running AWSIamAuth tests, skipping Env variable setup")
 		return nil
 	}
 

--- a/internal/test/e2e/cloudstack.go
+++ b/internal/test/e2e/cloudstack.go
@@ -14,7 +14,6 @@ const (
 func (e *E2ESession) setupCloudStackEnv(testRegex string) error {
 	re := regexp.MustCompile(cloudstackRegex)
 	if !re.MatchString(testRegex) {
-		e.logger.V(2).Info("Not running CloudStack tests, skipping Env variable setup")
 		return nil
 	}
 

--- a/internal/test/e2e/flux.go
+++ b/internal/test/e2e/flux.go
@@ -10,7 +10,6 @@ import (
 func (e *E2ESession) setupFluxEnv(testRegex string) error {
 	re := regexp.MustCompile(`^.*Flux.*$`)
 	if !re.MatchString(testRegex) {
-		e.logger.V(2).Info("Not running Flux tests, skipping Env variable setup")
 		return nil
 	}
 

--- a/internal/test/e2e/fluxGit.go
+++ b/internal/test/e2e/fluxGit.go
@@ -37,7 +37,6 @@ func (f *fileFromBytes) contentString() string {
 func (e *E2ESession) setupFluxGitEnv(testRegex string) error {
 	re := regexp.MustCompile(`^.*GitFlux.*$`)
 	if !re.MatchString(testRegex) {
-		e.logger.V(2).Info("Not running Flux Generic Git Provider tests, skipping environment setup")
 		return nil
 	}
 

--- a/internal/test/e2e/nutanix.go
+++ b/internal/test/e2e/nutanix.go
@@ -16,7 +16,6 @@ const (
 func (e *E2ESession) setupNutanixEnv(testRegex string) error {
 	re := regexp.MustCompile(nutanixRegex)
 	if !re.MatchString(testRegex) {
-		e.logger.V(2).Info("Not running Nutanix tests, skipping Env variable setup")
 		return nil
 	}
 

--- a/internal/test/e2e/oidc.go
+++ b/internal/test/e2e/oidc.go
@@ -22,7 +22,6 @@ const (
 func (e *E2ESession) setupOIDC(testRegex string) error {
 	re := regexp.MustCompile(`^.*OIDC.*$`)
 	if !re.MatchString(testRegex) {
-		e.logger.V(2).Info("Not running OIDC tests, skipping setup")
 		return nil
 	}
 

--- a/internal/test/e2e/packages.go
+++ b/internal/test/e2e/packages.go
@@ -14,7 +14,6 @@ const (
 func (e *E2ESession) setupPackagesEnv(testRegex string) error {
 	re := regexp.MustCompile(packagesRegex)
 	if !re.MatchString(testRegex) {
-		e.logger.V(2).Info("Not running Curated Packages tests, skipping Env variable setup")
 		return nil
 	}
 

--- a/internal/test/e2e/proxy.go
+++ b/internal/test/e2e/proxy.go
@@ -18,7 +18,6 @@ var proxyVarsByProvider = map[string]e2etests.ProxyRequiredEnvVars{
 func (e *E2ESession) setupProxyEnv(testRegex string) error {
 	re := regexp.MustCompile(`^.*Proxy.*$`)
 	if !re.MatchString(testRegex) {
-		e.logger.V(2).Info("Not running Proxy tests, skipping Env variable setup")
 		return nil
 	}
 	var requiredEnvVars e2etests.ProxyRequiredEnvVars

--- a/internal/test/e2e/registryMirror.go
+++ b/internal/test/e2e/registryMirror.go
@@ -16,7 +16,6 @@ import (
 func (e *E2ESession) setupRegistryMirrorEnv(testRegex string) error {
 	re := regexp.MustCompile(`^.*RegistryMirror.*$`)
 	if !re.MatchString(testRegex) {
-		e.logger.V(2).Info("Not running RegistryMirror tests, skipping Env variable setup")
 		return nil
 	}
 

--- a/internal/test/e2e/tinkerbell.go
+++ b/internal/test/e2e/tinkerbell.go
@@ -26,7 +26,6 @@ const (
 func (e *E2ESession) setupTinkerbellEnv(testRegex string) error {
 	re := regexp.MustCompile(tinkerbellTestsRe)
 	if !re.MatchString(testRegex) {
-		e.logger.V(2).Info("Not running Tinkerbell tests, skipping Env variable setup")
 		return nil
 	}
 

--- a/internal/test/e2e/vsphere.go
+++ b/internal/test/e2e/vsphere.go
@@ -18,7 +18,6 @@ const (
 func (e *E2ESession) setupVSphereEnv(testRegex string) error {
 	re := regexp.MustCompile(vsphereRegex)
 	if !re.MatchString(testRegex) {
-		e.logger.V(2).Info("Not running VSphere tests, skipping Env variable setup")
 		return nil
 	}
 


### PR DESCRIPTION
*Description of changes:*
There are certain logs of the form `Not running X tests, skipping Env variable setup` that get printed for every test that doesn't match the test regex. These logs aren't very meaningful and mostly just spam the logs

In the most recent e2e test run, there were `1612` instances of these logs
```
$ cat 2022-11-15T23_39_14-08_00-logs/codebuild-log.txt| grep "Not running" | wc -l
    1612
```
This PR removes these logs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

