### PR TITLE
Add Docker API e2e test upgrading worker node for mgmt cluster

### DIFF
--- a/test/e2e/multiple_worker_node_groups_test.go
+++ b/test/e2e/multiple_worker_node_groups_test.go
@@ -78,6 +78,31 @@ func TestVSphereKubernetes124UbuntuUpgradeAndRemoveWorkerNodeGroupsAPI(t *testin
 	)
 }
 
+func TestDockerKubernetes124UpgradeAndRemoveWorkerNodeGroupsAPI(t *testing.T) {
+	provider := framework.NewDocker(t)
+	test := framework.NewClusterE2ETest(
+		t, provider,
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(anywherev1.Kube124),
+			api.WithExternalEtcdTopology(1),
+			api.WithControlPlaneCount(1),
+			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+		),
+		provider.WithWorkerNodeGroup(framework.WithWorkerNodeGroup("worker-1", api.WithCount(2))),
+		provider.WithWorkerNodeGroup(framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
+	)
+
+	runUpgradeFlowWithAPI(
+		test,
+		api.ClusterToConfigFiller(
+			api.RemoveWorkerNodeGroup("worker-2"),
+			api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
+		),
+		provider.WithWorkerNodeGroup(framework.WithWorkerNodeGroup("worker-3", api.WithCount(1))),
+	)
+}
+
 func TestCloudStackKubernetes121RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
 	provider := framework.NewCloudStack(t,
 		framework.WithCloudStackWorkerNodeGroup(

--- a/test/framework/clustervalidator.go
+++ b/test/framework/clustervalidator.go
@@ -45,7 +45,7 @@ func (c *ClusterValidator) WithExpectedObjectsExist() {
 	c.WithValidation(validateClusterReady, 5*time.Second, 60)
 	c.WithValidation(validateEKSAObjects, 5*time.Second, 60)
 	c.WithValidation(validateControlPlaneNodes, 5*time.Second, 120)
-	c.WithValidation(validateWorkerNodes, 5*time.Second, 60)
+	c.WithValidation(validateWorkerNodes, 5*time.Second, 120)
 }
 
 // WithClusterDoesNotExist registers a validation to check that a cluster does not exist or has been deleted.

--- a/test/framework/docker.go
+++ b/test/framework/docker.go
@@ -50,3 +50,9 @@ func (d *Docker) ClusterConfigUpdates() []api.ClusterConfigFiller {
 	}
 	return []api.ClusterConfigFiller{api.ClusterToConfigFiller(f...)}
 }
+
+// WithWorkerNodeGroup returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration and
+// a corresponding DockerMachineConfig to the cluster config.
+func (d *Docker) WithWorkerNodeGroup(workerNodeGroup *WorkerNodeGroup) api.ClusterConfigFiller {
+	return api.ClusterToConfigFiller(workerNodeGroup.ClusterFiller())
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We currently only support upgrading worker node config fields for mgmt clusters when using the API, so here's a docker e2e test for that.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

