### PR TITLE
Add stale issue manager to GH actions

### DIFF
--- a/.github/workflows/stale-issue-mgr.yaml
+++ b/.github/workflows/stale-issue-mgr.yaml
@@ -3,7 +3,7 @@
 # This action will: 
 # * Add a label "stale" on issues after 60 days of inactivity and comment on them if they also have the "external" label
 # * Close the stale issues and pull requests after 7 days of inactivity
-# * If an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restartif they have the "external" label
+# * If an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restart if they have the "external" label
 
 # Runs every Monday morning at 1AM.
 # Docs: https://github.com/actions/stale
@@ -27,5 +27,5 @@ jobs:
           stale-issue-label: 'stale'
           any-of-issue-labels: 'external'
 env:
-  ISSUE_STALE_DAYS: 60
+  ISSUE_STALE_DAYS: 0
   ISSUE_CLOSE_AFTER_DAYS: 7

--- a/.github/workflows/stale-issue-mgr.yaml
+++ b/.github/workflows/stale-issue-mgr.yaml
@@ -5,7 +5,7 @@
 # * Close the stale issues and pull requests after 7 days of inactivity
 # * If an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restart if they have the "external" label
 
-# Runs every Monday morning at 1AM.
+# Runs every morning at 1AM: We don't want people having to wait a whole week to get the stale label removed 
 # Docs: https://github.com/actions/stale
 
 name: 'Label and close stale issues'

--- a/.github/workflows/stale-issue-mgr.yaml
+++ b/.github/workflows/stale-issue-mgr.yaml
@@ -23,9 +23,9 @@ jobs:
           days-before-close: ${{ env.ISSUE_CLOSE_AFTER_DAYS }}
           stale-issue-message: >
             This issue has had no activity for ${{ env.ISSUE_STALE_DAYS }} days. 
-            Labeling as stale and closing in ${{ env.ISSUE_CLOSE_AFTER_DAYS }} if no further activity.
+            Labeling as stale and closing in ${{ env.ISSUE_CLOSE_AFTER_DAYS }} days if no further activity.
           stale-issue-label: 'stale'
           any-of-issue-labels: 'external'
 env:
   ISSUE_STALE_DAYS: 60
-  ISSUE_CLOSE_AFTER_DAYS: 0
+  ISSUE_CLOSE_AFTER_DAYS: 7

--- a/.github/workflows/stale-issue-mgr.yaml
+++ b/.github/workflows/stale-issue-mgr.yaml
@@ -24,8 +24,8 @@ jobs:
           stale-issue-message: >
             This issue has had no activity for ${{ env.ISSUE_STALE_DAYS }} days. 
             Labeling as stale and closing in ${{ env.ISSUE_CLOSE_AFTER_DAYS }} if no further activity.
-          stale-issue-label: 'stale issue'
+          stale-issue-label: 'stale'
           any-of-issue-labels: 'external'
 env:
-  ISSUE_STALE_DAYS: 0
-  ISSUE_CLOSE_AFTER_DAYS: 7
+  ISSUE_STALE_DAYS: 60
+  ISSUE_CLOSE_AFTER_DAYS: 0

--- a/.github/workflows/stale-issue-mgr.yaml
+++ b/.github/workflows/stale-issue-mgr.yaml
@@ -8,7 +8,7 @@
 # Runs every Monday morning at 1AM.
 # Docs: https://github.com/actions/stale
 
-name: 'Close stale issues and PRs'
+name: 'Label and close stale issues'
 on:
   schedule:
     - cron: '0 1 * * MON'
@@ -18,13 +18,13 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          days-before-stale: ${{ env.STALE_ISSUE_DAYS }}
-          days-before-close: ${{ env.CLOSE_AFTER_DAYS }}
+          days-before-stale: ${{ env.ISSUE_STALE_DAYS }}
+          days-before-close: ${{ env.ISSUE_CLOSE_AFTER_DAYS }}
           stale-issue-message: >
-            This issue has had no activity for ${{ env.STALE_ISSUE_DAYS }} days. 
-            Labeling as stale and closing in ${{ env.CLOSE_AFTER_DAYS}} if not further activity.
+            This issue has had no activity for ${{ env.ISSUE_STALE_DAYS }} days. 
+            Labeling as stale and closing in ${{ env.ISSUE_CLOSE_AFTER_DAYS }} if no further activity.
           stale-issue-label: 'stale issue'
           any-of-issue-labels: 'external'
 env:
