### PR TITLE
Add validations webhook for Tinkerbell Datacenter config

### DIFF
--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig.go
@@ -1,7 +1,14 @@
 package v1alpha1
 
 import (
+	"errors"
+	"fmt"
+	"net/url"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/networkutils"
 )
 
 const TinkerbellDatacenterKind = "TinkerbellDatacenterConfig"
@@ -39,4 +46,42 @@ func GetTinkerbellDatacenterConfig(fileName string) (*TinkerbellDatacenterConfig
 		return nil, err
 	}
 	return &clusterConfig, nil
+}
+
+func validateDatacenterConfig(config *TinkerbellDatacenterConfig) error {
+	if config.Spec.OSImageURL != "" {
+		if _, err := url.ParseRequestURI(config.Spec.OSImageURL); err != nil {
+			return fmt.Errorf("parsing osImageOverride: %v", err)
+		}
+		logger.Info("OS image path override set", "path", config.Spec.OSImageURL)
+	}
+
+	if config.Spec.HookImagesURLPath != "" {
+		if _, err := url.ParseRequestURI(config.Spec.HookImagesURLPath); err != nil {
+			return fmt.Errorf("parsing hookOverride: %v", err)
+		}
+		logger.Info("hook path override set", "path", config.Spec.HookImagesURLPath)
+	}
+
+	if err := validateObjectMeta(config.ObjectMeta); err != nil {
+		return fmt.Errorf("TinkerbellDatacenterConfig: %v", err)
+	}
+
+	if config.Spec.TinkerbellIP == "" {
+		return errors.New("TinkerbellDatacenterConfig: missing spec.tinkerbellIP field")
+	}
+
+	if err := networkutils.ValidateIP(config.Spec.TinkerbellIP); err != nil {
+		return fmt.Errorf("TinkerbellDatacenterConfig: invalid tinkerbell ip: %v", err)
+	}
+
+	return nil
+}
+
+func validateObjectMeta(meta metav1.ObjectMeta) error {
+	if meta.Name == "" {
+		return errors.New("missing name")
+	}
+
+	return nil
 }

--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig.go
@@ -7,7 +7,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
 )
 
@@ -53,14 +52,12 @@ func validateDatacenterConfig(config *TinkerbellDatacenterConfig) error {
 		if _, err := url.ParseRequestURI(config.Spec.OSImageURL); err != nil {
 			return fmt.Errorf("parsing osImageOverride: %v", err)
 		}
-		logger.Info("OS image path override set", "path", config.Spec.OSImageURL)
 	}
 
 	if config.Spec.HookImagesURLPath != "" {
 		if _, err := url.ParseRequestURI(config.Spec.HookImagesURLPath); err != nil {
 			return fmt.Errorf("parsing hookOverride: %v", err)
 		}
-		logger.Info("hook path override set", "path", config.Spec.HookImagesURLPath)
 	}
 
 	if err := validateObjectMeta(config.ObjectMeta); err != nil {

--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig_types.go
@@ -65,6 +65,11 @@ func (t *TinkerbellDatacenterConfig) ClearPauseAnnotation() {
 	}
 }
 
