### PR TITLE
Update tag to consume bug fix for clusterresourceset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -172,7 +172,7 @@ require (
 	github.com/vmware/govmomi v0.29.0
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	go.uber.org/multierr v1.8.0
+	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/net v0.0.0-20220812174116-3211cb980234 // indirect
 	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde // indirect
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035 // indirect
@@ -209,5 +209,5 @@ replace (
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.2
 
 	// need the modifications eksa made to the capi api structs
-	sigs.k8s.io/cluster-api => github.com/abhay-krishna/cluster-api v1.2.0-custom.rc3
+	sigs.k8s.io/cluster-api => github.com/abhay-krishna/cluster-api v1.2.0-custom.rc5
 )

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/ReneKroon/ttlcache v1.7.0 h1:8BkjFfrzVFXyrqnMtezAaJ6AHPSsVV10m6w28N/F
 github.com/ReneKroon/ttlcache v1.7.0/go.mod h1:8BGGzdumrIjWxdRx8zpK6L3oGMWvIXdvB2GD1cfvd+I=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
 github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
-github.com/abhay-krishna/cluster-api v1.2.0-custom.rc3 h1:HfxwPaqe8ppgwpOoQEPlJqAMw4Q34Jv6EHS6GDnLlA4=
-github.com/abhay-krishna/cluster-api v1.2.0-custom.rc3/go.mod h1:UPhfJgbR0P6tjkcPXcB7PmKfTBS5iJHbe2anQGdE4Yk=
+github.com/abhay-krishna/cluster-api v1.2.0-custom.rc5 h1:XNSsijtksXr7QZt1+yW0e41XZZ8DhsCiPI86F30/Y8E=
+github.com/abhay-krishna/cluster-api v1.2.0-custom.rc5/go.mod h1:UPhfJgbR0P6tjkcPXcB7PmKfTBS5iJHbe2anQGdE4Yk=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Consume the tag that points to https://github.com/abhay-krishna/cluster-api/pull/6

(This got resolved, was an upstream Go issue) In order to get `go mod tidy` to work, I also needed to set `GOPRIVATE=github.com/abhay-krishna/cluster-api`

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

