### PR TITLE
Allow users to specify cloneMode for vSphere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,6 +383,7 @@ clean: ## Clean up resources created by make targets
 	rm -rf ./pkg/executables/cluster-name/
 	rm -rf ./pkg/executables/TestDeployTemplate*
 	rm -rf ./pkg/providers/vsphere/test/
+	rm -rf ./pkg/providers/vsphere/Test*
 	rm -rf ./pkg/providers/tinkerbell/stack/TestTinkerbellStackInstall*
 ifeq ($(UNAME), Darwin)
 	  find -E . -depth -type d -regex '.*\/Test.*-[0-9]{9}\/.*' -exec rm -rf {} \;

--- a/config/crd/bases/anywhere.eks.amazonaws.com_vspheremachineconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_vspheremachineconfigs.yaml
@@ -37,6 +37,13 @@ spec:
           spec:
             description: VSphereMachineConfigSpec defines the desired state of VSphereMachineConfig.
             properties:
+              cloneMode:
+                description: CloneMode describes the clone mode to be used when cloning
+                  vSphere VMs.
+                enum:
+                - fullClone
+                - linkedClone
+                type: string
               datastore:
                 type: string
               diskGiB:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -5440,6 +5440,13 @@ spec:
           spec:
             description: VSphereMachineConfigSpec defines the desired state of VSphereMachineConfig.
             properties:
+              cloneMode:
+                description: CloneMode describes the clone mode to be used when cloning
+                  vSphere VMs.
+                enum:
+                - fullClone
+                - linkedClone
+                type: string
               datastore:
                 type: string
               diskGiB:

--- a/pkg/api/v1alpha1/vsphereclonemode_types.go
+++ b/pkg/api/v1alpha1/vsphereclonemode_types.go
@@ -1,0 +1,19 @@
+package v1alpha1
+
+// +kubebuilder:validation:Enum=fullClone;linkedClone
+
+// CloneMode describes the clone mode to be used when cloning vSphere VMs.
+type CloneMode string
+
+const (
+	// FullClone indicates a VM will have no relationship to the source of the
+	// clone operation once the operation is complete. This is the safest clone
+	// mode, but it is not the fastest.
+	FullClone CloneMode = "fullClone"
+
+	// LinkedClone means resulting VMs will be dependent upon the snapshot of
+	// the source VM/template from which the VM was cloned. This is the fastest
+	// clone mode, but it also prevents expanding a VMs disk beyond the size of
+	// the source VM/template.
+	LinkedClone CloneMode = "linkedClone"
+)

