### PR TITLE
Ignore kubeadm manifest preflight for ubuntu snow

### DIFF
--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -20,9 +20,13 @@ import (
 )
 
 const (
-	SnowClusterKind         = "AWSSnowCluster"
+	// SnowClusterKind is the kubernetes object kind for CAPAS Cluster.
+	SnowClusterKind = "AWSSnowCluster"
+	// SnowMachineTemplateKind is the kubernetes object kind for CAPAS machine template.
 	SnowMachineTemplateKind = "AWSSnowMachineTemplate"
-	SnowIPPoolKind          = "AWSSnowIPPool"
+	// SnowIPPoolKind is the kubernetes object kind for CAPAS IP pool.
+	SnowIPPoolKind                                   = "AWSSnowIPPool"
+	ignoreEtcdKubernetesManifestFolderPreflightError = "DirAvailable--etc-kubernetes-manifests"
 )
 
 // CAPICluster generates the CAPICluster object for snow provider.
@@ -74,6 +78,10 @@ func KubeadmControlPlane(log logr.Logger, clusterSpec *cluster.Spec, snowMachine
 		clusterapi.CreateContainerdConfigFileInKubeadmControlPlane(kcp, clusterSpec.Cluster)
 		clusterapi.RestartContainerdInKubeadmControlPlane(kcp, clusterSpec.Cluster)
 		clusterapi.SetUnstackedEtcdConfigInKubeadmControlPlaneForUbuntu(kcp, clusterSpec.Cluster.Spec.ExternalEtcdConfiguration)
+		kcp.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = append(
+			kcp.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors,
+			ignoreEtcdKubernetesManifestFolderPreflightError,
+		)
 
 	default:
 		log.Info("Warning: unsupported OS family when setting up KubeadmControlPlane", "OS family", osFamily)

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -216,7 +216,8 @@ func TestKubeadmControlPlane(t *testing.T) {
 	tt.Expect(err).To(Succeed())
 
 	want := wantKubeadmControlPlane()
-	tt.Expect(got).To(Equal(want))
+	want.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = []string{"DirAvailable--etc-kubernetes-manifests"}
+	tt.Expect(got).To(BeComparableTo(want))
 }
 
 var registryMirrorTests = []struct {
@@ -383,7 +384,8 @@ func TestKubeadmControlPlaneWithRegistryMirrorUbuntu(t *testing.T) {
 			want := wantKubeadmControlPlane()
 			want.Spec.KubeadmConfigSpec.Files = append(want.Spec.KubeadmConfigSpec.Files, tt.wantFiles...)
 			want.Spec.KubeadmConfigSpec.PreKubeadmCommands = append(want.Spec.KubeadmConfigSpec.PreKubeadmCommands, wantRegistryMirrorCommands()...)
-			g.Expect(got).To(Equal(want))
+			want.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = []string{"DirAvailable--etc-kubernetes-manifests"}
+			g.Expect(got).To(BeComparableTo(want))
 		})
 	}
 }
@@ -451,7 +453,7 @@ func TestKubeadmControlPlaneWithRegistryMirrorBottlerocket(t *testing.T) {
 			want.Spec.KubeadmConfigSpec.JoinConfiguration.Pause = pause
 			want.Spec.KubeadmConfigSpec.ClusterConfiguration.RegistryMirror = tt.wantRegistryConfig
 			want.Spec.KubeadmConfigSpec.JoinConfiguration.RegistryMirror = tt.wantRegistryConfig
-			g.Expect(got).To(Equal(want))
+			g.Expect(got).To(BeComparableTo(want))
 		})
 	}
 }
@@ -516,7 +518,8 @@ func TestKubeadmControlPlaneWithProxyConfigUbuntu(t *testing.T) {
 			want := wantKubeadmControlPlane()
 			want.Spec.KubeadmConfigSpec.Files = append(want.Spec.KubeadmConfigSpec.Files, tt.wantFiles...)
 			want.Spec.KubeadmConfigSpec.PreKubeadmCommands = append(want.Spec.KubeadmConfigSpec.PreKubeadmCommands, wantProxyConfigCommands()...)
-			g.Expect(got).To(Equal(want))
+			want.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = []string{"DirAvailable--etc-kubernetes-manifests"}
+			g.Expect(got).To(BeComparableTo(want))
 		})
 	}
 }

