### PR TITLE
Add some extra messaging when secret creation fails

### DIFF
--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -124,7 +124,7 @@ func (pc *PackageControllerClient) EnableCuratedPackages(ctx context.Context) er
 //   - Creating a single run of the cron job to ensure the secret is consumed
 func (pc *PackageControllerClient) CreateCredentials(ctx context.Context) error {
 	if err := pc.ApplySecret(ctx); err != nil {
-		return errors.New("environment variables EKSA_AWS_SECRET_ACCESS_KEY and EKSA_AWS_ACCESS_KEY_ID not provided")
+		return errors.New("unable to detect AWS authentication credentials for curated packages. Skipping package installation. Follow documentation to set credentials after cluster creation completes")
 	}
 
 	return nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

