### PR TITLE
Add in missing docker login to long running container

### DIFF
--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -282,25 +282,6 @@ func TestFactoryBuildWithRegistryMirror(t *testing.T) {
 	tt.Expect(deps.Helm).NotTo(BeNil())
 }
 
-func TestFactoryBuildWithRegistryMirrorAuth(t *testing.T) {
-	tt := newTest(t, vsphere)
-	deps, err := dependencies.NewFactory().
-		WithLocalExecutables().
-		WithRegistryMirror(
-			&registrymirror.RegistryMirror{
-				BaseRegistry: "1.2.3.4:443",
-				NamespacedRegistryMap: map[string]string{
-					constants.DefaultCoreEKSARegistry: "1.2.3.4:443/custom",
-				},
-				Auth: true,
-			}).
-		WithHelm(executables.WithInsecure()).
-		Build(context.Background())
-
-	tt.Expect(err).To(BeNil())
-	tt.Expect(deps.Helm).NotTo(BeNil())
-}
-
 func TestFactoryBuildWithPackageInstaller(t *testing.T) {
 	spec := &cluster.Spec{
 		Config: &cluster.Config{

--- a/pkg/executables/builder.go
+++ b/pkg/executables/builder.go
@@ -69,6 +69,11 @@ func (b *ExecutablesBuilder) BuildHelmExecutable(opts ...HelmOpt) *Helm {
 	return NewHelm(b.executableBuilder.Build(helmPath), opts...)
 }
 
+// BuildDockerExecutable initializes a docker executable and returns it.
+func (b *ExecutablesBuilder) BuildDockerExecutable() *Docker {
+	return NewDocker(b.executableBuilder.Build(dockerPath))
+}
+
 // Init initializes the executable builder and returns a Closer
 // that needs to be called once the executables are not in used anymore
 // The closer will cleanup and free all internal resources.

--- a/pkg/executables/builder_test.go
+++ b/pkg/executables/builder_test.go
@@ -44,6 +44,8 @@ func TestLocalExecutablesBuilderAllExecutables(t *testing.T) {
 	g.Expect(trouble).NotTo(BeNil())
 	helm := b.BuildHelmExecutable()
 	g.Expect(helm).NotTo(BeNil())
+	docker := b.BuildDockerExecutable()
+	g.Expect(docker).NotTo(BeNil())
 
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(closer(ctx)).To(Succeed())


### PR DESCRIPTION
*Description of changes:*
fixed bug where pulling kind/node during bootstrap-cluster-init phase failed with "unauthorized to access repository: eks-anywhere/l0g8r8j6/kubernetes-sigs/kind/node"

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

