### PR TITLE
Fix typo in cloudstack getting started guide

### DIFF
--- a/docs/content/en/docs/getting-started/production-environment/cloudstack-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/cloudstack-getstarted.md
@@ -101,7 +101,7 @@ Follow these steps to create an EKS Anywhere cluster that can be used either as 
 
 1. Configure Curated Packages
 
-   The Amazon EKS Anywhere Curated Packages are only available to customers with the Amazon EKS Anywhere Enterprise Subscription. To request a free trial, talk to your Amazon representative or connect with one [here](https://aws.amazon.com/contact-us/sales-support-eks/). Cluster creation will succeed if authentication is not set up, but some warnings may be genered.  Detailed package configurations can be found [here]({{< relref "../../tasks/packages" >}}).
+   The Amazon EKS Anywhere Curated Packages are only available to customers with the Amazon EKS Anywhere Enterprise Subscription. To request a free trial, talk to your Amazon representative or connect with one [here](https://aws.amazon.com/contact-us/sales-support-eks/). Cluster creation will succeed if authentication is not set up, but some warnings may be generated.  Detailed package configurations can be found [here]({{< relref "../../tasks/packages" >}}).
 
    If you are going to use packages, set up authentication. These credentials should have [limited capabilities]({{< relref "../../tasks/packages/#setup-authentication-to-use-curated-packages" >}}):
    ```bash


### PR DESCRIPTION
*Description of changes:* Fixes a small typo in the cloudstack getting started guide.