### PR TITLE
Set user-agent in all file readers

### DIFF
--- a/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
@@ -78,22 +78,18 @@ func (gsbo *generateSupportBundleOptions) validateCmdInput() error {
 }
 
 func (gsbo *generateSupportBundleOptions) generateBundleConfig(ctx context.Context) (diagnostics.DiagnosticBundle, error) {
-	f := gsbo.fileName
-	if f == "" {
-		factory := diagnostics.NewFactory(diagnostics.EksaDiagnosticBundleFactoryOpts{
-			AnalyzerFactory:  diagnostics.NewAnalyzerFactory(),
-			CollectorFactory: diagnostics.NewDefaultCollectorFactory(),
-		})
-		return factory.DiagnosticBundleDefault(), nil
+	clusterConfigPath := gsbo.fileName
+	if clusterConfigPath == "" {
+		return gsbo.generateDefaultBundleConfig(ctx)
 	}
 
-	clusterSpec, err := readAndValidateClusterSpec(f, version.Get())
+	clusterSpec, err := readAndValidateClusterSpec(clusterConfigPath, version.Get())
 	if err != nil {
 		return nil, fmt.Errorf("unable to get cluster config from file: %v", err)
 	}
 
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).
-		WithProvider(f, clusterSpec.Cluster, cc.skipIpCheck, gsbo.hardwareFileName, false, gsbo.tinkerbellBootstrapIP).
+		WithProvider(clusterConfigPath, clusterSpec.Cluster, cc.skipIpCheck, gsbo.hardwareFileName, false, gsbo.tinkerbellBootstrapIP).
 		WithDiagnosticBundleFactory().
 		Build(ctx)
 	if err != nil {
@@ -102,4 +98,19 @@ func (gsbo *generateSupportBundleOptions) generateBundleConfig(ctx context.Conte
 	defer close(ctx, deps)
 
 	return deps.DignosticCollectorFactory.DiagnosticBundleWorkloadCluster(clusterSpec, deps.Provider, kubeconfig.FromClusterName(clusterSpec.Cluster.Name))
+}
+
+func (gsbo *generateSupportBundleOptions) generateDefaultBundleConfig(ctx context.Context) (diagnostics.DiagnosticBundle, error) {
+	f := dependencies.NewFactory().WithFileReader()
+	deps, err := f.Build(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer close(ctx, deps)
+
+	factory := diagnostics.NewFactory(diagnostics.EksaDiagnosticBundleFactoryOpts{
+		AnalyzerFactory:  diagnostics.NewAnalyzerFactory(),
+		CollectorFactory: diagnostics.NewDefaultCollectorFactory(deps.FileReader),
+	})
+	return factory.DiagnosticBundleDefault(), nil
 }

--- a/internal/test/files.go
+++ b/internal/test/files.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/aws/eks-anywhere/pkg/files"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 )
 
@@ -134,4 +135,11 @@ const sanitizePathReplacementChar = "_"
 // A-Z, a-z, 0-9, _ or - are illegal and replaces them with _.
 func SanitizePath(s string) string {
 	return sanitizePathChars.ReplaceAllString(s, sanitizePathReplacementChar)
+}
+
+// NewFileReader builds a file reader with a proper user-agent.
+// Unit tests should never make network call to the internet, but just in case we
+// set the user-agent to be able to pin-point them here.
+func NewFileReader() *files.Reader {
+	return files.NewReader(files.WithEKSAUserAgent("unit-test", "no-version"))
 }

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -1102,15 +1102,16 @@ func (f *Factory) WithDiagnosticCollectorImage(diagnosticCollectorImage string) 
 }
 
 func (f *Factory) WithCollectorFactory() *Factory {
+	f.WithFileReader()
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.dependencies.CollectorFactory != nil {
 			return nil
 		}
 
 		if f.diagnosticCollectorImage == "" {
-			f.dependencies.CollectorFactory = diagnostics.NewDefaultCollectorFactory()
+			f.dependencies.CollectorFactory = diagnostics.NewDefaultCollectorFactory(f.dependencies.FileReader)
 		} else {
-			f.dependencies.CollectorFactory = diagnostics.NewCollectorFactory(f.diagnosticCollectorImage)
+			f.dependencies.CollectorFactory = diagnostics.NewCollectorFactory(f.diagnosticCollectorImage, f.dependencies.FileReader)
 		}
 		return nil
 	})
@@ -1140,9 +1141,7 @@ func (f *Factory) WithFileReader() *Factory {
 			return nil
 		}
 
-		f.dependencies.FileReader = files.NewReader(files.WithUserAgent(
-			fmt.Sprintf("eks-a-cli/%s", version.Get().GitVersion)),
-		)
+		f.dependencies.FileReader = files.NewReader(files.WithEKSAUserAgent("cli", version.Get().GitVersion))
 		return nil
 	})
 

