### PR TITLE
Fix etcd cluster template for bottlerocket

### DIFF
--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -303,7 +303,6 @@ func EtcdadmCluster(clusterSpec *cluster.Spec, infrastructureTemplate APIObject)
 			Replicas: &replicas,
 			EtcdadmConfigSpec: etcdbootstrapv1.EtcdadmConfigSpec{
 				EtcdadmBuiltin: true,
-				Format:         etcdbootstrapv1.Format("cloud-config"),
 				CipherSuites:   crypto.SecureCipherSuitesString(),
 			},
 			InfrastructureTemplate: v1.ObjectReference{

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -521,7 +521,6 @@ func wantEtcdCluster() *etcdv1.EtcdadmCluster {
 			Replicas: &replicas,
 			EtcdadmConfigSpec: etcdbootstrapv1.EtcdadmConfigSpec{
 				EtcdadmBuiltin: true,
-				Format:         etcdbootstrapv1.Format("cloud-config"),
 				CipherSuites:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 			},
 			InfrastructureTemplate: v1.ObjectReference{

--- a/pkg/clusterapi/bottlerocket.go
+++ b/pkg/clusterapi/bottlerocket.go
@@ -6,6 +6,7 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
@@ -90,6 +91,7 @@ func SetBottlerocketControlContainerImageInKubeadmConfigTemplate(kct *bootstrapv
 
 // SetBottlerocketInEtcdCluster adds bottlerocket config in etcdadmCluster.
 func SetBottlerocketInEtcdCluster(etcd *etcdv1.EtcdadmCluster, versionsBundle *cluster.VersionsBundle) {
+	etcd.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format(anywherev1.Bottlerocket)
 	etcd.Spec.EtcdadmConfigSpec.BottlerocketConfig = &etcdbootstrapv1.BottlerocketConfig{
 		EtcdImage:      versionsBundle.KubeDistro.EtcdImage.VersionedImage(),
 		BootstrapImage: versionsBundle.BottleRocketHostContainers.KubeadmBootstrap.VersionedImage(),

--- a/pkg/clusterapi/bottlerocket_test.go
+++ b/pkg/clusterapi/bottlerocket_test.go
@@ -110,6 +110,7 @@ func TestSetBottlerocketInEtcdCluster(t *testing.T) {
 	g := newApiBuilerTest(t)
 	got := wantEtcdCluster()
 	want := got.DeepCopy()
+	want.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format("bottlerocket")
 	want.Spec.EtcdadmConfigSpec.BottlerocketConfig = &etcdbootstrapv1.BottlerocketConfig{
 		EtcdImage:      "public.ecr.aws/eks-distro/etcd-io/etcd:0.0.1",
 		BootstrapImage: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",

--- a/pkg/clusterapi/etcd.go
+++ b/pkg/clusterapi/etcd.go
@@ -15,6 +15,7 @@ import (
 
 // SetUbuntuConfigInEtcdCluster sets up the etcd config in EtcdadmCluster.
 func SetUbuntuConfigInEtcdCluster(etcd *etcdv1.EtcdadmCluster, version string) {
+	etcd.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format("cloud-config")
 	etcd.Spec.EtcdadmConfigSpec.CloudInitConfig = &etcdbootstrapv1.CloudInitConfig{
 		Version:    version,
 		InstallDir: "/usr/bin",

--- a/pkg/clusterapi/etcd_test.go
+++ b/pkg/clusterapi/etcd_test.go
@@ -17,6 +17,7 @@ func TestSetUbuntuConfigInEtcdCluster(t *testing.T) {
 	got := wantEtcdCluster()
 	v := "0.0.1"
 	want := got.DeepCopy()
+	want.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format("cloud-config")
 	want.Spec.EtcdadmConfigSpec.CloudInitConfig = &etcdbootstrapv1.CloudInitConfig{
 		Version:    v,
 		InstallDir: "/usr/bin",

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -872,7 +872,6 @@ func wantEtcdCluster() *etcdv1.EtcdadmCluster {
 			Replicas: &replicas,
 			EtcdadmConfigSpec: etcdbootstrapv1.EtcdadmConfigSpec{
 				EtcdadmBuiltin: true,
-				Format:         etcdbootstrapv1.Format("cloud-config"),
 				CipherSuites:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 			},
 			InfrastructureTemplate: v1.ObjectReference{
@@ -886,6 +885,7 @@ func wantEtcdCluster() *etcdv1.EtcdadmCluster {
 
 func wantEtcdClusterUbuntu() *etcdv1.EtcdadmCluster {
 	etcd := wantEtcdCluster()
+	etcd.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format("cloud-config")
 	etcd.Spec.EtcdadmConfigSpec.CloudInitConfig = &etcdbootstrapv1.CloudInitConfig{
 		Version:    "3.4.16",
 		InstallDir: "/usr/bin",
@@ -902,6 +902,7 @@ func wantEtcdClusterUbuntu() *etcdv1.EtcdadmCluster {
 
 func wantEtcdClusterBottlerocket() *etcdv1.EtcdadmCluster {
 	etcd := wantEtcdCluster()
+	etcd.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format("bottlerocket")
 	etcd.Spec.EtcdadmConfigSpec.BottlerocketConfig = &etcdbootstrapv1.BottlerocketConfig{
 		EtcdImage:      "public.ecr.aws/eks-distro/etcd-io/etcd:0.0.1",
 		BootstrapImage: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When osFamily is bottlerocket, `etcd.Spec.EtcdadmConfigSpec.Format` needs to be `bottlerocket` or etcd bootstrap controller will trigger the cloud init config which won't work for BR.

*Testing (if applicable):*

- Unit tests
- Manual e2e on snow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

