### PR TITLE
test: Set OSFamily for snow tests

### DIFF
--- a/internal/pkg/api/snow.go
+++ b/internal/pkg/api/snow.go
@@ -118,3 +118,12 @@ func WithSnowMachineConfig(name string, fillers ...SnowMachineConfigFiller) Snow
 		FillSnowMachineConfig(m, fillers...)
 	}
 }
+
+// WithOsFamilyForAllSnowMachines sets the OSFamily in the SnowMachineConfig.
+func WithOsFamilyForAllSnowMachines(value anywherev1.OSFamily) SnowFiller {
+	return func(config SnowConfig) {
+		for _, m := range config.machineConfigs {
+			m.Spec.OSFamily = value
+		}
+	}
+}

--- a/test/framework/snow.go
+++ b/test/framework/snow.go
@@ -104,6 +104,7 @@ func WithSnowUbuntu121() SnowOpt {
 		s.fillers = append(s.fillers,
 			api.WithSnowStringFromEnvVar(snowAMIIDUbuntu121, api.WithSnowAMIIDForAllMachines),
 			api.WithSnowStringFromEnvVar(snowDevices, api.WithSnowDevicesForAllMachines),
+			api.WithOsFamilyForAllSnowMachines(anywherev1.Ubuntu),
 		)
 	}
 }
@@ -113,6 +114,7 @@ func WithSnowUbuntu122() SnowOpt {
 		s.fillers = append(s.fillers,
 			api.WithSnowStringFromEnvVar(snowAMIIDUbuntu122, api.WithSnowAMIIDForAllMachines),
 			api.WithSnowStringFromEnvVar(snowDevices, api.WithSnowDevicesForAllMachines),
+			api.WithOsFamilyForAllSnowMachines(anywherev1.Ubuntu),
 		)
 	}
 }
@@ -122,6 +124,7 @@ func WithSnowUbuntu123() SnowOpt {
 		s.fillers = append(s.fillers,
 			api.WithSnowStringFromEnvVar(snowAMIIDUbuntu123, api.WithSnowAMIIDForAllMachines),
 			api.WithSnowStringFromEnvVar(snowDevices, api.WithSnowDevicesForAllMachines),
+			api.WithOsFamilyForAllSnowMachines(anywherev1.Ubuntu),
 		)
 	}
 }


### PR DESCRIPTION
In response to the default OS being changed from Ubuntu to Bottlerocket, the test framework needs matching updates for the snow provider to ensure that the OSFamily entry in the SnowMachineConfig is set appropriately.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

