### PR TITLE
Wait until status is refreshed in cache in envtest

### DIFF
--- a/internal/test/envtest/client.go
+++ b/internal/test/envtest/client.go
@@ -10,7 +10,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,29 +35,93 @@ func CreateObjs(ctx context.Context, t testing.TB, c client.Client, objs ...clie
 		}
 	}
 
-	for _, o := range objs {
-		obj := copyObject(t, o)
-		objReady := waitForObjectReady(ctx, t, c, obj)
+	newStatuses := []updatedStatus{}
 
-		// We need to update the status independently, kubernetes doesn't allow to create the main objects and
-		// its subresources all at once
-		obj.SetResourceVersion(objReady.GetResourceVersion())
-		if err := c.Status().Update(ctx, obj); apierrors.IsNotFound(err) {
-			// There is not easy way to check if an object has a status subresource
-			// So we just try and if it fails with a 404, we ignore the error
-			t.Logf(
-				"Try updating status but failed with a 404 error for [%s name=%s namespace=%s] object, most probably because it doesn't have a defined status subresource",
-				obj.GetObjectKind().GroupVersionKind().String(),
-				obj.GetName(),
-				obj.GetNamespace(),
-			)
-		} else if err != nil {
-			t.Fatal(err)
+	for _, o := range objs {
+		newStatus := updateStatus(ctx, t, c, o)
+		if newStatus != nil {
+			newStatuses = append(newStatuses, updatedStatus{
+				obj:       o,
+				newStatus: newStatus,
+			})
 		}
+	}
+	for _, u := range newStatuses {
+		waitForStatusUpdated(ctx, t, c, u.obj, u.newStatus)
 	}
 }
 
-func waitForObjectReady(ctx context.Context, t testing.TB, c client.Client, obj client.Object) client.Object {
+type updatedStatus struct {
+	obj       client.Object
+	newStatus map[string]interface{}
+}
+
+// UpdateStatusAndWait updates an objects status subresource and waits until the cache refreshes
+// and reflects the new status.
+func UpdateStatusAndWait(ctx context.Context, t testing.TB, c client.Client, o client.Object) {
+	newStatus := updateStatus(ctx, t, c, o)
+	if newStatus != nil {
+		waitForStatusUpdated(ctx, t, c, o, newStatus)
+	}
+}
+
+func updateStatus(ctx context.Context, t testing.TB, c client.Client, o client.Object) (newStatus map[string]interface{}) {
+	objUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(o)
+	if err != nil {
+		t.Fatalf("Failed converting object %s to unstructured: %v", klog.KObj(o), err)
+	}
+	obj := &unstructured.Unstructured{Object: objUnstructured}
+
+	newStatus, found, err := unstructured.NestedMap(objUnstructured, "status")
+	if err != nil {
+		t.Fatalf("Failed checking status for object %s: %v", klog.KObj(obj), err)
+	}
+	if !found || len(newStatus) == 0 {
+		return nil
+	}
+
+	objReady := waitForObjectReady(ctx, t, c, obj)
+
+	// We need to update the status independently, kubernetes doesn't allow to create the main objects and
+	// its subresources all at once
+	obj.SetResourceVersion(objReady.GetResourceVersion())
+	if err := c.Status().Update(ctx, obj); apierrors.IsNotFound(err) {
+		// Some objects without a subresource will fail here,
+		// so we just try and if it fails with a 404, we ignore the error
+		t.Logf(
+			"Try updating status but failed with a 404 error for [%s name=%s namespace=%s] object, most probably because it doesn't have a defined status subresource",
+			obj.GetObjectKind().GroupVersionKind().String(),
+			obj.GetName(),
+			obj.GetNamespace(),
+		)
+	} else if err != nil {
+		t.Fatal(err)
+	}
+
+	return newStatus
+}
+
+func waitForStatusUpdated(ctx context.Context, t testing.TB, c client.Client, o client.Object, newStatus map[string]interface{}) {
+	g := gomega.NewWithT(t)
+	g.Eventually(func(g gomega.Gomega) error {
+		updatedObj := &unstructured.Unstructured{}
+		updatedObj.SetGroupVersionKind(o.GetObjectKind().GroupVersionKind())
+		g.Expect(
+			c.Get(ctx, types.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}, updatedObj),
+		).To(gomega.Succeed())
+
+		updatedStatus, found, err := unstructured.NestedMap(updatedObj.Object, "status")
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		if !found {
+			return errors.New("no status found in updated object")
+		}
+		g.Expect(updatedStatus).To(gomega.Equal(newStatus), "updated status should be equal to desired status")
+
+		return nil
+	}, 5*time.Second).Should(gomega.Succeed(), "the status should be updated")
+}
+
+func waitForObjectReady(ctx context.Context, t testing.TB, c client.Client, obj client.Object) *unstructured.Unstructured {
 	unstructuredObj := &unstructured.Unstructured{}
 	for {
 		unstructuredObj.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())

--- a/internal/test/envtest/client_test.go
+++ b/internal/test/envtest/client_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -69,23 +70,21 @@ func TestCreateObjs(t *testing.T) {
 			Namespace: "eksa-system",
 		},
 	}
-
-	envtest.CreateObjs(ctx, t, client, secret, cm)
-}
-
-func TestCreateObjsErrorGet(t *testing.T) {
-	client := fake.NewClientBuilder().Build()
-	ctx := context.Background()
-	secret := &corev1.Secret{
+	pod := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "s",
+			Name:      "my-pod",
 			Namespace: "eksa-system",
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas: 10,
 		},
 	}
 
-	expectToFailTest(t, func(tb testing.TB) {
-		envtest.CreateObjs(ctx, tb, client, secret)
-	})
+	envtest.CreateObjs(ctx, t, client, secret, cm, pod)
 }
 
 func TestCreateObjsErrorCreate(t *testing.T) {

--- a/internal/test/testdata.go
+++ b/internal/test/testdata.go
@@ -12,7 +12,7 @@ import (
 func Namespace(name string) *corev1.Namespace {
 	return &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "namespace",
+			Kind:       "Namespace",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/providers/snow/reconciler/reconciler.go
+++ b/pkg/providers/snow/reconciler/reconciler.go
@@ -83,7 +83,7 @@ func (r *Reconciler) ValidateMachineConfigs(ctx context.Context, log logr.Logger
 				clusterSpec.Cluster.Status.FailureMessage = &failureMessage
 				log.Error(errors.New(*machineConfig.Status.FailureMessage), "Invalid SnowMachineConfig", "machineConfig", klog.KObj(machineConfig))
 			} else {
-				log.Info("SnowMachineConfig hasn't been validated yet", klog.KObj(machineConfig))
+				log.Info("SnowMachineConfig hasn't been validated yet", "machineConfig", klog.KObj(machineConfig))
 			}
 
 			return controller.ResultWithReturn(), nil


### PR DESCRIPTION
## Description of changes
If we don't wait for the subresource to be updated, there can be race conditions where the status still has the default value when reading from the cache. If the tests rely on the status to be updated to spec, this could cause flakiness.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

