### PR TITLE
docs: Clarify OIDC create/update documentation

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/optional/oidc.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/oidc.md
@@ -9,7 +9,9 @@ description: >
 
 ## OIDC support (optional)
 EKS Anywhere can create clusters that support api server OIDC authentication.
-In order to add OIDC support, you need to configure your cluster by updating the configuration file before creating the cluster.
+
+In order to add OIDC support, you need to configure your cluster by updating the configuration file to include the details below. The OIDC configuration can be added at cluster creation time, or introduced via a cluster upgrade in VMware and CloudStack.
+
 This is a generic template with detailed descriptions below for reference:
 ```yaml
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1


### PR DESCRIPTION
The current oidc reference doc states that OIDC can only be setup at cluster creation. That is not true for VMWare and Cloudstack.

*Issue #, if available:* None, sorry

*Description of changes:*
The current oidc reference doc states that OIDC can only be setup at cluster creation. That is not true for VMWare and Cloudstack.
*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

