### PR TITLE
Sample e2e test reusing long lived management cluster

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -93,7 +93,7 @@ func NewClusterE2ETest(t *testing.T, provider Provider, opts ...ClusterE2ETestOp
 	e := &ClusterE2ETest{
 		T:                     t,
 		Provider:              provider,
-		ClusterConfigLocation: defaultClusterConfigFile,
+		ClusterConfigLocation: fmt.Sprintf("%s-eks-a-cluster.yaml", getClusterName(t)),
 		ClusterName:           getClusterName(t),
 		clusterFillers:        make([]api.ClusterFiller, 0),
 		KubectlClient:         buildKubectl(t),
@@ -171,6 +171,12 @@ func WithWorkerHardware(requiredCount int) ClusterE2ETestOpt {
 
 func WithCustomLabelHardware(requiredCount int, label string) ClusterE2ETestOpt {
 	return withHardware(requiredCount, api.Worker, map[string]string{api.HardwareLabelTypeKeyName: label})
+}
+
+func WithClusterName(clusterName string) ClusterE2ETestOpt {
+	return func(e *ClusterE2ETest) {
+		e.ClusterName = clusterName
+	}
 }
 
 func WithExternalEtcdHardware(requiredCount int) ClusterE2ETestOpt {

--- a/test/framework/multicluster.go
+++ b/test/framework/multicluster.go
@@ -45,6 +45,10 @@ func (m *MulticlusterE2ETest) CreateManagementClusterForVersion(eksaVersion stri
 	m.ManagementCluster.CreateCluster(opts...)
 }
 
+func (m *MulticlusterE2ETest) UseExistingManagementCluster(clusterName string) {
+	m.ManagementCluster.ClusterName = clusterName
+}
+
 func (m *MulticlusterE2ETest) CreateManagementCluster(opts ...CommandOpt) {
 	m.ManagementCluster.GenerateClusterConfig()
 	m.ManagementCluster.CreateCluster(opts...)

--- a/test/framework/releaseVersions.go
+++ b/test/framework/releaseVersions.go
@@ -108,9 +108,13 @@ func GetReleaseBinaryFromVersion(version *semver.Version) (binaryPath string, er
 	var targetVersion *releasev1alpha1.EksARelease
 	for _, release := range releases.Spec.Releases {
 		releaseVersion := newVersion(release.Version)
-		if releaseVersion == version {
+		if releaseVersion.SamePatch(version) {
 			targetVersion = &release
+			break
 		}
+	}
+	if targetVersion == nil {
+		return "", fmt.Errorf("unable to find matching version in release manifest for %v", version)
 	}
 
 	binaryPath, err = getBinary(targetVersion)
@@ -123,7 +127,6 @@ func GetReleaseBinaryFromVersion(version *semver.Version) (binaryPath string, er
 
 func getBinary(release *releasev1alpha1.EksARelease) (string, error) {
 	r := platformAwareRelease{release}
-
 	latestReleaseBinaryFolder := filepath.Join("bin", r.Version)
 	latestReleaseBinaryPath := filepath.Join(latestReleaseBinaryFolder, releaseBinaryName)
 

--- a/test/framework/wait.go
+++ b/test/framework/wait.go
@@ -16,3 +16,11 @@ func (e *ClusterE2ETest) WaitForControlPlaneReady() {
 		e.T.Fatal(err)
 	}
 }
+func (e *ClusterE2ETest) WaitForWorkloadClusterControlPlaneReady(clusterName string) {
+	ctx := context.Background()
+	e.T.Logf("Waiting for control plane %s to be ready for cluster %s", clusterName, e.ClusterName)
+	err := e.KubectlClient.WaitForControlPlaneReady(ctx, e.cluster(), "5m", clusterName)
+	if err != nil {
+		e.T.Fatal(err)
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
First, this PR adds a test case which reuses an existing management cluster. It's not production quality and it's open to input.

Second, this PR simplifies the check for matching releaseVersions and adds some error handling in case a matching version isn't found. Usage of the method:

```
v121Semver, err := semver.New("v0.12.1")
eksaBinaryLocation, err := GetReleaseBinaryFromVersion(version)
```

and this allows the e2e test operations to run with that particular EKS-A release version.

*Testing (if applicable):*
Custom e2e test case upgrading workload clusters from v0.12.0 to v0.12.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

