### PR TITLE
Add docker e2e api tests workload cluster k8s upgrade, taints and labels

### DIFF
--- a/test/e2e/multiple_worker_node_groups_test.go
+++ b/test/e2e/multiple_worker_node_groups_test.go
@@ -65,6 +65,7 @@ func TestVSphereKubernetes124UbuntuUpgradeAndRemoveWorkerNodeGroupsAPI(t *testin
 		),
 		provider.WithWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(2))),
 		provider.WithWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
+		provider.WithWorkerNodeGroup("worker-3", framework.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithLabel("tier", "frontend"))),
 		provider.WithUbuntu124(),
 	)
 
@@ -73,8 +74,11 @@ func TestVSphereKubernetes124UbuntuUpgradeAndRemoveWorkerNodeGroupsAPI(t *testin
 		api.ClusterToConfigFiller(
 			api.RemoveWorkerNodeGroup("worker-2"),
 			api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
+			api.RemoveWorkerNodeGroup("worker-3"),
 		),
-		provider.WithWorkerNodeGroupConfiguration("worker-1", framework.WithWorkerNodeGroup("worker-3", api.WithCount(1))),
+		// Re-adding with no labels and a taint
+		provider.WithWorkerNodeGroupConfiguration("worker-3", framework.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithTaint(framework.NoScheduleTaint()))),
+		provider.WithWorkerNodeGroupConfiguration("worker-1", framework.WithWorkerNodeGroup("worker-4", api.WithCount(1))),
 	)
 }
 
@@ -91,6 +95,9 @@ func TestDockerKubernetes124UpgradeAndRemoveWorkerNodeGroupsAPI(t *testing.T) {
 		),
 		provider.WithWorkerNodeGroup(framework.WithWorkerNodeGroup("worker-1", api.WithCount(2))),
 		provider.WithWorkerNodeGroup(framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
+		provider.WithWorkerNodeGroup(
+			framework.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithLabel("tier", "frontend")),
+		),
 	)
 
 	runUpgradeFlowWithAPI(
@@ -98,8 +105,10 @@ func TestDockerKubernetes124UpgradeAndRemoveWorkerNodeGroupsAPI(t *testing.T) {
 		api.ClusterToConfigFiller(
 			api.RemoveWorkerNodeGroup("worker-2"),
 			api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
+			api.RemoveWorkerNodeGroup("worker-3"),
+			api.WithWorkerNodeGroup("worker-3", api.WithCount(1),api.WithTaint(framework.NoScheduleTaint())),
 		),
-		provider.WithWorkerNodeGroup(framework.WithWorkerNodeGroup("worker-3", api.WithCount(1))),
+		provider.WithWorkerNodeGroup(framework.WithWorkerNodeGroup("worker-4", api.WithCount(1))),
 	)
 }
 

--- a/test/e2e/workload_api_test.go
+++ b/test/e2e/workload_api_test.go
@@ -181,3 +181,84 @@ func TestVSphereUpgradeScaleWorkersUbuntuAPI(t *testing.T) {
 		vsphere.WithUbuntu124(),
 	)
 }
+
+func TestDockerUpgradeKubernetes123to124WorkloadClusterScaleWorkerNodesAPI(t *testing.T) {
+	provider := framework.NewDocker(t)
+	managementCluster := framework.NewClusterE2ETest(
+		t, provider,
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube124),
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
+			api.WithExternalEtcdTopology(1),
+		),
+	)
+	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+	test.WithWorkloadClusters(
+		framework.NewClusterE2ETest(
+			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+		).WithClusterConfig(
+			api.ClusterToConfigFiller(
+				api.WithKubernetesVersion(v1alpha1.Kube123),
+				api.WithManagementCluster(managementCluster.ClusterName),
+				api.WithControlPlaneCount(1),
+				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+				api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
+				api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
+				api.WithStackedEtcdTopology(),
+			),
+		),
+	)
+	runWorkloadClusterUpgradeFlowAPI(
+		test,
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube124),
+			api.WithControlPlaneCount(3),
+			api.WithWorkerNodeGroup("worker-0", api.WithCount(1)),
+			api.WithWorkerNodeGroup("worker-1", api.WithCount(2)),
+		),
+	)
+}
+
+func TestDockerUpgradeWorkloadClusterLabelsAndTaintsAPI(t *testing.T) {
+	provider := framework.NewDocker(t)
+	managementCluster := framework.NewClusterE2ETest(
+		t, provider,
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube124),
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
+			api.WithExternalEtcdTopology(1),
+		),
+	)
+	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+	test.WithWorkloadClusters(
+		framework.NewClusterE2ETest(
+			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+		).WithClusterConfig(
+			api.ClusterToConfigFiller(
+				api.WithKubernetesVersion(v1alpha1.Kube124),
+				api.WithManagementCluster(managementCluster.ClusterName),
+				api.WithControlPlaneCount(1),
+				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+				api.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithLabel("tier", "frontend"), api.WithTaint(framework.NoScheduleTaint())),
+				api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
+				api.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithTaint(framework.PreferNoScheduleTaint())),
+				api.WithStackedEtcdTopology(),
+			),
+		),
+	)
+	runWorkloadClusterUpgradeFlowAPI(
+		test,
+		api.ClusterToConfigFiller(
+			api.WithControlPlaneLabel("cpKey1", "cpVal1"),
+			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+			api.RemoveWorkerNodeGroup("worker-0"),
+			api.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithLabel("key1", "val1"), api.WithTaint(framework.NoExecuteTaint())),
+			api.WithWorkerNodeGroup("worker-1", api.WithLabel("key2", "val2"), api.WithTaint(framework.NoExecuteTaint())),
+			api.WithWorkerNodeGroup("worker-2", api.WithNoTaints()),
+		),
+	)
+}

