### PR TITLE
Add snowippool crd and register webhook

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
 - bases/anywhere.eks.amazonaws.com_tinkerbelltemplateconfigs.yaml
 - bases/anywhere.eks.amazonaws.com_snowdatacenterconfigs.yaml
 - bases/anywhere.eks.amazonaws.com_snowmachineconfigs.yaml
+- bases/anywhere.eks.amazonaws.com_snowippools.yaml
 - bases/anywhere.eks.amazonaws.com_nutanixmachineconfigs.yaml
 - bases/anywhere.eks.amazonaws.com_nutanixdatacenterconfigs.yaml
 #+kubebuilder:scaffold:crdkustomizeresource

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4767,6 +4767,85 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
+  name: snowippools.anywhere.eks.amazonaws.com
+spec:
+  group: anywhere.eks.amazonaws.com
+  names:
+    kind: SnowIPPool
+    listKind: SnowIPPoolList
+    plural: snowippools
+    singular: snowippool
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SnowIPPool is the Schema for the SnowIPPools API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SnowIPPoolSpec defines the desired state of SnowIPPool.
+            properties:
+              pools:
+                description: IPPools defines a list of ip pool for the DNI.
+                items:
+                  description: IPPool defines an ip pool with ip range, subnet and
+                    gateway.
+                  properties:
+                    gateway:
+                      description: Gateway is the gateway of the subnet for routing
+                        purpose.
+                      type: string
+                    ipEnd:
+                      description: IPEnd is the end address of an ip range.
+                      type: string
+                    ipStart:
+                      description: IPStart is the start address of an ip range.
+                      type: string
+                    subnet:
+                      description: Subnet is used to determine whether an ip is within
+                        subnet.
+                      type: string
+                  required:
+                  - gateway
+                  - ipEnd
+                  - ipStart
+                  - subnet
+                  type: object
+                type: array
+            type: object
+          status:
+            description: SnowIPPoolStatus defines the observed state of SnowIPPool.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
   name: snowmachineconfigs.anywhere.eks.amazonaws.com
 spec:
   group: anywhere.eks.amazonaws.com

--- a/manager/main.go
+++ b/manager/main.go
@@ -254,6 +254,10 @@ func setupSnowWebhooks(setupLog logr.Logger, mgr ctrl.Manager) {
 		setupLog.Error(err, "unable to create webhook", "webhook", "SnowDatacenterConfig")
 		os.Exit(1)
 	}
+	if err := (&anywherev1.SnowIPPool{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "SnowIPPool")
+		os.Exit(1)
+	}
 }
 
 func setupChecks(setupLog logr.Logger, mgr ctrl.Manager) {

--- a/pkg/api/v1alpha1/snowippool_test.go
+++ b/pkg/api/v1alpha1/snowippool_test.go
@@ -1,0 +1,57 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+func TestSnowIPPoolConvertConfigToConfigGenerateStruct(t *testing.T) {
+	g := NewWithT(t)
+
+	s := &v1alpha1.SnowIPPool{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       v1alpha1.SnowIPPoolKind,
+			APIVersion: v1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ippool",
+		},
+		Spec: v1alpha1.SnowIPPoolSpec{
+			Pools: []v1alpha1.IPPool{
+				{
+					IPStart: "start",
+					IPEnd:   "end",
+					Gateway: "gateway",
+					Subnet:  "subnet",
+				},
+			},
+		},
+	}
+
+	want := &v1alpha1.SnowIPPoolGenerate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       v1alpha1.SnowIPPoolKind,
+			APIVersion: v1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: v1alpha1.ObjectMeta{
+			Name:      "ippool",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.SnowIPPoolSpec{
+			Pools: []v1alpha1.IPPool{
+				{
+					IPStart: "start",
+					IPEnd:   "end",
+					Gateway: "gateway",
+					Subnet:  "subnet",
+				},
+			},
+		},
+	}
+
+	g.Expect(s.ConvertConfigToConfigGenerateStruct()).To(Equal(want))
+}

--- a/pkg/api/v1alpha1/snowippool_type.go
+++ b/pkg/api/v1alpha1/snowippool_type.go
@@ -40,6 +40,35 @@ type SnowIPPool struct {
 	Status SnowIPPoolStatus `json:"status,omitempty"`
 }
 
