### PR TITLE
Add cluster name to resources defined in clusterresourceset

### DIFF
--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -433,19 +433,19 @@ spec:
       cluster.x-k8s.io/cluster-name: {{.clusterName}}
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: {{.clusterName}}-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: {{.clusterName}}-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: {{.clusterName}}-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: {{.clusterName}}-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: {{.clusterName}}-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: {{.clusterName}}-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: {{.clusterName}}-vsphere-csi-controller
 ---
 {{- end }}
 apiVersion: addons.cluster.x-k8s.io/v1beta1
@@ -462,11 +462,11 @@ spec:
       cluster.x-k8s.io/cluster-name: {{.clusterName}}
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: {{.clusterName}}-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: {{.clusterName}}-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: {{.clusterName}}-cpi-manifests
 ---
 {{- if .externalEtcd }}
 kind: EtcdadmCluster
@@ -567,7 +567,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: {{.clusterName}}-vsphere-csi-controller
   namespace: {{.eksaSystemNamespace}}
 stringData:
   data: |
@@ -581,7 +581,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: {{.clusterName}}-csi-vsphere-config
   namespace: {{.eksaSystemNamespace}}
 stringData:
   data: |
@@ -716,7 +716,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: {{.clusterName}}-vsphere-csi-controller-role
   namespace: {{.eksaSystemNamespace}}
 ---
 apiVersion: v1
@@ -736,7 +736,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: {{.clusterName}}-vsphere-csi-controller-binding
   namespace: {{.eksaSystemNamespace}}
 ---
 apiVersion: v1
@@ -750,7 +750,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: {{.clusterName}}-csi.vsphere.vmware.com
   namespace: {{.eksaSystemNamespace}}
 ---
 apiVersion: v1
@@ -883,7 +883,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: {{.clusterName}}-vsphere-csi-node
   namespace: {{.eksaSystemNamespace}}
 ---
 apiVersion: v1
@@ -1018,7 +1018,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: {{.clusterName}}-vsphere-csi-controller
   namespace: {{.eksaSystemNamespace}}
 ---
 apiVersion: v1
