### PR TITLE
Adding Nutanix E2E Test for Emissary and Harbor

### DIFF
--- a/test/e2e/harbor_test.go
+++ b/test/e2e/harbor_test.go
@@ -6,6 +6,9 @@ package e2e
 import (
 	"testing"
 
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/test/framework"
 )
@@ -17,14 +20,26 @@ func TestCPackagesHarborInstallSimpleFlow(t *testing.T) {
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
 	)
-	runHarborInstallSimpleFlow(test) // other args as necessary
+	runHarborInstallSimpleFlowLocalStorageProvisioner(test) // other args as necessary
 }
 
-func runHarborInstallSimpleFlow(test *framework.ClusterE2ETest) {
+func TestCPackagesHarborNutanixKubernetes123SimpleFlow(t *testing.T) {
+	framework.CheckCuratedPackagesCredentials(t)
+	test := framework.NewClusterE2ETest(t,
+		framework.NewNutanix(t, framework.WithUbuntu123Nutanix()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube123)),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube123),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
+		framework.WithEnvVar(features.NutanixProviderEnvVar, "true"),
+	)
+	runHarborInstallSimpleFlowLocalStorageProvisioner(test)
+}
+
+func runHarborInstallSimpleFlowLocalStorageProvisioner(test *framework.ClusterE2ETest) {
 	test.WithCluster(func(test *framework.ClusterE2ETest) {
-		if _, ok := test.Provider.(*framework.Docker); ok {
-			test.InstallLocalStorageProvisioner()
-		}
+		test.InstallLocalStorageProvisioner()
+
 		packagePrefix := "test"
 		installNs := "harbor"
 		test.CreateNamespace(installNs)


### PR DESCRIPTION
Packages E2E Test for Nutanix for Harbor and Emissary.

Harbor will use local-provisioner untill storage class for Nutanix is figured out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

