### PR TITLE
Update WaitForPackagesInstalled command

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -379,8 +379,8 @@ func (k *Kubectl) WaitForJobCompleted(ctx context.Context, kubeconfig, timeout s
 }
 
 // WaitForPackagesInstalled waits for a package resource to reach installed state before returning.
-func (k *Kubectl) WaitForPackagesInstalled(ctx context.Context, cluster *types.Cluster, name string, timeout string, namespace string) error {
-	return k.WaitJSONPathLoop(ctx, cluster.KubeconfigFile, timeout, "status.state", "installed", fmt.Sprintf("%s/%s", eksaPackagesType, name), namespace)
+func (k *Kubectl) WaitForPackagesInstalled(ctx context.Context, kubeconfig, name string, timeout string, namespace string) error {
+	return k.WaitJSONPathLoop(ctx, kubeconfig, timeout, "status.state", "installed", fmt.Sprintf("%s/%s", eksaPackagesType, name), namespace)
 }
 
 // WaitForPodCompleted waits for a pod to be terminated with a Completed state before returning.

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -2881,7 +2881,7 @@ func TestWaitForPackagesInstalled(t *testing.T) {
 	tt := newKubectlTest(t)
 	expectedParam := []string{"get", "packages.packages.eks.amazonaws.com/testpackage", "-o", fmt.Sprintf("%s=%s", "jsonpath", "'{.status.state}'"), "--kubeconfig", "c.kubeconfig", "-n", "eksa-system"}
 	tt.e.EXPECT().Execute(gomock.Any(), gomock.Eq(expectedParam)).Return(b, nil).AnyTimes()
-	err := tt.k.WaitForPackagesInstalled(tt.ctx, tt.cluster, "testpackage", "2m", "eksa-system")
+	err := tt.k.WaitForPackagesInstalled(tt.ctx, tt.cluster.KubeconfigFile, "testpackage", "2m", "eksa-system")
 	tt.Expect(err).ToNot(HaveOccurred())
 }
 

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1098,7 +1098,7 @@ func (e *ClusterE2ETest) VerifyHelloPackageInstalled(name string, mgmtCluster *t
 
 	e.T.Log("Waiting for Package", name, "To be installed")
 	err := e.KubectlClient.WaitForPackagesInstalled(ctx,
-		mgmtCluster, name, "5m", fmt.Sprintf("%s-%s", ns, e.ClusterName))
+		mgmtCluster.KubeconfigFile, name, "5m", fmt.Sprintf("%s-%s", ns, e.ClusterName))
 	if err != nil {
 		e.T.Fatalf("waiting for hello-eks-anywhere package timed out: %s", err)
 	}
@@ -1206,7 +1206,7 @@ func (e *ClusterE2ETest) VerifyEmissaryPackageInstalled(name string, mgmtCluster
 
 	e.T.Log("Waiting for Package", name, "To be installed")
 	err := e.KubectlClient.WaitForPackagesInstalled(ctx,
-		mgmtCluster, name, "5m", fmt.Sprintf("%s-%s", ns, e.ClusterName))
+		mgmtCluster.KubeconfigFile, name, "5m", fmt.Sprintf("%s-%s", ns, e.ClusterName))
 	if err != nil {
 		e.T.Fatalf("waiting for emissary package timed out: %s", err)
 	}
@@ -1254,7 +1254,7 @@ func (e *ClusterE2ETest) TestEmissaryPackageRouting(name string, mgmtCluster *ty
 	}
 	e.T.Log("Waiting for Package", name, "To be upgraded")
 	err = e.KubectlClient.WaitForPackagesInstalled(ctx,
-		mgmtCluster, name, "10m", fmt.Sprintf("%s-%s", ns, e.ClusterName))
+		mgmtCluster.KubeconfigFile, name, "10m", fmt.Sprintf("%s-%s", ns, e.ClusterName))
 	if err != nil {
 		e.T.Fatalf("waiting for emissary package upgrade timed out: %s", err)
 	}


### PR DESCRIPTION
Instead of using cluster as a parameter, we will use kubeconfig instead. This allows more versatile use cases as kubeconfig can not only be obtained by the cluster object, but also by the E2E environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