--- a/pkg/providers/snow/objects_test.go
+++ b/pkg/providers/snow/objects_test.go
@@ -56,10 +56,11 @@ func TestControlPlaneObjects(t *testing.T) {
 	mt.Spec.Template.Spec.InstanceType = "sbe-c.large"
 	kcp := wantKubeadmControlPlane()
 	kcp.Spec.MachineTemplate.InfrastructureRef.Name = wantMachineTemplateName
+	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = []string{"DirAvailable--etc-kubernetes-manifests"}
 
 	got, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
-	g.Expect(got).To(Equal([]kubernetes.Object{wantCAPICluster(), kcp, wantSnowCluster(), mt, wantSnowCredentialsSecret()}))
+	g.Expect(got).To(BeComparableTo([]kubernetes.Object{wantCAPICluster(), kcp, wantSnowCluster(), mt, wantSnowCredentialsSecret()}))
 }
 
 func TestControlPlaneObjectsWithIPPools(t *testing.T) {
@@ -119,10 +120,11 @@ func TestControlPlaneObjectsWithIPPools(t *testing.T) {
 	mt.Spec.Template.Spec.InstanceType = "sbe-c.large"
 	kcp := wantKubeadmControlPlane()
 	kcp.Spec.MachineTemplate.InfrastructureRef.Name = wantMachineTemplateName
+	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = []string{"DirAvailable--etc-kubernetes-manifests"}
 
 	got, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
-	g.Expect(got).To(Equal([]kubernetes.Object{wantCAPICluster(), kcp, wantSnowCluster(), mt, wantSnowCredentialsSecret(), wantSnowIPPool()}))
+	g.Expect(got).To(BeComparableTo([]kubernetes.Object{wantCAPICluster(), kcp, wantSnowCluster(), mt, wantSnowCredentialsSecret(), wantSnowIPPool()}))
 }
 
 func TestControlPlaneObjectsUnstackedEtcd(t *testing.T) {
@@ -219,6 +221,7 @@ func TestControlPlaneObjectsUnstackedEtcd(t *testing.T) {
 	mtCp.Spec.Template.Spec.InstanceType = "sbe-c.large"
 	kcp := wantKubeadmControlPlaneUnstackedEtcd()
 	kcp.Spec.MachineTemplate.InfrastructureRef.Name = mtCpName
+	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = []string{"DirAvailable--etc-kubernetes-manifests"}
 
 	mtEtcdName := "test-etcd-2"
 	mtEtcd.SetName(mtEtcdName)
@@ -227,7 +230,7 @@ func TestControlPlaneObjectsUnstackedEtcd(t *testing.T) {
 
 	got, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
-	g.Expect(got).To(Equal([]kubernetes.Object{wantCAPIClusterUnstackedEtcd(), kcp, wantSnowCluster(), mtCp, etcdCluster, mtEtcd, wantSnowCredentialsSecret()}))
+	g.Expect(got).To(BeComparableTo([]kubernetes.Object{wantCAPIClusterUnstackedEtcd(), kcp, wantSnowCluster(), mtCp, etcdCluster, mtEtcd, wantSnowCredentialsSecret()}))
 }
 
 func TestControlPlaneObjectsCredentialsNil(t *testing.T) {
@@ -271,10 +274,12 @@ func TestControlPlaneObjectsOldControlPlaneNotExists(t *testing.T) {
 
 	mt.SetName("snow-test-control-plane-1")
 	mt.Spec.Template.Spec.InstanceType = "sbe-c.large"
+	kcp := wantKubeadmControlPlane()
+	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = []string{"DirAvailable--etc-kubernetes-manifests"}
 
 	got, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
-	g.Expect(got).To(Equal([]kubernetes.Object{wantCAPICluster(), wantKubeadmControlPlane(), wantSnowCluster(), mt, wantSnowCredentialsSecret()}))
+	g.Expect(got).To(Equal([]kubernetes.Object{wantCAPICluster(), kcp, wantSnowCluster(), mt, wantSnowCredentialsSecret()}))
 }
 
 func TestControlPlaneObjectsOldMachineTemplateNotExists(t *testing.T) {
@@ -302,10 +307,12 @@ func TestControlPlaneObjectsOldMachineTemplateNotExists(t *testing.T) {
 
 	mt.SetName("snow-test-control-plane-1")
 	mt.Spec.Template.Spec.InstanceType = "sbe-c.large"
+	kcp := wantKubeadmControlPlane()
+	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = []string{"DirAvailable--etc-kubernetes-manifests"}
 
 	got, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
 	g.Expect(err).To(Succeed())
-	g.Expect(got).To(Equal([]kubernetes.Object{wantCAPICluster(), wantKubeadmControlPlane(), wantSnowCluster(), mt, wantSnowCredentialsSecret()}))
+	g.Expect(got).To(Equal([]kubernetes.Object{wantCAPICluster(), kcp, wantSnowCluster(), mt, wantSnowCredentialsSecret()}))
 }
 
 func TestControlPlaneObjectsGetOldControlPlaneError(t *testing.T) {

--- a/pkg/providers/snow/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_cp.yaml
@@ -134,6 +134,8 @@ spec:
       bottlerocketControl: {}
       discovery: {}
       nodeRegistration:
+        ignorePreflightErrors:
+        - DirAvailable--etc-kubernetes-manifests
         kubeletExtraArgs:
           provider-id: aws-snow:////'{{ ds.meta_data.instance_id }}'
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256


### PR DESCRIPTION
## Description of changes
Kubeadm checks if /etc/kubernetes/manifests is empty when running kubeadm join. However, we add the kube-vip static pod manifest there in control plane nodes, which makes the join command to fail. Bottlerocket runs kubeadm in a different way, so it doesn't face this issue. Other providers use useExperimentalRetryJoin, which runs kubeadm from a bash script which adds a flag to ignore this same preflight check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

