### PR TITLE
Generate tinkerbell validation webhook skeleton

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -132,4 +132,20 @@ resources:
   version: v1alpha1
   webhooks:
     webhookVersion: v1
+- domain: eks.amazonaws.com
+  group: anywhere
+  kind: TinkerbellDatacenterConfig
+  path: github.com/aws/eks-anywhere/api/v1alpha1
+  version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
+- domain: eks.amazonaws.com
+  group: anywhere
+  kind: TinkerbellMachineConfig
+  path: github.com/aws/eks-anywhere/api/v1alpha1
+  version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 version: "3"

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -6414,6 +6414,48 @@ webhooks:
     service:
       name: eksa-webhook-service
       namespace: eksa-system
+      path: /validate-anywhere-eks-amazonaws-com-v1alpha1-tinkerbelldatacenterconfig
+  failurePolicy: Fail
+  name: vtinkerbelldatacenterconfig.kb.io
+  rules:
+  - apiGroups:
+    - anywhere.eks.amazonaws.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - tinkerbelldatacenterconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: eksa-webhook-service
+      namespace: eksa-system
+      path: /validate-anywhere-eks-amazonaws-com-v1alpha1-tinkerbellmachineconfig
+  failurePolicy: Fail
+  name: vtinkerbellmachineconfig.kb.io
+  rules:
+  - apiGroups:
+    - anywhere.eks.amazonaws.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - tinkerbellmachineconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: eksa-webhook-service
+      namespace: eksa-system
       path: /validate-anywhere-eks-amazonaws-com-v1alpha1-vspheredatacenterconfig
   failurePolicy: Fail
   name: validation.vspheredatacenterconfig.anywhere.amazonaws.com

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -6416,7 +6416,7 @@ webhooks:
       namespace: eksa-system
       path: /validate-anywhere-eks-amazonaws-com-v1alpha1-tinkerbelldatacenterconfig
   failurePolicy: Fail
-  name: vtinkerbelldatacenterconfig.kb.io
+  name: validation.tinkerbelldatacenterconfig.anywhere.amazonaws.com
   rules:
   - apiGroups:
     - anywhere.eks.amazonaws.com
@@ -6437,7 +6437,7 @@ webhooks:
       namespace: eksa-system
       path: /validate-anywhere-eks-amazonaws-com-v1alpha1-tinkerbellmachineconfig
   failurePolicy: Fail
-  name: vtinkerbellmachineconfig.kb.io
+  name: validation.tinkerbellmachineconfig.anywhere.amazonaws.com
   rules:
   - apiGroups:
     - anywhere.eks.amazonaws.com

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -336,6 +336,48 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-anywhere-eks-amazonaws-com-v1alpha1-tinkerbelldatacenterconfig
+  failurePolicy: Fail
+  name: vtinkerbelldatacenterconfig.kb.io
+  rules:
+  - apiGroups:
+    - anywhere.eks.amazonaws.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - tinkerbelldatacenterconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-anywhere-eks-amazonaws-com-v1alpha1-tinkerbellmachineconfig
+  failurePolicy: Fail
+  name: vtinkerbellmachineconfig.kb.io
+  rules:
+  - apiGroups:
+    - anywhere.eks.amazonaws.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - tinkerbellmachineconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-anywhere-eks-amazonaws-com-v1alpha1-vspheredatacenterconfig
   failurePolicy: Fail
   name: validation.vspheredatacenterconfig.anywhere.amazonaws.com

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -338,7 +338,7 @@ webhooks:
       namespace: system
       path: /validate-anywhere-eks-amazonaws-com-v1alpha1-tinkerbelldatacenterconfig
   failurePolicy: Fail
-  name: vtinkerbelldatacenterconfig.kb.io
+  name: validation.tinkerbelldatacenterconfig.anywhere.amazonaws.com
   rules:
   - apiGroups:
     - anywhere.eks.amazonaws.com
@@ -359,7 +359,7 @@ webhooks:
       namespace: system
       path: /validate-anywhere-eks-amazonaws-com-v1alpha1-tinkerbellmachineconfig
   failurePolicy: Fail
-  name: vtinkerbellmachineconfig.kb.io
+  name: validation.tinkerbellmachineconfig.anywhere.amazonaws.com
   rules:
   - apiGroups:
     - anywhere.eks.amazonaws.com

