### PR TITLE
Update stale labeler with new requirements

### DIFF
--- a/.github/workflows/stale-labeler.yaml
+++ b/.github/workflows/stale-labeler.yaml
@@ -1,14 +1,14 @@
-# Stale issue handler (could also be extended for stale PRs in future)
+# Stale labeler for PRs and issues
 
 # This action will: 
-# * Add a label "stale" on issues after 60 days of inactivity and comment on them if they also have the "external" label
+# * Add a label "stale" on issues and PRs after STALE_DAYS of inactivity and comment on them if they also have the "external" label
 # * Close the stale issues and pull requests after 7 days of inactivity
 # * If an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restart if they have the "external" label
 
 # Runs every morning at 1AM: We don't want people having to wait a whole week to get the stale label removed 
 # Docs: https://github.com/actions/stale
 
-name: 'Label and close stale issues'
+name: 'Label and close stale issues and PRs'
 on:
   schedule:
     - cron: '0 1 * * *'

--- a/.github/workflows/stale-labeler.yaml
+++ b/.github/workflows/stale-labeler.yaml
@@ -19,17 +19,21 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          days-before-stale: ${{ env.STALE_DAYS }}
-          days-before-close: ${{ env.CLOSE_AFTER_DAYS }}
+          days-before-issue-stale: ${{ env.ISSUE_STALE_DAYS }}
+          days-before-issue-close: ${{ env.ISSUE_CLOSE_AFTER_DAYS }}
+          days-before-pr-stale: -1 # With a negative number, this is currently turned off
+          days-before-pr-close: -1 # With a negative number, this is currently turned off
           stale-issue-message: >
             There has been no activity on this issue for ${{ env.STALE_DAYS }} days. 
             Labeling as stale and closing in ${{ env.CLOSE_AFTER_DAYS }} days if no further activity.
           stale-pr-message: >
-            There has been no activity on this PR for ${{ env.STALE_DAYS }} days. 
-            Labeling as stale and closing in ${{ env.CLOSE_AFTER_DAYS }} days if no further activity.
+            There has been no activity on this PR for ${{ env.PR_STALE_DAYS }} days. 
+            Labeling as stale and closing in ${{ env.PR_CLOSE_AFTER_DAYS }} days if no further activity.
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          any-of-labels: 'external'
+          only-issue-labels: 'status/needsinfo,priority/p2' # Only checks issues that have these labels 
 env:
-  STALE_DAYS: 60
-  CLOSE_AFTER_DAYS: 7
+  ISSUE_STALE_DAYS: 0
+  ISSUE_CLOSE_AFTER_DAYS: 7
+  PR_STALE_DAYS: 60
+  PR_CLOSE_AFTER_DAYS: 7

--- a/.github/workflows/stale-labeler.yaml
+++ b/.github/workflows/stale-labeler.yaml
@@ -31,7 +31,7 @@ jobs:
             Labeling as stale and closing in ${{ env.PR_CLOSE_AFTER_DAYS }} days if no further activity.
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          only-issue-labels: 'status/needsinfo,priority/p2' # Only checks issues that have these labels 
+          any-of-issue-labels: 'status/needinfo,priority/p2' # Only checks issues that have any of these labels 
 env:
   ISSUE_STALE_DAYS: 0
   ISSUE_CLOSE_AFTER_DAYS: 7

--- a/.github/workflows/stale-labeler.yaml
+++ b/.github/workflows/stale-labeler.yaml
@@ -31,5 +31,5 @@ jobs:
           stale-pr-label: 'stale'
           any-of-labels: 'external'
 env:
-  STALE_DAYS: 60
+  STALE_DAYS: 0
   CLOSE_AFTER_DAYS: 7

--- a/.github/workflows/stale-labeler.yaml
+++ b/.github/workflows/stale-labeler.yaml
@@ -31,5 +31,5 @@ jobs:
           stale-pr-label: 'stale'
           any-of-labels: 'external'
 env:
