### PR TITLE
Close controller dependencies before manager exits

### DIFF
--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -82,6 +82,11 @@ func (f *Factory) Build(ctx context.Context) (*Reconcilers, error) {
 	return &f.reconcilers, nil
 }
 
+// Close cleans up any open resources from the created dependencies.
+func (f *Factory) Close(ctx context.Context) error {
+	return f.deps.Close(ctx)
+}
+
 func (f *Factory) WithClusterReconciler(capiProviders []clusterctlv1.Provider) *Factory {
 	f.dependencyFactory.WithGovc()
 	f.withTracker().WithProviderClusterReconcilerRegistry(capiProviders).withAWSIamConfigReconciler()

--- a/controllers/factory_test.go
+++ b/controllers/factory_test.go
@@ -138,3 +138,18 @@ func TestFactoryBuildAllSnowReconciler(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(reconcilers.SnowMachineConfigReconciler).NotTo(BeNil())
 }
+
+func TestFactoryClose(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	logger := nullLog()
+	ctrl := gomock.NewController(t)
+	manager := mocks.NewMockManager(ctrl)
+	manager.EXPECT().GetClient().AnyTimes()
+	manager.EXPECT().GetScheme().AnyTimes()
+
+	f := controllers.NewFactory(logger, manager)
+	_, err := f.Build(ctx)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(f.Close(ctx)).To(Succeed())
+}


### PR DESCRIPTION
*Description of changes:*

This guarantees that things like govc sessions are destroyed before the container is stopped, avoiding lingering resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

