### PR TITLE
Add infrastructure for Cluster Lifecycle API GitOps e2e tests

### DIFF
--- a/pkg/cluster/fetch.go
+++ b/pkg/cluster/fetch.go
@@ -189,8 +189,7 @@ func BuildSpec(ctx context.Context, client Client, cluster *v1alpha1.Cluster) (*
 	return BuildSpecFromConfig(ctx, client, config)
 }
 
-// BuildSpecFromConfig constructs a cluster.Spec for an eks-a cluster by retrieving all
-// necessary objects from the cluster using a kubernetes client.
+// BuildSpecFromConfig constructs a cluster.Spec for an eks-a cluster config by retrieving all dependencies objects from the cluster using a kubernetes client.
 func BuildSpecFromConfig(ctx context.Context, client Client, config *Config) (*Spec, error) {
 	bundlesName, bundlesNamespace := bundlesNamespacedKey(config.Cluster)
 	bundles := &v1alpha1release.Bundles{}

--- a/pkg/filewriter/writer.go
+++ b/pkg/filewriter/writer.go
@@ -64,7 +64,7 @@ func (w *writer) CleanUpTemp() {
 	}
 }
 
-// Create creates a file with the given name rooted at w's base direcftion.
+// Create creates a file with the given name rooted at w's base directory.
 func (w *writer) Create(name string, opts ...FileOptionsFunc) (_ io.WriteCloser, path string, _ error) {
 	o := buildOptions(w, opts)
 

--- a/test/e2e/vsphere_workload_api_flux_test.go
+++ b/test/e2e/vsphere_workload_api_flux_test.go
@@ -10,42 +10,21 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-func TestVSphereMulticlusterWorkloadClusterAPI(t *testing.T) {
+func TestVSphereMulticlusterWorkloadClusterAPIGitHubFlux(t *testing.T) {
 	vsphere := framework.NewVSphere(t)
 	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere,
+		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
 	).WithClusterConfig(
 		api.ClusterToConfigFiller(
 			api.WithControlPlaneCount(1),
 			api.WithWorkerNodeCount(1),
 			api.WithStackedEtcdTopology(),
 		),
-		vsphere.WithUbuntu123(),
+		framework.WithFluxGithubConfig(),
+		vsphere.WithUbuntu124(),
 	)
 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
 	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-			vsphere.WithUbuntu121(),
-		),
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-			vsphere.WithUbuntu122(),
-		),
 		framework.NewClusterE2ETest(
 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
 		).WithClusterConfig(
@@ -64,17 +43,18 @@ func TestVSphereMulticlusterWorkloadClusterAPI(t *testing.T) {
 				api.WithManagementCluster(managementCluster.ClusterName),
 				api.WithControlPlaneCount(1),
 				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
+				api.WithExternalEtcdTopology(1),
 			),
 			vsphere.WithUbuntu124(),
 		),
 	)
+
 	test.CreateManagementCluster()
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
+	test.RunInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+		test.PushWorkloadClusterToGit(wc)
 		wc.WaitForKubeconfig()
 		wc.ValidateClusterState()
-		wc.DeleteClusterWithKubectl()
+		test.DeleteWorkloadClusterFromGit(wc)
 		wc.ValidateClusterDelete()
 	})
 	test.ManagementCluster.StopIfFailed()

--- a/test/framework/clustervalidator.go
+++ b/test/framework/clustervalidator.go
@@ -44,7 +44,7 @@ func (c *ClusterValidator) WithWorkloadClusterValidations() {}
 func (c *ClusterValidator) WithExpectedObjectsExist() {
 	c.WithValidation(validateClusterReady, 5*time.Second, 60)
 	c.WithValidation(validateEKSAObjects, 5*time.Second, 60)
-	c.WithValidation(validateControlPlaneNodes, 5*time.Second, 60)
+	c.WithValidation(validateControlPlaneNodes, 5*time.Second, 120)
 	c.WithValidation(validateWorkerNodes, 5*time.Second, 60)
 }
 

--- a/test/framework/multicluster.go
+++ b/test/framework/multicluster.go
@@ -148,3 +148,13 @@ func (m *MulticlusterE2ETest) DeleteTinkerbellManagementCluster() {
 	m.ManagementCluster.DeleteCluster()
 	m.ManagementCluster.ValidateHardwareDecommissioned()
 }
+
+// PushWorkloadClusterToGit builds the workload cluster config file for git and pushing changes to git.
+func (m *MulticlusterE2ETest) PushWorkloadClusterToGit(w *WorkloadCluster, opts ...api.ClusterConfigFiller) {
+	m.ManagementCluster.PushWorkloadClusterToGit(w, opts...)
+}
+
+// DeleteWorkloadClusterFromGit deletes a workload cluster config file and pushes the changes to git.
+func (m *MulticlusterE2ETest) DeleteWorkloadClusterFromGit(w *WorkloadCluster) {
+	m.ManagementCluster.DeleteWorkloadClusterFromGit(w)
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR includes some infrastructure needed to write Gitops e2e tests for the Cluster Lifecycle API and vSphere workload cluster e2e tests that utilizes it.

*Testing (if applicable):*
```
--- PASS: TestVSphereMulticlusterWorkloadClusterAPIGitHubFlux (1312.20s)
PASS
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

