### PR TITLE
Cluster Autoscaler with Metrics-server e2e

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -111,6 +111,19 @@ func WithWorkerNodeCount(r int) ClusterFiller {
 	}
 }
 
+func WithWorkerNodeAutoScalingConfig(min int, max int) ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		if len(c.Spec.WorkerNodeGroupConfigurations) == 0 {
+			c.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{{Count: ptr.Int(min)}}
+		}
+		c.Spec.WorkerNodeGroupConfigurations[0].AutoScalingConfiguration =
+			&anywherev1.AutoScalingConfiguration{
+				MinCount: min,
+				MaxCount: max,
+			}
+	}
+}
+
 func WithOIDCIdentityProviderRef(name string) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		c.Spec.IdentityProviderRefs = append(c.Spec.IdentityProviderRefs,

--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -111,16 +111,16 @@ func WithWorkerNodeCount(r int) ClusterFiller {
 	}
 }
 
+// WithWorkerNodeAutoScalingConfig adds an autoscaling configuration with a given min and max count.
 func WithWorkerNodeAutoScalingConfig(min int, max int) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		if len(c.Spec.WorkerNodeGroupConfigurations) == 0 {
 			c.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{{Count: ptr.Int(min)}}
 		}
-		c.Spec.WorkerNodeGroupConfigurations[0].AutoScalingConfiguration =
-			&anywherev1.AutoScalingConfiguration{
-				MinCount: min,
-				MaxCount: max,
-			}
+		c.Spec.WorkerNodeGroupConfigurations[0].AutoScalingConfiguration = &anywherev1.AutoScalingConfiguration{
+			MinCount: min,
+			MaxCount: max,
+		}
 	}
 }
 

--- a/internal/pkg/api/cluster_test.go
+++ b/internal/pkg/api/cluster_test.go
@@ -101,3 +101,109 @@ func TestWithWorkerNodeCount(t *testing.T) {
 		})
 	}
 }
+
+func TestWithWorkerNodeAutoScalingConfig(t *testing.T) {
+	expectedAutoScalingConfiguration := &anywherev1.AutoScalingConfiguration{
+		MinCount: 1,
+		MaxCount: 5,
+	}
+	tests := []struct {
+		name    string
+		cluster *anywherev1.Cluster
+		want    []anywherev1.WorkerNodeGroupConfiguration
+	}{
+		{
+			name: "with worker node config without autoscaling",
+			cluster: &anywherev1.Cluster{
+				Spec: anywherev1.ClusterSpec{
+					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+						{
+							Name:                     "md-0",
+							Count:                    ptr.Int(2),
+							AutoScalingConfiguration: nil,
+							MachineGroupRef:          nil,
+							Taints:                   nil,
+							Labels:                   nil,
+						},
+					},
+				},
+			},
+			want: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Name:                     "md-0",
+					Count:                    ptr.Int(2),
+					AutoScalingConfiguration: expectedAutoScalingConfiguration,
+					MachineGroupRef:          nil,
+					Taints:                   nil,
+					Labels:                   nil,
+				},
+			},
+		},
+		{
+			name: "with worker node config empty",
+			cluster: &anywherev1.Cluster{
+				Spec: anywherev1.ClusterSpec{},
+			},
+			want: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Name:                     "",
+					Count:                    ptr.Int(1),
+					AutoScalingConfiguration: expectedAutoScalingConfiguration,
+					MachineGroupRef:          nil,
+					Taints:                   nil,
+					Labels:                   nil,
+				},
+			},
+		},
+		{
+			name: "with worker node config greater than one",
+			cluster: &anywherev1.Cluster{
+				Spec: anywherev1.ClusterSpec{
+					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+						{
+							Name:                     "md-0",
+							Count:                    ptr.Int(1),
+							AutoScalingConfiguration: nil,
+							MachineGroupRef:          nil,
+							Taints:                   nil,
+							Labels:                   nil,
+						},
+						{
+							Name:                     "md-1",
+							Count:                    ptr.Int(1),
+							AutoScalingConfiguration: nil,
+							MachineGroupRef:          nil,
+							Taints:                   nil,
+							Labels:                   nil,
+						},
+					},
+				},
+			},
+			want: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Name:                     "md-0",
+					Count:                    ptr.Int(1),
+					AutoScalingConfiguration: expectedAutoScalingConfiguration,
+					MachineGroupRef:          nil,
+					Taints:                   nil,
+					Labels:                   nil,
+				},
+				{
+					Name:                     "md-1",
+					Count:                    ptr.Int(1),
+					AutoScalingConfiguration: nil,
+					MachineGroupRef:          nil,
+					Taints:                   nil,
+					Labels:                   nil,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api.WithWorkerNodeAutoScalingConfig(1, 5)(tt.cluster)
+			g := NewWithT(t)
+			g.Expect(tt.cluster.Spec.WorkerNodeGroupConfigurations).To(Equal(tt.want))
+		})
+	}
+}

