### PR TITLE
Add flag to set machine health check timeout (#3918)

### DIFF
--- a/cmd/eksctl-anywhere/cmd/constants.go
+++ b/cmd/eksctl-anywhere/cmd/constants.go
@@ -6,6 +6,7 @@ const (
 	cpWaitTimeoutFlag           = "control-plane-wait-timeout"
 	externalEtcdWaitTimeoutFlag = "external-etcd-wait-timeout"
 	perMachineWaitTimeoutFlag   = "per-machine-wait-timeout"
+	unhealthyMachineTimeoutFlag = "unhealthy-machine-timeout"
 )
 
 type Operation int

--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -26,6 +26,7 @@ type timeoutOptions struct {
 	cpWaitTimeout           string
 	externalEtcdWaitTimeout string
 	perMachineWaitTimeout   string
+	unhealthyMachineTimeout string
 }
 
 func applyTimeoutFlags(flagSet *pflag.FlagSet, t *timeoutOptions) {
@@ -37,6 +38,9 @@ func applyTimeoutFlags(flagSet *pflag.FlagSet, t *timeoutOptions) {
 
 	flagSet.StringVar(&t.perMachineWaitTimeout, perMachineWaitTimeoutFlag, clustermanager.DefaultMaxWaitPerMachine.String(), "Override the default machine wait timeout (10m)/per machine ")
 	markFlagHidden(flagSet, perMachineWaitTimeoutFlag)
+
+	flagSet.StringVar(&t.unhealthyMachineTimeout, unhealthyMachineTimeoutFlag, clustermanager.DefaultUnhealthyMachineTimeout.String(), "Override the default unhealthy machine timeout (5m) ")
+	markFlagHidden(flagSet, unhealthyMachineTimeoutFlag)
 }
 
 func buildClusterManagerOpts(t timeoutOptions) ([]clustermanager.ClusterManagerOpt, error) {
@@ -55,10 +59,16 @@ func buildClusterManagerOpts(t timeoutOptions) ([]clustermanager.ClusterManagerO
 		return nil, fmt.Errorf(timeoutErrorTemplate, perMachineWaitTimeoutFlag, err)
 	}
 
+	unhealthyMachineTimeout, err := time.ParseDuration(t.unhealthyMachineTimeout)
+	if err != nil {
+		return nil, fmt.Errorf(timeoutErrorTemplate, unhealthyMachineTimeoutFlag, err)
+	}
+
 	return []clustermanager.ClusterManagerOpt{
 		clustermanager.WithControlPlaneWaitTimeout(cpWaitTimeout),
 		clustermanager.WithExternalEtcdWaitTimeout(externalEtcdWaitTimeout),
 		clustermanager.WithMachineMaxWait(perMachineWaitTimeout),
+		clustermanager.WithUnhealthyMachineTimeout(unhealthyMachineTimeout),
 	}, nil
 }
 

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -36,18 +36,23 @@ import (
 )
 
 const (
-	maxRetries                = 30
-	defaultBackOffPeriod      = 5 * time.Second
-	machineBackoff            = 1 * time.Second
-	defaultMachinesMinWait    = 30 * time.Minute
-	moveCAPIWait              = 15 * time.Minute
-	DefaultMaxWaitPerMachine  = 10 * time.Minute
-	clusterWaitStr            = "60m"
+	maxRetries             = 30
+	defaultBackOffPeriod   = 5 * time.Second
+	machineBackoff         = 1 * time.Second
+	defaultMachinesMinWait = 30 * time.Minute
+	moveCAPIWait           = 15 * time.Minute
+	// DefaultMaxWaitPerMachine is the default max time the cluster manager will wait per a machine.
+	DefaultMaxWaitPerMachine = 10 * time.Minute
+	clusterWaitStr           = "60m"
+	// DefaultControlPlaneWait is the default time the cluster manager will wait for the control plane to be ready.
 	DefaultControlPlaneWait   = 60 * time.Minute
 	deploymentWaitStr         = "30m"
 	controlPlaneInProgressStr = "1m"
 	etcdInProgressStr         = "1m"
-	DefaultEtcdWait           = 60 * time.Minute
+	// DefaultEtcdWait is the default time the cluster manager will wait for ectd to be ready.
+	DefaultEtcdWait = 60 * time.Minute
+	// DefaultUnhealthyMachineTimeout is the default timeout for an unhealthy machine health check.
+	DefaultUnhealthyMachineTimeout = 5 * time.Minute
 )
 
 var eksaClusterResourceType = fmt.Sprintf("clusters.%s", v1alpha1.GroupVersion.Group)
@@ -65,6 +70,7 @@ type ClusterManager struct {
 	awsIamAuth              AwsIamAuth
 	controlPlaneWaitTimeout time.Duration
 	externalEtcdWaitTimeout time.Duration
+	unhealthyMachineTimeout time.Duration
 }
 
 type ClusterClient interface {
@@ -145,6 +151,7 @@ func New(clusterClient ClusterClient, networking Networking, writer filewriter.F
 		awsIamAuth:              awsIamAuth,
 		controlPlaneWaitTimeout: DefaultControlPlaneWait,
 		externalEtcdWaitTimeout: DefaultEtcdWait,
+		unhealthyMachineTimeout: DefaultUnhealthyMachineTimeout,
 	}
 
 	for _, o := range opts {
@@ -181,6 +188,13 @@ func WithMachineMaxWait(machineMaxWait time.Duration) ClusterManagerOpt {
 func WithMachineMinWait(machineMinWait time.Duration) ClusterManagerOpt {
 	return func(c *ClusterManager) {
 		c.machinesMinWait = machineMinWait
+	}
+}
+
+// WithUnhealthyMachineTimeout sets the timeout of an unhealthy machine health check.
+func WithUnhealthyMachineTimeout(timeout time.Duration) ClusterManagerOpt {
+	return func(c *ClusterManager) {
+		c.unhealthyMachineTimeout = timeout
 	}
 }
 
@@ -605,7 +619,7 @@ func (c *ClusterManager) InstallStorageClass(ctx context.Context, cluster *types
 }
 
 func (c *ClusterManager) InstallMachineHealthChecks(ctx context.Context, clusterSpec *cluster.Spec, workloadCluster *types.Cluster) error {
-	mhc, err := templater.ObjectsToYaml(clusterapi.MachineHealthCheckObjects(clusterSpec)...)
+	mhc, err := templater.ObjectsToYaml(clusterapi.MachineHealthCheckObjects(clusterSpec, c.unhealthyMachineTimeout)...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Before this change, an unhealthy machine health check would timeout after five minutes. This leads to an endless loop for a RolingUpgrade on a slow system. Disabling the health checks circumvents this issue, but is not ideal. This change adds a flag `--unhealthy-machine-timeout` which customers can use to make the upgrade process more reliable without sacrificing health checks.

*Issue #, if available:*  Resolves https://github.com/aws/eks-anywhere/issues/3918

*Description of changes:* Allow users to override the default unhealthy machine condition timeout using an `--unhealthy-machine-timeout` flag

*Testing (if applicable):* 

Created unit tests for the scenarios:
1. No environmental variable sets the timeout to the default value
2. Invalid environmental variable (e.g negatives, NaNs, large values which cause int overflows) sets the timeout to 5m
3. Valid environmental variable (e.g 20), sets the timeout to 20m

I performed a manual test by running the command
```eksctl anywhere create cluster --unhealthy-machine-timeout 20m -f mgmt_cluster.yaml```
and confirmed the timeout was set correctly with
```kubectl get -o yaml machinehealthcheck -A --kubeconfig sanjaqmo-healthcheck-test-mgmt/sanjaqmo-healthcheck-test-mgmt-eks-a-cluster.kubeconfig```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

