### PR TITLE
Removing setting provisioning field on the hardware metadata

### DIFF
--- a/pkg/providers/tinkerbell/hardware/catalogue.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue.go
@@ -18,8 +18,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/templater"
 )
 
-const Provisioning = "provisioning"
-
 // Indexer provides indexing behavior for objects.
 type Indexer interface {
 	// Lookup retrieves objects associated with the index => value pair.

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
@@ -290,7 +290,6 @@ func hardwareFromMachine(m Machine) *tinkv1alpha1.Hardware {
 					AllowPxe:        true,
 					AlwaysPxe:       true,
 				},
-				State: "provisioning",
 			},
 			Interfaces: []tinkv1alpha1.Interface{
 				{


### PR DESCRIPTION
*Issue #4655*

*Description of changes:*
Removing metadata.state from the default generated hardware objects for tinkerbell.

*Testing:*
```
eksctl-anywhere generate hardware -z .ignore/node1214hardware.csv
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

