### PR TITLE
Add validation for management cluster referenced in workload cluster spec to be valid

### DIFF
--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -1,6 +1,7 @@
 package validations
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -8,6 +9,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/types"
 )
 
 func ValidateCertForRegistryMirror(clusterSpec *cluster.Spec, tlsValidator TlsValidator) error {
@@ -52,6 +54,18 @@ func ValidateAuthenticationForRegistryMirror(clusterSpec *cluster.Spec) error {
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// ValidateManagementClusterName checks if the management cluster specified in the workload cluster spec is valid.
+func ValidateManagementClusterName(ctx context.Context, k KubectlClient, mgmtCluster *types.Cluster, mgmtClusterName string) error {
+	cluster, err := k.GetEksaCluster(ctx, mgmtCluster, mgmtClusterName)
+	if err != nil {
+		return err
+	}
+	if cluster.Name != cluster.Spec.ManagementCluster.Name {
+		return fmt.Errorf("%s is not a valid management cluster", mgmtClusterName)
 	}
 	return nil
 }

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -85,6 +85,14 @@ func (v *CreateValidations) BuildValidations(ctx context.Context) []validations.
 					Err:         ValidateManagementCluster(ctx, k, targetCluster),
 				}
 			},
+			func() *validations.ValidationResult {
+				return &validations.ValidationResult{
+					Name: "validate management cluster name is valid",
+					Remediation: "Specify a valid management cluster in the cluster spec. This cannot be a workload cluster that is managed by a different " +
+						"management cluster.",
+					Err: validations.ValidateManagementClusterName(ctx, k, v.Opts.ManagementCluster, v.Opts.Spec.Cluster.Spec.ManagementCluster.Name),
+				}
+			},
 		)
 	}
 

--- a/pkg/validations/upgradevalidations/immutableFields.go
+++ b/pkg/validations/upgradevalidations/immutableFields.go
@@ -97,6 +97,9 @@ func ValidateImmutableFields(ctx context.Context, k validations.KubectlClient, c
 	if spec.Cluster.IsSelfManaged() != prevSpec.IsSelfManaged() {
 		return fmt.Errorf("management flag is immutable")
 	}
+	if oSpec.ManagementCluster.Name != nSpec.ManagementCluster.Name {
+		return fmt.Errorf("management cluster name is immutable")
+	}
 
 	return provider.ValidateNewSpec(ctx, cluster, spec)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added additional validations to ensure that we are able to retrieve the EKS-A cluster object from the management cluster and also confirm that the cluster we have referenced is indeed a management cluster by checking if the management cluster name for that cluster references itself.

*Testing (if applicable):*
unit tests and testing these scenarios functionally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

