### PR TITLE
Update vSphere API flux test name 

### DIFF
--- a/test/e2e/workload_api_flux_test.go
+++ b/test/e2e/workload_api_flux_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-func TestVSphereMulticlusterWorkloadClusterAPIGitHubFlux(t *testing.T) {
+func TestVSphereMulticlusterWorkloadClusterGitHubFluxAPI(t *testing.T) {
 	vsphere := framework.NewVSphere(t)
 	managementCluster := framework.NewClusterE2ETest(
 		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `TestVSphereMulticlusterWorkloadClusterAPIGitHubFlux` keeps failing in the pipeline. This PR updates the name of the of test. Seeing if this may fix it because there is another test with the same prefix and it seems like the pipeline is running this twice, and failing only on the second run.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

