### PR TITLE
Update EKS-A release SNS message to include node image URIs

### DIFF
--- a/release/scripts/announce_eksa_release.sh
+++ b/release/scripts/announce_eksa_release.sh
@@ -28,10 +28,50 @@ EKSA_RELEASE_MANIFEST_URL="${EKSA_RELEASE_CDN}/releases/eks-a/manifest.yaml"
 LATEST_EKSA_VERSION=$(curl $EKSA_RELEASE_MANIFEST_URL | yq e '.spec.latestVersion')
 LATEST_EKSA_RELEASE_NUMBER=$(curl $EKSA_RELEASE_MANIFEST_URL | yq e '.spec.releases[] | select(.version == '\"$LATEST_EKSA_VERSION\"') | .number')
 LATEST_BUNDLE_RELEASE_MANIFEST_URI=$(curl $EKSA_RELEASE_MANIFEST_URL | yq e '.spec.releases[] | select(.version == '\"$LATEST_EKSA_VERSION\"') | .bundleManifestUrl')
-LATEST_EKSA_ADMIN_AMI_URI="$EKSA_RELEASE_CDN/releases/eks-a/$LATEST_EKSA_RELEASE_NUMBER/artifacts/eks-a-admin-ami/$LATEST_EKSA_VERSION/eks-anywhere-admin-ami-$LATEST_EKSA_VERSION-eks-a-$LATEST_EKSA_RELEASE_NUMBER.raw"
+LATEST_EKSA_ADMIN_IMAGE_URI="$EKSA_RELEASE_CDN/releases/eks-a/$LATEST_EKSA_RELEASE_NUMBER/artifacts/eks-a-admin-ami/$LATEST_EKSA_VERSION/eks-anywhere-admin-ami-$LATEST_EKSA_VERSION-eks-a-$LATEST_EKSA_RELEASE_NUMBER.raw"
 
 NOTIFICATION_SUBJECT="New release of EKS Anywhere - version $LATEST_EKSA_VERSION"
-NOTIFICATION_BODY="Amazon EKS Anywhere version $LATEST_EKSA_VERSION has been released. You can get the latest EKS-A CLI tarballs from GitHub releases. The bundle release manifest corresponding to this version of EKS-A is $LATEST_BUNDLE_RELEASE_MANIFEST_URI. This release includes a new build of the EKS-A Admin AMI image which is available at $LATEST_EKSA_ADMIN_AMI_URI"
+
+SNOW_NODE_IMAGES_JSON_ARRAY='[]'
+readarray bundles < <(curl $LATEST_BUNDLE_RELEASE_MANIFEST_URI | yq e -o=j -I=0 ".spec.versionsBundles[]" -)
+for bundle in "${bundles[@]}"; do
+  short_kube_version=$(echo $bundle | yq ".kubeVersion" -)
+  full_kube_version=$(echo $bundle | yq ".eksD.kubeVersion" -)
+  eksd_release_name=$(echo $bundle | yq ".eksD.name" -)
+  node_image_os=$(echo $bundle | yq ".eksD.raw.bottlerocket.os" -)
+  node_image_os_name=$(echo $bundle | yq ".eksD.raw.bottlerocket.osName" -)
+  node_image_uri=$(echo $bundle | yq ".eksD.raw.bottlerocket.uri" -)
+  node_image_sha256=$(echo $bundle | yq ".eksD.raw.bottlerocket.sha256" -)
+  node_image_sha512=$(echo $bundle | yq ".eksD.raw.bottlerocket.sha512" -)
+  if [[ "$node_image_uri" != "null" ]]; then
+    node_image_entry=$(jq -n \
+      --arg short_kube_version $short_kube_version \
+      --arg full_kube_version $full_kube_version \
+      --arg eksd_release_name $eksd_release_name \
+      --arg node_image_os $node_image_os \
+      --arg node_image_os_name $node_image_os_name \
+      --arg node_image_uri $node_image_uri \
+      --arg node_image_sha256 $node_image_sha256 \
+      --arg node_image_sha512 $node_image_sha512 \
+      '{"kubeChannel": $short_kube_version, "kubeVersion": $full_kube_version, "eksdReleaseName": $eksd_release_name, "bottlerocket": {"uri": $node_image_uri, "os": $node_image_os, "osName": $node_image_os_name, "sha256": $node_image_sha256, "sha512": $node_image_sha256}}'
+    )
+    SNOW_NODE_IMAGES_JSON_ARRAY=$(echo $SNOW_NODE_IMAGES_JSON_ARRAY | jq --argjson node_image_entry "$node_image_entry" '. += [$node_image_entry]')
+  fi
+done
+
+EKSA_ADMIN_IMAGE_JSON_OBJECT=$(jq -n \
+  --arg admin_image_uri $LATEST_EKSA_ADMIN_IMAGE_URI \
+  --arg admin_image_os "linux" \
+  --arg admin_image_os_name "amazonlinux2" \
+  '{"uri": $admin_image_uri, "os": $admin_image_os, "osName": $admin_image_os_name}'
+)
+
+NOTIFICATION_MESSAGE=$(jq -n \
+  --arg eksa_release_version $LATEST_EKSA_VERSION \
+  --argjson eksa_admin_image "$EKSA_ADMIN_IMAGE_JSON_OBJECT" \
+  --argjson snow_node_images "$SNOW_NODE_IMAGES_JSON_ARRAY" \
+  '{"releaseVersion": $eksa_release_version, "eksaAdminImage": {"amazonlinux2": $eksa_admin_image}, "snowNodeImages": $snow_node_images}'
+)
 
 echo "
 Sending SNS message with the following details:
@@ -52,6 +92,6 @@ if [ "$SNS_MESSAGE_ID" ]; then
   echo -e "\nRelease notification published with SNS MessageId $SNS_MESSAGE_ID"
 else
   echo "Received unexpected response while publishing to release SNS topic. An error may have occurred, and the \
-notification may not have not have been published"
+notification may not have been published"
   exit 1
 fi


### PR DESCRIPTION
Resolves #4681 

This PR modifies the SNS message into JSON format for easier consumption and also adds information pertaining to EKS-A node images, to be consumed downstream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

