### PR TITLE
Deprecate import-images command

### DIFF
--- a/cmd/eksctl-anywhere/cmd/importimages.go
+++ b/cmd/eksctl-anywhere/cmd/importimages.go
@@ -40,10 +40,11 @@ func init() {
 
 var importImagesCmdDeprecated = &cobra.Command{
 	Use:          "import-images",
-	Short:        "Push EKS Anywhere images to a private registry",
+	Short:        "Push EKS Anywhere images to a private registry (Deprecated)",
 	Long:         "This command is used to import images from an EKS Anywhere release bundle into a private registry",
 	PreRunE:      preRunImportImagesCmd,
 	SilenceUsage: true,
+	Deprecated:   "use `eksctl anywhere import images` instead",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := importImages(cmd.Context(), opts.fileName); err != nil {
 			return err

--- a/docs/content/en/docs/reference/clusterspec/optional/registrymirror.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/registrymirror.md
@@ -71,18 +71,19 @@ export REGISTRY_PASSWORD=<password>
 ```
 
 ## Import images into a private registry
-You can use the `import images` command to pull images from `public.ecr.aws` and push them to your
+You can use the `download images` and `import images` command to pull images from `public.ecr.aws` and push them to your
 private registry.
-The `import images` command also pulls the cilium chart from `public.ecr.aws` and pushes it to the registry mirror. It requires the registry credentials for performing a login. Set the following environment variables for the login:
+The `download images` command also pulls the cilium chart from `public.ecr.aws` and pushes it to the registry mirror. It requires the registry credentials for performing a login. Set the following environment variables for the login:
 ```bash
 export REGISTRY_USERNAME=<username>
 export REGISTRY_PASSWORD=<password>
 ```
 
 ```bash
+eksctl anywhere download images -o images.tar
 docker login https://<private registry endpoint>
 ...
-eksctl anywhere import images -i cluster-spec.yaml
+eksctl anywhere import images -i images.tar
 ```
 ## Docker configurations
 It is necessary to add the private registry's CA Certificate

--- a/docs/content/en/docs/reference/clusterspec/optional/registrymirror.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/registrymirror.md
@@ -80,7 +80,7 @@ export REGISTRY_PASSWORD=<password>
 ```
 
 ```bash
-eksctl anywhere download images -o images.tar
+eksctl anywhere download images -o eks-anywhere-images.tar
 docker login https://<private registry endpoint>
 ...
 eksctl anywhere import images -i images.tar

--- a/docs/content/en/docs/reference/clusterspec/optional/registrymirror.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/registrymirror.md
@@ -71,9 +71,9 @@ export REGISTRY_PASSWORD=<password>
 ```
 
 ## Import images into a private registry
-You can use the `import-images` command to pull images from `public.ecr.aws` and push them to your
+You can use the `import images` command to pull images from `public.ecr.aws` and push them to your
 private registry.
-Starting with release 0.8, import-images command also pulls the cilium chart from `public.ecr.aws` and pushes it to the registry mirror. It requires the registry credentials for performing a login. Set the following environment variables for the login:
+The `import images` command also pulls the cilium chart from `public.ecr.aws` and pushes it to the registry mirror. It requires the registry credentials for performing a login. Set the following environment variables for the login:
 ```bash
 export REGISTRY_USERNAME=<username>
 export REGISTRY_PASSWORD=<password>
@@ -82,7 +82,7 @@ export REGISTRY_PASSWORD=<password>
 ```bash
 docker login https://<private registry endpoint>
 ...
-eksctl anywhere import-images -f cluster-spec.yaml
+eksctl anywhere import images -i cluster-spec.yaml
 ```
 ## Docker configurations
 It is necessary to add the private registry's CA Certificate

--- a/docs/content/en/docs/reference/clusterspec/optional/registrymirror.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/registrymirror.md
@@ -71,7 +71,7 @@ export REGISTRY_PASSWORD=<password>
 ```
 
 ## Import images into a private registry
-You can use the `download images` and `import images` command to pull images from `public.ecr.aws` and push them to your
+You can use the `download images` and `import images` commands to pull images from `public.ecr.aws` and push them to your
 private registry.
 The `download images` command also pulls the cilium chart from `public.ecr.aws` and pushes it to the registry mirror. It requires the registry credentials for performing a login. Set the following environment variables for the login:
 ```bash

--- a/docs/content/en/docs/reference/clusterspec/optional/registrymirror.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/registrymirror.md
@@ -83,7 +83,7 @@ export REGISTRY_PASSWORD=<password>
 eksctl anywhere download images -o eks-anywhere-images.tar
 docker login https://<private registry endpoint>
 ...
-eksctl anywhere import images -i images.tar
+eksctl anywhere import images -i eks-anywhere-images.tar
 ```
 ## Docker configurations
 It is necessary to add the private registry's CA Certificate


### PR DESCRIPTION
Make it clearer that the `import-images` command is deprecated.

```
% eksctl anywhere import-images 
Command "import-images" is deprecated, use `eksctl anywhere import images` instead
Error: required flag(s) "filename" not set
```
No longer shows up in general help:
```
% eksctl anywhere help          
Use eksctl anywhere to build your own self-managing cluster on your hardware with the best of Amazon EKS

Usage:
  anywhere [command]

Available Commands:
  apply         Apply resources
  check-images  Check images used by EKS Anywhere do exist in the target registry
  completion    Generate the autocompletion script for the specified shell
  create        Create resources
  delete        Delete resources
  describe      Describe resources
  download      Download resources
  exp           experimental commands
  generate      Generate resources
  get           Get resources
  help          Help about any command
  import        Import resources
  install       Install resources to the cluster
  list          List resources
  upgrade       Upgrade resources
  version       Get the eksctl anywhere version

Flags:
  -h, --help            help for anywhere
  -v, --verbosity int   Set the log level verbosity

Use "anywhere [command] --help" for more information about a command.
```