--- a/test/framework/cloudstack.go
+++ b/test/framework/cloudstack.go
@@ -172,6 +172,11 @@ func (c *CloudStack) Name() string {
 
 func (c *CloudStack) Setup() {}
 
+// UpdateKubeConfig customizes generated kubeconfig for the provider.
+func (c *CloudStack) UpdateKubeConfig(content *[]byte, clusterName string) error {
+	return nil
+}
+
 // ClusterConfigUpdates satisfies the test framework Provider.
 func (c *CloudStack) ClusterConfigUpdates() []api.ClusterConfigFiller {
 	controlPlaneIP, err := c.getControlPlaneIP()

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -300,6 +300,7 @@ type Provider interface {
 	ClusterConfigUpdates() []api.ClusterConfigFiller
 	Setup()
 	CleanupVMs(clusterName string) error
+	UpdateKubeConfig(content *[]byte, clusterName string) error
 }
 
 func (e *ClusterE2ETest) GenerateClusterConfig(opts ...CommandOpt) {

--- a/test/framework/nutanix.go
+++ b/test/framework/nutanix.go
@@ -135,6 +135,11 @@ func (s *Nutanix) Name() string {
 
 func (s *Nutanix) Setup() {}
 
+// UpdateKubeConfig customizes generated kubeconfig for the provider.
+func (s *Nutanix) UpdateKubeConfig(content *[]byte, clusterName string) error {
+	return nil
+}
+
 // CleanupVMs satisfies the test framework Provider.
 func (s *Nutanix) CleanupVMs(clustername string) error {
 	return cleanup.NutanixTestResourcesCleanup(context.Background(), clustername, os.Getenv(nutanixEndpoint), os.Getenv(nutanixPort), true, true)

--- a/test/framework/snow.go
+++ b/test/framework/snow.go
@@ -63,6 +63,11 @@ func (s *Snow) Name() string {
 
 func (s *Snow) Setup() {}
 
+// UpdateKubeConfig customizes generated kubeconfig for the provider.
+func (s *Snow) UpdateKubeConfig(content *[]byte, clusterName string) error {
+	return nil
+}
+
 // ClusterConfigUpdates satisfies the test framework Provider.
 func (s *Snow) ClusterConfigUpdates() []api.ClusterConfigFiller {
 	ip, err := GenerateUniqueIp(s.cpCidr)

--- a/test/framework/tinkerbell.go
+++ b/test/framework/tinkerbell.go
@@ -107,6 +107,11 @@ func (t *Tinkerbell) Name() string {
 
 func (t *Tinkerbell) Setup() {}
 
+// UpdateKubeConfig customizes generated kubeconfig for the provider.
+func (t *Tinkerbell) UpdateKubeConfig(content *[]byte, clusterName string) error {
+	return nil
+}
+
 // ClusterConfigUpdates satisfies the test framework Provider.
 func (t *Tinkerbell) ClusterConfigUpdates() []api.ClusterConfigFiller {
 	clusterIP, err := GetIP(t.cidr, ClusterIPPoolEnvVar)

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -389,6 +389,11 @@ func (v *VSphere) Name() string {
 // Setup does nothing. It satisfies the test framework Provider.
 func (v *VSphere) Setup() {}
 
+// UpdateKubeConfig customizes generated kubeconfig for the provider.
+func (v *VSphere) UpdateKubeConfig(content *[]byte, clusterName string) error {
+	return nil
+}
+
 // ClusterConfigUpdates satisfies the test framework Provider.
 func (v *VSphere) ClusterConfigUpdates() []api.ClusterConfigFiller {
 	clusterIP, err := GetIP(v.cidr, ClusterIPPoolEnvVar)

--- a/test/framework/workload.go
+++ b/test/framework/workload.go
@@ -71,6 +71,9 @@ func (w *WorkloadCluster) writeKubeconfigToDisk(ctx context.Context) error {
 		return fmt.Errorf("failed to get kubeconfig for cluster: %s", err)
 	}
 	kubeconfig := secret.Data["value"]
+	if err := w.Provider.UpdateKubeConfig(&kubeconfig, w.ClusterName); err != nil {
+		return fmt.Errorf("failed to update kubeconfig for cluster: %s", err)
+	}
 	writer, err := filewriter.NewWriter(w.ClusterConfigFolder)
 	if err != nil {
 		return fmt.Errorf("failed to write kubeconfig to disk: %v", err)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR renames a file adds two docker e2e tests for the full lifecycle API, updates a vSphere API test with labels and taints to improve coverage without using more resources, and implements the `UpdateKubeConfig` to e2e Provider interface, which is required implementation for the docker provider. 

This is part 1 of a bigger PR. There will be another one adding validations for labels and taints to the controlplane and worker nodes validations.

`--- PASS: TestDockerUpgradeWorkloadClusterLabelsAndTaintsAPI (1086.90s)
`

`--- PASS: TestDockerUpgradeKubernetes123to124WorkloadClusterScaleWorkerNodesAPI (1418.77s)
`
*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

