### PR TITLE
Fix prometheus e2e test file

### DIFF
--- a/test/framework/testdata/prometheus_package_deployment.yaml
+++ b/test/framework/testdata/prometheus_package_deployment.yaml
@@ -6,7 +6,6 @@ spec:
   packageName: prometheus
   targetNamespace: observability
   config: |
-    mode: deployment
     server:
       service:
         servicePort: 9090


### PR DESCRIPTION
Mode is not an acceptable property for Prometheus helm json validation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

