### PR TITLE
Build Tinkerbell datacenter controller

### DIFF
--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -45,10 +45,11 @@ type Factory struct {
 }
 
 type Reconcilers struct {
-	ClusterReconciler           *ClusterReconciler
-	DockerDatacenterReconciler  *DockerDatacenterReconciler
-	VSphereDatacenterReconciler *VSphereDatacenterReconciler
-	SnowMachineConfigReconciler *SnowMachineConfigReconciler
+	ClusterReconciler              *ClusterReconciler
+	DockerDatacenterReconciler     *DockerDatacenterReconciler
+	VSphereDatacenterReconciler    *VSphereDatacenterReconciler
+	SnowMachineConfigReconciler    *SnowMachineConfigReconciler
+	TinkerbellDatacenterReconciler *TinkerbellDatacenterReconciler
 }
 
 type buildStep func(ctx context.Context) error
@@ -147,6 +148,22 @@ func (f *Factory) WithSnowMachineConfigReconciler() *Factory {
 			client,
 			snow.NewValidator(snowreconciler.NewAwsClientBuilder(client)),
 		)
+		return nil
+	})
+	return f
+}
+
+// WithTinkerbellDatacenterReconciler adds the TinkerbellDatacenterReconciler to the controller factory.
+func (f *Factory) WithTinkerbellDatacenterReconciler() *Factory {
+	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
+		if f.reconcilers.TinkerbellDatacenterReconciler != nil {
+			return nil
+		}
+
+		f.reconcilers.TinkerbellDatacenterReconciler = NewTinkerbellDatacenterReconciler(
+			f.manager.GetClient(),
+		)
+
 		return nil
 	})
 	return f

--- a/controllers/factory_test.go
+++ b/controllers/factory_test.go
@@ -52,6 +52,26 @@ func TestFactoryBuildAllDockerReconciler(t *testing.T) {
 	g.Expect(reconcilers.DockerDatacenterReconciler).NotTo(BeNil())
 }
 
+func TestFactoryBuildAllTinkerbellReconciler(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	logger := nullLog()
+	ctrl := gomock.NewController(t)
+	manager := mocks.NewMockManager(ctrl)
+	manager.EXPECT().GetClient().AnyTimes()
+	manager.EXPECT().GetScheme().AnyTimes()
+
+	f := controllers.NewFactory(logger, manager).
+		WithTinkerbellDatacenterReconciler()
+
+	// testing idempotence
+	f.WithTinkerbellDatacenterReconciler()
+
+	reconcilers, err := f.Build(ctx)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(reconcilers.TinkerbellDatacenterReconciler).NotTo(BeNil())
+}
+
 func TestFactoryBuildClusterReconciler(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()

--- a/controllers/tinkerbell_datacenter_controller.go
+++ b/controllers/tinkerbell_datacenter_controller.go
@@ -1,0 +1,37 @@
+package controllers
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+// TinkerbellDatacenterReconciler reconciles a TinkerbellDatacenterConfig object.
+type TinkerbellDatacenterReconciler struct {
+	client client.Client
+}
+
+// NewTinkerbellDatacenterReconciler creates a new instance of the TinkerbellDatacenterReconciler struct.
+func NewTinkerbellDatacenterReconciler(client client.Client) *TinkerbellDatacenterReconciler {
+	return &TinkerbellDatacenterReconciler{
+		client: client,
+	}
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *TinkerbellDatacenterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&anywherev1.TinkerbellDatacenterConfig{}).
+		Complete(r)
+}
+
+// TODO: add here kubebuilder permissions as neeeded.
+
+// Reconcile implements the reconcile.Reconciler interface.
+func (r *TinkerbellDatacenterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	// TODO fetch Tinkerbell datacenter object and implement reconcile
+	return ctrl.Result{}, nil
+}

--- a/controllers/tinkerbell_datacenter_controller_test.go
+++ b/controllers/tinkerbell_datacenter_controller_test.go
@@ -1,0 +1,17 @@
+package controllers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/controllers"
+)
+
+func TestTinkerbellDatacenterReconcilerSetupWithManager(t *testing.T) {
+	client := env.Client()
+	r := controllers.NewTinkerbellDatacenterReconciler(client)
+
+	g := NewWithT(t)
+	g.Expect(r.SetupWithManager(env.Manager())).To(Succeed())
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Build Tinkerbell datacenter controller
The controller does not call the Tinkerbell IP validations yet.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

