### PR TITLE
Fix validation where management cluster name is empty

### DIFF
--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -64,7 +64,7 @@ func ValidateManagementClusterName(ctx context.Context, k KubectlClient, mgmtClu
 	if err != nil {
 		return err
 	}
-	if cluster.Name != cluster.Spec.ManagementCluster.Name {
+	if cluster.IsManaged() {
 		return fmt.Errorf("%s is not a valid management cluster", mgmtClusterName)
 	}
 	return nil

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -162,6 +162,19 @@ func TestValidateManagementClusterNameValid(t *testing.T) {
 	tt.Expect(validations.ValidateManagementClusterName(ctx, tt.kubectl, managementCluster(mgmtName), mgmtName)).To(Succeed())
 }
 
+func TestValidateManagementClusterNameEmptyValid(t *testing.T) {
+	mgmtName := "test"
+	tt := newTest(t, withKubectl())
+	tt.clusterSpec.Cluster.Spec.ManagementCluster.Name = mgmtName
+
+	ctx := context.Background()
+	mgmtCluster := anywhereCluster(mgmtName)
+	mgmtCluster.Spec.ManagementCluster.Name = ""
+	tt.kubectl.EXPECT().GetEksaCluster(ctx, managementCluster(mgmtName), mgmtName).Return(anywhereCluster(mgmtName), nil)
+
+	tt.Expect(validations.ValidateManagementClusterName(ctx, tt.kubectl, managementCluster(mgmtName), mgmtName)).To(Succeed())
+}
+
 func TestValidateManagementClusterNameNotExist(t *testing.T) {
 	mgmtName := "test"
 	tt := newTest(t, withKubectl())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix bug introduced in https://github.com/aws/eks-anywhere/pull/4596. Current management clusters can have the management cluster name as empty, so need to account for that as well. Utilizing the `IsManaged()` function in the cluster types that checks for this anyways.

*Testing (if applicable):*
unit testing and functional testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