--- a/test/e2e/autoscaler_test.go
+++ b/test/e2e/autoscaler_test.go
@@ -28,8 +28,9 @@ func runAutoscalerCloudStackSimpleFlow(test *framework.ClusterE2ETest) {
 	test.WithCluster(func(e *framework.ClusterE2ETest) {
 		autoscalerName := "cluster-autoscaler"
 		metricServerName := "metrics-server"
-		test.InstallAutoScalerWithMetricServer()
-		test.CombinedAutoscalerMetricServerTest(autoscalerName, metricServerName, withMgmtCluster(test))
+		targetNamespace := "eksa-packages"
+		test.InstallAutoScalerWithMetricServer(targetNamespace)
+		test.CombinedAutoscalerMetricServerTest(autoscalerName, metricServerName, targetNamespace, withMgmtCluster(test))
 	})
 
 }

--- a/test/e2e/autoscaler_test.go
+++ b/test/e2e/autoscaler_test.go
@@ -12,25 +12,69 @@ import (
 )
 
 func TestCPackagesClusterAutoscalerCloudStackRedhatKubernetes121SimpleFlow(t *testing.T) {
+	minNodes := 1
+	maxNodes := 2
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewCloudStack(t, framework.WithCloudStackRedhat121()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121), api.WithWorkerNodeAutoScalingConfig(1, 2)),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121), api.WithWorkerNodeAutoScalingConfig(minNodes, maxNodes)),
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube121),
-			"my-autoscaler-test", EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
 	)
-	runAutoscalerCloudStackSimpleFlow(test)
+	runAutoscalerWitMetricsServerSimpleFlow(test)
 }
 