+// Validate validates the Tinkerbell datacenter config.
+func (t *TinkerbellDatacenterConfig) Validate() error {
+	return validateDatacenterConfig(t)
+}
+
 func (t *TinkerbellDatacenterConfig) ConvertConfigToConfigGenerateStruct() *TinkerbellDatacenterConfigGenerate {
 	namespace := defaultEksaNamespace
 	if t.Namespace != "" {

--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig_types_test.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig_types_test.go
@@ -1,0 +1,98 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+func TestTinkerbellDatacenterConfigValidateFail(t *testing.T) {
+	tests := []struct {
+		name    string
+		tinkDC  *v1alpha1.TinkerbellDatacenterConfig
+		wantErr string
+	}{
+		{
+			name: "Empty Tink IP",
+			tinkDC: newTinkerbellDatacenterConfig(func(dc *v1alpha1.TinkerbellDatacenterConfig) {
+				dc.Spec.TinkerbellIP = ""
+			}),
+			wantErr: "missing spec.tinkerbellIP field",
+		},
+		{
+			name: "Invalid Tink IP",
+			tinkDC: newTinkerbellDatacenterConfig(func(dc *v1alpha1.TinkerbellDatacenterConfig) {
+				dc.Spec.TinkerbellIP = "10"
+			}),
+			wantErr: "invalid tinkerbell ip: ",
+		},
+		{
+			name: "Invalid OS Image URL",
+			tinkDC: newTinkerbellDatacenterConfig(func(dc *v1alpha1.TinkerbellDatacenterConfig) {
+				dc.Spec.OSImageURL = "test"
+			}),
+			wantErr: "parsing osImageOverride: parse \"test\": invalid URI for request",
+		},
+		{
+			name: "Invalid hook Image URL",
+			tinkDC: newTinkerbellDatacenterConfig(func(dc *v1alpha1.TinkerbellDatacenterConfig) {
+				dc.Spec.HookImagesURLPath = "test"
+			}),
+			wantErr: "parsing hookOverride: parse \"test\": invalid URI for request",
+		},
+		{
+			name: "invalid object data",
+			tinkDC: newTinkerbellDatacenterConfig(func(dc *v1alpha1.TinkerbellDatacenterConfig) {
+				dc.ObjectMeta.Name = ""
+			}),
+			wantErr: "TinkerbellDatacenterConfig: missing name",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.tinkDC.Validate()).To(MatchError(ContainSubstring(tt.wantErr)))
+		})
+	}
+}
+
+func TestTinkerbellDatacenterConfigValidateSuccess(t *testing.T) {
+	tinkDC := createTinkerbellDatacenterConfig()
+
+	g := NewWithT(t)
+	g.Expect(tinkDC.Validate()).To(Succeed())
+}
+
+func newTinkerbellDatacenterConfig(opts ...func(*v1alpha1.TinkerbellDatacenterConfig)) *v1alpha1.TinkerbellDatacenterConfig {
+	c := createTinkerbellDatacenterConfig()
+	for _, o := range opts {
+		o(c)
+	}
+
+	return c
+}
+
+type tinkerbellDatacenterOpt func(dc *v1alpha1.TinkerbellDatacenterConfig)
+
+func createTinkerbellDatacenterConfig(opts ...tinkerbellDatacenterOpt) *v1alpha1.TinkerbellDatacenterConfig {
+	dc := &v1alpha1.TinkerbellDatacenterConfig{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: make(map[string]string, 1),
+			Name:        "tinkerbelldatacenterconfig",
+		},
+		Spec: v1alpha1.TinkerbellDatacenterConfigSpec{
+			TinkerbellIP: "1.1.1.1",
+		},
+		Status: v1alpha1.TinkerbellDatacenterConfigStatus{},
+	}
+
+	for _, opt := range opts {
+		opt(dc)
+	}
+
+	return dc
+}

--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook_test.go
@@ -1,0 +1,83 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+func TestTinkerbellDatacenterValidateCreate(t *testing.T) {
+	dataCenterConfig := tinkerbellDatacenterConfig()
+
+	g := NewWithT(t)
+	g.Expect(dataCenterConfig.ValidateCreate()).To(Succeed())
+}
+
+func TestTinkerbellDatacenterValidateCreateFail(t *testing.T) {
+	dataCenterConfig := tinkerbellDatacenterConfig()
+	dataCenterConfig.Spec.TinkerbellIP = ""
+
+	g := NewWithT(t)
+	g.Expect(dataCenterConfig.ValidateCreate()).NotTo(Succeed())
+}
+
+func TestTinkerbellDatacenterValidateUpdateSucceed(t *testing.T) {
+	tOld := tinkerbellDatacenterConfig()
+	tOld.Spec.TinkerbellIP = "1.1.1.1"
+	tNew := tOld.DeepCopy()
+
+	tNew.Spec.TinkerbellIP = "1.1.1.1"
+	g := NewWithT(t)
+	g.Expect(tNew.ValidateUpdate(&tOld)).To(Succeed())
+}
+
+func TestTinkerbellDatacenterValidateUpdateFailOSImageURL(t *testing.T) {
+	tOld := tinkerbellDatacenterConfig()
+	tNew := tOld.DeepCopy()
+
+	tNew.Spec.OSImageURL = "test"
+	g := NewWithT(t)
+	g.Expect(tNew.ValidateUpdate(&tOld)).ToNot(Succeed())
+}
+
+func TestTinkerbellDatacenterValidateUpdateFailBadReq(t *testing.T) {
+	cOld := &v1alpha1.Cluster{}
+	c := &v1alpha1.TinkerbellDatacenterConfig{}
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(cOld)).To(MatchError(ContainSubstring("expected a TinkerbellDatacenterConfig but got a *v1alpha1.Cluster")))
+}
+
+func TestTinkerbellDatacenterValidateUpdateImmutableTinkIP(t *testing.T) {
+	tOld := tinkerbellDatacenterConfig()
+	tOld.Spec.TinkerbellIP = "1.1.1.1"
+	tNew := tOld.DeepCopy()
+
+	tNew.Spec.TinkerbellIP = "1.1.1.2"
+	g := NewWithT(t)
+	g.Expect(tNew.ValidateUpdate(&tOld)).To(MatchError(ContainSubstring("spec.tinkerbellIP: Forbidden: field is immutable")))
+}
+
+func TestTinkerbellDatacenterValidateDelete(t *testing.T) {
+	tOld := tinkerbellDatacenterConfig()
+
+	g := NewWithT(t)
+	g.Expect(tOld.ValidateDelete()).To(Succeed())
+}
+
+func tinkerbellDatacenterConfig() v1alpha1.TinkerbellDatacenterConfig {
+	return v1alpha1.TinkerbellDatacenterConfig{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: make(map[string]string, 1),
+			Name:        "tinkerbelldatacenterconfig",
+		},
+		Spec: v1alpha1.TinkerbellDatacenterConfigSpec{
+			TinkerbellIP: "1.1.1.1",
+		},
+		Status: v1alpha1.TinkerbellDatacenterConfigStatus{},
+	}
+}

