### PR TITLE
22vibhutigoel || Fixing typo for multus

### DIFF
--- a/docs/content/en/docs/tasks/cluster/cluster-multus.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-multus.md
@@ -139,7 +139,7 @@ kubectl describe network-attachment-definitions ipvlan-conf
 1. Create a sample application 2 (app2) with the network annotation created in the previous step:
 
     ```bash
-    cat <<EOF | kubectl apply -f - kube
+    cat <<EOF | kubectl apply -f -
     apiVersion: v1
     kind: Pod
     metadata:


### PR DESCRIPTION
*Issue #, if available:* Typo Error 

*Description of changes:* There is a typo mistake in app2 yaml file and unable to create app2 pod , Hence removing unexpected "kube" keyword .

*Testing (if applicable):* Applied yaml on EKS-A cluster after removing  "kube" keyword and its working

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

