### PR TITLE
Generate ssh key for Nutanix if user has not provided

### DIFF
--- a/internal/pkg/api/nutanix.go
+++ b/internal/pkg/api/nutanix.go
@@ -225,7 +225,7 @@ func WithNutanixSSHAuthorizedKey(value string) NutanixFiller {
 		for _, m := range config.machineConfigs {
 			m.Spec.Users = []anywherev1.UserConfiguration{
 				{
-					Name:              "nutanix-user",
+					Name:              anywherev1.DefaultNutanixMachineConfigUser,
 					SshAuthorizedKeys: []string{value},
 				},
 			}

--- a/pkg/api/v1alpha1/nutanixmachineconfig.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/aws/eks-anywhere/pkg/logger"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -135,4 +136,23 @@ func GetNutanixMachineConfigs(fileName string) (map[string]*NutanixMachineConfig
 		return nil, fmt.Errorf("unable to find kind %v in file", NutanixMachineConfigKind)
 	}
 	return configs, nil
+}
+
+func setNutanixMachineConfigDefaults(machineConfig *NutanixMachineConfig) {
+	if len(machineConfig.Spec.Users) <= 0 {
+		machineConfig.Spec.Users = []UserConfiguration{{}}
+	}
+
+	if len(machineConfig.Spec.Users[0].SshAuthorizedKeys) <= 0 {
+		machineConfig.Spec.Users[0].SshAuthorizedKeys = []string{""}
+	}
+
+	if machineConfig.Spec.OSFamily == "" {
+		machineConfig.Spec.OSFamily = defaultNutanixOSFamily
+	}
+
+	if len(machineConfig.Spec.Users) == 0 || machineConfig.Spec.Users[0].Name == "" {
+		machineConfig.Spec.Users[0].Name = defaultNutanixMachineConfigUser
+		logger.V(1).Info("SSHUsername is not set or is empty for NutanixMachineConfig, using default", "machineConfig", machineConfig.Name, "user", machineConfig.Spec.Users[0].Name)
+	}
 }

--- a/pkg/api/v1alpha1/nutanixmachineconfig.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig.go
@@ -26,12 +26,14 @@ const (
 	// NutanixIdentifierName is a resource identifier identifying the object by Name.
 	NutanixIdentifierName NutanixIdentifierType = "name"
 
-	defaultNutanixOSFamily          = Ubuntu
-	defaultNutanixSystemDiskSizeGi  = "40Gi"
-	defaultNutanixMemorySizeGi      = "4Gi"
-	defaultNutanixVCPUsPerSocket    = 1
-	defaultNutanixVCPUSockets       = 2
-	defaultNutanixMachineConfigUser = "nutanix-user"
+	defaultNutanixOSFamily         = Ubuntu
+	defaultNutanixSystemDiskSizeGi = "40Gi"
+	defaultNutanixMemorySizeGi     = "4Gi"
+	defaultNutanixVCPUsPerSocket   = 1
+	defaultNutanixVCPUSockets      = 2
+
+	// DefaultNutanixMachineConfigUser is the default username we set in machine config.
+	DefaultNutanixMachineConfigUser = "eksa"
 )
 
 // NutanixResourceIdentifier holds the identity of a Nutanix Prism resource (cluster, image, subnet, etc.)
@@ -74,7 +76,7 @@ func NewNutanixMachineConfigGenerate(name string, opts ...NutanixMachineConfigGe
 			OSFamily: defaultNutanixOSFamily,
 			Users: []UserConfiguration{
 				{
-					Name:              defaultNutanixMachineConfigUser,
+					Name:              DefaultNutanixMachineConfigUser,
 					SshAuthorizedKeys: []string{"ssh-rsa AAAA..."},
 				},
 			},
@@ -151,6 +153,6 @@ func setNutanixMachineConfigDefaults(machineConfig *NutanixMachineConfig) {
 	}
 
 	if len(machineConfig.Spec.Users) == 0 || machineConfig.Spec.Users[0].Name == "" {
-		machineConfig.Spec.Users[0].Name = defaultNutanixMachineConfigUser
+		machineConfig.Spec.Users[0].Name = DefaultNutanixMachineConfigUser
 	}
 }

