### PR TITLE
Setup default ssh key based on cluster name and uuid for snow

### DIFF
--- a/pkg/providers/snow/defaults.go
+++ b/pkg/providers/snow/defaults.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
+
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/aws"
 	"github.com/aws/eks-anywhere/pkg/cluster"
@@ -16,6 +18,7 @@ type Defaulters struct {
 	clientRegistry ClientRegistry
 	writer         filewriter.FileWriter
 	keyGenerator   SshKeyGenerator
+	uuid           uuid.UUID
 }
 
 type SshKeyGenerator interface {
@@ -29,6 +32,7 @@ func NewDefaulters(clientRegistry ClientRegistry, writer filewriter.FileWriter, 
 		clientRegistry: clientRegistry,
 		writer:         writer,
 		keyGenerator:   common.SshAuthKeyGenerator{},
+		uuid:           uuid.New(), // In the future if we need a cluster wide uuid that is shared, we should move this call to the dependency factory for reuse.
 	}
 	for _, opt := range opts {
 		opt(defaulters)
@@ -42,12 +46,27 @@ func WithKeyGenerator(generator SshKeyGenerator) DefaultersOpt {
 	}
 }
 
-func (d *Defaulters) GenerateDefaultSshKeys(ctx context.Context, machineConfigs map[string]*v1alpha1.SnowMachineConfig) error {
+// WithUUID will set uuid generated outside of constructor.
+func WithUUID(uuid uuid.UUID) DefaultersOpt {
+	return func(defaulters *Defaulters) {
+		defaulters.uuid = uuid
+	}
+}
+
+// GenerateDefaultSSHKeys generates ssh key if it doesn't exist already.
+func (d *Defaulters) GenerateDefaultSSHKeys(ctx context.Context, machineConfigs map[string]*v1alpha1.SnowMachineConfig, clusterName string) error {
 	md := NewMachineConfigDefaulters(d)
 
 	for _, m := range machineConfigs {
-		if err := md.SetupDefaultSshKey(ctx, m); err != nil {
-			return err
+		if m.Spec.SshKeyName == "" {
+			if md.keyGenerated {
+				// Generate a random string so that other clusters with same name and devices won't conflict in case user doesn't have access to previous key
+				m.Spec.SshKeyName = md.defaultSSHKeyName(clusterName)
+			} else {
+				if err := md.SetupDefaultSSHKey(ctx, m, clusterName); err != nil {
+					return err
+				}
+			}
 		}
 	}
 
@@ -65,7 +84,7 @@ func NewMachineConfigDefaulters(d *Defaulters) *MachineConfigDefaulters {
 	}
 }
 
-func (md *MachineConfigDefaulters) defaultKeyCount(ctx context.Context, clientMap AwsClientMap, m *v1alpha1.SnowMachineConfig) (int, error) {
+func (md *MachineConfigDefaulters) defaultKeyCount(ctx context.Context, clientMap AwsClientMap, m *v1alpha1.SnowMachineConfig, keyName string) (int, error) {
 	var count int
 
 	for _, ip := range m.Spec.Devices {
@@ -74,7 +93,7 @@ func (md *MachineConfigDefaulters) defaultKeyCount(ctx context.Context, clientMa
 			return count, fmt.Errorf("credentials not found for device [%s]", ip)
 		}
 
-		keyExists, err := client.EC2KeyNameExists(ctx, defaultAwsSshKeyName)
+		keyExists, err := client.EC2KeyNameExists(ctx, keyName)
 		if err != nil {
 			return count, fmt.Errorf("describing key pair on snow device [deviceIP=%s]: %v", ip, err)
 		}
@@ -86,38 +105,28 @@ func (md *MachineConfigDefaulters) defaultKeyCount(ctx context.Context, clientMa
 	return count, nil
 }
 
-func (md *MachineConfigDefaulters) SetupDefaultSshKey(ctx context.Context, m *v1alpha1.SnowMachineConfig) error {
-	if m.Spec.SshKeyName != "" {
-		return nil
-	}
-
-	if md.keyGenerated {
-		m.Spec.SshKeyName = defaultAwsSshKeyName
-		return nil
-	}
+// SetupDefaultSSHKey checks the existing keys and sets up a default key.
+func (md *MachineConfigDefaulters) SetupDefaultSSHKey(ctx context.Context, m *v1alpha1.SnowMachineConfig, clusterName string) error {
+	defaultSSHKeyName := md.defaultSSHKeyName(clusterName)
 
 	clientMap, err := md.defaulters.clientRegistry.Get(ctx)
 	if err != nil {
 		return err
 	}
-
-	keyCount, err := md.defaultKeyCount(ctx, clientMap, m)
+	keyCount, err := md.defaultKeyCount(ctx, clientMap, m, defaultSSHKeyName)
 	if err != nil {
 		return err
 	}
-
 	if keyCount > 0 && keyCount < len(m.Spec.Devices) {
-		return fmt.Errorf("default key [keyName=%s] only exists on some of the devices. Use 'aws ec2 import-key-pair' to import this key to all the devices", defaultAwsSshKeyName)
+		return fmt.Errorf("default key [keyName=%s] only exists on some of the devices. Use 'aws ec2 import-key-pair' to import this key to all the devices", defaultSSHKeyName)
 	}
-
 	if keyCount == len(m.Spec.Devices) {
 		md.keyGenerated = true
-		m.Spec.SshKeyName = defaultAwsSshKeyName
+		m.Spec.SshKeyName = defaultSSHKeyName
 		return nil
 	}
 
-	logger.V(1).Info("SnowMachineConfig SshKey is empty. Creating default key pair", "default key name", defaultAwsSshKeyName)
-
+	logger.V(1).Info("SnowMachineConfig SshKey is empty. Creating default key pair", "default key name", defaultSSHKeyName)
 	key, err := md.defaulters.keyGenerator.GenerateSSHAuthKey(md.defaulters.writer)
 	if err != nil {
 		return err
@@ -129,17 +138,19 @@ func (md *MachineConfigDefaulters) SetupDefaultSshKey(ctx context.Context, m *v1
 			return fmt.Errorf("credentials not found for device [%s]", ip)
 		}
 
-		err := client.EC2ImportKeyPair(ctx, defaultAwsSshKeyName, []byte(key))
+		err := client.EC2ImportKeyPair(ctx, defaultSSHKeyName, []byte(key))
 		if err != nil {
 			return fmt.Errorf("importing key pair on snow device [deviceIP=%s]: %v", ip, err)
 		}
 	}
 
 	md.keyGenerated = true
-
-	m.Spec.SshKeyName = defaultAwsSshKeyName
-
+	m.Spec.SshKeyName = defaultSSHKeyName
 	return nil
+}
+
+func (md *MachineConfigDefaulters) defaultSSHKeyName(clusterName string) string {
+	return fmt.Sprintf("%s-%s-%s", defaultAwsSshKeyName, clusterName, md.defaulters.uuid.String())
 }
 
 func SetupEksaCredentialsSecret(c *cluster.Config) error {

--- a/pkg/providers/snow/defaults_test.go
+++ b/pkg/providers/snow/defaults_test.go
@@ -2,70 +2,96 @@ package snow_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
 const (
 	sshKey = "ssh-rsa ABCDE"
 )
 
-func TestSetDefaultSshKey(t *testing.T) {
+func TestGenerateDefaultSSHKeysExists(t *testing.T) {
 	g := newConfigManagerTest(t)
-	g.machineConfig.Spec.SshKeyName = ""
-	g.keyGenerator.EXPECT().GenerateSSHAuthKey(g.writer).Return(sshKey, nil)
-	g.aws.EXPECT().EC2KeyNameExists(g.ctx, "eksa-default").Return(false, nil).Times(2)
-	g.aws.EXPECT().EC2ImportKeyPair(g.ctx, "eksa-default", []byte(sshKey)).Return(nil).Times(2)
-	err := g.machineConfigDefaulters.SetupDefaultSshKey(g.ctx, g.machineConfig)
+	err := g.defaulters.GenerateDefaultSSHKeys(g.ctx, map[string]*v1alpha1.SnowMachineConfig{g.machineConfig.Name: g.machineConfig}, g.clusterName)
 	g.Expect(err).To(Succeed())
 }
 
-func TestSetDefaultSshKeyExistsOnAllDevices(t *testing.T) {
+func TestGenerateDefaultSSHKeysError(t *testing.T) {
 	g := newConfigManagerTest(t)
 	g.machineConfig.Spec.SshKeyName = ""
-	g.aws.EXPECT().EC2KeyNameExists(g.ctx, "eksa-default").Return(true, nil).Times(2)
-	err := g.machineConfigDefaulters.SetupDefaultSshKey(g.ctx, g.machineConfig)
-	g.Expect(g.machineConfig.Spec.SshKeyName).To(Equal("eksa-default"))
-	g.Expect(err).To(Succeed())
-}
-
-func TestSetDefaultSshKeyExistsOnPartialDevices(t *testing.T) {
-	g := newConfigManagerTest(t)
-	g.machineConfig.Spec.SshKeyName = ""
-	g.aws.EXPECT().EC2KeyNameExists(g.ctx, "eksa-default").Return(true, nil)
-	g.aws.EXPECT().EC2KeyNameExists(g.ctx, "eksa-default").Return(false, nil)
-	err := g.machineConfigDefaulters.SetupDefaultSshKey(g.ctx, g.machineConfig)
-	g.Expect(err).To((MatchError(ContainSubstring("default key [keyName=eksa-default] only exists on some of the devices"))))
-}
-
-func TestSetDefaultSshKeySkip(t *testing.T) {
-	g := newConfigManagerTest(t)
-	err := g.machineConfigDefaulters.SetupDefaultSshKey(g.ctx, g.machineConfig)
-	g.Expect(err).To(Succeed())
-}
-
-func TestSetDefaultSshKeyImportKeyError(t *testing.T) {
-	g := newConfigManagerTest(t)
-	g.machineConfig.Spec.SshKeyName = ""
-	g.keyGenerator.EXPECT().GenerateSSHAuthKey(g.writer).Return(sshKey, nil)
-	g.aws.EXPECT().EC2KeyNameExists(g.ctx, "eksa-default").Return(false, nil).Times(2)
-	g.aws.EXPECT().EC2ImportKeyPair(g.ctx, "eksa-default", []byte(sshKey)).Return(errors.New("error"))
-	err := g.machineConfigDefaulters.SetupDefaultSshKey(g.ctx, g.machineConfig)
+	g.aws.EXPECT().EC2KeyNameExists(g.ctx, g.defaultKeyName).Return(false, errors.New("test error"))
+	err := g.defaulters.GenerateDefaultSSHKeys(g.ctx, map[string]*v1alpha1.SnowMachineConfig{g.machineConfig.Name: g.machineConfig}, g.clusterName)
 	g.Expect(err).NotTo(Succeed())
 }
 
-func TestSetDefaultSshKeyClientMapError(t *testing.T) {
+func TestGenerateDefaultSSHKeysGenerated(t *testing.T) {
+	g := newConfigManagerTest(t)
+	g.machineConfig.Spec.SshKeyName = ""
+	secondMachineConfig := g.machineConfig.DeepCopy()
+	secondMachineConfig.Name = g.machineConfig.Name + "-2"
+	g.keyGenerator.EXPECT().GenerateSSHAuthKey(g.writer).Return(sshKey, nil)
+	g.aws.EXPECT().EC2KeyNameExists(g.ctx, g.defaultKeyName).Return(false, nil).Times(2)
+	g.aws.EXPECT().EC2ImportKeyPair(g.ctx, g.defaultKeyName, []byte(sshKey)).Return(nil).Times(2)
+	err := g.defaulters.GenerateDefaultSSHKeys(g.ctx, map[string]*v1alpha1.SnowMachineConfig{
+		g.machineConfig.Name:     g.machineConfig,
+		secondMachineConfig.Name: secondMachineConfig,
+	}, g.clusterName)
+	g.Expect(err).To(Succeed())
+}
+
+func TestSetDefaultSSHKey(t *testing.T) {
+	g := newConfigManagerTest(t)
+	g.machineConfig.Spec.SshKeyName = ""
+	g.keyGenerator.EXPECT().GenerateSSHAuthKey(g.writer).Return(sshKey, nil)
+	g.aws.EXPECT().EC2KeyNameExists(g.ctx, g.defaultKeyName).Return(false, nil).Times(2)
+	g.aws.EXPECT().EC2ImportKeyPair(g.ctx, g.defaultKeyName, []byte(sshKey)).Return(nil).Times(2)
+	err := g.machineConfigDefaulters.SetupDefaultSSHKey(g.ctx, g.machineConfig, g.clusterName)
+	g.Expect(err).To(Succeed())
+}
+
+func TestSetDefaultSSHKeyExistsOnAllDevices(t *testing.T) {
+	g := newConfigManagerTest(t)
+	g.machineConfig.Spec.SshKeyName = ""
+	g.aws.EXPECT().EC2KeyNameExists(g.ctx, g.defaultKeyName).Return(true, nil).Times(2)
+	err := g.machineConfigDefaulters.SetupDefaultSSHKey(g.ctx, g.machineConfig, g.clusterName)
+	g.Expect(g.machineConfig.Spec.SshKeyName).To(Equal(g.defaultKeyName))
+	g.Expect(err).To(Succeed())
+}
+
+func TestSetDefaultSSHKeyExistsOnPartialDevices(t *testing.T) {
+	g := newConfigManagerTest(t)
+	g.machineConfig.Spec.SshKeyName = ""
+	g.aws.EXPECT().EC2KeyNameExists(g.ctx, g.defaultKeyName).Return(true, nil)
+	g.aws.EXPECT().EC2KeyNameExists(g.ctx, g.defaultKeyName).Return(false, nil)
+	err := g.machineConfigDefaulters.SetupDefaultSSHKey(g.ctx, g.machineConfig, g.clusterName)
+	g.Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("default key [keyName=%s] only exists on some of the devices", g.defaultKeyName))))
+}
+
+func TestSetDefaultSSHKeyImportKeyError(t *testing.T) {
+	g := newConfigManagerTest(t)
+	g.machineConfig.Spec.SshKeyName = ""
+	g.keyGenerator.EXPECT().GenerateSSHAuthKey(g.writer).Return(sshKey, nil)
+	g.aws.EXPECT().EC2KeyNameExists(g.ctx, g.defaultKeyName).Return(false, nil).Times(2)
+	g.aws.EXPECT().EC2ImportKeyPair(g.ctx, g.defaultKeyName, []byte(sshKey)).Return(errors.New("error"))
+	err := g.machineConfigDefaulters.SetupDefaultSSHKey(g.ctx, g.machineConfig, g.clusterName)
+	g.Expect(err).NotTo(Succeed())
+}
+
+func TestSetDefaultSSHKeyClientMapError(t *testing.T) {
 	g := newConfigManagerTestClientMapError(t)
 	g.machineConfig.Spec.SshKeyName = ""
-	err := g.machineConfigDefaulters.SetupDefaultSshKey(g.ctx, g.machineConfig)
+	err := g.machineConfigDefaulters.SetupDefaultSSHKey(g.ctx, g.machineConfig, g.clusterName)
 	g.Expect(err).NotTo(Succeed())
 }
 
-func TestSetDefaultSshKeyDeviceNotFoundInClientMap(t *testing.T) {
+func TestSetDefaultSSHKeyDeviceNotFoundInClientMap(t *testing.T) {
 	g := newConfigManagerTest(t)
 	g.machineConfig.Spec.SshKeyName = ""
 	g.machineConfig.Spec.Devices = []string{"device-not-exist"}
-	err := g.machineConfigDefaulters.SetupDefaultSshKey(g.ctx, g.machineConfig)
+	err := g.machineConfigDefaulters.SetupDefaultSSHKey(g.ctx, g.machineConfig, g.clusterName)
 	g.Expect(err).To(MatchError(ContainSubstring("credentials not found for device")))
 }

--- a/pkg/providers/snow/entry.go
+++ b/pkg/providers/snow/entry.go
@@ -39,7 +39,7 @@ func (cm *ConfigManager) snowEntry(ctx context.Context) *cluster.ConfigManagerEn
 	return &cluster.ConfigManagerEntry{
 		Defaulters: []cluster.Defaulter{
 			func(c *cluster.Config) error {
-				return cm.defaulters.GenerateDefaultSshKeys(ctx, c.SnowMachineConfigs)
+				return cm.defaulters.GenerateDefaultSSHKeys(ctx, c.SnowMachineConfigs, c.Cluster.Name)
 			},
 			func(c *cluster.Config) error {
 				return SetupEksaCredentialsSecret(c)

--- a/pkg/providers/snow/validator_test.go
+++ b/pkg/providers/snow/validator_test.go
@@ -3,9 +3,11 @@ package snow_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -26,6 +28,9 @@ type configManagerTest struct {
 	defaulters              *snow.Defaulters
 	machineConfigDefaulters *snow.MachineConfigDefaulters
 	machineConfig           *v1alpha1.SnowMachineConfig
+	uuid                    uuid.UUID
+	clusterName             string
+	defaultKeyName          string
 }
 
 func newConfigManagerTest(t *testing.T) *configManagerTest {
@@ -55,7 +60,8 @@ func newConfigManagerTest(t *testing.T) *configManagerTest {
 	}
 	_, writer := test.NewWriter(t)
 	validators := snow.NewValidator(mockClientRegistry)
-	defaulters := snow.NewDefaulters(mockClientRegistry, writer, snow.WithKeyGenerator(mockKeyGenerator))
+	uuid := uuid.New()
+	defaulters := snow.NewDefaulters(mockClientRegistry, writer, snow.WithKeyGenerator(mockKeyGenerator), snow.WithUUID(uuid))
 	return &configManagerTest{
 		WithT:                   NewWithT(t),
 		ctx:                     ctx,
@@ -66,6 +72,9 @@ func newConfigManagerTest(t *testing.T) *configManagerTest {
 		defaulters:              defaulters,
 		machineConfigDefaulters: snow.NewMachineConfigDefaulters(defaulters),
 		machineConfig:           m,
+		uuid:                    uuid,
+		clusterName:             "test-snow",
+		defaultKeyName:          fmt.Sprintf("eksa-default-test-snow-%s", uuid),
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is to address the issue where a user creates a new cluster but doesn't have access to the previously generated key by default as it is stored in AWS. There is no way to retrieve the key to access the nodes in those situations. Instead, we are adding the cluster name to the default key so that there are more unique default keys. We are also appending a generated uuid in the cases that you have multiple clusters from different admin machines with the same name for additional uniqueness. 

Also needed to move around the code a little to resolve a cyclic complexity lint issue, which doesn't like too many if statements in one function. 

*Testing (if applicable):*
unit test and functional testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

