### PR TITLE
Add admin, control and snow bottlerocket bootstrap container image in etcd cluster

### DIFF
--- a/designs/snow-integration.md
+++ b/designs/snow-integration.md
@@ -51,7 +51,7 @@ type SnowMachineConfigSpec struct {
 	InstanceType SnowInstanceType `json:"instanceType,omitempty"`
 
 	// PhysicalNetworkConnector is the physical network connector type to use for creating direct network interfaces (DNI).
-	// Valid values: "SFP_PLUS" (default) and "QSFP"
+	// Valid values: "SFP_PLUS" (default) and "QSFP".
 	PhysicalNetworkConnector PhysicalNetworkConnectorType `json:"physicalNetworkConnector,omitempty"`
 
 	// SSHKeyName is the name of the ssh key defined in the aws snow key pairs, to attach to the instance.
@@ -64,8 +64,11 @@ type SnowMachineConfigSpec struct {
 	ContainersVolume *snowv1.Volume `json:"containersVolume,omitempty"`
 
 	// OSFamily is the node instance OS.
-	// Valid values: "bottlerocket" (default) and "ubuntu".
+	// Valid values: "bottlerocket" and "ubuntu".
 	OSFamily OSFamily `json:"osFamily,omitempty"`
+
+	// Network provides the custom network setting for the machine.
+	Network *snowv1.AWSSnowNetwork `json:"network,omitempty"`
 
 }
 ```
@@ -153,7 +156,7 @@ azBpMAwGA1UdEwQFMAMBAf8wHQYDVR0OBBYEFL/bRcnBRuSM5+FcYFa8HfIBomdF
 
 ### Control Plane Load Balancing
 
-EKS-A uses [kube-vip](https://kube-vip.chipzoller.dev/docs/) for control plane load balancing, where we create kube-vip as static pod in each control plane node instance. The kube-vip manifest template is built in as part of the EKS-D Node AMI for Snow integration specifically due to the EC2 instance user data limit of 16KB. The user specifies the control plane endpoint in the EKS-A `clusterSpec.controlPlaneConfiguration.endpoint` and EKS-A passes it down to the `kubeadmControlPlane` object as part of the pre/post KubeadmCommands. The control plane endpoint will be used as the vip_address along with the kube-vip container image when EKS-A runs the bootstrap script where it creates kube-vip pods.
+EKS-A uses [kube-vip](https://kube-vip.chipzoller.dev/docs/) for control plane load balancing, where we create kube-vip as static pod in each control plane node instance. As Snow increases the EC2 instance user data limit, the kube-vip manifest template now is passed in as user data in KubeadmControlPlane instead of being built in as part of the EKS-D Node AMI. The control plane endpoint will be used as the vip_address along with the kube-vip container image when EKS-A runs the bootstrap script where it creates kube-vip pods.
 
 ```yaml
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -163,9 +166,9 @@ metadata:
 spec:
   kubeadmConfigSpec:
     preKubeadmCommands:
-      - /etc/eks/bootstrap.sh  {{.kubeVipImage}} {{.controlPlaneEndpoint}}
+      - /etc/eks/bootstrap.sh
     postKubeadmCommands:
-      - /etc/eks/bootstrap-after.sh {{.kubeVipImage}} {{.controlPlaneEndpoint}}
+      - /etc/eks/bootstrap.sh
 ...
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/aws/eks-anywhere/internal/aws-sdk-go-v2/service/snowballdevice v0.0.0-00010101000000-000000000000
 	github.com/aws/eks-anywhere/release v0.0.0-20211130194657-f6e9593c6551
 	github.com/aws/eks-distro-build-tooling/release v0.0.0-20211103003257-a7e2379eae5e
-	github.com/aws/etcdadm-bootstrap-provider v1.0.5
-	github.com/aws/etcdadm-controller v1.0.4
+	github.com/aws/etcdadm-bootstrap-provider v1.0.5-rc1
+	github.com/aws/etcdadm-controller v1.0.4-rc1
 	github.com/aws/smithy-go v1.13.2
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -212,10 +212,10 @@ github.com/aws/eks-anywhere-packages v0.2.8 h1:v8RbLypdpVPyQ0Cd7e5ln4Wlhd6STv3F5
 github.com/aws/eks-anywhere-packages v0.2.8/go.mod h1:qNCSi6k9tb/9ztf2x98B32EDeIr/xwHemB7YNxtxd3U=
 github.com/aws/eks-distro-build-tooling/release v0.0.0-20211103003257-a7e2379eae5e h1:GB6Cn9yKEt31mDF7RrVWyM9WoppNkGYth8zBPIJGJ+w=
 github.com/aws/eks-distro-build-tooling/release v0.0.0-20211103003257-a7e2379eae5e/go.mod h1:p/KHVJAMv3kofnUnShkZ6pUnZYzm+LK2G7bIi8nnTKA=
-github.com/aws/etcdadm-bootstrap-provider v1.0.5 h1:pD8dk5SnoRbNR8zPa53ww4ghFGdlidu5hNwAGi3t4gM=
-github.com/aws/etcdadm-bootstrap-provider v1.0.5/go.mod h1:EJQ3MFeeE2SEfWA3aq84QSLXsQqAybvZe9l0LFSdoEk=
-github.com/aws/etcdadm-controller v1.0.4 h1:BPXNSCXWsNni1vlmOr4yKxU/rKyyN/lKD5xxfyhljQc=
-github.com/aws/etcdadm-controller v1.0.4/go.mod h1:CbSggaIaRBJ3w/cGrNKTDHJ1lC+Z9g9qoA/1cdcSCNw=
+github.com/aws/etcdadm-bootstrap-provider v1.0.5-rc1 h1:TiPJIryBsbWmx/l7WWmlsS4dw1nR8W+5LOD2QnPLkJg=
+github.com/aws/etcdadm-bootstrap-provider v1.0.5-rc1/go.mod h1:EJQ3MFeeE2SEfWA3aq84QSLXsQqAybvZe9l0LFSdoEk=
+github.com/aws/etcdadm-controller v1.0.4-rc1 h1:Gq7Fzy30nHIwa6NGsSWimV2GZW3STJl22XQ99w2N+oU=
+github.com/aws/etcdadm-controller v1.0.4-rc1/go.mod h1:Onv438npGbt1qaQQfLs7I6vRKs06eTy2hVcSrKeOF+A=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
 github.com/aws/smithy-go v1.13.2 h1:TBLKyeJfXTrTXRHmsv4qWt9IQGYyWThLYaJWSahTOGE=
 github.com/aws/smithy-go v1.13.2/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=

--- a/pkg/clusterapi/bottlerocket.go
+++ b/pkg/clusterapi/bottlerocket.go
@@ -96,3 +96,13 @@ func SetBottlerocketInEtcdCluster(etcd *etcdv1.EtcdadmCluster, versionsBundle *c
 		PauseImage:     versionsBundle.KubeDistro.Pause.VersionedImage(),
 	}
 }
