### PR TITLE
Delete unwanted MachineDeployments in reconcile

### DIFF
--- a/pkg/collection/set.go
+++ b/pkg/collection/set.go
@@ -1,0 +1,60 @@
+package collection
+
+// Set is a collection that only contains unique elements.
+type Set[T comparable] map[T]struct{}
+
+// NewSet creates an empty Set.
+func NewSet[T comparable]() Set[T] {
+	return newSet[T](0)
+}
+
+// NewSetFrom creates a Set from a list of elements.
+func NewSetFrom[T comparable](elements ...T) Set[T] {
+	s := NewSet[T]()
+	for _, e := range elements {
+		s.Add(e)
+	}
+
+	return s
+}
+
+func newSet[T comparable](size int) Set[T] {
+	return make(Set[T], size)
+}
+
+// Add stores a new element in the Set if wasn't contained yet.
+func (s Set[T]) Add(e T) {
+	s[e] = struct{}{}
+}
+
+// Delete removes an element from the Set if it existed.
+func (s Set[T]) Delete(e T) {
+	delete(s, e)
+}
+
+// Contains checks if an element is contained in the Set.
+func (s Set[T]) Contains(e T) bool {
+	_, present := s[e]
+	return present
+}
+
+// ToSlice generates a new slice with all elements in the Set.
+// Order is non deterministic.
+func (s Set[T]) ToSlice() []T {
+	keys := make([]T, 0, len(s))
+	for k := range s {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// MapSet allows to map a collection to a Set using a closure to extract
+// the values of type T.
+func MapSet[G any, T comparable](c []G, f func(G) T) Set[T] {
+	s := NewSet[T]()
+	for _, element := range c {
+		s.Add(f(element))
+	}
+
+	return s
+}

--- a/pkg/collection/set_test.go
+++ b/pkg/collection/set_test.go
@@ -1,0 +1,105 @@
+package collection_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/collection"
+)
+
+func TestSetContains(t *testing.T) {
+	testCases := []struct {
+		testName string
+		set      collection.Set[string]
+		element  string
+		want     bool
+	}{
+		{
+			testName: "empty set",
+			set:      collection.NewSet[string](),
+			element:  "a",
+			want:     false,
+		},
+		{
+			testName: "contained in non empty set",
+			set:      collection.NewSetFrom("b", "a", "c"),
+			element:  "a",
+			want:     true,
+		},
+		{
+			testName: "not contained in non empty set",
+			set:      collection.NewSetFrom("b", "a", "c"),
+			element:  "d",
+			want:     false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.set.Contains(tt.element)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestSetDelete(t *testing.T) {
+	g := NewWithT(t)
+	s := collection.NewSetFrom("b", "a", "c")
+	g.Expect(s.Contains("c")).To(BeTrue())
+	s.Delete("c")
+	g.Expect(s.Contains("c")).To(BeFalse())
+
+	g.Expect(s.ToSlice()).To(ConsistOf("a", "b"))
+}
+
+func TestSetToSlice(t *testing.T) {
+	testCases := []struct {
+		testName string
+		set      collection.Set[string]
+		want     []string
+	}{
+		{
+			testName: "empty set",
+			set:      collection.NewSet[string](),
+			want:     []string{},
+		},
+		{
+			testName: "non empty set",
+			set:      collection.NewSetFrom("b", "a", "c", "d", "a", "b"),
+			want: []string{
+				"a", "b", "c", "d",
+			},
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.set.ToSlice()).To(ConsistOf(tt.want))
+		})
+	}
+}
+
+func TestMapSet(t *testing.T) {
+	g := NewWithT(t)
+	elements := []myStruct{
+		{
+			name: "a",
+		},
+		{
+			name: "b",
+		},
+		{
+			name: "b",
+		},
+	}
+
+	s := collection.MapSet(elements, func(e myStruct) string {
+		return e.name
+	})
+
+	g.Expect(s.ToSlice()).To(ConsistOf("a", "b"))
+}
+
+type myStruct struct {
+	name string
+}

--- a/pkg/controller/clusters/workers.go
+++ b/pkg/controller/clusters/workers.go
@@ -49,7 +49,7 @@ func (g *WorkerGroup) objects() []client.Object {
 }
 
 // ToWorkers converts the generic clusterapi Workers definition to the concrete one defined
-// here. It's just a helper for callers generating workers spec using the clusterpai package.
+// here. It's just a helper for callers generating workers spec using the clusterapi package.
 func ToWorkers[M clusterapi.Object[M]](capiWorkers *clusterapi.Workers[M]) *Workers {
 	w := &Workers{
 		Groups: make([]WorkerGroup, 0, len(capiWorkers.Groups)),
@@ -76,7 +76,7 @@ func ReconcileWorkersForEKSA(ctx context.Context, log logr.Logger, c client.Clie
 	}
 
 	if capiCluster == nil {
-		// cluster doesn't exit, this might be transient, requeuing
+		// cluster doesn't exist, this might be transient, requeuing
 		log.Info("CAPI cluster doesn't exist yet, this might be transient if the CP have just been created, requeueing")
 		return controller.ResultWithRequeue(5 * time.Second), nil
 	}

--- a/pkg/controller/clusters/workers.go
+++ b/pkg/controller/clusters/workers.go
@@ -1,0 +1,122 @@
+package clusters
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	"github.com/aws/eks-anywhere/pkg/collection"
+	"github.com/aws/eks-anywhere/pkg/controller"
+	"github.com/aws/eks-anywhere/pkg/controller/serverside"
+)
+
+// Workers represents the CAPI spec for an eks-a cluster's workers.
+type Workers struct {
+	Groups []WorkerGroup
+}
+
+// objects returns a list of API objects for a collection of worker groups.
+func (w *Workers) objects() []client.Object {
+	objs := make([]client.Object, 0, len(w.Groups)*3)
+	for _, g := range w.Groups {
+		objs = append(objs, g.objects()...)
+	}
+
+	return objs
+}
+
+// WorkerGroup represents the CAPI spec for an eks-a worker group.
+type WorkerGroup struct {
+	KubeadmConfigTemplate   *kubeadmv1.KubeadmConfigTemplate
+	MachineDeployment       *clusterv1.MachineDeployment
+	ProviderMachineTemplate client.Object
+}
+
+func (g *WorkerGroup) objects() []client.Object {
+	return []client.Object{
+		g.KubeadmConfigTemplate,
+		g.MachineDeployment,
+		g.ProviderMachineTemplate,
+	}
+}
+
+// ToWorkers converts the generic clusterapi Workers definition to the concrete one defined
+// here. It's just a helper for callers generating workers spec using the clusterpai package.
+func ToWorkers[M clusterapi.Object[M]](capiWorkers *clusterapi.Workers[M]) *Workers {
+	w := &Workers{
+		Groups: make([]WorkerGroup, 0, len(capiWorkers.Groups)),
+	}
+
+	for _, g := range capiWorkers.Groups {
+		w.Groups = append(w.Groups, WorkerGroup{
+			MachineDeployment:       g.MachineDeployment,
+			KubeadmConfigTemplate:   g.KubeadmConfigTemplate,
+			ProviderMachineTemplate: g.ProviderMachineTemplate,
+		})
+	}
+
+	return w
+}
+
+// ReconcileWorkersForEKSA orchestrates the worker node reconciliation logic for a particular EKS-A cluster.
+// It takes care of applying all desired objects in the Workers spec and deleting the
+// old MachineDeployments that are not in it.
+func ReconcileWorkersForEKSA(ctx context.Context, log logr.Logger, c client.Client, cluster *anywherev1.Cluster, w *Workers) (controller.Result, error) {
+	capiCluster, err := controller.GetCAPICluster(ctx, c, cluster)
+	if err != nil {
+		return controller.Result{}, errors.Wrap(err, "reconciling workers for EKS-A cluster")
+	}
+
+	if capiCluster == nil {
+		// cluster doesn't exit, this might be transient, requeuing
+		log.Info("CAPI cluster doesn't exist yet, this might be transient if the CP have just been created, requeueing")
+		return controller.ResultWithRequeue(5 * time.Second), nil
+	}
+
+	return ReconcileWorkers(ctx, c, capiCluster, w)
+}
+
+// ReconcileWorkers orchestrates the worker node reconciliation logic.
+// It takes care of applying all desired objects in the Workers spec and deleting the
+// old MachineDeployments that are not in it.
+func ReconcileWorkers(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, w *Workers) (controller.Result, error) {
+	if err := serverside.ReconcileObjects(ctx, c, w.objects()); err != nil {
+		return controller.Result{}, errors.Wrap(err, "applying worker nodes CAPI objects")
+	}
+
+	machineDeployments := &clusterv1.MachineDeploymentList{}
+	if err := c.List(ctx, machineDeployments,
+		client.MatchingLabels{clusterv1.ClusterLabelName: cluster.Name},
+		client.InNamespace(cluster.Namespace)); err != nil {
+		return controller.Result{}, errors.Wrap(err, "listing current machine deployments")
+	}
+
+	desiredMachineDeploymentNames := collection.MapSet(w.Groups, func(g WorkerGroup) string {
+		return g.MachineDeployment.Name
+	})
+
+	var allErrs []error
+
+	for _, m := range machineDeployments.Items {
+		if !desiredMachineDeploymentNames.Contains(m.Name) {
+			if err := c.Delete(ctx, &m); err != nil {
+				allErrs = append(allErrs, err)
+			}
+		}
+	}
+
+	if len(allErrs) > 0 {
+		aggregate := utilerrors.NewAggregate(allErrs)
+		return controller.Result{}, errors.Wrap(aggregate, "deleting machine deployments during worker node reconciliation")
+	}
+
+	return controller.Result{}, nil
+}

--- a/pkg/controller/clusters/workers_test.go
+++ b/pkg/controller/clusters/workers_test.go
@@ -70,7 +70,7 @@ func TestReconcileWorkersErrorApplyingObjects(t *testing.T) {
 	c := env.Client()
 	ctx := context.Background()
 	ns := "fake-ns"
-	// ns doesn't exit, it will fail
+	// ns doesn't exist, it will fail
 	w := workers(ns)
 	cluster := &clusterv1.Cluster{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/clusters/workers_test.go
+++ b/pkg/controller/clusters/workers_test.go
@@ -1,0 +1,271 @@
+package clusters_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/internal/test/envtest"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/controller"
+	"github.com/aws/eks-anywhere/pkg/controller/clusters"
+)
+
+func TestReconcileWorkersSuccess(t *testing.T) {
+	g := NewWithT(t)
+	c := env.Client()
+	api := envtest.NewAPIExpecter(t, c)
+	ctx := context.Background()
+	ns := env.CreateNamespaceForTest(ctx, t)
+	w := workers(ns)
+	cluster := &clusterv1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "cluster.x-k8s.io/v1beta1",
+			Kind:       "Cluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: ns,
+		},
+	}
+
+	existingMachineDeployment1 := machineDeployment("my-cluster-md-1", ns)
+	existingMachineDeployment2 := machineDeployment("my-cluster-md-2", ns)
+	existingMachineDeployment3 := machineDeployment("my-other-cluster-md-1", ns)
+	existingMachineDeployment3.Labels[clusterv1.ClusterLabelName] = "my-other-cluster"
+	envtest.CreateObjs(ctx, t, c,
+		existingMachineDeployment1,
+		existingMachineDeployment2,
+		existingMachineDeployment3,
+	)
+
+	g.Expect(clusters.ReconcileWorkers(ctx, c, cluster, w)).To(Equal(controller.Result{}))
+
+	api.ShouldEventuallyExist(ctx, w.Groups[0].MachineDeployment)
+	api.ShouldEventuallyExist(ctx, w.Groups[0].KubeadmConfigTemplate)
+	api.ShouldEventuallyExist(ctx, w.Groups[0].ProviderMachineTemplate)
+	api.ShouldEventuallyExist(ctx, w.Groups[1].MachineDeployment)
+	api.ShouldEventuallyExist(ctx, w.Groups[1].KubeadmConfigTemplate)
+	api.ShouldEventuallyExist(ctx, w.Groups[1].ProviderMachineTemplate)
+
+	api.ShouldEventuallyNotExist(ctx, existingMachineDeployment1)
+	api.ShouldEventuallyNotExist(ctx, existingMachineDeployment2)
+	api.ShouldEventuallyExist(ctx, existingMachineDeployment3)
+}
+
+func TestReconcileWorkersErrorApplyingObjects(t *testing.T) {
+	g := NewWithT(t)
+	c := env.Client()
+	ctx := context.Background()
+	ns := "fake-ns"
+	// ns doesn't exit, it will fail
+	w := workers(ns)
+	cluster := &clusterv1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "cluster.x-k8s.io/v1beta1",
+			Kind:       "Cluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: ns,
+		},
+	}
+
+	g.Expect(clusters.ReconcileWorkers(ctx, c, cluster, w)).Error().To(
+		MatchError(ContainSubstring("applying worker nodes CAPI objects")),
+	)
+}
+
+func TestToWorkers(t *testing.T) {
+	g := NewWithT(t)
+	namespace := constants.EksaSystemNamespace
+	w := &clusterapi.Workers[*dockerv1.DockerMachineTemplate]{
+		Groups: []clusterapi.WorkerGroup[*dockerv1.DockerMachineTemplate]{
+			{
+				MachineDeployment:       machineDeployment("my-cluster-md-0", namespace),
+				KubeadmConfigTemplate:   kubeadmConfigTemplate("my-cluster-md-0-1", namespace),
+				ProviderMachineTemplate: dockerMachineTemplate("my-cluster-md-0-1", namespace),
+			},
+			{
+				MachineDeployment:       machineDeployment("my-cluster-md-3", namespace),
+				KubeadmConfigTemplate:   kubeadmConfigTemplate("my-cluster-md-3-1", namespace),
+				ProviderMachineTemplate: dockerMachineTemplate("my-cluster-md-3-1", namespace),
+			},
+		},
+	}
+
+	want := &clusters.Workers{
+		Groups: []clusters.WorkerGroup{
+			{
+				MachineDeployment:       w.Groups[0].MachineDeployment,
+				KubeadmConfigTemplate:   w.Groups[0].KubeadmConfigTemplate,
+				ProviderMachineTemplate: w.Groups[0].ProviderMachineTemplate,
+			},
+			{
+				MachineDeployment:       w.Groups[1].MachineDeployment,
+				KubeadmConfigTemplate:   w.Groups[1].KubeadmConfigTemplate,
+				ProviderMachineTemplate: w.Groups[1].ProviderMachineTemplate,
+			},
+		},
+	}
+
+	g.Expect(clusters.ToWorkers(w)).To(Equal(want))
+}
+
+func workers(namespace string) *clusters.Workers {
+	return &clusters.Workers{
+		Groups: []clusters.WorkerGroup{
+			{
+				MachineDeployment:       machineDeployment("my-cluster-md-0", namespace),
+				KubeadmConfigTemplate:   kubeadmConfigTemplate("my-cluster-md-0-1", namespace),
+				ProviderMachineTemplate: dockerMachineTemplate("my-cluster-md-0-1", namespace),
+			},
+			{
+				MachineDeployment:       machineDeployment("my-cluster-md-3", namespace),
+				KubeadmConfigTemplate:   kubeadmConfigTemplate("my-cluster-md-3-1", namespace),
+				ProviderMachineTemplate: dockerMachineTemplate("my-cluster-md-3-1", namespace),
+			},
+		},
+	}
+}
+
+func machineDeployment(name, namespace string) *clusterv1.MachineDeployment {
+	return &clusterv1.MachineDeployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "cluster.x-k8s.io/v1beta1",
+			Kind:       "MachineDeployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: "my-cluster",
+			},
+		},
+		Spec: clusterv1.MachineDeploymentSpec{
+			ClusterName: "my-cluster",
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					ClusterName: "my-cluster",
+				},
+			},
+		},
+	}
+}
+
+func kubeadmConfigTemplate(name, namespace string) *bootstrapv1.KubeadmConfigTemplate {
+	return &bootstrapv1.KubeadmConfigTemplate{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+			Kind:       "KubeadmConfigTemplate",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func dockerMachineTemplate(name, namespace string) *dockerv1.DockerMachineTemplate {
+	return &dockerv1.DockerMachineTemplate{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			Kind:       "DockerMachineTemplate",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func TestReconcileWorkersForEKSAErrorGettingCAPICluster(t *testing.T) {
+	g := NewWithT(t)
+	c := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+	ctx := context.Background()
+	ns := "ns"
+	w := workers(ns)
+	cluster := &anywherev1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: ns,
+		},
+	}
+
+	g.Expect(
+		clusters.ReconcileWorkersForEKSA(ctx, env.Manager().GetLogger(), c, cluster, w),
+	).Error().To(MatchError(ContainSubstring("reconciling workers for EKS-A cluster")))
+}
+
+func TestReconcileWorkersForEKSANoCAPICluster(t *testing.T) {
+	g := NewWithT(t)
+	c := env.Client()
+	ctx := context.Background()
+	ns := "ns"
+	w := workers(ns)
+	cluster := &anywherev1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: ns,
+		},
+	}
+
+	g.Expect(
+		clusters.ReconcileWorkersForEKSA(ctx, env.Manager().GetLogger(), c, cluster, w),
+	).To(Equal(controller.Result{Result: &reconcile.Result{RequeueAfter: 5 * time.Second}}))
+}
+
+func TestReconcileWorkersForEKSASuccess(t *testing.T) {
+	g := NewWithT(t)
+	c := env.Client()
+	api := envtest.NewAPIExpecter(t, c)
+	ctx := context.Background()
+	ns := env.CreateNamespaceForTest(ctx, t)
+	w := workers(ns)
+	capiCluster := &clusterv1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "cluster.x-k8s.io/v1beta1",
+			Kind:       "Cluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: constants.EksaSystemNamespace,
+		},
+	}
+	cluster := &anywherev1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: ns,
+		},
+	}
+
+	envtest.CreateObjs(ctx, t, c,
+		test.Namespace(constants.EksaSystemNamespace),
+		capiCluster,
+	)
+
+	g.Expect(
+		clusters.ReconcileWorkersForEKSA(ctx, env.Manager().GetLogger(), c, cluster, w),
+	).To(Equal(controller.Result{}))
+
+	api.ShouldEventuallyExist(ctx, w.Groups[0].MachineDeployment)
+	api.ShouldEventuallyExist(ctx, w.Groups[0].KubeadmConfigTemplate)
+	api.ShouldEventuallyExist(ctx, w.Groups[0].ProviderMachineTemplate)
+	api.ShouldEventuallyExist(ctx, w.Groups[1].MachineDeployment)
+	api.ShouldEventuallyExist(ctx, w.Groups[1].KubeadmConfigTemplate)
+	api.ShouldEventuallyExist(ctx, w.Groups[1].ProviderMachineTemplate)
+
+	api.DeleteAndWait(ctx, capiCluster)
+}

