### PR TITLE
Add snow specific Bottlerocket settings: admin, control, bootstrap snow containers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -209,5 +209,5 @@ replace (
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.2
 
 	// need the modifications eksa made to the capi api structs
-	sigs.k8s.io/cluster-api => github.com/abhay-krishna/cluster-api v1.2.0-custom.rc2
+	sigs.k8s.io/cluster-api => github.com/abhay-krishna/cluster-api v1.2.0-custom.rc3
 )

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/ReneKroon/ttlcache v1.7.0 h1:8BkjFfrzVFXyrqnMtezAaJ6AHPSsVV10m6w28N/F
 github.com/ReneKroon/ttlcache v1.7.0/go.mod h1:8BGGzdumrIjWxdRx8zpK6L3oGMWvIXdvB2GD1cfvd+I=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
 github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
-github.com/abhay-krishna/cluster-api v1.2.0-custom.rc2 h1:VC2E9nXDC5dNGTWij+7cgLihUX1852QBWT+ZaWGIWko=
-github.com/abhay-krishna/cluster-api v1.2.0-custom.rc2/go.mod h1:UPhfJgbR0P6tjkcPXcB7PmKfTBS5iJHbe2anQGdE4Yk=
+github.com/abhay-krishna/cluster-api v1.2.0-custom.rc3 h1:HfxwPaqe8ppgwpOoQEPlJqAMw4Q34Jv6EHS6GDnLlA4=
+github.com/abhay-krishna/cluster-api v1.2.0-custom.rc3/go.mod h1:UPhfJgbR0P6tjkcPXcB7PmKfTBS5iJHbe2anQGdE4Yk=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -109,6 +109,12 @@ func newApiBuilerTest(t *testing.T) apiBuilerTest {
 			},
 			VersionsBundle: &v1alpha1.VersionsBundle{
 				BottleRocketHostContainers: v1alpha1.BottlerocketHostContainersBundle{
+					Admin: v1alpha1.Image{
+						URI: "public.ecr.aws/eks-anywhere/bottlerocket-admin:0.0.1",
+					},
+					Control: v1alpha1.Image{
+						URI: "public.ecr.aws/eks-anywhere/bottlerocket-control:0.0.1",
+					},
 					KubeadmBootstrap: v1alpha1.Image{
 						URI: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",
 					},

--- a/pkg/clusterapi/bottlerocket.go
+++ b/pkg/clusterapi/bottlerocket.go
@@ -17,6 +17,24 @@ func bottlerocketBootstrap(image v1alpha1.Image) bootstrapv1.BottlerocketBootstr
 	}
 }
 