-func runAutoscalerCloudStackSimpleFlow(test *framework.ClusterE2ETest) {
+func TestCPackagesClusterAutoscalerVSphereKubernetes122UbuntuSimpleFlow(t *testing.T) {
+	minNodes := 1
+	maxNodes := 2
+	framework.CheckCuratedPackagesCredentials(t)
+	test := framework.NewClusterE2ETest(t,
+		framework.NewVSphere(t, framework.WithUbuntu122()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube122), api.WithWorkerNodeAutoScalingConfig(minNodes, maxNodes)),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube122),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
+	)
+	runAutoscalerWitMetricsServerSimpleFlow(test)
+}
+
+func TestCPackagesClusterAutoscalerVSphereKubernetes123BottleRocketSimpleFlow(t *testing.T) {
+	minNodes := 1
+	maxNodes := 2
+	framework.CheckCuratedPackagesCredentials(t)
+	test := framework.NewClusterE2ETest(t,
+		framework.NewVSphere(t, framework.WithBottleRocket123()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube123), api.WithWorkerNodeAutoScalingConfig(minNodes, maxNodes)),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube123),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
+	)
+	runAutoscalerWitMetricsServerSimpleFlow(test)
+}
+
+func TestCPackagesClusterAutoscalerNutanixKubernetes124UbuntuSimpleFlow(t *testing.T) {
+	minNodes := 1
+	maxNodes := 2
+	framework.CheckCuratedPackagesCredentials(t)
+	test := framework.NewClusterE2ETest(t,
+		framework.NewNutanix(t, framework.WithUbuntu124Nutanix()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube124), api.WithWorkerNodeAutoScalingConfig(minNodes, maxNodes)),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube124),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
+	)
+	runAutoscalerWitMetricsServerSimpleFlow(test)
+}
+
+func runAutoscalerWitMetricsServerSimpleFlow(test *framework.ClusterE2ETest) {
 	test.WithCluster(func(e *framework.ClusterE2ETest) {
 		autoscalerName := "cluster-autoscaler"
 		metricServerName := "metrics-server"
 		targetNamespace := "eksa-packages"
 		test.InstallAutoScalerWithMetricServer(targetNamespace)
-		test.CombinedAutoscalerMetricServerTest(autoscalerName, metricServerName, targetNamespace, withMgmtCluster(test))
+		test.CombinedAutoScalerMetricServerTest(autoscalerName, metricServerName, targetNamespace, withMgmtCluster(test))
 	})
 
 }

--- a/test/e2e/autoscaler_test.go
+++ b/test/e2e/autoscaler_test.go
@@ -1,0 +1,43 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/test/framework"
+)
+
+func TestCPackagesClusterAutoscalerCloudStackRedhatKubernetes121SimpleFlow(t *testing.T) {
+	framework.CheckCuratedPackagesCredentials(t)
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewCloudStack(t, framework.WithCloudStackRedhat121()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube121), api.WithWorkerNodeAutoScalingConfig(1, 2)),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube121),
+			"my-autoscaler-test", EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues),
+	)
+	runAutoscalerCloudStackSimpleFlow(test)
+}
+
+func runAutoscalerCloudStackSimpleFlow(test *framework.ClusterE2ETest) {
+	test.WithCluster(func(e *framework.ClusterE2ETest) {
+		autoscalerName := "cluster-autoscaler"
+		metricServerName := "metrics-server"
+		installNs := "eksa-packages"
+		test.InstallCuratedPackage(autoscalerName, "", kubeconfig.FromClusterName(test.ClusterName),
+			installNs,
+			"--set cloudProvider=clusterapi",
+			"--set autoDiscovery.clusterName="+test.ClusterName,
+		)
+		test.InstallCuratedPackage(metricServerName, "", kubeconfig.FromClusterName(test.ClusterName), installNs,
+			"--set args={--kubelet-insecure-tls}")
+		test.CombinedAutoscalerMetricServerTest(autoscalerName, metricServerName, withMgmtCluster(test))
+	})
+
+}

--- a/test/e2e/autoscaler_test.go
+++ b/test/e2e/autoscaler_test.go
@@ -28,7 +28,6 @@ func runAutoscalerCloudStackSimpleFlow(test *framework.ClusterE2ETest) {
 	test.WithCluster(func(e *framework.ClusterE2ETest) {
 		autoscalerName := "cluster-autoscaler"
 		metricServerName := "metrics-server"
-		installNs := "eksa-packages"
 		test.InstallAutoScalerWithMetricServer()
 		test.CombinedAutoscalerMetricServerTest(autoscalerName, metricServerName, withMgmtCluster(test))
 	})

--- a/test/e2e/autoscaler_test.go
+++ b/test/e2e/autoscaler_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -30,13 +29,7 @@ func runAutoscalerCloudStackSimpleFlow(test *framework.ClusterE2ETest) {
 		autoscalerName := "cluster-autoscaler"
 		metricServerName := "metrics-server"
 		installNs := "eksa-packages"
-		test.InstallCuratedPackage(autoscalerName, "", kubeconfig.FromClusterName(test.ClusterName),
-			installNs,
-			"--set cloudProvider=clusterapi",
-			"--set autoDiscovery.clusterName="+test.ClusterName,
-		)
-		test.InstallCuratedPackage(metricServerName, "", kubeconfig.FromClusterName(test.ClusterName), installNs,
-			"--set args={--kubelet-insecure-tls}")
+		test.InstallAutoScalerWithMetricServer()
 		test.CombinedAutoscalerMetricServerTest(autoscalerName, metricServerName, withMgmtCluster(test))
 	})
 

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1450,6 +1450,29 @@ func (e *ClusterE2ETest) VerifyMetricServerPackageInstalled(name string, mgmtClu
 	}
 }
 
