### PR TITLE
Support bottlerocket OS for snow provider

### DIFF
--- a/internal/test/kubevip.go
+++ b/internal/test/kubevip.go
@@ -1,0 +1,55 @@
+package test
+
+// KubeVipTemplate is the default kube-vip pod template for internal testing.
+const KubeVipTemplate = `apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  name: kube-vip
+  namespace: kube-system
+spec:
+  containers:
+  - args:
+    - manager
+    env:
+    - name: vip_arp
+      value: "true"
+    - name: port
+      value: "6443"
+    - name: vip_cidr
+      value: "32"
+    - name: cp_enable
+      value: "true"
+    - name: cp_namespace
+      value: kube-system
+    - name: vip_ddns
+      value: "false"
+    - name: vip_leaderelection
+      value: "true"
+    - name: vip_leaseduration
+      value: "15"
+    - name: vip_renewdeadline
+      value: "10"
+    - name: vip_retryperiod
+      value: "2"
+    - name: address
+      value: 1.2.3.4
+    image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433
+    imagePullPolicy: IfNotPresent
+    name: kube-vip
+    resources: {}
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_RAW
+    volumeMounts:
+    - mountPath: /etc/kubernetes/admin.conf
+      name: kubeconfig
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes/admin.conf
+    name: kubeconfig
+status: {}
+`

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/utils/ptr"
+	"github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 type apiBuilerTest struct {
@@ -87,12 +88,33 @@ func newApiBuilerTest(t *testing.T) apiBuilerTest {
 				KubernetesVersion: "1.21",
 			},
 		}
-		s.VersionsBundle.KubeDistro.Kubernetes.Repository = "public.ecr.aws/eks-distro/kubernetes"
-		s.VersionsBundle.KubeDistro.Kubernetes.Tag = "v1.21.5-eks-1-21-9"
-		s.VersionsBundle.KubeDistro.CoreDNS.Repository = "public.ecr.aws/eks-distro/coredns"
-		s.VersionsBundle.KubeDistro.CoreDNS.Tag = "v1.8.4-eks-1-21-9"
-		s.VersionsBundle.KubeDistro.Etcd.Repository = "public.ecr.aws/eks-distro/etcd-io"
-		s.VersionsBundle.KubeDistro.Etcd.Tag = "v3.4.16-eks-1-21-9"
+
+		s.VersionsBundle = &cluster.VersionsBundle{
+			KubeDistro: &cluster.KubeDistro{
+				Kubernetes: cluster.VersionedRepository{
+					Repository: "public.ecr.aws/eks-distro/kubernetes",
+					Tag:        "v1.21.5-eks-1-21-9",
+				},
+				CoreDNS: cluster.VersionedRepository{
+					Repository: "public.ecr.aws/eks-distro/coredns",
+					Tag:        "v1.8.4-eks-1-21-9",
+				},
+				Etcd: cluster.VersionedRepository{
+					Repository: "public.ecr.aws/eks-distro/etcd-io",
+					Tag:        "v3.4.16-eks-1-21-9",
+				},
+				Pause: v1alpha1.Image{
+					URI: "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
+				},
+			},
+			VersionsBundle: &v1alpha1.VersionsBundle{
+				BottleRocketBootstrap: v1alpha1.BottlerocketBootstrapBundle{
+					Bootstrap: v1alpha1.Image{
+						URI: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",
+					},
+				},
+			},
+		}
 	})
 
 	controlPlane := &controlplanev1.KubeadmControlPlane{

--- a/pkg/clusterapi/bottlerocket.go
+++ b/pkg/clusterapi/bottlerocket.go
@@ -1,0 +1,45 @@
+package clusterapi
+
+import (
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/release/api/v1alpha1"
+)
+
+func bottlerocketBootstrap(image v1alpha1.Image) bootstrapv1.BottlerocketBootstrap {
+	return bootstrapv1.BottlerocketBootstrap{
+		ImageMeta: bootstrapv1.ImageMeta{
+			ImageRepository: image.Image(),
+			ImageTag:        image.Tag(),
+		},
+	}
+}
+
+func pause(image v1alpha1.Image) bootstrapv1.Pause {
+	return bootstrapv1.Pause{
+		ImageMeta: bootstrapv1.ImageMeta{
+			ImageRepository: image.Image(),
+			ImageTag:        image.Tag(),
+		},
+	}
+}
+
+// SetBottlerocketInKubeadmControlPlane adds bottlerocket bootstrap image metadata in kubeadmControlPlane.
+func SetBottlerocketInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, versionsBundle *cluster.VersionsBundle) {
+	b := bottlerocketBootstrap(versionsBundle.BottleRocketBootstrap.Bootstrap)
+	p := pause(versionsBundle.KubeDistro.Pause)
+	kcp.Spec.KubeadmConfigSpec.Format = bootstrapv1.Bottlerocket
+	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketBootstrap = b
+	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Pause = p
+	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketBootstrap = b
+	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.Pause = p
+}
+
+// SetBottlerocketInKubeadmConfigTemplate adds bottlerocket bootstrap image metadata in kubeadmConfigTemplate.
+func SetBottlerocketInKubeadmConfigTemplate(kct *bootstrapv1.KubeadmConfigTemplate, versionsBundle *cluster.VersionsBundle) {
+	kct.Spec.Template.Spec.Format = bootstrapv1.Bottlerocket
+	kct.Spec.Template.Spec.JoinConfiguration.BottlerocketBootstrap = bottlerocketBootstrap(versionsBundle.BottleRocketBootstrap.Bootstrap)
+	kct.Spec.Template.Spec.JoinConfiguration.Pause = pause(versionsBundle.KubeDistro.Pause)
+}

--- a/pkg/clusterapi/bottlerocket_test.go
+++ b/pkg/clusterapi/bottlerocket_test.go
@@ -1,0 +1,50 @@
+package clusterapi_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+)
+
+var pause = bootstrapv1.Pause{
+	ImageMeta: bootstrapv1.ImageMeta{
+		ImageRepository: "public.ecr.aws/eks-distro/kubernetes/pause",
+		ImageTag:        "0.0.1",
+	},
+}
+
+var bootstrap = bootstrapv1.BottlerocketBootstrap{
+	ImageMeta: bootstrapv1.ImageMeta{
+		ImageRepository: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap",
+		ImageTag:        "0.0.1",
+	},
+}
+
+func TestSetBottlerocketInKubeadmControlPlane(t *testing.T) {
+	g := newApiBuilerTest(t)
+	got := wantKubeadmControlPlane()
+	want := got.DeepCopy()
+	want.Spec.KubeadmConfigSpec.Format = "bottlerocket"
+	want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketBootstrap = bootstrap
+	want.Spec.KubeadmConfigSpec.ClusterConfiguration.Pause = pause
+	want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketBootstrap = bootstrap
+	want.Spec.KubeadmConfigSpec.JoinConfiguration.Pause = pause
+
+	clusterapi.SetBottlerocketInKubeadmControlPlane(got, g.clusterSpec.VersionsBundle)
+	g.Expect(got).To(Equal(want))
+}
+
+func TestSetBottlerocketInKubeadmConfigTemplate(t *testing.T) {
+	g := newApiBuilerTest(t)
+	got := wantKubeadmConfigTemplate()
+	want := got.DeepCopy()
+	want.Spec.Template.Spec.Format = "bottlerocket"
+	want.Spec.Template.Spec.JoinConfiguration.BottlerocketBootstrap = bootstrap
+	want.Spec.Template.Spec.JoinConfiguration.Pause = pause
+
+	clusterapi.SetBottlerocketInKubeadmConfigTemplate(got, g.clusterSpec.VersionsBundle)
+	g.Expect(got).To(Equal(want))
+}

