### PR TITLE
Remove 120 e2e tests

### DIFF
--- a/docs/content/en/docs/reference/changelog.md
+++ b/docs/content/en/docs/reference/changelog.md
@@ -3,7 +3,6 @@ title: "What's New?"
 linkTitle: "What's New?"
 weight: 35
 ---
-
 ## Unreleased
 
 

--- a/docs/content/en/docs/reference/changelog.md
+++ b/docs/content/en/docs/reference/changelog.md
@@ -3,6 +3,7 @@ title: "What's New?"
 linkTitle: "What's New?"
 weight: 35
 ---
+
 ## Unreleased
 
 

--- a/test/e2e/awsiam_test.go
+++ b/test/e2e/awsiam_test.go
@@ -42,15 +42,6 @@ func runTinkerbellAWSIamAuthFlow(test *framework.ClusterE2ETest) {
 	test.ValidateHardwareDecommissioned()
 }
 
-func TestDockerKubernetes120AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
 func TestDockerKubernetes121AWSIamAuth(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
@@ -83,16 +74,6 @@ func TestDockerKubernetes124AWSIamAuth(t *testing.T) {
 		framework.NewDocker(t),
 		framework.WithAWSIam(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube124)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
-func TestVSphereKubernetes120AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu120()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
 	)
 	runAWSIamAuthFlow(test)
 }
@@ -133,16 +114,6 @@ func TestVSphereKubernetes124AWSIamAuth(t *testing.T) {
 		framework.NewVSphere(t, framework.WithUbuntu124()),
 		framework.WithAWSIam(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube124)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
-func TestVSphereKubernetes120BottleRocketAWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket120()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
 	)
 	runAWSIamAuthFlow(test)
 }

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -31,16 +31,6 @@ func runTinkerbellConformanceFlow(test *framework.ClusterE2ETest) {
 	test.ValidateHardwareDecommissioned()
 }
 
-func TestDockerKubernetes120ThreeWorkersConformanceFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runConformanceFlow(test)
-}
-
 func TestDockerKubernetes121ThreeWorkersConformanceFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
@@ -76,16 +66,6 @@ func TestDockerKubernetes124ThreeWorkersConformanceFlow(t *testing.T) {
 		t,
 		framework.NewDocker(t),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube124)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runConformanceFlow(test)
-}
-
-func TestVSphereKubernetes120ThreeWorkersConformanceFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu120()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
 	)
 	runConformanceFlow(test)
@@ -131,16 +111,6 @@ func TestVSphereKubernetes124ThreeWorkersConformanceFlow(t *testing.T) {
 	runConformanceFlow(test)
 }
 
-func TestVSphereKubernetes120BottleRocketThreeWorkersConformanceFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket120()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runConformanceFlow(test)
-}
-
 func TestVSphereKubernetes121BottleRocketThreeWorkersConformanceFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
@@ -176,16 +146,6 @@ func TestVSphereKubernetes124BottleRocketThreeWorkersConformanceFlow(t *testing.
 		t,
 		framework.NewVSphere(t, framework.WithBottleRocket124()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube124)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runConformanceFlow(test)
-}
-
-func TestCloudStackKubernetes120ThreeWorkersConformanceFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat120()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
 	)
 	runConformanceFlow(test)
@@ -337,17 +297,6 @@ func TestSnowKubernetes123ThreeWorkersConformanceFlow(t *testing.T) {
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
 		framework.WithEnvVar(features.SnowProviderEnvVar, "true"),
 		framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
-	)
-	runConformanceFlow(test)
-}
-
-func TestNutanixKubernetes120ThreeWorkersConformanceFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu120Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(features.NutanixProviderEnvVar, "true"),
 	)
 	runConformanceFlow(test)
 }

--- a/test/e2e/curated_packages_test.go
+++ b/test/e2e/curated_packages_test.go
@@ -258,18 +258,6 @@ func runCuratedPackageInstallSimpleFlow(test *framework.ClusterE2ETest) {
 // but this is a simple solution for now, without having to make any major
 // decisions about test packages or methodologies, right now.
 
-func TestCPackagesDockerUbuntuKubernetes120SimpleFlow(t *testing.T) {
-	framework.CheckCuratedPackagesCredentials(t)
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube120),
-			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
-			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
-	)
-	runCuratedPackageInstallSimpleFlow(test)
-}
-
 func TestCPackagesDockerUbuntuKubernetes121SimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
