### PR TITLE
Add option to override default nodeStartupTimeout in machine health c…

### DIFF
--- a/cmd/eksctl-anywhere/cmd/constants.go
+++ b/cmd/eksctl-anywhere/cmd/constants.go
@@ -7,6 +7,7 @@ const (
 	externalEtcdWaitTimeoutFlag = "external-etcd-wait-timeout"
 	perMachineWaitTimeoutFlag   = "per-machine-wait-timeout"
 	unhealthyMachineTimeoutFlag = "unhealthy-machine-timeout"
+	nodeStartupTimeoutFlag      = "node-startup-timeout"
 )
 
 type Operation int

--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -27,6 +27,7 @@ type timeoutOptions struct {
 	externalEtcdWaitTimeout string
 	perMachineWaitTimeout   string
 	unhealthyMachineTimeout string
+	nodeStartupTimeout      string
 }
 
 func applyTimeoutFlags(flagSet *pflag.FlagSet, t *timeoutOptions) {
@@ -41,6 +42,9 @@ func applyTimeoutFlags(flagSet *pflag.FlagSet, t *timeoutOptions) {
 
 	flagSet.StringVar(&t.unhealthyMachineTimeout, unhealthyMachineTimeoutFlag, clustermanager.DefaultUnhealthyMachineTimeout.String(), "Override the default unhealthy machine timeout (5m) ")
 	markFlagHidden(flagSet, unhealthyMachineTimeoutFlag)
+
+	flagSet.StringVar(&t.nodeStartupTimeout, nodeStartupTimeoutFlag, clustermanager.DefaultNodeStartupTimeout.String(), "Override the default node startup timeout (10m) ")
+	markFlagHidden(flagSet, nodeStartupTimeoutFlag)
 }
 
 func buildClusterManagerOpts(t timeoutOptions) ([]clustermanager.ClusterManagerOpt, error) {
@@ -64,11 +68,17 @@ func buildClusterManagerOpts(t timeoutOptions) ([]clustermanager.ClusterManagerO
 		return nil, fmt.Errorf(timeoutErrorTemplate, unhealthyMachineTimeoutFlag, err)
 	}
 
+	nodeStartupTimeout, err := time.ParseDuration(t.nodeStartupTimeout)
+	if err != nil {
+		return nil, fmt.Errorf(timeoutErrorTemplate, nodeStartupTimeoutFlag, err)
+	}
+
 	return []clustermanager.ClusterManagerOpt{
 		clustermanager.WithControlPlaneWaitTimeout(cpWaitTimeout),
 		clustermanager.WithExternalEtcdWaitTimeout(externalEtcdWaitTimeout),
 		clustermanager.WithMachineMaxWait(perMachineWaitTimeout),
 		clustermanager.WithUnhealthyMachineTimeout(unhealthyMachineTimeout),
+		clustermanager.WithNodeStartupTimeout(nodeStartupTimeout),
 	}, nil
 }
 


### PR DESCRIPTION
…heck in create and upgrade commands

*Issue #, if available:*

https://github.com/aws/eks-anywhere/issues/4709

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