--- a/pkg/providers/tinkerbell/assert.go
+++ b/pkg/providers/tinkerbell/assert.go
@@ -24,7 +24,7 @@ func AssertMachineConfigsValid(spec *ClusterSpec) error {
 
 // AssertDatacenterConfigValid asserts the DatacenterConfig in spec is valid.
 func AssertDatacenterConfigValid(spec *ClusterSpec) error {
-	return validateDatacenterConfig(spec.DatacenterConfig)
+	return spec.DatacenterConfig.Validate()
 }
 
 // AssertMachineConfigNamespaceMatchesDatacenterConfig ensures all machine configuration instances

--- a/pkg/providers/tinkerbell/validate.go
+++ b/pkg/providers/tinkerbell/validate.go
@@ -3,46 +3,15 @@ package tinkerbell
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"strings"
 
 	tinkv1alpha1 "github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
 )
-
-func validateDatacenterConfig(config *v1alpha1.TinkerbellDatacenterConfig) error {
-	if config.Spec.OSImageURL != "" {
-		if _, err := url.ParseRequestURI(config.Spec.OSImageURL); err != nil {
-			return fmt.Errorf("parsing osImageOverride: %v", err)
-		}
-	}
-
-	if config.Spec.HookImagesURLPath != "" {
-		if _, err := url.ParseRequestURI(config.Spec.HookImagesURLPath); err != nil {
-			return fmt.Errorf("parsing hookOverride: %v", err)
-		}
-		logger.Info("hook path override set", "path", config.Spec.HookImagesURLPath)
-	}
-
-	if err := validateObjectMeta(config.ObjectMeta); err != nil {
-		return fmt.Errorf("TinkerbellDatacenterConfig: %v", err)
-	}
-
-	if config.Spec.TinkerbellIP == "" {
-		return errors.New("TinkerbellDatacenterConfig: missing spec.tinkerbellIP field")
-	}
-
-	if err := networkutils.ValidateIP(config.Spec.TinkerbellIP); err != nil {
-		return fmt.Errorf("TinkerbellDatacenterConfig: invalid tinkerbell ip: %v", err)
-	}
-
-	return nil
-}
 
 func validateMachineConfig(config *v1alpha1.TinkerbellMachineConfig) error {
 	if err := validateObjectMeta(config.ObjectMeta); err != nil {

--- a/test/e2e/multiple_worker_node_groups_test.go
+++ b/test/e2e/multiple_worker_node_groups_test.go
@@ -106,7 +106,7 @@ func TestDockerKubernetes124UpgradeAndRemoveWorkerNodeGroupsAPI(t *testing.T) {
 			api.RemoveWorkerNodeGroup("worker-2"),
 			api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
 			api.RemoveWorkerNodeGroup("worker-3"),
-			api.WithWorkerNodeGroup("worker-3", api.WithCount(1),api.WithTaint(framework.NoScheduleTaint())),
+			api.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithTaint(framework.NoScheduleTaint())),
 		),
 		provider.WithWorkerNodeGroup(framework.WithWorkerNodeGroup("worker-4", api.WithCount(1))),
 	)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add validations webhook for Tinkerbell Datacenter config
*Testing (if applicable):*
- unit tests
- manual test with tilt

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

