### PR TITLE
Use concrete structs for govc devices.info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ docs/.hugo_build.lock
 *-logs
 *-artifacts
 *.log
+pkg/executables/TestDeployTemplate*

--- a/Makefile
+++ b/Makefile
@@ -372,6 +372,7 @@ update-brew-formula:
 clean: ## Clean up resources created by make targets
 	rm -rf ./bin/*
 	rm -rf ./pkg/executables/cluster-name/
+	rm -rf ./pkg/executables/TestDeployTemplate*
 	rm -rf ./pkg/providers/vsphere/test/
 	rm -rf ./pkg/providers/tinkerbell/stack/TestTinkerbellStackInstall*
 ifeq ($(UNAME), Darwin)


### PR DESCRIPTION
*Description of changes:*
Use predefined structs instead of generic `map[string]interface{}` to unmarshal `govc devices.info` response.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

