### PR TITLE
Add wait awsiam e2e

### DIFF
--- a/test/framework/awsiam.go
+++ b/test/framework/awsiam.go
@@ -66,13 +66,16 @@ func (e *ClusterE2ETest) ValidateAWSIamAuth() {
 		e.T.Fatalf("Error updating PATH: %v", err)
 	}
 	kubectlClient := buildLocalKubectl()
-	e.T.Log("Waiting for aws-iam-authenticator daemonset ready")
-	kubectlClient.WaitForDaemonsetRolledout(ctx,
+	e.T.Log("Waiting for aws-iam-authenticator daemonset rollout status")
+	err = kubectlClient.WaitForDaemonsetRolledout(ctx,
 		e.cluster(),
 		"2m",
 		"aws-iam-authenticator",
 		constants.KubeSystemNamespace,
 	)
+	if err != nil {
+		e.T.Fatalf("Error waiting aws-iam-authenticator daemonset rollout: %v", err)
+	}
 	e.T.Log("Getting pods with aws-iam-authenticator kubeconfig")
 	pods, err := kubectlClient.GetPods(ctx,
 		executables.WithAllNamespaces(),


### PR DESCRIPTION
*Description of changes:*
When upgrading to kube 1.24 I noticed in some cases the aws-iam-authenticator rollout took a few extra seconds and hence e2e tests were failing intermittently.

*Testing:*
```bash
--- PASS: TestVSphereKubernetes124AWSIamAuth (655.03s)
PASS

[1]+  Done.   ./bin/e2e.test -test.v -test.run TestVSphereKubernetes124AWSIamAuth
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