+func bottlerocketAdmin(image v1alpha1.Image) bootstrapv1.BottlerocketAdmin {
+	return bootstrapv1.BottlerocketAdmin{
+		ImageMeta: bootstrapv1.ImageMeta{
+			ImageRepository: image.Image(),
+			ImageTag:        image.Tag(),
+		},
+	}
+}
+
+func bottlerocketControl(image v1alpha1.Image) bootstrapv1.BottlerocketControl {
+	return bootstrapv1.BottlerocketControl{
+		ImageMeta: bootstrapv1.ImageMeta{
+			ImageRepository: image.Image(),
+			ImageTag:        image.Tag(),
+		},
+	}
+}
+
 func pause(image v1alpha1.Image) bootstrapv1.Pause {
 	return bootstrapv1.Pause{
 		ImageMeta: bootstrapv1.ImageMeta{
@@ -37,9 +55,33 @@ func SetBottlerocketInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlan
 	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.Pause = p
 }
 
+// SetBottlerocketAdminContainerImageInKubeadmControlPlane overrides the default bottlerocket admin container image metadata in kubeadmControlPlane.
+func SetBottlerocketAdminContainerImageInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, versionsBundle *cluster.VersionsBundle) {
+	b := bottlerocketAdmin(versionsBundle.BottleRocketHostContainers.Admin)
+	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketAdmin = b
+	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketAdmin = b
+}
+
+// SetBottlerocketControlContainerImageInKubeadmControlPlane overrides the default bottlerocket control container image metadata in kubeadmControlPlane.
+func SetBottlerocketControlContainerImageInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, versionsBundle *cluster.VersionsBundle) {
+	b := bottlerocketControl(versionsBundle.BottleRocketHostContainers.Control)
+	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketControl = b
+	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketControl = b
+}
+
 // SetBottlerocketInKubeadmConfigTemplate adds bottlerocket bootstrap image metadata in kubeadmConfigTemplate.
 func SetBottlerocketInKubeadmConfigTemplate(kct *bootstrapv1.KubeadmConfigTemplate, versionsBundle *cluster.VersionsBundle) {
 	kct.Spec.Template.Spec.Format = bootstrapv1.Bottlerocket
 	kct.Spec.Template.Spec.JoinConfiguration.BottlerocketBootstrap = bottlerocketBootstrap(versionsBundle.BottleRocketHostContainers.KubeadmBootstrap)
 	kct.Spec.Template.Spec.JoinConfiguration.Pause = pause(versionsBundle.KubeDistro.Pause)
+}
+
+// SetBottlerocketAdminContainerImageInKubeadmConfigTemplate overrides the default bottlerocket admin container image metadata in kubeadmConfigTemplate.
+func SetBottlerocketAdminContainerImageInKubeadmConfigTemplate(kct *bootstrapv1.KubeadmConfigTemplate, versionsBundle *cluster.VersionsBundle) {
+	kct.Spec.Template.Spec.JoinConfiguration.BottlerocketAdmin = bottlerocketAdmin(versionsBundle.BottleRocketHostContainers.Admin)
+}
+
+// SetBottlerocketControlContainerImageInKubeadmConfigTemplate overrides the default bottlerocket control container image metadata in kubeadmConfigTemplate.
+func SetBottlerocketControlContainerImageInKubeadmConfigTemplate(kct *bootstrapv1.KubeadmConfigTemplate, versionsBundle *cluster.VersionsBundle) {
+	kct.Spec.Template.Spec.JoinConfiguration.BottlerocketControl = bottlerocketControl(versionsBundle.BottleRocketHostContainers.Control)
 }

--- a/pkg/clusterapi/bottlerocket_test.go
+++ b/pkg/clusterapi/bottlerocket_test.go
@@ -23,6 +23,20 @@ var bootstrap = bootstrapv1.BottlerocketBootstrap{
 	},
 }
 
