### PR TITLE
Refactor preflight validations so remediation steps can be printed

### DIFF
--- a/pkg/validations/createcluster/createcluster.go
+++ b/pkg/validations/createcluster/createcluster.go
@@ -21,7 +21,7 @@ type ValidationManager struct {
 }
 
 type Validator interface {
-	BuildValidations(ctx context.Context) []validations.Validation
+	PreflightValidations(ctx context.Context) []validations.Validation
 }
 
 func NewValidations(clusterSpec *cluster.Spec, provider providers.Provider, gitOpsFlux *flux.Flux, createValidations Validator, dockerExec validations.DockerExecutable) *ValidationManager {
@@ -74,7 +74,7 @@ func (v *ValidationManager) generateCreateValidations(ctx context.Context) []val
 		},
 	}
 
-	vs = append(vs, v.createValidations.BuildValidations(ctx)...)
+	vs = append(vs, v.createValidations.PreflightValidations(ctx)...)
 
 	return vs
 }

--- a/pkg/validations/createcluster/createcluster_test.go
+++ b/pkg/validations/createcluster/createcluster_test.go
@@ -113,7 +113,7 @@ type validation struct {
 
 func (c *createClusterValidationTest) expectBuildValidations() *validation {
 	v := &validation{}
-	c.createValidations.EXPECT().BuildValidations(c.ctx).Return(
+	c.createValidations.EXPECT().PreflightValidations(c.ctx).Return(
 		[]validations.Validation{
 			func() *validations.ValidationResult {
 				v.run = true

--- a/pkg/validations/createcluster/mocks/createcluster.go
+++ b/pkg/validations/createcluster/mocks/createcluster.go
@@ -35,16 +35,16 @@ func (m *MockValidator) EXPECT() *MockValidatorMockRecorder {
 	return m.recorder
 }
 
-// BuildValidations mocks base method.
-func (m *MockValidator) BuildValidations(ctx context.Context) []validations.Validation {
+// PreflightValidations mocks base method.
+func (m *MockValidator) PreflightValidations(ctx context.Context) []validations.Validation {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildValidations", ctx)
+	ret := m.ctrl.Call(m, "PreflightValidations", ctx)
 	ret0, _ := ret[0].([]validations.Validation)
 	return ret0
 }
 
-// BuildValidations indicates an expected call of BuildValidations.
-func (mr *MockValidatorMockRecorder) BuildValidations(ctx interface{}) *gomock.Call {
+// PreflightValidations indicates an expected call of PreflightValidations.
+func (mr *MockValidatorMockRecorder) PreflightValidations(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildValidations", reflect.TypeOf((*MockValidator)(nil).BuildValidations), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreflightValidations", reflect.TypeOf((*MockValidator)(nil).PreflightValidations), ctx)
 }

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -11,17 +11,8 @@ import (
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
 
-func (v *CreateValidations) PreflightValidations(ctx context.Context) (err error) {
-	vs := v.BuildValidations(ctx)
-	results := make([]validations.ValidationResult, 0, len(vs))
-	for _, validation := range vs {
-		results = append(results, *validation())
-	}
-
-	return validations.ProcessValidationResults(results)
-}
-
-func (v *CreateValidations) BuildValidations(ctx context.Context) []validations.Validation {
+// PreflightValidations returns the validations required before creating a cluster.
+func (v *CreateValidations) PreflightValidations(ctx context.Context) []validations.Validation {
 	k := v.Opts.Kubectl
 
 	targetCluster := &types.Cluster{

--- a/pkg/validations/createvalidations/preflightvalidations_test.go
+++ b/pkg/validations/createvalidations/preflightvalidations_test.go
@@ -51,7 +51,7 @@ func newPreflightValidationsTest(t *testing.T) *preflightValidationsTest {
 
 func TestPreFlightValidationsGitProvider(t *testing.T) {
 	tt := newPreflightValidationsTest(t)
-	tt.Expect(tt.c.PreflightValidations(tt.ctx)).To(Succeed())
+	tt.Expect(validations.ProcessValidationResults(tt.c.PreflightValidations(tt.ctx))).To(Succeed())
 }
 
 func TestPreFlightValidationsWorkloadCluster(t *testing.T) {
@@ -73,5 +73,5 @@ func TestPreFlightValidationsWorkloadCluster(t *testing.T) {
 		},
 	}, nil)
 
-	tt.Expect(tt.c.PreflightValidations(tt.ctx)).To(Succeed())
+	tt.Expect(validations.ProcessValidationResults(tt.c.PreflightValidations(tt.ctx))).To(Succeed())
 }

--- a/pkg/validations/preflightvalidations.go
+++ b/pkg/validations/preflightvalidations.go
@@ -1,12 +1,17 @@
 package validations
 
-func ProcessValidationResults(validations []ValidationResult) error {
+// ProcessValidationResults is currently used for unit test processing.
+func ProcessValidationResults(validations []Validation) error {
 	var errs []string
+	results := make([]ValidationResult, 0, len(validations))
 	for _, validation := range validations {
-		if validation.Err != nil {
-			errs = append(errs, validation.Err.Error())
-		} else if !validation.Silent {
-			validation.LogPass()
+		results = append(results, *validation())
+	}
+	for _, result := range results {
+		if result.Err != nil {
+			errs = append(errs, result.Err.Error())
+		} else if !result.Silent {
+			result.LogPass()
 		}
 	}
 

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -13,66 +13,86 @@ import (
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
 
-func (u *UpgradeValidations) PreflightValidations(ctx context.Context) (err error) {
+// PreflightValidations returns the validations required before upgrading a cluster.
+func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validations.Validation {
 	k := u.Opts.Kubectl
 
 	targetCluster := &types.Cluster{
 		Name:           u.Opts.WorkloadCluster.Name,
 		KubeconfigFile: u.Opts.ManagementCluster.KubeconfigFile,
 	}
-	upgradeValidations := []validations.ValidationResult{
-		{
-			Name:        "validate certificate for registry mirror",
-			Remediation: fmt.Sprintf("provide a valid certificate for you registry endpoint using %s env var", anywherev1.RegistryMirrorCAKey),
-			Err:         validations.ValidateCertForRegistryMirror(u.Opts.Spec, u.Opts.TlsValidator),
+	upgradeValidations := []validations.Validation{
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "validate certificate for registry mirror",
+				Remediation: fmt.Sprintf("provide a valid certificate for you registry endpoint using %s env var", anywherev1.RegistryMirrorCAKey),
+				Err:         validations.ValidateCertForRegistryMirror(u.Opts.Spec, u.Opts.TlsValidator),
+			}
 		},
-		{
-			Name:        "control plane ready",
-			Remediation: fmt.Sprintf("ensure control plane nodes and pods for cluster %s are Ready", u.Opts.WorkloadCluster.Name),
-			Err:         k.ValidateControlPlaneNodes(ctx, targetCluster, targetCluster.Name),
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "control plane ready",
+				Remediation: fmt.Sprintf("ensure control plane nodes and pods for cluster %s are Ready", u.Opts.WorkloadCluster.Name),
+				Err:         k.ValidateControlPlaneNodes(ctx, targetCluster, targetCluster.Name),
+			}
 		},
-		{
-			Name:        "worker nodes ready",
-			Remediation: fmt.Sprintf("ensure machine deployments for cluster %s are Ready", u.Opts.WorkloadCluster.Name),
-			Err:         k.ValidateWorkerNodes(ctx, u.Opts.Spec.Cluster.Name, targetCluster.KubeconfigFile),
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "worker nodes ready",
+				Remediation: fmt.Sprintf("ensure machine deployments for cluster %s are Ready", u.Opts.WorkloadCluster.Name),
+				Err:         k.ValidateWorkerNodes(ctx, u.Opts.Spec.Cluster.Name, targetCluster.KubeconfigFile),
+			}
 		},
-		{
-			Name:        "nodes ready",
-			Remediation: fmt.Sprintf("check the Status of the control plane and worker nodes in cluster %s and verify they are Ready", u.Opts.WorkloadCluster.Name),
-			Err:         k.ValidateNodes(ctx, u.Opts.WorkloadCluster.KubeconfigFile),
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "nodes ready",
+				Remediation: fmt.Sprintf("check the Status of the control plane and worker nodes in cluster %s and verify they are Ready", u.Opts.WorkloadCluster.Name),
+				Err:         k.ValidateNodes(ctx, u.Opts.WorkloadCluster.KubeconfigFile),
+			}
 		},
-		{
-			Name:        "cluster CRDs ready",
-			Remediation: "",
-			Err:         k.ValidateClustersCRD(ctx, u.Opts.ManagementCluster),
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "cluster CRDs ready",
+				Remediation: "",
+				Err:         k.ValidateClustersCRD(ctx, u.Opts.ManagementCluster),
+			}
 		},
-		{
-			Name:        "cluster object present on workload cluster",
-			Remediation: fmt.Sprintf("ensure that the CAPI cluster object %s representing cluster %s is present", clusterv1.GroupVersion, u.Opts.WorkloadCluster.Name),
-			Err:         ValidateClusterObjectExists(ctx, k, u.Opts.ManagementCluster),
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "cluster object present on workload cluster",
+				Remediation: fmt.Sprintf("ensure that the CAPI cluster object %s representing cluster %s is present", clusterv1.GroupVersion, u.Opts.WorkloadCluster.Name),
+				Err:         ValidateClusterObjectExists(ctx, k, u.Opts.ManagementCluster),
+			}
 		},
-		{
-			Name:        "upgrade cluster kubernetes version increment",
-			Remediation: "ensure that the cluster kubernetes version is incremented by one minor version exactly (e.g. 1.18 -> 1.19)",
-			Err:         ValidateServerVersionSkew(ctx, u.Opts.Spec.Cluster.Spec.KubernetesVersion, u.Opts.WorkloadCluster, k),
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "upgrade cluster kubernetes version increment",
+				Remediation: "ensure that the cluster kubernetes version is incremented by one minor version exactly (e.g. 1.18 -> 1.19)",
+				Err:         ValidateServerVersionSkew(ctx, u.Opts.Spec.Cluster.Spec.KubernetesVersion, u.Opts.WorkloadCluster, k),
+			}
 		},
-		{
-			Name:        "validate authentication for git provider",
-			Remediation: fmt.Sprintf("ensure %s, %s env variable are set and valid", config.EksaGitPrivateKeyTokenEnv, config.EksaGitKnownHostsFileEnv),
-			Err:         validations.ValidateAuthenticationForGitProvider(u.Opts.Spec, u.Opts.CliConfig),
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "validate authentication for git provider",
+				Remediation: fmt.Sprintf("ensure %s, %s env variable are set and valid", config.EksaGitPrivateKeyTokenEnv, config.EksaGitKnownHostsFileEnv),
+				Err:         validations.ValidateAuthenticationForGitProvider(u.Opts.Spec, u.Opts.CliConfig),
+			}
 		},
-		{
-			Name:        "validate immutable fields",
-			Remediation: "",
-			Err:         ValidateImmutableFields(ctx, k, targetCluster, u.Opts.Spec, u.Opts.Provider),
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "validate immutable fields",
+				Remediation: "",
+				Err:         ValidateImmutableFields(ctx, k, targetCluster, u.Opts.Spec, u.Opts.Provider),
+			}
 		},
-		{
-			Name:        "validate kubernetes version 1.25 support",
-			Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s125SupportEnvVar),
-			Err:         validations.ValidateK8s125Support(u.Opts.Spec),
-			Silent:      true,
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "validate kubernetes version 1.25 support",
+				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s125SupportEnvVar),
+				Err:         validations.ValidateK8s125Support(u.Opts.Spec),
+				Silent:      true,
+			}
 		},
 	}
-
-	return validations.ProcessValidationResults(upgradeValidations)
+	return upgradeValidations
 }

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -415,7 +415,7 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 			k.EXPECT().GetEksaCluster(ctx, workloadCluster, clusterSpec.Cluster.Name).Return(existingClusterSpec.Cluster, nil)
 			k.EXPECT().Version(ctx, workloadCluster).Return(versionResponse, nil)
 			upgradeValidations := upgradevalidations.New(opts)
-			err := upgradeValidations.PreflightValidations(ctx)
+			err := validations.ProcessValidationResults(upgradeValidations.PreflightValidations(ctx))
 			if !reflect.DeepEqual(err, tc.wantErr) {
 				t.Errorf("%s want err=%v\n got err=%v\n", tc.name, tc.wantErr, err)
 			}
@@ -1192,7 +1192,7 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 			k.EXPECT().GetEksaAWSIamConfig(ctx, clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.AWSIamConfig, nil).MaxTimes(1)
 			k.EXPECT().Version(ctx, workloadCluster).Return(versionResponse, nil)
 			upgradeValidations := upgradevalidations.New(opts)
-			err := upgradeValidations.PreflightValidations(ctx)
+			err := validations.ProcessValidationResults(upgradeValidations.PreflightValidations(ctx))
 			if !reflect.DeepEqual(err, tc.wantErr) {
 				t.Errorf("%s want err=%v\n got err=%v\n", tc.name, tc.wantErr, err)
 			}
@@ -1426,7 +1426,7 @@ func TestPreFlightValidationsGit(t *testing.T) {
 			k.EXPECT().GetEksaAWSIamConfig(ctx, clusterSpec.Cluster.Spec.IdentityProviderRefs[1].Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.AWSIamConfig, nil).MaxTimes(1)
 			k.EXPECT().Version(ctx, workloadCluster).Return(versionResponse, nil)
 			upgradeValidations := upgradevalidations.New(opts)
-			err := upgradeValidations.PreflightValidations(ctx)
+			err := validations.ProcessValidationResults(upgradeValidations.PreflightValidations(ctx))
 			if !reflect.DeepEqual(err, tc.wantErr) {
 				t.Errorf("%s want err=%v\n got err=%v\n", tc.name, tc.wantErr, err)
 			}

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -172,7 +172,7 @@ func (s *SetAndValidateTask) Run(ctx context.Context, commandContext *task.Comma
 	runner := validations.NewRunner()
 	runner.Register(s.providerValidation(ctx, commandContext)...)
 	runner.Register(commandContext.GitOpsManager.Validations(ctx, commandContext.ClusterSpec)...)
-	runner.Register(s.validations(ctx, commandContext)...)
+	runner.Register(commandContext.Validations.PreflightValidations(ctx)...)
 
 	err := runner.Run()
 	if err != nil {
@@ -180,17 +180,6 @@ func (s *SetAndValidateTask) Run(ctx context.Context, commandContext *task.Comma
 		return nil
 	}
 	return &CreateBootStrapClusterTask{}
-}
-
-func (s *SetAndValidateTask) validations(ctx context.Context, commandContext *task.CommandContext) []validations.Validation {
-	return []validations.Validation{
-		func() *validations.ValidationResult {
-			return &validations.ValidationResult{
-				Name: "create preflight validations pass",
-				Err:  commandContext.Validations.PreflightValidations(ctx),
-			}
-		},
-	}
 }
 
 func (s *SetAndValidateTask) providerValidation(ctx context.Context, commandContext *task.CommandContext) []validations.Validation {

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -56,7 +56,7 @@ type GitOpsManager interface {
 }
 
 type Validator interface {
-	PreflightValidations(ctx context.Context) error
+	PreflightValidations(ctx context.Context) []validations.Validation
 }
 
 type CAPIManager interface {

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -617,10 +617,10 @@ func (m *MockValidator) EXPECT() *MockValidatorMockRecorder {
 }
 
 // PreflightValidations mocks base method.
-func (m *MockValidator) PreflightValidations(arg0 context.Context) error {
+func (m *MockValidator) PreflightValidations(arg0 context.Context) []validations.Validation {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PreflightValidations", arg0)
-	ret0, _ := ret[0].(error)
+	ret0, _ := ret[0].([]validations.Validation)
 	return ret0
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reorganize preflight validations so that we have only the runner that processes the validations, allowing for each preflight validation to be separate and have the remediation steps print, which was not printed before.

Before:
```
Performing setup and validations
✅ Connected to server
✅ Authenticated to vSphere
✅ Datacenter validated
✅ Network validated
Warning: VSphereMachineConfig MemoryMiB for etcd machines should not be less than 8192. Defaulting to 8192
Warning: Your VM template includes snapshot(s). LinkedClone mode will be used. DiskGiB cannot be customizable as disks cannot be expanded when using LinkedClone mode. Using default of 25 for DiskGiBs.
Warning: Your VM template includes snapshot(s). LinkedClone mode will be used. DiskGiB cannot be customizable as disks cannot be expanded when using LinkedClone mode. Using default of 25 for DiskGiBs.
✅ Datastore validated
✅ Folder validated
✅ Resource pool validated
✅ Datastore validated
✅ Folder validated
✅ Resource pool validated
✅ Machine config tags validated
✅ Control plane and Workload templates validated
Provided sshAuthorizedKey is not set or is empty, auto-generating new key pair...	{"vSphereMachineConfig": "demo2-cp"}
Private key saved to demo23/eks-a-id_rsa. Use 'ssh -i demo23/eks-a-id_rsa <username>@<Node-IP-Address>' to login to your cluster node
❌ Validation failed	{"validation": "vsphere Provider setup is valid", "error": "searching eksa VSphereMachineConfigResponse: The connection to the server localhost:8080 was refused - did you specify the right host or port?\n", "remediation": ""}
✅ Validate certificate for registry mirror
✅ Validate authentication for git provider
✅ Validate gitops
✅ Validate identity providers' name
❌ Validation failed	{"validation": "create preflight validations pass", "error": "validation failed with 3 errors: getting clusters: The connection to the server localhost:8080 was refused - did you specify the right host or port?\n,getting clusters crd: The connection to the server localhost:8080 was refused - did you specify the right host or port?\n,getting eksa cluster: The connection to the server localhost:8080 was refused - did you specify the right host or port?\n", "remediation": ""}
Error: validations failed
```

After:
```
Performing setup and validations
✅ Connected to server
✅ Authenticated to vSphere
✅ Datacenter validated
✅ Network validated
Warning: VSphereMachineConfig MemoryMiB for etcd machines should not be less than 8192. Defaulting to 8192
Warning: Your VM template includes snapshot(s). LinkedClone mode will be used. DiskGiB cannot be customizable as disks cannot be expanded when using LinkedClone mode. Using default of 25 for DiskGiBs.
Warning: Your VM template includes snapshot(s). LinkedClone mode will be used. DiskGiB cannot be customizable as disks cannot be expanded when using LinkedClone mode. Using default of 25 for DiskGiBs.
✅ Datastore validated
✅ Folder validated
✅ Resource pool validated
✅ Datastore validated
✅ Folder validated
✅ Resource pool validated
✅ Machine config tags validated
✅ Control plane and Workload templates validated
Provided sshAuthorizedKey is not set or is empty, auto-generating new key pair...	{"vSphereMachineConfig": "demo2"}
Private key saved to demo23/eks-a-id_rsa. Use 'ssh -i demo23/eks-a-id_rsa <username>@<Node-IP-Address>' to login to your cluster node
❌ Validation failed	{"validation": "vsphere Provider setup is valid", "error": "searching eksa VSphereMachineConfigResponse: The connection to the server localhost:8080 was refused - did you specify the right host or port?\n", "remediation": ""}
✅ Validate certificate for registry mirror
✅ Validate authentication for git provider
❌ Validation failed	{"validation": "validate cluster name", "error": "getting clusters: The connection to the server localhost:8080 was refused - did you specify the right host or port?\n", "remediation": ""}
✅ Validate gitops
✅ Validate identity providers' name
❌ Validation failed	{"validation": "validate management cluster has eksa crds", "error": "getting clusters crd: The connection to the server localhost:8080 was refused - did you specify the right host or port?\n", "remediation": ""}
❌ Validation failed	{"validation": "validate management cluster name is valid", "error": "getting eksa cluster: The connection to the server localhost:8080 was refused - did you specify the right host or port?\n", "remediation": "Specify a valid management cluster in the cluster spec. This cannot be a workload cluster that is managed by a different management cluster."}
Error: validations failed
```

*Testing (if applicable):*
unit testing and functional tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