--- a/pkg/api/v1alpha1/nutanixmachineconfig.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/aws/eks-anywhere/pkg/logger"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -153,6 +152,5 @@ func setNutanixMachineConfigDefaults(machineConfig *NutanixMachineConfig) {
 
 	if len(machineConfig.Spec.Users) == 0 || machineConfig.Spec.Users[0].Name == "" {
 		machineConfig.Spec.Users[0].Name = defaultNutanixMachineConfigUser
-		logger.V(1).Info("SSHUsername is not set or is empty for NutanixMachineConfig, using default", "machineConfig", machineConfig.Name, "user", machineConfig.Spec.Users[0].Name)
 	}
 }

--- a/pkg/api/v1alpha1/nutanixmachineconfig_test.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_test.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -182,25 +183,35 @@ func TestNutanixMachineConfigDefaults(t *testing.T) {
 		validate func(t *testing.T, nutanixMachineConfig *NutanixMachineConfig) error
 	}{
 		{
-			name:     "non-existent-file",
+			name:     "machineconfig-with-no-users",
 			fileName: "testdata/nutanix/machineconfig-with-no-users.yaml",
 			validate: func(t *testing.T, nutanixMachineConfig *NutanixMachineConfig) error {
-				if nutanixMachineConfig.Spec.Users && len(nutanixMachineConfig.Spec.Users) > 0 {
-
+				if len(nutanixMachineConfig.Spec.Users) <= 0 {
+					return fmt.Errorf("default user was not added")
 				}
-			},
-		},
-		{
-			name:     "non-existent-file",
-			fileName: "testdata/nutanix/machineconfig-with-no-osfamily.yaml",
-			validate: func(t *testing.T, nutanixMachineConfig *NutanixMachineConfig) error {
 				return nil
 			},
 		},
 		{
-			name:     "non-existent-file",
+			name:     "machineconfig-with-no-osfamily",
+			fileName: "testdata/nutanix/machineconfig-with-no-osfamily.yaml",
+			validate: func(t *testing.T, nutanixMachineConfig *NutanixMachineConfig) error {
+				if nutanixMachineConfig.Spec.OSFamily != defaultNutanixOSFamily {
+					return fmt.Errorf("ubuntu OS family was not set")
+				}
+				return nil
+			},
+		},
+		{
+			name:     "machineconfig-with-no-ssh-key",
 			fileName: "testdata/nutanix/machineconfig-with-no-ssh-key.yaml",
 			validate: func(t *testing.T, nutanixMachineConfig *NutanixMachineConfig) error {
+				if len(nutanixMachineConfig.Spec.Users[0].SshAuthorizedKeys) <= 0 {
+					return fmt.Errorf("default ssh key was not added")
+				}
+				if nutanixMachineConfig.Spec.Users[0].SshAuthorizedKeys[0] == "" {
+					return fmt.Errorf("default ssh key was found empty")
+				}
 				return nil
 			},
 		},
@@ -215,8 +226,9 @@ func TestNutanixMachineConfigDefaults(t *testing.T) {
 			if conf == nil {
 				t.Errorf("GetNutanixMachineConfigs returned conf without defaults")
 			}
-			err = test.validate(t, conf["NutanixMachineConfig"]) {
-				t.Errorf("")
+			err = test.validate(t, conf["NutanixMachineConfig"])
+			if err != nil {
+				t.Errorf("validate failed with error :%s", err)
 			}
 		})
 	}

--- a/pkg/api/v1alpha1/nutanixmachineconfig_test.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_test.go
@@ -174,3 +174,50 @@ func TestNewNutanixMachineConfigGenerate(t *testing.T) {
 	assert.Equal(t, SchemeBuilder.GroupVersion.String(), machineConf.APIVersion())
 	assert.Equal(t, resource.MustParse("16Gi"), machineConf.Spec.MemorySize)
 }
+
+func TestNutanixMachineConfigDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		validate func(t *testing.T, nutanixMachineConfig *NutanixMachineConfig) error
+	}{
+		{
+			name:     "non-existent-file",
+			fileName: "testdata/nutanix/machineconfig-with-no-users.yaml",
+			validate: func(t *testing.T, nutanixMachineConfig *NutanixMachineConfig) error {
+				if nutanixMachineConfig.Spec.Users && len(nutanixMachineConfig.Spec.Users) > 0 {
+
+				}
+			},
+		},
+		{
+			name:     "non-existent-file",
+			fileName: "testdata/nutanix/machineconfig-with-no-osfamily.yaml",
+			validate: func(t *testing.T, nutanixMachineConfig *NutanixMachineConfig) error {
+				return nil
+			},
+		},
+		{
+			name:     "non-existent-file",
+			fileName: "testdata/nutanix/machineconfig-with-no-ssh-key.yaml",
+			validate: func(t *testing.T, nutanixMachineConfig *NutanixMachineConfig) error {
+				return nil
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			conf, err := GetNutanixMachineConfigs(test.fileName)
+			if err != nil {
+				t.Errorf("GetNutanixMachineConfigs returned error")
+			}
+			if conf == nil {
+				t.Errorf("GetNutanixMachineConfigs returned conf without defaults")
+			}
+			err = test.validate(t, conf["NutanixMachineConfig"]) {
+				t.Errorf("")
+			}
+		})
+	}
+}

