### PR TITLE
Add systemd kubelet extra arg

### DIFF
--- a/docs/content/en/docs/reference/changelog.md
+++ b/docs/content/en/docs/reference/changelog.md
@@ -3,7 +3,6 @@ title: "What's New?"
 linkTitle: "What's New?"
 weight: 35
 ---
-
 ## Unreleased
 
 

--- a/docs/content/en/docs/reference/changelog.md
+++ b/docs/content/en/docs/reference/changelog.md
@@ -3,6 +3,7 @@ title: "What's New?"
 linkTitle: "What's New?"
 weight: 35
 ---
+
 ## Unreleased
 
 

--- a/pkg/clusterapi/extraargs.go
+++ b/pkg/clusterapi/extraargs.go
@@ -103,9 +103,16 @@ func ControlPlaneNodeLabelsExtraArgs(cpc v1alpha1.ControlPlaneConfiguration) Ext
 }
 
 // CgroupDriverExtraArgs args added for kube versions below 1.24.
-func CgroupDriverExtraArgs() ExtraArgs {
+func CgroupDriverCgroupfsExtraArgs() ExtraArgs {
 	args := ExtraArgs{}
 	args.AddIfNotEmpty("cgroup-driver", "cgroupfs")
+	return args
+}
+
+// CgroupDriverSystemdExtraArgs args added for kube versions 1.24 and above.
+func CgroupDriverSystemdExtraArgs() ExtraArgs {
+	args := ExtraArgs{}
+	args.AddIfNotEmpty("cgroup-driver", "systemd")
 	return args
 }
 

--- a/pkg/clusterapi/extraargs_test.go
+++ b/pkg/clusterapi/extraargs_test.go
@@ -310,7 +310,7 @@ func TestSecureEtcdTlsCipherSuitesExtraArgs(t *testing.T) {
 	}
 }
 
-func TestCgroupDriverExtraArgs(t *testing.T) {
+func TestCgroupDriverCgroupfsExtraArgs(t *testing.T) {
 	tests := []struct {
 		testName string
 		want     clusterapi.ExtraArgs
@@ -325,8 +325,30 @@ func TestCgroupDriverExtraArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
-			if got := clusterapi.CgroupDriverExtraArgs(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CgroupDriverExtraArgs() = %v, want %v", got, tt.want)
+			if got := clusterapi.CgroupDriverCgroupfsExtraArgs(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CgroupDriverCgroupfsExtraArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCgroupDriverSystemdExtraArgs(t *testing.T) {
+	tests := []struct {
+		testName string
+		want     clusterapi.ExtraArgs
+	}{
+		{
+			testName: "default",
+			want: clusterapi.ExtraArgs{
+				"cgroup-driver": "systemd",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			if got := clusterapi.CgroupDriverSystemdExtraArgs(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CgroupDriverSystemdExtraArgs() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -222,10 +222,10 @@ func kubeletCgroupDriverExtraArgs(kubeVersion v1alpha1.KubernetesVersion) (clust
 		return nil, fmt.Errorf("error converting kubeVersion %v to semver %v", v1alpha1.Kube124, err)
 	}
 	if clusterKubeVersionSemver.Compare(kube124Semver) != -1 {
-		return nil, nil
+		return clusterapi.CgroupDriverSystemdExtraArgs(), nil
 	}
 
-	return clusterapi.CgroupDriverExtraArgs(), nil
+	return clusterapi.CgroupDriverCgroupfsExtraArgs(), nil
 }
 
 func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, error) {

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected_124onwards.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected_124onwards.yaml
@@ -297,12 +297,14 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: systemd
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          cgroup-driver: systemd
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   replicas: 3
   version: v1.19.6-eks-1-19-2

--- a/pkg/providers/docker/testdata/valid_deployment_md_expected_124onwards.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_md_expected_124onwards.yaml
@@ -12,6 +12,7 @@ spec:
           taints: []
           kubeletExtraArgs:
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cgroup-driver: systemd
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ---
 apiVersion: cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
*Description of changes:*
- `TestDockerKubernetes123to124UpgradeFromLatestMinorRelease` has been failing for the last few runs. This PR fixes that for unstacked topology.

*Testing (if applicable):*
- make e2e
- Run manual upgrade test
- Run e2e test `TestDockerKubernetes123to124UpgradeFromLatestMinorRelease`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

