### PR TITLE
adding pre-requisites for nutanix csi driver

### DIFF
--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -155,6 +155,9 @@ spec:
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   $(hostname)" >> /etc/hosts
+      - apt update
+      - apt install -y nfs-common open-iscsi
+      - systemctl enable --now iscsid
     postKubeadmCommands:
       - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
     useExperimentalRetryJoin: true

--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -154,6 +154,7 @@ spec:
     preKubeadmCommands:
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
+      # This section should be removed once these packages are added to the image builder process
       - echo "127.0.0.1   $(hostname)" >> /etc/hosts
       - apt update
       - apt install -y nfs-common open-iscsi

--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -154,8 +154,8 @@ spec:
     preKubeadmCommands:
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      # This section should be removed once these packages are added to the image builder process
       - echo "127.0.0.1   $(hostname)" >> /etc/hosts
+      # This section should be removed once these packages are added to the image builder process
       - apt update
       - apt install -y nfs-common open-iscsi
       - systemctl enable --now iscsid


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

after this, we can do following steps to install nutanix csi driver 
<pre>
#Add the official Nutanix Helm repo and get the latest update
helm repo add nutanix https://nutanix.github.io/helm/
helm repo update

# Install the nutanix-csi-snapshot chart
helm install nutanix-csi-snapshot nutanix/nutanix-csi-snapshot -n ntnx-system --create-namespace

# Install the nutanix-csi-storage chart
helm install nutanix-storage nutanix/nutanix-csi-storage -n ntnx-system  
</pre>

for more details: https://opendocs.nutanix.com/capx/latest/addons/install_csi_driver/
After above helm charts were installed, i created following
- [create secret](https://portal.nutanix.com/page/documents/details?targetId=CSI-Volume-Driver-v2_6:csi-csi-plugin-create-secret-t.html) 
- [create storage class](https://portal.nutanix.com/page/documents/details?targetId=CSI-Volume-Driver-v2_6:csi-csi-plugin-manage-storage-t.html)
- [create statefulset app](https://portal.nutanix.com/page/documents/details?targetId=CSI-Volume-Driver-v2_6:csi-csi-plugin-deploy-pvc-t.html) 
- [create pvc](https://portal.nutanix.com/page/documents/details?targetId=CSI-Volume-Driver-v2_6:csi-csi-plugin-create-volume-claim-t.html)

In future, TODO
- we will be moving the preKubeadmCommands to os image build itself

*Testing (if applicable):*
<pre>
 kubectl describe pvc silver-claim
Name:          silver-claim
Namespace:     default
StorageClass:  nutanix-volume
Status:        Bound
Volume:        pvc-d2c43758-e61c-4ded-9cf8-e4dc3a71be50
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.nutanix.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      3Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       server-h47qr
Events:
  Type    Reason                 Age   From                                                                                               Message
  ----    ------                 ----  ----                                                                                               -------
  Normal  Provisioning           14s   csi.nutanix.com_nutanix-dev-cluster-md-0-1669148644791-fdkvg_7916a39b-78c9-4d54-a58b-69ffc7b4cade  External provisioner is provisioning volume for claim "default/silver-claim"
  Normal  ExternalProvisioning   14s   persistentvolume-controller                                                                        waiting for a volume to be created, either by external provisioner "csi.nutanix.com" or manually created by system administrator
  Normal  ProvisioningSucceeded  10s   csi.nutanix.com_nutanix-dev-cluster-md-0-1669148644791-fdkvg_7916a39b-78c9-4d54-a58b-69ffc7b4cade  Successfully provisioned volume pvc-d2c43758-e61c-4ded-9cf8-e4dc3a71be50
</pre>

<pre>
 kubectl get pvc                  
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS     AGE
silver-claim   Bound    pvc-d2c43758-e61c-4ded-9cf8-e4dc3a71be50   3Gi        RWO            nutanix-volume   45s
</pre>

<pre>
 kubectl get pv 
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                  STORAGECLASS     REASON   AGE
pvc-d2c43758-e61c-4ded-9cf8-e4dc3a71be50   3Gi        RWO            Delete           Bound    default/silver-claim   nutanix-volume            51s
</pre>

<pre>
 kubectl get sc
NAME             PROVISIONER       RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
nutanix-volume   csi.nutanix.com   Delete          Immediate           true                   36m
</pre>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

