### PR TITLE
Removing postbuild to cleanup CloudStack resources

### DIFF
--- a/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/test-eks-a-cli.yml
@@ -192,10 +192,6 @@ phases:
         ./bin/test e2e cleanup vsphere
         -n ${CLUSTER_NAME_PREFIX}
         -v 4
-      - >
-        ./bin/test e2e cleanup cloudstack
-        -n ${CLUSTER_NAME_PREFIX}
-        -v 4
       # Clean up test runner instances in EKS-A Baremetal lab
       - export EKSA_VSPHERE_USERNAME=${TEST_RUNNER_GOVC_USERNAME}
       - export EKSA_VSPHERE_PASSWORD=${TEST_RUNNER_GOVC_PASSWORD}


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
From previous changes, leftover VM's from e2e tests in CloudStack are already being cleaned up at the single test level. We do not need this suite-level cleanup as well. It also doesn't work in our CI environment due to networking issues between the build machines and the CloudStack environment, so to avoid further confusion it's being removed.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

