### PR TITLE
Remove old check to prevent self-managed cluster upgrades with controller

### DIFF
--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -84,10 +84,6 @@ func (r *Cluster) ValidateUpdate(old runtime.Object) error {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", old))
 	}
 
-	if r.IsSelfManaged() && !r.IsReconcilePaused() && features.IsActive(features.FullLifecycleAPI()) && !r.Equal(oldCluster) {
-		return apierrors.NewBadRequest(fmt.Sprintf("upgrading self managed clusters is not supported: %s", r.Name))
-	}
-
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, validateImmutableFieldsCluster(r, oldCluster)...)

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -1715,7 +1715,7 @@ func TestClusterValidateUpdateInvalidRequest(t *testing.T) {
 	cNew.Spec.ControlPlaneConfiguration.Count = cNew.Spec.ControlPlaneConfiguration.Count + 1
 	g := NewWithT(t)
 	err := cNew.ValidateUpdate(cOld)
-	g.Expect(err).To(MatchError(ContainSubstring("upgrading self managed clusters is not supported")))
+	g.Expect(err).To(MatchError(ContainSubstring("spec.ControlPlaneConfiguration: Forbidden: field is immutable")))
 }
 
 func newCluster(opts ...func(*v1alpha1.Cluster)) *v1alpha1.Cluster {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We now allow users to update worker node configs for the self-managed clusters through the controller, so we can remove this check

*Testing (if applicable):*
Unit tests + upgraded self-managed Docker cluster (scaled nodes up/down  + added a new wn group) using `kubectl apply` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