+var adminContainer = bootstrapv1.BottlerocketAdmin{
+	ImageMeta: bootstrapv1.ImageMeta{
+		ImageRepository: "public.ecr.aws/eks-anywhere/bottlerocket-admin",
+		ImageTag:        "0.0.1",
+	},
+}
+
+var controlContainer = bootstrapv1.BottlerocketControl{
+	ImageMeta: bootstrapv1.ImageMeta{
+		ImageRepository: "public.ecr.aws/eks-anywhere/bottlerocket-control",
+		ImageTag:        "0.0.1",
+	},
+}
+
 func TestSetBottlerocketInKubeadmControlPlane(t *testing.T) {
 	g := newApiBuilerTest(t)
 	got := wantKubeadmControlPlane()
@@ -37,6 +51,28 @@ func TestSetBottlerocketInKubeadmControlPlane(t *testing.T) {
 	g.Expect(got).To(Equal(want))
 }
 
+func TestSetBottlerocketAdminContainerImageInKubeadmControlPlane(t *testing.T) {
+	g := newApiBuilerTest(t)
+	got := wantKubeadmControlPlane()
+	want := got.DeepCopy()
+	want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketAdmin = adminContainer
+	want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketAdmin = adminContainer
+
+	clusterapi.SetBottlerocketAdminContainerImageInKubeadmControlPlane(got, g.clusterSpec.VersionsBundle)
+	g.Expect(got).To(Equal(want))
+}
+
+func TestSetBottlerocketControlContainerImageInKubeadmControlPlane(t *testing.T) {
+	g := newApiBuilerTest(t)
+	got := wantKubeadmControlPlane()
+	want := got.DeepCopy()
+	want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketControl = controlContainer
+	want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketControl = controlContainer
+
+	clusterapi.SetBottlerocketControlContainerImageInKubeadmControlPlane(got, g.clusterSpec.VersionsBundle)
+	g.Expect(got).To(Equal(want))
+}
+
 func TestSetBottlerocketInKubeadmConfigTemplate(t *testing.T) {
 	g := newApiBuilerTest(t)
 	got := wantKubeadmConfigTemplate()
@@ -46,5 +82,25 @@ func TestSetBottlerocketInKubeadmConfigTemplate(t *testing.T) {
 	want.Spec.Template.Spec.JoinConfiguration.Pause = pause
 
 	clusterapi.SetBottlerocketInKubeadmConfigTemplate(got, g.clusterSpec.VersionsBundle)
+	g.Expect(got).To(Equal(want))
+}
+
+func TestSetBottlerocketAdminContainerImageInKubeadmConfigTemplate(t *testing.T) {
+	g := newApiBuilerTest(t)
+	got := wantKubeadmConfigTemplate()
+	want := got.DeepCopy()
+	want.Spec.Template.Spec.JoinConfiguration.BottlerocketAdmin = adminContainer
+
+	clusterapi.SetBottlerocketAdminContainerImageInKubeadmConfigTemplate(got, g.clusterSpec.VersionsBundle)
+	g.Expect(got).To(Equal(want))
+}
+
+func TestSetBottlerocketControlContainerImageInKubeadmConfigTemplate(t *testing.T) {
+	g := newApiBuilerTest(t)
+	got := wantKubeadmConfigTemplate()
+	want := got.DeepCopy()
+	want.Spec.Template.Spec.JoinConfiguration.BottlerocketControl = controlContainer
+
+	clusterapi.SetBottlerocketControlContainerImageInKubeadmConfigTemplate(got, g.clusterSpec.VersionsBundle)
 	g.Expect(got).To(Equal(want))
 }

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -69,6 +69,9 @@ func KubeadmControlPlane(log logr.Logger, clusterSpec *cluster.Spec, snowMachine
 		clusterapi.SetProxyConfigInKubeadmControlPlaneForBottlerocket(kcp, clusterSpec.Cluster)
 		clusterapi.SetRegistryMirrorInKubeadmControlPlaneForBottlerocket(kcp, clusterSpec.Cluster.Spec.RegistryMirrorConfiguration)
 		clusterapi.SetBottlerocketInKubeadmControlPlane(kcp, clusterSpec.VersionsBundle)
+		clusterapi.SetBottlerocketAdminContainerImageInKubeadmControlPlane(kcp, clusterSpec.VersionsBundle)
+		clusterapi.SetBottlerocketControlContainerImageInKubeadmControlPlane(kcp, clusterSpec.VersionsBundle)
+		addBottlerocketBootstrapSnowInKubeadmControlPlane(kcp, clusterSpec.VersionsBundle.Snow.BottlerocketBootstrapSnow)
 
 	case v1alpha1.Ubuntu:
 		if err := clusterapi.SetProxyConfigInKubeadmControlPlaneForUbuntu(kcp, clusterSpec.Cluster); err != nil {
@@ -113,6 +116,9 @@ func KubeadmConfigTemplate(log logr.Logger, clusterSpec *cluster.Spec, workerNod
 		clusterapi.SetProxyConfigInKubeadmConfigTemplateForBottlerocket(kct, clusterSpec.Cluster)
 		clusterapi.SetRegistryMirrorInKubeadmConfigTemplateForBottlerocket(kct, clusterSpec.Cluster.Spec.RegistryMirrorConfiguration)
 		clusterapi.SetBottlerocketInKubeadmConfigTemplate(kct, clusterSpec.VersionsBundle)
+		clusterapi.SetBottlerocketAdminContainerImageInKubeadmConfigTemplate(kct, clusterSpec.VersionsBundle)
+		clusterapi.SetBottlerocketControlContainerImageInKubeadmConfigTemplate(kct, clusterSpec.VersionsBundle)
+		addBottlerocketBootstrapSnowInKubeadmConfigTemplate(kct, clusterSpec.VersionsBundle.Snow.BottlerocketBootstrapSnow)
 
 	case v1alpha1.Ubuntu:
 		if err := clusterapi.SetProxyConfigInKubeadmConfigTemplateForUbuntu(kct, clusterSpec.Cluster); err != nil {

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -330,6 +330,31 @@ var bootstrap = bootstrapv1.BottlerocketBootstrap{
 	},
 }
 
+var admin = bootstrapv1.BottlerocketAdmin{
+	ImageMeta: bootstrapv1.ImageMeta{
+		ImageRepository: "public.ecr.aws/eks-anywhere/bottlerocket-admin",
+		ImageTag:        "0.0.1",
+	},
+}
+
+var control = bootstrapv1.BottlerocketControl{
+	ImageMeta: bootstrapv1.ImageMeta{
+		ImageRepository: "public.ecr.aws/eks-anywhere/bottlerocket-control",
+		ImageTag:        "0.0.1",
+	},
+}
+
+var bootstrapCustom = []bootstrapv1.BottlerocketBootstrapContainer{
+	{
+		Name: "bottlerocket-bootstrap-snow",
+		ImageMeta: bootstrapv1.ImageMeta{
+			ImageRepository: "public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap-snow",
+			ImageTag:        "v1-20-22-eks-a-v0.0.0-dev-build.4984",
+		},
+		Mode: "always",
+	},
+}
+
 func TestKubeadmControlPlaneWithRegistryMirrorBottlerocket(t *testing.T) {
 	for _, tt := range registryMirrorTests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -342,8 +367,14 @@ func TestKubeadmControlPlaneWithRegistryMirrorBottlerocket(t *testing.T) {
 			want := wantKubeadmControlPlane()
 			want.Spec.KubeadmConfigSpec.Format = "bottlerocket"
 			want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketBootstrap = bootstrap
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketAdmin = admin
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketControl = control
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketCustomBootstrapContainers = bootstrapCustom
 			want.Spec.KubeadmConfigSpec.ClusterConfiguration.Pause = pause
 			want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketBootstrap = bootstrap
+			want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketAdmin = admin
+			want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketControl = control
+			want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketCustomBootstrapContainers = bootstrapCustom
 			want.Spec.KubeadmConfigSpec.JoinConfiguration.Pause = pause
 			want.Spec.KubeadmConfigSpec.ClusterConfiguration.RegistryMirror = tt.wantRegistryConfig
 			want.Spec.KubeadmConfigSpec.JoinConfiguration.RegistryMirror = tt.wantRegistryConfig
@@ -429,8 +460,14 @@ func TestKubeadmControlPlaneWithProxyConfigBottlerocket(t *testing.T) {
 			want := wantKubeadmControlPlane()
 			want.Spec.KubeadmConfigSpec.Format = "bottlerocket"
 			want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketBootstrap = bootstrap
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketAdmin = admin
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketControl = control
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketCustomBootstrapContainers = bootstrapCustom
 			want.Spec.KubeadmConfigSpec.ClusterConfiguration.Pause = pause
 			want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketBootstrap = bootstrap
+			want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketAdmin = admin
+			want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketControl = control
+			want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketCustomBootstrapContainers = bootstrapCustom
 			want.Spec.KubeadmConfigSpec.JoinConfiguration.Pause = pause
 			want.Spec.KubeadmConfigSpec.ClusterConfiguration.Proxy = tt.wantProxyConfig
 			want.Spec.KubeadmConfigSpec.JoinConfiguration.Proxy = tt.wantProxyConfig

--- a/pkg/providers/snow/bottlerocket.go
+++ b/pkg/providers/snow/bottlerocket.go
@@ -1,0 +1,29 @@
+package snow
+
+import (
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+
+	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
+)
+
+func bottlerocketBootstrapSnow(image releasev1.Image) bootstrapv1.BottlerocketBootstrapContainer {
+	return bootstrapv1.BottlerocketBootstrapContainer{
+		Name: "bottlerocket-bootstrap-snow",
+		ImageMeta: bootstrapv1.ImageMeta{
+			ImageRepository: image.Image(),
+			ImageTag:        image.Tag(),
+		},
+		Mode: "always",
+	}
+}
+
+func addBottlerocketBootstrapSnowInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, image releasev1.Image) {
+	b := bottlerocketBootstrapSnow(image)
+	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketCustomBootstrapContainers = []bootstrapv1.BottlerocketBootstrapContainer{b}
+	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketCustomBootstrapContainers = []bootstrapv1.BottlerocketBootstrapContainer{b}
+}
+
+func addBottlerocketBootstrapSnowInKubeadmConfigTemplate(kct *bootstrapv1.KubeadmConfigTemplate, image releasev1.Image) {
+	kct.Spec.Template.Spec.JoinConfiguration.BottlerocketCustomBootstrapContainers = []bootstrapv1.BottlerocketBootstrapContainer{bottlerocketBootstrapSnow(image)}
+}

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -162,8 +162,22 @@ func givenClusterSpec() *cluster.Spec {
 						Description: "Container image for cluster-api-snow-controller image",
 						Arch:        []string{"amd64"},
 					},
+					BottlerocketBootstrapSnow: releasev1alpha1.Image{
+						Name:        "bottlerocket-bootstrap-snow",
+						OS:          "linux",
+						URI:         "public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap-snow:v1-20-22-eks-a-v0.0.0-dev-build.4984",
+						ImageDigest: "sha256:59da9c726c4816c29d119e77956c6391e2dff451daf36aeb60e5d6425eb88018",
+						Description: "Container image for bottlerocket-bootstrap-snow image",
+						Arch:        []string{"amd64"},
+					},
 				},
 				BottleRocketHostContainers: releasev1alpha1.BottlerocketHostContainersBundle{
+					Admin: releasev1alpha1.Image{
+						URI: "public.ecr.aws/eks-anywhere/bottlerocket-admin:0.0.1",
+					},
+					Control: releasev1alpha1.Image{
+						URI: "public.ecr.aws/eks-anywhere/bottlerocket-control:0.0.1",
+					},
 					KubeadmBootstrap: releasev1alpha1.Image{
 						URI: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",
 					},

--- a/pkg/providers/snow/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_cp.yaml
@@ -62,6 +62,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer: {}
+      bottlerocketAdmin: {}
       bottlerocketBootstrap: {}
       bottlerocketControl: {}
       controllerManager:
@@ -145,6 +146,7 @@ spec:
           provider-id: aws-snow:////'{{ ds.meta_data.instance_id }}'
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     joinConfiguration:
+      bottlerocketAdmin: {}
       bottlerocketBootstrap: {}
       bottlerocketControl: {}
       discovery: {}

--- a/pkg/providers/snow/testdata/expected_results_main_md.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_md.yaml
@@ -9,6 +9,7 @@ spec:
     spec:
       clusterConfiguration:
         apiServer: {}
+        bottlerocketAdmin: {}
         bottlerocketBootstrap: {}
         bottlerocketControl: {}
         controllerManager: {}
@@ -20,6 +21,7 @@ spec:
         registryMirror: {}
         scheduler: {}
       joinConfiguration:
+        bottlerocketAdmin: {}
         bottlerocketBootstrap: {}
         bottlerocketControl: {}
         discovery: {}


### PR DESCRIPTION
*Issue #, if available:*

#4050 

Base on #4208 

*Description of changes:*

- Override default BR admin, control container images URL
- Add bottlerocket-bootstrap-snow to custom bootstrap container image

Hold till #4208 is merged first.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