+// ConvertConfigToConfigGenerateStruct converts a SnowIPPool to SnowIPPoolGenerate object.
+func (s *SnowIPPool) ConvertConfigToConfigGenerateStruct() *SnowIPPoolGenerate {
+	namespace := defaultEksaNamespace
+	if s.Namespace != "" {
+		namespace = s.Namespace
+	}
+	config := &SnowIPPoolGenerate{
+		TypeMeta: s.TypeMeta,
+		ObjectMeta: ObjectMeta{
+			Name:        s.Name,
+			Annotations: s.Annotations,
+			Namespace:   namespace,
+		},
+		Spec: s.Spec,
+	}
+
+	return config
+}
+
+// +kubebuilder:object:generate=false
+
+// SnowIPPoolGenerate is same as SnowIPPool except stripped down for generation of yaml file during generate clusterconfig.
+type SnowIPPoolGenerate struct {
+	metav1.TypeMeta `json:",inline"`
+	ObjectMeta      `json:"metadata,omitempty"`
+
+	Spec SnowIPPoolSpec `json:"spec,omitempty"`
+}
+
 //+kubebuilder:object:root=true
 
 // SnowIPPoolList contains a list of SnowIPPool.

--- a/pkg/clustermanager/eksa_installer_test.go
+++ b/pkg/clustermanager/eksa_installer_test.go
@@ -59,7 +59,7 @@ func TestEKSAInstallerInstallSuccessWithRealManifest(t *testing.T) {
 	tt := newInstallerTest(t)
 	tt.newSpec.VersionsBundle.Eksa.Components.URI = "../../config/manifest/eksa-components.yaml"
 	tt.client.EXPECT().Apply(tt.ctx, tt.cluster.KubeconfigFile, gomock.AssignableToTypeOf(&appsv1.Deployment{}))
-	tt.client.EXPECT().Apply(tt.ctx, tt.cluster.KubeconfigFile, gomock.Any()).Times(32) // there 30 other objects in the manifes
+	tt.client.EXPECT().Apply(tt.ctx, tt.cluster.KubeconfigFile, gomock.Any()).Times(33) // there are 33 objects in the manifest
 	tt.client.EXPECT().WaitForDeployment(tt.ctx, tt.cluster, "30m", "Available", "eksa-controller-manager", "eksa-system")
 
 	tt.Expect(tt.installer.Install(tt.ctx, test.NewNullLogger(), tt.cluster, tt.newSpec)).To(Succeed())

--- a/pkg/clustermarshaller/clustermarshaller.go
+++ b/pkg/clustermarshaller/clustermarshaller.go
@@ -14,7 +14,7 @@ import (
 )
 
 func MarshalClusterSpec(clusterSpec *cluster.Spec, datacenterConfig providers.DatacenterConfig, machineConfigs []providers.MachineConfig) ([]byte, error) {
-	marshallables := make([]v1alpha1.Marshallable, 0, 5+len(machineConfigs)+len(clusterSpec.TinkerbellTemplateConfigs))
+	marshallables := make([]v1alpha1.Marshallable, 0, 5+len(machineConfigs)+len(clusterSpec.TinkerbellTemplateConfigs)+len(clusterSpec.SnowIPPools))
 	marshallables = append(marshallables,
 		clusterSpec.Cluster.ConvertConfigToConfigGenerateStruct(),
 		datacenterConfig.Marshallable(),
@@ -42,6 +42,11 @@ func MarshalClusterSpec(clusterSpec *cluster.Spec, datacenterConfig providers.Da
 	}
 	if clusterSpec.TinkerbellTemplateConfigs != nil {
 		for _, t := range clusterSpec.TinkerbellTemplateConfigs {
+			marshallables = append(marshallables, t.ConvertConfigToConfigGenerateStruct())
+		}
+	}
+	if clusterSpec.SnowIPPools != nil {
+		for _, t := range clusterSpec.SnowIPPools {
 			marshallables = append(marshallables, t.ConvertConfigToConfigGenerateStruct())
 		}
 	}

--- a/pkg/clustermarshaller/clustermarshaller_test.go
+++ b/pkg/clustermarshaller/clustermarshaller_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/clustermarshaller"
 	"github.com/aws/eks-anywhere/pkg/providers"
-	"github.com/aws/eks-anywhere/pkg/providers/snow"
 )
 
 func TestWriteClusterConfigWithOIDCAndGitOps(t *testing.T) {
@@ -342,7 +341,7 @@ func TestWriteClusterConfigSnow(t *testing.T) {
 		s.SnowIPPools = map[string]*v1alpha1.SnowIPPool{
 			"ippool": {
 				TypeMeta: v1.TypeMeta{
-					Kind:       snow.SnowIPPoolKind,
+					Kind:       v1alpha1.SnowIPPoolKind,
 					APIVersion: v1alpha1.GroupVersion.String(),
 				},
 				ObjectMeta: v1.ObjectMeta{

--- a/pkg/clustermarshaller/testdata/expected_marshalled_snow.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_snow.yaml
@@ -44,7 +44,7 @@ spec:
 
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
-kind: AWSSnowIPPool
+kind: SnowIPPool
 metadata:
   name: ippool
   namespace: default

--- a/pkg/clustermarshaller/testdata/expected_marshalled_snow.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_snow.yaml
@@ -1,0 +1,58 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: testcluster
+  namespace: default
+spec:
+  clusterNetwork:
+    pods: {}
+    services: {}
+  controlPlaneConfiguration:
+    machineGroupRef:
+      kind: SnowMachineConfig
+      name: testsnow
+  datacenterRef:
+    kind: SnowDatacenterConfig
+    name: testsnow
+  managementCluster:
+    name: testcluster
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: SnowDatacenterConfig
+metadata:
+  name: testsnow
+  namespace: default
+spec:
+  identityRef: {}
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: SnowMachineConfig
+metadata:
+  name: testsnow
+  namespace: default
+spec:
+  amiID: ""
+  network:
+    directNetworkInterfaces:
+    - index: 1
+      ipPoolRef:
+        kind: SnowIPPool
+        name: ippool
+      primary: true
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: AWSSnowIPPool
+metadata:
+  name: ippool
+  namespace: default
+spec:
+  pools:
+  - gateway: gateway
+    ipEnd: end
+    ipStart: start
+    subnet: subnet
+
+---

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -923,7 +923,7 @@ func TestUpgradeNeededMachineConfigNil(t *testing.T) {
 	tt.kubeconfigClient.EXPECT().
 		Get(
 			tt.ctx,
-			"test-cp",
+			gomock.Any(),
 			"test-namespace",
 			&v1alpha1.SnowMachineConfig{},
 		).


### PR DESCRIPTION
*Issue #, if available:*

Controller error with `SnowIPPool` kind not exists.

```
{"ts":1672820348229.5503,"caller":"controller/controller.go:326","msg":"Reconciler error","controller":"cluster","controllerGroup":"anywhere.eks.amazonaws.com","controllerKind":"Cluster","C
luster":{"name":"test-snow-2","namespace":"default"},"namespace":"default","name":"test-snow-2","reconcileID":"37fdc63b-2de9-47ab-8a33-0bf16537c443","err":"building Config from a cluster cl
ient: no matches for kind \"SnowIPPool\" in version \"anywhere.eks.amazonaws.com/v1alpha1\"","errVerbose":"no matches for kind \"SnowIPPool\" in version \"anywhere.eks.amazonaws.com/v1alpha
1\"\nbuilding Config from a cluster client\ngithub.com/aws/eks-anywhere/pkg/cluster.(*ConfigClientBuilder).Build\n\t/codebuild/output/src575995265/src/git-codecommit.us-west-2.amazonaws.com
/v1/repos/aws.eks-anywhere/pkg/cluster/client_builder.go:47\ngithub.com/aws/eks-anywhere/controllers.(*ClusterReconciler).ensureClusterOwnerReferences\n\t/codebuild/output/src575995265/src/
git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere/controllers/cluster_controller.go:281\ngithub.com/aws/eks-anywhere/controllers.(*ClusterReconciler).Reconcile\n\t/codebuild/
output/src575995265/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere/controllers/cluster_controller.go:163\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Cont
roller).Reconcile\n\t/codebuild/output/src575995265/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/contro
ller.go:121\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/codebuild/output/src575995265/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.
eks-anywhere/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:320\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/co
debuild/output/src575995265/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:273\nsigs.k8s.io
/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/codebuild/output/src575995265/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere/vendor/sigs.k8
s.io/controller-runtime/pkg/internal/controller/controller.go:234\nruntime.goexit\n\t/root/sdk/go1.18.9/src/runtime/asm_amd64.s:1571"}
```

*Description of changes:*

- Add `SnowIPPool` in crd kustomization and in eksa-components.yaml
- Add `SnowIPPool` object when applying the eks-a spec in CLI

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