+
+// SetBottlerocketAdminContainerImageInEtcdCluster overrides the default bottlerocket admin container image metadata in etcdadmCluster.
+func SetBottlerocketAdminContainerImageInEtcdCluster(etcd *etcdv1.EtcdadmCluster, adminImage v1alpha1.Image) {
+	etcd.Spec.EtcdadmConfigSpec.BottlerocketConfig.AdminImage = adminImage.VersionedImage()
+}
+
+// SetBottlerocketControlContainerImageInEtcdCluster overrides the default bottlerocket control container image metadata in etcdadmCluster.
+func SetBottlerocketControlContainerImageInEtcdCluster(etcd *etcdv1.EtcdadmCluster, controlImage v1alpha1.Image) {
+	etcd.Spec.EtcdadmConfigSpec.BottlerocketConfig.ControlImage = controlImage.VersionedImage()
+}

--- a/pkg/clusterapi/bottlerocket_test.go
+++ b/pkg/clusterapi/bottlerocket_test.go
@@ -118,3 +118,31 @@ func TestSetBottlerocketInEtcdCluster(t *testing.T) {
 	clusterapi.SetBottlerocketInEtcdCluster(got, g.clusterSpec.VersionsBundle)
 	g.Expect(got).To(Equal(want))
 }
+
+func TestSetBottlerocketAdminContainerImageInEtcdCluster(t *testing.T) {
+	g := newApiBuilerTest(t)
+	got := wantEtcdCluster()
+	got.Spec.EtcdadmConfigSpec.BottlerocketConfig = &etcdbootstrapv1.BottlerocketConfig{
+		EtcdImage:      "public.ecr.aws/eks-distro/etcd-io/etcd:0.0.1",
+		BootstrapImage: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",
+		PauseImage:     "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
+	}
+	want := got.DeepCopy()
+	want.Spec.EtcdadmConfigSpec.BottlerocketConfig.AdminImage = "public.ecr.aws/eks-anywhere/bottlerocket-admin:0.0.1"
+	clusterapi.SetBottlerocketAdminContainerImageInEtcdCluster(got, g.clusterSpec.VersionsBundle.BottleRocketHostContainers.Admin)
+	g.Expect(got).To(Equal(want))
+}
+
+func TestSetBottlerocketControlContainerImageInEtcdCluster(t *testing.T) {
+	g := newApiBuilerTest(t)
+	got := wantEtcdCluster()
+	got.Spec.EtcdadmConfigSpec.BottlerocketConfig = &etcdbootstrapv1.BottlerocketConfig{
+		EtcdImage:      "public.ecr.aws/eks-distro/etcd-io/etcd:0.0.1",
+		BootstrapImage: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",
+		PauseImage:     "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
+	}
+	want := got.DeepCopy()
+	want.Spec.EtcdadmConfigSpec.BottlerocketConfig.ControlImage = "public.ecr.aws/eks-anywhere/bottlerocket-control:0.0.1"
+	clusterapi.SetBottlerocketControlContainerImageInEtcdCluster(got, g.clusterSpec.VersionsBundle.BottleRocketHostContainers.Control)
+	g.Expect(got).To(Equal(want))
+}

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -47,7 +47,7 @@ func KubeadmControlPlane(log logr.Logger, clusterSpec *cluster.Spec, snowMachine
 	joinConfigKubeletExtraArg["provider-id"] = "aws-snow:////'{{ ds.meta_data.instance_id }}'"
 
 	kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands = append(kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands,
-		fmt.Sprintf("/etc/eks/bootstrap.sh %s %s", clusterSpec.VersionsBundle.Snow.KubeVip.VersionedImage(), clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host),
+		"/etc/eks/bootstrap.sh",
 	)
 
 	if snowMachineTemplate.Spec.Template.Spec.ContainersVolume != nil {
@@ -57,7 +57,7 @@ func KubeadmControlPlane(log logr.Logger, clusterSpec *cluster.Spec, snowMachine
 	}
 
 	kcp.Spec.KubeadmConfigSpec.PostKubeadmCommands = append(kcp.Spec.KubeadmConfigSpec.PostKubeadmCommands,
-		fmt.Sprintf("/etc/eks/bootstrap-after.sh %s %s", clusterSpec.VersionsBundle.Snow.KubeVip.VersionedImage(), clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host),
+		"/etc/eks/bootstrap.sh",
 	)
 
 	addStackedEtcdExtraArgsInKubeadmControlPlane(kcp, clusterSpec.Cluster.Spec.ExternalEtcdConfiguration)
@@ -163,6 +163,9 @@ func EtcdadmCluster(log logr.Logger, clusterSpec *cluster.Spec, snowMachineTempl
 	switch osFamily {
 	case v1alpha1.Bottlerocket:
 		clusterapi.SetBottlerocketInEtcdCluster(etcd, clusterSpec.VersionsBundle)
+		clusterapi.SetBottlerocketAdminContainerImageInEtcdCluster(etcd, clusterSpec.VersionsBundle.BottleRocketHostContainers.Admin)
+		clusterapi.SetBottlerocketControlContainerImageInEtcdCluster(etcd, clusterSpec.VersionsBundle.BottleRocketHostContainers.Control)
+		addBottlerocketBootstrapSnowInEtcdCluster(etcd, clusterSpec.VersionsBundle.Snow.BottlerocketBootstrapSnow)
 
 	case v1alpha1.Ubuntu:
 		clusterapi.SetUbuntuConfigInEtcdCluster(etcd, clusterSpec.VersionsBundle.KubeDistro.EtcdVersion)

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -168,10 +168,10 @@ func wantKubeadmControlPlane() *controlplanev1.KubeadmControlPlane {
 					},
 				},
 				PreKubeadmCommands: []string{
-					"/etc/eks/bootstrap.sh public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433 1.2.3.4",
+					"/etc/eks/bootstrap.sh",
 				},
 				PostKubeadmCommands: []string{
-					"/etc/eks/bootstrap-after.sh public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433 1.2.3.4",
+					"/etc/eks/bootstrap.sh",
 				},
 				Files: []bootstrapv1.File{
 					{
@@ -874,6 +874,16 @@ func wantEtcdClusterBottlerocket() *etcdv1.EtcdadmCluster {
 		EtcdImage:      "public.ecr.aws/eks-distro/etcd-io/etcd:0.0.1",
 		BootstrapImage: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",
 		PauseImage:     "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
+		AdminImage:     "public.ecr.aws/eks-anywhere/bottlerocket-admin:0.0.1",
+		ControlImage:   "public.ecr.aws/eks-anywhere/bottlerocket-control:0.0.1",
+		CustomBootstrapContainers: []etcdbootstrapv1.BottlerocketBootstrapContainer{
+			{
+				Name:      "bottlerocket-bootstrap-snow",
+				Image:     "public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap-snow:v1-20-22-eks-a-v0.0.0-dev-build.4984",
+				Essential: false,
+				Mode:      "always",
+			},
+		},
 	}
 	return etcd
 }

--- a/pkg/providers/snow/bottlerocket.go
+++ b/pkg/providers/snow/bottlerocket.go
@@ -1,15 +1,19 @@
 package snow
 
 import (
+	etcdbootstrapv1 "github.com/aws/etcdadm-bootstrap-provider/api/v1beta1"
+	etcdv1 "github.com/aws/etcdadm-controller/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
+const bottlerocketBootstrapImage = "bottlerocket-bootstrap-snow"
+
 func bottlerocketBootstrapSnow(image releasev1.Image) bootstrapv1.BottlerocketBootstrapContainer {
 	return bootstrapv1.BottlerocketBootstrapContainer{
-		Name: "bottlerocket-bootstrap-snow",
+		Name: bottlerocketBootstrapImage,
 		ImageMeta: bootstrapv1.ImageMeta{
 			ImageRepository: image.Image(),
 			ImageTag:        image.Tag(),
@@ -26,4 +30,14 @@ func addBottlerocketBootstrapSnowInKubeadmControlPlane(kcp *controlplanev1.Kubea
 
 func addBottlerocketBootstrapSnowInKubeadmConfigTemplate(kct *bootstrapv1.KubeadmConfigTemplate, image releasev1.Image) {
 	kct.Spec.Template.Spec.JoinConfiguration.BottlerocketCustomBootstrapContainers = []bootstrapv1.BottlerocketBootstrapContainer{bottlerocketBootstrapSnow(image)}
+}
+
+func addBottlerocketBootstrapSnowInEtcdCluster(etcd *etcdv1.EtcdadmCluster, image releasev1.Image) {
+	etcd.Spec.EtcdadmConfigSpec.BottlerocketConfig.CustomBootstrapContainers = []etcdbootstrapv1.BottlerocketBootstrapContainer{
+		{
+			Name:  bottlerocketBootstrapImage,
+			Image: image.VersionedImage(),
+			Mode:  "always",
+		},
+	}
 }

--- a/pkg/providers/snow/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_cp.yaml
@@ -141,11 +141,9 @@ spec:
       proxy: {}
       registryMirror: {}
     postKubeadmCommands:
-    - /etc/eks/bootstrap-after.sh public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433
-      1.2.3.4
+    - /etc/eks/bootstrap.sh
     preKubeadmCommands:
-    - /etc/eks/bootstrap.sh public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433
-      1.2.3.4
+    - /etc/eks/bootstrap.sh
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
*Issue #, if available:*

#3283

*Description of changes:*

- override the default admin, control images in etcd cluster to support bootstraping etcd nodes on snowball
- update pre/post kubeadm commands to use single bootstrap.sh script

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

