### PR TITLE
Package the skipped tests file to be consumed in test stage

### DIFF
--- a/cmd/integration_test/build/buildspecs/build-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/build-eks-a-cli.yml
@@ -10,4 +10,5 @@ artifacts:
   files:
   - "bin/**/*"
   - "cmd/integration_test/build/**/*"
+  - "test/e2e/SKIPPED_TESTS.yaml"
   - "ATTRIBUTION.txt"


### PR DESCRIPTION
The test stage does not have a source, so we need to get the file from the previous stage as an artifact.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

