### PR TITLE
Fix Nutanix UUID tests

### DIFF
--- a/test/e2e/simpleflow_test.go
+++ b/test/e2e/simpleflow_test.go
@@ -514,7 +514,7 @@ func TestSnowKubernetes123SimpleFlow(t *testing.T) {
 	runSimpleFlow(test)
 }
 
-func TestNutanixKubernetes121SimpleFlow(t *testing.T) {
+func TestNutanixKubernetes121SimpleFlowWithName(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewNutanix(t, framework.WithUbuntu121Nutanix()),
@@ -523,7 +523,7 @@ func TestNutanixKubernetes121SimpleFlow(t *testing.T) {
 	runSimpleFlow(test)
 }
 
-func TestNutanixKubernetes122SimpleFlow(t *testing.T) {
+func TestNutanixKubernetes122SimpleFlowWithName(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewNutanix(t, framework.WithUbuntu122Nutanix()),
@@ -532,7 +532,7 @@ func TestNutanixKubernetes122SimpleFlow(t *testing.T) {
 	runSimpleFlow(test)
 }
 
-func TestNutanixKubernetes123SimpleFlow(t *testing.T) {
+func TestNutanixKubernetes123SimpleFlowWithName(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewNutanix(t, framework.WithUbuntu123Nutanix()),
@@ -541,7 +541,7 @@ func TestNutanixKubernetes123SimpleFlow(t *testing.T) {
 	runSimpleFlow(test)
 }
 
-func TestNutanixKubernetes124SimpleFlow(t *testing.T) {
+func TestNutanixKubernetes124SimpleFlowWithName(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewNutanix(t, framework.WithUbuntu124Nutanix()),
@@ -550,7 +550,7 @@ func TestNutanixKubernetes124SimpleFlow(t *testing.T) {
 	runSimpleFlow(test)
 }
 
-func TestNutanixKubernetes121SimpleFlowUUID(t *testing.T) {
+func TestNutanixKubernetes121SimpleFlowWithUUID(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewNutanix(t, framework.WithUbuntu121NutanixUUID(),
@@ -561,7 +561,7 @@ func TestNutanixKubernetes121SimpleFlowUUID(t *testing.T) {
 	runSimpleFlow(test)
 }
 
-func TestNutanixKubernetes122SimpleFlowUUID(t *testing.T) {
+func TestNutanixKubernetes122SimpleFlowWithUUID(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewNutanix(t, framework.WithUbuntu122NutanixUUID(),
@@ -572,7 +572,7 @@ func TestNutanixKubernetes122SimpleFlowUUID(t *testing.T) {
 	runSimpleFlow(test)
 }
 
-func TestNutanixKubernetes123SimpleFlowUUID(t *testing.T) {
+func TestNutanixKubernetes123SimpleFlowWithUUID(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewNutanix(t, framework.WithUbuntu123NutanixUUID(),
@@ -583,7 +583,7 @@ func TestNutanixKubernetes123SimpleFlowUUID(t *testing.T) {
 	runSimpleFlow(test)
 }
 
-func TestNutanixKubernetes124SimpleFlowUUID(t *testing.T) {
+func TestNutanixKubernetes124SimpleFlowWithUUID(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewNutanix(t, framework.WithUbuntu124NutanixUUID(),

--- a/test/framework/nutanix.go
+++ b/test/framework/nutanix.go
@@ -271,7 +271,7 @@ func WithUbuntu124NutanixUUID() NutanixOpt {
 func WithPrismElementClusterUUID() NutanixOpt {
 	return func(v *Nutanix) {
 		v.fillers = append(v.fillers,
-			api.WithNutanixStringFromEnvVar(nutanixPrismElementClusterUUID, api.WithNutanixMachineTemplateImageUUID),
+			api.WithNutanixStringFromEnvVar(nutanixPrismElementClusterUUID, api.WithNutanixPrismElementClusterUUID),
 		)
 	}
 }


### PR DESCRIPTION
*Description of changes:*
Give Nutanix tests unique names to avoid running multiple tests on the same instance
Also, fix UUID tests to correctly set UUID for os image

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