@@ -312,18 +300,6 @@ func TestCPackagesDockerUbuntuKubernetes124SimpleFlow(t *testing.T) {
 		framework.NewDocker(t),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube124)),
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube124),
-			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
-			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
-	)
-	runCuratedPackageInstallSimpleFlow(test)
-}
-
-func TestCPackagesVSphereKubernetes120SimpleFlow(t *testing.T) {
-	framework.CheckCuratedPackagesCredentials(t)
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu120()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube120),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
 	)
@@ -551,18 +527,6 @@ func TestCPackagesCloudStackRedhatKubernetes121WorkloadCluster(t *testing.T) {
 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat121())
 	test := setupSimpleMultiCluster(t, provider, v1alpha1.Kube121)
 	runCuratedPackageRemoteClusterInstallSimpleFlow(test)
-}
-
-func TestCPackagesNutanixKubernetes120SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewNutanix(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube120),
-			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
-			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
-		framework.WithEnvVar(features.NutanixProviderEnvVar, "true"),
-	)
-	runCuratedPackageInstallSimpleFlow(test)
 }
 
 func TestCPackagesNutanixKubernetes121SimpleFlow(t *testing.T) {

--- a/test/e2e/flux_test.go
+++ b/test/e2e/flux_test.go
@@ -35,15 +35,6 @@ func runFluxFlow(test *framework.ClusterE2ETest) {
 	test.DeleteCluster()
 }
 
-func TestDockerKubernetes120FluxLegacy(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithFluxLegacy(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-	)
-	runFluxFlow(test)
-}
-
 func TestDockerKubernetes124GithubFlux(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
@@ -67,18 +58,6 @@ func TestDockerKubernetes121FluxLegacy(t *testing.T) {
 		framework.NewDocker(t),
 		framework.WithFluxLegacy(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes120FluxLegacy(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu120()),
-		framework.WithFluxLegacy(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 	)
 	runFluxFlow(test)
 }
@@ -124,18 +103,6 @@ func TestVSphereKubernetes124GitFlux(t *testing.T) {
 		framework.NewVSphere(t, framework.WithUbuntu124()),
 		framework.WithFluxGit(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube124)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes120BottleRocketFluxLegacy(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket120()),
-		framework.WithFluxLegacy(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
@@ -219,30 +186,6 @@ func TestVSphereKubernetes124GitopsOptionsFluxLegacy(t *testing.T) {
 		),
 	)
 	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes120GitopsOptionsFluxLegacy(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat120())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithFluxLegacy(),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube120),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-	)
-
-	test.RunClusterFlowWithGitOps(
-		framework.WithClusterUpgradeGit(
-			api.WithWorkerNodeCount(3),
-		),
-		// Needed in order to replace the CloudStackDatacenterConfig namespace field with the value specified
-		// compared to when it was initially created without it.
-		provider.WithProviderUpgradeGit(),
-	)
 }
 
 func TestVSphereKubernetes123To124FluxUpgradeLegacy(t *testing.T) {

--- a/test/e2e/oidc_test.go
+++ b/test/e2e/oidc_test.go
@@ -42,15 +42,6 @@ func runUpgradeFlowWithOIDC(test *framework.ClusterE2ETest, updateVersion v1alph
 	test.DeleteCluster()
 }
 
-func TestDockerKubernetes120OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-	)
-	runOIDCFlow(test)
-}
-
 func TestDockerKubernetes121OIDC(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
@@ -87,19 +78,6 @@ func TestDockerKubernetes124OIDC(t *testing.T) {
 	runOIDCFlow(test)
 }
 
-func TestVSphereKubernetes120OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu120()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
 func TestVSphereKubernetes121OIDC(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
@@ -123,19 +101,6 @@ func TestSnowKubernetes121OIDC(t *testing.T) {
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 		framework.WithEnvVar(features.SnowProviderEnvVar, "true"),
 		framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
-	)
-	runOIDCFlow(test)
-}
-
-func TestCloudStackKubernetes120OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat120()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 	)
 	runOIDCFlow(test)
 }

--- a/test/e2e/simpleflow_test.go
+++ b/test/e2e/simpleflow_test.go
@@ -43,15 +43,6 @@ func runSimpleFlow(test *framework.ClusterE2ETest) {
 	test.DeleteCluster()
 }
 
-func TestDockerKubernetes120SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-	)
-	runSimpleFlow(test)
-}
-
 func TestDockerKubernetes121SimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
@@ -88,15 +79,6 @@ func TestDockerKubernetes124SimpleFlow(t *testing.T) {
 	runSimpleFlow(test)
 }
 
