### PR TITLE
Fix snow etcd cluster object

### DIFF
--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -304,6 +304,7 @@ func EtcdadmCluster(clusterSpec *cluster.Spec, infrastructureTemplate APIObject)
 			EtcdadmConfigSpec: etcdbootstrapv1.EtcdadmConfigSpec{
 				EtcdadmBuiltin: true,
 				CipherSuites:   crypto.SecureCipherSuitesString(),
+				PreEtcdadmCommands: []string{},
 			},
 			InfrastructureTemplate: v1.ObjectReference{
 				APIVersion: infrastructureTemplate.GetObjectKind().GroupVersionKind().GroupVersion().String(),

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -520,8 +520,9 @@ func wantEtcdCluster() *etcdv1.EtcdadmCluster {
 		Spec: etcdv1.EtcdadmClusterSpec{
 			Replicas: &replicas,
 			EtcdadmConfigSpec: etcdbootstrapv1.EtcdadmConfigSpec{
-				EtcdadmBuiltin: true,
-				CipherSuites:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				EtcdadmBuiltin:     true,
+				CipherSuites:       "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				PreEtcdadmCommands: []string{},
 			},
 			InfrastructureTemplate: v1.ObjectReference{
 				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",

--- a/pkg/clusterapi/etcd.go
+++ b/pkg/clusterapi/etcd.go
@@ -20,13 +20,6 @@ func SetUbuntuConfigInEtcdCluster(etcd *etcdv1.EtcdadmCluster, version string) {
 		Version:    version,
 		InstallDir: "/usr/bin",
 	}
-	etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands = []string{
-		"hostname \"{{`{{ ds.meta_data.hostname }}`}}",
-		"echo \"::1         ipv6-localhost ipv6-loopback\" >/etc/hosts",
-		"echo \"127.0.0.1   localhost\" >>/etc/hosts",
-		"echo \"127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}\" >>/etc/hosts",
-		"echo \"{{`{{ ds.meta_data.hostname }}`}}\" >/etc/hostname",
-	}
 }
 
 // SetEtcdConfigInCluster sets up the etcd config in CAPI Cluster.

--- a/pkg/clusterapi/etcd_test.go
+++ b/pkg/clusterapi/etcd_test.go
@@ -22,13 +22,6 @@ func TestSetUbuntuConfigInEtcdCluster(t *testing.T) {
 		Version:    v,
 		InstallDir: "/usr/bin",
 	}
-	want.Spec.EtcdadmConfigSpec.PreEtcdadmCommands = []string{
-		"hostname \"{{`{{ ds.meta_data.hostname }}`}}",
-		"echo \"::1         ipv6-localhost ipv6-loopback\" >/etc/hosts",
-		"echo \"127.0.0.1   localhost\" >>/etc/hosts",
-		"echo \"127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}\" >>/etc/hosts",
-		"echo \"{{`{{ ds.meta_data.hostname }}`}}\" >/etc/hostname",
-	}
 	clusterapi.SetUbuntuConfigInEtcdCluster(got, v)
 	g.Expect(got).To(Equal(want))
 }

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -141,6 +141,9 @@ func EtcdadmCluster(log logr.Logger, clusterSpec *cluster.Spec, snowMachineTempl
 
 	case v1alpha1.Ubuntu:
 		clusterapi.SetUbuntuConfigInEtcdCluster(etcd, clusterSpec.VersionsBundle.KubeDistro.EtcdVersion)
+		etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands = append(etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands,
+			"/etc/eks/bootstrap.sh",
+		)
 
 	default:
 		log.Info("Warning: unsupported OS family when setting up EtcdadmCluster", "OS family", osFamily)

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -871,8 +871,9 @@ func wantEtcdCluster() *etcdv1.EtcdadmCluster {
 		Spec: etcdv1.EtcdadmClusterSpec{
 			Replicas: &replicas,
 			EtcdadmConfigSpec: etcdbootstrapv1.EtcdadmConfigSpec{
-				EtcdadmBuiltin: true,
-				CipherSuites:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				EtcdadmBuiltin:     true,
+				CipherSuites:       "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				PreEtcdadmCommands: []string{},
 			},
 			InfrastructureTemplate: v1.ObjectReference{
 				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
@@ -891,11 +892,7 @@ func wantEtcdClusterUbuntu() *etcdv1.EtcdadmCluster {
 		InstallDir: "/usr/bin",
 	}
 	etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands = []string{
-		"hostname \"{{`{{ ds.meta_data.hostname }}`}}",
-		"echo \"::1         ipv6-localhost ipv6-loopback\" >/etc/hosts",
-		"echo \"127.0.0.1   localhost\" >>/etc/hosts",
-		"echo \"127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}\" >>/etc/hosts",
-		"echo \"{{`{{ ds.meta_data.hostname }}`}}\" >/etc/hostname",
+		"/etc/eks/bootstrap.sh",
 	}
 	return etcd
 }


### PR DESCRIPTION
*Issue #, if available:*

Fix snow unstacked etcd cluster creation on ubuntu.

*Description of changes:*

- Add the snow bootstrap.sh in preEtcdadmCommands
- Remove the hostname configuration from apibuilder since snow does not need it. The hostname is set through CAPAS via userdata. AWS IMDS uses internal ip as hostname, which can be same on different devices.

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