-  STALE_ISSUE_DAYS: 60
-  CLOSE_AFTER_DAYS: 7
+  ISSUE_STALE_DAYS: 60
+  ISSUE_CLOSE_AFTER_DAYS: 7

--- a/.github/workflows/stale-issue-mgr.yaml
+++ b/.github/workflows/stale-issue-mgr.yaml
@@ -12,6 +12,7 @@ name: 'Label and close stale issues'
 on:
   schedule:
     - cron: '0 1 * * MON'
+  workflow_dispatch:
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -26,5 +27,5 @@ jobs:
           stale-issue-label: 'stale issue'
           any-of-issue-labels: 'external'
 env:
-  ISSUE_STALE_DAYS: 60
+  ISSUE_STALE_DAYS: 0
   ISSUE_CLOSE_AFTER_DAYS: 7

--- a/.github/workflows/stale-issue-mgr.yaml
+++ b/.github/workflows/stale-issue-mgr.yaml
@@ -25,7 +25,7 @@ jobs:
             This issue has had no activity for ${{ env.ISSUE_STALE_DAYS }} days. 
             Labeling as stale and closing in ${{ env.ISSUE_CLOSE_AFTER_DAYS }} days if no further activity.
           stale-issue-label: 'stale'
-          any-of-issue-labels: 'external2'
+          any-of-issue-labels: 'external'
 env:
-  ISSUE_STALE_DAYS: 0
+  ISSUE_STALE_DAYS: 60
   ISSUE_CLOSE_AFTER_DAYS: 7

--- a/.github/workflows/stale-issue-mgr.yaml
+++ b/.github/workflows/stale-issue-mgr.yaml
@@ -1,7 +1,7 @@
 # Stale issue handler (could also be extended for stale PRs in future)
 
 # This action will: 
-# * Add a label "stale issue" on issues after 60 days of inactivity and comment on them if they also have the "external" label
+# * Add a label "stale" on issues after 60 days of inactivity and comment on them if they also have the "external" label
 # * Close the stale issues and pull requests after 7 days of inactivity
 # * If an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restartif they have the "external" label
 

--- a/.github/workflows/stale-issue-mgr.yaml
+++ b/.github/workflows/stale-issue-mgr.yaml
@@ -1,0 +1,30 @@
+# Stale issue handler (could also be extended for stale PRs in future)
+
+# This action will: 
+# * Add a label "stale issue" on issues after 60 days of inactivity and comment on them if they also have the "external" label
+# * Close the stale issues and pull requests after 7 days of inactivity
+# * If an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restartif they have the "external" label
+
+# Runs every Monday morning at 1AM.
+# Docs: https://github.com/actions/stale
+
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 1 * * MON'
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        with:
+          days-before-stale: ${{ env.STALE_ISSUE_DAYS }}
+          days-before-close: ${{ env.CLOSE_AFTER_DAYS }}
+          stale-issue-message: >
+            This issue has had no activity for ${{ env.STALE_ISSUE_DAYS }} days. 
+            Labeling as stale and closing in ${{ env.CLOSE_AFTER_DAYS}} if not further activity.
+          stale-issue-label: 'stale issue'
+          any-of-issue-labels: 'external'
+env:
+  STALE_ISSUE_DAYS: 60
+  CLOSE_AFTER_DAYS: 7

--- a/.github/workflows/stale-issue-mgr.yaml
+++ b/.github/workflows/stale-issue-mgr.yaml
@@ -11,7 +11,7 @@
 name: 'Label and close stale issues'
 on:
   schedule:
-    - cron: '0 1 * * MON'
+    - cron: '0 1 * * *'
   workflow_dispatch:
 jobs:
   stale:
@@ -25,7 +25,7 @@ jobs:
             This issue has had no activity for ${{ env.ISSUE_STALE_DAYS }} days. 
             Labeling as stale and closing in ${{ env.ISSUE_CLOSE_AFTER_DAYS }} days if no further activity.
           stale-issue-label: 'stale'
-          any-of-issue-labels: 'external'
+          any-of-issue-labels: 'external2'
 env:
   ISSUE_STALE_DAYS: 0
   ISSUE_CLOSE_AFTER_DAYS: 7


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add GH workflow to mark and auto close stale issues. Can easily be extended to apply to PRs as well

*Testing (if applicable):*
Tested on my fork and works as expected 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

