### PR TITLE
Add `govc` installation step to OVA build instructions

### DIFF
--- a/docs/content/en/docs/reference/artifacts.md
+++ b/docs/content/en/docs/reference/artifacts.md
@@ -223,6 +223,10 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
    sudo tar xvf image-builder*.tar.gz
    sudo cp image-builder /usr/local/bin
    ```
+1. Get the latest version of `govc`:
+   ```
+   curl -L -o - "https://github.com/vmware/govmomi/releases/latest/download/govc_$(uname -s)_$(uname -m).tar.gz" | sudo tar -C /usr/local/bin -xvzf - govc
+   ```
 1. Create a content library on vSphere:
    ```
    govc library.create "<library name>"


### PR DESCRIPTION
We patch `kubernetes-sigs/image-builder` to use `govc` in one of the post-processor steps to export VSphere library contents prior to OVA creation. This requires `govc` binary to exist on the admin machine from which the image build is run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

