### PR TITLE
Fix ADOT e2e daemonset not found error

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1273,6 +1273,7 @@ func (e *ClusterE2ETest) VerifyAdotPackageDaemonSetUpdated(packageName string, t
 		e.T.Fatalf("waiting for adot package update timed out: %s", err)
 	}
 
+	time.Sleep(15 * time.Second) // Add sleep to allow daemonset to be created
 	e.T.Log("Waiting for package", packageName, "daemonset to be rolled out")
 	err = e.KubectlClient.WaitForDaemonsetRolledout(ctx,
 		e.cluster(), "5m", fmt.Sprintf("%s-aws-otel-collector-agent", packageName), targetNamespace)


### PR DESCRIPTION
Occasionally, some tests will fail due to an error daemonsets.apps "generated-adot-aws-otel-collector-agent" not found. It appears that after the package changed to the "installed" state, some time buffer is still needed in between before we can check the daemonset status. The time needed may vary by machine. We will start with 15s.

*Issue #, if available:* https://github.com/aws/eks-anywhere-packages/issues/631

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

