### PR TITLE
fix secret creation during mgmt/workload topology creation work…

### DIFF
--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -1,3 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{.clusterName}}"
+  namespace: "{{.eksaSystemNamespace}}"
+data:
+  credentials: "{{.base64EncodedCredentials}}"
+---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: NutanixCluster
 metadata:

--- a/pkg/providers/nutanix/config/secret-template.yaml
+++ b/pkg/providers/nutanix/config/secret-template.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "{{.clusterName}}"
-  namespace: "{{.eksaSystemNamespace}}"
-data:
-  credentials: "{{.base64EncodedCredentials}}"

--- a/pkg/providers/nutanix/provider.go
+++ b/pkg/providers/nutanix/provider.go
@@ -187,7 +187,7 @@ func (p *Provider) UpdateSecrets(ctx context.Context, cluster *types.Cluster, cl
 func (p *Provider) GenerateCAPISpecForCreate(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	clusterName := clusterSpec.Cluster.Name
 
-	credsJSON, err := p.templateBuilder.getCredsJson()
+	credsJSON, err := p.templateBuilder.getCredsJSON()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/providers/nutanix/provider_test.go
+++ b/pkg/providers/nutanix/provider_test.go
@@ -274,6 +274,21 @@ func TestNutanixProviderGenerateCAPISpecForCreate(t *testing.T) {
 	provider := testDefaultNutanixProvider(t)
 	cluster := &types.Cluster{Name: "eksa-unit-test"}
 	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
+
+	storedMarshal := jsonMarshal
+	jsonMarshal = fakemarshal
+	defer restoremarshal(storedMarshal)
+
+	cpSpec, workerSpec, err := provider.GenerateCAPISpecForCreate(context.Background(), cluster, clusterSpec)
+	assert.Error(t, err)
+	assert.Nil(t, cpSpec)
+	assert.Nil(t, workerSpec)
+}
+
+func TestNutanixProviderGenerateCAPISpecForCreateFailedToGetCreds(t *testing.T) {
+	provider := testDefaultNutanixProvider(t)
+	cluster := &types.Cluster{Name: "eksa-unit-test"}
+	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
 	cpSpec, workerSpec, err := provider.GenerateCAPISpecForCreate(context.Background(), cluster, clusterSpec)
 	assert.NoError(t, err)
 	assert.NotNil(t, cpSpec)

--- a/pkg/providers/nutanix/provider_test.go
+++ b/pkg/providers/nutanix/provider_test.go
@@ -262,6 +262,14 @@ func TestNutanixProviderSetupAndValidateUpgradeCluster(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestNutanixProviderUpdateSecrets(t *testing.T) {
+	provider := testDefaultNutanixProvider(t)
+	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
+	cluster := &types.Cluster{Name: "eksa-unit-test"}
+	err := provider.UpdateSecrets(context.Background(), cluster, clusterSpec)
+	assert.NoError(t, err)
+}
+
 func TestNutanixProviderGenerateCAPISpecForCreate(t *testing.T) {
 	provider := testDefaultNutanixProvider(t)
 	cluster := &types.Cluster{Name: "eksa-unit-test"}
@@ -665,6 +673,14 @@ func TestNutanixProviderMachineDeploymentsToDelete(t *testing.T) {
 	deps := provider.MachineDeploymentsToDelete(cluster, clusterSpec, clusterSpec)
 	assert.NotNil(t, deps)
 	assert.Len(t, deps, 0)
+}
+
+func TestNutanixProviderPreCAPIInstallOnBootstrap(t *testing.T) {
+	provider := testDefaultNutanixProvider(t)
+	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
+	cluster := &types.Cluster{Name: "eksa-unit-test"}
+	err := provider.PreCAPIInstallOnBootstrap(context.Background(), cluster, clusterSpec)
+	assert.NoError(t, err)
 }
 
 func TestNutanixProviderPostMoveManagementToBootstrap(t *testing.T) {

--- a/pkg/providers/nutanix/provider_test.go
+++ b/pkg/providers/nutanix/provider_test.go
@@ -262,21 +262,6 @@ func TestNutanixProviderSetupAndValidateUpgradeCluster(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestNutanixProviderUpdateSecrets(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	executable := mockexecutables.NewMockExecutable(ctrl)
-	executable.EXPECT().ExecuteWithStdin(gomock.Any(), gomock.Any(), gomock.Any()).Return(bytes.Buffer{}, nil)
-	kubectl := executables.NewKubectl(executable)
-	mockClient := NewMockClient(ctrl)
-	mockCertValidator := mockCrypto.NewMockTlsValidator(ctrl)
-	provider := testNutanixProvider(t, mockClient, kubectl, mockCertValidator)
-
-	cluster := &types.Cluster{Name: "eksa-unit-test"}
-	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
-	err := provider.UpdateSecrets(context.Background(), cluster, clusterSpec)
-	assert.NoError(t, err)
-}
-
 func TestNutanixProviderGenerateCAPISpecForCreate(t *testing.T) {
 	provider := testDefaultNutanixProvider(t)
 	cluster := &types.Cluster{Name: "eksa-unit-test"}
@@ -680,21 +665,6 @@ func TestNutanixProviderMachineDeploymentsToDelete(t *testing.T) {
 	deps := provider.MachineDeploymentsToDelete(cluster, clusterSpec, clusterSpec)
 	assert.NotNil(t, deps)
 	assert.Len(t, deps, 0)
-}
-
-func TestNutanixProviderPreCAPIInstallOnBootstrap(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	executable := mockexecutables.NewMockExecutable(ctrl)
-	executable.EXPECT().ExecuteWithStdin(gomock.Any(), gomock.Any(), gomock.Any()).Return(bytes.Buffer{}, nil)
-	kubectl := executables.NewKubectl(executable)
-	mockClient := NewMockClient(ctrl)
-	mockCertValidator := mockCrypto.NewMockTlsValidator(ctrl)
-	provider := testNutanixProvider(t, mockClient, kubectl, mockCertValidator)
-
-	cluster := &types.Cluster{Name: "eksa-unit-test"}
-	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
-	err := provider.PreCAPIInstallOnBootstrap(context.Background(), cluster, clusterSpec)
-	assert.NoError(t, err)
 }
 
 func TestNutanixProviderPostMoveManagementToBootstrap(t *testing.T) {

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -83,7 +83,7 @@ func (ntb *TemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, w
 	return templater.AppendYamlResources(workerSpecs...), nil
 }
 
-func (ntb *TemplateBuilder) getCredsJson() ([]byte, error) {
+func (ntb *TemplateBuilder) getCredsJSON() ([]byte, error) {
 	encodedCreds, err := jsonMarshal(ntb.creds)
 	if err != nil {
 		return nil, err

--- a/pkg/providers/nutanix/template_test.go
+++ b/pkg/providers/nutanix/template_test.go
@@ -3,7 +3,6 @@ package nutanix
 import (
 	_ "embed"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
@@ -89,31 +88,4 @@ func TestNewNutanixTemplateBuilder(t *testing.T) {
 	workerSpec, err := builder.GenerateCAPISpecWorkers(buildSpec, workloadTemplateNames, kubeadmconfigTemplateNames)
 	assert.NoError(t, err)
 	assert.NotNil(t, workerSpec)
-
-	secretSpec, err := builder.GenerateCAPISpecSecret(buildSpec)
-	assert.NoError(t, err)
-	assert.NotNil(t, secretSpec)
-	expectedSecret, err := os.ReadFile("testdata/templated_secret.yaml")
-	require.NoError(t, err)
-	assert.Equal(t, expectedSecret, secretSpec)
-}
-
-func TestNewNutanixTemplateBuilderGenerateCAPISpecSecret(t *testing.T) {
-	storedMarshal := jsonMarshal
-	jsonMarshal = fakemarshal
-	defer restoremarshal(storedMarshal)
-
-	t.Setenv(constants.NutanixUsernameKey, "admin")
-	t.Setenv(constants.NutanixPasswordKey, "password")
-	creds := GetCredsFromEnv()
-	builder := NewNutanixTemplateBuilder(nil, nil, nil, nil, creds, time.Now)
-	assert.NotNil(t, builder)
-
-	v := version.Info{GitVersion: "v0.0.1"}
-	buildSpec, err := cluster.NewSpecFromClusterConfig("testdata/eksa-cluster.yaml", v, cluster.WithReleasesManifest("testdata/simple_release.yaml"))
-	assert.NoError(t, err)
-
-	secretSpec, err := builder.GenerateCAPISpecSecret(buildSpec)
-	assert.Nil(t, secretSpec)
-	assert.Error(t, err)
 }

--- a/pkg/providers/nutanix/template_test.go
+++ b/pkg/providers/nutanix/template_test.go
@@ -3,6 +3,7 @@ package nutanix
 import (
 	_ "embed"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -88,4 +89,11 @@ func TestNewNutanixTemplateBuilder(t *testing.T) {
 	workerSpec, err := builder.GenerateCAPISpecWorkers(buildSpec, workloadTemplateNames, kubeadmconfigTemplateNames)
 	assert.NoError(t, err)
 	assert.NotNil(t, workerSpec)
+
+	credJSON, err := builder.getCredsJSON()
+	assert.NoError(t, err)
+	assert.NotNil(t, credJSON)
+	expectedCredSecret, err := os.ReadFile("testdata/nutanix_secret_cred.json")
+	require.NoError(t, err)
+	assert.Equal(t, expectedCredSecret, credJSON)
 }

--- a/pkg/providers/nutanix/template_test.go
+++ b/pkg/providers/nutanix/template_test.go
@@ -97,3 +97,18 @@ func TestNewNutanixTemplateBuilder(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, expectedCredSecret, credJSON)
 }
+func TestNewNutanixTemplateBuilderGetCredsJSON(t *testing.T) {
+	storedMarshal := jsonMarshal
+	jsonMarshal = fakemarshal
+	defer restoremarshal(storedMarshal)
+
+	t.Setenv(constants.NutanixUsernameKey, "admin")
+	t.Setenv(constants.NutanixPasswordKey, "password")
+	creds := GetCredsFromEnv()
+	builder := NewNutanixTemplateBuilder(nil, nil, nil, nil, creds, time.Now)
+	assert.NotNil(t, builder)
+
+	credsJSON, err := builder.getCredsJSON()
+	assert.Nil(t, credsJSON)
+	assert.Error(t, err)
+}

--- a/pkg/providers/nutanix/testdata/nutanix_secret_cred.json
+++ b/pkg/providers/nutanix/testdata/nutanix_secret_cred.json
@@ -1,0 +1,1 @@
+[{"type":"basic_auth","data":{"prismCentral":{"username":"admin","password":"password"},"prismElements":null}}]

--- a/pkg/providers/nutanix/testdata/templated_secret.yaml
+++ b/pkg/providers/nutanix/testdata/templated_secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "eksa-unit-test"
-  namespace: "eksa-system"
-data:
-  credentials: "W3sidHlwZSI6ImJhc2ljX2F1dGgiLCJkYXRhIjp7InByaXNtQ2VudHJhbCI6eyJ1c2VybmFtZSI6ImFkbWluIiwicGFzc3dvcmQiOiJwYXNzd29yZCJ9LCJwcmlzbUVsZW1lbnRzIjpudWxsfX1d"


### PR DESCRIPTION
…flow

testing in progress

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

<pre>
✚  export CLUSTER_NAME=nutanix-dev-cluster   
export CLUSTER_NS=eksa-system
export NUTANIX_PROVIDER=true
export NUTANIX_USER=user
export NUTANIX_PASSWORD=pwd

✚  bin/eksctl-anywhere generate clusterconfig ${CLUSTER_NAME} --provider nutanix > ${CLUSTER_NAME}.yaml

✚  bin/eksctl-anywhere create cluster -f ./${CLUSTER_NAME}.yaml
WorkerNodeGroupConfigurations: UpgradeRolloutStrategy not specified in cluster config. CAPI will default to 'RollingUpdate' with maxSurge=1 and maxUnavailable=0
ControlPlaneConfiguration: UpgradeRolloutStrategy not specified in cluster config. CAPI will default to 'RollingUpdate' with maxSurge=1
WorkerNodeGroupConfigurations: UpgradeRolloutStrategy not specified in cluster config. CAPI will default to 'RollingUpdate' with maxSurge=1 and maxUnavailable=0
ControlPlaneConfiguration: UpgradeRolloutStrategy not specified in cluster config. CAPI will default to 'RollingUpdate' with maxSurge=1
Performing setup and validations
Warning: The nutanix infrastructure provider is still in development and should not be used in production
✅ Nutanix Provider setup is valid
✅ Validate certificate for registry mirror
✅ Validate authentication for git provider
✅ Create preflight validations pass
Creating new bootstrap cluster
Provider specific pre-capi-install-setup on bootstrap cluster
Installing cluster-api providers on bootstrap cluster
Provider specific post-setup
Creating new workload cluster
Installing networking on workload cluster
Creating EKS-A namespace
Installing cluster-api providers on workload cluster
Installing EKS-A secrets on workload cluster
Installing resources on management cluster
Moving cluster management from bootstrap to workload cluster
Installing EKS-A custom components (CRD and controller) on workload cluster
Installing EKS-D components on workload cluster
Creating EKS-A CRDs instances on workload cluster
Installing GitOps Toolkit on workload cluster
GitOps field not specified, bootstrap flux skipped
Writing cluster config file
Deleting bootstrap cluster
🎉 Cluster created!
--------------------------------------------------------------------------------------
The Amazon EKS Anywhere Curated Packages are only available to customers with the 
Amazon EKS Anywhere Enterprise Subscription
--------------------------------------------------------------------------------------
Enabling curated packages on the cluster
Installing helm chart on cluster	{"chart": "eks-anywhere-packages", "version": "0.2.20-eks-a-v0.0.0-dev-build.4895"}
secret/aws-secret created


 export CLUSTER_NAME=nutanix-dev-cluster-workload

 bin/eksctl-anywhere generate clusterconfig ${CLUSTER_NAME} --provider nutanix > ${CLUSTER_NAME}.yaml

 bin/eksctl-anywhere create cluster -f ./${CLUSTER_NAME}.yaml --kubeconfig nutanix-dev-cluster/nutanix-dev-cluster-eks-a-cluster.kubeconfig
WorkerNodeGroupConfigurations: UpgradeRolloutStrategy not specified in cluster config. CAPI will default to 'RollingUpdate' with maxSurge=1 and maxUnavailable=0
ControlPlaneConfiguration: UpgradeRolloutStrategy not specified in cluster config. CAPI will default to 'RollingUpdate' with maxSurge=1
WorkerNodeGroupConfigurations: UpgradeRolloutStrategy not specified in cluster config. CAPI will default to 'RollingUpdate' with maxSurge=1 and maxUnavailable=0
ControlPlaneConfiguration: UpgradeRolloutStrategy not specified in cluster config. CAPI will default to 'RollingUpdate' with maxSurge=1
Performing setup and validations
Warning: The nutanix infrastructure provider is still in development and should not be used in production
✅ Nutanix Provider setup is valid
✅ Validate certificate for registry mirror
✅ Validate authentication for git provider
✅ Validate cluster name
✅ Validate gitops
✅ Validate identity providers' name
✅ Validate management cluster has eksa crds
✅ Create preflight validations pass
Creating new workload cluster
Installing networking on workload cluster
Creating EKS-A CRDs instances on workload cluster
Installing GitOps Toolkit on workload cluster
GitOps field not specified, bootstrap flux skipped
Writing cluster config file
🎉 Cluster created!
--------------------------------------------------------------------------------------
The Amazon EKS Anywhere Curated Packages are only available to customers with the 
Amazon EKS Anywhere Enterprise Subscription
--------------------------------------------------------------------------------------
Enabling curated packages on the cluster
packagebundlecontroller.packages.eks.amazonaws.com/nutanix-dev-cluster-workload created
</pre>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

