### PR TITLE
Add manual activate bundle step for ADOT e2e

### DIFF
--- a/test/e2e/adot_test.go
+++ b/test/e2e/adot_test.go
@@ -104,6 +104,7 @@ func TestCPackagesAdotTinkerbellBottleRocketKubernetes123SimpleFlow(t *testing.T
 }
 
 func runCuratedPackagesAdotInstall(test *framework.ClusterE2ETest) {
+	test.SetPackageBundleActive()
 	test.CreateNamespace(adotTargetNamespace)
 	test.InstallCuratedPackage(adotPackageName, adotPackagePrefix+"-"+adotPackageName,
 		kubeconfig.FromClusterName(test.ClusterName), adotTargetNamespace,
@@ -112,6 +113,7 @@ func runCuratedPackagesAdotInstall(test *framework.ClusterE2ETest) {
 }
 
 func runCuratedPackagesAdotInstallWithUpdate(test *framework.ClusterE2ETest) {
+	test.SetPackageBundleActive()
 	test.CreateNamespace(adotTargetNamespace)
 	test.InstallCuratedPackage(adotPackageName, adotPackagePrefix+"-"+adotPackageName,
 		kubeconfig.FromClusterName(test.ClusterName), adotTargetNamespace,


### PR DESCRIPTION
Occasionally, tests fail due to "no bundle name specified". This is because package bundle controller didn't activate the bundle by the given time.

*Issue #, if available:* https://github.com/aws/eks-anywhere-packages/issues/631

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

