### PR TITLE
Fix management cluster from current context

### DIFF
--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -117,6 +117,14 @@ func newClusterSpec(options clusterOptions) (*cluster.Spec, error) {
 		return nil, fmt.Errorf("unable to get cluster config from file: %v", err)
 	}
 
+	if clusterSpec.Cluster.IsManaged() && options.managementKubeconfig == "" {
+		options.managementKubeconfig = kubeconfig.FromEnvironment()
+		clusterSpec.ManagementCluster = &types.Cluster{
+			Name:               clusterSpec.Cluster.ManagedBy(),
+			KubeconfigFile:     options.managementKubeconfig,
+			ExistingManagement: true,
+		}
+	}
 	return clusterSpec, nil
 }
 


### PR DESCRIPTION
If you attempt to create a cluster using the management cluster in your current context, it fails in vsphere because it is supposed to use a management cluster, but no ManagementCluster is set. https://github.com/aws/eks-anywhere/blob/main/pkg/providers/vsphere/vsphere.go#L301:L303

The only place it seems to make a ManagementCluster object is https://github.com/aws/eks-anywhere/blob/main/cmd/eksctl-anywhere/cmd/options.go#L107:L113 which requires kubeconfig to be passed in.

Not sure if this is the best way to fix this, but it does.

