### PR TITLE
Add infrastructure for Cluster Lifecycle API e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ coverage.out
 docs/.hugo_build.lock
 *-logs
 *-artifacts
+*.log

--- a/pkg/clients/kubernetes/runtimeclient.go
+++ b/pkg/clients/kubernetes/runtimeclient.go
@@ -1,0 +1,69 @@
+package kubernetes
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewRuntimeClientFromFileName creates a new controller runtime client given a kubeconfig filename.
+func NewRuntimeClientFromFileName(kubeConfigFilename string) (client.Client, error) {
+	data, err := os.ReadFile(kubeConfigFilename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new client: %s", err)
+	}
+
+	return newRuntimeClient(data, nil, runtime.NewScheme())
+}
+
+func initScheme(scheme *runtime.Scheme) error {
+	adders := append([]schemeAdder{
+		clientgoscheme.AddToScheme,
+	}, schemeAdders...)
+	if scheme == nil {
+		return fmt.Errorf("scheme was not provided")
+	}
+	return addToScheme(scheme, adders...)
+}
+
+func newRuntimeClient(data []byte, rc restConfigurator, scheme *runtime.Scheme) (client.Client, error) {
+	if rc == nil {
+		rc = restConfigurator(clientcmd.RESTConfigFromKubeConfig)
+	}
+	restConfig, err := rc.Config(data)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := initScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to init client scheme %v", err)
+	}
+
+	err = clientgoscheme.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.New(restConfig, client.Options{Scheme: scheme})
+}
+
+// restConfigurator abstracts the creation of a controller-runtime *rest.Config.
+//
+// This abstraction improves testing, as all known methods of instantiating a
+// *rest.Config try to make network calls, and that's something we'd like to
+// keep out of our unit tests as much as possible. In addition, where we do
+// use them in unit tests, we need to be prepared with a controller-runtime
+// EnvTest environment.
+//
+// For normal, non-test use, this can safely be ignored.
+type restConfigurator func([]byte) (*rest.Config, error)
+
+// Config generates and returns a rest.Config from a kubeconfig in bytes.
+func (c restConfigurator) Config(data []byte) (*rest.Config, error) {
+	return c(data)
+}

--- a/pkg/clients/kubernetes/runtimeclient_test.go
+++ b/pkg/clients/kubernetes/runtimeclient_test.go
@@ -1,0 +1,63 @@
+package kubernetes_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+)
+
+func TestNewRuntimeClient(t *testing.T) {
+	g := NewWithT(t)
+	cfg := test.UseEnvTest(t)
+	rc := kubernetes.RestConfigurator(func(_ []byte) (*rest.Config, error) { return cfg, nil })
+	c, err := kubernetes.NewRuntimeClient([]byte{}, rc, runtime.NewScheme())
+	g.Expect(err).To(BeNil())
+
+	ctx := context.Background()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "name",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Image: "nginx",
+					Name:  "nginx",
+				},
+			},
+		},
+	}
+	err = c.Create(ctx, pod)
+	g.Expect(err).To(BeNil())
+}
+
+func TestNewRuntimeClientInvalidRestConfig(t *testing.T) {
+	g := NewWithT(t)
+	rc := kubernetes.RestConfigurator(func(_ []byte) (*rest.Config, error) { return nil, errors.New("failed to build rest.Config") })
+	_, err := kubernetes.NewRuntimeClient([]byte{}, rc, runtime.NewScheme())
+	g.Expect(err).To(MatchError(ContainSubstring("failed to build rest.Config")))
+}
+
+func TestNewRuntimeClientInvalidScheme(t *testing.T) {
+	g := NewWithT(t)
+	cfg := test.UseEnvTest(t)
+	rc := kubernetes.RestConfigurator(func(_ []byte) (*rest.Config, error) { return cfg, nil })
+	_, err := kubernetes.NewRuntimeClient([]byte{}, rc, nil)
+	g.Expect(err).To(MatchError(ContainSubstring("scheme was not provided")))
+}
+
+func TestNewRuntimeClientFromFilename(t *testing.T) {
+	g := NewWithT(t)
+	_, err := kubernetes.NewRuntimeClientFromFileName("file-does-not-exist.txt")
+	g.Expect(err).To(MatchError(ContainSubstring("open file-does-not-exist.txt: no such file or directory")))
+}