--- a/pkg/api/v1alpha1/vspheremachineconfig_types.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_types.go
@@ -17,6 +17,7 @@ type VSphereMachineConfigSpec struct {
 	Template          string              `json:"template,omitempty"`
 	Users             []UserConfiguration `json:"users,omitempty"`
 	TagIDs            []string            `json:"tags,omitempty"`
+	CloneMode         CloneMode           `json:"cloneMode,omitempty"`
 }
 
 func (c *VSphereMachineConfig) PauseReconcile() {

--- a/pkg/cluster/tinkerbell.go
+++ b/pkg/cluster/tinkerbell.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -50,7 +50,7 @@ metadata:
 spec:
   template:
     spec:
-      cloneMode: linkedClone
+      cloneMode: {{.controlPlaneCloneMode}}
       datacenter: '{{.vsphereDatacenter}}'
       datastore: {{.controlPlaneVsphereDatastore}}
       diskGiB: {{.controlPlaneDiskGiB}}
@@ -537,7 +537,7 @@ metadata:
 spec:
   template:
     spec:
-      cloneMode: linkedClone
+      cloneMode: {{.etcdCloneMode}}
       datacenter: '{{.vsphereDatacenter}}'
       datastore: {{.etcdVsphereDatastore}}
       diskGiB: {{.etcdDiskGiB}}

--- a/pkg/providers/vsphere/config/template-md.yaml
+++ b/pkg/providers/vsphere/config/template-md.yaml
@@ -156,7 +156,7 @@ metadata:
 spec:
   template:
     spec:
-      cloneMode: linkedClone
+      cloneMode: {{.workerCloneMode}}
       datacenter: '{{.vsphereDatacenter}}'
       datastore: {{.workerVsphereDatastore}}
       diskGiB: {{.workloadDiskGiB}}

--- a/pkg/providers/vsphere/mocks/client.go
+++ b/pkg/providers/vsphere/mocks/client.go
@@ -255,6 +255,21 @@ func (mr *MockProviderGovcClientMockRecorder) GetTags(arg0, arg1 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTags", reflect.TypeOf((*MockProviderGovcClient)(nil).GetTags), arg0, arg1)
 }
 
+// GetVMDiskSizeInGB mocks base method.
+func (m *MockProviderGovcClient) GetVMDiskSizeInGB(arg0 context.Context, arg1, arg2 string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVMDiskSizeInGB", arg0, arg1, arg2)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVMDiskSizeInGB indicates an expected call of GetVMDiskSizeInGB.
+func (mr *MockProviderGovcClientMockRecorder) GetVMDiskSizeInGB(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMDiskSizeInGB", reflect.TypeOf((*MockProviderGovcClient)(nil).GetVMDiskSizeInGB), arg0, arg1, arg2)
+}
+
 // GetWorkloadAvailableSpace mocks base method.
 func (m *MockProviderGovcClient) GetWorkloadAvailableSpace(arg0 context.Context, arg1 string) (float64, error) {
 	m.ctrl.T.Helper()

--- a/pkg/providers/vsphere/template.go
+++ b/pkg/providers/vsphere/template.go
@@ -203,6 +203,8 @@ func buildTemplateMapCP(
 		"eksaCSIUsername":                      vuc.EksaVsphereCSIUsername,
 		"eksaCSIPassword":                      vuc.EksaVsphereCSIPassword,
 		"disableCSI":                           datacenterSpec.DisableCSI,
+		"controlPlaneCloneMode":                controlPlaneMachineSpec.CloneMode,
+		"etcdCloneMode":                        etcdMachineSpec.CloneMode,
 	}
 
 	auditPolicy, err := common.GetAuditPolicy(clusterSpec.Cluster.Spec.KubernetesVersion)
@@ -335,6 +337,7 @@ func buildTemplateMapMD(
 		"workerNodeGroupName":            fmt.Sprintf("%s-%s", clusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name),
 		"workerNodeGroupTaints":          workerNodeGroupConfiguration.Taints,
 		"autoscalingConfig":              workerNodeGroupConfiguration.AutoScalingConfiguration,
+		"workerCloneMode":                workerNodeGroupMachineSpec.CloneMode,
 	}
 
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {

--- a/pkg/providers/vsphere/testdata/cluster_bottlerocket_external_etcd.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_bottlerocket_external_etcd.yaml
@@ -45,6 +45,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   osFamily: bottlerocket
@@ -63,6 +64,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   osFamily: bottlerocket
@@ -81,6 +83,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   osFamily: bottlerocket

--- a/pkg/providers/vsphere/testdata/cluster_bottlerocket_mirror_config.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_bottlerocket_mirror_config.yaml
@@ -46,6 +46,7 @@ metadata:
   name: test-cp
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192
@@ -65,6 +66,7 @@ metadata:
   name: test-wn
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096
@@ -84,6 +86,7 @@ metadata:
   name: test-etcd
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096

--- a/pkg/providers/vsphere/testdata/cluster_bottlerocket_mirror_with_cert_config.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_bottlerocket_mirror_with_cert_config.yaml
@@ -61,6 +61,7 @@ metadata:
   name: test-cp
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192
@@ -80,6 +81,7 @@ metadata:
   name: test-wn
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096
@@ -99,6 +101,7 @@ metadata:
   name: test-etcd
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096

--- a/pkg/providers/vsphere/testdata/cluster_full_oidc.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_full_oidc.yaml
@@ -40,6 +40,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   osFamily: ubuntu
@@ -58,6 +59,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   osFamily: ubuntu

--- a/pkg/providers/vsphere/testdata/cluster_main.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_main.yaml
@@ -44,6 +44,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192
@@ -64,6 +65,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096
@@ -84,6 +86,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096

--- a/pkg/providers/vsphere/testdata/cluster_main_121.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_main_121.yaml
@@ -42,6 +42,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192
@@ -62,6 +63,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096
@@ -82,6 +84,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096

--- a/pkg/providers/vsphere/testdata/cluster_main_121_cp_upgrade_strategy.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_main_121_cp_upgrade_strategy.yaml
@@ -47,6 +47,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192
@@ -67,6 +68,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096
@@ -87,6 +89,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096

--- a/pkg/providers/vsphere/testdata/cluster_main_121_md_upgrade_strategy.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_main_121_md_upgrade_strategy.yaml
@@ -47,6 +47,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192
@@ -67,6 +68,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096
@@ -87,6 +89,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096

--- a/pkg/providers/vsphere/testdata/cluster_main_multiple_worker_node_groups.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_main_multiple_worker_node_groups.yaml
@@ -55,6 +55,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192
@@ -75,6 +76,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096
@@ -107,6 +109,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096

--- a/pkg/providers/vsphere/testdata/cluster_main_with_cp_node_labels.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_main_with_cp_node_labels.yaml
@@ -45,6 +45,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192
@@ -65,6 +66,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096
@@ -85,6 +87,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096

--- a/pkg/providers/vsphere/testdata/cluster_main_with_node_labels.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_main_with_node_labels.yaml
@@ -45,6 +45,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192
@@ -65,6 +66,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096
@@ -85,6 +87,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096

--- a/pkg/providers/vsphere/testdata/cluster_main_with_taints.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_main_with_taints.yaml
@@ -56,6 +56,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192
@@ -76,6 +77,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096
@@ -96,6 +98,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096

--- a/pkg/providers/vsphere/testdata/cluster_minimal.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_minimal.yaml
@@ -37,6 +37,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192

--- a/pkg/providers/vsphere/testdata/cluster_minimal_autoscaling.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_minimal_autoscaling.yaml
@@ -40,6 +40,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192

--- a/pkg/providers/vsphere/testdata/cluster_minimal_disable_csi.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_minimal_disable_csi.yaml
@@ -37,6 +37,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192

--- a/pkg/providers/vsphere/testdata/cluster_minimal_oidc.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_minimal_oidc.yaml
@@ -40,6 +40,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   osFamily: ubuntu
@@ -58,6 +59,7 @@ metadata:
   namespace: test-namespace
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   osFamily: ubuntu

--- a/pkg/providers/vsphere/testdata/cluster_mirror_config.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_mirror_config.yaml
@@ -46,6 +46,7 @@ metadata:
   name: test-cp
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192
@@ -65,6 +66,7 @@ metadata:
   name: test-wn
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096
@@ -84,6 +86,7 @@ metadata:
   name: test-etcd
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096

--- a/pkg/providers/vsphere/testdata/cluster_mirror_with_auth_config.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_mirror_with_auth_config.yaml
@@ -62,6 +62,7 @@ metadata:
   name: test-cp
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192
@@ -81,6 +82,7 @@ metadata:
   name: test-wn
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096
@@ -100,6 +102,7 @@ metadata:
   name: test-etcd
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096

--- a/pkg/providers/vsphere/testdata/cluster_mirror_with_cert_config.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_mirror_with_cert_config.yaml
@@ -66,6 +66,7 @@ metadata:
   name: test-cp
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 8192
@@ -85,6 +86,7 @@ metadata:
   name: test-wn
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096
@@ -104,6 +106,7 @@ metadata:
   name: test-etcd
 spec:
   diskGiB: 25
+  cloneMode: linkedClone
   datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
   folder: "/SDDC-Datacenter/vm"
   memoryMiB: 4096

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -98,6 +98,7 @@ type ProviderGovcClient interface {
 	CreateLibrary(ctx context.Context, datastore, library string) error
 	DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, datacenter, datastore, network, resourcePool string, resizeDisk2 bool) error
 	ImportTemplate(ctx context.Context, library, ovaURL, name string) error
+	GetVMDiskSizeInGB(ctx context.Context, vm, datacenter string) (int, error)
 	GetTags(ctx context.Context, path string) (tags []string, err error)
 	ListTags(ctx context.Context) ([]executables.Tag, error)
 	CreateTag(ctx context.Context, tag, category string) error


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/3467

*Description of changes:*
Currently, EKS-A for vSphere defaults to LinkedClone for cloning the node VMs. This falls back to FullClone if some conditions are not met. 
With this change, users will be able to explicitly set the cloneMode to either `fullClone` or `linkedClone`. 

Alternatively, they can also skip the cloneMode and EKS-A will determine which cloneMode to use based on the following parameters:
 - if the `VSphereMachineConfig.Spec.Template` has a snapshot and its diskSize matches the `VSphereMachineConfig.Spec.DiskGiB`, `linkedClone` is used.
- else `fullClone` is used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

