### PR TITLE
Fix snow flaky test

### DIFF
--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -977,18 +977,7 @@ func TestUpgradeNeededMachineConfigChanged(t *testing.T) {
 	tt.kubeconfigClient.EXPECT().
 		Get(
 			tt.ctx,
-			"test-cp",
-			"test-namespace",
-			&v1alpha1.SnowMachineConfig{},
-		).
-		DoAndReturn(func(_ context.Context, _, _ string, obj *v1alpha1.SnowMachineConfig) error {
-			tt.clusterSpec.SnowMachineConfig("test-cp").DeepCopyInto(obj)
-			return nil
-		})
-	tt.kubeconfigClient.EXPECT().
-		Get(
-			tt.ctx,
-			"test-wn",
+			gomock.Any(),
 			"test-namespace",
 			&v1alpha1.SnowMachineConfig{},
 		).


### PR DESCRIPTION
*Issue #, if available:*

`TestUpgradeNeededMachineConfigChanged` fails half of the time because the method being tested loop a machineconfig map and order of the machine config is not fixed.

*Description of changes:*

Loose check on machine config of any name and validate.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

