### PR TITLE
now passing insecure true if additionaltrustbundle is set

### DIFF
--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -159,6 +159,18 @@ func buildTemplateMapCP(
 		"subnetName":                   controlPlaneMachineSpec.Subnet.Name,  // TODO(nutanix): pass name or uuid based on type of identifier
 	}
 
+	// We intend on supporting three options until Prism Central starts shipping with
+	// valid self-signed certificates. The recommended order from a customer guidance
+	// perspective should be:
+	// - Use a Legitimate certificate
+	// - Use a valid self-signed cert and provide the CA cert through the trust bundle
+	// - Skip TLS verification
+
+	// set Insecure to always true if AdditionalTrustBundle if provided
+	if datacenterSpec.AdditionalTrustBundle != "" {
+		values["nutanixInsecure"] = true
+	}
+
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		values["externalEtcd"] = true
 		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count


### PR DESCRIPTION
since user may not have set this explicitely.`

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*
This should unblock e2e tests which are run internally in CI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

