### PR TITLE
Update worker node validation for API e2e tests

### DIFF
--- a/test/e2e/workload_api_test.go
+++ b/test/e2e/workload_api_test.go
@@ -100,7 +100,7 @@ func TestVSphereMulticlusterWorkloadClusterAPI(t *testing.T) {
 	test.DeleteManagementCluster()
 }
 
-func TestVSphereUpgradeLabelsTaintsUbuntuAPI(t *testing.T) {
+func TestVSphereUpgradeLabelsTaintsBottleRocketAPI(t *testing.T) {
 	vsphere := framework.NewVSphere(t)
 
 	managementCluster := framework.NewClusterE2ETest(
@@ -111,7 +111,7 @@ func TestVSphereUpgradeLabelsTaintsUbuntuAPI(t *testing.T) {
 			api.WithWorkerNodeCount(1),
 			api.WithStackedEtcdTopology(),
 		),
-		vsphere.WithUbuntu124(),
+		vsphere.WithBottleRocket124(),
 	)
 
 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
@@ -128,7 +128,7 @@ func TestVSphereUpgradeLabelsTaintsUbuntuAPI(t *testing.T) {
 			vsphere.WithWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(2), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
 			vsphere.WithWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
 			vsphere.WithWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithLabel("key2", "val2"), api.WithTaint(framework.PreferNoScheduleTaint()))),
-			vsphere.WithUbuntu124(),
+			vsphere.WithBottleRocket124(),
 		),
 	)
 

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1735,11 +1735,10 @@ func (e *ClusterE2ETest) buildClusterValidator(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create management cluster client: %s", err)
 	}
