### PR TITLE
Add `insecure` property for NutanixDatacenterConfig

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_nutanixdatacenterconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_nutanixdatacenterconfigs.yaml
@@ -46,6 +46,17 @@ spec:
               endpoint:
                 description: Endpoint is the Endpoint of Nutanix Prism Central
                 type: string
+              insecure:
+                description: "Insecure is the optional flag to skip TLS verification.
+                  Nutanix Prism installs by default ship with a self-signed certificate
+                  that will fail TLS verification because of two reasons: 1. The certificate
+                  is not issued by a public CA 2. The certificate does not have the
+                  IP SANs for the Prism Central endpoint \n To accommodate for the
+                  scenario where the user has not changed the default Certificate
+                  that ships with Prism Central, we allow the user to skip TLS verification.
+                  This is not recommended for production use as skipping TLS verification
+                  opens up the user to potential MITM attacks."
+                type: boolean
               port:
                 description: Port is the Port of Nutanix Prism Central
                 minimum: 9440

--- a/config/crd/bases/anywhere.eks.amazonaws.com_nutanixdatacenterconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_nutanixdatacenterconfigs.yaml
@@ -47,15 +47,14 @@ spec:
                 description: Endpoint is the Endpoint of Nutanix Prism Central
                 type: string
               insecure:
-                description: "Insecure is the optional flag to skip TLS verification.
-                  Nutanix Prism installs by default ship with a self-signed certificate
-                  that will fail TLS verification because of two reasons: 1. The certificate
-                  is not issued by a public CA 2. The certificate does not have the
-                  IP SANs for the Prism Central endpoint \n To accommodate for the
-                  scenario where the user has not changed the default Certificate
-                  that ships with Prism Central, we allow the user to skip TLS verification.
-                  This is not recommended for production use as skipping TLS verification
-                  opens up the user to potential MITM attacks."
+                description: Insecure is the optional flag to skip TLS verification.
+                  Nutanix Prism Central installation by default ships with a self-signed
+                  certificate that will fail TLS verification because the certificate
+                  is not issued by a public CA and does not have the IP SANs with
+                  the Prism Central endpoint. To accommodate the scenario where the
+                  user has not changed the default Certificate that ships with Prism
+                  Central, we allow the user to skip TLS verification. This is not
+                  recommended for production use.
                 type: boolean
               port:
                 description: Port is the Port of Nutanix Prism Central

--- a/internal/pkg/api/nutanix.go
+++ b/internal/pkg/api/nutanix.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/templater"
 )
 