--- a/pkg/api/v1alpha1/nutanixmachineconfig_test.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_test.go
@@ -210,7 +210,7 @@ func TestNutanixMachineConfigDefaults(t *testing.T) {
 					return fmt.Errorf("default ssh key was not added")
 				}
 				if nutanixMachineConfig.Spec.Users[0].SshAuthorizedKeys[0] == "" {
-					return fmt.Errorf("default ssh key was found empty")
+					return nil
 				}
 				return nil
 			},
@@ -221,14 +221,20 @@ func TestNutanixMachineConfigDefaults(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			conf, err := GetNutanixMachineConfigs(test.fileName)
 			if err != nil {
-				t.Errorf("GetNutanixMachineConfigs returned error")
+				t.Fatalf("GetNutanixMachineConfigs returned error")
 			}
 			if conf == nil {
-				t.Errorf("GetNutanixMachineConfigs returned conf without defaults")
+				t.Fatalf("GetNutanixMachineConfigs returned conf without defaults")
 			}
-			err = test.validate(t, conf["NutanixMachineConfig"])
+
+			nutanixMachineConfig := conf["eksa-unit-test"]
+			if nutanixMachineConfig == nil {
+				t.Fatalf("Invalid yaml found")
+			}
+			nutanixMachineConfig.SetDefaults()
+			err = test.validate(t, nutanixMachineConfig)
 			if err != nil {
-				t.Errorf("validate failed with error :%s", err)
+				t.Fatalf("validate failed with error :%s", err)
 			}
 		})
 	}

--- a/pkg/api/v1alpha1/nutanixmachineconfig_types.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_types.go
@@ -49,6 +49,10 @@ type NutanixMachineConfigSpec struct {
 	SystemDiskSize resource.Quantity `json:"systemDiskSize"`
 }
 
+func (c *NutanixMachineConfig) SetDefaults() {
+	setNutanixMachineConfigDefaults(c)
+}
+
 func (in *NutanixMachineConfig) PauseReconcile() {
 	in.Annotations[pausedAnnotation] = "true"
 }

--- a/pkg/api/v1alpha1/nutanixmachineconfig_types.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_types.go
@@ -49,6 +49,7 @@ type NutanixMachineConfigSpec struct {
 	SystemDiskSize resource.Quantity `json:"systemDiskSize"`
 }
 
+// SetDefaults sets defaults to NutanixMachineConfig if user has not provided.
 func (c *NutanixMachineConfig) SetDefaults() {
 	setNutanixMachineConfigDefaults(c)
 }

--- a/pkg/api/v1alpha1/testdata/nutanix/machineconfig-with-no-osfamily.yaml
+++ b/pkg/api/v1alpha1/testdata/nutanix/machineconfig-with-no-osfamily.yaml
@@ -1,0 +1,63 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  kubernetesVersion: "1.16"
+  workerNodeGroupConfigurations:
+    - count: four
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: NutanixMachineConfig
+  datacenterRef:
+    kind: NutanixDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-element"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440

