### PR TITLE
Make SnowMachineConfig OSFamily required field

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_snowmachineconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_snowmachineconfigs.yaml
@@ -180,7 +180,7 @@ spec:
                 type: object
               osFamily:
                 description: 'OSFamily is the node instance OS. Valid values: "bottlerocket"
-                  (default) and "ubuntu".'
+                  and "ubuntu".'
                 type: string
               physicalNetworkConnector:
                 description: 'PhysicalNetworkConnector is the physical network connector

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4921,7 +4921,7 @@ spec:
                 type: object
               osFamily:
                 description: 'OSFamily is the node instance OS. Valid values: "bottlerocket"
-                  (default) and "ubuntu".'
+                  and "ubuntu".'
                 type: string
               physicalNetworkConnector:
                 description: 'PhysicalNetworkConnector is the physical network connector

--- a/pkg/api/v1alpha1/snowmachineconfig.go
+++ b/pkg/api/v1alpha1/snowmachineconfig.go
@@ -61,6 +61,10 @@ func validateSnowMachineConfig(config *SnowMachineConfig) error {
 		return errors.New("SnowMachineConfig Devices must contain at least one device IP")
 	}
 
+	if len(config.Spec.OSFamily) <= 0 {
+		return errors.New("SnowMachineConfig OSFamily must be specified")
+	}
+
 	if config.Spec.OSFamily != Bottlerocket && config.Spec.OSFamily != Ubuntu {
 		return fmt.Errorf("SnowMachineConfig OSFamily %s is not supported, please use one of the following: %s, %s", config.Spec.OSFamily, Bottlerocket, Ubuntu)
 	}
@@ -77,10 +81,5 @@ func setSnowMachineConfigDefaults(config *SnowMachineConfig) {
 	if config.Spec.PhysicalNetworkConnector == "" {
 		config.Spec.PhysicalNetworkConnector = DefaultSnowPhysicalNetworkConnectorType
 		logger.V(1).Info("SnowMachineConfig PhysicalNetworkConnector is empty. Using default", "default physical network connector", DefaultSnowPhysicalNetworkConnectorType)
-	}
-
-	if config.Spec.OSFamily == "" {
-		config.Spec.OSFamily = Bottlerocket
-		logger.V(1).Info("SnowMachineConfig OSFamily is empty. Using default", "default os family", Bottlerocket)
 	}
 }

--- a/pkg/api/v1alpha1/snowmachineconfig_test.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_test.go
@@ -24,7 +24,6 @@ func TestSnowMachineConfigSetDefaults(t *testing.T) {
 				Spec: SnowMachineConfigSpec{
 					InstanceType:             DefaultSnowInstanceType,
 					PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
-					OSFamily:                 Bottlerocket,
 				},
 			},
 		},
@@ -39,7 +38,6 @@ func TestSnowMachineConfigSetDefaults(t *testing.T) {
 				Spec: SnowMachineConfigSpec{
 					InstanceType:             "instance-type-1",
 					PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
-					OSFamily:                 Bottlerocket,
 				},
 			},
 		},
@@ -55,7 +53,6 @@ func TestSnowMachineConfigSetDefaults(t *testing.T) {
 					SshKeyName:               "ssh-name",
 					InstanceType:             DefaultSnowInstanceType,
 					PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
-					OSFamily:                 Bottlerocket,
 				},
 			},
 		},
@@ -70,7 +67,6 @@ func TestSnowMachineConfigSetDefaults(t *testing.T) {
 				Spec: SnowMachineConfigSpec{
 					PhysicalNetworkConnector: "network-1",
 					InstanceType:             DefaultSnowInstanceType,
-					OSFamily:                 Bottlerocket,
 				},
 			},
 		},
@@ -177,6 +173,18 @@ func TestSnowMachineConfigValidate(t *testing.T) {
 				},
 			},
 			wantErr: "SnowMachineConfig OSFamily invalidOS is not supported",
+		},
+		{
+			name: "empty os family",
+			obj: &SnowMachineConfig{
+				Spec: SnowMachineConfigSpec{
+					AMIID:        "ami-1",
+					InstanceType: DefaultSnowInstanceType,
+					Devices:      []string{"1.2.3.4"},
+					OSFamily:     "",
+				},
+			},
+			wantErr: "SnowMachineConfig OSFamily must be specified",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/api/v1alpha1/snowmachineconfig_types.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_types.go
@@ -48,7 +48,7 @@ type SnowMachineConfigSpec struct {
 	ContainersVolume *snowv1.Volume `json:"containersVolume,omitempty"`
 
 	// OSFamily is the node instance OS.
-	// Valid values: "bottlerocket" (default) and "ubuntu".
+	// Valid values: "bottlerocket" and "ubuntu".
 	OSFamily OSFamily `json:"osFamily,omitempty"`
 
 	// Network provides the custom network setting for the machine.


### PR DESCRIPTION
*Issue #, if available:*

Requested by Snow PM, we make osFamily a required field for snow provider, instead of defaulting to `bottlerocket` since it is only going to be supported for beta users. We also do not default to `ubuntu` since `bottlerocket` will be the default in the future when GA.

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

