### PR TITLE
Remove method from provider reconciler interface

### DIFF
--- a/controllers/mocks/provider.go
+++ b/controllers/mocks/provider.go
@@ -9,7 +9,6 @@ import (
 	reflect "reflect"
 
 	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	cluster "github.com/aws/eks-anywhere/pkg/cluster"
 	controller "github.com/aws/eks-anywhere/pkg/controller"
 	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
@@ -51,21 +50,6 @@ func (m *MockProviderClusterReconciler) Reconcile(ctx context.Context, log logr.
 func (mr *MockProviderClusterReconcilerMockRecorder) Reconcile(ctx, log, cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockProviderClusterReconciler)(nil).Reconcile), ctx, log, cluster)
-}
-
-// ReconcileCNI mocks base method.
-func (m *MockProviderClusterReconciler) ReconcileCNI(ctx context.Context, log logr.Logger, clusterSpec *cluster.Spec) (controller.Result, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReconcileCNI", ctx, log, clusterSpec)
-	ret0, _ := ret[0].(controller.Result)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReconcileCNI indicates an expected call of ReconcileCNI.
-func (mr *MockProviderClusterReconcilerMockRecorder) ReconcileCNI(ctx, log, clusterSpec interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileCNI", reflect.TypeOf((*MockProviderClusterReconciler)(nil).ReconcileCNI), ctx, log, clusterSpec)
 }
 
 // ReconcileWorkerNodes mocks base method.

--- a/pkg/controller/clusters/registry.go
+++ b/pkg/controller/clusters/registry.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-logr/logr"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/controller"
 )
 
@@ -16,8 +15,6 @@ type ProviderClusterReconciler interface {
 	Reconcile(ctx context.Context, log logr.Logger, cluster *anywherev1.Cluster) (controller.Result, error)
 	// ReconcileWorkerNodes handles only the worker node reconciliation. Intended to be used on self managed clusters.
 	ReconcileWorkerNodes(ctx context.Context, log logr.Logger, cluster *anywherev1.Cluster) (controller.Result, error)
-	// ReconcileCNI handles the cni reconciliation to install networking on the clusters.
-	ReconcileCNI(ctx context.Context, log logr.Logger, clusterSpec *cluster.Spec) (controller.Result, error)
 }
 
 // ProviderClusterReconcilerRegistry holds a collection of cluster provider reconcilers


### PR DESCRIPTION
*Description of changes:*
This method won't be needed and not used anywhere.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

