### PR TITLE
Embed staging bundle into the staging e2e test binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,7 @@ eks-a-binary:
 
 .PHONY: eks-a-embed-config
 eks-a-embed-config: ## Build a dev release version of eks-a with embed cluster spec config
+	yq -i e ".spec.releases[0].version = \"$(DEV_GIT_VERSION)\"" pkg/cluster/config/releases.yaml
 	$(MAKE) eks-a-binary GIT_VERSION=$(DEV_GIT_VERSION) RELEASE_MANIFEST_URL=embed:///config/releases.yaml BUILD_TAGS='$(BUILD_TAGS) spec_embed_config'
 
 .PHONY: eks-a-cross-platform-embed-latest-config
@@ -588,8 +589,8 @@ eks-a-e2e:
 	if [ "$(CODEBUILD_CI)" = "true" ]; then \
 		if [[ "$(CODEBUILD_BUILD_ID)" =~ "aws-staging-eks-a-build" ]]; then \
 			make eks-a-release-cross-platform GIT_VERSION=$(shell cat release/triggers/eks-a-release/development/RELEASE_VERSION) RELEASE_MANIFEST_URL=https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml; \
-			make eks-a-release GIT_VERSION=$(DEV_GIT_VERSION); \
 			scripts/get_bundle.sh; \
+			make eks-a-embed-config GIT_VERSION=$(DEV_GIT_VERSION) LINKER_FLAGS='-s -w -X github.com/aws/eks-anywhere/pkg/eksctl.enabled=true'; \
 		else \
 			make eks-a-cross-platform; \
 			make eks-a; \

--- a/pkg/cluster/config/releases.yaml
+++ b/pkg/cluster/config/releases.yaml
@@ -19,18 +19,4 @@ spec:
       gitTag: ""
       number: 0
       version: v0.0.0-custom
-    - bundleManifestUrl: "https://eks-anywhere-beta.s3.amazonaws.com/0.3.0/bundle-release.yaml"
-      date: ""
-      eksABinary: {}
-      gitCommit: ""
-      gitTag: ""
-      number: 0
-      version: v0.3.0
-    - bundleManifestUrl: "https://eks-anywhere-beta.s3.amazonaws.com/0.4.0/bundle-release.yaml"
-      date: ""
-      eksABinary: { }
-      gitCommit: ""
-      gitTag: ""
-      number: 0
-      version: v0.4.0
 status: {}

--- a/scripts/get_bundle.sh
+++ b/scripts/get_bundle.sh
@@ -20,3 +20,4 @@ set -o pipefail
 bundle_number=$(cat "${CODEBUILD_SRC_DIR}/release/triggers/bundle-release/development/BUNDLE_NUMBER")
 bundle_url="https://beta-assets.eks-anywhere.model-rocket.aws.dev/releases/bundles/${bundle_number}/manifest.yaml"
 wget -O "${CODEBUILD_SRC_DIR}/bin/local-bundle-release.yaml" "${bundle_url}"
+cp "${CODEBUILD_SRC_DIR}/bin/local-bundle-release.yaml" "${CODEBUILD_SRC_DIR}/pkg/cluster/config/bundle-release.yaml"


### PR DESCRIPTION
Embedding the staging bundle into the staging E2E test binary for ease of distribution and use.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