@@ -1033,14 +1033,14 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: {{.clusterName}}-internal-feature-states.csi.vsphere.vmware.com
   namespace: {{.eksaSystemNamespace}}
 ---
 {{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: {{.clusterName}}-cloud-controller-manager
   namespace: {{.eksaSystemNamespace}}
 stringData:
   data: |
@@ -1054,7 +1054,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: {{.clusterName}}-cloud-provider-vsphere-credentials
   namespace: {{.eksaSystemNamespace}}
 stringData:
   data: |
@@ -1282,5 +1282,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: {{.clusterName}}-cpi-manifests
   namespace: {{.eksaSystemNamespace}}

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -320,16 +320,16 @@ func TestReconcilerReconcileControlPlaneSuccess(t *testing.T) {
 	})
 	tt.ShouldEventuallyExist(tt.ctx, capiCluster)
 
-	tt.ShouldEventuallyExist(tt.ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vsphere-csi-controller", Namespace: "eksa-system"}})
-	tt.ShouldEventuallyExist(tt.ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "csi-vsphere-config", Namespace: "eksa-system"}})
-	tt.ShouldEventuallyExist(tt.ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "cloud-controller-manager", Namespace: "eksa-system"}})
-	tt.ShouldEventuallyExist(tt.ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "cloud-provider-vsphere-credentials", Namespace: "eksa-system"}})
-	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "vsphere-csi-controller-role", Namespace: "eksa-system"}})
-	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "vsphere-csi-controller-binding", Namespace: "eksa-system"}})
-	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "csi.vsphere.vmware.com", Namespace: "eksa-system"}})
-	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "vsphere-csi-node", Namespace: "eksa-system"}})
-	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "vsphere-csi-controller", Namespace: "eksa-system"}})
-	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cpi-manifests", Namespace: "eksa-system"}})
+	tt.ShouldEventuallyExist(tt.ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "workload-cluster-vsphere-csi-controller", Namespace: "eksa-system"}})
+	tt.ShouldEventuallyExist(tt.ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "workload-cluster-csi-vsphere-config", Namespace: "eksa-system"}})
+	tt.ShouldEventuallyExist(tt.ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "workload-cluster-cloud-controller-manager", Namespace: "eksa-system"}})
+	tt.ShouldEventuallyExist(tt.ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "workload-cluster-cloud-provider-vsphere-credentials", Namespace: "eksa-system"}})
+	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "workload-cluster-vsphere-csi-controller-role", Namespace: "eksa-system"}})
+	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "workload-cluster-vsphere-csi-controller-binding", Namespace: "eksa-system"}})
+	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "workload-cluster-csi.vsphere.vmware.com", Namespace: "eksa-system"}})
+	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "workload-cluster-vsphere-csi-node", Namespace: "eksa-system"}})
+	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "workload-cluster-vsphere-csi-controller", Namespace: "eksa-system"}})
+	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "workload-cluster-cpi-manifests", Namespace: "eksa-system"}})
 }
 
 func TestReconcilerReconcileControlPlaneFailure(t *testing.T) {

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
@@ -411,19 +411,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -439,11 +439,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -509,7 +509,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -523,7 +523,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -658,7 +658,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -678,7 +678,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -692,7 +692,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -825,7 +825,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -950,7 +950,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -965,13 +965,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -985,7 +985,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1203,5 +1203,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
@@ -408,19 +408,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -436,11 +436,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -508,7 +508,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -522,7 +522,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -657,7 +657,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -677,7 +677,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -691,7 +691,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -824,7 +824,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -949,7 +949,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -964,13 +964,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -984,7 +984,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1202,5 +1202,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -444,19 +444,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -472,11 +472,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -562,7 +562,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -576,7 +576,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -711,7 +711,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -731,7 +731,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -745,7 +745,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -878,7 +878,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -1003,7 +1003,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -1018,13 +1018,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -1038,7 +1038,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1256,5 +1256,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
@@ -381,19 +381,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -409,11 +409,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -484,7 +484,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -498,7 +498,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -633,7 +633,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -653,7 +653,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -667,7 +667,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -800,7 +800,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -925,7 +925,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -940,13 +940,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -960,7 +960,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1178,5 +1178,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
@@ -381,19 +381,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -409,11 +409,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 apiVersion: v1
 kind: Secret
@@ -429,7 +429,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -443,7 +443,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -578,7 +578,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -598,7 +598,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -612,7 +612,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -745,7 +745,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -870,7 +870,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -885,13 +885,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -905,7 +905,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1123,5 +1123,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
@@ -379,19 +379,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -407,11 +407,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -482,7 +482,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -496,7 +496,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -631,7 +631,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -651,7 +651,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -665,7 +665,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -798,7 +798,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -923,7 +923,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -938,13 +938,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -958,7 +958,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1176,5 +1176,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -379,19 +379,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -407,11 +407,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -482,7 +482,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -496,7 +496,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -631,7 +631,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -651,7 +651,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -665,7 +665,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -798,7 +798,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -923,7 +923,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -938,13 +938,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -958,7 +958,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1176,5 +1176,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
@@ -379,19 +379,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -407,11 +407,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -482,7 +482,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -496,7 +496,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -631,7 +631,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -651,7 +651,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -665,7 +665,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -798,7 +798,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -923,7 +923,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -938,13 +938,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -958,7 +958,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1176,5 +1176,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
@@ -379,19 +379,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -407,11 +407,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -482,7 +482,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -496,7 +496,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -631,7 +631,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -651,7 +651,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -665,7 +665,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -798,7 +798,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -923,7 +923,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -938,13 +938,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -958,7 +958,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1176,5 +1176,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
@@ -379,19 +379,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -407,11 +407,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -482,7 +482,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -496,7 +496,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -631,7 +631,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -651,7 +651,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -665,7 +665,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -798,7 +798,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -923,7 +923,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -938,13 +938,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -958,7 +958,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1176,5 +1176,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -379,19 +379,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -407,11 +407,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -482,7 +482,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -496,7 +496,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -631,7 +631,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -651,7 +651,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -665,7 +665,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -798,7 +798,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -923,7 +923,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -938,13 +938,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -958,7 +958,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1176,5 +1176,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
@@ -381,19 +381,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -409,11 +409,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -484,7 +484,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -498,7 +498,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -633,7 +633,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -653,7 +653,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -667,7 +667,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -800,7 +800,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -925,7 +925,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -940,13 +940,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -960,7 +960,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1178,5 +1178,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -399,19 +399,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -427,11 +427,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -502,7 +502,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -516,7 +516,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -651,7 +651,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -671,7 +671,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -685,7 +685,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -818,7 +818,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -952,7 +952,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -967,13 +967,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -987,7 +987,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1214,5 +1214,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
@@ -373,19 +373,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -401,11 +401,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 apiVersion: v1
 kind: Secret
@@ -421,7 +421,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -435,7 +435,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -570,7 +570,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -590,7 +590,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -604,7 +604,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -737,7 +737,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -862,7 +862,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -877,13 +877,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -897,7 +897,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1115,5 +1115,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_disable_csi_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_disable_csi_cp.yaml
@@ -373,11 +373,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 apiVersion: v1
 kind: Secret
@@ -393,7 +393,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -407,7 +407,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -625,5 +625,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
@@ -376,19 +376,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -404,11 +404,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 apiVersion: v1
 kind: Secret
@@ -424,7 +424,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -438,7 +438,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -573,7 +573,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -593,7 +593,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -607,7 +607,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -740,7 +740,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -865,7 +865,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -880,13 +880,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -900,7 +900,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1118,5 +1118,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -388,19 +388,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -416,11 +416,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -493,7 +493,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -507,7 +507,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -642,7 +642,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -662,7 +662,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -676,7 +676,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -809,7 +809,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -934,7 +934,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -949,13 +949,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -969,7 +969,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1187,5 +1187,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -410,19 +410,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -438,11 +438,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -533,7 +533,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -547,7 +547,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -682,7 +682,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -702,7 +702,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -716,7 +716,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -849,7 +849,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -974,7 +974,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -989,13 +989,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -1009,7 +1009,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1227,5 +1227,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -413,19 +413,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -441,11 +441,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -536,7 +536,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -550,7 +550,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -685,7 +685,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -705,7 +705,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -719,7 +719,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -852,7 +852,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -977,7 +977,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -992,13 +992,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -1012,7 +1012,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1230,5 +1230,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -380,19 +380,19 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
   - kind: ConfigMap
-    name: vsphere-csi-controller-role
+    name: test-vsphere-csi-controller-role
   - kind: ConfigMap
-    name: vsphere-csi-controller-binding
+    name: test-vsphere-csi-controller-binding
   - kind: Secret
-    name: csi-vsphere-config
+    name: test-csi-vsphere-config
   - kind: ConfigMap
-    name: csi.vsphere.vmware.com
+    name: test-csi.vsphere.vmware.com
   - kind: ConfigMap
-    name: vsphere-csi-node
+    name: test-vsphere-csi-node
   - kind: ConfigMap
-    name: vsphere-csi-controller
+    name: test-vsphere-csi-controller
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -408,11 +408,11 @@ spec:
       cluster.x-k8s.io/cluster-name: test
   resources:
   - kind: Secret
-    name: cloud-controller-manager
+    name: test-cloud-controller-manager
   - kind: Secret
-    name: cloud-provider-vsphere-credentials
+    name: test-cloud-provider-vsphere-credentials
   - kind: ConfigMap
-    name: cpi-manifests
+    name: test-cpi-manifests
 ---
 kind: EtcdadmCluster
 apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
@@ -483,7 +483,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 stringData:
   data: |
@@ -497,7 +497,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-vsphere-config
+  name: test-csi-vsphere-config
   namespace: eksa-system
 stringData:
   data: |
@@ -632,7 +632,7 @@ data:
       - list
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-role
+  name: test-vsphere-csi-controller-role
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -652,7 +652,7 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller-binding
+  name: test-vsphere-csi-controller-binding
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -666,7 +666,7 @@ data:
       attachRequired: true
 kind: ConfigMap
 metadata:
-  name: csi.vsphere.vmware.com
+  name: test-csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -799,7 +799,7 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-node
+  name: test-vsphere-csi-node
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -924,7 +924,7 @@ data:
             name: socket-dir
 kind: ConfigMap
 metadata:
-  name: vsphere-csi-controller
+  name: test-vsphere-csi-controller
   namespace: eksa-system
 ---
 apiVersion: v1
@@ -939,13 +939,13 @@ data:
       namespace: kube-system
 kind: ConfigMap
 metadata:
-  name: internal-feature-states.csi.vsphere.vmware.com
+  name: test-internal-feature-states.csi.vsphere.vmware.com
   namespace: eksa-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-controller-manager
+  name: test-cloud-controller-manager
   namespace: eksa-system
 stringData:
   data: |
@@ -959,7 +959,7 @@ type: addons.cluster.x-k8s.io/resource-set
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: test-cloud-provider-vsphere-credentials
   namespace: eksa-system
 stringData:
   data: |
@@ -1177,5 +1177,5 @@ data:
         type: RollingUpdate
 kind: ConfigMap
 metadata:
-  name: cpi-manifests
+  name: test-cpi-manifests
   namespace: eksa-system


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If there is a mgmt cluster and a workload cluster, the resources in the clusterresourceset conflict, so adding the cluster name so that those resources can be managed separately

*Testing (if applicable):*
unit tests, functional test with tilt

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

