### PR TITLE
E2E Tagging busybox image with tag for consistency

### DIFF
--- a/test/framework/testdata/hpa_busybox.yaml
+++ b/test/framework/testdata/hpa_busybox.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: busybox
-          image: busybox
+          image: busybox:1.34
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
E2E test failures for metric server and autoscaler caused by new busybox image not triggering the scaling targets for test. Tagging to an older known working version and to avoid using the latest image.

