### PR TITLE
Copy the package bundle once

### DIFF
--- a/pkg/curatedpackages/reader.go
+++ b/pkg/curatedpackages/reader.go
@@ -53,7 +53,6 @@ func (r *PackageReader) ReadImagesFromBundles(ctx context.Context, b *releasev1.
 			logger.Info("Warning: Failed getting bundle reference", "error", err)
 			continue
 		}
-		images = append(images, releasev1.Image{URI: bundleURI})
 		packageImages := r.fetchImagesFromBundle(bundleURI, bundle)
 		images = append(images, packageImages...)
 	}


### PR DESCRIPTION
We were copying the bundle twice. Once for charts and once for images. This PR removes one of those copies.
