### PR TITLE
Avoid deleting paused workload clusters

### DIFF
--- a/internal/test/envtest/client.go
+++ b/internal/test/envtest/client.go
@@ -232,6 +232,20 @@ func (a *APIExpecter) ShouldEventuallyMatch(ctx context.Context, obj client.Obje
 	}, a.timeout).Should(gomega.Succeed(), "object %s should eventually match", obj.GetName())
 }
 
+// CloneNameNamespace returns an empty client object of the same type
+// with the same and namespace. This is a helper to pass a new object to the "Eventually"
+// methods while preserving the original object's data.
+func CloneNameNamespace[T any, PT interface {
+	*T
+	client.Object
+}](obj PT,
+) PT {
+	copyObj := PT(new(T))
+	copyObj.SetName(obj.GetName())
+	copyObj.SetNamespace(obj.GetNamespace())
+	return copyObj
+}
+
 // ShouldEventuallyNotExist defines an eventual expectation that succeeds if the provided object
 // becomes not found by the client before the timeout expires.
 func (a *APIExpecter) ShouldEventuallyNotExist(ctx context.Context, obj client.Object) {


### PR DESCRIPTION
## Description of changes

The CLI still allows to delete workload clusters and it doesn't yet use the controller to do this. This means that the controller shouldn't try to reconcile deletions for workload clusters that are paused, so the CLI can perform its own logic.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