--- a/pkg/clients/kubernetes/runtimeclient_wb_test.go
+++ b/pkg/clients/kubernetes/runtimeclient_wb_test.go
@@ -1,0 +1,5 @@
+package kubernetes
+
+var NewRuntimeClient = newRuntimeClient
+
+type RestConfigurator = restConfigurator

--- a/pkg/clients/kubernetes/scheme.go
+++ b/pkg/clients/kubernetes/scheme.go
@@ -24,7 +24,7 @@ var schemeAdders = []schemeAdder{
 	dockerv1.AddToScheme,
 }
 
-func addToScheme(scheme *runtime.Scheme, schemeAdder ...schemeAdder) error {
+func addToScheme(scheme *runtime.Scheme, schemeAdders ...schemeAdder) error {
 	for _, adder := range schemeAdders {
 		if err := adder(scheme); err != nil {
 			return err

--- a/pkg/cluster/fetch.go
+++ b/pkg/cluster/fetch.go
@@ -186,13 +186,19 @@ func BuildSpec(ctx context.Context, client Client, cluster *v1alpha1.Cluster) (*
 		return nil, err
 	}
 
-	bundlesName, bundlesNamespace := bundlesNamespacedKey(cluster)
+	return BuildSpecFromConfig(ctx, client, config)
+}
+
+// BuildSpecFromConfig constructs a cluster.Spec for an eks-a cluster by retrieving all
+// necessary objects from the cluster using a kubernetes client.
+func BuildSpecFromConfig(ctx context.Context, client Client, config *Config) (*Spec, error) {
+	bundlesName, bundlesNamespace := bundlesNamespacedKey(config.Cluster)
 	bundles := &v1alpha1release.Bundles{}
-	if err = client.Get(ctx, bundlesName, bundlesNamespace, bundles); err != nil {
+	if err := client.Get(ctx, bundlesName, bundlesNamespace, bundles); err != nil {
 		return nil, err
 	}
 
-	versionsBundle, err := GetVersionsBundle(cluster, bundles)
+	versionsBundle, err := GetVersionsBundle(config.Cluster, bundles)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/vsphere_workload_api_test.go
+++ b/test/e2e/vsphere_workload_api_test.go
@@ -4,32 +4,20 @@
 package e2e
 
 import (
-	"context"
 	"testing"
-	"time"
-
-	"github.com/onsi/gomega"
-
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
-	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
-	"github.com/aws/eks-anywhere/pkg/clusterapi"
-	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-// TODO(g-gaston): this is a WIP. It serves as an example on how tests
-// exercising the full cluster lifecycle can be written. It needs to0 be cleaned up
-// and a more robust validation set.
 func TestVSphereMulticlusterWorkloadClusterAPI(t *testing.T) {
-	ctx := context.Background()
 	vsphere := framework.NewVSphere(t)
 	managementCluster := framework.NewClusterE2ETest(
 		t, vsphere,
 	).WithClusterConfig(
 		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube123),
 			api.WithControlPlaneCount(1),
 			api.WithWorkerNodeCount(1),
 			api.WithStackedEtcdTopology(),
@@ -85,38 +73,8 @@ func TestVSphereMulticlusterWorkloadClusterAPI(t *testing.T) {
 	)
 	test.CreateManagementCluster()
 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.T.Logf("Applying workload cluster %s spec for creation", wc.ClusterName)
-		if err := wc.KubectlClient.ApplyManifest(ctx, wc.ManagementClusterKubeconfigFile(), wc.ClusterConfigLocation); err != nil {
-			wc.T.Errorf("Failed applying workload cluster config: %s", err)
-		}
-
-		// ------------------------
-		// This is where the proper validation should start, these are a quick place holder
-		// ------------------------
-
-		wc.T.Logf("Waiting for CAPI cluster %s to be created", wc.ClusterName)
-		g := gomega.NewWithT(t)
-		kc := kubernetes.NewUnAuthClient(wc.KubectlClient)
-		g.Expect(kc.Init()).To(gomega.Succeed())
-		client := kubernetes.NewKubeconfigClient(kc, wc.ManagementClusterKubeconfigFile())
-		g.Eventually(func(gg gomega.Gomega) {
-			gg.Expect(
-				client.Get(ctx, clusterapi.ClusterName(wc.ClusterConfig.Cluster), constants.EksaSystemNamespace, &clusterv1.Cluster{}),
-			).To(gomega.Succeed())
-		}, 1*time.Minute).Should(gomega.Succeed())
-
-		wc.T.Logf("Waiting for workload cluster %s to be ready", wc.ClusterName)
-		c := &types.Cluster{KubeconfigFile: wc.ManagementClusterKubeconfigFile(), Name: wc.ClusterName}
-		if err := wc.KubectlClient.WaitForClusterReady(ctx, c, "20m", clusterapi.ClusterName(wc.ClusterConfig.Cluster)); err != nil {
-			wc.T.Errorf("Failed waiting for cluster read: %s", err)
-		}
-
-		// ------------------------
-		// This is where validations end
-		// ------------------------
-
-		wc.T.Logf("Deleting workload cluster %s through API", wc.ClusterName)
-		g.Expect(wc.KubectlClient.DeleteEKSACluster(ctx, c, wc.ClusterName, wc.ClusterConfig.Cluster.Namespace)).To(gomega.Succeed())
+		wc.ApplyClusterManifest()
+		wc.DeleteClusterWithKubectl()
 	})
 	test.ManagementCluster.StopIfFailed()
 	test.DeleteManagementCluster()

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -22,13 +22,16 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	packagesv1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/git"
@@ -72,6 +75,7 @@ type ClusterE2ETest struct {
 	WithNoPowerActions     bool
 	ClusterName            string
 	ClusterConfig          *cluster.Config
+	clusterValidator       *ClusterValidator
 	Provider               Provider
 	clusterFillers         []api.ClusterFiller
 	KubectlClient          *executables.Kubectl
@@ -541,6 +545,21 @@ func (e *ClusterE2ETest) parseClusterConfigFromDisk() {
 	e.ClusterConfig = config
 }
 
+func (e *ClusterE2ETest) parseClusterConfigWithDefaultsFromDisk() (*v1alpha1.Cluster, error) {
+	fullClusterConfigLocation := filepath.Join(e.ClusterConfigFolder, e.ClusterName+"-eks-a-cluster.yaml")
+	content, err := os.ReadFile(fullClusterConfigLocation)
+	if err != nil {
+		return nil, fmt.Errorf("reading cluster config file: %v", err)
+	}
+
+	parsedCluster := &v1alpha1.Cluster{}
+	if err := yaml.Unmarshal(content, parsedCluster); err != nil {
+		return nil, fmt.Errorf("unable to marshal cluster config file contents %v", err)
+	}
+
+	return parsedCluster, err
+}
+
 // WithClusterConfig generates a base cluster config using the CLI `generate clusterconfig` command
 // and udpates them with the provided fillers. Helpful for defining the initial Cluster config
 // before running a create operation.
@@ -812,6 +831,13 @@ func (e *ClusterE2ETest) cluster() *types.Cluster {
 	return &types.Cluster{
 		Name:           e.ClusterName,
 		KubeconfigFile: e.kubeconfigFilePath(),
+	}
+}
+
+func (e *ClusterE2ETest) managementCluster() *types.Cluster {
+	return &types.Cluster{
+		Name:           e.ClusterConfig.Cluster.ManagedBy(),
+		KubeconfigFile: e.managementKubeconfigFilePath(),
 	}
 }
 
@@ -1657,4 +1683,95 @@ func (e *ClusterE2ETest) CombinedAutoScalerMetricServerTest(autoscalerName strin
 	}
 
 	e.T.Log("Finished scaling up machines")
+}
+
+// ValidateClusterState runs a set of validations against the cluster to identify an invalid cluster state.
+func (e *ClusterE2ETest) ValidateClusterState() {
+	e.T.Logf("Validating cluster %s", e.ClusterName)
+	ctx := context.Background()
+	err := retrier.Retry(12, 5*time.Second, func() error {
+		return e.buildClusterValidator(ctx)
+	})
+	if err != nil {
+		e.T.Fatalf("failed to build cluster validator %v", err)
+	}
+
+	if e.ClusterConfig.Cluster.IsManaged() {
+		e.clusterValidator.WithWorkloadClusterValidations()
+	}
+	if err := e.clusterValidator.Validate(ctx); err != nil {
+		e.T.Fatalf("failed to validate cluster %v", err)
+	}
+}
+
+// ValidateClusterDelete verifies the cluster has been deleted.
+func (e *ClusterE2ETest) ValidateClusterDelete() {
+	ctx := context.Background()
+	e.T.Logf("Validating cluster deletion %s", e.ClusterName)
+	if e.clusterValidator == nil {
+		return
+	}
+
+	e.clusterValidator.Reset()
+	if e.ClusterConfig.Cluster.IsManaged() {
+		e.clusterValidator.WithClusterDoesNotExist()
+	}
+	if err := e.clusterValidator.Validate(ctx); err != nil {
+		e.T.Fatalf("failed to validate cluster deletion %v", err)
+	}
+	e.clusterValidator = nil
+}
+
+func (e *ClusterE2ETest) buildClusterValidator(ctx context.Context) error {
+	mc, err := kubernetes.NewRuntimeClientFromFileName(e.managementKubeconfigFilePath())
+	if err != nil {
+		return fmt.Errorf("failed to create management cluster client: %s", err)
+	}
+	if e.ClusterConfig.Cluster.IsSelfManaged() {
+		mc = nil
+	}
+
+	c, err := kubernetes.NewRuntimeClientFromFileName(e.kubeconfigFilePath())
+	if err != nil {
+		return fmt.Errorf("failed to create cluster client: %s", err)
+	}
+
+	spec, err := e.buildClusterSpec(ctx, c, e.ClusterConfig)
+	if err != nil {
+		return fmt.Errorf("failed to build cluster spec %s", err)
+	}
+
+	e.clusterValidator = NewClusterValidator(func(cv *ClusterValidator) {
+		cv.ClusterOpts.ClusterClient = c
+		cv.ClusterOpts.ManagmentClusterClient = mc
+		cv.ClusterOpts.ClusterSpec = spec
+	})
+
+	return nil
+}
+
+func (e *ClusterE2ETest) buildClusterSpec(ctx context.Context, client client.Client, config *cluster.Config) (*cluster.Spec, error) {
+	if config.Cluster.IsManaged() {
+		spec := cluster.NewSpec(func(spec *cluster.Spec) {
+			spec.Config = config
+		})
+
+		return spec, nil
+	}
+
+	parsedCluster, err := e.parseClusterConfigWithDefaultsFromDisk()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cluster config with defaults from disk: %v", err)
+	}
+
+	config.Cluster.Spec.BundlesRef = parsedCluster.Spec.BundlesRef
+	if config.Cluster.Namespace == "" {
+		config.Cluster.Namespace = "default"
+	}
+	spec, err := cluster.BuildSpecFromConfig(ctx, clientutil.NewKubeClient(client), config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build cluster spec from config: %s", err)
+	}
+
+	return spec, err
 }

--- a/test/framework/clustervalidator.go
+++ b/test/framework/clustervalidator.go
@@ -1,0 +1,178 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/controller"
+	"github.com/aws/eks-anywhere/pkg/retrier"
+)
+
+type clusterValidation = func(ctx context.Context, validateOpts clusterOpts) error
+
+type retriableValidation struct {
+	validation    clusterValidation // the validation to run against the cluster.
+	backoffPeriod time.Duration     // the duration to wait another validation attempt.
+	maxRetries    int               // the maximum number of retries to validate.
+}
+
+// ClusterValidator is responsible for checking if a cluster is valid against the spec that is provided.
+type ClusterValidator struct {
+	ClusterOpts clusterOpts
+	validations []retriableValidation
+}
+
+// WithValidation registers a validation to the ClusterValidator that will be run when Validate is called.
+func (c *ClusterValidator) WithValidation(validation clusterValidation, backoffPeriod time.Duration, maxRetries int) {
+	c.validations = append(c.validations, retriableValidation{validation, backoffPeriod, maxRetries})
+}
+
+// WithWorkloadClusterValidations registers a validation set for a management cluster.
+func (c *ClusterValidator) WithWorkloadClusterValidations() {
+	c.WithValidation(validateClusterReady, 5*time.Second, 60)
+	c.WithValidation(validateEKSAObjects, 5*time.Second, 60)
+	c.WithValidation(validateControlPlaneNodes, 5*time.Second, 60)
+}
+
+// WithClusterDoesNotExist registers a validation to check that a cluster does not exist or has been deleted.
+func (c *ClusterValidator) WithClusterDoesNotExist() {
+	c.WithValidation(validateClusterDoesNotExist, 5*time.Second, 60)
+}
+
+// Validate runs through the set registered validations and returns an error if any of them fail after a number of retries.
+func (c *ClusterValidator) Validate(ctx context.Context) error {
+	for _, v := range c.validations {
+		err := retrier.Retry(v.maxRetries, v.backoffPeriod, func() error {
+			return v.validation(ctx, c.ClusterOpts)
+		})
+		if err != nil {
+			return fmt.Errorf("validation faild %v", err)
+		}
+	}
+
+	return nil
+}
+
+// Reset clears the registered validations.
+func (c *ClusterValidator) Reset() {
+	c.validations = []retriableValidation{}
+}
+
+// ClusterValidatorOpts represent the data to be passed as an argument to the Validate method.
+type ClusterValidatorOpts = func(cv *ClusterValidator)
+
+// NewClusterValidator returns a cluster validator.
+func NewClusterValidator(opts ...ClusterValidatorOpts) *ClusterValidator {
+	cv := ClusterValidator{
+		ClusterOpts: clusterOpts{},
+		validations: []retriableValidation{},
+	}
+
+	for _, opt := range opts {
+		opt(&cv)
+	}
+	return &cv
+}
+
+type clusterOpts struct {
+	ClusterClient          client.Client // the client for the cluster
+	ManagmentClusterClient client.Client // the client for the management cluster
+	ClusterSpec            *cluster.Spec // the cluster spec
+}
+
+func validateEKSAObjects(ctx context.Context, validateOpts clusterOpts) error {
+	for _, obj := range validateOpts.ClusterSpec.ChildObjects() {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
+		key := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+
+		if key.Namespace == "" {
+			key.Namespace = "default"
+		}
+
+		err := validateOpts.ManagmentClusterClient.Get(ctx, key, u)
+		if err != nil {
+			return fmt.Errorf("cluster object does not exist %s", err)
+		}
+	}
+
+	return nil
+}
+
+func validateClusterReady(ctx context.Context, validateOpts clusterOpts) error {
+	capiCluster, err := controller.GetCAPICluster(ctx, validateOpts.ManagmentClusterClient, validateOpts.ClusterSpec.Cluster)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve cluster %s", err)
+	}
+
+	if capiCluster == nil && err == nil {
+		return fmt.Errorf("cluster %s does not exist", capiCluster.Name)
+	}
+
+	if err := checkClusterReady(capiCluster); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateControlPlaneNodes(ctx context.Context, validateOpts clusterOpts) error {
+	cpNodes := &corev1.NodeList{}
+	err := validateOpts.ClusterClient.List(ctx, cpNodes, client.MatchingLabels{"node-role.kubernetes.io/control-plane": ""})
+	if err != nil {
+		return fmt.Errorf("failed to list controlplane nodes %s", err)
+	}
+
+	cpConfig := validateOpts.ClusterSpec.Cluster.Spec.ControlPlaneConfiguration
+	if len(cpNodes.Items) != cpConfig.Count {
+		return fmt.Errorf("control plane node count does not match expected: %v of %v", len(cpNodes.Items), cpConfig.Count)
+	}
+
+	for _, node := range cpNodes.Items {
+		err := validateNodeReady(node)
+		if err != nil {
+			return fmt.Errorf("failed to validate controlplane %s", err)
+		}
+	}
+	return nil
+}
+
+func validateNodeReady(node corev1.Node) error {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == "Ready" && condition.Status != "True" {
+			return fmt.Errorf("node %s not ready yet. %s", node.GetName(), condition.Reason)
+		}
+	}
+
+	return nil
+}
+
+func validateClusterDoesNotExist(ctx context.Context, validateOpts clusterOpts) error {
+	capiCluster, err := controller.GetCAPICluster(ctx, validateOpts.ManagmentClusterClient, validateOpts.ClusterSpec.Cluster)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve cluster %s", err)
+	}
+
+	if capiCluster != nil {
+		return fmt.Errorf("cluster %s exists", capiCluster.Name)
+	}
+
+	return nil
+}
+
+func checkClusterReady(cluster *v1beta1.Cluster) error {
+	for _, condition := range cluster.Status.Conditions {
+		if condition.Type == "Ready" && condition.Status != "True" {
+			return fmt.Errorf("node %s not ready yet. %s", cluster.GetName(), condition.Reason)
+		}
+	}
+
+	return nil
+}

--- a/test/framework/workload.go
+++ b/test/framework/workload.go
@@ -1,5 +1,16 @@
 package framework
 
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/filewriter"
+	"github.com/aws/eks-anywhere/pkg/retrier"
+)
+
 type WorkloadCluster struct {
 	*ClusterE2ETest
 	ManagementClusterKubeconfigFile func() string
@@ -20,4 +31,61 @@ func (w *WorkloadCluster) UpgradeCluster(clusterOpts []ClusterE2ETestOpt, comman
 func (w *WorkloadCluster) DeleteCluster(opts ...CommandOpt) {
 	opts = append(opts, withKubeconfig(w.ManagementClusterKubeconfigFile()))
 	w.deleteCluster(opts...)
+}
+
+// ApplyClusterManifest uses client-side logic to create/update objects defined in a cluster yaml manifest.
+func (w *WorkloadCluster) ApplyClusterManifest() {
+	ctx := context.Background()
+	w.T.Logf("Applying workload cluster %s spec located at %s", w.ClusterName, w.ClusterConfigLocation)
+	w.applyClusterManifest(ctx)
+	w.waitForKubeconfig(ctx)
+	w.ValidateClusterState()
+	w.StopIfFailed()
+}
+
+// DeleteClusterWithKubectl uses client-side logic to delete a cluster.
+func (w *WorkloadCluster) DeleteClusterWithKubectl() {
+	ctx := context.Background()
+	w.T.Logf("Deleting workload cluster %s with kubectl", w.ClusterName)
+	if err := w.KubectlClient.DeleteCluster(ctx, w.managementCluster(), w.cluster()); err != nil {
+		w.T.Fatalf("failed to delete workload cluster config: %s", err)
+	}
+	w.ValidateClusterDelete()
+	w.StopIfFailed()
+}
+
+func (w *WorkloadCluster) applyClusterManifest(ctx context.Context) {
+	if err := w.KubectlClient.ApplyManifest(ctx, w.ManagementClusterKubeconfigFile(), w.ClusterConfigLocation); err != nil {
+		w.T.Fatalf("Failed to apply workload cluster config: %s", err)
+	}
+}
+
+func (w *WorkloadCluster) waitForKubeconfig(ctx context.Context) {
+	w.T.Logf("Waiting for workload cluster %s kubeconfig to be available", w.ClusterName)
+	err := retrier.Retry(12, 5*time.Second, func() error {
+		return w.writeKubeconfigToDisk(ctx)
+	})
+	if err != nil {
+		w.T.Fatalf("Failed waiting for cluster kubeconfig: %s", err)
+	}
+}
+
+func (w *WorkloadCluster) writeKubeconfigToDisk(ctx context.Context) error {
+	secret, err := w.KubectlClient.GetSecretFromNamespace(ctx, w.ManagementClusterKubeconfigFile(), fmt.Sprintf("%s-kubeconfig", w.ClusterName), constants.EksaSystemNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to get kubeconfig for cluster: %s", err)
+	}
+	kubeconfig := secret.Data["value"]
+	writer, err := filewriter.NewWriter(w.ClusterConfigFolder)
+	if err != nil {
+		return fmt.Errorf("failed to write kubeconfig to disk: %v", err)
+	}
+
+	_, err = writer.Write(filepath.Base(w.kubeconfigFilePath()), kubeconfig, func(op *filewriter.FileOptions) {
+		op.IsTemp = false
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write kubeconfig to disk: %v", err)
+	}
+	return err
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR includes some infrastructure needed to write e2e tests for the Cluster Lifecycle API and a vSphere workload cluster e2e test that utilizes it.

*Testing (if applicable):*
Run `TestVSphereMulticlusterWorkloadClusterAPI` e2e test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