-  STALE_DAYS: 0
+  STALE_DAYS: 60
   CLOSE_AFTER_DAYS: 7

--- a/.github/workflows/stale-labeler.yaml
+++ b/.github/workflows/stale-labeler.yaml
@@ -33,7 +33,7 @@ jobs:
           stale-pr-label: 'stale'
           any-of-issue-labels: 'status/needinfo,priority/p2' # Only checks issues that have any of these labels 
 env:
-  ISSUE_STALE_DAYS: 0
+  ISSUE_STALE_DAYS: 60
   ISSUE_CLOSE_AFTER_DAYS: 7
   PR_STALE_DAYS: 60
   PR_CLOSE_AFTER_DAYS: 7

--- a/.github/workflows/stale-labeler.yaml
+++ b/.github/workflows/stale-labeler.yaml
@@ -24,8 +24,8 @@ jobs:
           days-before-pr-stale: -1 # With a negative number, this is currently turned off
           days-before-pr-close: -1 # With a negative number, this is currently turned off
           stale-issue-message: >
-            There has been no activity on this issue for ${{ env.STALE_DAYS }} days. 
-            Labeling as stale and closing in ${{ env.CLOSE_AFTER_DAYS }} days if no further activity.
+            There has been no activity on this issue for ${{ env.ISSUE_STALE_DAYS }} days. 
+            Labeling as stale and closing in ${{ env.ISSUE_CLOSE_AFTER_DAYS }} days if no further activity.
           stale-pr-message: >
             There has been no activity on this PR for ${{ env.PR_STALE_DAYS }} days. 
             Labeling as stale and closing in ${{ env.PR_CLOSE_AFTER_DAYS }} days if no further activity.

--- a/.github/workflows/stale-labeler.yaml
+++ b/.github/workflows/stale-labeler.yaml
@@ -8,7 +8,7 @@
 # Runs every morning at 1AM: We don't want people having to wait a whole week to get the stale label removed 
 # Docs: https://github.com/actions/stale
 
-name: 'Label and close stale issues and PRs'
+name: 'Stale Labeler and Closer'
 on:
   schedule:
     - cron: '0 1 * * *'

--- a/.github/workflows/stale-mgr.yaml
+++ b/.github/workflows/stale-mgr.yaml
@@ -19,13 +19,17 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          days-before-stale: ${{ env.ISSUE_STALE_DAYS }}
-          days-before-close: ${{ env.ISSUE_CLOSE_AFTER_DAYS }}
+          days-before-stale: ${{ env.STALE_DAYS }}
+          days-before-close: ${{ env.CLOSE_AFTER_DAYS }}
           stale-issue-message: >
-            This issue has had no activity for ${{ env.ISSUE_STALE_DAYS }} days. 
-            Labeling as stale and closing in ${{ env.ISSUE_CLOSE_AFTER_DAYS }} days if no further activity.
+            There has been no activity on this issue for ${{ env.STALE_DAYS }} days. 
+            Labeling as stale and closing in ${{ env.CLOSE_AFTER_DAYS }} days if no further activity.
+          stale-pr-message: >
+            There has been no activity on this PR for ${{ env.STALE_DAYS }} days. 
+            Labeling as stale and closing in ${{ env.CLOSE_AFTER_DAYS }} days if no further activity.
           stale-issue-label: 'stale'
-          any-of-issue-labels: 'external'
+          stale-pr-label: 'stale'
+          any-of-labels: 'external'
 env:
-  ISSUE_STALE_DAYS: 60
-  ISSUE_CLOSE_AFTER_DAYS: 7
+  STALE_DAYS: 60
+  CLOSE_AFTER_DAYS: 7


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Makes some changes to the stale labeler after talking with @drewvanstone :
* Toggles off labeler for PRs but puts a few values in place for if we turn it on. 
* Renames the file to be more general
* Checks against issues already labeled with `status/needinfo` and `priority/p2` only, instead of `external`

*Testing (if applicable):*
Tested on my fork

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

