### PR TITLE
Adding artifacts and logs generated by e2e tool to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ support-bundle*
 /.ignore
 coverage.out
 docs/.hugo_build.lock
+*-logs
+*-artifacts


### PR DESCRIPTION
*Description of changes:*
Adding a gitignore on files downloaded by e2e tool.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

