### PR TITLE
Bubble up not found errors to cluster status

### DIFF
--- a/pkg/cluster/client_builder.go
+++ b/pkg/cluster/client_builder.go
@@ -2,7 +2,8 @@ package cluster
 
 import (
 	"context"
-	"fmt"
+
+	"github.com/pkg/errors"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
@@ -43,7 +44,7 @@ func (b *ConfigClientBuilder) Build(ctx context.Context, client Client, cluster 
 
 	for _, p := range b.processors {
 		if err := p(ctx, client, c); err != nil {
-			return nil, fmt.Errorf("building Config from a cluster client: %v", err)
+			return nil, errors.Wrap(err, "building Config from a cluster client")
 		}
 	}
 


### PR DESCRIPTION
## Description of changes
This should help users debug issues when misspelling object names or when a child object is not created successfully (think flux erroring in out in a machine config validation). This way we avoid having them checking the controller logs and can get everything from the API.

----------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

