### PR TITLE
Pass a right number params to logger.Info function

### DIFF
--- a/pkg/workflows/delete.go
+++ b/pkg/workflows/delete.go
@@ -239,7 +239,7 @@ func (s *deletePackageResources) Run(ctx context.Context, commandContext *task.C
 	}
 	err := commandContext.ClusterManager.DeletePackageResources(ctx, cluster, commandContext.WorkloadCluster.Name)
 	if err != nil {
-		logger.Info("Problem delete package resources: %v", err)
+		logger.Info("Problem delete package resources", "error", err)
 	}
 
 	// A bit odd to traverse to this state here, but it is the terminal state


### PR DESCRIPTION
*Issue #, if available:* #4345

*Description of changes:* Passing a right number of params (an odd number) to logger.Info function

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

