### PR TITLE
Fix snow bottlerocket kube scheduler and controller-manager crash during upgrade

### DIFF
--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -160,7 +160,12 @@ func KubeadmControlPlane(clusterSpec *cluster.Spec, infrastructureObject APIObje
 						},
 					},
 					ControllerManager: bootstrapv1.ControlPlaneComponent{
-						ExtraArgs: ControllerManagerArgs(clusterSpec),
+						ExtraArgs:    ControllerManagerArgs(clusterSpec),
+						ExtraVolumes: []bootstrapv1.HostPathMount{},
+					},
+					Scheduler: bootstrapv1.ControlPlaneComponent{
+						ExtraArgs:    map[string]string{},
+						ExtraVolumes: []bootstrapv1.HostPathMount{},
 					},
 				},
 				InitConfiguration: &bootstrapv1.InitConfiguration{

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -311,7 +311,12 @@ func wantKubeadmControlPlane() *controlplanev1.KubeadmControlPlane {
 						},
 					},
 					ControllerManager: bootstrapv1.ControlPlaneComponent{
-						ExtraArgs: tlsCipherSuitesArgs(),
+						ExtraArgs:    tlsCipherSuitesArgs(),
+						ExtraVolumes: []bootstrapv1.HostPathMount{},
+					},
+					Scheduler: bootstrapv1.ControlPlaneComponent{
+						ExtraArgs:    map[string]string{},
+						ExtraVolumes: []bootstrapv1.HostPathMount{},
 					},
 				},
 				InitConfiguration: &bootstrapv1.InitConfiguration{

--- a/pkg/clusterapi/bottlerocket.go
+++ b/pkg/clusterapi/bottlerocket.go
@@ -56,6 +56,27 @@ func SetBottlerocketInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlan
 	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Pause = p
 	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketBootstrap = b
 	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.Pause = p
+
+	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager.ExtraVolumes = append(kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager.ExtraVolumes,
+		bootstrapv1.HostPathMount{
+			HostPath:  "/var/lib/kubeadm/controller-manager.conf",
+			MountPath: "/etc/kubernetes/controller-manager.conf",
+			Name:      "kubeconfig",
+			PathType:  "File",
+			ReadOnly:  true,
+		},
+	)
+
+	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Scheduler.ExtraVolumes = append(kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Scheduler.ExtraVolumes,
+		bootstrapv1.HostPathMount{
+			HostPath:  "/var/lib/kubeadm/scheduler.conf",
+			MountPath: "/etc/kubernetes/scheduler.conf",
+			Name:      "kubeconfig",
+			PathType:  "File",
+			ReadOnly:  true,
+		},
+	)
+	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.CertificatesDir = "/var/lib/kubeadm/pki"
 }
 
 // SetBottlerocketAdminContainerImageInKubeadmControlPlane overrides the default bottlerocket admin container image metadata in kubeadmControlPlane.

