### PR TITLE
adding Tinkerbell watches to legacy cluster controller

### DIFF
--- a/controllers/cluster_controller_legacy.go
+++ b/controllers/cluster_controller_legacy.go
@@ -130,6 +130,8 @@ func (r *ClusterReconcilerLegacy) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &anywherev1.VSphereMachineConfig{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &anywherev1.CloudStackDatacenterConfig{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &anywherev1.CloudStackMachineConfig{}}, &handler.EnqueueRequestForObject{}).
+		Watches(&source.Kind{Type: &anywherev1.TinkerbellDatacenterConfig{}}, &handler.EnqueueRequestForObject{}).
+		Watches(&source.Kind{Type: &anywherev1.TinkerbellMachineConfig{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &anywherev1.DockerDatacenterConfig{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &anywherev1.AWSIamConfig{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &anywherev1.OIDCConfig{}}, &handler.EnqueueRequestForObject{}).


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding Tinkerbell watches to legacy cluster controller for parity

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

