### PR TITLE
Add docker API E2E test upgrade from latest minor release

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -38,6 +38,13 @@ func WithKubernetesVersion(v anywherev1.KubernetesVersion) ClusterFiller {
 	}
 }
 
+// WithBundlesRef sets BundlesRef with the provided name to use.
+func WithBundlesRef(name string, namespace string, apiVersion string) ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		c.Spec.BundlesRef = &anywherev1.BundlesRef{Name: name, Namespace: namespace, APIVersion: apiVersion}
+	}
+}
+
 func WithCiliumPolicyEnforcementMode(mode anywherev1.CiliumPolicyEnforcementMode) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		if c.Spec.ClusterNetwork.CNIConfig == nil {

--- a/test/e2e/workload_api_test.go
+++ b/test/e2e/workload_api_test.go
@@ -306,10 +306,12 @@ func TestDockerKubernetes123to124UpgradeFromLatestMinorReleaseAPI(t *testing.T) 
 	release := latestMinorRelease(t)
 	provider := framework.NewDocker(t)
 	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube123)),
+		t, provider,
 	)
+	managementCluster.GenerateClusterConfigForVersion(release.Version, framework.ExecuteWithEksaRelease(release))
+	managementCluster.UpdateClusterConfig(api.ClusterToConfigFiller(
+		api.WithKubernetesVersion(v1alpha1.Kube123),
+	))
 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
 	test.WithWorkloadClusters(
 		framework.NewClusterE2ETest(
@@ -325,11 +327,9 @@ func TestDockerKubernetes123to124UpgradeFromLatestMinorReleaseAPI(t *testing.T) 
 		),
 	)
 
-	wantVersion := v1alpha1.Kube124
 	runMulticlusterUpgradeFromReleaseFlowAPI(
 		test,
 		release,
-		wantVersion,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(wantVersion)),
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube124)),
 	)
 }

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -667,6 +667,16 @@ func (e *ClusterE2ETest) WaitForMachineDeploymentReady(machineDeploymentName str
 	}
 }
 
+// GetEKSACluster retrieves the EKSA cluster from the runtime environment using kubectl.
+func (e *ClusterE2ETest) GetEKSACluster() *v1alpha1.Cluster {
+	ctx := context.Background()
+	clus, err := e.KubectlClient.GetEksaCluster(ctx, e.Cluster(), e.ClusterName)
+	if err != nil {
+		e.T.Fatal(err)
+	}
+	return clus
+}
+
 func (e *ClusterE2ETest) GetCapiMachinesForCluster(clusterName string) map[string]types.Machine {
 	ctx := context.Background()
 	capiMachines, err := e.KubectlClient.GetMachines(ctx, e.Cluster(), clusterName)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a docker API E2E test for upgrading from the latest minor release test. The runs through the flow of upgrading a workload cluster to a new version of EKS-A through the API after first upgrading the management cluster.

*Testing (if applicable):*
```
--- PASS: TestDockerKubernetes123to124UpgradeFromLatestMinorReleaseAPI (1291.08s)
PASS
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