--- a/pkg/providers/snow/objects.go
+++ b/pkg/providers/snow/objects.go
@@ -73,6 +73,7 @@ func WorkersSpec(ctx context.Context, spec *cluster.Spec, kubeClient kubernetes.
 	return w, nil
 }
 
+// WorkersObjects generates all the objects that compose a Snow specific CAPI spec for the worker nodes of an eks-a cluster.
 func WorkersObjects(ctx context.Context, clusterSpec *cluster.Spec, kubeClient kubernetes.Client) ([]kubernetes.Object, error) {
 	w, err := WorkersSpec(ctx, clusterSpec, kubeClient)
 	if err != nil {

--- a/pkg/providers/snow/objects_test.go
+++ b/pkg/providers/snow/objects_test.go
@@ -262,7 +262,7 @@ func TestWorkersObjects(t *testing.T) {
 
 	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
-	g.Expect(got).To(Equal([]kubernetes.Object{md, wantKubeadmConfigTemplate(), mt}))
+	g.Expect(got).To(ConsistOf([]kubernetes.Object{md, wantKubeadmConfigTemplate(), mt}))
 }
 
 func TestWorkersObjectsFromBetaMachineTemplateName(t *testing.T) {
@@ -321,7 +321,7 @@ func TestWorkersObjectsFromBetaMachineTemplateName(t *testing.T) {
 
 	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
-	g.Expect(got).To(Equal([]kubernetes.Object{md, kct, mt}))
+	g.Expect(got).To(ConsistOf([]kubernetes.Object{md, kct, mt}))
 }
 
 func TestWorkersObjectsOldMachineDeploymentNotExists(t *testing.T) {
@@ -338,7 +338,7 @@ func TestWorkersObjectsOldMachineDeploymentNotExists(t *testing.T) {
 
 	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
-	g.Expect(got).To(Equal([]kubernetes.Object{wantMachineDeployment(), wantKubeadmConfigTemplate(), mt}))
+	g.Expect(got).To(ConsistOf([]kubernetes.Object{wantMachineDeployment(), wantKubeadmConfigTemplate(), mt}))
 }
 
 func TestWorkersObjectsOldKubeadmConfigTemplateNotExists(t *testing.T) {
@@ -376,7 +376,7 @@ func TestWorkersObjectsOldKubeadmConfigTemplateNotExists(t *testing.T) {
 
 	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
-	g.Expect(got).To(Equal([]kubernetes.Object{wantMachineDeployment(), wantKubeadmConfigTemplate(), mt}))
+	g.Expect(got).To(ConsistOf([]kubernetes.Object{wantMachineDeployment(), wantKubeadmConfigTemplate(), mt}))
 }
 
 func TestWorkersObjectsOldMachineTemplateNotExists(t *testing.T) {
@@ -417,7 +417,7 @@ func TestWorkersObjectsOldMachineTemplateNotExists(t *testing.T) {
 
 	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
-	g.Expect(got).To(Equal([]kubernetes.Object{wantMachineDeployment(), wantKubeadmConfigTemplate(), mt}))
+	g.Expect(got).To(ConsistOf([]kubernetes.Object{wantMachineDeployment(), wantKubeadmConfigTemplate(), mt}))
 }
 
 func TestWorkersObjectsTaintsUpdated(t *testing.T) {
@@ -476,7 +476,7 @@ func TestWorkersObjectsTaintsUpdated(t *testing.T) {
 	mt.SetName("snow-test-md-0-2")
 
 	g.Expect(err).To(Succeed())
-	g.Expect(got).To(Equal([]kubernetes.Object{md, kct, mt}))
+	g.Expect(got).To(ConsistOf([]kubernetes.Object{md, kct, mt}))
 }
 
 func TestWorkersObjectsLabelsUpdated(t *testing.T) {
@@ -540,7 +540,7 @@ func TestWorkersObjectsLabelsUpdated(t *testing.T) {
 	mt.SetName("snow-test-md-0-2")
 
 	g.Expect(err).To(Succeed())
-	g.Expect(got[1]).To(Equal(kct))
+	g.Expect(got).To(ContainElement(kct))
 }
 
 func TestWorkersObjectsGetMachineDeploymentError(t *testing.T) {

--- a/pkg/providers/snow/reconciler/reconciler.go
+++ b/pkg/providers/snow/reconciler/reconciler.go
@@ -122,7 +122,10 @@ func (s *Reconciler) ReconcileWorkers(ctx context.Context, log logr.Logger, clus
 	log = log.WithValues("phase", "reconcileWorkers")
 	log.Info("Applying worker CAPI objects")
 
-	return s.Apply(ctx, func() ([]kubernetes.Object, error) {
-		return snow.WorkersObjects(ctx, clusterSpec, clientutil.NewKubeClient(s.client))
-	})
+	w, err := snow.WorkersSpec(ctx, clusterSpec, clientutil.NewKubeClient(s.client))
+	if err != nil {
+		return controller.Result{}, err
+	}
+
+	return clusters.ReconcileWorkersForEKSA(ctx, log, s.client, clusterSpec.Cluster, clusters.ToWorkers(w))
 }

--- a/pkg/providers/snow/reconciler/reconciler_test.go
+++ b/pkg/providers/snow/reconciler/reconciler_test.go
@@ -146,6 +146,10 @@ func TestReconcilerValidateMachineConfigsMachineConfigNotValidated(t *testing.T)
 
 func TestReconcilerReconcileWorkers(t *testing.T) {
 	tt := newReconcilerTest(t)
+	capiCluster := capiCluster(func(c *clusterv1.Cluster) {
+		c.Name = tt.cluster.Name
+	})
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, capiCluster)
 	tt.createAllObjs()
 
 	result, err := tt.reconciler().ReconcileWorkers(tt.ctx, test.NewNullLogger(), tt.buildSpec())

--- a/pkg/providers/snow/reconciler/reconciler_test.go
+++ b/pkg/providers/snow/reconciler/reconciler_test.go
@@ -146,7 +146,7 @@ func TestReconcilerValidateMachineConfigsMachineConfigNotValidated(t *testing.T)
 
 func TestReconcilerReconcileWorkers(t *testing.T) {
 	tt := newReconcilerTest(t)
-	capiCluster := capiCluster(func(c *clusterv1.Cluster) {
+	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
 		c.Name = tt.cluster.Name
 	})
 	tt.eksaSupportObjs = append(tt.eksaSupportObjs, capiCluster)

--- a/pkg/providers/snow/testdata/expected_results_main_md.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_md.yaml
@@ -1,3 +1,38 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  creationTimestamp: null
+  name: snow-test-md-0-1
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      clusterConfiguration:
+        apiServer: {}
+        bottlerocketBootstrap: {}
+        bottlerocketControl: {}
+        controllerManager: {}
+        dns: {}
+        etcd: {}
+        networking: {}
+        pause: {}
+        proxy: {}
+        registryMirror: {}
+        scheduler: {}
+      joinConfiguration:
+        bottlerocketBootstrap: {}
+        bottlerocketControl: {}
+        discovery: {}
+        nodeRegistration:
+          kubeletExtraArgs:
+            provider-id: aws-snow:////'{{ ds.meta_data.instance_id }}'
+        pause: {}
+        proxy: {}
+        registryMirror: {}
+      preKubeadmCommands:
+      - /etc/eks/bootstrap.sh
+
+---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
@@ -34,41 +69,6 @@ status:
   replicas: 0
   unavailableReplicas: 0
   updatedReplicas: 0
-
----
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-kind: KubeadmConfigTemplate
-metadata:
-  creationTimestamp: null
-  name: snow-test-md-0-1
-  namespace: eksa-system
-spec:
-  template:
-    spec:
-      clusterConfiguration:
-        apiServer: {}
-        bottlerocketBootstrap: {}
-        bottlerocketControl: {}
-        controllerManager: {}
-        dns: {}
-        etcd: {}
-        networking: {}
-        pause: {}
-        proxy: {}
-        registryMirror: {}
-        scheduler: {}
-      joinConfiguration:
-        bottlerocketBootstrap: {}
-        bottlerocketControl: {}
-        discovery: {}
-        nodeRegistration:
-          kubeletExtraArgs:
-            provider-id: aws-snow:////'{{ ds.meta_data.instance_id }}'
-        pause: {}
-        proxy: {}
-        registryMirror: {}
-      preKubeadmCommands:
-      - /etc/eks/bootstrap.sh
 
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -172,7 +172,7 @@ func TestReconcilerControlPlaneIsNotReady(t *testing.T) {
 
 func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
 	tt := newReconcilerTest(t)
-	capiCluster := capiCluster(func(c *clusterv1.Cluster) {
+	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
 		c.Name = tt.cluster.Name
 	})
 	tt.eksaSupportObjs = append(tt.eksaSupportObjs, capiCluster)

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -172,6 +172,10 @@ func TestReconcilerControlPlaneIsNotReady(t *testing.T) {
 
 func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
 	tt := newReconcilerTest(t)
+	capiCluster := capiCluster(func(c *clusterv1.Cluster) {
+		c.Name = tt.cluster.Name
+	})
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, capiCluster)
 	tt.createAllObjs()
 
 	result, err := tt.reconciler().ReconcileWorkers(tt.ctx, test.NewNullLogger(), tt.buildSpec())


### PR DESCRIPTION
*Description of changes:*
Fixes a bug where machines didn't get deleted when removing worker node groups from the eks-a cluster object.

*Testing (if applicable):*
Unite tests and manual e2e with tilt

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

