### PR TITLE
Ensure users download latest version of imagebuilder CLI for building node images

### DIFF
--- a/docs/content/en/docs/reference/artifacts.md
+++ b/docs/content/en/docs/reference/artifacts.md
@@ -434,7 +434,7 @@ These steps use `image-builder` to create an Ubuntu-based Amazon Machine Image (
 1. Install packages and prepare environment:
    ```
    sudo apt update -y
-   sudo apt install jq unzip make ansible python3-pip -y
+   sudo apt install gh jq unzip make ansible python3-pip -y
    sudo snap install yq
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
@@ -444,7 +444,8 @@ These steps use `image-builder` to create an Ubuntu-based Amazon Machine Image (
    
    ```bash
     cd /tmp
-    sudo wget https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.0.0-dev-build.4813/image-builder/0.1.2/image-builder-v0.0.0-dev-build.4813-linux-amd64.tar.gz
+    LATEST_WEEKLY_RELEASE=$(gh release list --repo aws/eks-anywhere | grep Weekly | awk 'NR==1 {print $5}')
+    gh release download $LATEST_WEEKLY_RELEASE --pattern "image-builder*.tar.gz"
     sudo tar xvf image-builder*.tar.gz
     sudo cp image-builder /usr/local/bin
     ```


### PR DESCRIPTION
Instead of pointing to a static version of the image-builder CLI, this instructs users to fetch the latest weekly development build of the image-builder tarball.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