-func TestVSphereKubernetes120SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu120()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-	)
-	runSimpleFlow(test)
-}
-
 func TestVSphereKubernetes121SimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
@@ -129,15 +111,6 @@ func TestVSphereKubernetes124SimpleFlow(t *testing.T) {
 		t,
 		framework.NewVSphere(t, framework.WithUbuntu124()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube124)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes120RedHatSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithRedHat120VSphere()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
 	)
 	runSimpleFlow(test)
 }
@@ -217,15 +190,6 @@ func TestVSphereKubernetes124BottleRocketDifferentNamespaceSimpleFlow(t *testing
 			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube124)),
 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes120SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat120()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
 	)
 	runSimpleFlow(test)
 }
@@ -546,16 +510,6 @@ func TestSnowKubernetes123SimpleFlow(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube123)),
 		framework.WithEnvVar(features.SnowProviderEnvVar, "true"),
 		framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes120SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu120Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithEnvVar(features.NutanixProviderEnvVar, "true"),
 	)
 	runSimpleFlow(test)
 }

--- a/test/e2e/stackedetcd_test.go
+++ b/test/e2e/stackedetcd_test.go
@@ -17,24 +17,6 @@ func runStackedEtcdFlow(test *framework.ClusterE2ETest) {
 	test.DeleteCluster()
 }
 
-func TestVSphereKubernetes120StackedEtcdBottlerocket(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket120()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
-	runStackedEtcdFlow(test)
-}
-
-func TestVSphereKubernetes120StackedEtcdUbuntu(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu120()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
-	runStackedEtcdFlow(test)
-}
-
 func TestVSphereKubernetes121StackedEtcdBottlerocket(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket121()),
@@ -83,15 +65,6 @@ func TestVSphereKubernetes124StackedEtcdUbuntu(t *testing.T) {
 func TestDockerKubernetesStackedEtcd(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
-	runStackedEtcdFlow(test)
-}
-
-func TestCloudStackKubernetes120StackedEtcdRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat120()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
 	runStackedEtcdFlow(test)
 }

--- a/test/e2e/upgrade_dev_test.go
+++ b/test/e2e/upgrade_dev_test.go
@@ -11,182 +11,20 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-func TestVSphereKubernetes118To119CpVmNumCpuUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu118())
-	test := framework.NewE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube118)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube119,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube119)),
-		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate119Var(),
-			api.WithControlPlaneVMsNumCPUs(vsphereCpVmNumCpuUpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes118To119CpVmMemoryUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu118())
-	test := framework.NewE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube118)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube119,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube119)),
-		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate119Var(),
-			api.WithControlPlaneVMsMemoryMiB(vsphereCpVmMemoryUpdate),
-		),
-	)
-}
-
-func TestVSphereKubernetes118To119CpDiskGiBUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu118())
-	test := framework.NewE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube118)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube119,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube119)),
-		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate119Var(),
-			api.WithControlPlaneDiskGiB(vsphereCpDiskGiBUpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes118To119WlVmNumCpuUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu118())
-	test := framework.NewE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube118)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube119,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube119)),
-		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate119Var(),
-			api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes118To119WlVmMemoryUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu118())
-	test := framework.NewE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube118)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube119,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube119)),
-		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate119Var(),
-			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
-		),
-	)
-}
-
-func TestVSphereKubernetes118To119WlDiskGiBUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu118())
-	test := framework.NewE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube118)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube119,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube119)),
-		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate119Var(),
-			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),
-		),
-	)
-}
-
-func TestVSphereKubernetes118To119FolderUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu118())
-	test := framework.NewE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube118)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube119,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube119)),
-		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate119Var(),
-			api.WithFolder(vsphereFolderUpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes118To119Network1to2Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu118())
-	test := framework.NewE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube118)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube119,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube119)),
-		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate119Var(),
-			api.WithNetwork(vsphereNetwork2UpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes118To119Network1to3Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu118())
-	test := framework.NewE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube118)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube119,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube119)),
-		provider.WithProviderUpgrade(
-			framework.UpdateUbuntuTemplate119Var(),
-			api.WithNetwork(vsphereNetwork3UpdateVar),
-		),
-	)
-}
-
-func TestCloudStackKubernetes120To121CpComputeOfferingUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat120())
+func TestCloudStackKubernetes121To122CpComputeOfferingUpgrade(t *testing.T) {
+	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat121())
 	test := framework.NewE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
 	)
 	runSimpleUpgradeFlow(
 		test,
-		v1alpha1.Kube120,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		v1alpha1.Kube121,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube122)),
 		provider.WithProviderUpgrade(
-			framework.UpdateRedhatTemplate121Var(),
+			framework.UpdateRedhatTemplate122Var(),
 			api.WithCloudStackComputeOfferingForAllMachines(cloudstackComputeOfferingUpdateVar),
 		),
 	)

