### PR TITLE
Skip checking hardware-csv flag for workload cluster tinkerbell

### DIFF
--- a/cmd/eksctl-anywhere/cmd/flags.go
+++ b/cmd/eksctl-anywhere/cmd/flags.go
@@ -14,6 +14,7 @@ const (
 	TinkerbellHardwareCSVFlagName        = "hardware-csv"
 	TinkerbellHardwareCSVFlagAlias       = "z"
 	TinkerbellHardwareCSVFlagDescription = "Path to a CSV file containing hardware data."
+	KubeconfigFile                       = "kubeconfig"
 )
 
 func bindFlagsToViper(cmd *cobra.Command, args []string) error {
@@ -53,7 +54,7 @@ func checkTinkerbellFlags(flagSet *pflag.FlagSet, hardwareCSVPath string, operat
 	}
 
 	if !viper.IsSet(TinkerbellHardwareCSVFlagName) || viper.GetString(TinkerbellHardwareCSVFlagName) == "" {
-		if operationType == Create { // For upgrade, hardware-csv is an optional flag
+		if operationType == Create && !viper.IsSet(KubeconfigFile) { // For upgrade and workload cluster create, hardware-csv is an optional flag
 			return fmt.Errorf("required flag \"%v\" not set", TinkerbellHardwareCSVFlagName)
 		}
 		return nil

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -129,9 +129,10 @@ func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpe
 	if err := p.configureSshKeys(); err != nil {
 		return err
 	}
-
-	if err := p.readCSVToCatalogue(); err != nil {
-		return err
+	if p.hardwareCSVIsProvided() {
+		if err := p.readCSVToCatalogue(); err != nil {
+			return err
+		}
 	}
 
 	if p.datacenterConfig.Spec.OSImageURL != "" {


### PR DESCRIPTION
*Description of changes:*
Skip checking for hardware-csv flag for tinkerbell creation if kubeconfig flag is given

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

