### PR TITLE
Refactor ip in use algorithm

### DIFF
--- a/pkg/networkutils/networkutils.go
+++ b/pkg/networkutils/networkutils.go
@@ -1,9 +1,11 @@
 package networkutils
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
+	"syscall"
 	"time"
 )
 
@@ -24,23 +26,25 @@ func ValidateIP(ip string) error {
 	return nil
 }
 
-// IsIPInUse performs a soft check to see if there are any services listening on a selection of common ports at
-// ip by trying to establish a TCP connection. Ports checked include: 22, 23, 80, 443 and 6443 (Kubernetes API Server).
-// Each connection attempt allows up-to 500ms for a response.
-//
-// todo(chrisdoherty) change to an icmp approach to eliminate the need for ports.
+// IsIPInUse performs a best effort check to see if an IP address is in use. It is not completely
+// reliable as testing if an IP is in use is inherently difficult, particularly with non-trivial
+// network topologies.
 func IsIPInUse(client NetClient, ip string) bool {
-	ports := []string{"22", "23", "80", "443", "6443"}
-	for _, port := range ports {
-		address := net.JoinHostPort(ip, port)
-		conn, err := client.DialTimeout("tcp", address, 500*time.Millisecond)
-		if err == nil {
-			conn.Close()
-			return true
-		}
+	// Dial and immediately close the connection if it was established as its superfluous for
+	// our check. We use port 80 as its common and is more likely to get through firewalls
+	// than other ports.
+	conn, err := client.DialTimeout("tcp", net.JoinHostPort(ip, "80"), 500*time.Millisecond)
+	if err == nil {
+		conn.Close()
 	}
 
-	return false
+	// If we establish a connection or we receive an ECONNRESET error the IP is in use. The latter
+	// case represents a host advertising the target IP, but without any services listening on the
+	// port. This is similar to how nmap works.
+	//
+	// Note this isn't cross platform. If we want to support non-unix systems we'll need to
+	// factor the error check into a platform specific function.
+	return err == nil || errors.Is(err, syscall.ECONNRESET)
 }
 
 func IsPortInUse(client NetClient, host string, port string) bool {


### PR DESCRIPTION
Refactor the `IsIPInUse` algorithm to run inside .5s instead of 2.5s and fix a bug that falsely reports an IP is not in use.

The `IsIPInUse` algorithm iterated over a series of ports testing if they were open at some target address via TCP. It failed to take into consideration devices that are serving the IP but have no services listening on the checked ports resulting in a false negative. 

Instead of relying on ports we can focus on whether the device _responded_. That can be achieved by either validating a TCP connection was in-fact established, or simply that the connection was reset by the server. The timeout period is still our indicator that the IP is not in use.

This check is still best effort but fixes the false negative case where none of the checked ports are open while also being 2s faster.