### PR TITLE
Update snowmachineconfig defaults for generate clusterconfig cmd

### DIFF
--- a/internal/pkg/api/snowmachines.go
+++ b/internal/pkg/api/snowmachines.go
@@ -18,7 +18,7 @@ func WithSnowMachineDefaultValues() SnowMachineConfigFiller {
 	return func(m *anywherev1.SnowMachineConfig) {
 		m.Spec.InstanceType = anywherev1.DefaultSnowInstanceType
 		m.Spec.PhysicalNetworkConnector = anywherev1.DefaultSnowPhysicalNetworkConnectorType
-		m.Spec.SshKeyName = anywherev1.DefaultSnowSshKeyName
+		m.Spec.SshKeyName = anywherev1.DefaultSnowSSHKeyName
 	}
 }
 

--- a/pkg/api/v1alpha1/snowmachineconfig.go
+++ b/pkg/api/v1alpha1/snowmachineconfig.go
@@ -7,20 +7,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/pkg/logger"
-	snowv1 "github.com/aws/eks-anywhere/pkg/providers/snow/api/v1beta1"
 )
 
 const (
 	SnowMachineConfigKind                   = "SnowMachineConfig"
-	DefaultSnowSshKeyName                   = "default"
+	DefaultSnowSSHKeyName                   = ""
 	DefaultSnowInstanceType                 = SbeCLarge
 	DefaultSnowPhysicalNetworkConnectorType = SFPPlus
-	DefaultOSFamily                         = Bottlerocket
+	DefaultOSFamily                         = Ubuntu
 	MinimumContainerVolumeSizeUbuntu        = 8
 	MinimumContainerVolumeSizeBottlerocket  = 25
 )
 
-// Used for generating yaml for generate clusterconfig command.
+// NewSnowMachineConfigGenerate generates snowMachineConfig example for generate clusterconfig command.
 func NewSnowMachineConfigGenerate(name string) *SnowMachineConfigGenerate {
 	return &SnowMachineConfigGenerate{
 		TypeMeta: metav1.TypeMeta{
@@ -32,8 +31,9 @@ func NewSnowMachineConfigGenerate(name string) *SnowMachineConfigGenerate {
 		},
 		Spec: SnowMachineConfigSpec{
 			AMIID:                    "",
+			Devices:                  []string{""},
 			InstanceType:             DefaultSnowInstanceType,
-			SshKeyName:               DefaultSnowSshKeyName,
+			SshKeyName:               DefaultSnowSSHKeyName,
 			PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
 			OSFamily:                 DefaultOSFamily,
 			Network: SnowNetwork{
@@ -44,9 +44,6 @@ func NewSnowMachineConfigGenerate(name string) *SnowMachineConfigGenerate {
 						Primary: true,
 					},
 				},
-			},
-			ContainersVolume: &snowv1.Volume{
-				Size: 25,
 			},
 		},
 	}

--- a/pkg/api/v1alpha1/snowmachineconfig_test.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_test.go
@@ -427,8 +427,9 @@ func TestNewSnowMachineConfigGenerate(t *testing.T) {
 		},
 		Spec: SnowMachineConfigSpec{
 			AMIID:                    "",
+			Devices:                  []string{""},
 			InstanceType:             DefaultSnowInstanceType,
-			SshKeyName:               DefaultSnowSshKeyName,
+			SshKeyName:               DefaultSnowSSHKeyName,
 			PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
 			OSFamily:                 DefaultOSFamily,
 			Network: SnowNetwork{
@@ -439,9 +440,6 @@ func TestNewSnowMachineConfigGenerate(t *testing.T) {
 						Primary: true,
 					},
 				},
-			},
-			ContainersVolume: &snowv1.Volume{
-				Size: 25,
 			},
 		},
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. default generated ssh key to "" so eks-a can auto create and import the key to snow ec2
2. default os to ubuntu
3. add devices since its a required field
4. remove ContainersVolume since its optional, and the field may be deprecated after

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

