### PR TITLE
Modifying docker test no double cluster run

### DIFF
--- a/test/e2e/emissary_test.go
+++ b/test/e2e/emissary_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/test/framework"
 )
@@ -23,10 +24,9 @@ func runCuratedPackageEmissaryInstall(test *framework.ClusterE2ETest) {
 	packageFile := test.BuildPackageConfigFile(emissaryPackageName, emissaryPackagePrefix, EksaPackagesNamespace)
 	test.InstallCuratedPackageFile(packageFile, kubeconfig.FromClusterName(test.ClusterName))
 	test.VerifyEmissaryPackageInstalled(emissaryPackagePrefix+"-"+emissaryPackageName, withMgmtCluster(test))
-}
-
-func runCuratedPackageEmissaryIngressTest(test *framework.ClusterE2ETest) {
-	test.TestEmissaryPackageRouting(emissaryPackagePrefix+"-"+emissaryPackageName, withMgmtCluster(test))
+	if test.Provider.Name() == constants.DockerProviderName {
+		test.TestEmissaryPackageRouting(emissaryPackagePrefix+"-"+emissaryPackageName, withMgmtCluster(test))
+	}
 }
 
 func runCuratedPackageEmissaryRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2ETest) {
@@ -61,11 +61,6 @@ func runCuratedPackageEmissaryInstallSimpleFlow(test *framework.ClusterE2ETest) 
 	test.WithCluster(runCuratedPackageEmissaryInstall)
 }
 
-func runCuratedPackageEmissaryInstallAdvancedFlow(test *framework.ClusterE2ETest) {
-	test.WithCluster(runCuratedPackageEmissaryInstall)
-	test.WithCluster(runCuratedPackageEmissaryIngressTest)
-}
-
 func TestCPackagesEmissaryDockerUbuntuKubernetes122SimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
@@ -75,7 +70,7 @@ func TestCPackagesEmissaryDockerUbuntuKubernetes122SimpleFlow(t *testing.T) {
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
 	)
-	runCuratedPackageEmissaryInstallAdvancedFlow(test)
+	runCuratedPackageEmissaryInstallSimpleFlow(test)
 }
 
 func TestCPackagesEmissaryVSphereKubernetes122SimpleFlow(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

This function was trying to spin up two bootstrap clusters during the flow, and caused failures.
```
func runCuratedPackageEmissaryInstallAdvancedFlow(test *framework.ClusterE2ETest) {
	test.WithCluster(runCuratedPackageEmissaryInstall)
	test.WithCluster(runCuratedPackageEmissaryIngressTest)
}
```
Adding a different way to execute the advanced tests only on docker provider for now.