### PR TITLE
Remove labels for worker node groups

### DIFF
--- a/controllers/resource/vsphere.go
+++ b/controllers/resource/vsphere.go
@@ -14,7 +14,7 @@ func needsVSphereNewKubeadmConfigTemplate(
 	newWorkerNodeGroup, oldWorkerNodeGroup *anywherev1.WorkerNodeGroupConfiguration,
 	oldWorkerNodeVmc, newWorkerNodeVmc *anywherev1.VSphereMachineConfig,
 ) bool {
-	return !anywherev1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints) || !anywherev1.LabelsMapEqual(newWorkerNodeGroup.Labels, oldWorkerNodeGroup.Labels) ||
+	return !anywherev1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints) || !anywherev1.MapEqual(newWorkerNodeGroup.Labels, oldWorkerNodeGroup.Labels) ||
 		!equivalentUsers(oldWorkerNodeVmc.Spec.Users, newWorkerNodeVmc.Spec.Users)
 }
 

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -191,7 +191,8 @@ func TaintsSliceEqual(s1, s2 []corev1.Taint) bool {
 	return true
 }
 
-func LabelsMapEqual(s1, s2 map[string]string) bool {
+// MapEqual compares two maps to check whether or not they are equal.
+func MapEqual(s1, s2 map[string]string) bool {
 	if len(s1) != len(s2) {
 		return false
 	}
@@ -215,7 +216,7 @@ func (n *ControlPlaneConfiguration) Equal(o *ControlPlaneConfiguration) bool {
 		return false
 	}
 	return n.Count == o.Count && n.Endpoint.Equal(o.Endpoint) && n.MachineGroupRef.Equal(o.MachineGroupRef) &&
-		TaintsSliceEqual(n.Taints, o.Taints) && LabelsMapEqual(n.Labels, o.Labels)
+		TaintsSliceEqual(n.Taints, o.Taints) && MapEqual(n.Labels, o.Labels)
 }
 
 type Endpoint struct {
@@ -324,7 +325,7 @@ func WorkerNodeGroupConfigurationsLabelsMapEqual(a, b []WorkerNodeGroupConfigura
 			// if a node group is present in a but not b, or vise versa, it's immaterial
 			continue
 		} else {
-			if !LabelsMapEqual(m[nodeGroup.Name], nodeGroup.Labels) {
+			if !MapEqual(m[nodeGroup.Name], nodeGroup.Labels) {
 				return false
 			}
 		}

--- a/pkg/clusterapi/workers.go
+++ b/pkg/clusterapi/workers.go
@@ -119,12 +119,12 @@ func GetKubeadmConfigTemplate(ctx context.Context, client kubernetes.Client, nam
 }
 
 // KubeadmConfigTemplateEqual returns true only if the new version of a KubeadmConfigTemplate
-// involves changes with respect6 to the old one when applied to the cluster
+// involves changes with respect to the old one when applied to the cluster.
 // Implements ObjectComparator.
 func KubeadmConfigTemplateEqual(new, old *kubeadmv1.KubeadmConfigTemplate) bool {
 	// DeepDerivative treats empty map (length == 0) as unset field. We need to manually compare certain fields
 	// such as taints, so that setting it to empty will trigger machine recreate
-	return kubeadmConfigTemplateTaintsEqual(new, old) &&
+	return kubeadmConfigTemplateTaintsEqual(new, old) && kubeadmConfigTemplateExtraArgsEqual(new, old) &&
 		equality.Semantic.DeepDerivative(new.Spec, old.Spec)
 }
 
@@ -134,5 +134,14 @@ func kubeadmConfigTemplateTaintsEqual(new, old *kubeadmv1.KubeadmConfigTemplate)
 		anywherev1.TaintsSliceEqual(
 			new.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints,
 			old.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints,
+		)
+}
+
+func kubeadmConfigTemplateExtraArgsEqual(new, old *kubeadmv1.KubeadmConfigTemplate) bool {
+	return new.Spec.Template.Spec.JoinConfiguration == nil ||
+		old.Spec.Template.Spec.JoinConfiguration == nil ||
+		anywherev1.MapEqual(
+			new.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs,
+			old.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs,
 		)
 }

--- a/pkg/clusterapi/workers_test.go
+++ b/pkg/clusterapi/workers_test.go
@@ -289,6 +289,55 @@ func TestKubeadmConfigTemplateEqual(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "diff labels",
+			new: &kubeadmv1.KubeadmConfigTemplate{
+				Spec: kubeadmv1.KubeadmConfigTemplateSpec{
+					Template: kubeadmv1.KubeadmConfigTemplateResource{
+						Spec: kubeadmv1.KubeadmConfigSpec{
+							JoinConfiguration: &kubeadmv1.JoinConfiguration{
+								NodeRegistration: kubeadmv1.NodeRegistrationOptions{
+									KubeletExtraArgs: map[string]string{
+										"tls-cipher-suites": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+										"cgroup-driver":     "cgroupfs",
+										"eviction-hard":     "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%",
+									},
+								},
+							},
+							Files: []kubeadmv1.File{
+								{
+									Owner: "me",
+								},
+							},
+						},
+					},
+				},
+			},
+			old: &kubeadmv1.KubeadmConfigTemplate{
+				Spec: kubeadmv1.KubeadmConfigTemplateSpec{
+					Template: kubeadmv1.KubeadmConfigTemplateResource{
+						Spec: kubeadmv1.KubeadmConfigSpec{
+							JoinConfiguration: &kubeadmv1.JoinConfiguration{
+								NodeRegistration: kubeadmv1.NodeRegistrationOptions{
+									KubeletExtraArgs: map[string]string{
+										"tls-cipher-suites": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+										"cgroup-driver":     "cgroupfs",
+										"eviction-hard":     "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%",
+										"node-labels":       "foo-bar",
+									},
+								},
+							},
+							Files: []kubeadmv1.File{
+								{
+									Owner: "me",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "new JoinConfiguration nil",
 			new: &kubeadmv1.KubeadmConfigTemplate{
 				Spec: kubeadmv1.KubeadmConfigTemplateSpec{

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -551,7 +551,7 @@ func NeedsNewWorkloadTemplate(oldSpec, newSpec *cluster.Spec, oldCsdc, newCsdc *
 }
 
 func NeedsNewKubeadmConfigTemplate(newWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration, oldWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration) bool {
-	return !v1alpha1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints) || !v1alpha1.LabelsMapEqual(newWorkerNodeGroup.Labels, oldWorkerNodeGroup.Labels)
+	return !v1alpha1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints) || !v1alpha1.MapEqual(newWorkerNodeGroup.Labels, oldWorkerNodeGroup.Labels)
 }
 
 func needsNewEtcdTemplate(oldSpec, newSpec *cluster.Spec, oldCsmc, newCsmc *v1alpha1.CloudStackMachineConfig, log logr.Logger) bool {

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -336,7 +336,7 @@ func NeedsNewWorkloadTemplate(oldSpec, newSpec *cluster.Spec) bool {
 }
 
 func NeedsNewKubeadmConfigTemplate(newWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration, oldWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration) bool {
-	return !v1alpha1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints) || !v1alpha1.LabelsMapEqual(newWorkerNodeGroup.Labels, oldWorkerNodeGroup.Labels)
+	return !v1alpha1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints) || !v1alpha1.MapEqual(newWorkerNodeGroup.Labels, oldWorkerNodeGroup.Labels)
 }
 
 func NeedsNewEtcdTemplate(oldSpec, newSpec *cluster.Spec) bool {

--- a/pkg/providers/nutanix/provider.go
+++ b/pkg/providers/nutanix/provider.go
@@ -325,7 +325,7 @@ func NeedsNewWorkloadTemplate(oldSpec, newSpec *cluster.Spec, oldNmc, newNmc *v1
 }
 
 func NeedsNewKubeadmConfigTemplate(newWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration, oldWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration, oldWorkerNodeNmc *v1alpha1.NutanixMachineConfig, newWorkerNodeNmc *v1alpha1.NutanixMachineConfig) bool {
-	return !v1alpha1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints) || !v1alpha1.LabelsMapEqual(newWorkerNodeGroup.Labels, oldWorkerNodeGroup.Labels) ||
+	return !v1alpha1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints) || !v1alpha1.MapEqual(newWorkerNodeGroup.Labels, oldWorkerNodeGroup.Labels) ||
 		!v1alpha1.UsersSliceEqual(oldWorkerNodeNmc.Spec.Users, newWorkerNodeNmc.Spec.Users)
 }
 

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -44,7 +44,7 @@ func NeedsNewWorkloadTemplate(oldSpec, newSpec *cluster.Spec, oldVdc, newVdc *v1
 }
 
 func NeedsNewKubeadmConfigTemplate(newWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration, oldWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration) bool {
-	return !v1alpha1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints) || !v1alpha1.LabelsMapEqual(newWorkerNodeGroup.Labels, oldWorkerNodeGroup.Labels)
+	return !v1alpha1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints) || !v1alpha1.MapEqual(newWorkerNodeGroup.Labels, oldWorkerNodeGroup.Labels)
 }
 
 func NeedsNewEtcdTemplate(oldSpec, newSpec *cluster.Spec, oldVdc, newVdc *v1alpha1.TinkerbellDatacenterConfig, oldTmc, newTmc *v1alpha1.TinkerbellMachineConfig) bool {

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -481,7 +481,7 @@ func NeedsNewWorkloadTemplate(oldSpec, newSpec *cluster.Spec, oldVdc, newVdc *v1
 }
 
 func NeedsNewKubeadmConfigTemplate(newWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration, oldWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration, oldWorkerNodeVmc *v1alpha1.VSphereMachineConfig, newWorkerNodeVmc *v1alpha1.VSphereMachineConfig) bool {
-	return !v1alpha1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints) || !v1alpha1.LabelsMapEqual(newWorkerNodeGroup.Labels, oldWorkerNodeGroup.Labels) ||
+	return !v1alpha1.TaintsSliceEqual(newWorkerNodeGroup.Taints, oldWorkerNodeGroup.Taints) || !v1alpha1.MapEqual(newWorkerNodeGroup.Labels, oldWorkerNodeGroup.Labels) ||
 		!v1alpha1.UsersSliceEqual(oldWorkerNodeVmc.Spec.Users, newWorkerNodeVmc.Spec.Users)
 }
 

--- a/test/framework/labels.go
+++ b/test/framework/labels.go
@@ -48,7 +48,7 @@ func validateLabels(expectedLabels map[string]string, node corev1.Node) error {
 	actualLabels := retrieveTestNodeLabels(node.Labels)
 	expectedBytes, _ := json.Marshal(expectedLabels)
 	actualBytes, _ := json.Marshal(actualLabels)
-	if !v1alpha1.LabelsMapEqual(expectedLabels, actualLabels) {
+	if !v1alpha1.MapEqual(expectedLabels, actualLabels) {
 		return fmt.Errorf("labels on node %v and corresponding configuration do not match; configured labels: %v; node labels: %v",
 			node.Name, string(expectedBytes), string(actualBytes))
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We need to directly compare the labels maps to ensure a new name for the immutable kubeadm config template object when removing worker node labels

*Testing (if applicable):*
Unit test. Upgrade with new API on Docker cluster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

