### PR TITLE
test: Allow setting Pod CIDR blocks w/ Docker provider (2 of 2)

### DIFF
--- a/test/framework/docker.go
+++ b/test/framework/docker.go
@@ -1,27 +1,36 @@
 package framework
 
 import (
+	"os"
 	"testing"
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 )
 
+// Docker is a Provider for running end-to-end tests.
 type Docker struct {
 	t *testing.T
 }
 
+const dockerPodCidrVar = "T_DOCKER_POD_CIDR"
+
+// NewDocker creates a new Docker object implementing the Provider interface
+// for testing.
 func NewDocker(t *testing.T) *Docker {
 	return &Docker{
 		t: t,
 	}
 }
 
+// Name implements the Provider interface.
 func (d *Docker) Name() string {
 	return "docker"
 }
 
+// Setup implements the Provider interface.
 func (d *Docker) Setup() {}
 
+// CleanupVMs implements the Provider interface.
 func (d *Docker) CleanupVMs(_ string) error {
 	return nil
 }
@@ -34,5 +43,10 @@ func (d *Docker) WithProviderUpgradeGit() ClusterE2ETestOpt {
 
 // ClusterConfigUpdates satisfies the test framework Provider.
 func (d *Docker) ClusterConfigUpdates() []api.ClusterConfigFiller {
-	return nil
+	f := []api.ClusterFiller{}
+	podCidr := os.Getenv(dockerPodCidrVar)
+	if podCidr != "" {
+		f = append(f, api.WithPodCidr(podCidr))
+	}
+	return []api.ClusterConfigFiller{api.ClusterToConfigFiller(f...)}
 }


### PR DESCRIPTION
On some networks, the default pod CIDR conflicts, and must be overridden in order for tests to pass successfully.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

