### PR TITLE
Make snow amiID optional

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_snowmachineconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_snowmachineconfigs.yaml
@@ -146,7 +146,6 @@ spec:
                   aws snow key pairs, to attach to the instance.
                 type: string
             required:
-            - amiID
             - network
             type: object
           status:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4986,7 +4986,6 @@ spec:
                   aws snow key pairs, to attach to the instance.
                 type: string
             required:
-            - amiID
             - network
             type: object
           status:

--- a/pkg/api/v1alpha1/snowmachineconfig_types.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_types.go
@@ -29,7 +29,7 @@ type SnowMachineConfigSpec struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
 
 	// The AMI ID from which to create the machine instance.
-	AMIID string `json:"amiID"`
+	AMIID string `json:"amiID,omitempty"`
 
 	// InstanceType is the type of instance to create.
 	// Valid values: "sbe-c.large" (default), "sbe-c.xlarge", "sbe-c.2xlarge" and "sbe-c.4xlarge".

--- a/pkg/clustermarshaller/testdata/expected_marshalled_snow.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_snow.yaml
@@ -33,7 +33,6 @@ metadata:
   name: testsnow
   namespace: default
 spec:
-  amiID: ""
   network:
     directNetworkInterfaces:
     - index: 1


### PR DESCRIPTION
*Issue #, if available:*

Below warning shows when applying eksa spec in cluster to create workload cluster.
```
$ k apply -f joeywang-snow-workload.yaml 
error validating "joeywang-snow-workload.yaml": error validating data: ValidationError(SnowMachineConfig.spec): missing required field "amiID" in com.amazonaws.eks.anywhere.v1alpha1.SnowMachineConfig.spec; if you choose to ignore these errors, turn validation off with --validate=false
```

*Description of changes:*

amiID is optional since capas will fill in a match with its image lookup logic.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

