### PR TITLE
Don't assume env vars when running tests

### DIFF
--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -1296,6 +1296,7 @@ func TestClusterValidateCreateSelfManagedUnpaused(t *testing.T) {
 
 func TestClusterValidateCreateManagedUnpaused(t *testing.T) {
 	features.ClearCache()
+	t.Setenv(features.FullLifecycleAPIEnvVar, "")
 	cluster := createCluster()
 	g := NewWithT(t)
 	cluster.SetManagedBy("mgmt2")

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -1748,6 +1748,7 @@ func TestClusterManagerInstallCustomComponentsSuccess(t *testing.T) {
 	tt.clusterSpec.VersionsBundle.Eksa.Components.URI = "testdata/testClusterSpec.yaml"
 
 	tt.mocks.client.EXPECT().ApplyKubeSpecFromBytes(tt.ctx, tt.cluster, gomock.Not(gomock.Nil())).Return(nil)
+	tt.mocks.client.EXPECT().SetEksaControllerEnvVar(tt.ctx, features.FullLifecycleAPIEnvVar, "true", tt.cluster.KubeconfigFile).AnyTimes()
 
 	for namespace, deployments := range internal.EksaDeployments {
 		for _, deployment := range deployments {

--- a/pkg/providers/snow/clientregistry_test.go
+++ b/pkg/providers/snow/clientregistry_test.go
@@ -27,6 +27,7 @@ func TestGetSnowAwsClientMapSuccess(t *testing.T) {
 
 func TestBuildSnowAwsClientMapFailure(t *testing.T) {
 	g := NewWithT(t)
+	t.Setenv(credsFileEnvVar, "")
 	ctx := context.Background()
 	clientBuilder := snow.NewAwsClientRegistry()
 


### PR DESCRIPTION
Some tests are assuming the values of environment variables when they're run, instead of setting them to known values first. This can cause test failures when running in environments where those variables are already set to different values than expected.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

