### PR TITLE
Fixes a platform-dependent test

### DIFF
--- a/pkg/registry/credentials_test.go
+++ b/pkg/registry/credentials_test.go
@@ -37,7 +37,10 @@ func TestCredentialStore_Init(t *testing.T) {
 	assert.Equal(t, "", result.RefreshToken)
 
 	result, err = credentialStore.Credential("5551212.dkr.ecr.us-west-2.amazonaws.com")
-	assert.EqualError(t, err, "error getting credentials - err: exec: \"docker-credential-bogus\": executable file not found in $PATH, out: ``")
+	// This is a generic error, so using errors.Is won't work, and this is as
+	// much of the string as we can reliably match against in a cross-platform
+	// fashion. Until they change it, then everything will break.
+	assert.ErrorContains(t, err, "error getting credentials - err")
 	assert.Equal(t, "", result.Username)
 	assert.Equal(t, "", result.Password)
 	assert.Equal(t, "", result.AccessToken)


### PR DESCRIPTION
This fix isn't much better, as it matches against the text in a generic error, but it should work regardless of platform.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

