### PR TITLE
Reconcile Cilium Enforcement Policy

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -363,7 +363,10 @@ func (n *ClusterNetwork) Equal(o *ClusterNetwork) bool {
 		return false
 	}
 
-	return n.Pods.Equal(&o.Pods) && n.Services.Equal(&o.Services) && n.DNS.Equal(&o.DNS)
+	return n.Pods.Equal(&o.Pods) &&
+		n.Services.Equal(&o.Services) &&
+		n.DNS.Equal(&o.DNS) &&
+		n.Nodes.Equal(o.Nodes)
 }
 
 func getCNIConfig(cn *ClusterNetwork) *CNIConfig {
@@ -551,6 +554,25 @@ type ResolvConf struct {
 type Nodes struct {
 	// CIDRMaskSize defines the mask size for node cidr in the cluster, default for ipv4 is 24. This is an optional field
 	CIDRMaskSize *int `json:"cidrMaskSize,omitempty"`
+}
+
+// Equal compares two Nodes definitions and return true if the are equivalent.
+func (n *Nodes) Equal(o *Nodes) bool {
+	if n == o {
+		return true
+	}
+	if n == nil || o == nil {
+		return false
+	}
+
+	if n.CIDRMaskSize == o.CIDRMaskSize {
+		return true
+	}
+	if n.CIDRMaskSize == nil || o.CIDRMaskSize == nil {
+		return false
+	}
+
+	return *n.CIDRMaskSize == *o.CIDRMaskSize
 }
 
 func (n *ResolvConf) Equal(o *ResolvConf) bool {

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -890,6 +890,18 @@ func TestClusterEqualClusterNetwork(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			testName: "diff Nodes",
+			cluster1ClusterNetwork: v1alpha1.ClusterNetwork{
+				Nodes: &v1alpha1.Nodes{},
+			},
+			cluster2ClusterNetwork: v1alpha1.ClusterNetwork{
+				Nodes: &v1alpha1.Nodes{
+					CIDRMaskSize: ptr.Int(3),
+				},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
@@ -1637,5 +1649,72 @@ func setSelfManaged(c *v1alpha1.Cluster, s bool) {
 		c.SetSelfManaged()
 	} else {
 		c.SetManagedBy("management-cluster")
+	}
+}
+
+func TestNodes_Equal(t *testing.T) {
+	tests := []struct {
+		name           string
+		nodes1, nodes2 *v1alpha1.Nodes
+		want           bool
+	}{
+		{
+			name:   "one nil",
+			nodes1: nil,
+			nodes2: &v1alpha1.Nodes{},
+			want:   false,
+		},
+		{
+			name:   "other nil",
+			nodes1: &v1alpha1.Nodes{},
+			nodes2: nil,
+			want:   false,
+		},
+		{
+			name:   "both nil",
+			nodes1: nil,
+			nodes2: nil,
+			want:   true,
+		},
+		{
+			name:   "one nil CIDRMasK",
+			nodes1: &v1alpha1.Nodes{},
+			nodes2: &v1alpha1.Nodes{
+				CIDRMaskSize: ptr.Int(2),
+			},
+			want: false,
+		},
+		{
+			name:   "both nil CIDRMasK",
+			nodes1: &v1alpha1.Nodes{},
+			nodes2: &v1alpha1.Nodes{},
+			want:   true,
+		},
+		{
+			name: "different not nil CIDRMasK",
+			nodes1: &v1alpha1.Nodes{
+				CIDRMaskSize: ptr.Int(3),
+			},
+			nodes2: &v1alpha1.Nodes{
+				CIDRMaskSize: ptr.Int(2),
+			},
+			want: false,
+		},
+		{
+			name: "equal not nil CIDRMasK",
+			nodes1: &v1alpha1.Nodes{
+				CIDRMaskSize: ptr.Int(2),
+			},
+			nodes2: &v1alpha1.Nodes{
+				CIDRMaskSize: ptr.Int(2),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.nodes1.Equal(tt.nodes2)).To(Equal(tt.want))
+		})
 	}
 }

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -148,10 +148,28 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 			field.Forbidden(specPath.Child("datacenterRef"), fmt.Sprintf("field is immutable %v", new.Spec.DatacenterRef)))
 	}
 
-	if !new.Spec.ClusterNetwork.Equal(&old.Spec.ClusterNetwork) {
+	if !new.Spec.ClusterNetwork.Pods.Equal(&old.Spec.ClusterNetwork.Pods) {
 		allErrs = append(
 			allErrs,
-			field.Forbidden(specPath.Child("ClusterNetwork"), fmt.Sprintf("field is immutable %v", new.Spec.ClusterNetwork)))
+			field.Forbidden(specPath.Child("clusterNetwork", "pods"), "field is immutable"))
+	}
+
+	if !new.Spec.ClusterNetwork.Services.Equal(&old.Spec.ClusterNetwork.Services) {
+		allErrs = append(
+			allErrs,
+			field.Forbidden(specPath.Child("clusterNetwork", "services"), "field is immutable"))
+	}
+
+	if !new.Spec.ClusterNetwork.DNS.Equal(&old.Spec.ClusterNetwork.DNS) {
+		allErrs = append(
+			allErrs,
+			field.Forbidden(specPath.Child("clusterNetwork", "dns"), "field is immutable"))
+	}
+
+	if !new.Spec.ClusterNetwork.Nodes.Equal(old.Spec.ClusterNetwork.Nodes) {
+		allErrs = append(
+			allErrs,
+			field.Forbidden(specPath.Child("clusterNetwork", "nodes"), "field is immutable"))
 	}
 
 	if !new.Spec.ProxyConfiguration.Equal(old.Spec.ProxyConfiguration) {

--- a/pkg/networking/cilium/client.go
+++ b/pkg/networking/cilium/client.go
@@ -18,6 +18,9 @@ const (
 	PreflightDaemonSetName  = "cilium-pre-flight-check"
 	DeploymentName          = "cilium-operator"
 	PreflightDeploymentName = "cilium-pre-flight-check"
+	// ConfigMapName is the default name for the Cilium ConfigMap
+	// containing Cilium's configuration.
+	ConfigMapName = "cilium-config"
 )
 
 // Client allows to interact with the Kubernetes API.

--- a/pkg/networking/cilium/installation.go
+++ b/pkg/networking/cilium/installation.go
@@ -1,14 +1,20 @@
 package cilium
 
-import appsv1 "k8s.io/api/apps/v1"
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
 
 // Installation represents the Cilium components installed in a cluster.
 type Installation struct {
 	DaemonSet *appsv1.DaemonSet
 	Operator  *appsv1.Deployment
+	ConfigMap *corev1.ConfigMap
 }
 
 // Installed determines if all Cilium components are present.
+// If the ConfigMap doesn't exist we still considered Cilium is installed.
+// The installation might not be complete but it can be functional.
 func (i Installation) Installed() bool {
 	return i.DaemonSet != nil && i.Operator != nil
 }

--- a/pkg/networking/cilium/upgrade_plan.go
+++ b/pkg/networking/cilium/upgrade_plan.go
@@ -10,47 +10,117 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 )
 
+const (
+	// PolicyEnforcementConfigMapKey is the key used in the "cilium-config" ConfigMap to
+	// store the value for the PolicyEnforcementMode.
+	PolicyEnforcementConfigMapKey = "enable-policy"
+
+	// PolicyEnforcementComponentName is the ConfigComponentUpdatePlan name for the
+	// PolicyEnforcement configuration component.
+	PolicyEnforcementComponentName = "PolicyEnforcementMode"
+)
+
 // UpgradePlan contains information about a Cilium installation upgrade.
 type UpgradePlan struct {
-	DaemonSet ComponentUpgradePlan
-	Operator  ComponentUpgradePlan
+	DaemonSet VersionedComponentUpgradePlan
+	Operator  VersionedComponentUpgradePlan
+	ConfigMap ConfigUpdatePlan
 }
 
 // Needed determines if an upgrade is needed or not
 // Returns true if any of the installation components needs an upgrade.
 func (c UpgradePlan) Needed() bool {
+	return c.VersionUpgradeNeeded() || c.ConfigUpdateNeeded()
+}
+
+// VersionUpgradeNeeded determines if a version upgrade is needed or not
+// Returns true if any of the installation components needs an upgrade.
+func (c UpgradePlan) VersionUpgradeNeeded() bool {
 	return c.DaemonSet.Needed() || c.Operator.Needed()
+}
+
+// ConfigUpdateNeeded determines if an upgrade is needed on the cilium config or not.
+func (c UpgradePlan) ConfigUpdateNeeded() bool {
+	return c.ConfigMap.Needed()
 }
 
 // Reason returns the reason why an upgrade might be needed
 // If no upgrade needed, returns empty string
 // For multiple components with needed upgrades, it composes their reasons into one.
 func (c UpgradePlan) Reason() string {
-	if !c.Needed() {
-		return ""
+	components := []interface {
+		reason() string
+	}{
+		c.DaemonSet,
+		c.Operator,
+		c.ConfigMap,
 	}
 
-	s := make([]string, 0, 2)
-	if c.DaemonSet.UpgradeReason != "" {
-		s = append(s, c.DaemonSet.UpgradeReason)
-	}
-	if c.Operator.UpgradeReason != "" {
-		s = append(s, c.Operator.UpgradeReason)
+	s := make([]string, 0, 3)
+	for _, component := range components {
+		if reason := component.reason(); reason != "" {
+			s = append(s, reason)
+		}
 	}
 
 	return strings.Join(s, " - ")
 }
 
-// ComponentUpgradePlan contains upgrade information for a Cilium component.
-type ComponentUpgradePlan struct {
+// VersionedComponentUpgradePlan contains upgrade information for a Cilium versioned component.
+type VersionedComponentUpgradePlan struct {
 	UpgradeReason string
 	OldImage      string
 	NewImage      string
 }
 
 // Needed determines if an upgrade is needed or not.
-func (c ComponentUpgradePlan) Needed() bool {
+func (c VersionedComponentUpgradePlan) Needed() bool {
 	return c.UpgradeReason != ""
+}
+
+// reason returns the reason for the upgrade if needed.
+// If upgrade is not needed, it returns an empty string.
+func (c VersionedComponentUpgradePlan) reason() string {
+	return c.UpgradeReason
+}
+
+// ConfigUpdatePlan contains update information for the Cilium config.
+type ConfigUpdatePlan struct {
+	UpdateReason string
+	Components   []ConfigComponentUpdatePlan
+}
+
+// Needed determines if an upgrade is needed or not.
+func (c ConfigUpdatePlan) Needed() bool {
+	return c.UpdateReason != ""
+}
+
+// reason returns the reason for the upgrade if needed.
+// If upgrade is not needed, it returns an empty string.
+func (c ConfigUpdatePlan) reason() string {
+	return c.UpdateReason
+}
+
+// generateUpdateReasonFromComponents reads the update reasons for the components
+// and generates a compounded update reason. This is not thread safe.
+func (c *ConfigUpdatePlan) generateUpdateReasonFromComponents() {
+	r := make([]string, 0, len(c.Components))
+	for _, component := range c.Components {
+		if reason := component.UpdateReason; reason != "" {
+			r = append(r, reason)
+		}
+	}
+
+	if newReason := strings.Join(r, " - "); newReason != "" {
+		c.UpdateReason = newReason
+	}
+}
+
+// ConfigComponentUpdatePlan contains update information for a Cilium config component.
+type ConfigComponentUpdatePlan struct {
+	Name               string
+	UpdateReason       string
+	OldValue, NewValue string
 }
 
 // BuildUpgradePlan generates the upgrade plan information for a cilium installation by comparing it
@@ -59,12 +129,13 @@ func BuildUpgradePlan(installation *Installation, clusterSpec *cluster.Spec) Upg
 	return UpgradePlan{
 		DaemonSet: daemonSetUpgradePlan(installation.DaemonSet, clusterSpec),
 		Operator:  operatorUpgradePlan(installation.Operator, clusterSpec),
+		ConfigMap: configMapUpgradePlan(installation.ConfigMap, clusterSpec),
 	}
 }
 
-func daemonSetUpgradePlan(ds *appsv1.DaemonSet, clusterSpec *cluster.Spec) ComponentUpgradePlan {
+func daemonSetUpgradePlan(ds *appsv1.DaemonSet, clusterSpec *cluster.Spec) VersionedComponentUpgradePlan {
 	dsImage := clusterSpec.VersionsBundle.Cilium.Cilium.VersionedImage()
-	info := ComponentUpgradePlan{
+	info := VersionedComponentUpgradePlan{
 		NewImage: dsImage,
 	}
 
@@ -90,9 +161,9 @@ func daemonSetUpgradePlan(ds *appsv1.DaemonSet, clusterSpec *cluster.Spec) Compo
 	return info
 }
 
-func operatorUpgradePlan(operator *appsv1.Deployment, clusterSpec *cluster.Spec) ComponentUpgradePlan {
+func operatorUpgradePlan(operator *appsv1.Deployment, clusterSpec *cluster.Spec) VersionedComponentUpgradePlan {
 	newImage := clusterSpec.VersionsBundle.Cilium.Operator.VersionedImage()
-	info := ComponentUpgradePlan{
+	info := VersionedComponentUpgradePlan{
 		NewImage: newImage,
 	}
 
@@ -115,4 +186,36 @@ func operatorUpgradePlan(operator *appsv1.Deployment, clusterSpec *cluster.Spec)
 	}
 
 	return info
+}
+
+func configMapUpgradePlan(configMap *corev1.ConfigMap, clusterSpec *cluster.Spec) ConfigUpdatePlan {
+	updatePlan := &ConfigUpdatePlan{}
+
+	var newEnforcementPolicy string
+	if clusterSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode == "" {
+		newEnforcementPolicy = "default"
+	} else {
+		newEnforcementPolicy = string(clusterSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode)
+	}
+
+	policyEnforcementUpdate := ConfigComponentUpdatePlan{
+		Name:     PolicyEnforcementComponentName,
+		NewValue: newEnforcementPolicy,
+	}
+
+	if configMap == nil {
+		updatePlan.UpdateReason = "Cilium config doesn't exist"
+	} else if val, ok := configMap.Data[PolicyEnforcementConfigMapKey]; ok && val != "" {
+		policyEnforcementUpdate.OldValue = val
+		if policyEnforcementUpdate.OldValue != policyEnforcementUpdate.NewValue {
+			policyEnforcementUpdate.UpdateReason = fmt.Sprintf("Cilium enable-policy changed: [%s] -> [%s]", policyEnforcementUpdate.OldValue, policyEnforcementUpdate.NewValue)
+		}
+	} else {
+		policyEnforcementUpdate.UpdateReason = "Cilium enable-policy field is not present in config"
+	}
+
+	updatePlan.Components = append(updatePlan.Components, policyEnforcementUpdate)
+	updatePlan.generateUpdateReasonFromComponents()
+
+	return *updatePlan
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/4089

*Description of changes:*
Before this, the reconciler only reacted to changes in the Cilium
version specified in the Bundles. Now it will detect changes in the
Cilium config as well and reapply the manifest without going through the
version upgrade process.

*Testing (if applicable):*
Manual and unit test


<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->