--- a/manager/main.go
+++ b/manager/main.go
@@ -198,6 +198,7 @@ func setupWebhooks(setupLog logr.Logger, mgr ctrl.Manager) {
 	setupVSphereWebhooks(setupLog, mgr)
 	setupCloudstackWebhooks(setupLog, mgr)
 	setupSnowWebhooks(setupLog, mgr)
+	setupTinkerbellWebhooks(setupLog, mgr)
 }
 
 func setupCoreWebhooks(setupLog logr.Logger, mgr ctrl.Manager) {
@@ -256,6 +257,17 @@ func setupSnowWebhooks(setupLog logr.Logger, mgr ctrl.Manager) {
 	}
 	if err := (&anywherev1.SnowIPPool{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "SnowIPPool")
+		os.Exit(1)
+	}
+}
+
+func setupTinkerbellWebhooks(setupLog logr.Logger, mgr ctrl.Manager) {
+	if err := (&anywherev1.TinkerbellDatacenterConfig{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", WEBHOOK, anywherev1.TinkerbellDatacenterKind)
+		os.Exit(1)
+	}
+	if err := (&anywherev1.TinkerbellMachineConfig{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", WEBHOOK, anywherev1.TinkerbellMachineConfigKind)
 		os.Exit(1)
 	}
 }

--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook.go
@@ -1,0 +1,62 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var tinkerbelldatacenterconfiglog = logf.Log.WithName("tinkerbelldatacenterconfig-resource")
+
+func (r *TinkerbellDatacenterConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-anywhere-eks-amazonaws-com-v1alpha1-tinkerbelldatacenterconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=anywhere.eks.amazonaws.com,resources=tinkerbelldatacenterconfigs,verbs=create;update,versions=v1alpha1,name=vtinkerbelldatacenterconfig.kb.io,admissionReviewVersions={v1,v1beta1}
+
+var _ webhook.Validator = &TinkerbellDatacenterConfig{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *TinkerbellDatacenterConfig) ValidateCreate() error {
+	tinkerbelldatacenterconfiglog.Info("validate create", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object creation.
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *TinkerbellDatacenterConfig) ValidateUpdate(old runtime.Object) error {
+	tinkerbelldatacenterconfiglog.Info("validate update", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object update.
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *TinkerbellDatacenterConfig) ValidateDelete() error {
+	tinkerbelldatacenterconfiglog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil
+}

--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook.go
@@ -24,6 +24,7 @@ import (
 // log is for logging in this package.
 var tinkerbelldatacenterconfiglog = logf.Log.WithName("tinkerbelldatacenterconfig-resource")
 
+// SetupWebhookWithManager sets up TinkerbellDatacenterConfig webhook to controller manager.
 func (r *TinkerbellDatacenterConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -37,7 +38,7 @@ func (r *TinkerbellDatacenterConfig) SetupWebhookWithManager(mgr ctrl.Manager) e
 
 var _ webhook.Validator = &TinkerbellDatacenterConfig{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *TinkerbellDatacenterConfig) ValidateCreate() error {
 	tinkerbelldatacenterconfiglog.Info("validate create", "name", r.Name)
 
@@ -45,7 +46,7 @@ func (r *TinkerbellDatacenterConfig) ValidateCreate() error {
 	return nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *TinkerbellDatacenterConfig) ValidateUpdate(old runtime.Object) error {
 	tinkerbelldatacenterconfiglog.Info("validate update", "name", r.Name)
 
@@ -53,7 +54,7 @@ func (r *TinkerbellDatacenterConfig) ValidateUpdate(old runtime.Object) error {
 	return nil
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *TinkerbellDatacenterConfig) ValidateDelete() error {
 	tinkerbelldatacenterconfiglog.Info("validate delete", "name", r.Name)
 

--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook.go
@@ -33,7 +33,7 @@ func (r *TinkerbellDatacenterConfig) SetupWebhookWithManager(mgr ctrl.Manager) e
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:path=/validate-anywhere-eks-amazonaws-com-v1alpha1-tinkerbelldatacenterconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=anywhere.eks.amazonaws.com,resources=tinkerbelldatacenterconfigs,verbs=create;update,versions=v1alpha1,name=vtinkerbelldatacenterconfig.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-anywhere-eks-amazonaws-com-v1alpha1-tinkerbelldatacenterconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=anywhere.eks.amazonaws.com,resources=tinkerbelldatacenterconfigs,verbs=create;update,versions=v1alpha1,name=validation.tinkerbelldatacenterconfig.anywhere.amazonaws.com,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &TinkerbellDatacenterConfig{}
 

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
@@ -33,7 +33,7 @@ func (r *TinkerbellMachineConfig) SetupWebhookWithManager(mgr ctrl.Manager) erro
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:path=/validate-anywhere-eks-amazonaws-com-v1alpha1-tinkerbellmachineconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=anywhere.eks.amazonaws.com,resources=tinkerbellmachineconfigs,verbs=create;update,versions=v1alpha1,name=vtinkerbellmachineconfig.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-anywhere-eks-amazonaws-com-v1alpha1-tinkerbellmachineconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=anywhere.eks.amazonaws.com,resources=tinkerbellmachineconfigs,verbs=create;update,versions=v1alpha1,name=validation.tinkerbellmachineconfig.anywhere.amazonaws.com,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &TinkerbellMachineConfig{}
 

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
@@ -1,0 +1,62 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var tinkerbellmachineconfiglog = logf.Log.WithName("tinkerbellmachineconfig-resource")
+
+func (r *TinkerbellMachineConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-anywhere-eks-amazonaws-com-v1alpha1-tinkerbellmachineconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=anywhere.eks.amazonaws.com,resources=tinkerbellmachineconfigs,verbs=create;update,versions=v1alpha1,name=vtinkerbellmachineconfig.kb.io,admissionReviewVersions={v1,v1beta1}
+
+var _ webhook.Validator = &TinkerbellMachineConfig{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *TinkerbellMachineConfig) ValidateCreate() error {
+	tinkerbellmachineconfiglog.Info("validate create", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object creation.
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *TinkerbellMachineConfig) ValidateUpdate(old runtime.Object) error {
+	tinkerbellmachineconfiglog.Info("validate update", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object update.
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *TinkerbellMachineConfig) ValidateDelete() error {
+	tinkerbellmachineconfiglog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil
+}

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
@@ -24,6 +24,7 @@ import (
 // log is for logging in this package.
 var tinkerbellmachineconfiglog = logf.Log.WithName("tinkerbellmachineconfig-resource")
 
+// SetupWebhookWithManager sets up TinkerbellMachineConfig webhook to controller manager.
 func (r *TinkerbellMachineConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -37,7 +38,7 @@ func (r *TinkerbellMachineConfig) SetupWebhookWithManager(mgr ctrl.Manager) erro
 
 var _ webhook.Validator = &TinkerbellMachineConfig{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *TinkerbellMachineConfig) ValidateCreate() error {
 	tinkerbellmachineconfiglog.Info("validate create", "name", r.Name)
 
@@ -45,7 +46,7 @@ func (r *TinkerbellMachineConfig) ValidateCreate() error {
 	return nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *TinkerbellMachineConfig) ValidateUpdate(old runtime.Object) error {
 	tinkerbellmachineconfiglog.Info("validate update", "name", r.Name)
 
@@ -53,7 +54,7 @@ func (r *TinkerbellMachineConfig) ValidateUpdate(old runtime.Object) error {
 	return nil
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *TinkerbellMachineConfig) ValidateDelete() error {
 	tinkerbellmachineconfiglog.Info("validate delete", "name", r.Name)
 

--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -302,8 +302,8 @@ func EtcdadmCluster(clusterSpec *cluster.Spec, infrastructureTemplate APIObject)
 		Spec: etcdv1.EtcdadmClusterSpec{
 			Replicas: &replicas,
 			EtcdadmConfigSpec: etcdbootstrapv1.EtcdadmConfigSpec{
-				EtcdadmBuiltin: true,
-				CipherSuites:   crypto.SecureCipherSuitesString(),
+				EtcdadmBuiltin:     true,
+				CipherSuites:       crypto.SecureCipherSuitesString(),
 				PreEtcdadmCommands: []string{},
 			},
 			InfrastructureTemplate: v1.ObjectReference{


### PR DESCRIPTION
*Issue #, if available:*
[Skeleton for webhooks#982](https://github.com/aws/eks-anywhere-internal/issues/982)

*Description of changes:*
- run `make hack/tools/bin/kubebuilder` to build kubebuilder
- run `./hack/kubebuilder.sh create api --group anywhere --version v1alpha1 --kind TinkerbellDatacenterConfig` to add api to [PROJECT](https://github.com/aws/eks-anywhere/blob/main/PROJECT)
- run `./hack/kubebuilder.sh create webhook --group anywhere --version v1alpha1 --programmatic-validation --kind TinkerbellDatacenterConfig` to generate webhook.go
- run `make release-manifests` to generate manifests

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

