### PR TITLE
Add UsesKubeRbacProxy for CAPX

### DIFF
--- a/release/pkg/assets/config/bundle_release.go
+++ b/release/pkg/assets/config/bundle_release.go
@@ -257,6 +257,7 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 			},
 		},
 		OnlyForDevRelease: true,
+		UsesKubeRbacProxy: true,
 	},
 	// Cluster-api-provider-tinkerbell artifacts
 	{

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -57,772 +57,6 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-20-22-eks-a-v0.0.0-dev-build.1
-    certManager:
-      acmesolver:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-acmesolver image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-acmesolver
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-build.1
-      cainjector:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-cainjector image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-cainjector
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-build.1
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-build.1
-      ctl:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-ctl image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-ctl
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-build.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
-      version: v1.9.1+abcdef1
-      webhook:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-webhook image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-webhook
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-build.1
-    cilium:
-      cilium:
-        arch:
-        - amd64
-        description: Container image for cilium image
-        imageDigest: sha256:4a778c1df3ad766771e951bfb451d4ec81cef8b1516c04a9d82ee61258e1ea86
-        name: cilium
-        os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.8-eksa.1
-      helmChart:
-        description: Helm chart for cilium-chart
-        imageDigest: sha256:ee2450e71d015f6e2d88d37ddb13bf9e77a56311cf34fb7260ef0bce6c1698ef
-        name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.8-eksa.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.11.8-eksa.1/cilium.yaml
-      operator:
-        arch:
-        - amd64
-        description: Container image for operator-generic image
-        imageDigest: sha256:36befe05f9cafac9a7f3c7dee047c18c250d0dd8bebed7eff8592b0083e12412
-        name: operator-generic
-        os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.8-eksa.1
-      version: v1.11.8-eksa.1
-    cloudStack:
-      clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-cloudstack image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-cloudstack
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc1-eks-a-v0.0.0-dev-build.1
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc1/infrastructure-components.yaml
-      kubeRbacProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc1/metadata.yaml
-      version: v0.4.9-rc1+abcdef1
-    clusterAPI:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
-    controlPlane:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kubeadm-control-plane-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kubeadm-control-plane-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
-    docker:
-      clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
-      manager:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-docker image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-docker
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
-    eksD:
-      channel: 1-20
-      components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      crictl:
-        arch:
-        - amd64
-        description: cri-tools tarball for linux/amd64
-        name: cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
-        os: linux
-        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
-      etcdadm:
-        arch:
-        - amd64
-        description: etcdadm tarball for linux/amd64
-        name: etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
-        os: linux
-        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
-      gitCommit: 0123456789abcdef0123456789abcdef01234567
-      imagebuilder:
-        arch:
-        - amd64
-        description: image-builder tarball for linux/amd64
-        name: image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
-        os: linux
-        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
-      kindNode:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kind-node image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kind-node
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.20.15-eks-d-1-20-22-eks-a-v0.0.0-dev-build.1
-      kubeVersion: v1.20.15
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-20/kubernetes-1-20-eks-22.yaml
-      name: kubernetes-1-20-eks-22
-      ova:
-        bottlerocket:
-          arch:
-          - amd64
-          description: Bottlerocket Ova image for EKS-D 1-20-22 release
-          name: bottlerocket-v1.20.15-eks-d-1-20-22-eks-a-v0.0.0-dev-build.0-amd64.ova
-          os: linux
-          osName: bottlerocket
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-20/1-20-22/bottlerocket-v1.20.15-eks-d-1-20-22-eks-a-v0.0.0-dev-build.0-amd64.ova
-      raw:
-        bottlerocket: {}
-    eksa:
-      cliTools:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for eks-anywhere-cli-tools image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-cli-tools
-        os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.12.2-eks-a-v0.0.0-dev-build.1
-      clusterController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for eks-anywhere-cluster-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-cluster-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.12.2-eks-a-v0.0.0-dev-build.1
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.12.2/eksa-components.yaml
-      diagnosticCollector:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for eks-anywhere-diagnostic-collector image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-diagnostic-collector
-        os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.12.2-eks-a-v0.0.0-dev-build.1
-      version: v0.0.0-dev+build.0+abcdef1
-    etcdadmBootstrap:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5/bootstrap-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for etcdadm-bootstrap-provider image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: etcdadm-bootstrap-provider
-        os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-eks-a-v0.0.0-dev-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5/metadata.yaml
-      version: v1.0.5+abcdef1
-    etcdadmController:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4/bootstrap-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for etcdadm-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: etcdadm-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-eks-a-v0.0.0-dev-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4/metadata.yaml
-      version: v1.0.4+abcdef1
-    flux:
-      helmController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for helm-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: helm-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-build.1
-      kustomizeController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kustomize-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kustomize-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-build.1
-      notificationController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for notification-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: notification-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-build.1
-      sourceController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for source-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: source-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-build.1
-      version: v0.31.3+abcdef1
-    haproxy:
-      image:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for haproxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: haproxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-build.1
-    kindnetd:
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
-    kubeVersion: "1.20"
-    nutanix:
-      clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-nutanix image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-nutanix
-        os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.0.1-eks-a-v0.0.0-dev-build.1
-      clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.0.1/cluster-template.yaml
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.0.1/infrastructure-components.yaml
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.0.1/metadata.yaml
-      version: v1.0.1+abcdef1
-    packageController:
-      helmChart:
-        description: Helm chart for eks-anywhere-packages
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.20-eks-a-v0.0.0-dev-build.1
-      packageController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for eks-anywhere-packages image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-packages
-        os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.20-eks-a-v0.0.0-dev-build.1
-      tokenRefresher:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for ecr-token-refresher image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: ecr-token-refresher
-        os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.20-eks-a-v0.0.0-dev-build.1
-      version: v0.2.20+abcdef1
-    snow:
-      bottlerocketBootstrapSnow:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for bottlerocket-bootstrap-snow image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: bottlerocket-bootstrap-snow
-        os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-20-22-eks-a-v0.0.0-dev-build.1
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
-      manager:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-snow-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-snow-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.8-eks-a-v0.0.0-dev-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/metadata.yaml
-      version: v0.1.8+abcdef1
-    tinkerbell:
-      clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-tinkerbell image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-tinkerbell
-        os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-build.1
-      clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
-      envoy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for envoy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: envoy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-build.1
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
-      tinkerbellStack:
-        actions:
-          cexec:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for cexec image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: cexec
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
-          imageToDisk:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for image2disk image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: image2disk
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
-          kexec:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for kexec image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: kexec
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
-          ociToDisk:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for oci2disk image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: oci2disk
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
-          reboot:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for reboot image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: reboot
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
-          writeFile:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for writefile image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: writefile
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
-        boots:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for boots image
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: boots
-          os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:79b1d9acb65dfd0527b44800eddbdcf6b751c8d8-eks-a-v0.0.0-dev-build.1
-        hegel:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for hegel image
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: hegel
-          os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-build.1
-        hook:
-          bootkit:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for hook-bootkit image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: hook-bootkit
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-build.1
-          docker:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for hook-docker image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: hook-docker
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-build.1
-          initramfs:
-            amd:
-              description: Tinkerbell operating system installation environment (osie)
-                component
-              name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-x86_64
-            arm:
-              description: Tinkerbell operating system installation environment (osie)
-                component
-              name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-aarch64
-          kernel:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for hook-kernel image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: hook-kernel
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-build.1
-          vmlinuz:
-            amd:
-              description: Tinkerbell operating system installation environment (osie)
-                component
-              name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-x86_64
-            arm:
-              description: Tinkerbell operating system installation environment (osie)
-                component
-              name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-aarch64
-        rufio:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for rufio image
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: rufio
-          os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-build.1
-        tink:
-          tinkController:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for tink-controller image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-controller
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-build.1
-          tinkServer:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for tink-server image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-server
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-build.1
-          tinkWorker:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for tink-worker image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-worker
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-build.1
-        tinkerbellChart:
-          description: Helm chart for tinkerbell-chart
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-build.1
-      version: v0.1.0
-    vSphere:
-      clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-vsphere image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-vsphere
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-build.1
-      clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
-      driver:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-driver image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-driver
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
-      manager:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cloud-provider-vsphere image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cloud-provider-vsphere
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.20.1-eks-d-1-20-eks-a-v0.0.0-dev-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
-      syncer:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-syncer image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-syncer
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.1
-      version: v1.3.1+abcdef1
-  - bootstrap:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kubeadm-bootstrap-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kubeadm-bootstrap-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
-    bottlerocketHostContainers:
-      admin:
-        arch:
-        - amd64
-        description: Container image for bottlerocket-admin image
-        imageDigest: sha256:bf56c9712189f5fc65d35544e2a84d3a7a1a2c05f2840fab54c57e8a3f8b57a4
-        name: bottlerocket-admin
-        os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.2
-      control:
-        arch:
-        - amd64
-        description: Container image for bottlerocket-control image
-        imageDigest: sha256:a8f8f30ed6bd3f4848cf79d19f6c31d60b9c898649e7ee1d3081dac4a36421a7
-        name: bottlerocket-control
-        os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3
-      kubeadmBootstrap:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for bottlerocket-bootstrap image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: bottlerocket-bootstrap
-        os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-21-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
@@ -1233,7 +467,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.20-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.21-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1242,7 +476,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.20-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.21-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1251,8 +485,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.20-eks-a-v0.0.0-dev-build.1
-      version: v0.2.20+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.21-eks-a-v0.0.0-dev-build.1
+      version: v0.2.21+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -1264,7 +498,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-21-21-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.10/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -1282,10 +516,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.8-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.10-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/metadata.yaml
-      version: v0.1.8+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.10/metadata.yaml
+      version: v0.1.10+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -2008,7 +1242,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.20-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.21-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -2017,7 +1251,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.20-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.21-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2026,8 +1260,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.20-eks-a-v0.0.0-dev-build.1
-      version: v0.2.20+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.21-eks-a-v0.0.0-dev-build.1
+      version: v0.2.21+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -2039,7 +1273,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-22-13-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.10/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2057,10 +1291,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.8-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.10-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/metadata.yaml
-      version: v0.1.8+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.10/metadata.yaml
+      version: v0.1.10+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -2783,7 +2017,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.20-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.21-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -2792,7 +2026,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.20-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.21-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2801,8 +2035,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.20-eks-a-v0.0.0-dev-build.1
-      version: v0.2.20+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.21-eks-a-v0.0.0-dev-build.1
+      version: v0.2.21+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -2814,7 +2048,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-23-8-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.10/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2832,10 +2066,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.8-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.10-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/metadata.yaml
-      version: v0.1.8+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.10/metadata.yaml
+      version: v0.1.10+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -3540,7 +2774,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.20-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.21-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -3549,7 +2783,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.20-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.21-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -3558,8 +2792,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.20-eks-a-v0.0.0-dev-build.1
-      version: v0.2.20+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.21-eks-a-v0.0.0-dev-build.1
+      version: v0.2.21+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -3571,7 +2805,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-24-3-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.10/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -3589,10 +2823,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.8-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.10-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.8/metadata.yaml
-      version: v0.1.8+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.10/metadata.yaml
+      version: v0.1.10+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:


### PR DESCRIPTION
*Description of changes:*
Add UsesKubeRbacProxy for CAPX
This is needed because CAPX uses `kube-rbac-proxy` and adding this should replace `kube-rbac-proxy` image with the proper `public.ecr.aws` URI 
```
curl -s https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.0.0-dev-build.5064/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.0.1/infrastructure-components.yaml | grep "image: .*"
        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/brancz/kube-rbac-proxy:latest
        image: public.ecr.aws/l0g8r8j6/nutanix-cloud-native/cluster-api-provider-nutanix:v1.0.1-eks-a-v0.0.0-dev-build.4684
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