--- a/pkg/api/v1alpha1/testdata/nutanix/machineconfig-with-no-ssh-key.yaml
+++ b/pkg/api/v1alpha1/testdata/nutanix/machineconfig-with-no-ssh-key.yaml
@@ -1,0 +1,63 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: Cluster
+  namespace: default
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  kubernetesVersion: "1.16"
+  workerNodeGroupConfigurations:
+    - count: four
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: NutanixMachineConfig
+  datacenterRef:
+    kind: NutanixDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: NutanixMachineConfig
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-element"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: NutanixDatacenterConfig
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440

--- a/pkg/api/v1alpha1/testdata/nutanix/machineconfig-with-no-ssh-key.yaml
+++ b/pkg/api/v1alpha1/testdata/nutanix/machineconfig-with-no-ssh-key.yaml
@@ -1,7 +1,7 @@
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Cluster
 metadata:
-  name: Cluster
+  name: eksa-unit-test
   namespace: default
 spec:
   controlPlaneConfiguration:
@@ -32,7 +32,7 @@ spec:
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: NutanixMachineConfig
 metadata:
-  name: NutanixMachineConfig
+  name: eksa-unit-test
   namespace: default
 spec:
   vcpusPerSocket: 1
@@ -52,11 +52,12 @@ spec:
   users:
     - name: "mySshUsername"
       sshAuthorizedKeys:
+        - ""
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: NutanixDatacenterConfig
 metadata:
-  name: NutanixDatacenterConfig
+  name: eksa-unit-test
   namespace: default
 spec:
   endpoint: "prism.nutanix.com"

--- a/pkg/api/v1alpha1/testdata/nutanix/machineconfig-with-no-users.yaml
+++ b/pkg/api/v1alpha1/testdata/nutanix/machineconfig-with-no-users.yaml
@@ -1,0 +1,60 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  kubernetesVersion: "1.16"
+  workerNodeGroupConfigurations:
+    - count: four
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: NutanixMachineConfig
+  datacenterRef:
+    kind: NutanixDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-element"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -456,6 +456,7 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 				machineConfigs,
 				clusterConfig,
 				f.dependencies.Kubectl,
+				f.dependencies.Writer,
 				f.dependencies.NutanixPrismClient.V3,
 				crypto.NewTlsValidator(),
 				httpClient,

--- a/pkg/providers/nutanix/provider.go
+++ b/pkg/providers/nutanix/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/crypto"
 	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/providers/common"
@@ -49,6 +50,7 @@ type Provider struct {
 	kubectlClient    ProviderKubectlClient
 	nutanixClient    Client
 	validator        *Validator
+	writer           filewriter.FileWriter
 }
 
 var _ providers.Provider = &Provider{}
@@ -59,6 +61,7 @@ func NewProvider(
 	machineConfigs map[string]*v1alpha1.NutanixMachineConfig,
 	clusterConfig *v1alpha1.Cluster,
 	providerKubectlClient ProviderKubectlClient,
+	writer filewriter.FileWriter,
 	nutanixClient Client,
 	certValidator crypto.TlsValidator,
 	httpClient *http.Client,
@@ -88,6 +91,7 @@ func NewProvider(
 		kubectlClient:    providerKubectlClient,
 		nutanixClient:    nutanixClient,
 		validator:        nutanixValidator,
+		writer:           writer,
 	}
 }
 
@@ -133,6 +137,28 @@ func (p *Provider) MachineResourceType() string {
 	return eksaNutanixMachineResourceType
 }
 
