### PR TITLE
Add client processor for Tinkerbell machine config

### DIFF
--- a/pkg/cluster/build.go
+++ b/pkg/cluster/build.go
@@ -4,6 +4,7 @@ package cluster
 // default processors to build a Config.
 func NewDefaultConfigClientBuilder() *ConfigClientBuilder {
 	return NewConfigClientBuilder().Register(
+		getTinkerbellMachineConfigs,
 		getTinkerbellDatacenter,
 		getDockerDatacenter,
 		getVSphereDatacenter,

--- a/pkg/cluster/tinkerbell.go
+++ b/pkg/cluster/tinkerbell.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"context"
-
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
@@ -85,5 +84,28 @@ func getTinkerbellDatacenter(ctx context.Context, client Client, c *Config) erro
 	}
 
 	c.TinkerbellDatacenter = datacenter
+	return nil
+}
+
+func getTinkerbellMachineConfigs(ctx context.Context, client Client, c *Config) error {
+	if c.Cluster.Spec.DatacenterRef.Kind != anywherev1.TinkerbellDatacenterKind {
+		return nil
+	}
+
+	if c.TinkerbellMachineConfigs == nil {
+		c.TinkerbellMachineConfigs = map[string]*anywherev1.TinkerbellMachineConfig{}
+	}
+	for _, machineRef := range c.Cluster.MachineConfigRefs() {
+		if machineRef.Kind != anywherev1.TinkerbellMachineConfigKind {
+			continue
+		}
+
+		machineConfig := &anywherev1.TinkerbellMachineConfig{}
+		if err := client.Get(ctx, machineRef.Name, c.Cluster.Namespace, machineConfig); err != nil {
+			return err
+		}
+
+		c.TinkerbellMachineConfigs[machineConfig.Name] = machineConfig
+	}
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*
[Implement Client processor for Tinkerbell machine config#984](https://github.com/aws/eks-anywhere-internal/issues/984)
*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

