### PR TITLE
Add client processor for Tinkerbell datacenter config

### DIFF
--- a/pkg/cluster/build.go
+++ b/pkg/cluster/build.go
@@ -4,6 +4,7 @@ package cluster
 // default processors to build a Config.
 func NewDefaultConfigClientBuilder() *ConfigClientBuilder {
 	return NewConfigClientBuilder().Register(
+		getTinkerbellDatacenter,
 		getDockerDatacenter,
 		getVSphereDatacenter,
 		getVSphereMachineConfigs,

--- a/pkg/cluster/tinkerbell.go
+++ b/pkg/cluster/tinkerbell.go
@@ -1,6 +1,10 @@
 package cluster
 
-import anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+import (
+	"context"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
 
 // tinkerbellEntry is unimplemented. Its boiler plate to mute warnings that could confuse the customer until we
 // get round to implementing it.
@@ -68,4 +72,18 @@ func processTinkerbellMachineConfig(c *Config, objects ObjectLookup, machineRef 
 	}
 
 	c.TinkerbellMachineConfigs[m.GetName()] = m.(*anywherev1.TinkerbellMachineConfig)
+}
+
+func getTinkerbellDatacenter(ctx context.Context, client Client, c *Config) error {
+	if c.Cluster.Spec.DatacenterRef.Kind != anywherev1.TinkerbellDatacenterKind {
+		return nil
+	}
+
+	datacenter := &anywherev1.TinkerbellDatacenterConfig{}
+	if err := client.Get(ctx, c.Cluster.Spec.DatacenterRef.Name, c.Cluster.Namespace, datacenter); err != nil {
+		return err
+	}
+
+	c.TinkerbellDatacenter = datacenter
+	return nil
 }

--- a/pkg/cluster/tinkerbell_test.go
+++ b/pkg/cluster/tinkerbell_test.go
@@ -1,14 +1,18 @@
 package cluster_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1/thirdparty/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/cluster/mocks"
 	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
@@ -163,4 +167,52 @@ func TestParseConfigFromFileTinkerbellCluster(t *testing.T) {
 			},
 		),
 	)
+}
+
+func TestDefaultConfigClientBuilderTinkerbellCluster(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	b := cluster.NewDefaultConfigClientBuilder()
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockClient(ctrl)
+	cluster := &anywherev1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: "default",
+		},
+		Spec: anywherev1.ClusterSpec{
+			DatacenterRef: anywherev1.Ref{
+				Kind: anywherev1.TinkerbellDatacenterKind,
+				Name: "datacenter",
+			},
+			ControlPlaneConfiguration: anywherev1.ControlPlaneConfiguration{
+				Count: 1,
+			},
+			WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Name: "md-0",
+				},
+			},
+		},
+	}
+	datacenter := &anywherev1.TinkerbellDatacenterConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datacenter",
+			Namespace: "default",
+		},
+	}
+	client.EXPECT().Get(ctx, "datacenter", "default", &anywherev1.TinkerbellDatacenterConfig{}).Return(nil).DoAndReturn(
+		func(ctx context.Context, name, namespace string, obj runtime.Object) error {
+			d := obj.(*anywherev1.TinkerbellDatacenterConfig)
+			d.ObjectMeta = datacenter.ObjectMeta
+			d.Spec = datacenter.Spec
+			return nil
+		},
+	)
+
+	config, err := b.Build(ctx, client, cluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(config).NotTo(BeNil())
+	g.Expect(config.Cluster).To(Equal(cluster))
+	g.Expect(config.TinkerbellDatacenter).To(Equal(datacenter))
 }


### PR DESCRIPTION
*Issue #, if available:*
[Implement Client processor for Tinkerbell datacenter config#983](https://github.com/aws/eks-anywhere-internal/issues/983)
*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

