### PR TITLE
Updating test name for Metallb Packages Test

### DIFF
--- a/test/e2e/metallb_test.go
+++ b/test/e2e/metallb_test.go
@@ -23,7 +23,7 @@ type Suite struct {
 	cluster *framework.ClusterE2ETest
 }
 
-func TestPackagesMetalLB(t *testing.T) {
+func TestCPackagesMetalLB(t *testing.T) {
 	suite.Run(t, new(Suite))
 }
 


### PR DESCRIPTION
Package test need to have CPackages in name to properly pass credentials from https://github.com/aws/eks-anywhere/blob/fc63a6efa1bb506593224216f48f530824d2088e/internal/test/e2e/packages.go#L11