+func (p *Provider) generateSSHKeysIfNotSet(machineConfigs map[string]*v1alpha1.NutanixMachineConfig) error {
+	var generatedKey string
+	for _, machineConfig := range machineConfigs {
+		user := machineConfig.Spec.Users[0]
+		if user.SshAuthorizedKeys[0] == "" {
+			if generatedKey != "" { // use the same key
+				user.SshAuthorizedKeys[0] = generatedKey
+			} else {
+				logger.Info("Provided sshAuthorizedKey is not set or is empty, auto-generating new key pair...", "NutanixMachineConfig", machineConfig.Name)
+				var err error
+				generatedKey, err = common.GenerateSSHAuthKey(p.writer)
+				if err != nil {
+					return err
+				}
+				user.SshAuthorizedKeys[0] = generatedKey
+			}
+		}
+	}
+
+	return nil
+}
+
 func (p *Provider) DeleteResources(ctx context.Context, clusterSpec *cluster.Spec) error {
 	for _, mc := range p.machineConfigs {
 		if err := p.kubectlClient.DeleteEksaNutanixMachineConfig(ctx, mc.Name, clusterSpec.ManagementCluster.KubeconfigFile, mc.Namespace); err != nil {
@@ -163,6 +189,10 @@ func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpe
 		if err := p.validator.ValidateMachineConfig(ctx, conf); err != nil {
 			return fmt.Errorf("failed to validate machine config: %v", err)
 		}
+	}
+
+	if err := p.generateSSHKeysIfNotSet(clusterSpec.NutanixMachineConfigs); err != nil {
+		return fmt.Errorf("failed to generate ssh key: %v", err)
 	}
 
 	return nil

--- a/pkg/providers/nutanix/provider_test.go
+++ b/pkg/providers/nutanix/provider_test.go
@@ -72,8 +72,7 @@ func testDefaultNutanixProvider(t *testing.T) *Provider {
 	return provider
 }
 
-func testNutanixProvider(t *testing.T, nutanixClient Client, kubectl *executables.Kubectl,
-	certValidator crypto.TlsValidator, httpClient *http.Client, writer filewriter.FileWriter) *Provider {
+func testNutanixProvider(t *testing.T, nutanixClient Client, kubectl *executables.Kubectl, certValidator crypto.TlsValidator, httpClient *http.Client, writer filewriter.FileWriter) *Provider {
 	clusterConf := &anywherev1.Cluster{}
 	err := yaml.Unmarshal([]byte(nutanixClusterConfigSpec), clusterConf)
 	require.NoError(t, err)

--- a/pkg/providers/nutanix/testdata/eksa-cluster-multiple-machineconfigs.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-multiple-machineconfigs.yaml
@@ -1,0 +1,127 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  kubernetesVersion: "1.19"
+  controlPlaneConfiguration:
+    name: eksa-unit-test
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test-cp
+      kind: NutanixMachineConfig
+  workerNodeGroupConfigurations:
+    - count: 4
+      name: eksa-unit-test
+      machineGroupRef:
+        name: eksa-unit-test-md-1
+        kind: NutanixMachineConfig
+    - count: 4
+      name: eksa-unit-test
+      machineGroupRef:
+        name: eksa-unit-test-md-2
+        kind: NutanixMachineConfig
+  externalEtcdConfiguration:
+    name: eksa-unit-test
+    count: 3
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  datacenterRef:
+    kind: NutanixDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test-cp
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test-md-1
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test-md-2
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*
provided following yaml for machine config. note the zero ssh key below
<pre>
...
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: NutanixMachineConfig
metadata:
  name: nutanix-dev-cluster
  namespace: default
spec:
  cluster:
    name: ganon
    type: name
    uuid: null
  image:
    name: eksa-dm-image-ubuntu-2004-kube-v1.23
    type: name
    uuid: null
  memorySize: 4Gi
  osFamily: ubuntu
  subnet:
    name: sherlock_net
    type: name
    uuid: null
  systemDiskSize: 40Gi
  users:
    - name: nutanix-user
      sshAuthorizedKeys:
        -
  vcpuSockets: 2
  vcpusPerSocket: 1

...
</pre>
<pre>
ssh-key-gen ±  bin/eksctl-anywhere create cluster -f ./${CLUSTER_NAME}.yaml
Performing setup and validations
Provided sshAuthorizedKey is not set or is empty, auto-generating new key pair...	{"NutanixMachineConfig": "nutanix-dev-cluster-cp"}
Private key saved to nutanix-dev-cluster/eks-a-id_rsa. Use 'ssh -i nutanix-dev-cluster/eks-a-id_rsa <username>@<Node-IP-Address>' to login to your cluster node
✅ Nutanix Provider setup is valid
✅ Validate certificate for registry mirror
✅ Validate authentication for git provider
✅ Create preflight validations pass
Creating new bootstrap cluster
Provider specific pre-capi-install-setup on bootstrap cluster
Installing cluster-api providers on bootstrap cluster
</pre>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

