### PR TITLE
Adjust ADOT e2e sleep time while waiting on daemonset

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1263,10 +1263,11 @@ func (e *ClusterE2ETest) VerifyAdotPackageDaemonSetUpdated(packageName string, t
 		e.T.Fatalf("waiting for adot package update timed out: %s", err)
 	}
 
-	time.Sleep(30 * time.Second) // Add sleep to allow daemonset to be created
 	e.T.Log("Waiting for package", packageName, "daemonset to be rolled out")
-	err = e.KubectlClient.WaitForDaemonsetRolledout(ctx,
-		e.cluster(), "5m", fmt.Sprintf("%s-aws-otel-collector-agent", packageName), targetNamespace)
+	err = retrier.New(6 * time.Minute).Retry(func() error {
+		return e.KubectlClient.WaitForDaemonsetRolledout(ctx,
+			e.cluster(), "5m", fmt.Sprintf("%s-aws-otel-collector-agent", packageName), targetNamespace)
+	})
 	if err != nil {
 		e.T.Fatalf("waiting for adot daemonset timed out: %s", err)
 	}
@@ -1276,15 +1277,21 @@ func (e *ClusterE2ETest) VerifyAdotPackageDaemonSetUpdated(packageName string, t
 	if err != nil {
 		e.T.Fatalf("unable to get name of the aws-otel-collector pod: %s", err)
 	}
-	logs, err := e.KubectlClient.GetPodLogs(context.TODO(), targetNamespace, adotPodName, "aws-otel-collector", e.kubeconfigFilePath())
-	if err != nil {
-		e.T.Fatalf("failure getting pod logs %s", err)
-	}
-	fmt.Printf("Logs from aws-otel-collector pod\n %s\n", logs)
 	expectedLogs := "MetricsExporter	{\"kind\": \"exporter\", \"data_type\": \"metrics\", \"name\": \"logging\", \"#metrics\":"
-	ok := strings.Contains(logs, expectedLogs)
-	if !ok {
-		e.T.Fatalf("expected to find %s in the log, got %s", expectedLogs, logs)
+	err = retrier.New(5 * time.Minute).Retry(func() error {
+		logs, err := e.KubectlClient.GetPodLogs(context.TODO(), targetNamespace, adotPodName, "aws-otel-collector", e.kubeconfigFilePath())
+		if err != nil {
+			e.T.Fatalf("failure getting pod logs %s", err)
+		}
+		fmt.Printf("Logs from aws-otel-collector pod\n %s\n", logs)
+		ok := strings.Contains(logs, expectedLogs)
+		if !ok {
+			fmt.Errorf("expected to find %s in the log, got %s", expectedLogs, logs)
+		}
+		return nil
+	})
+	if err != nil {
+		e.T.Fatalf("unable to match logs", err)
 	}
 }
 

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1263,7 +1263,7 @@ func (e *ClusterE2ETest) VerifyAdotPackageDaemonSetUpdated(packageName string, t
 		e.T.Fatalf("waiting for adot package update timed out: %s", err)
 	}
 
-	time.Sleep(15 * time.Second) // Add sleep to allow daemonset to be created
+	time.Sleep(30 * time.Second) // Add sleep to allow daemonset to be created
 	e.T.Log("Waiting for package", packageName, "daemonset to be rolled out")
 	err = e.KubectlClient.WaitForDaemonsetRolledout(ctx,
 		e.cluster(), "5m", fmt.Sprintf("%s-aws-otel-collector-agent", packageName), targetNamespace)

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1286,12 +1286,12 @@ func (e *ClusterE2ETest) VerifyAdotPackageDaemonSetUpdated(packageName string, t
 		fmt.Printf("Logs from aws-otel-collector pod\n %s\n", logs)
 		ok := strings.Contains(logs, expectedLogs)
 		if !ok {
-			fmt.Errorf("expected to find %s in the log, got %s", expectedLogs, logs)
+			return fmt.Errorf("expected to find %s in the log, got %s", expectedLogs, logs)
 		}
 		return nil
 	})
 	if err != nil {
-		e.T.Fatalf("unable to match logs", err)
+		e.T.Fatalf("unable to finish log comparison: %s", err)
 	}
 }
 


### PR DESCRIPTION
15s wait time appears to be not sufficient in some cases, mainly Nutanix and vSphere Bottle Rocket (about 75% pass rate). Increase sleep time to 30s.

*Issue #, if available:* https://github.com/aws/eks-anywhere-packages/issues/631

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

