### PR TITLE
Fix delete workload clusters from CLI

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -15,6 +15,11 @@ const (
 	// object to prevent a controller from processing a resource.
 	pausedAnnotation = "anywhere.eks.amazonaws.com/paused"
 
+	// ManagedByCLIAnnotation can be applied to an EKS-A Cluster to signal when the CLI is currently
+	// performing an operation so the controller should not take any action. When marked for deletion,
+	// the controller will remove the finalizer and let the cluster be deleted.
+	ManagedByCLIAnnotation = "anywhere.eks.amazonaws.com/managed-by-cli"
+
 	// ControlPlaneAnnotation is an annotation that can be applied to EKS-A machineconfig
 	// object to prevent a controller from making changes to that resource.
 	controlPlaneAnnotation = "anywhere.eks.amazonaws.com/control-plane"

--- a/pkg/clustermanager/retrier_client.go
+++ b/pkg/clustermanager/retrier_client.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/retrier"
 	"github.com/aws/eks-anywhere/pkg/types"
 )
@@ -75,6 +76,60 @@ func (c *RetrierClient) RemoveAnnotationInNamespace(ctx context.Context, resourc
 	return c.Retry(
 		func() error {
 			return c.ClusterClient.RemoveAnnotationInNamespace(ctx, resourceType, objectName, key, cluster, namespace)
+		},
+	)
+}
+
+// ListObjects reads all Objects of a particular resource type in a namespace.
+func (c *RetrierClient) ListObjects(ctx context.Context, resourceType, namespace, kubeconfig string, list kubernetes.ObjectList) error {
+	return c.Retry(
+		func() error {
+			return c.ClusterClient.ListObjects(ctx, resourceType, namespace, kubeconfig, list)
+		},
+	)
+}
+
+// DeleteGitOpsConfig deletes a GitOpsConfigObject from the cluster.
+func (c *RetrierClient) DeleteGitOpsConfig(ctx context.Context, cluster *types.Cluster, name string, namespace string) error {
+	return c.Retry(
+		func() error {
+			return c.ClusterClient.DeleteGitOpsConfig(ctx, cluster, name, namespace)
+		},
+	)
+}
+
+// DeleteEKSACluster deletes an EKSA Cluster object from the cluster.
+func (c *RetrierClient) DeleteEKSACluster(ctx context.Context, cluster *types.Cluster, name string, namespace string) error {
+	return c.Retry(
+		func() error {
+			return c.ClusterClient.DeleteEKSACluster(ctx, cluster, name, namespace)
+		},
+	)
+}
+
+// DeleteAWSIamConfig deletes an AWSIamConfig object from the cluster.
+func (c *RetrierClient) DeleteAWSIamConfig(ctx context.Context, cluster *types.Cluster, name string, namespace string) error {
+	return c.Retry(
+		func() error {
+			return c.ClusterClient.DeleteAWSIamConfig(ctx, cluster, name, namespace)
+		},
+	)
+}
+
+// DeleteOIDCConfig deletes a OIDCConfig object from the cluster.
+func (c *RetrierClient) DeleteOIDCConfig(ctx context.Context, cluster *types.Cluster, name string, namespace string) error {
+	return c.Retry(
+		func() error {
+			return c.ClusterClient.DeleteOIDCConfig(ctx, cluster, name, namespace)
+		},
+	)
+}
+
+// DeleteCluster deletes a CAPI Cluster from the cluster.
+func (c *RetrierClient) DeleteCluster(ctx context.Context, cluster, clusterToDelete *types.Cluster) error {
+	return c.Retry(
+		func() error {
+			return c.ClusterClient.DeleteCluster(ctx, cluster, clusterToDelete)
 		},
 	)
 }


### PR DESCRIPTION
## Description of changes
The new full lifecycle controller adds a finalizer to eks-a Clusters to be able to orchestrate its deletion. This interferes with the delete CLI operation, since it doesn't yet make use of the controller and it implements its own logic. The CLI tried to delete the eks-a cluster and get blocked forever since the controller wouldn't remove the finalizer for a paused cluster.

To solve this, we introduce a new annotation that signals the controller that the cluster is being managed the CLI and hence it should allow to be deleted without going through its normal deletion process.

There were also other hidden problems in the way cluster manager implemented the deletion, by wrapping a bunch of API operations in one big retry block. Some of these are not idempotent in combination with the others (for example, try to update annotations after deleting a resource). In addition, some of these operations had their own retry mechanisms internally, causing the total timeout to increase significantly. Now each individual operation has its own retry mechanism.

## Testing
Unit tests and manually ran `TestVSphereKubernetes121MulticlusterWorkloadCluster`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

