### PR TITLE
Patch erroneous machine deployment state check on upgrade

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -816,7 +816,7 @@ func (k *Kubectl) ValidateWorkerNodes(ctx context.Context, clusterName string, k
 
 func (k *Kubectl) CountMachineDeploymentReplicasReady(ctx context.Context, clusterName string, kubeconfig string) (ready, total int, err error) {
 	logger.V(6).Info("counting ready machine deployment replicas", "cluster", clusterName)
-	deployments, err := k.GetMachineDeployments(ctx, WithKubeconfig(kubeconfig), WithNamespace(constants.EksaSystemNamespace))
+	deployments, err := k.GetMachineDeploymentsForCluster(ctx, clusterName, WithKubeconfig(kubeconfig), WithNamespace(constants.EksaSystemNamespace))
 	if err != nil {
 		return 0, 0, err
 	}

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -1730,10 +1730,26 @@ func TestKubectlCountMachineDeploymentReplicasReady(t *testing.T) {
 			k, ctx, cluster, e := newKubectl(t)
 			tt := newKubectlTest(t)
 			if tc.returnError {
-				e.EXPECT().Execute(ctx, []string{"get", "machinedeployments.cluster.x-k8s.io", "-o", "json", "--kubeconfig", cluster.KubeconfigFile, "--namespace", "eksa-system"}).Return(*bytes.NewBufferString(""), errors.New(""))
+				e.EXPECT().
+					Execute(ctx, []string{
+						"get", "machinedeployments.cluster.x-k8s.io",
+						"-o", "json",
+						"--kubeconfig", cluster.KubeconfigFile,
+						"--namespace", "eksa-system",
+						"--selector=cluster.x-k8s.io/cluster-name=test-cluster",
+					}).
+					Return(*bytes.NewBufferString(""), errors.New(""))
 			} else {
 				fileContent := test.ReadFile(t, tc.jsonResponseFile)
-				e.EXPECT().Execute(ctx, []string{"get", "machinedeployments.cluster.x-k8s.io", "-o", "json", "--kubeconfig", cluster.KubeconfigFile, "--namespace", "eksa-system"}).Return(*bytes.NewBufferString(fileContent), nil)
+				e.EXPECT().
+					Execute(ctx, []string{
+						"get", "machinedeployments.cluster.x-k8s.io",
+						"-o", "json",
+						"--kubeconfig", cluster.KubeconfigFile,
+						"--namespace", "eksa-system",
+						"--selector=cluster.x-k8s.io/cluster-name=test-cluster",
+					}).
+					Return(*bytes.NewBufferString(fileContent), nil)
 			}
 
 			ready, total, err := k.CountMachineDeploymentReplicasReady(ctx, cluster.Name, cluster.KubeconfigFile)
@@ -1781,7 +1797,15 @@ func TestKubectlValidateWorkerNodes(t *testing.T) {
 			k, ctx, cluster, e := newKubectl(t)
 			tt := newKubectlTest(t)
 			fileContent := test.ReadFile(t, tc.jsonResponseFile)
-			e.EXPECT().Execute(ctx, []string{"get", "machinedeployments.cluster.x-k8s.io", "-o", "json", "--kubeconfig", cluster.KubeconfigFile, "--namespace", "eksa-system"}).Return(*bytes.NewBufferString(fileContent), nil)
+			e.EXPECT().
+				Execute(ctx, []string{
+					"get", "machinedeployments.cluster.x-k8s.io",
+					"-o", "json",
+					"--kubeconfig", cluster.KubeconfigFile,
+					"--namespace", "eksa-system",
+					"--selector=cluster.x-k8s.io/cluster-name=test-cluster",
+				}).
+				Return(*bytes.NewBufferString(fileContent), nil)
 
 			err := k.ValidateWorkerNodes(ctx, cluster.Name, cluster.KubeconfigFile)
 			if tc.wantError {


### PR DESCRIPTION
Preflights check if machine deployments are in an appropriate state before an upgrade can proceed. The check eneds to retrieve machines associated with the target cluster only, not all machine deployments.