+//go:embed testdata/autoscaler_package.yaml
+var autoscalerPackageDeployment []byte
+
+//go:embed testdata/metrics_server_package.yaml
+var metricsServerPackageDeployment []byte
+
+func (e *ClusterE2ETest) InstallAutoScalerWithMetricServer() {
+	ctx := context.Background()
+	packageInstallNamespace := fmt.Sprintf("%s-%s", "eksa-packages", e.ClusterName)
+
+	err := e.KubectlClient.ApplyKubeSpecFromBytesWithNamespace(ctx, e.cluster(), metricsServerPackageDeployment,
+		packageInstallNamespace)
+	if err != nil {
+		e.T.Fatalf("Error installing metrics server pacakge: %s", err)
+	}
+
+	err = e.KubectlClient.ApplyKubeSpecFromBytesWithNamespace(ctx, e.cluster(), autoscalerPackageDeployment,
+		packageInstallNamespace)
+	if err != nil {
+		e.T.Fatalf("Error installing cluster autoscaler pacakge: %s", err)
+	}
+}
+
 func (e *ClusterE2ETest) CombinedAutoscalerMetricServerTest(autoscalerName string, metricServerName string, mgmtCluster *types.Cluster) {
 	ctx := context.Background()
 	ns := "default"

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1498,14 +1498,14 @@ func (e *ClusterE2ETest) CombinedAutoScalerMetricServerTest(autoscalerName strin
 	e.VerifyMetricServerPackageInstalled(metricServerName, targetNamespace, mgmtCluster)
 	e.VerifyAutoScalerPackageInstalled(autoscalerName, targetNamespace, mgmtCluster)
 
-	fmt.Printf("Metrics Server and Cluster Autoscaler ready\n")
+	e.T.Log("Metrics Server and Cluster Autoscaler ready")
 
 	err := e.KubectlClient.ApplyKubeSpecFromBytes(ctx, mgmtCluster, hpaBusybox)
 	if err != nil {
 		e.T.Fatalf("Failed to apply hpa busybox load %s", err)
 	}
 
-	fmt.Printf("Deploying test workload\n")
+	e.T.Log("Deploying test workload")
 
 	err = e.KubectlClient.WaitForDeployment(ctx,
 		e.cluster(), "5m", "Available", name, ns)
@@ -1519,14 +1519,14 @@ func (e *ClusterE2ETest) CombinedAutoScalerMetricServerTest(autoscalerName strin
 		e.T.Fatalf("Failed to autoscale deployent: %s", err)
 	}
 
-	fmt.Printf("Waiting for machinedeployment to begin scaling up\n")
+	e.T.Log("Waiting for machinedeployment to begin scaling up")
 	err = e.KubectlClient.WaitJSONPathLoop(ctx, mgmtCluster.KubeconfigFile, "5m", "status.phase", "ScalingUp",
 		fmt.Sprintf("machinedeployments.cluster.x-k8s.io/%s", machineDeploymentName), constants.EksaSystemNamespace)
 	if err != nil {
 		e.T.Fatalf("Failed to get ScalingUp phase for machinedeployment: %s", err)
 	}
 
-	fmt.Printf("Waiting for machinedeployment to finish scaling up\n")
+	e.T.Log("Waiting for machinedeployment to finish scaling up")
 	err = e.KubectlClient.WaitJSONPathLoop(ctx, mgmtCluster.KubeconfigFile, "10m", "status.phase", "Running",
 		fmt.Sprintf("machinedeployments.cluster.x-k8s.io/%s", machineDeploymentName), constants.EksaSystemNamespace)
 	if err != nil {
@@ -1539,5 +1539,5 @@ func (e *ClusterE2ETest) CombinedAutoScalerMetricServerTest(autoscalerName strin
 		e.T.Fatalf("Machine deployment stuck in scaling up: %s", err)
 	}
 
-	fmt.Printf("Finished scaling up machines\n")
+	e.T.Log("Finished scaling up machines")
 }

--- a/test/framework/testdata/autoscaler_package.yaml
+++ b/test/framework/testdata/autoscaler_package.yaml
@@ -4,11 +4,11 @@ metadata:
   name: cluster-autoscaler
 spec:
   packageName: cluster-autoscaler
-  targetNamespace: eksa-packages
+  targetNamespace: {{.targetNamespace}}
   config: |-
     cloudProvider: "clusterapi"
     autoDiscovery:
-      clusterName: ""
+      clusterName: {{.clusterName}}
     extraArgs:
       scale-down-delay-after-add: 2m
       scale-down-delay-after-failure: 3m

--- a/test/framework/testdata/autoscaler_package.yaml
+++ b/test/framework/testdata/autoscaler_package.yaml
@@ -1,0 +1,17 @@
+apiVersion: packages.eks.amazonaws.com/v1alpha1
+kind: Package
+metadata:
+  name: cluster-autoscaler
+spec:
+  packageName: cluster-autoscaler
+  targetNamespace: eksa-packages
+  config: |-
+    cloudProvider: "clusterapi"
+    autoDiscovery:
+      clusterName: ""
+    extraArgs:
+      scale-down-delay-after-add: 2m
+      scale-down-delay-after-failure: 3m
+      scale-down-unneeded-time: 2m
+
+---

--- a/test/framework/testdata/hpa_busybox.yaml
+++ b/test/framework/testdata/hpa_busybox.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hpa-busybox-test
+spec:
+  selector:
+    matchLabels:
+      run: hpa-busybox-test
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: hpa-busybox-test
+    spec:
+      containers:
+        - name: busybox
+          image: busybox
+          resources:
+            limits:
+              cpu: 500m
+            requests:
+              cpu: 20m
+              memory: 500Mi
+          command: ["sh", "-c"]
+          args:
+            - while [ 1 ]; do
+              echo "Test";
+              sleep 0.01;
+              done

--- a/test/framework/testdata/metrics_server_package.yaml
+++ b/test/framework/testdata/metrics_server_package.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metrics-server
 spec:
   packageName: metrics-server
-  targetNamespace: eksa-packages
+  targetNamespace: {{.targetNamespace}}
   config: |-
     args:
       - "--kubelet-insecure-tls"

--- a/test/framework/testdata/metrics_server_package.yaml
+++ b/test/framework/testdata/metrics_server_package.yaml
@@ -1,0 +1,11 @@
+apiVersion: packages.eks.amazonaws.com/v1alpha1
+kind: Package
+metadata:
+  name: metrics-server
+spec:
+  packageName: metrics-server
+  targetNamespace: eksa-packages
+  config: |-
+    args:
+      - "--kubelet-insecure-tls"
+---


### PR DESCRIPTION
Adding a simple flow to test cluster autoscaler and metrics-server packages. This test 
- Deploys both cluster autoscaler and metrics-server packages. 
- Uses a HorizontalPodAutoscaler on a sample busybox workload. 
- Verifies that the machine deployments scale up to meet the new demand.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