--- a/pkg/clusterapi/kubevip.go
+++ b/pkg/clusterapi/kubevip.go
@@ -1,0 +1,123 @@
+package clusterapi
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
+)
+
+// SetKubeVipInKubeadmControlPlane appends kube-vip manifest to kubeadmControlPlane's kubeadmConfigSpec files.
+func SetKubeVipInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, address, image string) error {
+	b, err := yaml.Marshal(kubeVip(address, image))
+	if err != nil {
+		return fmt.Errorf("marshalling kube-vip pod: %v", err)
+	}
+
+	kcp.Spec.KubeadmConfigSpec.Files = append(kcp.Spec.KubeadmConfigSpec.Files, bootstrapv1.File{
+		Path:    "/etc/kubernetes/manifests/kube-vip.yaml",
+		Owner:   "root:root",
+		Content: string(b),
+	})
+
+	return nil
+}
+
+func kubeVip(address, image string) *corev1.Pod {
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-vip",
+			Namespace: constants.KubeSystemNamespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "kube-vip",
+					Image: image,
+					Args:  []string{"manager"},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "vip_arp",
+							Value: "true",
+						},
+						{
+							Name:  "port",
+							Value: "6443",
+						},
+						{
+							Name:  "vip_cidr",
+							Value: "32",
+						},
+						{
+							Name:  "cp_enable",
+							Value: "true",
+						},
+						{
+							Name:  "cp_namespace",
+							Value: "kube-system",
+						},
+						{
+							Name:  "vip_ddns",
+							Value: "false",
+						},
+						{
+							Name:  "vip_leaderelection",
+							Value: "true",
+						},
+						{
+							Name:  "vip_leaseduration",
+							Value: "15",
+						},
+						{
+							Name:  "vip_renewdeadline",
+							Value: "10",
+						},
+						{
+							Name:  "vip_retryperiod",
+							Value: "2",
+						},
+						{
+							Name:  "address",
+							Value: address,
+						},
+					},
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					SecurityContext: &corev1.SecurityContext{
+						Capabilities: &corev1.Capabilities{
+							Add: []corev1.Capability{
+								"NET_ADMIN",
+								"NET_RAW",
+							},
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "kubeconfig",
+							MountPath: "/etc/kubernetes/admin.conf",
+						},
+					},
+				},
+			},
+			HostNetwork: true,
+			Volumes: []corev1.Volume{
+				{
+					Name: "kubeconfig",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/etc/kubernetes/admin.conf",
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/clusterapi/kubevip_test.go
+++ b/pkg/clusterapi/kubevip_test.go
@@ -1,0 +1,27 @@
+package clusterapi_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+)
+
+func TestSetKubeVipInKubeadmControlPlane(t *testing.T) {
+	g := newApiBuilerTest(t)
+	got := wantKubeadmControlPlane()
+	want := got.DeepCopy()
+	want.Spec.KubeadmConfigSpec.Files = []bootstrapv1.File{
+		{
+			Path:    "/etc/kubernetes/manifests/kube-vip.yaml",
+			Owner:   "root:root",
+			Content: test.KubeVipTemplate,
+		},
+	}
+
+	g.Expect(clusterapi.SetKubeVipInKubeadmControlPlane(got, g.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host, "public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433")).To(Succeed())
+	g.Expect(got).To(Equal(want))
+}

--- a/pkg/clusterapi/proxy.go
+++ b/pkg/clusterapi/proxy.go
@@ -14,6 +14,50 @@ import (
 //go:embed config/http-proxy.conf
 var proxyConfig string
 
+func proxy(cluster *v1alpha1.Cluster) bootstrapv1.ProxyConfiguration {
+	return bootstrapv1.ProxyConfiguration{
+		HTTPSProxy: cluster.Spec.ProxyConfiguration.HttpsProxy,
+		NoProxy:    noProxyList(cluster),
+	}
+}
+
+// SetProxyConfigInKubeadmControlPlaneForBottlerocket sets up proxy configuration in kubeadmControlPlane for bottlerocket.
+func SetProxyConfigInKubeadmControlPlaneForBottlerocket(kcp *controlplanev1.KubeadmControlPlane, cluster *v1alpha1.Cluster) {
+	if cluster.Spec.ProxyConfiguration == nil {
+		return
+	}
+
+	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Proxy = proxy(cluster)
+	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.Proxy = proxy(cluster)
+}
+
+// SetProxyConfigInKubeadmControlPlaneForUbuntu sets up proxy configuration in kubeadmControlPlane for ubuntu.
+func SetProxyConfigInKubeadmControlPlaneForUbuntu(kcp *controlplanev1.KubeadmControlPlane, cluster *v1alpha1.Cluster) error {
+	if cluster.Spec.ProxyConfiguration == nil {
+		return nil
+	}
+
+	return addProxyConfigInKubeadmConfigSpecFiles(&kcp.Spec.KubeadmConfigSpec, cluster)
+}
+
+// SetProxyConfigInKubeadmConfigTemplateForBottlerocket sets up proxy configuration in kubeadmConfigTemplate for bottlerocket.
+func SetProxyConfigInKubeadmConfigTemplateForBottlerocket(kct *bootstrapv1.KubeadmConfigTemplate, cluster *v1alpha1.Cluster) {
+	if cluster.Spec.ProxyConfiguration == nil {
+		return
+	}
+
+	kct.Spec.Template.Spec.JoinConfiguration.Proxy = proxy(cluster)
+}
+
+// SetProxyConfigInKubeadmConfigTemplateForUbuntu sets up proxy configuration in kubeadmConfigTemplate for ubuntu.
+func SetProxyConfigInKubeadmConfigTemplateForUbuntu(kct *bootstrapv1.KubeadmConfigTemplate, cluster *v1alpha1.Cluster) error {
+	if cluster.Spec.ProxyConfiguration == nil {
+		return nil
+	}
+
+	return addProxyConfigInKubeadmConfigSpecFiles(&kct.Spec.Template.Spec, cluster)
+}
+
 func NoProxyDefaults() []string {
 	return []string{
 		"localhost",
@@ -22,24 +66,28 @@ func NoProxyDefaults() []string {
 	}
 }
 
-func proxyConfigContent(cluster v1alpha1.ClusterSpec) (string, error) {
-	capacity := len(cluster.ClusterNetwork.Pods.CidrBlocks) +
-		len(cluster.ClusterNetwork.Services.CidrBlocks) +
-		len(cluster.ProxyConfiguration.NoProxy) + 4
+func noProxyList(cluster *v1alpha1.Cluster) []string {
+	capacity := len(cluster.Spec.ClusterNetwork.Pods.CidrBlocks) +
+		len(cluster.Spec.ClusterNetwork.Services.CidrBlocks) +
+		len(cluster.Spec.ProxyConfiguration.NoProxy) + 4
 
 	noProxyList := make([]string, 0, capacity)
-	noProxyList = append(noProxyList, cluster.ClusterNetwork.Pods.CidrBlocks...)
-	noProxyList = append(noProxyList, cluster.ClusterNetwork.Services.CidrBlocks...)
-	noProxyList = append(noProxyList, cluster.ProxyConfiguration.NoProxy...)
+	noProxyList = append(noProxyList, cluster.Spec.ClusterNetwork.Pods.CidrBlocks...)
+	noProxyList = append(noProxyList, cluster.Spec.ClusterNetwork.Services.CidrBlocks...)
+	noProxyList = append(noProxyList, cluster.Spec.ProxyConfiguration.NoProxy...)
 
 	// Add no-proxy defaults
 	noProxyList = append(noProxyList, NoProxyDefaults()...)
-	noProxyList = append(noProxyList, cluster.ControlPlaneConfiguration.Endpoint.Host)
+	noProxyList = append(noProxyList, cluster.Spec.ControlPlaneConfiguration.Endpoint.Host)
 
+	return noProxyList
+}
+
+func proxyConfigContent(cluster *v1alpha1.Cluster) (string, error) {
 	val := values{
-		"httpProxy":  cluster.ProxyConfiguration.HttpProxy,
-		"httpsProxy": cluster.ProxyConfiguration.HttpsProxy,
-		"noProxy":    noProxyList,
+		"httpProxy":  cluster.Spec.ProxyConfiguration.HttpProxy,
+		"httpsProxy": cluster.Spec.ProxyConfiguration.HttpsProxy,
+		"noProxy":    noProxyList(cluster),
 	}
 
 	config, err := templater.Execute(proxyConfig, val)
@@ -49,7 +97,7 @@ func proxyConfigContent(cluster v1alpha1.ClusterSpec) (string, error) {
 	return string(config), nil
 }
 
-func proxyConfigFile(cluster v1alpha1.ClusterSpec) (bootstrapv1.File, error) {
+func proxyConfigFile(cluster *v1alpha1.Cluster) (bootstrapv1.File, error) {
 	proxyConfig, err := proxyConfigContent(cluster)
 	if err != nil {
 		return bootstrapv1.File{}, err
@@ -62,32 +110,13 @@ func proxyConfigFile(cluster v1alpha1.ClusterSpec) (bootstrapv1.File, error) {
 	}, nil
 }
 
-func SetProxyConfigInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, cluster v1alpha1.ClusterSpec) error {
-	if cluster.ProxyConfiguration == nil {
-		return nil
-	}
-
+func addProxyConfigInKubeadmConfigSpecFiles(kcs *bootstrapv1.KubeadmConfigSpec, cluster *v1alpha1.Cluster) error {
 	proxyConfigFile, err := proxyConfigFile(cluster)
 	if err != nil {
 		return err
 	}
 
-	kcp.Spec.KubeadmConfigSpec.Files = append(kcp.Spec.KubeadmConfigSpec.Files, proxyConfigFile)
-
-	return nil
-}
-
-func SetProxyConfigInKubeadmConfigTemplate(kct *bootstrapv1.KubeadmConfigTemplate, cluster v1alpha1.ClusterSpec) error {
-	if cluster.ProxyConfiguration == nil {
-		return nil
-	}
-
-	proxyConfigFile, err := proxyConfigFile(cluster)
-	if err != nil {
-		return err
-	}
-
-	kct.Spec.Template.Spec.Files = append(kct.Spec.Template.Spec.Files, proxyConfigFile)
+	kcs.Files = append(kcs.Files, proxyConfigFile)
 
 	return nil
 }

--- a/pkg/clusterapi/registry_mirror.go
+++ b/pkg/clusterapi/registry_mirror.go
@@ -15,6 +15,50 @@ import (
 //go:embed config/containerd_config_append.toml
 var containerdConfig string
 
+// SetRegistryMirrorInKubeadmControlPlaneForBottlerocket sets up registry mirror configuration in kubeadmControlPlane for bottlerocket.
+func SetRegistryMirrorInKubeadmControlPlaneForBottlerocket(kcp *controlplanev1.KubeadmControlPlane, mirrorConfig *v1alpha1.RegistryMirrorConfiguration) {
+	if mirrorConfig == nil {
+		return
+	}
+
+	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.RegistryMirror = registryMirror(mirrorConfig)
+	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.RegistryMirror = registryMirror(mirrorConfig)
+}
+
+// SetRegistryMirrorInKubeadmControlPlaneForUbuntu sets up registry mirror configuration in kubeadmControlPlane for ubuntu.
+func SetRegistryMirrorInKubeadmControlPlaneForUbuntu(kcp *controlplanev1.KubeadmControlPlane, mirrorConfig *v1alpha1.RegistryMirrorConfiguration) error {
+	if mirrorConfig == nil {
+		return nil
+	}
+
+	return addRegistryMirrorInKubeadmConfigSpecFiles(&kcp.Spec.KubeadmConfigSpec, mirrorConfig)
+}
+
+// SetRegistryMirrorInKubeadmConfigTemplateForBottlerocket sets up registry mirror configuration in kubeadmConfigTemplate for bottlerocket.
+func SetRegistryMirrorInKubeadmConfigTemplateForBottlerocket(kct *bootstrapv1.KubeadmConfigTemplate, mirrorConfig *v1alpha1.RegistryMirrorConfiguration) {
+	if mirrorConfig == nil {
+		return
+	}
+
+	kct.Spec.Template.Spec.JoinConfiguration.RegistryMirror = registryMirror(mirrorConfig)
+}
+
+// SetRegistryMirrorInKubeadmConfigTemplateForUbuntu sets up registry mirror configuration in kubeadmConfigTemplate for ubuntu.
+func SetRegistryMirrorInKubeadmConfigTemplateForUbuntu(kct *bootstrapv1.KubeadmConfigTemplate, mirrorConfig *v1alpha1.RegistryMirrorConfiguration) error {
+	if mirrorConfig == nil {
+		return nil
+	}
+
+	return addRegistryMirrorInKubeadmConfigSpecFiles(&kct.Spec.Template.Spec, mirrorConfig)
+}
+
+func registryMirror(mirrorConfig *v1alpha1.RegistryMirrorConfiguration) bootstrapv1.RegistryMirrorConfiguration {
+	return bootstrapv1.RegistryMirrorConfiguration{
+		Endpoint: net.JoinHostPort(mirrorConfig.Endpoint, mirrorConfig.Port),
+		CACert:   mirrorConfig.CACertContent,
+	}
+}
+
 type values map[string]interface{}
 
 func registryMirrorConfigContent(registryAddress, registryCert string, insecureSkip bool) (string, error) {
@@ -56,32 +100,13 @@ func registryMirrorConfig(registryMirrorConfig *v1alpha1.RegistryMirrorConfigura
 	return files, nil
 }
 
-func SetRegistryMirrorInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, mirrorConfig *v1alpha1.RegistryMirrorConfiguration) error {
-	if mirrorConfig == nil {
-		return nil
-	}
-
+func addRegistryMirrorInKubeadmConfigSpecFiles(kcs *bootstrapv1.KubeadmConfigSpec, mirrorConfig *v1alpha1.RegistryMirrorConfiguration) error {
 	containerdFiles, err := registryMirrorConfig(mirrorConfig)
 	if err != nil {
 		return fmt.Errorf("setting registry mirror configuration: %v", err)
 	}
 
-	kcp.Spec.KubeadmConfigSpec.Files = append(kcp.Spec.KubeadmConfigSpec.Files, containerdFiles...)
-
-	return nil
-}
-
-func SetRegistryMirrorInKubeadmConfigTemplate(kct *bootstrapv1.KubeadmConfigTemplate, mirrorConfig *v1alpha1.RegistryMirrorConfiguration) error {
-	if mirrorConfig == nil {
-		return nil
-	}
-
-	containerdFiles, err := registryMirrorConfig(mirrorConfig)
-	if err != nil {
-		return fmt.Errorf("setting registry mirror configuration: %v", err)
-	}
-
-	kct.Spec.Template.Spec.Files = append(kct.Spec.Template.Spec.Files, containerdFiles...)
+	kcs.Files = append(kcs.Files, containerdFiles...)
 
 	return nil
 }

--- a/pkg/clusterapi/systemctl.go
+++ b/pkg/clusterapi/systemctl.go
@@ -16,30 +16,34 @@ var restartContainerdCommands = []string{
 	"sudo systemctl restart containerd",
 }
 
-func CreateContainerdConfigFileInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, cluster v1alpha1.ClusterSpec) {
-	if cluster.RegistryMirrorConfiguration != nil {
+// CreateContainerdConfigFileInKubeadmControlPlane adds the prekubeadm command to create containerd config file in kubeadmControlPlane if registry mirror config exists.
+func CreateContainerdConfigFileInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, cluster *v1alpha1.Cluster) {
+	if cluster.Spec.RegistryMirrorConfiguration != nil {
 		kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands = append(kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands, buildContainerdConfigCommands...)
 	}
 }
 
-func CreateContainerdConfigFileInKubeadmConfigTemplate(kct *bootstrapv1.KubeadmConfigTemplate, cluster v1alpha1.ClusterSpec) {
-	if cluster.RegistryMirrorConfiguration != nil {
+// CreateContainerdConfigFileInKubeadmConfigTemplate adds the prekubeadm command to create containerd config file in kubeadmConfigTemplate if registry mirror config exists.
+func CreateContainerdConfigFileInKubeadmConfigTemplate(kct *bootstrapv1.KubeadmConfigTemplate, cluster *v1alpha1.Cluster) {
+	if cluster.Spec.RegistryMirrorConfiguration != nil {
 		kct.Spec.Template.Spec.PreKubeadmCommands = append(kct.Spec.Template.Spec.PreKubeadmCommands, buildContainerdConfigCommands...)
 	}
 }
 
-func RestartContainerdInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, cluster v1alpha1.ClusterSpec) {
+// RestartContainerdInKubeadmControlPlane adds the prekubeadm command to restart containerd daemon in kubeadmControlPlane if registry mirror or proxy config exists.
+func RestartContainerdInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, cluster *v1alpha1.Cluster) {
 	if restartContainerdNeeded(cluster) {
 		kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands = append(kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands, restartContainerdCommands...)
 	}
 }
 
-func RestartContainerdInKubeadmConfigTemplate(kct *bootstrapv1.KubeadmConfigTemplate, cluster v1alpha1.ClusterSpec) {
+// RestartContainerdInKubeadmConfigTemplate adds the prekubeadm command to restart containerd daemon in kubeadmConfigTemplate if registry mirror or proxy config exists.
+func RestartContainerdInKubeadmConfigTemplate(kct *bootstrapv1.KubeadmConfigTemplate, cluster *v1alpha1.Cluster) {
 	if restartContainerdNeeded(cluster) {
 		kct.Spec.Template.Spec.PreKubeadmCommands = append(kct.Spec.Template.Spec.PreKubeadmCommands, restartContainerdCommands...)
 	}
 }
 
-func restartContainerdNeeded(cluster v1alpha1.ClusterSpec) bool {
-	return cluster.RegistryMirrorConfiguration != nil || cluster.ProxyConfiguration != nil
+func restartContainerdNeeded(cluster *v1alpha1.Cluster) bool {
+	return cluster.Spec.RegistryMirrorConfiguration != nil || cluster.Spec.ProxyConfiguration != nil
 }

--- a/pkg/clusterapi/systemctl_test.go
+++ b/pkg/clusterapi/systemctl_test.go
@@ -57,8 +57,9 @@ func TestRestartContainerdInKubeadmControlPlane(t *testing.T) {
 	for _, tt := range restartContainerdTests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := newApiBuilerTest(t)
+			g.clusterSpec.Cluster.Spec = tt.cluster
 			got := wantKubeadmControlPlane()
-			clusterapi.RestartContainerdInKubeadmControlPlane(got, tt.cluster)
+			clusterapi.RestartContainerdInKubeadmControlPlane(got, g.clusterSpec.Cluster)
 			want := wantKubeadmControlPlane()
 			want.Spec.KubeadmConfigSpec.PreKubeadmCommands = tt.want
 
@@ -71,8 +72,9 @@ func TestRestartContainerdInKubeadmConfigTemplate(t *testing.T) {
 	for _, tt := range restartContainerdTests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := newApiBuilerTest(t)
+			g.clusterSpec.Cluster.Spec = tt.cluster
 			got := wantKubeadmConfigTemplate()
-			clusterapi.RestartContainerdInKubeadmConfigTemplate(got, tt.cluster)
+			clusterapi.RestartContainerdInKubeadmConfigTemplate(got, g.clusterSpec.Cluster)
 			want := wantKubeadmConfigTemplate()
 			want.Spec.Template.Spec.PreKubeadmCommands = tt.want
 			g.Expect(got).To(Equal(want))
@@ -111,8 +113,9 @@ func TestCreateContainerdConfigFileInKubeadmControlPlane(t *testing.T) {
 	for _, tt := range createContainerdConfigTests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := newApiBuilerTest(t)
+			g.clusterSpec.Cluster.Spec = tt.cluster
 			got := wantKubeadmControlPlane()
-			clusterapi.CreateContainerdConfigFileInKubeadmControlPlane(got, tt.cluster)
+			clusterapi.CreateContainerdConfigFileInKubeadmControlPlane(got, g.clusterSpec.Cluster)
 			want := wantKubeadmControlPlane()
 			want.Spec.KubeadmConfigSpec.PreKubeadmCommands = tt.want
 			g.Expect(got).To(Equal(want))
@@ -124,8 +127,9 @@ func TestCreateContainerdConfigFileInKubeadmConfigTemplate(t *testing.T) {
 	for _, tt := range createContainerdConfigTests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := newApiBuilerTest(t)
+			g.clusterSpec.Cluster.Spec = tt.cluster
 			got := wantKubeadmConfigTemplate()
-			clusterapi.CreateContainerdConfigFileInKubeadmConfigTemplate(got, tt.cluster)
+			clusterapi.CreateContainerdConfigFileInKubeadmConfigTemplate(got, g.clusterSpec.Cluster)
 			want := wantKubeadmConfigTemplate()
 			want.Spec.Template.Spec.PreKubeadmCommands = tt.want
 			g.Expect(got).To(Equal(want))

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -3,6 +3,7 @@ package snow
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -26,10 +27,15 @@ func CAPICluster(clusterSpec *cluster.Spec, snowCluster *snowv1.AWSSnowCluster, 
 	return clusterapi.Cluster(clusterSpec, snowCluster, kubeadmControlPlane)
 }
 
-func KubeadmControlPlane(clusterSpec *cluster.Spec, snowMachineTemplate *snowv1.AWSSnowMachineTemplate) (*controlplanev1.KubeadmControlPlane, error) {
+// KubeadmControlPlane generates the kubeadmControlPlane object for snow provider from clusterSpec and snowMachineTemplate.
+func KubeadmControlPlane(log logr.Logger, clusterSpec *cluster.Spec, snowMachineTemplate *snowv1.AWSSnowMachineTemplate) (*controlplanev1.KubeadmControlPlane, error) {
 	kcp, err := clusterapi.KubeadmControlPlane(clusterSpec, snowMachineTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("generating KubeadmControlPlane: %v", err)
+	}
+
+	if err := clusterapi.SetKubeVipInKubeadmControlPlane(kcp, clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host, clusterSpec.VersionsBundle.Snow.KubeVip.VersionedImage()); err != nil {
+		return nil, fmt.Errorf("setting kube-vip: %v", err)
 	}
 
 	// TODO: support unstacked etcd
@@ -57,21 +63,32 @@ func KubeadmControlPlane(clusterSpec *cluster.Spec, snowMachineTemplate *snowv1.
 		fmt.Sprintf("/etc/eks/bootstrap-after.sh %s %s", clusterSpec.VersionsBundle.Snow.KubeVip.VersionedImage(), clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host),
 	)
 
-	if err := clusterapi.SetRegistryMirrorInKubeadmControlPlane(kcp, clusterSpec.Cluster.Spec.RegistryMirrorConfiguration); err != nil {
-		return nil, err
-	}
+	osFamily := clusterSpec.SnowMachineConfig(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name).OSFamily()
+	switch osFamily {
+	case v1alpha1.Bottlerocket:
+		clusterapi.SetProxyConfigInKubeadmControlPlaneForBottlerocket(kcp, clusterSpec.Cluster)
+		clusterapi.SetRegistryMirrorInKubeadmControlPlaneForBottlerocket(kcp, clusterSpec.Cluster.Spec.RegistryMirrorConfiguration)
+		clusterapi.SetBottlerocketInKubeadmControlPlane(kcp, clusterSpec.VersionsBundle)
 
-	if err := clusterapi.SetProxyConfigInKubeadmControlPlane(kcp, clusterSpec.Cluster.Spec); err != nil {
-		return nil, err
-	}
+	case v1alpha1.Ubuntu:
+		if err := clusterapi.SetProxyConfigInKubeadmControlPlaneForUbuntu(kcp, clusterSpec.Cluster); err != nil {
+			return nil, err
+		}
+		if err := clusterapi.SetRegistryMirrorInKubeadmControlPlaneForUbuntu(kcp, clusterSpec.Cluster.Spec.RegistryMirrorConfiguration); err != nil {
+			return nil, err
+		}
+		clusterapi.CreateContainerdConfigFileInKubeadmControlPlane(kcp, clusterSpec.Cluster)
+		clusterapi.RestartContainerdInKubeadmControlPlane(kcp, clusterSpec.Cluster)
 
-	clusterapi.CreateContainerdConfigFileInKubeadmControlPlane(kcp, clusterSpec.Cluster.Spec)
-	clusterapi.RestartContainerdInKubeadmControlPlane(kcp, clusterSpec.Cluster.Spec)
+	default:
+		log.Info("Warning: unsupported OS family when setting up KubeadmControlPlane", "OS family", osFamily)
+	}
 
 	return kcp, nil
 }
 
-func KubeadmConfigTemplate(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) (*bootstrapv1.KubeadmConfigTemplate, error) {
+// KubeadmConfigTemplate generates the kubeadmConfigTemplate object for snow provider from clusterSpec and workerNodeGroupConfig.
+func KubeadmConfigTemplate(log logr.Logger, clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) (*bootstrapv1.KubeadmConfigTemplate, error) {
 	kct, err := clusterapi.KubeadmConfigTemplate(clusterSpec, workerNodeGroupConfig)
 	if err != nil {
 		return nil, fmt.Errorf("generating KubeadmConfigTemplate: %v", err)
@@ -90,16 +107,26 @@ func KubeadmConfigTemplate(clusterSpec *cluster.Spec, workerNodeGroupConfig v1al
 		)
 	}
 
-	if err := clusterapi.SetRegistryMirrorInKubeadmConfigTemplate(kct, clusterSpec.Cluster.Spec.RegistryMirrorConfiguration); err != nil {
-		return nil, err
-	}
+	osFamily := clusterSpec.SnowMachineConfig(workerNodeGroupConfig.MachineGroupRef.Name).OSFamily()
+	switch osFamily {
+	case v1alpha1.Bottlerocket:
+		clusterapi.SetProxyConfigInKubeadmConfigTemplateForBottlerocket(kct, clusterSpec.Cluster)
+		clusterapi.SetRegistryMirrorInKubeadmConfigTemplateForBottlerocket(kct, clusterSpec.Cluster.Spec.RegistryMirrorConfiguration)
+		clusterapi.SetBottlerocketInKubeadmConfigTemplate(kct, clusterSpec.VersionsBundle)
 
-	if err := clusterapi.SetProxyConfigInKubeadmConfigTemplate(kct, clusterSpec.Cluster.Spec); err != nil {
-		return nil, err
-	}
+	case v1alpha1.Ubuntu:
+		if err := clusterapi.SetProxyConfigInKubeadmConfigTemplateForUbuntu(kct, clusterSpec.Cluster); err != nil {
+			return nil, err
+		}
+		if err := clusterapi.SetRegistryMirrorInKubeadmConfigTemplateForUbuntu(kct, clusterSpec.Cluster.Spec.RegistryMirrorConfiguration); err != nil {
+			return nil, err
+		}
+		clusterapi.CreateContainerdConfigFileInKubeadmConfigTemplate(kct, clusterSpec.Cluster)
+		clusterapi.RestartContainerdInKubeadmConfigTemplate(kct, clusterSpec.Cluster)
 
-	clusterapi.CreateContainerdConfigFileInKubeadmConfigTemplate(kct, clusterSpec.Cluster.Spec)
-	clusterapi.RestartContainerdInKubeadmConfigTemplate(kct, clusterSpec.Cluster.Spec)
+	default:
+		log.Info("Warning: unsupported OS family when setting up KubeadmConfigTemplate", "OS family", osFamily)
+	}
 
 	return kct, nil
 }

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -3,13 +3,16 @@ package snow_test
 import (
 	"testing"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/providers/snow"
@@ -20,13 +23,16 @@ type apiBuilerTest struct {
 	*WithT
 	clusterSpec    *cluster.Spec
 	machineConfigs map[string]*v1alpha1.SnowMachineConfig
+	logger         logr.Logger
 }
 
 func newApiBuilerTest(t *testing.T) apiBuilerTest {
+	format.MaxLength = 0
 	return apiBuilerTest{
 		WithT:          NewWithT(t),
 		clusterSpec:    givenClusterSpec(),
 		machineConfigs: givenMachineConfigs(),
+		logger:         test.NewNullLogger(),
 	}
 }
 
@@ -76,7 +82,7 @@ func TestCAPICluster(t *testing.T) {
 	tt := newApiBuilerTest(t)
 	snowCluster := snow.SnowCluster(tt.clusterSpec, wantSnowCredentialsSecret())
 	controlPlaneMachineTemplate := snow.SnowMachineTemplate("snow-test-control-plane-1", tt.machineConfigs[tt.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name])
-	kubeadmControlPlane, err := snow.KubeadmControlPlane(tt.clusterSpec, controlPlaneMachineTemplate)
+	kubeadmControlPlane, err := snow.KubeadmControlPlane(tt.logger, tt.clusterSpec, controlPlaneMachineTemplate)
 	tt.Expect(err).To(Succeed())
 
 	got := snow.CAPICluster(tt.clusterSpec, snowCluster, kubeadmControlPlane)
@@ -155,7 +161,13 @@ func wantKubeadmControlPlane() *controlplanev1.KubeadmControlPlane {
 				PostKubeadmCommands: []string{
 					"/etc/eks/bootstrap-after.sh public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433 1.2.3.4",
 				},
-				Files: []bootstrapv1.File{},
+				Files: []bootstrapv1.File{
+					{
+						Path:    "/etc/kubernetes/manifests/kube-vip.yaml",
+						Owner:   "root:root",
+						Content: test.KubeVipTemplate,
+					},
+				},
 			},
 			Replicas: &wantReplicas,
 			Version:  "v1.21.5-eks-1-21-9",
@@ -174,7 +186,7 @@ func wantRegistryMirrorCommands() []string {
 func TestKubeadmControlPlane(t *testing.T) {
 	tt := newApiBuilerTest(t)
 	controlPlaneMachineTemplate := snow.SnowMachineTemplate("snow-test-control-plane-1", tt.machineConfigs[tt.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name])
-	got, err := snow.KubeadmControlPlane(tt.clusterSpec, controlPlaneMachineTemplate)
+	got, err := snow.KubeadmControlPlane(tt.logger, tt.clusterSpec, controlPlaneMachineTemplate)
 	tt.Expect(err).To(Succeed())
 
 	want := wantKubeadmControlPlane()
@@ -185,6 +197,7 @@ var registryMirrorTests = []struct {
 	name                 string
 	registryMirrorConfig *v1alpha1.RegistryMirrorConfiguration
 	wantFiles            []bootstrapv1.File
+	wantRegistryConfig   bootstrapv1.RegistryMirrorConfiguration
 }{
 	{
 		name: "with ca cert",
@@ -209,6 +222,10 @@ var registryMirrorTests = []struct {
 				Content: "xyz",
 			},
 		},
+		wantRegistryConfig: bootstrapv1.RegistryMirrorConfiguration{
+			Endpoint: "1.2.3.4:443",
+			CACert:   "xyz",
+		},
 	},
 	{
 		name: "with insecure skip",
@@ -228,6 +245,9 @@ var registryMirrorTests = []struct {
     insecure_skip_verify = true`,
 			},
 		},
+		wantRegistryConfig: bootstrapv1.RegistryMirrorConfiguration{
+			Endpoint: "1.2.3.4:443",
+		},
 	},
 	{
 		name: "without ca cert",
@@ -243,6 +263,9 @@ var registryMirrorTests = []struct {
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
     endpoint = ["https://1.2.3.4:443"]`,
 			},
+		},
+		wantRegistryConfig: bootstrapv1.RegistryMirrorConfiguration{
+			Endpoint: "1.2.3.4:443",
 		},
 	},
 	{
@@ -270,20 +293,60 @@ var registryMirrorTests = []struct {
 				Content: "xyz",
 			},
 		},
+		wantRegistryConfig: bootstrapv1.RegistryMirrorConfiguration{
+			Endpoint: "1.2.3.4:443",
+			CACert:   "xyz",
+		},
 	},
 }
 
-func TestKubeadmControlPlaneWithRegistryMirror(t *testing.T) {
+func TestKubeadmControlPlaneWithRegistryMirrorUbuntu(t *testing.T) {
 	for _, tt := range registryMirrorTests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := newApiBuilerTest(t)
 			g.clusterSpec.Cluster.Spec.RegistryMirrorConfiguration = tt.registryMirrorConfig
 			controlPlaneMachineTemplate := snow.SnowMachineTemplate("snow-test-control-plane-1", g.machineConfigs[g.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name])
-			got, err := snow.KubeadmControlPlane(g.clusterSpec, controlPlaneMachineTemplate)
+			got, err := snow.KubeadmControlPlane(g.logger, g.clusterSpec, controlPlaneMachineTemplate)
 			g.Expect(err).To(Succeed())
 			want := wantKubeadmControlPlane()
-			want.Spec.KubeadmConfigSpec.Files = tt.wantFiles
+			want.Spec.KubeadmConfigSpec.Files = append(want.Spec.KubeadmConfigSpec.Files, tt.wantFiles...)
 			want.Spec.KubeadmConfigSpec.PreKubeadmCommands = append(want.Spec.KubeadmConfigSpec.PreKubeadmCommands, wantRegistryMirrorCommands()...)
+			g.Expect(got).To(Equal(want))
+		})
+	}
+}
+
+var pause = bootstrapv1.Pause{
+	ImageMeta: bootstrapv1.ImageMeta{
+		ImageRepository: "public.ecr.aws/eks-distro/kubernetes/pause",
+		ImageTag:        "0.0.1",
+	},
+}
+
+var bootstrap = bootstrapv1.BottlerocketBootstrap{
+	ImageMeta: bootstrapv1.ImageMeta{
+		ImageRepository: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap",
+		ImageTag:        "0.0.1",
+	},
+}
+
+func TestKubeadmControlPlaneWithRegistryMirrorBottlerocket(t *testing.T) {
+	for _, tt := range registryMirrorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newApiBuilerTest(t)
+			g.clusterSpec.Cluster.Spec.RegistryMirrorConfiguration = tt.registryMirrorConfig
+			g.clusterSpec.SnowMachineConfig("test-cp").Spec.OSFamily = v1alpha1.Bottlerocket
+			controlPlaneMachineTemplate := snow.SnowMachineTemplate("snow-test-control-plane-1", g.machineConfigs["test-cp"])
+			got, err := snow.KubeadmControlPlane(g.logger, g.clusterSpec, controlPlaneMachineTemplate)
+			g.Expect(err).To(Succeed())
+			want := wantKubeadmControlPlane()
+			want.Spec.KubeadmConfigSpec.Format = "bottlerocket"
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketBootstrap = bootstrap
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.Pause = pause
+			want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketBootstrap = bootstrap
+			want.Spec.KubeadmConfigSpec.JoinConfiguration.Pause = pause
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.RegistryMirror = tt.wantRegistryConfig
+			want.Spec.KubeadmConfigSpec.JoinConfiguration.RegistryMirror = tt.wantRegistryConfig
 			g.Expect(got).To(Equal(want))
 		})
 	}
@@ -297,9 +360,10 @@ func wantProxyConfigCommands() []string {
 }
 
 var proxyTests = []struct {
-	name      string
-	proxy     *v1alpha1.ProxyConfiguration
-	wantFiles []bootstrapv1.File
+	name            string
+	proxy           *v1alpha1.ProxyConfiguration
+	wantFiles       []bootstrapv1.File
+	wantProxyConfig bootstrapv1.ProxyConfiguration
 }{
 	{
 		name: "with proxy, pods cidr, service cidr, cp endpoint",
@@ -321,20 +385,55 @@ Environment="HTTPS_PROXY=1.2.3.4:8888"
 Environment="NO_PROXY=10.1.0.0/16,10.96.0.0/12,1.2.3.4/0,1.2.3.5/0,localhost,127.0.0.1,.svc,1.2.3.4"`,
 			},
 		},
+		wantProxyConfig: bootstrapv1.ProxyConfiguration{
+			HTTPSProxy: "1.2.3.4:8888",
+			NoProxy: []string{
+				"10.1.0.0/16",
+				"10.96.0.0/12",
+				"1.2.3.4/0",
+				"1.2.3.5/0",
+				"localhost",
+				"127.0.0.1",
+				".svc",
+				"1.2.3.4",
+			},
+		},
 	},
 }
 
-func TestKubeadmControlPlaneWithProxyConfig(t *testing.T) {
+func TestKubeadmControlPlaneWithProxyConfigUbuntu(t *testing.T) {
 	for _, tt := range proxyTests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := newApiBuilerTest(t)
 			g.clusterSpec.Cluster.Spec.ProxyConfiguration = tt.proxy
 			controlPlaneMachineTemplate := snow.SnowMachineTemplate("snow-test-control-plane-1", g.machineConfigs[g.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name])
-			got, err := snow.KubeadmControlPlane(g.clusterSpec, controlPlaneMachineTemplate)
+			got, err := snow.KubeadmControlPlane(g.logger, g.clusterSpec, controlPlaneMachineTemplate)
 			g.Expect(err).To(Succeed())
 			want := wantKubeadmControlPlane()
-			want.Spec.KubeadmConfigSpec.Files = tt.wantFiles
+			want.Spec.KubeadmConfigSpec.Files = append(want.Spec.KubeadmConfigSpec.Files, tt.wantFiles...)
 			want.Spec.KubeadmConfigSpec.PreKubeadmCommands = append(want.Spec.KubeadmConfigSpec.PreKubeadmCommands, wantProxyConfigCommands()...)
+			g.Expect(got).To(Equal(want))
+		})
+	}
+}
+
+func TestKubeadmControlPlaneWithProxyConfigBottlerocket(t *testing.T) {
+	for _, tt := range proxyTests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newApiBuilerTest(t)
+			g.clusterSpec.Cluster.Spec.ProxyConfiguration = tt.proxy
+			g.clusterSpec.SnowMachineConfig("test-cp").Spec.OSFamily = v1alpha1.Bottlerocket
+			controlPlaneMachineTemplate := snow.SnowMachineTemplate("snow-test-control-plane-1", g.machineConfigs["test-cp"])
+			got, err := snow.KubeadmControlPlane(g.logger, g.clusterSpec, controlPlaneMachineTemplate)
+			g.Expect(err).To(Succeed())
+			want := wantKubeadmControlPlane()
+			want.Spec.KubeadmConfigSpec.Format = "bottlerocket"
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketBootstrap = bootstrap
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.Pause = pause
+			want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketBootstrap = bootstrap
+			want.Spec.KubeadmConfigSpec.JoinConfiguration.Pause = pause
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.Proxy = tt.wantProxyConfig
+			want.Spec.KubeadmConfigSpec.JoinConfiguration.Proxy = tt.wantProxyConfig
 			g.Expect(got).To(Equal(want))
 		})
 	}
@@ -351,7 +450,7 @@ func TestKubeadmControlPlaneWithContainersVolume(t *testing.T) {
 	cpMachineConfig := g.machineConfigs[g.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name]
 	cpMachineConfig.Spec.ContainersVolume = &snowv1.Volume{Size: 8}
 	controlPlaneMachineTemplate := snow.SnowMachineTemplate("snow-test-control-plane-1", cpMachineConfig)
-	got, err := snow.KubeadmControlPlane(g.clusterSpec, controlPlaneMachineTemplate)
+	got, err := snow.KubeadmControlPlane(g.logger, g.clusterSpec, controlPlaneMachineTemplate)
 	g.Expect(err).To(Succeed())
 	want := wantKubeadmControlPlane()
 	want.Spec.KubeadmConfigSpec.PreKubeadmCommands = append(want.Spec.KubeadmConfigSpec.PreKubeadmCommands, wantContainersVolumeCommands()...)
@@ -403,7 +502,7 @@ func TestKubeadmConfigTemplateWithContainersVolume(t *testing.T) {
 	g := newApiBuilerTest(t)
 	workerNodeGroupConfig := g.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0]
 	g.clusterSpec.SnowMachineConfigs["test-wn"].Spec.ContainersVolume = &snowv1.Volume{Size: 8}
-	got, err := snow.KubeadmConfigTemplate(g.clusterSpec, workerNodeGroupConfig)
+	got, err := snow.KubeadmConfigTemplate(g.logger, g.clusterSpec, workerNodeGroupConfig)
 	g.Expect(err).To(Succeed())
 	want := wantKubeadmConfigTemplate()
 	want.Spec.Template.Spec.PreKubeadmCommands = append(want.Spec.Template.Spec.PreKubeadmCommands, wantContainersVolumeCommands()...)

--- a/pkg/providers/snow/objects_test.go
+++ b/pkg/providers/snow/objects_test.go
@@ -54,7 +54,7 @@ func TestControlPlaneObjects(t *testing.T) {
 	kcp := wantKubeadmControlPlane()
 	kcp.Spec.MachineTemplate.InfrastructureRef.Name = wantMachineTemplateName
 
-	got, err := snow.ControlPlaneObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	got, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
 	g.Expect(got).To(Equal([]kubernetes.Object{wantCAPICluster(), wantSnowCluster(), kcp, mt, wantSnowCredentialsSecret()}))
 }
@@ -62,7 +62,7 @@ func TestControlPlaneObjects(t *testing.T) {
 func TestControlPlaneObjectsCredentialsNil(t *testing.T) {
 	g := newSnowTest(t)
 	g.clusterSpec.SnowCredentialsSecret = nil
-	_, err := snow.ControlPlaneObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	_, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(MatchError(ContainSubstring("snowCredentialsSecret in clusterSpec shall not be nil")))
 }
 
@@ -72,7 +72,7 @@ func TestControlPlaneObjectsSecretMissCredentialsKey(t *testing.T) {
 		"ca-bundle": []byte("eksa-certs"),
 	}
 
-	_, err := snow.ControlPlaneObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	_, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(MatchError(ContainSubstring("unable to retrieve credentials from secret")))
 }
 
@@ -82,7 +82,7 @@ func TestControlPlaneObjectsSecretMissCertificatesKey(t *testing.T) {
 		"credentials": []byte("eksa-creds"),
 	}
 
-	_, err := snow.ControlPlaneObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	_, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(MatchError(ContainSubstring("unable to retrieve ca-bundle from secret")))
 }
 
@@ -120,7 +120,7 @@ func TestControlPlaneObjectsUpgradeFromBetaMachineTemplateName(t *testing.T) {
 	kcp := wantKubeadmControlPlane()
 	kcp.Spec.MachineTemplate.InfrastructureRef.Name = wantMachineTemplateName
 
-	got, err := snow.ControlPlaneObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	got, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
 	g.Expect(got).To(Equal([]kubernetes.Object{wantCAPICluster(), wantSnowCluster(), kcp, mt, wantSnowCredentialsSecret()}))
 }
@@ -140,7 +140,7 @@ func TestControlPlaneObjectsOldControlPlaneNotExists(t *testing.T) {
 	mt.SetName("snow-test-control-plane-1")
 	mt.Spec.Template.Spec.InstanceType = "sbe-c.large"
 
-	got, err := snow.ControlPlaneObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	got, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
 	g.Expect(got).To(Equal([]kubernetes.Object{wantCAPICluster(), wantSnowCluster(), wantKubeadmControlPlane(), mt, wantSnowCredentialsSecret()}))
 }
@@ -171,7 +171,7 @@ func TestControlPlaneObjectsOldMachineTemplateNotExists(t *testing.T) {
 	mt.SetName("snow-test-control-plane-1")
 	mt.Spec.Template.Spec.InstanceType = "sbe-c.large"
 
-	got, err := snow.ControlPlaneObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	got, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
 	g.Expect(got).To(Equal([]kubernetes.Object{wantCAPICluster(), wantSnowCluster(), wantKubeadmControlPlane(), mt, wantSnowCredentialsSecret()}))
 }
@@ -187,7 +187,7 @@ func TestControlPlaneObjectsGetOldControlPlaneError(t *testing.T) {
 		).
 		Return(errors.New("get cp error"))
 
-	_, err := snow.ControlPlaneObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	_, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).NotTo(Succeed())
 }
 
@@ -210,7 +210,7 @@ func TestControlPlaneObjectsGetOldMachineTemplateError(t *testing.T) {
 		).
 		Return(errors.New("get mt error"))
 
-	_, err := snow.ControlPlaneObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	_, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).NotTo(Succeed())
 }
 
@@ -260,7 +260,7 @@ func TestWorkersObjects(t *testing.T) {
 	md := wantMachineDeployment()
 	md.Spec.Template.Spec.InfrastructureRef.Name = wantMachineTemplateName
 
-	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	got, err := snow.WorkersObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
 	g.Expect(got).To(ConsistOf([]kubernetes.Object{md, wantKubeadmConfigTemplate(), mt}))
 }
@@ -319,7 +319,7 @@ func TestWorkersObjectsFromBetaMachineTemplateName(t *testing.T) {
 	kct.SetName(wantKctName)
 	md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = wantKctName
 
-	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	got, err := snow.WorkersObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
 	g.Expect(got).To(ConsistOf([]kubernetes.Object{md, kct, mt}))
 }
@@ -336,7 +336,7 @@ func TestWorkersObjectsOldMachineDeploymentNotExists(t *testing.T) {
 		).
 		Return(apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: ""}, ""))
 
-	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	got, err := snow.WorkersObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
 	g.Expect(got).To(ConsistOf([]kubernetes.Object{wantMachineDeployment(), wantKubeadmConfigTemplate(), mt}))
 }
@@ -374,7 +374,7 @@ func TestWorkersObjectsOldKubeadmConfigTemplateNotExists(t *testing.T) {
 		).
 		Return(apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: ""}, ""))
 
-	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	got, err := snow.WorkersObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
 	g.Expect(got).To(ConsistOf([]kubernetes.Object{wantMachineDeployment(), wantKubeadmConfigTemplate(), mt}))
 }
@@ -415,7 +415,7 @@ func TestWorkersObjectsOldMachineTemplateNotExists(t *testing.T) {
 		).
 		Return(apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: ""}, ""))
 
-	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	got, err := snow.WorkersObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
 	g.Expect(got).To(ConsistOf([]kubernetes.Object{wantMachineDeployment(), wantKubeadmConfigTemplate(), mt}))
 }
@@ -466,7 +466,7 @@ func TestWorkersObjectsTaintsUpdated(t *testing.T) {
 			return nil
 		})
 
-	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	got, err := snow.WorkersObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 
 	md := wantMachineDeployment()
 	md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "snow-test-md-0-2"
@@ -526,7 +526,7 @@ func TestWorkersObjectsLabelsUpdated(t *testing.T) {
 			return nil
 		})
 
-	got, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	got, err := snow.WorkersObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 
 	md := wantMachineDeployment()
 	md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "snow-test-md-0-2"
@@ -554,7 +554,7 @@ func TestWorkersObjectsGetMachineDeploymentError(t *testing.T) {
 		).
 		Return(errors.New("get md error"))
 
-	_, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	_, err := snow.WorkersObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).NotTo(Succeed())
 }
 
@@ -590,7 +590,7 @@ func TestWorkersObjectsGetKubeadmConfigTemplateError(t *testing.T) {
 		).
 		Return(nil)
 
-	_, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	_, err := snow.WorkersObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).NotTo(Succeed())
 }
 
@@ -618,7 +618,7 @@ func TestWorkersObjectsGetMachineTemplateError(t *testing.T) {
 		).
 		Return(errors.New("get mt error"))
 
-	_, err := snow.WorkersObjects(g.ctx, g.clusterSpec, g.kubeconfigClient)
+	_, err := snow.WorkersObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).NotTo(Succeed())
 }
 
@@ -637,7 +637,7 @@ func TestKubeadmConfigTemplatesWithRegistryMirror(t *testing.T) {
 				Return(apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: ""}, ""))
 
 			g.clusterSpec.Cluster.Spec.RegistryMirrorConfiguration = tt.registryMirrorConfig
-			gotMt, gotKct, err := snow.WorkersMachineAndConfigTemplate(g.ctx, g.kubeconfigClient, g.clusterSpec)
+			gotMt, gotKct, err := snow.WorkersMachineAndConfigTemplate(g.ctx, g.logger, g.kubeconfigClient, g.clusterSpec)
 			g.Expect(err).To(Succeed())
 			wantMt := map[string]*snowv1.AWSSnowMachineTemplate{
 				"md-0": wantSnowMachineTemplate(),
@@ -669,7 +669,7 @@ func TestKubeadmConfigTemplatesWithProxyConfig(t *testing.T) {
 
 			g.clusterSpec.Cluster.Spec.ProxyConfiguration = tt.proxy
 
-			_, got, err := snow.WorkersMachineAndConfigTemplate(g.ctx, g.kubeconfigClient, g.clusterSpec)
+			_, got, err := snow.WorkersMachineAndConfigTemplate(g.ctx, g.logger, g.kubeconfigClient, g.clusterSpec)
 			g.Expect(err).To(Succeed())
 			want := map[string]*bootstrapv1.KubeadmConfigTemplate{
 				"md-0": wantKubeadmConfigTemplate(),

--- a/pkg/providers/snow/reconciler/reconciler.go
+++ b/pkg/providers/snow/reconciler/reconciler.go
@@ -99,7 +99,7 @@ func (s *Reconciler) ReconcileControlPlane(ctx context.Context, log logr.Logger,
 	log.Info("Applying control plane CAPI objects")
 
 	return s.Apply(ctx, func() ([]kubernetes.Object, error) {
-		return snow.ControlPlaneObjects(ctx, clusterSpec, clientutil.NewKubeClient(s.client))
+		return snow.ControlPlaneObjects(ctx, log, clusterSpec, clientutil.NewKubeClient(s.client))
 	})
 }
 
@@ -123,7 +123,7 @@ func (s *Reconciler) ReconcileWorkers(ctx context.Context, log logr.Logger, clus
 	log = log.WithValues("phase", "reconcileWorkers")
 	log.Info("Applying worker CAPI objects")
 
-	w, err := snow.WorkersSpec(ctx, clusterSpec, clientutil.NewKubeClient(s.client))
+	w, err := snow.WorkersSpec(ctx, log, clusterSpec, clientutil.NewKubeClient(s.client))
 	if err != nil {
 		return controller.Result{}, err
 	}

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -46,6 +47,7 @@ type snowTest struct {
 	provider         *snow.SnowProvider
 	cluster          *types.Cluster
 	clusterSpec      *cluster.Spec
+	logger           logr.Logger
 }
 
 func newSnowTest(t *testing.T) snowTest {
@@ -67,6 +69,7 @@ func newSnowTest(t *testing.T) snowTest {
 		provider:         provider,
 		cluster:          cluster,
 		clusterSpec:      givenClusterSpec(),
+		logger:           test.NewNullLogger(),
 	}
 }
 
@@ -135,6 +138,9 @@ func givenClusterSpec() *cluster.Spec {
 					Repository: "public.ecr.aws/eks-distro/etcd-io",
 					Tag:        "v3.4.16-eks-1-21-9",
 				},
+				Pause: releasev1alpha1.Image{
+					URI: "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
+				},
 			},
 			VersionsBundle: &releasev1alpha1.VersionsBundle{
 				KubeVersion: "1.21",
@@ -155,6 +161,11 @@ func givenClusterSpec() *cluster.Spec {
 						ImageDigest: "sha256:59da9c726c4816c29d119e77956c6391e2dff451daf36aeb60e5d6425eb88018",
 						Description: "Container image for cluster-api-snow-controller image",
 						Arch:        []string{"amd64"},
+					},
+				},
+				BottleRocketBootstrap: releasev1alpha1.BottlerocketBootstrapBundle{
+					Bootstrap: releasev1alpha1.Image{
+						URI: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",
 					},
 				},
 			},
@@ -204,6 +215,7 @@ func givenMachineConfigs() map[string]*v1alpha1.SnowMachineConfig {
 					"1.2.3.4",
 					"1.2.3.5",
 				},
+				OSFamily: v1alpha1.Ubuntu,
 			},
 		},
 		"test-wn": {
@@ -223,6 +235,7 @@ func givenMachineConfigs() map[string]*v1alpha1.SnowMachineConfig {
 					"1.2.3.4",
 					"1.2.3.5",
 				},
+				OSFamily: v1alpha1.Ubuntu,
 			},
 		},
 	}

--- a/pkg/providers/snow/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_cp.yaml
@@ -83,6 +83,61 @@ spec:
       proxy: {}
       registryMirror: {}
       scheduler: {}
+    files:
+    - content: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          creationTimestamp: null
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+          - args:
+            - manager
+            env:
+            - name: vip_arp
+              value: "true"
+            - name: port
+              value: "6443"
+            - name: vip_cidr
+              value: "32"
+            - name: cp_enable
+              value: "true"
+            - name: cp_namespace
+              value: kube-system
+            - name: vip_ddns
+              value: "false"
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_leaseduration
+              value: "15"
+            - name: vip_renewdeadline
+              value: "10"
+            - name: vip_retryperiod
+              value: "2"
+            - name: address
+              value: 1.2.3.4
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433
+            imagePullPolicy: IfNotPresent
+            name: kube-vip
+            resources: {}
+            securityContext:
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+            volumeMounts:
+            - mountPath: /etc/kubernetes/admin.conf
+              name: kubeconfig
+          hostNetwork: true
+          volumes:
+          - hostPath:
+              path: /etc/kubernetes/admin.conf
+            name: kubeconfig
+        status: {}
+      owner: root:root
+      path: /etc/kubernetes/manifests/kube-vip.yaml
     initConfiguration:
       localAPIEndpoint: {}
       nodeRegistration:


### PR DESCRIPTION
*Issue #, if available:*

#4050 

*Description of changes:*

Add bottlerocket support for Snow
- move kube-vip pod manifest to user data
- update proxy, registry mirror config option for BR

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

