### PR TITLE
Fix kubeadmcontrolplane with unstacked etcd template

### DIFF
--- a/pkg/clusterapi/etcd.go
+++ b/pkg/clusterapi/etcd.go
@@ -45,9 +45,10 @@ func SetUnstackedEtcdConfigInKubeadmControlPlaneForBottlerocket(kcp *controlplan
 	}
 
 	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External = &bootstrapv1.ExternalEtcd{
-		CAFile:   "/var/lib/kubeadm/pki/etcd/ca.crt",
-		CertFile: "/var/lib/kubeadm/pki/server-etcd-client.crt",
-		KeyFile:  "/var/lib/kubeadm/pki/apiserver-etcd-client.key",
+		Endpoints: []string{},
+		CAFile:    "/var/lib/kubeadm/pki/etcd/ca.crt",
+		CertFile:  "/var/lib/kubeadm/pki/server-etcd-client.crt",
+		KeyFile:   "/var/lib/kubeadm/pki/apiserver-etcd-client.key",
 	}
 }
 

--- a/pkg/clusterapi/etcd_test.go
+++ b/pkg/clusterapi/etcd_test.go
@@ -55,9 +55,10 @@ func TestSetUnstackedEtcdConfigInKubeadmControlPlaneForBottlerocket(t *testing.T
 	}
 	got := wantKubeadmControlPlane()
 	got.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External = &bootstrapv1.ExternalEtcd{
-		CAFile:   "/var/lib/kubeadm/pki/etcd/ca.crt",
-		CertFile: "/var/lib/kubeadm/pki/server-etcd-client.crt",
-		KeyFile:  "/var/lib/kubeadm/pki/apiserver-etcd-client.key",
+		Endpoints: []string{},
+		CAFile:    "/var/lib/kubeadm/pki/etcd/ca.crt",
+		CertFile:  "/var/lib/kubeadm/pki/server-etcd-client.crt",
+		KeyFile:   "/var/lib/kubeadm/pki/apiserver-etcd-client.key",
 	}
 	want := got.DeepCopy()
 	clusterapi.SetUnstackedEtcdConfigInKubeadmControlPlaneForBottlerocket(got, etcdConfig)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Cluster creation failed bc of KCP missing etcd.external.endpoints.
```
2022-12-21T21:28:44.302Z        V5      Error happened during retry     {"error": "executing apply: error: error validating \"STDIN\": error validating data: ValidationError(KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.external): missing required field \"endpoints\" in io.x-k8s.cluster.controlplane.v1beta1.KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.external; if you choose to ignore these errors, turn validation off with --validate=false\n", "retries": 8}
```

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

