### PR TITLE
Removed unused latest minor release e2e test helper methods

### DIFF
--- a/test/framework/commands.go
+++ b/test/framework/commands.go
@@ -3,7 +3,6 @@ package framework
 import (
 	"strings"
 
-	"github.com/aws/eks-anywhere/pkg/semver"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
@@ -36,33 +35,9 @@ func WithPerMachineWaitTimeout(timeout string) CommandOpt {
 	return appendOpt("--per-machine-wait-timeout", timeout)
 }
 
-func ExecuteWithEksaVersion(version *semver.Version) CommandOpt {
-	return executeWithBinaryCommandOpt(func() (string, error) {
-		return GetReleaseBinaryFromVersion(version)
-	})
-}
-
 func ExecuteWithEksaRelease(release *releasev1alpha1.EksARelease) CommandOpt {
 	return executeWithBinaryCommandOpt(func() (string, error) {
 		return getBinary(release)
-	})
-}
-
-func ExecuteWithLatestMinorReleaseFromVersion(version *semver.Version) CommandOpt {
-	return executeWithBinaryCommandOpt(func() (string, error) {
-		return GetLatestMinorReleaseBinaryFromVersion(version)
-	})
-}
-
-func ExecuteWithLatestMinorReleaseFromMain() CommandOpt {
-	return executeWithBinaryCommandOpt(func() (string, error) {
-		return GetLatestMinorReleaseBinaryFromMain()
-	})
-}
-
-func ExecuteWithLatestReleaseFromTestBranch() CommandOpt {
-	return executeWithBinaryCommandOpt(func() (string, error) {
-		return GetLatestMinorReleaseBinaryFromTestBranch()
 	})
 }
 

--- a/test/framework/eksaVersions.go
+++ b/test/framework/eksaVersions.go
@@ -6,19 +6,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/semver"
 )
 
-const (
-	v060 = "0.6.0"
-	v050 = "0.5.0"
-)
-
-func Eksa060() *semver.Version {
-	return newVersion(v060)
-}
-
-func Eksa050() *semver.Version {
-	return newVersion(v050)
-}
-
 func newVersion(version string) *semver.Version {
 	v, err := semver.New(version)
 	if err != nil {

--- a/test/framework/releaseVersions.go
+++ b/test/framework/releaseVersions.go
@@ -23,10 +23,6 @@ const (
 	defaultTestBranch    = "main"
 )
 
-func GetLatestMinorReleaseBinaryFromTestBranch() (binaryPath string, err error) {
-	return getBinaryFromRelease(GetLatestMinorReleaseFromTestBranch())
-}
-
 func GetLatestMinorReleaseFromTestBranch() (*releasev1alpha1.EksARelease, error) {
 	testBranch := testBranch()
 	if testBranch == "main" {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Noticed some unused e2e test helper methods while looking into other things related to e2e tests. This PR removes them

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

