### PR TITLE
Add / update ADOT e2e test cases

### DIFF
--- a/test/e2e/adot_test.go
+++ b/test/e2e/adot_test.go
@@ -18,11 +18,11 @@ const (
 	adotTargetNamespace = "observability"
 )
 
-func TestCPackagesAdotDockerUbuntuKubernetes121SimpleFlow(t *testing.T) {
+func TestCPackagesAdotDockerUbuntuKubernetes124SimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t, framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
-		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube121),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube124)),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube124),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
 	)
@@ -38,7 +38,7 @@ func TestCPackagesAdotVSphereKubernetes122BottleRocketSimpleFlow(t *testing.T) {
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
 	)
-	runCuratedPackagesAdotInstallSimpleFlow(test)
+	runCuratedPackagesAdotInstallUpdateFlow(test)
 }
 
 func TestCPackagesAdotVSphereKubernetes123UbuntuUpdateFlow(t *testing.T) {
@@ -53,10 +53,58 @@ func TestCPackagesAdotVSphereKubernetes123UbuntuUpdateFlow(t *testing.T) {
 	runCuratedPackagesAdotInstallUpdateFlow(test)
 }
 
+func TestCPackagesAdotCloudStackRedhatKubernetes121SimpleFlow(t *testing.T) {
+	framework.CheckCuratedPackagesCredentials(t)
+	test := framework.NewClusterE2ETest(t,
+		framework.NewCloudStack(t, framework.WithCloudStackRedhat121()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121)),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube121),
+			"my-packages-test", EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
+	)
+	runCuratedPackagesAdotInstallSimpleFlow(test)
+}
+
+func TestCPackagesAdotNutanixKubernetes122SimpleFlow(t *testing.T) {
+	framework.CheckCuratedPackagesCredentials(t)
+	test := framework.NewClusterE2ETest(t,
+		framework.NewNutanix(t, framework.WithUbuntu122Nutanix()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122)),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube122),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
+	)
+	runCuratedPackagesAdotInstallUpdateFlow(test)
+}
+
+func TestCPackagesAdotTinkerbellUbuntuKubernetes122SingleNodeFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(t,
+		framework.NewTinkerbell(t, framework.WithUbuntu122Tinkerbell()),
+		framework.WithClusterSingleNode(v1alpha1.Kube122),
+		framework.WithControlPlaneHardware(1),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube122),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
+	)
+	runCuratedPackagesAdotInstallTinkerbellSingleNodeFlow(test)
+}
+
+func TestCPackagesAdotTinkerbellBottleRocketKubernetes123SingleNodeFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(t,
+		framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell()),
+		framework.WithClusterSingleNode(v1alpha1.Kube123),
+		framework.WithControlPlaneHardware(1),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube123),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
+	)
+	runCuratedPackagesAdotInstallTinkerbellSingleNodeFlow(test)
+}
+
 func runCuratedPackagesAdotInstallSimpleFlow(test *framework.ClusterE2ETest) {
 	test.WithCluster(func(test *framework.ClusterE2ETest) {
 		test.CreateNamespace(adotTargetNamespace)
-		test.InstallCuratedPackage("adot", adotPackagePrefix+"-"+adotPackageName,
+		test.InstallCuratedPackage(adotPackageName, adotPackagePrefix+"-"+adotPackageName,
 			kubeconfig.FromClusterName(test.ClusterName), adotTargetNamespace,
 			"--set mode=deployment")
 		test.VerifyAdotPackageInstalled(adotPackagePrefix+"-"+adotPackageName, adotTargetNamespace)
@@ -66,11 +114,23 @@ func runCuratedPackagesAdotInstallSimpleFlow(test *framework.ClusterE2ETest) {
 func runCuratedPackagesAdotInstallUpdateFlow(test *framework.ClusterE2ETest) {
 	test.WithCluster(func(test *framework.ClusterE2ETest) {
 		test.CreateNamespace(adotTargetNamespace)
-		test.InstallCuratedPackage("adot", adotPackagePrefix+"-"+adotPackageName,
+		test.InstallCuratedPackage(adotPackageName, adotPackagePrefix+"-"+adotPackageName,
 			kubeconfig.FromClusterName(test.ClusterName), adotTargetNamespace,
 			"--set mode=deployment")
 		test.VerifyAdotPackageInstalled(adotPackagePrefix+"-"+adotPackageName, adotTargetNamespace)
 		test.VerifyAdotPackageDeploymentUpdated(adotPackagePrefix+"-"+adotPackageName, adotTargetNamespace)
 		test.VerifyAdotPackageDaemonSetUpdated(adotPackagePrefix+"-"+adotPackageName, adotTargetNamespace)
 	})
+}
+
+func runCuratedPackagesAdotInstallTinkerbellSingleNodeFlow(test *framework.ClusterE2ETest) {
+	test.GenerateClusterConfig()
+	test.GenerateHardwareConfig()
+	test.PowerOnHardware()
+	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
+	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneNoTaints, framework.ValidateControlPlaneLabels)
+	runCuratedPackagesAdotInstallSimpleFlow(test)
+	test.DeleteCluster()
+	test.PowerOffHardware()
+	test.ValidateHardwareDecommissioned()
 }

--- a/test/e2e/adot_test.go
+++ b/test/e2e/adot_test.go
@@ -78,6 +78,7 @@ func TestCPackagesAdotNutanixKubernetes122SimpleFlow(t *testing.T) {
 }
 
 func TestCPackagesAdotTinkerbellUbuntuKubernetes122SingleNodeFlow(t *testing.T) {
+	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewTinkerbell(t, framework.WithUbuntu122Tinkerbell()),
 		framework.WithClusterSingleNode(v1alpha1.Kube122),
@@ -90,6 +91,7 @@ func TestCPackagesAdotTinkerbellUbuntuKubernetes122SingleNodeFlow(t *testing.T) 
 }
 
 func TestCPackagesAdotTinkerbellBottleRocketKubernetes123SingleNodeFlow(t *testing.T) {
+	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell()),
 		framework.WithClusterSingleNode(v1alpha1.Kube123),


### PR DESCRIPTION
Added test cases for Cloudstack, Nutanix, and Tinkerbell; updated test cases for Docker and vSphere

*Issue #, if available:* https://github.com/aws/eks-anywhere-packages/issues/631

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

