### PR TITLE
Add sshkeyname check in snowmachineconfig validation webhook

### DIFF
--- a/pkg/api/v1alpha1/snowmachineconfig_types.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	snowv1 "github.com/aws/eks-anywhere/pkg/providers/snow/api/v1beta1"
@@ -132,6 +133,16 @@ func (s *SnowMachineConfig) SetDefaults() {
 
 func (s *SnowMachineConfig) Validate() error {
 	return validateSnowMachineConfig(s)
+}
+
+// ValidateHasSSHKeyName verifies a SnowMachineConfig object must have a SshKeyName.
+// This validation only runs in SnowMachineConfig validation webhook, as we support
+// auto-generate and import ssh key when creating a cluster via CLI.
+func (s *SnowMachineConfig) ValidateHasSSHKeyName() error {
+	if len(s.Spec.SshKeyName) <= 0 {
+		return errors.New("SnowMachineConfig SshKeyName must not be empty")
+	}
+	return nil
 }
 
 func (s *SnowMachineConfig) SetControlPlaneAnnotation() {

--- a/pkg/api/v1alpha1/snowmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_webhook.go
@@ -49,12 +49,20 @@ var _ webhook.Validator = &SnowMachineConfig{}
 func (r *SnowMachineConfig) ValidateCreate() error {
 	snowmachineconfiglog.Info("validate create", "name", r.Name)
 
+	if err := r.ValidateHasSSHKeyName(); err != nil {
+		return err
+	}
+
 	return r.Validate()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *SnowMachineConfig) ValidateUpdate(old runtime.Object) error {
 	snowmachineconfiglog.Info("validate update", "name", r.Name)
+
+	if err := r.ValidateHasSSHKeyName(); err != nil {
+		return err
+	}
 
 	return r.Validate()
 }


### PR DESCRIPTION
*Issue #, if available:*

We do not auto create and import ssh key to snow devices when creating a cluster through cluster lifecycle API.

*Description of changes:*

Add in validation webhook.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