--- a/test/e2e/upgrade_from_latest_test.go
+++ b/test/e2e/upgrade_from_latest_test.go
@@ -47,50 +47,6 @@ func latestMinorRelease(t testing.TB) *releasev1.EksARelease {
 	return latestRelease
 }
 
-func TestVSphereKubernetes120BottlerocketUpgradeFromLatestMinorRelease(t *testing.T) {
-	release := latestMinorRelease(t)
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(anywherev1.Bottlerocket),
-		),
-		framework.WithBottlerocketFromRelease(release, anywherev1.Kube120),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(anywherev1.Kube120)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		anywherev1.Kube120,
-		provider.WithProviderUpgrade(
-			provider.Bottlerocket120Template(), // Set the template so it doesn't get autoimported
-		),
-	)
-}
-
-func TestCloudStackKubernetes120UpgradeFromLatestMinorRelease(t *testing.T) {
-	release := latestMinorRelease(t)
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat120())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(anywherev1.Kube120)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		anywherev1.Kube120,
-		provider.WithProviderUpgrade(),
-	)
-}
 
 func TestVSphereKubernetes121BottlerocketUpgradeFromLatestMinorRelease(t *testing.T) {
 	release := latestMinorRelease(t)
@@ -114,32 +70,6 @@ func TestVSphereKubernetes121BottlerocketUpgradeFromLatestMinorRelease(t *testin
 		anywherev1.Kube121,
 		provider.WithProviderUpgrade(
 			provider.Bottlerocket121Template(), // Set the template so it doesn't get autoimported
-		),
-	)
-}
-
-func TestVSphereKubernetes120UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
-	release := latestMinorRelease(t)
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(anywherev1.Ubuntu),
-		),
-		framework.WithUbuntuForRelease(release, anywherev1.Kube120),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(anywherev1.Kube120)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		anywherev1.Kube120,
-		provider.WithProviderUpgrade(
-			provider.Ubuntu120Template(), // Set the template so it doesn't get autoimported
 		),
 	)
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -59,21 +59,6 @@ func runSimpleUpgradeFlowForBareMetal(test *framework.ClusterE2ETest, updateVers
 	test.ValidateHardwareDecommissioned()
 }
 
-func TestVSphereKubernetes120UbuntuTo121Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu120())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube121,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		provider.WithProviderUpgrade(provider.Ubuntu121Template()),
-	)
-}
-
 func TestVSphereKubernetes121UbuntuTo122Upgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu121())
 	test := framework.NewClusterE2ETest(
@@ -396,76 +381,6 @@ func TestVSphereKubernetes123BottlerocketTo124StackedEtcdUpgrade(t *testing.T) {
 		v1alpha1.Kube124,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
 		provider.WithProviderUpgrade(provider.Bottlerocket124Template()),
-	)
-}
-
-func TestCloudStackKubernetes120RedhatTo121Upgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat120())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube121,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		provider.WithProviderUpgrade(framework.UpdateRedhatTemplate121Var()),
-	)
-}
-
-func TestCloudStackKubernetesUnstacked120RedhatTo121Upgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat120())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube121,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		provider.WithProviderUpgrade(framework.UpdateRedhatTemplate121Var()),
-	)
-}
-
-func TestCloudStackKubernetes120RedhatTo121MultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat120())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube121,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		provider.WithProviderUpgrade(
-			framework.UpdateRedhatTemplate121Var(),
-			framework.UpdateLargerCloudStackComputeOffering(),
-		),
-	)
-}
-
-func TestCloudStackKubernetes120RedhatWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat120())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube120,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
 	)
 }
 
