### PR TITLE
test: Allow override of Pod CIDR blocks w/ Docker provider

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -69,9 +71,10 @@ func WithControlPlaneLabel(key string, val string) ClusterFiller {
 	}
 }
 
+// WithPodCidr sets an explicit pod CIDR, overriding the provider's default.
 func WithPodCidr(podCidr string) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
-		c.Spec.ClusterNetwork.Pods.CidrBlocks = []string{podCidr}
+		c.Spec.ClusterNetwork.Pods.CidrBlocks = strings.Split(podCidr, ",")
 	}
 }
 

--- a/internal/pkg/api/cluster_test.go
+++ b/internal/pkg/api/cluster_test.go
@@ -207,3 +207,27 @@ func TestWithWorkerNodeAutoScalingConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestWithPodCidr(t *testing.T) {
+	cluster := &anywherev1.Cluster{
+		Spec: anywherev1.ClusterSpec{
+			ClusterNetwork: anywherev1.ClusterNetwork{
+				Pods: anywherev1.Pods{
+					CidrBlocks: []string{"192.168.0.0/16"},
+				},
+			},
+		},
+	}
+
+	t.Run("with a single CIDR block", func(t *testing.T) {
+		api.WithPodCidr("10.0.0.0/20")(cluster)
+		g := NewWithT(t)
+		g.Expect(cluster.Spec.ClusterNetwork.Pods.CidrBlocks).To(Equal([]string{"10.0.0.0/20"}))
+	})
+
+	t.Run("with a multiple CIDR blocks", func(t *testing.T) {
+		api.WithPodCidr("10.0.0.0/16,172.16.42.0/20")(cluster)
+		g := NewWithT(t)
+		g.Expect(cluster.Spec.ClusterNetwork.Pods.CidrBlocks).To(Equal([]string{"10.0.0.0/16", "172.16.42.0/20"}))
+	})
+}


### PR DESCRIPTION
On some networks, the default pod CIDR conflicts, and must be overridden in order for tests to pass successfully.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