--- a/pkg/diagnostics/analyzers_test.go
+++ b/pkg/diagnostics/analyzers_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/diagnostics"
 )
@@ -32,7 +33,7 @@ func getDeploymentStatusAnalyzer(analyzers []*diagnostics.Analyze, name string) 
 }
 
 func TestEksaLogTextAnalyzers(t *testing.T) {
-	collectorFactory := diagnostics.NewDefaultCollectorFactory()
+	collectorFactory := diagnostics.NewDefaultCollectorFactory(test.NewFileReader())
 	collectors := collectorFactory.DefaultCollectors()
 	collectors = append(collectors, collectorFactory.ManagementClusterCollectors()...)
 	analyzerFactory := diagnostics.NewAnalyzerFactory()

--- a/pkg/diagnostics/collectors_test.go
+++ b/pkg/diagnostics/collectors_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestFileCollectors(t *testing.T) {
 	g := NewGomegaWithT(t)
-	factory := diagnostics.NewDefaultCollectorFactory()
+	factory := diagnostics.NewDefaultCollectorFactory(test.NewFileReader())
 
 	w, err := filewriter.NewWriter(t.TempDir())
 	g.Expect(err).To(BeNil())
@@ -73,7 +73,7 @@ func TestVsphereDataCenterConfigCollectors(t *testing.T) {
 		}
 	})
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.VSphereDatacenterKind}
-	factory := diagnostics.NewDefaultCollectorFactory()
+	factory := diagnostics.NewDefaultCollectorFactory(test.NewFileReader())
 	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
 	g.Expect(collectors).To(HaveLen(11), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapvSystemNamespace))
@@ -91,7 +91,7 @@ func TestCloudStackDataCenterConfigCollectors(t *testing.T) {
 	g := NewGomegaWithT(t)
 	spec := test.NewClusterSpec(func(s *cluster.Spec) {})
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.CloudStackDatacenterKind}
-	factory := diagnostics.NewDefaultCollectorFactory()
+	factory := diagnostics.NewDefaultCollectorFactory(test.NewFileReader())
 	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
 	g.Expect(collectors).To(HaveLen(10), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapcSystemNamespace))
@@ -106,7 +106,7 @@ func TestTinkerbellDataCenterConfigCollectors(t *testing.T) {
 	g := NewGomegaWithT(t)
 	spec := test.NewClusterSpec(func(s *cluster.Spec) {})
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.TinkerbellDatacenterKind}
-	factory := diagnostics.NewDefaultCollectorFactory()
+	factory := diagnostics.NewDefaultCollectorFactory(test.NewFileReader())
 	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
 	g.Expect(collectors).To(HaveLen(13), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CaptSystemNamespace))
@@ -121,7 +121,7 @@ func TestSnowCollectors(t *testing.T) {
 	g := NewGomegaWithT(t)
 	spec := test.NewClusterSpec(func(s *cluster.Spec) {})
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.SnowDatacenterKind}
-	factory := diagnostics.NewDefaultCollectorFactory()
+	factory := diagnostics.NewDefaultCollectorFactory(test.NewFileReader())
 	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
 	g.Expect(collectors).To(HaveLen(6), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapasSystemNamespace))
@@ -136,7 +136,7 @@ func TestNutanixCollectors(t *testing.T) {
 	g := NewGomegaWithT(t)
 	spec := test.NewClusterSpec(func(s *cluster.Spec) {})
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.NutanixDatacenterKind}
-	factory := diagnostics.NewDefaultCollectorFactory()
+	factory := diagnostics.NewDefaultCollectorFactory(test.NewFileReader())
 	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
 	g.Expect(collectors).To(HaveLen(6), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapxSystemNamespace))

--- a/pkg/diagnostics/interfaces.go
+++ b/pkg/diagnostics/interfaces.go
@@ -51,6 +51,7 @@ type AnalyzerFactory interface {
 	PackageAnalyzers() []*Analyze
 }
 
+// CollectorFactory generates support-bundle collectors.
 type CollectorFactory interface {
 	PackagesCollectors() []*Collect
 	DefaultCollectors() []*Collect

--- a/pkg/files/reader.go
+++ b/pkg/files/reader.go
@@ -34,11 +34,18 @@ func WithUserAgent(userAgent string) ReaderOpt {
 	}
 }
 
