### PR TITLE
Move Tinkerbell datacenter config validations

### DIFF
--- a/pkg/providers/tinkerbell/assert_test.go
+++ b/pkg/providers/tinkerbell/assert_test.go
@@ -77,6 +77,20 @@ func TestAssertDatacenterConfigValid_InvalidFails(t *testing.T) {
 	}
 }
 
+func TestAssertDatacenterConfigValidEmptyOSImageURL(t *testing.T) {
+	g := gomega.NewWithT(t)
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec.DatacenterConfig.Spec.OSImageURL = "test"
+	g.Expect(tinkerbell.AssertDatacenterConfigValid(clusterSpec)).To(gomega.MatchError("parsing osImageOverride: parse \"test\": invalid URI for request"))
+}
+
+func TestAssertDatacenterConfigValidEmptyHookImagesURLPath(t *testing.T) {
+	g := gomega.NewWithT(t)
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec.DatacenterConfig.Spec.HookImagesURLPath = "test"
+	g.Expect(tinkerbell.AssertDatacenterConfigValid(clusterSpec)).To(gomega.MatchError("parsing hookOverride: parse \"test\": invalid URI for request"))
+}
+
 func TestAssertMachineConfigNamespaceMatchesDatacenterConfig_Same(t *testing.T) {
 	g := gomega.NewWithT(t)
 	builder := NewDefaultValidClusterSpecBuilder()

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -3,7 +3,6 @@ package tinkerbell
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -133,19 +132,6 @@ func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpe
 		if err := p.readCSVToCatalogue(); err != nil {
 			return err
 		}
-	}
-
-	if p.datacenterConfig.Spec.OSImageURL != "" {
-		if _, err := url.ParseRequestURI(p.datacenterConfig.Spec.OSImageURL); err != nil {
-			return fmt.Errorf("parsing osImageOverride: %v", err)
-		}
-	}
-
-	if p.datacenterConfig.Spec.HookImagesURLPath != "" {
-		if _, err := url.ParseRequestURI(p.datacenterConfig.Spec.HookImagesURLPath); err != nil {
-			return fmt.Errorf("parsing hookOverride: %v", err)
-		}
-		logger.Info("hook path override set", "path", p.datacenterConfig.Spec.HookImagesURLPath)
 	}
 
 	spec := NewClusterSpec(clusterSpec, p.machineConfigs, p.datacenterConfig)

--- a/pkg/providers/tinkerbell/validate.go
+++ b/pkg/providers/tinkerbell/validate.go
@@ -3,17 +3,32 @@ package tinkerbell
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	tinkv1alpha1 "github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
 )
 
 func validateDatacenterConfig(config *v1alpha1.TinkerbellDatacenterConfig) error {
+	if config.Spec.OSImageURL != "" {
+		if _, err := url.ParseRequestURI(config.Spec.OSImageURL); err != nil {
+			return fmt.Errorf("parsing osImageOverride: %v", err)
+		}
+	}
+
+	if config.Spec.HookImagesURLPath != "" {
+		if _, err := url.ParseRequestURI(config.Spec.HookImagesURLPath); err != nil {
+			return fmt.Errorf("parsing hookOverride: %v", err)
+		}
+		logger.Info("hook path override set", "path", config.Spec.HookImagesURLPath)
+	}
+
 	if err := validateObjectMeta(config.ObjectMeta); err != nil {
 		return fmt.Errorf("TinkerbellDatacenterConfig: %v", err)
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Move Tinkerbell datacenter config validations. This makes all datacenter config validations invokable from once place for webhooks.
*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

