### PR TITLE
Add passing the insecure flag to packages

### DIFF
--- a/pkg/curatedpackages/config/secrets.yaml
+++ b/pkg/curatedpackages/config/secrets.yaml
@@ -3,6 +3,7 @@ registryMirrorSecret:
   username: "{{.mirrorUsername}}"
   password: "{{.mirrorPassword}}"
   cacertcontent: "{{.mirrorCACertContent}}"
+  insecure: "{{.insecureSkipVerify}}"
 awsSecret:
   id: "{{.eksaAccessKeyId}}"
   secret: "{{.eksaSecretAccessKey}}"

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -168,7 +168,7 @@ func (pc *PackageControllerClient) CreateHelmOverrideValuesYaml() (string, []byt
 
 func (pc *PackageControllerClient) generateHelmOverrideValues() ([]byte, error) {
 	var err error
-	endpoint, username, password, caCertContent := "", "", "", ""
+	endpoint, username, password, caCertContent, insecureSkipVerify := "", "", "", "", "false"
 	if pc.registryMirror != nil {
 		endpoint = pc.registryMirror.BaseRegistry
 		username, password, err = config.ReadCredentials()
@@ -176,6 +176,9 @@ func (pc *PackageControllerClient) generateHelmOverrideValues() ([]byte, error) 
 			return []byte{}, err
 		}
 		caCertContent = pc.registryMirror.CACertContent
+		if pc.registryMirror.InsecureSkipVerify {
+			insecureSkipVerify = "true"
+		}
 	}
 	templateValues := map[string]interface{}{
 		"eksaAccessKeyId":     base64.StdEncoding.EncodeToString([]byte(pc.eksaAccessKeyID)),
@@ -185,6 +188,7 @@ func (pc *PackageControllerClient) generateHelmOverrideValues() ([]byte, error) 
 		"mirrorUsername":      base64.StdEncoding.EncodeToString([]byte(username)),
 		"mirrorPassword":      base64.StdEncoding.EncodeToString([]byte(password)),
 		"mirrorCACertContent": base64.StdEncoding.EncodeToString([]byte(caCertContent)),
+		"insecureSkipVerify":  base64.StdEncoding.EncodeToString([]byte(insecureSkipVerify)),
 	}
 	result, err := templater.Execute(secretsValueYaml, templateValues)
 	if err != nil {

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -72,8 +72,19 @@ func newPackageControllerTests(t *testing.T) []*packageControllerTest {
 			constants.DefaultCoreEKSARegistry:             "1.2.3.4:443/public",
 			constants.DefaultCuratedPackagesRegistryRegex: "1.2.3.4:443/private",
 		},
-		Auth:          true,
-		CACertContent: "-----BEGIN CERTIFICATE-----\nabc\nefg\n-----END CERTIFICATE-----\n",
+		Auth:               true,
+		CACertContent:      "-----BEGIN CERTIFICATE-----\nabc\nefg\n-----END CERTIFICATE-----\n",
+		InsecureSkipVerify: false,
+	}
+	registryMirrorInsecure := &registrymirror.RegistryMirror{
+		BaseRegistry: "1.2.3.4:8443",
+		NamespacedRegistryMap: map[string]string{
+			constants.DefaultCoreEKSARegistry:             "1.2.3.4:443/public",
+			constants.DefaultCuratedPackagesRegistryRegex: "1.2.3.4:443/private",
+		},
+		Auth:               true,
+		CACertContent:      "-----BEGIN CERTIFICATE-----\nabc\nefg\n-----END CERTIFICATE-----\n",
+		InsecureSkipVerify: true,
 	}
 	writer, _ := filewriter.NewWriter(clusterName)
 	return []*packageControllerTest{
@@ -136,7 +147,7 @@ func newPackageControllerTests(t *testing.T) []*packageControllerTest {
 			kubectl:        k,
 			chartInstaller: ci,
 			command: curatedpackages.NewPackageControllerClient(
-				ci, k, clusterName, kubeConfig, chart, registryMirror,
+				ci, k, clusterName, kubeConfig, chart, registryMirrorInsecure,
 				curatedpackages.WithManagementClusterName(clusterName),
 				curatedpackages.WithValuesFileWriter(writer),
 			),
@@ -149,7 +160,7 @@ func newPackageControllerTests(t *testing.T) []*packageControllerTest {
 			httpProxy:      "1.1.1.1",
 			httpsProxy:     "1.1.1.1",
 			noProxy:        []string{"1.1.1.1/24"},
-			registryMirror: registryMirror,
+			registryMirror: registryMirrorInsecure,
 			writer:         writer,
 			wantValueFile:  "testdata/values_empty_awssecret.yaml",
 		},

--- a/pkg/curatedpackages/testdata/values_empty.yaml
+++ b/pkg/curatedpackages/testdata/values_empty.yaml
@@ -3,6 +3,7 @@ registryMirrorSecret:
   username: ""
   password: ""
   cacertcontent: ""
+  insecure: "ZmFsc2U="
 awsSecret:
   id: ""
   secret: ""

--- a/pkg/curatedpackages/testdata/values_empty_awssecret.yaml
+++ b/pkg/curatedpackages/testdata/values_empty_awssecret.yaml
@@ -3,6 +3,7 @@ registryMirrorSecret:
   username: "dXNlcm5hbWU="
   password: "cGFzc3dvcmQ="
   cacertcontent: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCmFiYwplZmcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+  insecure: "ZmFsc2U="
 awsSecret:
   id: ""
   secret: ""

--- a/pkg/curatedpackages/testdata/values_empty_awssecret.yaml
+++ b/pkg/curatedpackages/testdata/values_empty_awssecret.yaml
@@ -1,9 +1,9 @@
 registryMirrorSecret:
-  endpoint: "MS4yLjMuNDo0NDM="
+  endpoint: "MS4yLjMuNDo4NDQz"
   username: "dXNlcm5hbWU="
   password: "cGFzc3dvcmQ="
   cacertcontent: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCmFiYwplZmcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
-  insecure: "ZmFsc2U="
+  insecure: "dHJ1ZQ=="
 awsSecret:
   id: ""
   secret: ""

--- a/pkg/curatedpackages/testdata/values_empty_registrymirrorsecret.yaml
+++ b/pkg/curatedpackages/testdata/values_empty_registrymirrorsecret.yaml
@@ -3,6 +3,7 @@ registryMirrorSecret:
   username: ""
   password: ""
   cacertcontent: ""
+  insecure: "ZmFsc2U="
 awsSecret:
   id: "dGVzdC1hY2Nlc3MtaWQ="
   secret: "dGVzdC1hY2Nlc3Mta2V5"

--- a/pkg/curatedpackages/testdata/values_test.yaml
+++ b/pkg/curatedpackages/testdata/values_test.yaml
@@ -3,6 +3,7 @@ registryMirrorSecret:
   username: "dXNlcm5hbWU="
   password: "cGFzc3dvcmQ="
   cacertcontent: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCmFiYwplZmcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+  insecure: "ZmFsc2U="
 awsSecret:
   id: "dGVzdC1hY2Nlc3MtaWQ="
   secret: "dGVzdC1hY2Nlc3Mta2V5"


### PR DESCRIPTION
The cluster spec has `insecureSkipVerify`, but we were not passing that to packages