@@ -868,21 +783,6 @@ func TestTinkerbellKubernetes123UbuntuTo124Upgrade(t *testing.T) {
 //
 // Nutanix Upgrade tests START
 //
-func TestNutanixKubernetes120To121UbuntuUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu120Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithEnvVar(features.NutanixProviderEnvVar, "true"),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube121,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		provider.WithProviderUpgrade(framework.UpdateNutanixUbuntuTemplate121Var()),
-	)
-}
 
 func TestNutanixKubernetes121To122UbuntuUpgrade(t *testing.T) {
 	provider := framework.NewNutanix(t, framework.WithUbuntu121Nutanix())
@@ -923,42 +823,6 @@ func TestNutanixKubernetes122To123UbuntuUpgrade(t *testing.T) {
 //
 // Nutanix Worker Scale Up tests START
 //
-
-// 1 worker node cluster scaled up to 3
-func TestNutanixKubernetes120UbuntuWorkerNodeScaleUp1To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu120Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithEnvVar(features.NutanixProviderEnvVar, "true"),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube120,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(3)),
-	)
-}
-
-// 2 worker nodes clusters scaled up to 5
-func TestNutanixKubernetes120UbuntuWorkerNodeScaleUp2To5(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu120Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(2)),
-		framework.WithEnvVar(features.NutanixProviderEnvVar, "true"),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube120,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
 
 // 1 worker node cluster scaled up to 3
 func TestNutanixKubernetes121UbuntuWorkerNodeScaleUp1To3(t *testing.T) {
@@ -1077,42 +941,6 @@ func TestNutanixKubernetes123UbuntuWorkerNodeScaleUp2To5(t *testing.T) {
 //
 
 // 1 node control plane cluster scaled up to 3
-func TestNutanixKubernetes120UbuntuControlPlaneNodeScaleUp1To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu120Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithEnvVar("features.NutanixProviderEnvVarProviderEnvVar", "true"),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube120,
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-	)
-}
-
-// 3 node control plane cluster scaled up to 5
-func TestNutanixKubernetes120UbuntuControlPlaneNodeScaleUp3To5(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu120Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithEnvVar(features.NutanixProviderEnvVar, "true"),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube120,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(5)),
-	)
-}
-
-// 1 node control plane cluster scaled up to 3
 func TestNutanixKubernetes121UbuntuControlPlaneNodeScaleUp1To3(t *testing.T) {
 	provider := framework.NewNutanix(t, framework.WithUbuntu121Nutanix())
 	test := framework.NewClusterE2ETest(
@@ -1229,42 +1057,6 @@ func TestNutanixKubernetes123UbuntuControlPlaneNodeScaleUp3To5(t *testing.T) {
 //
 
 // 3 worker node cluster scaled down to 1
-func TestNutanixKubernetes120UbuntuWorkerNodeScaleDown3To1(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu120Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(features.NutanixProviderEnvVar, "true"),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube120,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
-	)
-}
-
-// 5 worker nodes clusters scaled down to 2
-func TestNutanixKubernetes120UbuntuWorkerNodeScaleDown5To2(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu120Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-		framework.WithEnvVar(features.NutanixProviderEnvVar, "true"),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube120,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(2)),
-	)
-}
-
-// 3 worker node cluster scaled down to 1
 func TestNutanixKubernetes121UbuntuWorkerNodeScaleDown3To1(t *testing.T) {
 	provider := framework.NewNutanix(t, framework.WithUbuntu121Nutanix())
 	test := framework.NewClusterE2ETest(
@@ -1379,42 +1171,6 @@ func TestNutanixKubernetes123UbuntuWorkerNodeScaleDown5To2(t *testing.T) {
 //
 // Nutanix Control Plane Scale Down tests START
 //
-
-// 3 node control plane cluster scaled down to 1
-func TestNutanixKubernetes120UbuntuControlPlaneNodeScaleDown3To1(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu120Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithEnvVar(features.NutanixProviderEnvVar, "true"),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube120,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-}
-
-// 5 node control plane cluster scaled down to 3
-func TestNutanixKubernetes120UbuntuControlPlaneNodeScaleDown5To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu120Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(5)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithEnvVar(features.NutanixProviderEnvVar, "true"),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube120,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
 
 // 3 node control plane cluster scaled down to 1
 func TestNutanixKubernetes121UbuntuControlPlaneNodeScaleDown3To1(t *testing.T) {

--- a/test/e2e/vsphere_autoimport_test.go
+++ b/test/e2e/vsphere_autoimport_test.go
@@ -42,21 +42,6 @@ func deleteTemplates(test *framework.ClusterE2ETest, provider *framework.VSphere
 	}
 }
 
-func TestVSphereKubernetes120BottlerocketAutoimport(t *testing.T) {
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithTemplateForAllMachines(""),
-			api.WithOsFamilyForAllMachines(v1alpha1.Bottlerocket),
-		),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube120)),
-	)
-	runAutoImportFlow(test, provider)
-}
-
 func TestVSphereKubernetes121BottlerocketAutoimport(t *testing.T) {
 	provider := framework.NewVSphere(t,
 		framework.WithVSphereFillers(

--- a/test/e2e/workload_clusters_test.go
+++ b/test/e2e/workload_clusters_test.go
@@ -158,7 +158,7 @@ func TestVSphereKubernetes121MulticlusterWorkloadCluster(t *testing.T) {
 }
 
 func TestVSphereUpgradeMulticlusterWorkloadClusterWithFluxLegacy(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu120())
+	provider := framework.NewVSphere(t, framework.WithUbuntu121())
 	test := framework.NewMulticlusterE2ETest(
 		t,
 		framework.NewClusterE2ETest(
@@ -166,7 +166,7 @@ func TestVSphereUpgradeMulticlusterWorkloadClusterWithFluxLegacy(t *testing.T) {
 			provider,
 			framework.WithFluxLegacy(),
 			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube120),
+				api.WithKubernetesVersion(v1alpha1.Kube121),
 				api.WithControlPlaneCount(1),
 				api.WithWorkerNodeCount(1),
 				api.WithStackedEtcdTopology(),
@@ -177,7 +177,7 @@ func TestVSphereUpgradeMulticlusterWorkloadClusterWithFluxLegacy(t *testing.T) {
 			provider,
 			framework.WithFluxLegacy(),
 			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube120),
+				api.WithKubernetesVersion(v1alpha1.Kube121),
 				api.WithControlPlaneCount(1),
 				api.WithWorkerNodeCount(1),
 				api.WithStackedEtcdTopology(),
@@ -187,12 +187,12 @@ func TestVSphereUpgradeMulticlusterWorkloadClusterWithFluxLegacy(t *testing.T) {
 	runWorkloadClusterFlowWithGitOps(
 		test,
 		framework.WithClusterUpgradeGit(
-			api.WithKubernetesVersion(v1alpha1.Kube121),
+			api.WithKubernetesVersion(v1alpha1.Kube122),
 			api.WithControlPlaneCount(3),
 			api.WithWorkerNodeCount(3),
 		),
 		provider.WithProviderUpgradeGit(
-			provider.Ubuntu121Template(),
+			provider.Ubuntu122Template(),
 		),
 	)
 }
@@ -206,7 +206,7 @@ func TestDockerUpgradeWorkloadClusterWithFluxLegacy(t *testing.T) {
 			provider,
 			framework.WithFluxLegacy(),
 			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube120),
+				api.WithKubernetesVersion(v1alpha1.Kube121),
 				api.WithControlPlaneCount(1),
 				api.WithWorkerNodeCount(1),
 			),
@@ -216,7 +216,7 @@ func TestDockerUpgradeWorkloadClusterWithFluxLegacy(t *testing.T) {
 			provider,
 			framework.WithFluxLegacy(),
 			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube120),
+				api.WithKubernetesVersion(v1alpha1.Kube121),
 				api.WithControlPlaneCount(1),
 				api.WithWorkerNodeCount(1),
 			),
@@ -225,7 +225,7 @@ func TestDockerUpgradeWorkloadClusterWithFluxLegacy(t *testing.T) {
 	runWorkloadClusterFlowWithGitOps(
 		test,
 		framework.WithClusterUpgradeGit(
-			api.WithKubernetesVersion(v1alpha1.Kube121),
+			api.WithKubernetesVersion(v1alpha1.Kube122),
 			api.WithControlPlaneCount(2),
 			api.WithWorkerNodeCount(2),
 		),
@@ -339,46 +339,6 @@ func TestCloudStackKubernetes121WorkloadCluster(t *testing.T) {
 		),
 	)
 	runWorkloadClusterFlow(test)
-}
-
-func TestCloudStackUpgradeMulticlusterWorkloadClusterWithFluxLegacy(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat120())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxLegacy(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube120),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxLegacy(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube120),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlowWithGitOps(
-		test,
-		framework.WithClusterUpgradeGit(
-			api.WithKubernetesVersion(v1alpha1.Kube121),
-			api.WithControlPlaneCount(3),
-			api.WithWorkerNodeCount(3),
-		),
-		provider.WithProviderUpgradeGit(
-			framework.UpdateRedhatTemplate121Var(),
-		),
-	)
 }
 
 func TestCloudStackKubernetes121ManagementClusterUpgradeFromLatest(t *testing.T) {


### PR DESCRIPTION
*Description of changes:*
Remove 120 e2e tests and clean up 1.18 AND 1.19 tests.

*Testing (if applicable):*
- make e2e

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