--- a/pkg/clusterapi/bottlerocket_test.go
+++ b/pkg/clusterapi/bottlerocket_test.go
@@ -47,6 +47,25 @@ func TestSetBottlerocketInKubeadmControlPlane(t *testing.T) {
 	want.Spec.KubeadmConfigSpec.ClusterConfiguration.Pause = pause
 	want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketBootstrap = bootstrap
 	want.Spec.KubeadmConfigSpec.JoinConfiguration.Pause = pause
+	want.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager.ExtraVolumes = append(want.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager.ExtraVolumes,
+		bootstrapv1.HostPathMount{
+			HostPath:  "/var/lib/kubeadm/controller-manager.conf",
+			MountPath: "/etc/kubernetes/controller-manager.conf",
+			Name:      "kubeconfig",
+			PathType:  "File",
+			ReadOnly:  true,
+		},
+	)
+	want.Spec.KubeadmConfigSpec.ClusterConfiguration.Scheduler.ExtraVolumes = append(want.Spec.KubeadmConfigSpec.ClusterConfiguration.Scheduler.ExtraVolumes,
+		bootstrapv1.HostPathMount{
+			HostPath:  "/var/lib/kubeadm/scheduler.conf",
+			MountPath: "/etc/kubernetes/scheduler.conf",
+			Name:      "kubeconfig",
+			PathType:  "File",
+			ReadOnly:  true,
+		},
+	)
+	want.Spec.KubeadmConfigSpec.ClusterConfiguration.CertificatesDir = "/var/lib/kubeadm/pki"
 
 	clusterapi.SetBottlerocketInKubeadmControlPlane(got, g.clusterSpec.VersionsBundle)
 	g.Expect(got).To(Equal(want))

--- a/pkg/clusterapi/identity_test.go
+++ b/pkg/clusterapi/identity_test.go
@@ -107,7 +107,12 @@ func TestConfigureAWSIAMAuthInKubeadmControlPlane(t *testing.T) {
 								},
 							},
 							ControllerManager: bootstrapv1.ControlPlaneComponent{
-								ExtraArgs: tlsCipherSuitesArgs(),
+								ExtraArgs:    tlsCipherSuitesArgs(),
+								ExtraVolumes: []bootstrapv1.HostPathMount{},
+							},
+							Scheduler: bootstrapv1.ControlPlaneComponent{
+								ExtraArgs:    map[string]string{},
+								ExtraVolumes: []bootstrapv1.HostPathMount{},
 							},
 						},
 						InitConfiguration: &bootstrapv1.InitConfiguration{
@@ -299,7 +304,12 @@ func TestConfigureOIDCInKubeadmControlPlane(t *testing.T) {
 								},
 							},
 							ControllerManager: bootstrapv1.ControlPlaneComponent{
-								ExtraArgs: tlsCipherSuitesArgs(),
+								ExtraArgs:    tlsCipherSuitesArgs(),
+								ExtraVolumes: []bootstrapv1.HostPathMount{},
+							},
+							Scheduler: bootstrapv1.ControlPlaneComponent{
+								ExtraArgs:    map[string]string{},
+								ExtraVolumes: []bootstrapv1.HostPathMount{},
 							},
 						},
 						InitConfiguration: &bootstrapv1.InitConfiguration{
@@ -418,7 +428,12 @@ func TestConfigurePodIamAuthInKubeadmControlPlane(t *testing.T) {
 								},
 							},
 							ControllerManager: bootstrapv1.ControlPlaneComponent{
-								ExtraArgs: tlsCipherSuitesArgs(),
+								ExtraArgs:    tlsCipherSuitesArgs(),
+								ExtraVolumes: []bootstrapv1.HostPathMount{},
+							},
+							Scheduler: bootstrapv1.ControlPlaneComponent{
+								ExtraArgs:    map[string]string{},
+								ExtraVolumes: []bootstrapv1.HostPathMount{},
 							},
 						},
 						InitConfiguration: &bootstrapv1.InitConfiguration{

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -151,7 +151,12 @@ func wantKubeadmControlPlane() *controlplanev1.KubeadmControlPlane {
 						},
 					},
 					ControllerManager: bootstrapv1.ControlPlaneComponent{
-						ExtraArgs: tlsCipherSuitesArgs(),
+						ExtraArgs:    tlsCipherSuitesArgs(),
+						ExtraVolumes: []bootstrapv1.HostPathMount{},
+					},
+					Scheduler: bootstrapv1.ControlPlaneComponent{
+						ExtraArgs:    map[string]string{},
+						ExtraVolumes: []bootstrapv1.HostPathMount{},
 					},
 				},
 				InitConfiguration: &bootstrapv1.InitConfiguration{
@@ -453,6 +458,26 @@ func TestKubeadmControlPlaneWithRegistryMirrorBottlerocket(t *testing.T) {
 			want.Spec.KubeadmConfigSpec.JoinConfiguration.Pause = pause
 			want.Spec.KubeadmConfigSpec.ClusterConfiguration.RegistryMirror = tt.wantRegistryConfig
 			want.Spec.KubeadmConfigSpec.JoinConfiguration.RegistryMirror = tt.wantRegistryConfig
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager.ExtraVolumes = append(want.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager.ExtraVolumes,
+				bootstrapv1.HostPathMount{
+					HostPath:  "/var/lib/kubeadm/controller-manager.conf",
+					MountPath: "/etc/kubernetes/controller-manager.conf",
+					Name:      "kubeconfig",
+					PathType:  "File",
+					ReadOnly:  true,
+				},
+			)
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.Scheduler.ExtraVolumes = append(want.Spec.KubeadmConfigSpec.ClusterConfiguration.Scheduler.ExtraVolumes,
+				bootstrapv1.HostPathMount{
+					HostPath:  "/var/lib/kubeadm/scheduler.conf",
+					MountPath: "/etc/kubernetes/scheduler.conf",
+					Name:      "kubeconfig",
+					PathType:  "File",
+					ReadOnly:  true,
+				},
+			)
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.CertificatesDir = "/var/lib/kubeadm/pki"
+
 			g.Expect(got).To(BeComparableTo(want))
 		})
 	}
