### PR TITLE
Add docker workers CAPI spec generator

### DIFF
--- a/pkg/clusterapi/workers.go
+++ b/pkg/clusterapi/workers.go
@@ -22,7 +22,7 @@ type Workers[M Object[M]] struct {
 func (w *Workers[M]) WorkerObjects() []kubernetes.Object {
 	objs := make([]kubernetes.Object, 0, len(w.Groups)*3)
 	for _, g := range w.Groups {
-		objs = append(objs, g.workerGroupObjects()...)
+		objs = append(objs, g.Objects()...)
 	}
 
 	return objs
@@ -53,7 +53,8 @@ type WorkerGroup[M Object[M]] struct {
 	ProviderMachineTemplate M
 }
 
-func (g *WorkerGroup[M]) workerGroupObjects() []kubernetes.Object {
+// Objects returns a list of API objects for a provider-specific of the worker group.
+func (g *WorkerGroup[M]) Objects() []kubernetes.Object {
 	return []kubernetes.Object{
 		g.KubeadmConfigTemplate,
 		g.MachineDeployment,

--- a/pkg/providers/docker/controlplane_test.go
+++ b/pkg/providers/docker/controlplane_test.go
@@ -254,6 +254,11 @@ func testClusterSpec() *cluster.Spec {
 						MachineGroupRef: &anywherev1.Ref{Name: name},
 						Name:            "md-0",
 					},
+					{
+						Count:           ptr.Int(3),
+						MachineGroupRef: &anywherev1.Ref{Name: name},
+						Name:            "md-1",
+					},
 				},
 				ExternalEtcdConfiguration: &anywherev1.ExternalEtcdConfiguration{
 					Count: 3,

--- a/pkg/providers/docker/workers.go
+++ b/pkg/providers/docker/workers.go
@@ -1,0 +1,70 @@
+package docker
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	capiyaml "github.com/aws/eks-anywhere/pkg/clusterapi/yaml"
+	"github.com/aws/eks-anywhere/pkg/yamlutil"
+)
+
+type (
+	// Workers represents the docker specific CAPI spec for worker nodes.
+	Workers        = clusterapi.Workers[*dockerv1.DockerMachineTemplate]
+	workersBuilder = capiyaml.WorkersBuilder[*dockerv1.DockerMachineTemplate]
+)
+
+// WorkersSpec generates a Docker specific CAPI spec for an eks-a cluster worker nodes.
+// It talks to the cluster with a client to detect changes in immutable objects and generates new
+// names for them.
+func WorkersSpec(ctx context.Context, logger logr.Logger, client kubernetes.Client, spec *cluster.Spec) (*Workers, error) {
+	templateBuilder := NewDockerTemplateBuilder(time.Now)
+	workersYaml, err := templateBuilder.CAPIWorkersSpecWithInitialNames(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	parser, builder, err := newWorkersParserAndBuilder(logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = parser.Parse(workersYaml, builder); err != nil {
+		return nil, errors.Wrap(err, "parsing docker CAPI workers yaml")
+	}
+
+	workers := builder.Workers
+	if err = workers.UpdateImmutableObjectNames(ctx, client, GetMachineTemplate, MachineTemplateEqual); err != nil {
+		return nil, errors.Wrap(err, "updating docker worker immutable object names")
+	}
+
+	return workers, nil
+}
+
+func newWorkersParserAndBuilder(logger logr.Logger) (*yamlutil.Parser, *workersBuilder, error) {
+	parser, builder, err := capiyaml.NewWorkersParserAndBuilder(
+		logger,
+		machineTemplateMapping(),
+	)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "building docker workers parser and builder")
+	}
+
+	return parser, builder, nil
+}
+
+func machineTemplateMapping() yamlutil.Mapping[*dockerv1.DockerMachineTemplate] {
+	return yamlutil.NewMapping(
+		"DockerMachineTemplate",
+		func() *dockerv1.DockerMachineTemplate {
+			return &dockerv1.DockerMachineTemplate{}
+		},
+	)
+}

--- a/pkg/providers/docker/workers_test.go
+++ b/pkg/providers/docker/workers_test.go
@@ -1,0 +1,288 @@
+package docker_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
+	"github.com/aws/eks-anywhere/pkg/providers/docker"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
+	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
+)
+
+func TestWorkersSpecNewCluster(t *testing.T) {
+	g := NewWithT(t)
+	logger := test.NewNullLogger()
+	ctx := context.Background()
+	spec := testClusterSpec()
+	client := test.NewFakeKubeClient()
+
+	workers, err := docker.WorkersSpec(ctx, logger, client, spec)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(workers).NotTo(BeNil())
+	g.Expect(workers.Groups).To(HaveLen(2))
+	g.Expect(workers.Groups).To(ConsistOf(
+		clusterapi.WorkerGroup[*dockerv1.DockerMachineTemplate]{
+			KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+			MachineDeployment:       machineDeployment(),
+			ProviderMachineTemplate: dockerMachineTemplate("test-md-0-1"),
+		},
+		clusterapi.WorkerGroup[*dockerv1.DockerMachineTemplate]{
+			KubeadmConfigTemplate: kubeadmConfigTemplate(
+				func(kct *bootstrapv1.KubeadmConfigTemplate) {
+					kct.Name = "test-md-1-1"
+				},
+			),
+			MachineDeployment: machineDeployment(
+				func(md *clusterv1.MachineDeployment) {
+					md.Name = "test-md-1"
+					md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-1-1"
+					md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-1-1"
+				},
+			),
+			ProviderMachineTemplate: dockerMachineTemplate("test-md-1-1"),
+		},
+	))
+}
+
+func TestWorkersSpecUpgradeCluster(t *testing.T) {
+	g := NewWithT(t)
+	logger := test.NewNullLogger()
+	ctx := context.Background()
+	spec := testClusterSpec()
+
+	currentGroup1 := clusterapi.WorkerGroup[*dockerv1.DockerMachineTemplate]{
+		KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+		MachineDeployment:       machineDeployment(),
+		ProviderMachineTemplate: dockerMachineTemplate("test-md-0-1"),
+	}
+
+	currentGroup2 := clusterapi.WorkerGroup[*dockerv1.DockerMachineTemplate]{
+		KubeadmConfigTemplate: kubeadmConfigTemplate(
+			func(kct *bootstrapv1.KubeadmConfigTemplate) {
+				kct.Name = "test-md-1-1"
+			},
+		),
+		MachineDeployment: machineDeployment(
+			func(md *clusterv1.MachineDeployment) {
+				md.Name = "test-md-1"
+				md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-1-1"
+				md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-1-1"
+			},
+		),
+		ProviderMachineTemplate: dockerMachineTemplate("test-md-1-1"),
+	}
+
+	// Always make copies before passing to client since it does modifies the api objects
+	// Like for example, the ResourceVersion
+	expectedGroup1 := currentGroup1.DeepCopy()
+	expectedGroup2 := currentGroup2.DeepCopy()
+
+	objs := make([]kubernetes.Object, 0, 6)
+	objs = append(objs, currentGroup1.Objects()...)
+	objs = append(objs, currentGroup2.Objects()...)
+	client := test.NewFakeKubeClient(clientutil.ObjectsToClientObjects(objs)...)
+
+	// This will cause a change in the kubeadmconfigtemplate which we also treat as immutable
+	spec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Taints = []corev1.Taint{
+		{
+			Key:    "a",
+			Value:  "accept",
+			Effect: corev1.TaintEffectNoSchedule,
+		},
+	}
+	expectedGroup1.KubeadmConfigTemplate.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints = []corev1.Taint{
+		{
+			Key:    "a",
+			Value:  "accept",
+			Effect: corev1.TaintEffectNoSchedule,
+		},
+	}
+	expectedGroup1.KubeadmConfigTemplate.Name = "test-md-0-2"
+	expectedGroup1.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-0-2"
+
+	// This will cause a change in the docker machine templates, which are immutable
+	spec.VersionsBundle.EksD.KindNode = releasev1.Image{
+		URI: "my-new-kind-image:tag",
+	}
+	expectedGroup1.ProviderMachineTemplate.Spec.Template.Spec.CustomImage = "my-new-kind-image:tag"
+	expectedGroup1.ProviderMachineTemplate.Name = "test-md-0-2"
+	expectedGroup1.MachineDeployment.Spec.Template.Spec.InfrastructureRef.Name = "test-md-0-2"
+
+	expectedGroup2.ProviderMachineTemplate.Spec.Template.Spec.CustomImage = "my-new-kind-image:tag"
+	expectedGroup2.ProviderMachineTemplate.Name = "test-md-1-2"
+	expectedGroup2.MachineDeployment.Spec.Template.Spec.InfrastructureRef.Name = "test-md-1-2"
+
+	workers, err := docker.WorkersSpec(ctx, logger, client, spec)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(workers).NotTo(BeNil())
+	g.Expect(workers.Groups).To(HaveLen(2))
+	g.Expect(workers.Groups).To(ConsistOf(*expectedGroup1, *expectedGroup2))
+}
+
+func TestWorkersSpecNoMachineTemplateChanges(t *testing.T) {
+	g := NewWithT(t)
+	logger := test.NewNullLogger()
+	ctx := context.Background()
+	spec := testClusterSpec()
+
+	currentGroup1 := clusterapi.WorkerGroup[*dockerv1.DockerMachineTemplate]{
+		KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+		MachineDeployment:       machineDeployment(),
+		ProviderMachineTemplate: dockerMachineTemplate("test-md-0-1"),
+	}
+
+	currentGroup2 := clusterapi.WorkerGroup[*dockerv1.DockerMachineTemplate]{
+		KubeadmConfigTemplate: kubeadmConfigTemplate(
+			func(kct *bootstrapv1.KubeadmConfigTemplate) {
+				kct.Name = "test-md-1-1"
+			},
+		),
+		MachineDeployment: machineDeployment(
+			func(md *clusterv1.MachineDeployment) {
+				md.Name = "test-md-1"
+				md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-1-1"
+				md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-1-1"
+			},
+		),
+		ProviderMachineTemplate: dockerMachineTemplate("test-md-1-1"),
+	}
+
+	// Always make copies before passing to client since it does modifies the api objects
+	// Like for example, the ResourceVersion
+	expectedGroup1 := currentGroup1.DeepCopy()
+	expectedGroup2 := currentGroup2.DeepCopy()
+
+	// This mimics what would happen if the objects were returned by a real api server
+	// It helps make sure that the immutable object comparison is able to deal with these
+	// kind of changes.
+	currentGroup1.ProviderMachineTemplate.CreationTimestamp = metav1.NewTime(time.Now())
+	currentGroup1.ProviderMachineTemplate.CreationTimestamp = metav1.NewTime(time.Now())
+
+	// This is testing defaults. It's possible that some default logic will set items that are not set in our machine templates.
+	// We need to take this into consideration when checking for equality.
+	currentGroup1.ProviderMachineTemplate.Spec.Template.Spec.ProviderID = ptr.String("default-id")
+	currentGroup2.ProviderMachineTemplate.Spec.Template.Spec.ProviderID = ptr.String("default-id")
+
+	objs := make([]kubernetes.Object, 0, 6)
+	objs = append(objs, currentGroup1.Objects()...)
+	objs = append(objs, currentGroup2.Objects()...)
+	client := test.NewFakeKubeClient(clientutil.ObjectsToClientObjects(objs)...)
+
+	workers, err := docker.WorkersSpec(ctx, logger, client, spec)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(workers).NotTo(BeNil())
+	g.Expect(workers.Groups).To(HaveLen(2))
+	g.Expect(workers.Groups).To(ConsistOf(*expectedGroup1, *expectedGroup2))
+}
+
+func TestWorkersSpecErrorFromClient(t *testing.T) {
+	g := NewWithT(t)
+	logger := test.NewNullLogger()
+	ctx := context.Background()
+	spec := testClusterSpec()
+	client := test.NewFakeKubeClientAlwaysError()
+	_, err := docker.WorkersSpec(ctx, logger, client, spec)
+	g.Expect(err).To(MatchError(ContainSubstring("updating docker worker immutable object names")))
+}
+
+func TestWorkersSpecMachineTemplateNotFound(t *testing.T) {
+	g := NewWithT(t)
+	logger := test.NewNullLogger()
+	ctx := context.Background()
+	spec := testClusterSpec()
+	client := test.NewFakeKubeClient(machineDeployment())
+	_, err := docker.WorkersSpec(ctx, logger, client, spec)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func kubeadmConfigTemplate(opts ...func(*bootstrapv1.KubeadmConfigTemplate)) *bootstrapv1.KubeadmConfigTemplate {
+	o := &bootstrapv1.KubeadmConfigTemplate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeadmConfigTemplate",
+			APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-md-0-1",
+			Namespace: "eksa-system",
+		},
+		Spec: bootstrapv1.KubeadmConfigTemplateSpec{
+			Template: bootstrapv1.KubeadmConfigTemplateResource{
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					JoinConfiguration: &bootstrapv1.JoinConfiguration{
+						NodeRegistration: bootstrapv1.NodeRegistrationOptions{
+							CRISocket: "/var/run/containerd/containerd.sock",
+							KubeletExtraArgs: map[string]string{
+								"tls-cipher-suites": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+								"cgroup-driver":     "cgroupfs",
+								"eviction-hard":     "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%",
+							},
+							Taints: []corev1.Taint{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return o
+}
+
+func machineDeployment(opts ...func(*clusterv1.MachineDeployment)) *clusterv1.MachineDeployment {
+	o := &clusterv1.MachineDeployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MachineDeployment",
+			APIVersion: "cluster.x-k8s.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-md-0",
+			Namespace: "eksa-system",
+		},
+		Spec: clusterv1.MachineDeploymentSpec{
+			ClusterName: "test",
+			Replicas:    ptr.Int32(3),
+			Template: clusterv1.MachineTemplateSpec{
+				ObjectMeta: clusterv1.ObjectMeta{},
+				Spec: clusterv1.MachineSpec{
+					ClusterName: "test",
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{
+							Kind:       "KubeadmConfigTemplate",
+							Name:       "test-md-0-1",
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+							Namespace:  "eksa-system",
+						},
+					},
+					InfrastructureRef: corev1.ObjectReference{
+						Kind:       "DockerMachineTemplate",
+						Name:       "test-md-0-1",
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+						Namespace:  "eksa-system",
+					},
+					Version: ptr.String("v1.23.12-eks-1-23-6"),
+				},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return o
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add docker workers CAPI spec generator
*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

