### PR TITLE
Add a nil check for CAPI diff for upgrade plan

### DIFF
--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -102,8 +102,20 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 	}
 
 	componentChangeDiffs := eksaupgrader.EksaChangeDiff(currentSpec, newClusterSpec)
+	if componentChangeDiffs == nil {
+		componentChangeDiffs = &types.ChangeDiff{}
+	}
+
 	componentChangeDiffs.Append(fluxupgrader.FluxChangeDiff(currentSpec, newClusterSpec))
+	if componentChangeDiffs == nil {
+		componentChangeDiffs = &types.ChangeDiff{}
+	}
+
 	componentChangeDiffs.Append(capiupgrader.CapiChangeDiff(currentSpec, newClusterSpec, deps.Provider))
+	if componentChangeDiffs == nil {
+		componentChangeDiffs = &types.ChangeDiff{}
+	}
+
 	componentChangeDiffs.Append(cilium.ChangeDiff(currentSpec, newClusterSpec))
 
 	serializedDiff, err := serialize(componentChangeDiffs, output)

--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -105,17 +105,8 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 	if componentChangeDiffs == nil {
 		componentChangeDiffs = &types.ChangeDiff{}
 	}
-
 	componentChangeDiffs.Append(fluxupgrader.FluxChangeDiff(currentSpec, newClusterSpec))
-	if componentChangeDiffs == nil {
-		componentChangeDiffs = &types.ChangeDiff{}
-	}
-
 	componentChangeDiffs.Append(capiupgrader.CapiChangeDiff(currentSpec, newClusterSpec, deps.Provider))
-	if componentChangeDiffs == nil {
-		componentChangeDiffs = &types.ChangeDiff{}
-	}
-
 	componentChangeDiffs.Append(cilium.ChangeDiff(currentSpec, newClusterSpec))
 
 	serializedDiff, err := serialize(componentChangeDiffs, output)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -54,14 +54,14 @@ const (
 	DefaultCuratedPackagesRegistryRegex = "783794618700.dkr.ecr.*.amazonaws.com"
 
 	// Provider specific env vars.
-	VSphereUsernameKey = "VSPHERE_USERNAME"
-	VSpherePasswordKey = "VSPHERE_PASSWORD"
-	GovcUsernameKey    = "GOVC_USERNAME"
-	GovcPasswordKey    = "GOVC_PASSWORD"
-	SnowCredentialsKey = "AWS_B64ENCODED_CREDENTIALS"
-	SnowCertsKey       = "AWS_B64ENCODED_CA_BUNDLES"
-	NutanixUsernameKey = "NUTANIX_USER"
-	NutanixPasswordKey = "NUTANIX_PASSWORD"
+	VSphereUsernameKey     = "VSPHERE_USERNAME"
+	VSpherePasswordKey     = "VSPHERE_PASSWORD"
+	GovcUsernameKey        = "GOVC_USERNAME"
+	GovcPasswordKey        = "GOVC_PASSWORD"
+	SnowCredentialsKey     = "AWS_B64ENCODED_CREDENTIALS"
+	SnowCertsKey           = "AWS_B64ENCODED_CA_BUNDLES"
+	NutanixUsernameKey     = "NUTANIX_USER"
+	NutanixPasswordKey     = "NUTANIX_PASSWORD"
 	EksaNutanixUsernameKey = "EKSA_NUTANIX_USERNAME"
 	EksaNutanixPasswordKey = "EKSA_NUTANIX_PASSWORD"
 

--- a/pkg/curatedpackages/curatedpackages.go
+++ b/pkg/curatedpackages/curatedpackages.go
@@ -62,6 +62,7 @@ func PrintLicense() {
 	fmt.Println(license)
 	fmt.Println(userMsgSeparator)
 }
+
 func PullLatestBundle(ctx context.Context, art string) ([]byte, error) {
 	puller := artifacts.NewRegistryPuller()
 

--- a/pkg/providers/nutanix/validator_test.go
+++ b/pkg/providers/nutanix/validator_test.go
@@ -433,7 +433,6 @@ func TestNutanixValidatorValidateDatacenterConfigWithInvalidCreds(t *testing.T) 
 			} else {
 				assert.NoError(t, err, tc.name)
 			}
-
 		})
 	}
 }

--- a/pkg/types/upgrades_test.go
+++ b/pkg/types/upgrades_test.go
@@ -1,0 +1,58 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/pkg/types"
+)
+
+func TestAppend(t *testing.T) {
+	tests := []struct {
+		testName         string
+		changeDiffs      *types.ChangeDiff
+		componentReports []types.ComponentChangeDiff
+	}{
+		{
+			testName: "empty changeDiff",
+			componentReports: []types.ComponentChangeDiff{
+				{
+					ComponentName: "test",
+					OldVersion:    "0.0.1",
+					NewVersion:    "0.0.2",
+				},
+			},
+			changeDiffs: &types.ChangeDiff{},
+		},
+		{
+			testName: "non empty changeDiff",
+			componentReports: []types.ComponentChangeDiff{
+				{
+					ComponentName: "test2",
+					OldVersion:    "0.0.2",
+					NewVersion:    "0.0.3",
+				},
+			},
+			changeDiffs: &types.ChangeDiff{
+				[]types.ComponentChangeDiff{
+					{
+						ComponentName: "test",
+						OldVersion:    "0.0.1",
+						NewVersion:    "0.0.2",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			changeDiffs := &types.ChangeDiff{tt.componentReports}
+			prevLen := len(tt.changeDiffs.ComponentReports)
+			tt.changeDiffs.Append(changeDiffs)
+
+			if len(tt.changeDiffs.ComponentReports) != (len(tt.componentReports))+prevLen {
+				t.Errorf("Component Reports were not appended")
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Description of changes:*
Add a nil check for CAPI diff for upgrade plan. Customer saw a nil pointer thrown while running the upgrade plan.

CAPI change diff does not have the Components Reports initialized because of empty Flux Change Diff.
*Testing (if applicable):*
- make and manual testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