+// WithEKSAUserAgent sets the user agent for a particular eks-a component and version.
+// component should be something like "cli", "controller", "e2e", etc.
+// version should generally be a semver, but when not available, any string is valid.
+func WithEKSAUserAgent(eksAComponent, version string) ReaderOpt {
+	return WithUserAgent(eksaUserAgent(eksAComponent, version))
+}
+
 func NewReader(opts ...ReaderOpt) *Reader {
 	r := &Reader{
 		embedFS:    embed.FS{},
 		httpClient: &http.Client{},
-		userAgent:  "eks-a/unknown",
+		userAgent:  eksaUserAgent("unknown", "no-version"),
 	}
 
 	for _, o := range opts {
@@ -101,4 +108,8 @@ func readLocalFile(filename string) ([]byte, error) {
 	}
 
 	return data, nil
+}
+
+func eksaUserAgent(eksAComponent, version string) string {
+	return fmt.Sprintf("eks-a-%s/%s", eksAComponent, version)
 }

--- a/pkg/files/reader_wb_test.go
+++ b/pkg/files/reader_wb_test.go
@@ -1,0 +1,13 @@
+package files
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestWithEKSAUserAgent(t *testing.T) {
+	g := NewWithT(t)
+	r := NewReader(WithEKSAUserAgent("cli", "v0.10.0"))
+	g.Expect(r.userAgent).To(Equal("eks-a-cli/v0.10.0"))
+}

--- a/test/framework/awsiam.go
+++ b/test/framework/awsiam.go
@@ -14,7 +14,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
-	"github.com/aws/eks-anywhere/pkg/files"
 	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/version"
 )
@@ -121,7 +120,7 @@ func (e *ClusterE2ETest) setIamAuthClientPATH() error {
 
 func (e *ClusterE2ETest) getEksdReleaseManifest() (*eksdv1alpha1.Release, error) {
 	c := e.ClusterConfig.Cluster
-	r := manifests.NewReader(files.NewReader())
+	r := manifests.NewReader(newFileReader())
 	eksdRelease, err := r.ReadEKSD(version.Get().GitVersion, string(c.Spec.KubernetesVersion))
 	if err != nil {
 		return nil, fmt.Errorf("getting EKS-D release spec from bundle: %v", err)

--- a/test/framework/conformance.go
+++ b/test/framework/conformance.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/conformance"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/files"
 	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
 	"github.com/aws/eks-anywhere/pkg/version"
@@ -62,7 +61,7 @@ func (e *ClusterE2ETest) getEksdReleaseKubeVersion() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("fetching cluster config from file: %v", err)
 	}
-	r := manifests.NewReader(files.NewReader())
+	r := manifests.NewReader(newFileReader())
 	b, err := r.ReadBundlesForVersion(version.Get().GitVersion)
 	if err != nil {
 		return "", fmt.Errorf("getting EKS-D release spec from bundle: %v", err)

--- a/test/framework/reader.go
+++ b/test/framework/reader.go
@@ -1,0 +1,7 @@
+package framework
+
+import "github.com/aws/eks-anywhere/pkg/files"
+
+func newFileReader() *files.Reader {
+	return files.NewReader(files.WithEKSAUserAgent("e2e-test", testBranch()))
+}

--- a/test/framework/releaseVersions.go
+++ b/test/framework/releaseVersions.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/aws/eks-anywhere/internal/pkg/files"
-	filereader "github.com/aws/eks-anywhere/pkg/files"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/manifests/releases"
 	"github.com/aws/eks-anywhere/pkg/semver"
@@ -180,7 +179,7 @@ func devReleases() (release *releasev1alpha1.Release, err error) {
 }
 
 func getReleases(url string) (release *releasev1alpha1.Release, err error) {
-	reader := filereader.NewReader()
+	reader := newFileReader()
 	logger.Info("Reading release manifest", "manifest", url)
 	releases, err := releases.ReadReleasesFromURL(reader, url)
 	if err != nil {

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/eks-anywhere/internal/test/cleanup"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/executables"
-	filereader "github.com/aws/eks-anywhere/pkg/files"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
 	"github.com/aws/eks-anywhere/pkg/manifests/releases"
 	"github.com/aws/eks-anywhere/pkg/retrier"
@@ -699,7 +698,7 @@ func defaultEnvVarForTemplate(osFamily string, kubeVersion anywherev1.Kubernetes
 }
 
 func readVersionsBundles(t testing.TB, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) *releasev1.VersionsBundle {
-	reader := filereader.NewReader(filereader.WithUserAgent("eks-a-e2e-tests"))
+	reader := newFileReader()
 	b, err := releases.ReadBundlesForRelease(reader, release)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Description of changes
This should fix the "eks-a-unknown" user-agent in requests for the release and bundles manifests.

There is still cleanup due in the e2e framework where too many readers are instantiated. The cluster.Spec also does too many things, we should remove the read/load functionality it has and make it a pure data struct. However, that would blow up the scope of this change, so leaving that for other PRs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

