### PR TITLE
Update preKubeadmCommands for Nutanix

### DIFF
--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -158,9 +158,10 @@ spec:
         sshAuthorizedKeys:
           - "{{.controlPlaneSshAuthorizedKey}}"
     preKubeadmCommands:
+      - hostnamectl set-hostname "{{`{{ ds.meta_data.hostname }}`}}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   $(hostname)" >> /etc/hosts
+      - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >> /etc/hosts
       # This section should be removed once these packages are added to the image builder process
       - apt update
       - apt install -y nfs-common open-iscsi

--- a/pkg/providers/nutanix/config/md-template.yaml
+++ b/pkg/providers/nutanix/config/md-template.yaml
@@ -78,6 +78,8 @@ metadata:
 spec:
   template:
     spec:
+      preKubeadmCommands:
+        - hostnamectl set-hostname "{{`{{ ds.meta_data.hostname }}`}}"
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:

--- a/pkg/providers/nutanix/template_test.go
+++ b/pkg/providers/nutanix/template_test.go
@@ -144,5 +144,5 @@ func TestNutanixTemplateBuilderGenerateCAPISpecForCreateWithAutoscalingConfigura
 	assert.NoError(t, err)
 	expectedWorkerSpec, err := os.ReadFile("testdata/expected_results_autoscaling_md.yaml")
 	require.NoError(t, err)
-	assert.Equal(t, workerSpec, expectedWorkerSpec)
+	assert.Equal(t, string(workerSpec), string(expectedWorkerSpec))
 }

--- a/pkg/providers/nutanix/testdata/expected_results_autoscaling_md.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_autoscaling_md.yaml
@@ -62,6 +62,8 @@ metadata:
 spec:
   template:
     spec:
+      preKubeadmCommands:
+        - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:


### PR DESCRIPTION
Use VM Guest Customization Metadata to set the hostname on Nutanix.
This aligns the templates with what CAPX is expecting in v1.1.1.

**How has this been tested?**
* Modified the bundle-release.yaml by substituting CAPX entries to get latest CAPX version
```yaml
nutanix:
      clusterAPIController:
        arch:
          - amd64
          - arm64
        description: Container image for cluster-api-provider-nutanix image
        imageDigest: sha256:708c4e1a2049f37c8840b5516dca6fc4d96a7b073ab5ea1fd80b4430c7d03b1f
        name: cluster-api-provider-nutanix
        os: linux
        uri: ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:v1.1.1
      clusterTemplate:
        uri: https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/releases/download/v1.1.1/cluster-template.yaml
      components:
        uri: https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/releases/download/v1.1.1/infrastructure-components.yaml
      kubeVip:
        arch:
          - amd64
          - arm64
        description: Container image for kube-vip image
        imageDigest: sha256:48e9c1e6e1ae5a943cccf6def867c67f1b576fc191f4ac757cd007f345b0f4d0
        name: kube-vip
        os: linux
        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.4452
      metadata:
        uri: https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/releases/download/v1.1.1/metadata.yaml
      version: v1.1.0+bd2ef19
```
* Built a binary with `BUNDLE_MANIFEST_URL=./bundle-release.yaml make eks-a`
* Created a cluster successfully with `bin/eksctl-anywhere create cluster -f ./${CLUSTER_NAME}.yaml --bundles-override ./bundle-release.yaml` 