-	if e.ClusterConfig.Cluster.IsSelfManaged() {
-		mc = nil
+	c := mc
+	if e.managementKubeconfigFilePath() != e.kubeconfigFilePath() {
+		c, err = kubernetes.NewRuntimeClientFromFileName(e.kubeconfigFilePath())
 	}
-
-	c, err := kubernetes.NewRuntimeClientFromFileName(e.kubeconfigFilePath())
 	if err != nil {
 		return fmt.Errorf("failed to create cluster client: %s", err)
 	}
@@ -1750,9 +1749,9 @@ func (e *ClusterE2ETest) buildClusterValidator(ctx context.Context) error {
 	}
 
 	e.clusterValidator = NewClusterValidator(func(cv *ClusterValidator) {
-		cv.ClusterOpts.ClusterClient = c
-		cv.ClusterOpts.ManagementClusterClient = mc
-		cv.ClusterOpts.ClusterSpec = spec
+		cv.Config.ClusterClient = c
+		cv.Config.ManagementClusterClient = mc
+		cv.Config.ClusterSpec = spec
 	})
 
 	return nil

--- a/test/framework/clustervalidator.go
+++ b/test/framework/clustervalidator.go
@@ -173,7 +173,7 @@ func validateWorkerNodes(ctx context.Context, vc ClusterValidatorConfig) error {
 	// deduce the worker node group configuration to node mapping via the machine deployment and machine set
 	for _, w := range wn {
 		workerGroupCount := 0
-		ms, err := GetWorkerNodeMachineSets(ctx, vc, w)
+		ms, err := getWorkerNodeMachineSets(ctx, vc, w)
 		if err != nil {
 			return fmt.Errorf("failed to get machine sets when validating worker node: %v", err)
 		}
@@ -226,8 +226,8 @@ func validateClusterDoesNotExist(ctx context.Context, vc ClusterValidatorConfig)
 	return nil
 }
 
-// GetWorkerNodeMachineSets gets a list of MachineSets corresponding the provided WorkerNodeGroupConfiguration from the management cluster.
-func GetWorkerNodeMachineSets(ctx context.Context, vc ClusterValidatorConfig, w v1alpha1.WorkerNodeGroupConfiguration) ([]v1beta1.MachineSet, error) {
+// getWorkerNodeMachineSets gets a list of MachineSets corresponding the provided WorkerNodeGroupConfiguration from the management cluster.
+func getWorkerNodeMachineSets(ctx context.Context, vc ClusterValidatorConfig, w v1alpha1.WorkerNodeGroupConfiguration) ([]v1beta1.MachineSet, error) {
 	md := &v1beta1.MachineDeployment{}
 	mdName := fmt.Sprintf("%s-%s", vc.ClusterSpec.Cluster.Name, w.Name)
 	key := types.NamespacedName{Name: mdName, Namespace: constants.EksaSystemNamespace}

--- a/test/framework/clustervalidator.go
+++ b/test/framework/clustervalidator.go
@@ -14,26 +14,31 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/controller"
+	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/retrier"
 )
 
-type clusterValidation = func(ctx context.Context, validateOpts clusterOpts) error
+// TODO: Move ClusterValidator to a separate package
+
+// ClusterValidation defines a validation that can be registered to the ClusterValidator.
+type ClusterValidation = func(ctx context.Context, vc ClusterValidatorConfig) error
 
 type retriableValidation struct {
-	validation    clusterValidation // the validation to run against the cluster.
+	validation    ClusterValidation // the validation to run against the cluster.
 	backoffPeriod time.Duration     // the duration to wait another validation attempt.
 	maxRetries    int               // the maximum number of retries to validate.
 }
 
 // ClusterValidator is responsible for checking if a cluster is valid against the spec that is provided.
 type ClusterValidator struct {
-	ClusterOpts clusterOpts
+	Config      ClusterValidatorConfig
 	validations []retriableValidation
 }
 
 // WithValidation registers a validation to the ClusterValidator that will be run when Validate is called.
-func (c *ClusterValidator) WithValidation(validation clusterValidation, backoffPeriod time.Duration, maxRetries int) {
+func (c *ClusterValidator) WithValidation(validation ClusterValidation, backoffPeriod time.Duration, maxRetries int) {
 	c.validations = append(c.validations, retriableValidation{validation, backoffPeriod, maxRetries})
 }
 
@@ -57,7 +62,7 @@ func (c *ClusterValidator) WithClusterDoesNotExist() {
 func (c *ClusterValidator) Validate(ctx context.Context) error {
 	for _, v := range c.validations {
 		err := retrier.Retry(v.maxRetries, v.backoffPeriod, func() error {
-			return v.validation(ctx, c.ClusterOpts)
+			return v.validation(ctx, c.Config)
 		})
 		if err != nil {
 			return fmt.Errorf("validation failed %v", err)
@@ -72,13 +77,13 @@ func (c *ClusterValidator) Reset() {
 	c.validations = []retriableValidation{}
 }
 
-// ClusterValidatorOpts represent the data to be passed as an argument to the Validate method.
-type ClusterValidatorOpts = func(cv *ClusterValidator)
+// ClusterValidatorOpt is a function that receives a ClusterValidator to be customized.
+type ClusterValidatorOpt = func(cv *ClusterValidator)
 
-// NewClusterValidator returns a cluster validator.
-func NewClusterValidator(opts ...ClusterValidatorOpts) *ClusterValidator {
+// NewClusterValidator returns a cluster validator which can be configured by passing ClusterValidatorOpt arguments.
+func NewClusterValidator(opts ...ClusterValidatorOpt) *ClusterValidator {
 	cv := ClusterValidator{
-		ClusterOpts: clusterOpts{},
+		Config:      ClusterValidatorConfig{},
 		validations: []retriableValidation{},
 	}
 
@@ -88,19 +93,19 @@ func NewClusterValidator(opts ...ClusterValidatorOpts) *ClusterValidator {
 	return &cv
 }
 
-type clusterOpts struct {
+// ClusterValidatorConfig holds the data required to perform validations on a cluster.
+type ClusterValidatorConfig struct {
 	ClusterClient           client.Client // the client for the cluster
 	ManagementClusterClient client.Client // the client for the management cluster
 	ClusterSpec             *cluster.Spec // the cluster spec
 }
 
-func validateEKSAObjects(ctx context.Context, validateOpts clusterOpts) error {
-	clusterClient := validateOpts.ClusterClient
-	if validateOpts.ClusterSpec.Cluster.IsManaged() {
-		clusterClient = validateOpts.ManagementClusterClient
-	}
+// TODO: Move Validations to separate package
 
-	for _, obj := range validateOpts.ClusterSpec.ChildObjects() {
+func validateEKSAObjects(ctx context.Context, vc ClusterValidatorConfig) error {
+	clus := vc.ClusterSpec.Cluster
+	mgmtClusterClient := vc.ManagementClusterClient
+	for _, obj := range vc.ClusterSpec.ChildObjects() {
 		u := &unstructured.Unstructured{}
 		u.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
 		key := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
@@ -109,79 +114,89 @@ func validateEKSAObjects(ctx context.Context, validateOpts clusterOpts) error {
 			key.Namespace = "default"
 		}
 
-		if err := clusterClient.Get(ctx, key, u); err != nil {
+		if err := mgmtClusterClient.Get(ctx, key, u); err != nil {
 			return fmt.Errorf("cluster object does not exist %s", err)
 		}
 	}
-
+	logger.V(4).Info("EKSA objects exists validated", "cluster", clus.Name)
 	return nil
 }
 
-func validateClusterReady(ctx context.Context, validateOpts clusterOpts) error {
-	clusterClient := validateOpts.ClusterClient
-	if validateOpts.ClusterSpec.Cluster.IsManaged() {
-		clusterClient = validateOpts.ManagementClusterClient
-	}
-
-	capiCluster, err := controller.GetCAPICluster(ctx, clusterClient, validateOpts.ClusterSpec.Cluster)
+func validateClusterReady(ctx context.Context, vc ClusterValidatorConfig) error {
+	clus := vc.ClusterSpec.Cluster
+	mgmtClusterClient := vc.ManagementClusterClient
+	capiCluster, err := controller.GetCAPICluster(ctx, mgmtClusterClient, clus)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve cluster %s", err)
 	}
-
 	if capiCluster == nil {
-		return fmt.Errorf("cluster %s does not exist", validateOpts.ClusterSpec.Cluster.Name)
+		return fmt.Errorf("cluster %s does not exist", clus.Name)
 	}
-
-	if err := checkClusterReady(capiCluster); err != nil {
-		return err
+	for _, condition := range capiCluster.GetConditions() {
+		if condition.Type == "Ready" && condition.Status != "True" {
+			return fmt.Errorf("node %s not ready yet. %s", capiCluster.GetName(), condition.Reason)
+		}
 	}
+	logger.V(4).Info("CAPI cluster ready validated", "cluster", clus.Name)
 	return nil
 }
 
-func validateControlPlaneNodes(ctx context.Context, validateOpts clusterOpts) error {
+func validateControlPlaneNodes(ctx context.Context, vc ClusterValidatorConfig) error {
+	clus := vc.ClusterSpec.Cluster
 	cpNodes := &corev1.NodeList{}
-	if err := validateOpts.ClusterClient.List(ctx, cpNodes, client.MatchingLabels{"node-role.kubernetes.io/control-plane": ""}); err != nil {
+	if err := vc.ClusterClient.List(ctx, cpNodes, client.MatchingLabels{"node-role.kubernetes.io/control-plane": ""}); err != nil {
 		return fmt.Errorf("failed to list controlplane nodes %s", err)
 	}
 
-	cpConfig := validateOpts.ClusterSpec.Cluster.Spec.ControlPlaneConfiguration
+	cpConfig := clus.Spec.ControlPlaneConfiguration
 	if len(cpNodes.Items) != cpConfig.Count {
 		return fmt.Errorf("control plane node count does not match expected: %v of %v", len(cpNodes.Items), cpConfig.Count)
 	}
 
 	for _, node := range cpNodes.Items {
-		if err := validateNodeReady(node, validateOpts.ClusterSpec.Cluster.Spec.KubernetesVersion); err != nil {
+		if err := validateNodeReady(node, clus.Spec.KubernetesVersion); err != nil {
 			return fmt.Errorf("failed to validate controlplane %s", err)
 		}
 	}
+	logger.V(4).Info("Control plane nodes validated", "cluster", clus.Name)
 	return nil
 }
 
-// TODO: Update this to also validate BottleRocket nodes
-func validateWorkerNodes(ctx context.Context, validateOpts clusterOpts) error {
-	var workerNodes []corev1.Node
+func validateWorkerNodes(ctx context.Context, vc ClusterValidatorConfig) error {
+	clus := vc.ClusterSpec.Cluster
+	clusterName := clus.Name
 	nodes := &corev1.NodeList{}
-	if err := validateOpts.ClusterClient.List(ctx, nodes); err != nil {
+	if err := vc.ClusterClient.List(ctx, nodes); err != nil {
 		return fmt.Errorf("failed to list nodes %s", err)
 	}
-	for _, wnConfig := range validateOpts.ClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
-		nodeNamePrefix := fmt.Sprintf("%s-%s", validateOpts.ClusterSpec.Cluster.Name, wnConfig.Name)
+	wn := clus.Spec.WorkerNodeGroupConfigurations
+	// deduce the worker node group configuration to node mapping via the machine deployment and machine set
+	for _, w := range wn {
 		workerGroupCount := 0
-		for _, n := range nodes.Items {
-			if strings.HasPrefix(n.Name, nodeNamePrefix) {
-				workerGroupCount++
-				workerNodes = append(workerNodes, n)
+		ms, err := GetWorkerNodeMachineSets(ctx, vc, w)
+		if err != nil {
+			return fmt.Errorf("failed to get machine sets when validating worker node: %v", err)
+		}
+		for _, node := range nodes.Items {
+			ownerName, ok := node.Annotations["cluster.x-k8s.io/owner-name"]
+			if ok {
+				// there will be multiple machineSets present on a cluster following an upgrade.
+				// find the one that is associated with this worker node, and execute the validations.
+				for _, machineSet := range ms {
+					if ownerName == machineSet.Name {
+						workerGroupCount++
+						if err := validateNodeReady(node, vc.ClusterSpec.Cluster.Spec.KubernetesVersion); err != nil {
+							return fmt.Errorf("failed to validate worker node ready %v", err)
+						}
+					}
+				}
 			}
 		}
-		if workerGroupCount != *wnConfig.Count {
-			return fmt.Errorf("worker node group %s count does not match expected: %v of %v", wnConfig.Name, workerGroupCount, *wnConfig.Count)
+		if workerGroupCount != *w.Count {
+			return fmt.Errorf("worker node group %s count does not match expected: %d of %d", w.Name, workerGroupCount, *w.Count)
 		}
 	}
-	for _, node := range workerNodes {
-		if err := validateNodeReady(node, validateOpts.ClusterSpec.Cluster.Spec.KubernetesVersion); err != nil {
-			return fmt.Errorf("failed to validate worker node ready %s", err)
-		}
-	}
+	logger.V(4).Info("Worker nodes validated", "cluster", clusterName)
 	return nil
 }
 
@@ -195,29 +210,39 @@ func validateNodeReady(node corev1.Node, kubeVersion v1alpha1.KubernetesVersion)
 	if !strings.Contains(kubeletVersion, string(kubeVersion)) {
 		return fmt.Errorf("validating node version: kubernetes version %s does not match expected version %s", kubeletVersion, kubeVersion)
 	}
-
 	return nil
 }
 
-func validateClusterDoesNotExist(ctx context.Context, validateOpts clusterOpts) error {
-	capiCluster, err := controller.GetCAPICluster(ctx, validateOpts.ManagementClusterClient, validateOpts.ClusterSpec.Cluster)
+func validateClusterDoesNotExist(ctx context.Context, vc ClusterValidatorConfig) error {
+	clus := vc.ClusterSpec.Cluster
+	capiCluster, err := controller.GetCAPICluster(ctx, vc.ManagementClusterClient, clus)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve cluster %s", err)
 	}
-
 	if capiCluster != nil {
 		return fmt.Errorf("cluster %s exists", capiCluster.Name)
 	}
-
+	logger.V(4).Info("Cluster does not exist validated", "cluster", clus.Name)
 	return nil
 }
 
-func checkClusterReady(cluster *v1beta1.Cluster) error {
-	for _, condition := range cluster.Status.Conditions {
-		if condition.Type == "Ready" && condition.Status != "True" {
-			return fmt.Errorf("node %s not ready yet. %s", cluster.GetName(), condition.Reason)
-		}
+// GetWorkerNodeMachineSets gets a list of MachineSets corresponding the provided WorkerNodeGroupConfiguration from the management cluster.
+func GetWorkerNodeMachineSets(ctx context.Context, vc ClusterValidatorConfig, w v1alpha1.WorkerNodeGroupConfiguration) ([]v1beta1.MachineSet, error) {
+	md := &v1beta1.MachineDeployment{}
+	mdName := fmt.Sprintf("%s-%s", vc.ClusterSpec.Cluster.Name, w.Name)
+	key := types.NamespacedName{Name: mdName, Namespace: constants.EksaSystemNamespace}
+	if err := vc.ManagementClusterClient.Get(ctx, key, md); err != nil {
+		return nil, fmt.Errorf("failed to get machine deployment %s when validating worker node: %v", w.Name, err)
 	}
-
-	return nil
+	ms := &v1beta1.MachineSetList{}
+	err := vc.ManagementClusterClient.List(ctx, ms, client.InNamespace(constants.EksaSystemNamespace), client.MatchingLabels{
+		"cluster.x-k8s.io/deployment-name": md.Name,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get machine sets for deployment %s: %v", md.Name, err)
+	}
+	if len(ms.Items) == 0 {
+		return nil, fmt.Errorf("invalid number of machine sets associated with worker node configuration %s", w.Name)
+	}
+	return ms.Items, nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previous worker node validation didn't work for BottleRocket. This PR updates it and also does some refactoring.

*Testing (if applicable):*
```
--- PASS: TestVSphereUpgradeLabelsTaintsBottleRocketAPI (1615.58s)
PASS
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

