### PR TITLE
Update usage of control plane node role

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,5 +40,5 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
         - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+          key: node-role.kubernetes.io/control-plane
       serviceAccountName: manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,5 +40,7 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
         - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
       serviceAccountName: manager

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -6048,6 +6048,8 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       volumes:
       - name: cert
         secret:

--- a/pkg/awsiamauth/config/aws-iam-authenticator.yaml
+++ b/pkg/awsiamauth/config/aws-iam-authenticator.yaml
@@ -92,22 +92,16 @@ spec:
       # run on the host network (don't depend on CNI)
       hostNetwork: true
 
-      # run on each master node
+      # run on each control plane node
       nodeSelector:
-{{- if .kubeVersion124 }}
-        node-role.kubernetes.io/control-plane: ""
-{{- else }}
-        node-role.kubernetes.io/master: ""
-{{- end }}
+      {{ .cpNodeSelector | indent 2 }}
       tolerations:
       - effect: NoSchedule 
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - key: CriticalAddonsOnly
         operator: Exists
-{{- if .kubeVersion124 }}
-      - effect: NoSchedule 
-        key: node-role.kubernetes.io/control-plane
-{{- end }}
 {{- if .controlPlaneTaints }}
 {{- range .controlPlaneTaints }}
       - key: {{ .Key }}

--- a/pkg/awsiamauth/installer_test.go
+++ b/pkg/awsiamauth/installer_test.go
@@ -52,6 +52,9 @@ func TestInstallAWSIAMAuth(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
+				Spec: v1alpha1.ClusterSpec{
+					KubernetesVersion: v1alpha1.Kube124,
+				},
 			},
 		},
 		VersionsBundle: &cluster.VersionsBundle{
@@ -154,6 +157,9 @@ func TestInstallAWSIAMAuthErrors(t *testing.T) {
 					Cluster: &v1alpha1.Cluster{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "test-cluster",
+						},
+						Spec: v1alpha1.ClusterSpec{
+							KubernetesVersion: v1alpha1.Kube124,
 						},
 					},
 				},
@@ -308,6 +314,9 @@ func TestUpgradeAWSIAMAuth(t *testing.T) {
 			Cluster: &v1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
+				},
+				Spec: v1alpha1.ClusterSpec{
+					KubernetesVersion: v1alpha1.Kube123,
 				},
 			},
 		},

--- a/pkg/awsiamauth/testdata/InstallAWSIAMAuth-manifest.yaml
+++ b/pkg/awsiamauth/testdata/InstallAWSIAMAuth-manifest.yaml
@@ -92,12 +92,14 @@ spec:
       # run on the host network (don't depend on CNI)
       hostNetwork: true
 
-      # run on each master node
+      # run on each control plane node
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
       - effect: NoSchedule 
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - key: CriticalAddonsOnly
         operator: Exists
 

--- a/pkg/awsiamauth/testdata/UpgradeAWSIAMAuth-manifest.yaml
+++ b/pkg/awsiamauth/testdata/UpgradeAWSIAMAuth-manifest.yaml
@@ -92,12 +92,14 @@ spec:
       # run on the host network (don't depend on CNI)
       hostNetwork: true
 
-      # run on each master node
+      # run on each control plane node
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
       - effect: NoSchedule 
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - key: CriticalAddonsOnly
         operator: Exists
 

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -1006,6 +1006,9 @@ data:
           serviceAccountName: vsphere-csi-controller
           tolerations:
           - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+            operator: Exists
+          - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane
             operator: Exists
 {{- if .controlPlaneTaints }}
@@ -1268,6 +1271,8 @@ data:
           - effect: NoSchedule
             key: node.cloudprovider.kubernetes.io/uninitialized
             value: "true"
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
           - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -1006,7 +1006,7 @@ data:
           serviceAccountName: vsphere-csi-controller
           tolerations:
           - effect: NoSchedule
-            key: node-role.kubernetes.io/master
+            key: node-role.kubernetes.io/control-plane
             operator: Exists
 {{- if .controlPlaneTaints }}
 {{- range .controlPlaneTaints}}
@@ -1269,7 +1269,7 @@ data:
             key: node.cloudprovider.kubernetes.io/uninitialized
             value: "true"
           - effect: NoSchedule
-            key: node-role.kubernetes.io/master
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
 {{- if .controlPlaneTaints }}

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
@@ -942,6 +942,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1193,6 +1196,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
@@ -941,6 +941,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1192,6 +1195,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -995,6 +995,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1246,6 +1249,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
@@ -917,6 +917,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1168,6 +1171,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
@@ -862,6 +862,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1113,6 +1116,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
@@ -915,6 +915,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1166,6 +1169,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -915,6 +915,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1166,6 +1169,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
@@ -915,6 +915,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1166,6 +1169,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
@@ -915,6 +915,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1166,6 +1169,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
@@ -915,6 +915,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1166,6 +1169,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -915,6 +915,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1166,6 +1169,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
@@ -917,6 +917,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1168,6 +1171,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -935,6 +935,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           - key: key1
             value: val1
             effect: PreferNoSchedule
@@ -1195,6 +1198,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           - key: key1

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
@@ -854,6 +854,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1105,6 +1108,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_disable_csi_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_disable_csi_cp.yaml
@@ -616,6 +616,8 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
           - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+          - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:
           - configMap:

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
@@ -857,6 +857,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1108,6 +1111,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -926,6 +926,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1177,6 +1180,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -968,6 +968,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1219,6 +1222,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -969,6 +969,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1220,6 +1223,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -916,6 +916,9 @@ data:
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
             operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - name: vsphere-config-volume
             secret:
@@ -1167,6 +1170,8 @@ data:
             value: "true"
           - effect: NoSchedule
             key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
           volumes:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For kubernetes 1.25+, `node-role.kubernetes.io/master`is deprecated, but it is still the only default taint on control plane nodes for 1.22, so we must add this toleration for both of those options.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

