### PR TITLE
Use go install instead of go get to install executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ AWS_REGION=us-west-2
 
 BIN_DIR := bin
 TOOLS_BIN_DIR := hack/tools/bin
+TOOLS_BIN_DIR_ABS := $(shell pwd)/$(TOOLS_BIN_DIR)
 
 OUTPUT_DIR := _output
 OUTPUT_BIN_DIR := ${OUTPUT_DIR}/bin
@@ -251,7 +252,10 @@ $(KUBEBUILDER): $(TOOLS_BIN_DIR)
 	chmod +x $(KUBEBUILDER)
 
 $(CONTROLLER_GEN): $(TOOLS_BIN_DIR)
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1)
+	GOBIN=$(TOOLS_BIN_DIR_ABS) go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1
+
+$(GO_VULNCHECK): $(TOOLS_BIN_DIR)
+	GOBIN=$(TOOLS_BIN_DIR_ABS) go install golang.org/x/vuln/cmd/govulncheck@latest
 
 $(SETUP_ENVTEST): $(TOOLS_BIN_DIR)
 	cd $(TOOLS_BIN_DIR); $(GO) build -tags=tools -o $(SETUP_ENVTEST_BIN) sigs.k8s.io/controller-runtime/tools/setup-envtest
@@ -265,12 +269,8 @@ $(GOLANGCI_LINT): $(TOOLS_BIN_DIR) $(GOLANGCI_LINT_CONFIG)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLS_BIN_DIR) $(GOLANGCI_LINT_VERSION)
 
 .PHONY: vulncheck
-vulncheck: govulncheck
-	$(TOOLS_BIN_DIR)/govulncheck ./...
-
-govulncheck: ## Download and install govulncheck
-govulncheck:
-	$(call go-get-tool,$(GO_VULNCHECK),golang.org/x/vuln/cmd/govulncheck@latest)
+vulncheck: $(GO_VULNCHECK)
+	$(GO_VULNCHECK) ./...
 
 .PHONY: build-cross-platform
 build-cross-platform: eks-a-cross-platform
@@ -689,21 +689,6 @@ fake-controller-image-deps:
 .PHONY: run-controller # Run eksa controller from local repo with tilt
 run-controller: $(KUSTOMIZE) $(ORGANIZE_BINARIES_TARGETS) fake-controller-image-deps
 	tilt up --file manager/Tiltfile
-
-# go-get-tool will 'go get' any package $2 and install it to $1.
-# originally copied from kubebuilder
-define go-get-tool
-@[ -f $(1) ] || { \
-set -e ;\
-BIN_PATH=$$(realpath $$(dirname $(1))) ;\
-PKG_BIN_NAME=$$(echo "$(2)" | sed 's,^.*/\(.*\)@v.*$$,\1,') ;\
-BIN_NAME=$$(basename $(1)) ;\
-echo "Install dir $$BIN_PATH" ;\
-echo "Downloading $(2)" ;\
-GOBIN=$$BIN_PATH go install $(2) ;\
-[[ $$PKG_BIN_NAME == $$BIN_NAME ]] || mv -f $$BIN_PATH/$$PKG_BIN_NAME $$BIN_PATH/$$BIN_NAME ;\
-}
-endef
 
 define BUILDCTL
 	$(BUILDKIT) \


### PR DESCRIPTION
*Issue #, if available:*

In Go 1.18, go get will no longer build packages: https://go.dev/doc/go-get-install-deprecation
Kubebuilder also deprecated `go get` in the `Makefile` template: https://github.com/kubernetes-sigs/kubebuilder/pull/2486

*Description of changes:*

Use `go install` to install the tool binaries instead of with `go get`

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

