### PR TITLE
docs: Add kubectl to manual install instructions

### DIFF
--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -69,6 +69,17 @@ curl "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/${RELEASE_NUMBER}
 sudo mv ./eksctl-anywhere /usr/local/bin/
 ```
 
+Install the `kubectl` Kubernetes command line tool.
+This can be done by following the instructions [here](https://kubernetes.io/docs/tasks/tools/).
+
+On __Linux__ you can install the latest kubectl with the following.
+
+```bash
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+sudo mv ./kubectl /usr/local/bin
+sudo chmod +x /usr/local/bin/kubectl
+```
+
 ### Upgrade eksctl-anywhere
 
 If you installed `eksctl-anywhere` via homebrew you can upgrade the binary with

--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -75,7 +75,8 @@ This can be done by following the instructions [here](https://kubernetes.io/docs
 On __Linux__ you can install the latest kubectl with the following.
 
 ```bash
-curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+ARCH=$(test "$(uname -m)" = 'x86_64' && echo 'amd64' || echo 'arm64')
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl"
 sudo mv ./kubectl /usr/local/bin
 sudo chmod +x /usr/local/bin/kubectl
 ```

--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -72,11 +72,11 @@ sudo mv ./eksctl-anywhere /usr/local/bin/
 Install the `kubectl` Kubernetes command line tool.
 This can be done by following the instructions [here](https://kubernetes.io/docs/tasks/tools/).
 
-On __Linux__ you can install the latest kubectl with the following.
+Or you can install the latest kubectl directly with the following.
 
 ```bash
-ARCH=$(test "$(uname -m)" = 'x86_64' && echo 'amd64' || echo 'arm64')
-curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl"
+export OS="$(uname -s | tr A-Z a-z)" ARCH=$(test "$(uname -m)" = 'x86_64' && echo 'amd64' || echo 'arm64')
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${OS}/${ARCH}/kubectl"
 sudo mv ./kubectl /usr/local/bin
 sudo chmod +x /usr/local/bin/kubectl
 ```


### PR DESCRIPTION
The manuall install instructions for eksctl and eksctl-anywhere do not include kubectl. For completeness, we should include this.

Refs: #4482

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

