### PR TITLE
prefer os.ReadFile, as it's not deprecated

### DIFF
--- a/pkg/registry/certificates.go
+++ b/pkg/registry/certificates.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -12,7 +12,7 @@ func GetCertificates(certFile string) (certificates *x509.CertPool, err error) {
 	if len(certFile) < 1 {
 		return nil, nil
 	}
-	fileContents, err := ioutil.ReadFile(filepath.Clean(certFile))
+	fileContents, err := os.ReadFile(filepath.Clean(certFile))
 	if err != nil {
 		return nil, fmt.Errorf("error reading certificate file <%s>: %v", certFile, err)
 	}


### PR DESCRIPTION
My (possibly newer than the original author's) version of gofumpt complains about this.
