### PR TITLE
adding external etcd unsupported for Tinkerbell check

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -187,7 +187,7 @@ func NewCluster(clusterName string) *Cluster {
 var clusterConfigValidations = []func(*Cluster) error{
 	validateClusterConfigName,
 	validateControlPlaneEndpoint,
-	validateUnsupportedFeatures,
+	validateExternalEtcdSupport,
 	validateMachineGroupRefs,
 	validateControlPlaneReplicas,
 	validateWorkerNodeGroups,
@@ -364,7 +364,7 @@ func validateClusterConfigName(clusterConfig *Cluster) error {
 	return nil
 }
 
-func validateUnsupportedFeatures(cluster *Cluster) error {
+func validateExternalEtcdSupport(cluster *Cluster) error {
 	if cluster.Spec.DatacenterRef.Kind == TinkerbellDatacenterKind {
 		if cluster.Spec.ExternalEtcdConfiguration != nil {
 			return errors.New("tinkerbell external etcd configuration is unsupported")

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -187,6 +187,7 @@ func NewCluster(clusterName string) *Cluster {
 var clusterConfigValidations = []func(*Cluster) error{
 	validateClusterConfigName,
 	validateControlPlaneEndpoint,
+	validateUnsupportedFeatures,
 	validateMachineGroupRefs,
 	validateControlPlaneReplicas,
 	validateWorkerNodeGroups,
@@ -360,6 +361,16 @@ func validateClusterConfigName(clusterConfig *Cluster) error {
 	if err != nil {
 		return fmt.Errorf("failed to validate cluster config name: %v", err)
 	}
+	return nil
+}
+
+func validateUnsupportedFeatures(cluster *Cluster) error {
+	if cluster.Spec.DatacenterRef.Kind == TinkerbellDatacenterKind {
+		if cluster.Spec.ExternalEtcdConfiguration != nil {
+			return errors.New("tinkerbell external etcd configuration is unsupported")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -131,7 +131,7 @@ func TestValidateExternalEtcdSupport(t *testing.T) {
 		t.Run(tc.name, func(tt *testing.T) {
 			got := validateExternalEtcdSupport(tc.wantCluster)
 			if tc.wantErr {
-				g.Expect(got).To(MatchError(ContainSubstring("unsupported")))
+				g.Expect(got).To(MatchError(ContainSubstring("external etcd configuration is unsupported")))
 			} else {
 				g.Expect(got).To(Succeed())
 			}

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -93,26 +93,14 @@ func TestClusterNameLength(t *testing.T) {
 	}
 }
 
-func TestUnsupportedFeatures(t *testing.T) {
+func TestValidateExternalEtcdSupport(t *testing.T) {
 	tests := []struct {
 		name        string
 		wantCluster *Cluster
 		wantErr     error
 	}{
 		{
-			name: "SuccessTinkerbellDatacenter",
-			wantCluster: &Cluster{
-				Spec: ClusterSpec{
-					DatacenterRef: Ref{
-						Kind: TinkerbellDatacenterKind,
-						Name: "eksa-unit-test",
-					},
-				},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "FailureTinkerbellExternalEtcd",
+			name: "tinkerbell config with external etcd",
 			wantCluster: &Cluster{
 				Spec: ClusterSpec{
 					ExternalEtcdConfiguration: &ExternalEtcdConfiguration{Count: 1},
@@ -128,10 +116,9 @@ func TestUnsupportedFeatures(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(tt *testing.T) {
-			got := validateUnsupportedFeatures(tc.wantCluster)
-			if !reflect.DeepEqual(tc.wantErr, got) {
-				t.Errorf("%v got = %v, want %v", tc.name, got, tc.wantErr)
-			}
+			g := NewWithT(t)
+			got := validateExternalEtcdSupport(tc.wantCluster)
+			g.Expect(got).To(MatchError(tc.wantErr))
 		})
 	}
 }

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -93,6 +93,49 @@ func TestClusterNameLength(t *testing.T) {
 	}
 }
 
+func TestUnsupportedFeatures(t *testing.T) {
+	tests := []struct {
+		name        string
+		wantCluster *Cluster
+		wantErr     error
+	}{
+		{
+			name: "SuccessTinkerbellDatacenter",
+			wantCluster: &Cluster{
+				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: TinkerbellDatacenterKind,
+						Name: "eksa-unit-test",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "FailureTinkerbellExternalEtcd",
+			wantCluster: &Cluster{
+				Spec: ClusterSpec{
+					ExternalEtcdConfiguration: &ExternalEtcdConfiguration{Count: 1},
+					DatacenterRef: Ref{
+						Kind: TinkerbellDatacenterKind,
+						Name: "eksa-unit-test",
+					},
+				},
+			},
+			wantErr: errors.New("tinkerbell external etcd configuration is unsupported"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(tt *testing.T) {
+			got := validateUnsupportedFeatures(tc.wantCluster)
+			if !reflect.DeepEqual(tc.wantErr, got) {
+				t.Errorf("%v got = %v, want %v", tc.name, got, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestGetAndValidateClusterConfig(t *testing.T) {
 	tests := []struct {
 		testName    string


### PR DESCRIPTION
*Issue #, if available:*
1033

*Description of changes:*
Tinkerbell external etcd is currently unsupported. Added a validation to prevent this configuration.

*Testing (if applicable):*
Added tests to cluster validations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