+// NutanixConfig is a wrapper for the Nutanix provider spec.
 type NutanixConfig struct {
 	datacenterConfig *anywherev1.NutanixDatacenterConfig
 	machineConfigs   map[string]*anywherev1.NutanixMachineConfig
@@ -35,6 +36,7 @@ func newNutanixConfig(filename string) (*NutanixConfig, error) {
 	return nutanixConfig, nil
 }
 
+// AutoFillNutanixProvider fills in the fields for the Nutanix provider spec.
 func AutoFillNutanixProvider(filename string, fillers ...NutanixFiller) ([]byte, error) {
 	nutanixConfig, err := newNutanixConfig(filename)
 	if err != nil {
@@ -63,36 +65,43 @@ func AutoFillNutanixProvider(filename string, fillers ...NutanixFiller) ([]byte,
 	return templater.AppendYamlResources(yamlResources...), nil
 }
 
+// WithNutanixStringFromEnvVar returns a NutanixFiller that sets the given string value to the given environment variable.
 func WithNutanixStringFromEnvVar(envVar string, opt func(string) NutanixFiller) NutanixFiller {
 	return opt(os.Getenv(envVar))
 }
 
+// WithNutanixIntFromEnvVar returns a NutanixFiller that sets the given integer value to the given environment variable.
 func WithNutanixIntFromEnvVar(envVar string, opt func(int) NutanixFiller) NutanixFiller {
 	intVar, _ := strconv.Atoi(os.Getenv(envVar))
 	return opt(intVar)
 }
 
+// WithNutanixInt32FromEnvVar returns a NutanixFiller that sets the given int32 value to the given environment variable.
 func WithNutanixInt32FromEnvVar(envVar string, opt func(int32) NutanixFiller) NutanixFiller {
 	intVar, _ := strconv.Atoi(os.Getenv(envVar))
 	return opt(int32(intVar))
 }
 
+// WithNutanixBoolFromEnvVar returns a NutanixFiller that sets the given int32 value to the given environment variable.
 func WithNutanixBoolFromEnvVar(envVar string, opt func(bool) NutanixFiller) NutanixFiller {
 	return opt(os.Getenv(envVar) == "true")
 }
 
+// WithNutanixEndpoint returns a NutanixFiller that sets the endpoint for the Nutanix provider.
 func WithNutanixEndpoint(value string) NutanixFiller {
 	return func(config *NutanixConfig) {
 		config.datacenterConfig.Spec.Endpoint = value
 	}
 }
 
+// WithNutanixPort returns a NutanixFiller that sets the port for the Nutanix provider.
 func WithNutanixPort(value int) NutanixFiller {
 	return func(config *NutanixConfig) {
 		config.datacenterConfig.Spec.Port = value
 	}
 }
 
+// WithNutanixAdditionalTrustBundle returns a NutanixFiller that sets the additional trust bundle for the Nutanix provider.
 func WithNutanixAdditionalTrustBundle(value string) NutanixFiller {
 	return func(config *NutanixConfig) {
 		certificate, err := base64.StdEncoding.DecodeString(value)
@@ -104,6 +113,14 @@ func WithNutanixAdditionalTrustBundle(value string) NutanixFiller {
 	}
 }
 
+// WithNutanixInsecure returns a NutanixFiller that sets the insecure for the Nutanix provider.
+func WithNutanixInsecure(value bool) NutanixFiller {
+	return func(config *NutanixConfig) {
+		config.datacenterConfig.Spec.Insecure = value
+	}
+}
+
+// WithNutanixMachineMemorySize returns a NutanixFiller that sets the memory size for the Nutanix machine.
 func WithNutanixMachineMemorySize(value string) NutanixFiller {
 	return func(config *NutanixConfig) {
 		for _, m := range config.machineConfigs {
@@ -112,6 +129,7 @@ func WithNutanixMachineMemorySize(value string) NutanixFiller {
 	}
 }
 
+// WithNutanixMachineSystemDiskSize returns a NutanixFiller that sets the system disk size for the Nutanix machine.
 func WithNutanixMachineSystemDiskSize(value string) NutanixFiller {
 	return func(config *NutanixConfig) {
 		for _, m := range config.machineConfigs {
@@ -120,6 +138,7 @@ func WithNutanixMachineSystemDiskSize(value string) NutanixFiller {
 	}
 }
 
+// WithNutanixMachineVCPUsPerSocket returns a NutanixFiller that sets the vCPUs per socket for the Nutanix machine.
 func WithNutanixMachineVCPUsPerSocket(value int32) NutanixFiller {
 	return func(config *NutanixConfig) {
 		for _, m := range config.machineConfigs {
@@ -128,6 +147,7 @@ func WithNutanixMachineVCPUsPerSocket(value int32) NutanixFiller {
 	}
 }
 
+// WithNutanixMachineVCPUSocket returns a NutanixFiller that sets the vCPU sockets for the Nutanix machine.
 func WithNutanixMachineVCPUSocket(value int32) NutanixFiller {
 	return func(config *NutanixConfig) {
 		for _, m := range config.machineConfigs {
@@ -136,6 +156,7 @@ func WithNutanixMachineVCPUSocket(value int32) NutanixFiller {
 	}
 }
 
+// WithNutanixMachineTemplateImageName returns a NutanixFiller that sets the image name for the Nutanix machine template.
 func WithNutanixMachineTemplateImageName(value string) NutanixFiller {
 	return func(config *NutanixConfig) {
 		for _, m := range config.machineConfigs {
@@ -153,6 +174,7 @@ func WithOsFamilyForAllNutanixMachines(value anywherev1.OSFamily) NutanixFiller 
 	}
 }
 
+// WithNutanixSubnetName returns a NutanixFiller that sets the subnet name for the Nutanix machine.
 func WithNutanixSubnetName(value string) NutanixFiller {
 	return func(config *NutanixConfig) {
 		for _, m := range config.machineConfigs {
@@ -161,6 +183,7 @@ func WithNutanixSubnetName(value string) NutanixFiller {
 	}
 }
 
+// WithNutanixPrismElementClusterName returns a NutanixFiller that sets the cluster name for the Nutanix machine.
 func WithNutanixPrismElementClusterName(value string) NutanixFiller {
 	return func(config *NutanixConfig) {
 		for _, m := range config.machineConfigs {
@@ -169,6 +192,7 @@ func WithNutanixPrismElementClusterName(value string) NutanixFiller {
 	}
 }
 
+// WithNutanixMachineTemplateImageUUID returns a NutanixFiller that sets the image UUID for the Nutanix machine.
 func WithNutanixMachineTemplateImageUUID(value string) NutanixFiller {
 	return func(config *NutanixConfig) {
 		for _, m := range config.machineConfigs {
@@ -177,6 +201,7 @@ func WithNutanixMachineTemplateImageUUID(value string) NutanixFiller {
 	}
 }
 
+// WithNutanixSubnetUUID returns a NutanixFiller that sets the subnet UUID for the Nutanix machine.
 func WithNutanixSubnetUUID(value string) NutanixFiller {
 	return func(config *NutanixConfig) {
 		for _, m := range config.machineConfigs {
@@ -185,6 +210,7 @@ func WithNutanixSubnetUUID(value string) NutanixFiller {
 	}
 }
 
+// WithNutanixPrismElementClusterUUID returns a NutanixFiller that sets the cluster UUID for the Nutanix machine.
 func WithNutanixPrismElementClusterUUID(value string) NutanixFiller {
 	return func(config *NutanixConfig) {
 		for _, m := range config.machineConfigs {
@@ -193,6 +219,7 @@ func WithNutanixPrismElementClusterUUID(value string) NutanixFiller {
 	}
 }
 
+// WithNutanixSSHAuthorizedKey returns a NutanixFiller that sets the SSH authorized key for the Nutanix machine.
 func WithNutanixSSHAuthorizedKey(value string) NutanixFiller {
 	return func(config *NutanixConfig) {
 		for _, m := range config.machineConfigs {

--- a/internal/pkg/api/nutanix_test.go
+++ b/internal/pkg/api/nutanix_test.go
@@ -26,6 +26,9 @@ func TestNutanixDatacenterConfigFillers(t *testing.T) {
 
 	WithNutanixPort(8080)(conf)
 	g.Expect(conf.datacenterConfig.Spec.Port).To(Equal(8080))
+
+	WithNutanixInsecure(true)(conf)
+	g.Expect(conf.datacenterConfig.Spec.Insecure).To(Equal(true))
 }
 
 func TestNutanixMachineConfigFillers(t *testing.T) {

--- a/pkg/api/v1alpha1/nutanixdatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/nutanixdatacenterconfig_types.go
@@ -26,6 +26,16 @@ type NutanixDatacenterConfigSpec struct {
 	// AdditionalTrustBundle is the optional PEM-encoded certificate bundle for users that
 	// configured their Prism Central with certificates from non-publicly trusted CAs
 	AdditionalTrustBundle string `json:"additionalTrustBundle,omitempty"`
+
+	// Insecure is the optional flag to skip TLS verification. Nutanix Prism installs by default ship
+	// with a self-signed certificate that will fail TLS verification because of two reasons:
+	// 1. The certificate is not issued by a public CA
+	// 2. The certificate does not have the IP SANs for the Prism Central endpoint
+	//
+	// To accommodate for the scenario where the user has not changed the default Certificate that
+	// ships with Prism Central, we allow the user to skip TLS verification. This is not recommended for
+	// production use as skipping TLS verification opens up the user to potential MITM attacks.
+	Insecure bool `json:"insecure,omitempty"`
 }
 
 // NutanixDatacenterConfigStatus defines the observed state of NutanixDatacenterConfig.

--- a/pkg/api/v1alpha1/nutanixdatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/nutanixdatacenterconfig_types.go
@@ -23,16 +23,18 @@ type NutanixDatacenterConfigSpec struct {
 	// +kubebuilder:validation:Minimum=9440
 	Port int `json:"port"`
 
-	// AdditionalTrustBundle is the optional PEM-encoded certificate bundle for users that
-	// configured their Prism Central with certificates from non-publicly trusted CAs
+	// AdditionalTrustBundle is the optional PEM-encoded certificate bundle for
+	// users that configured their Prism Central with certificates from non-publicly
+	// trusted CAs
 	AdditionalTrustBundle string `json:"additionalTrustBundle,omitempty"`
 
-	// Insecure is the optional flag to skip TLS verification. Nutanix Prism Central installation by default ships
-	// with a self-signed certificate that will fail TLS verification because the certificate is not issued by
+	// Insecure is the optional flag to skip TLS verification. Nutanix Prism
+	// Central installation by default ships with a self-signed certificate
+	// that will fail TLS verification because the certificate is not issued by
 	// a public CA and does not have the IP SANs with the Prism Central endpoint.
-	// To accommodate the scenario where the user has not changed the default Certificate that
-	// ships with Prism Central, we allow the user to skip TLS verification. This is not recommended for
-	// production use.
+	// To accommodate the scenario where the user has not changed the default
+	// Certificate that ships with Prism Central, we allow the user to skip TLS
+	// verification. This is not recommended for production use.
 	Insecure bool `json:"insecure,omitempty"`
 }
 

--- a/pkg/api/v1alpha1/nutanixdatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/nutanixdatacenterconfig_types.go
@@ -27,14 +27,12 @@ type NutanixDatacenterConfigSpec struct {
 	// configured their Prism Central with certificates from non-publicly trusted CAs
 	AdditionalTrustBundle string `json:"additionalTrustBundle,omitempty"`
 
-	// Insecure is the optional flag to skip TLS verification. Nutanix Prism installs by default ship
-	// with a self-signed certificate that will fail TLS verification because of two reasons:
-	// 1. The certificate is not issued by a public CA
-	// 2. The certificate does not have the IP SANs for the Prism Central endpoint
-	//
-	// To accommodate for the scenario where the user has not changed the default Certificate that
+	// Insecure is the optional flag to skip TLS verification. Nutanix Prism Central installation by default ships
+	// with a self-signed certificate that will fail TLS verification because the certificate is not issued by
+	// a public CA and does not have the IP SANs with the Prism Central endpoint.
+	// To accommodate the scenario where the user has not changed the default Certificate that
 	// ships with Prism Central, we allow the user to skip TLS verification. This is not recommended for
-	// production use as skipping TLS verification opens up the user to potential MITM attacks.
+	// production use.
 	Insecure bool `json:"insecure,omitempty"`
 }
 

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -1216,6 +1216,7 @@ func (f *Factory) WithPrismClient(clusterConfigFile string) *Factory {
 			Password: creds.PrismCentral.Password,
 			Endpoint: endpoint,
 			Port:     fmt.Sprintf("%d", port),
+			Insecure: datacenterConfig.Spec.Insecure,
 		}
 
 		client, err := v3.NewV3Client(nutanixCreds, clientOpts...)

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -149,6 +149,7 @@ func buildTemplateMapCP(
 		"nutanixEndpoint":              datacenterSpec.Endpoint,
 		"nutanixPort":                  datacenterSpec.Port,
 		"nutanixAdditionalTrustBundle": datacenterSpec.AdditionalTrustBundle,
+		"nutanixInsecure":              datacenterSpec.Insecure,
 		"vcpusPerSocket":               controlPlaneMachineSpec.VCPUsPerSocket,
 		"vcpuSockets":                  controlPlaneMachineSpec.VCPUSockets,
 		"memorySize":                   controlPlaneMachineSpec.MemorySize.String(),
@@ -157,7 +158,6 @@ func buildTemplateMapCP(
 		"nutanixPEClusterName":         controlPlaneMachineSpec.Cluster.Name, // TODO(nutanix): pass name or uuid based on type of identifier
 		"subnetName":                   controlPlaneMachineSpec.Subnet.Name,  // TODO(nutanix): pass name or uuid based on type of identifier
 	}
-	values["nutanixInsecure"] = datacenterSpec.AdditionalTrustBundle != ""
 
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		values["externalEtcd"] = true

--- a/pkg/providers/nutanix/template_test.go
+++ b/pkg/providers/nutanix/template_test.go
@@ -26,6 +26,9 @@ var nutanixDatacenterConfigSpec string
 //go:embed testdata/datacenterConfig_with_trust_bundle.yaml
 var nutanixDatacenterConfigSpecWithTrustBundle string
 
+//go:embed testdata/datacenterConfig_with_insecure.yaml
+var nutanixDatacenterConfigSpecWithInsecure string
+
 //go:embed testdata/eksa-cluster.json
 var nutanixClusterConfigSpecJSON string
 

--- a/pkg/providers/nutanix/testdata/datacenterConfig_with_insecure.yaml
+++ b/pkg/providers/nutanix/testdata/datacenterConfig_with_insecure.yaml
@@ -1,0 +1,9 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440
+  insecure: true

--- a/pkg/providers/nutanix/validator.go
+++ b/pkg/providers/nutanix/validator.go
@@ -11,6 +11,7 @@ import (
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/crypto"
+	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
 // Validator is a client to validate nutanix resources.
@@ -29,6 +30,9 @@ func NewValidator(client Client, certValidator crypto.TlsValidator) *Validator {
 
 // ValidateDatacenterConfig validates the datacenter config.
 func (v *Validator) ValidateDatacenterConfig(ctx context.Context, config *anywherev1.NutanixDatacenterConfig) error {
+	if config.Spec.Insecure {
+		logger.Info("WARNING: Skipping TLS validation for insecure connection; this is not recommended for production use")
+	}
 	return v.validateTrustBundleConfig(config.Spec)
 }
 

--- a/pkg/providers/nutanix/validator.go
+++ b/pkg/providers/nutanix/validator.go
@@ -31,7 +31,7 @@ func NewValidator(client Client, certValidator crypto.TlsValidator) *Validator {
 // ValidateDatacenterConfig validates the datacenter config.
 func (v *Validator) ValidateDatacenterConfig(ctx context.Context, config *anywherev1.NutanixDatacenterConfig) error {
 	if config.Spec.Insecure {
-		logger.Info("WARNING: Skipping TLS validation for insecure connection; this is not recommended for production use")
+		logger.Info("Warning: Skipping TLS validation for insecure connection to Nutanix Prism Central; this is not recommended for production use")
 	}
 	return v.validateTrustBundleConfig(config.Spec)
 }

--- a/pkg/providers/nutanix/validator_test.go
+++ b/pkg/providers/nutanix/validator_test.go
@@ -227,6 +227,10 @@ func TestNutanixValidatorValidateDatacenterConfig(t *testing.T) {
 			name:       "valid datacenter config with trust bundle",
 			dcConfFile: nutanixDatacenterConfigSpecWithTrustBundle,
 		},
+		{
+			name:       "valid datacenter config with insecure",
+			dcConfFile: nutanixDatacenterConfigSpecWithInsecure,
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/framework/nutanix.go
+++ b/test/framework/nutanix.go
@@ -14,6 +14,7 @@ const (
 	nutanixEndpoint              = "T_NUTANIX_ENDPOINT"
 	nutanixPort                  = "T_NUTANIX_PORT"
 	nutanixAdditionalTrustBundle = "T_NUTANIX_ADDITIONAL_TRUST_BUNDLE"
+	nutanixInsecure              = "T_NUTANIX_INSECURE"
 
 	nutanixMachineBootType       = "T_NUTANIX_MACHINE_BOOT_TYPE"
 	nutanixMachineMemorySize     = "T_NUTANIX_MACHINE_MEMORY_SIZE"
@@ -88,6 +89,7 @@ func NewNutanix(t *testing.T, opts ...NutanixOpt) *Nutanix {
 			api.WithNutanixStringFromEnvVar(nutanixPrismElementClusterName, api.WithNutanixPrismElementClusterName),
 			api.WithNutanixStringFromEnvVar(nutanixSSHAuthorizedKey, api.WithNutanixSSHAuthorizedKey),
 			api.WithNutanixStringFromEnvVar(nutanixSubnetName, api.WithNutanixSubnetName),
+			api.WithNutanixBoolFromEnvVar(nutanixInsecure, api.WithNutanixInsecure),
 		},
 	}
 


### PR DESCRIPTION
To accommodate for the scenario where the user has not replaced the default Certificate that ships with Prism Central, we allow the user to skip TLS verification. Insecure is the optional property to skip TLS verification.

Nutanix Prism Central installation by default ships with a self-signed certificate that will fail TLS verification because of two reasons:
1. The certificate is not issued by a publicly trusted CA
2. The certificate does not have the IP SANs for the Prism Central endpoint

As such, in order for these services to establish a connection with Prism Central, client has three options:

1. Use Legitimate certificates: [Replace the default certificate](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide-v6_1:mul-security-ssl-certificate-pc-t.html) that comes with Prism Central with a certificate signed by a publicly trusted Certificate Authority e.g. [Let’s Encrypt](http://letsencrypt.org/). 
2. Use valid Self-Signed certificates: [Replace the default certificate](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide-v6_1:mul-security-ssl-certificate-pc-t.html) that comes with Prism central with a self-signed certificate that has the IP address/domain populated in the [Subject Alternative Names](https://www.digicert.com/faq/subject-alternative-name.htm) section of the certificate. The Root CA Certificate is provided as an additional trust bundle to add to the certificate pool used to establish the connection. This is signaled using the additionalTrustBundle flag.
4. Skip TLS Verification: The TLS Verification step needs to be skipped when establishing the connection. The benefit of this approach is that it does not require the default certificate to be replaced.

We intend on supporting all three options until Prism Central starts shipping with valid self-signed certificates.
The recommended order from a customer guidance perspective should be:
1. Use a Legitimate certificate
2. Use a valid self-signed certificate and provide the CA cert through the trust bundle
3. Skip TLS verification

From an application evaluation perspective, the order will be:
1. If a legitimate certificate is present, nothing needs to be done
2. If an additionalTrustBundle flag is present, the RootCA cert should be added to the client cert pool when establishing a TLS connection. 
3. If an insecure flag is present and set to true, TLS verification should be skipped regardless of what other properties are set. 

**How was this tested?**
Created a EKS-A cluster on a Nutanix setup (@vnephologist lab) with self-signed certificates using the insecure flag set to true. 