@@ -548,6 +573,26 @@ func TestKubeadmControlPlaneWithProxyConfigBottlerocket(t *testing.T) {
 			want.Spec.KubeadmConfigSpec.JoinConfiguration.Pause = pause
 			want.Spec.KubeadmConfigSpec.ClusterConfiguration.Proxy = tt.wantProxyConfig
 			want.Spec.KubeadmConfigSpec.JoinConfiguration.Proxy = tt.wantProxyConfig
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager.ExtraVolumes = append(want.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager.ExtraVolumes,
+				bootstrapv1.HostPathMount{
+					HostPath:  "/var/lib/kubeadm/controller-manager.conf",
+					MountPath: "/etc/kubernetes/controller-manager.conf",
+					Name:      "kubeconfig",
+					PathType:  "File",
+					ReadOnly:  true,
+				},
+			)
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.Scheduler.ExtraVolumes = append(want.Spec.KubeadmConfigSpec.ClusterConfiguration.Scheduler.ExtraVolumes,
+				bootstrapv1.HostPathMount{
+					HostPath:  "/var/lib/kubeadm/scheduler.conf",
+					MountPath: "/etc/kubernetes/scheduler.conf",
+					Name:      "kubeconfig",
+					PathType:  "File",
+					ReadOnly:  true,
+				},
+			)
+			want.Spec.KubeadmConfigSpec.ClusterConfiguration.CertificatesDir = "/var/lib/kubeadm/pki"
+
 			g.Expect(got).To(Equal(want))
 		})
 	}

--- a/pkg/providers/snow/testdata/expected_results_main_cp_bottlerocket.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_cp_bottlerocket.yaml
@@ -59,9 +59,16 @@ spec:
         imageTag: v1-20-22-eks-a-v0.0.0-dev-build.4984
         mode: always
         name: bottlerocket-bootstrap-snow
+      certificatesDir: /var/lib/kubeadm/pki
       controllerManager:
         extraArgs:
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        extraVolumes:
+        - hostPath: /var/lib/kubeadm/controller-manager.conf
+          mountPath: /etc/kubernetes/controller-manager.conf
+          name: kubeconfig
+          pathType: File
+          readOnly: true
       dns:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.4-eks-1-21-9
@@ -80,7 +87,13 @@ spec:
         imageTag: 0.0.1
       proxy: {}
       registryMirror: {}
-      scheduler: {}
+      scheduler:
+        extraVolumes:
+        - hostPath: /var/lib/kubeadm/scheduler.conf
+          mountPath: /etc/kubernetes/scheduler.conf
+          name: kubeconfig
+          pathType: File
+          readOnly: true
     files:
     - content: |
         apiVersion: v1


### PR DESCRIPTION
*Issue #, if available:*

During Snow BR cluster upgrade, one new CP node will come up and be in running state, while other CPs are not able to join the cluster. 

For stacked etcd case, we see
```
I0105 23:00:10.429921       1 scale.go:212]  "msg"="Waiting for control plane to pass preflight checks" "cluster-name"="test-snow" "name"="test-snow" "namespace"="eksa-system" "failures"="[machine test-snow-hnxjn reports APIServerPodHealthy condition is false (Error, Missing node), machine test-snow-hnxjn reports ControllerManagerPodHealthy condition is false (Error, Missing node), machine test-snow-hnxjn reports SchedulerPodHealthy condition is false (Error, Missing node), machine test-snow-hnxjn reports EtcdPodHealthy condition is false (Error, Missing node), machine test-snow-hnxjn reports EtcdMemberHealthy condition is false (Error, Missing etcd member)]"
```
Because the leader election is not functioning properly and etcd members are not able to join.

The leader election is handled by `kube-scheduler` and `kube-controller-manager`. Further look into the two controllers, we saw the EKS-A workload cluster has both `kube-scheduler` and `kube-controller-manager` in crash loop due to 

```
E0106 17:34:48.374440       1 run.go:74] "command failed" err="failed to get delegated authentication kubeconfig: failed to get delegated authentication kubeconfig: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable"
```

```
kube-system                         kube-controller-manager-joeywang-control-plane-2-slz74           0/1     CrashLoopBackOff   21 (77s ago)   84m
kube-system                         kube-scheduler-joeywang-control-plane-2-slz74                    0/1     CrashLoopBackOff   21 (76s ago)   84m
```

The kubeconfig content is missing for both `/etc/kubernetes/scheduler.conf` and `/etc/kubernetes/controller-manager.conf` in the new BR CP instance.

Looking at the controller spec, we see

New cp kube-scheduler:
```
Volumes:
  kubeconfig:
    Type:          HostPath (bare host directory volume)
    Path:          /etc/kubernetes/scheduler.conf
    HostPathType:  FileOrCreate
```

Old cp kube-scheduler
```
Volumes:
  kubeconfig:
    Type:          HostPath (bare host directory volume)
    Path:          /var/lib/kubeadm/scheduler.conf
    HostPathType:  File
```

Turn out we are missing the extraVolumeMount in KubeadmControlPlane for both `kube-scheduler` and `kube-controller-manager`, only for snow BR.

*Description of changes:*

Add extraVolumeMount option for both `kube-scheduler` and `kube-controller-manager`

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

