### PR TITLE
Replaces *testing.T with framework.T implementations

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	rapi "github.com/tinkerbell/rufio/api/v1alpha1"
@@ -65,7 +64,7 @@ var oidcRoles []byte
 var hpaBusybox []byte
 
 type ClusterE2ETest struct {
-	T                      *testing.T
+	T                      T
 	ClusterConfigLocation  string
 	ClusterConfigFolder    string
 	HardwareConfigLocation string
@@ -90,7 +89,8 @@ type ClusterE2ETest struct {
 
 type ClusterE2ETestOpt func(e *ClusterE2ETest)
 
-func NewClusterE2ETest(t *testing.T, provider Provider, opts ...ClusterE2ETestOpt) *ClusterE2ETest {
+// NewClusterE2ETest is a support structure for defining an end-to-end test.
+func NewClusterE2ETest(t T, provider Provider, opts ...ClusterE2ETestOpt) *ClusterE2ETest {
 	e := &ClusterE2ETest{
 		T:                     t,
 		Provider:              provider,
@@ -916,7 +916,7 @@ func GetTestNameHash(name string) string {
 	return testNameHash[:7]
 }
 
-func getClusterName(t *testing.T) string {
+func getClusterName(t T) string {
 	value := os.Getenv(ClusterPrefixVar)
 	// Append hash to make each cluster name unique per test. Using the testname will be too long
 	// and would fail validations
@@ -1094,8 +1094,6 @@ func (e *ClusterE2ETest) CreateResource(ctx context.Context, resource string) {
 }
 
 func (e *ClusterE2ETest) UninstallCuratedPackage(packagePrefix string, opts ...string) {
-	os.Setenv("CURATED_PACKAGES_SUPPORT", "true")
-	os.Setenv("KUBECONFIG", e.kubeconfigFilePath())
 	e.RunEKSA([]string{
 		"delete", "package", packagePrefix, "-v=9",
 		strings.Join(opts, " "),

--- a/test/framework/envars.go
+++ b/test/framework/envars.go
@@ -2,10 +2,9 @@ package framework
 
 import (
 	"os"
-	"testing"
 )
 
-func checkRequiredEnvVars(t *testing.T, requiredEnvVars []string) {
+func checkRequiredEnvVars(t T, requiredEnvVars []string) {
 	for _, eVar := range requiredEnvVars {
 		if _, ok := os.LookupEnv(eVar); !ok {
 			t.Fatalf("Required env var [%s] not present", eVar)
@@ -13,7 +12,7 @@ func checkRequiredEnvVars(t *testing.T, requiredEnvVars []string) {
 	}
 }
 
-func setKubeconfigEnvVar(t *testing.T, clusterName string) {
+func setKubeconfigEnvVar(t T, clusterName string) {
 	err := os.Setenv("KUBECONFIG", clusterName+"/"+clusterName+"-eks-a-cluster.kubeconfig")
 	if err != nil {
 		t.Fatalf("Error setting KUBECONFIG env var: %v", err)

--- a/test/framework/executables.go
+++ b/test/framework/executables.go
@@ -2,15 +2,14 @@ package framework
 
 import (
 	"context"
-	"testing"
 
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 )
 
-func buildKubectl(t *testing.T) *executables.Kubectl {
+func buildKubectl(t T) *executables.Kubectl {
 	ctx := context.Background()
-	kubectl := executableBuilder(t, ctx).BuildKubectlExecutable()
+	kubectl := executableBuilder(ctx, t).BuildKubectlExecutable()
 
 	return kubectl
 }
@@ -19,7 +18,7 @@ func buildLocalKubectl() *executables.Kubectl {
 	return executables.NewLocalExecutablesBuilder().BuildKubectlExecutable()
 }
 
-func executableBuilder(t *testing.T, ctx context.Context) *executables.ExecutablesBuilder {
+func executableBuilder(ctx context.Context, t T) *executables.ExecutablesBuilder {
 	executableBuilder, close, err := executables.InitInDockerExecutablesBuilder(ctx, executables.DefaultEksaImage())
 	if err != nil {
 		t.Fatalf("Unable initialize executable builder: %v", err)
@@ -33,13 +32,13 @@ func executableBuilder(t *testing.T, ctx context.Context) *executables.Executabl
 	return executableBuilder
 }
 
-func buildGovc(t *testing.T) *executables.Govc {
+func buildGovc(t T) *executables.Govc {
 	ctx := context.Background()
 	tmpWriter, err := filewriter.NewWriter("unique-ip")
 	if err != nil {
 		t.Fatalf("Error creating tmp writer")
 	}
-	govc := executableBuilder(t, ctx).BuildGovcExecutable(tmpWriter)
+	govc := executableBuilder(ctx, t).BuildGovcExecutable(tmpWriter)
 	t.Cleanup(func() {
 		govc.Close(ctx)
 	})
@@ -47,13 +46,13 @@ func buildGovc(t *testing.T) *executables.Govc {
 	return govc
 }
 
-func buildDocker(t *testing.T) *executables.Docker {
+func buildDocker(t T) *executables.Docker {
 	return executables.BuildDockerExecutable()
 }
 
-func buildHelm(t *testing.T) *executables.Helm {
+func buildHelm(t T) *executables.Helm {
 	ctx := context.Background()
-	helm := executableBuilder(t, ctx).BuildHelmExecutable(executables.WithInsecure())
+	helm := executableBuilder(ctx, t).BuildHelmExecutable(executables.WithInsecure())
 
 	return helm
 }

--- a/test/framework/testingt.go
+++ b/test/framework/testingt.go
@@ -1,0 +1,149 @@
+package framework
+
+import "testing"
+
+// T defines test support functionality, ala the Go stdlib testing.T.
+//
+// Being able to change its implementation supports logging functionality for
+// test support methods that are executed outside of a test, such as when
+// bringing up or tearing down test clusters that will be used and re-used
+// throughout multiple tests.
+//
+// Only those methods currently in use are defined. Add more methods from
+// stdlib testing.T as necessary.
+type T interface {
+	Cleanup(func())
+	Error(...any)
+	Errorf(string, ...any)
+	Fail()
+	FailNow()
+	Failed() bool
+	Fatal(...any)
+	Fatalf(string, ...any)
+	Helper()
+	Log(args ...any)
+	Logf(format string, args ...any)
+	Name() string
+	Parallel()
+	Run(string, func(*testing.T)) bool
+	Setenv(string, string)
+	Skip(...any)
+	SkipNow()
+	Skipf(string, ...any)
+	Skipped() bool
+	TempDir() string
+}
+
+// T ensures that *testing.T implements T, to detect API drift.
+var _ T = (*testing.T)(nil)
+
+// LoggingOnlyT implements select logging and error handling functionality of T.
+//
+// Most non-logging, non-error reporting methods will simply panic.
+type LoggingOnlyT struct{}
+
+// NewLoggingOnlyT creates a LoggingOnlyT, which does what its name implies.
+func NewLoggingOnlyT() *LoggingOnlyT { return &LoggingOnlyT{} }
+
+// Cleanup implements T.
+func (t LoggingOnlyT) Cleanup(_ func()) {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// Error implements T.
+func (t LoggingOnlyT) Error(_ ...any) {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// Errorf implements T.
+func (t LoggingOnlyT) Errorf(_ string, _ ...any) {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// Fail implements T.
+func (t LoggingOnlyT) Fail() {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// FailNow implements T.
+func (t LoggingOnlyT) FailNow() {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// Failed implements T.
+func (t LoggingOnlyT) Failed() bool {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// Fatal implements T.
+func (t LoggingOnlyT) Fatal(_ ...any) {
+	v := &testing.T{}
+	v.Fatal("foo")
+	// panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// Fatalf implements T.
+func (t LoggingOnlyT) Fatalf(format string, args ...any) {
+	v := &testing.T{}
+	v.Fatalf(format, args...)
+}
+
+// Helper implements T.
+func (t LoggingOnlyT) Helper() {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// Log implements T.
+func (t LoggingOnlyT) Log(args ...any) {
+	(&testing.T{}).Log(args...)
+}
+
+// Logf implements T.
+func (t LoggingOnlyT) Logf(format string, args ...any) {
+	(&testing.T{}).Logf(format, args...)
+}
+
+// Name implements T.
+func (t LoggingOnlyT) Name() string {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// Parallel implements T.
+func (t LoggingOnlyT) Parallel() {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// Run implements T.
+func (t LoggingOnlyT) Run(_ string, _ func(*testing.T)) bool {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// Setenv implements T.
+func (t LoggingOnlyT) Setenv(_ string, _ string) {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// Skip implements T.
+func (t LoggingOnlyT) Skip(_ ...any) {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// SkipNow implements T.
+func (t LoggingOnlyT) SkipNow() {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// Skipf implements T.
+func (t LoggingOnlyT) Skipf(_ string, _ ...any) {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// Skipped implements T.
+func (t LoggingOnlyT) Skipped() bool {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}
+
+// TempDir implements T.
+func (t LoggingOnlyT) TempDir() string {
+	panic("LoggingOnlyT implements only the logging methods of T")
+}

--- a/test/framework/vspherecsi.go
+++ b/test/framework/vspherecsi.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"testing"
 	"time"
 
 	v1 "k8s.io/api/storage/v1"
@@ -51,7 +50,7 @@ func (e *ClusterE2ETest) ValidateVSphereCSI(installed bool) {
 	}
 }
 
-func handleError(t *testing.T, installed bool, err error) {
+func handleError(t T, installed bool, err error) {
 	if installed || !strings.Contains(err.Error(), "not found") {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The *testing.T provided in tests is handy, but it panics when used outside of a running unit test's goroutine. Replacing it with an interface allows alternative implementations that can provide select logging and utility without having to be executed from within a test's goroutine. This is useful for setting up or tearing down test scaffolding (like reusable k8s clusters for E2E tests) before or after a test execution.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

