### PR TITLE
Add cleanup step for Nutanix E2E tests

### DIFF
--- a/test/framework/nutanix.go
+++ b/test/framework/nutanix.go
@@ -1,10 +1,12 @@
 package framework
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/internal/test/cleanup"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 )
@@ -134,8 +136,8 @@ func (s *Nutanix) Name() string {
 func (s *Nutanix) Setup() {}
 
 // CleanupVMs satisfies the test framework Provider.
-func (s *Nutanix) CleanupVMs(_ string) error {
-	return nil
+func (s *Nutanix) CleanupVMs(clustername string) error {
+	return cleanup.NutanixTestResourcesCleanup(context.Background(), clustername, os.Getenv(nutanixEndpoint), os.Getenv(nutanixPort), true, true)
 }
 
 // ClusterConfigUpdates satisfies the test framework Provider.


### PR DESCRIPTION
*Description of changes:*
Implementing the cleanup step for Nutanix E2E so any leftover VMs get cleaned up

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

