### PR TITLE
Update vSphere api test to use new structure

### DIFF
--- a/test/e2e/multiple_worker_node_groups_test.go
+++ b/test/e2e/multiple_worker_node_groups_test.go
@@ -53,41 +53,28 @@ func TestVSphereKubernetes124BottlerocketAndRemoveWorkerNodeGroups(t *testing.T)
 }
 
 func TestVSphereKubernetes124UbuntuUpgradeAndRemoveWorkerNodeGroupsAPI(t *testing.T) {
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			"worker-2",
-			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
-		),
-		framework.WithUbuntu124(),
-	)
+	provider := framework.NewVSphere(t)
 	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
+		t, provider,
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
 			api.WithKubernetesVersion(anywherev1.Kube124),
 			api.WithExternalEtcdTopology(1),
 			api.WithControlPlaneCount(1),
 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 		),
+		provider.WithWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(2))),
+		provider.WithWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
+		provider.WithUbuntu124(),
 	)
 
 	runUpgradeFlowWithAPI(
 		test,
-		framework.WithClusterUpgrade(
-			api.RemoveWorkerNodeGroup("workers-2"),
-			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
+		api.ClusterToConfigFiller(
+			api.RemoveWorkerNodeGroup("worker-2"),
+			api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
 		),
-		provider.WithNewVSphereWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup(
-				"workers-3",
-				api.WithCount(1),
-			),
-		),
+		provider.WithWorkerNodeGroupConfiguration("worker-1", framework.WithWorkerNodeGroup("worker-3", api.WithCount(1))),
 	)
 }
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -37,10 +37,9 @@ func runSimpleUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1
 	test.DeleteCluster()
 }
 
-func runUpgradeFlowWithAPI(test *framework.ClusterE2ETest, clusterOpts ...framework.ClusterE2ETestOpt) {
-	test.GenerateClusterConfig()
+func runUpgradeFlowWithAPI(test *framework.ClusterE2ETest, fillers ...api.ClusterConfigFiller) {
 	test.CreateCluster()
-	test.UpgradeClusterWithKubectl(clusterOpts)
+	test.UpgradeClusterWithKubectl(fillers...)
 	test.ValidateClusterState()
 	test.StopIfFailed()
 	test.DeleteCluster()

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -680,13 +680,10 @@ func WithClusterUpgrade(fillers ...api.ClusterFiller) ClusterE2ETestOpt {
 }
 
 // UpgradeClusterWithKubectl uses client-side logic to upgrade a cluster.
-func (e *ClusterE2ETest) UpgradeClusterWithKubectl(clusterOpts []ClusterE2ETestOpt) {
+func (e *ClusterE2ETest) UpgradeClusterWithKubectl(fillers ...api.ClusterConfigFiller) {
 	fullClusterConfigLocation := filepath.Join(e.ClusterConfigFolder, e.ClusterName+"-eks-a-cluster.yaml")
 	e.parseClusterConfigFromDisk(fullClusterConfigLocation)
-	for _, opt := range clusterOpts {
-		opt(e)
-	}
-	e.buildClusterConfigFile()
+	e.UpdateClusterConfig(fillers...)
 	e.ApplyClusterManifest()
 }
 

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -360,6 +360,20 @@ func WithVSphereWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup, f
 	}
 }
 
+// WithWorkerNodeGroup returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration and
+// a corresponding VSphereMachineConfig to the cluster config.
+func (v *VSphere) WithWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup, fillers ...api.VSphereMachineConfigFiller) api.ClusterConfigFiller {
+	return api.JoinClusterConfigFillers(
+		api.VSphereToConfigFiller(vSphereMachineConfig(name, fillers...)),
+		api.ClusterToConfigFiller(buildVSphereWorkerNodeGroupClusterFiller(name, workerNodeGroup)),
+	)
+}
+
+// WithWorkerNodeGroupConfiguration returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration item to the cluster config.
+func (v *VSphere) WithWorkerNodeGroupConfiguration(name string, workerNodeGroup *WorkerNodeGroup) api.ClusterConfigFiller {
+	return api.ClusterToConfigFiller(buildVSphereWorkerNodeGroupClusterFiller(name, workerNodeGroup))
+}
+
 // WithVSphereFillers adds VSphereFiller to the provider default fillers.
 func WithVSphereFillers(fillers ...api.VSphereFiller) VSphereOpt {
 	return func(v *VSphere) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update vSphere api test to setup using `WithCusterConfig` for the first cluster definition, since we’re trying to enforce this structure for the new tests.

*Testing (if applicable):*
```
--- PASS: TestVSphereKubernetes124UbuntuUpgradeAndRemoveWorkerNodeGroupsAPI (1257.54s)
PASS
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

