### PR TITLE
Copy package tag charts with versions

### DIFF
--- a/cmd/eksctl-anywhere/cmd/copypackages.go
+++ b/cmd/eksctl-anywhere/cmd/copypackages.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
 	"github.com/aws/eks-anywhere/pkg/registry"
-	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 // copyPackagesCmd is the context for the copy packages command.
@@ -111,14 +110,14 @@ func (c CopyPackagesCommand) call(ctx context.Context, credentialStore *registry
 	return c.copyImages(ctx, dstRegistry, credentialStore, imageList)
 }
 
-func (c CopyPackagesCommand) copyImages(ctx context.Context, dstRegistry registry.StorageClient, credentialStore *registry.CredentialStore, imageList []releasev1.Image) error {
+func (c CopyPackagesCommand) copyImages(ctx context.Context, dstRegistry registry.StorageClient, credentialStore *registry.CredentialStore, imageList []registry.Artifact) error {
 	certificates, err := registry.GetCertificates(c.srcCert)
 	if err != nil {
 		return err
 	}
 
 	for _, image := range imageList {
-		host := image.Registry()
+		host := image.Registry
 
 		srcContext := registry.NewStorageContext(host, credentialStore, certificates, c.insecure)
 		srcRegistry, err := c.registryCache.Get(srcContext)
@@ -126,7 +125,7 @@ func (c CopyPackagesCommand) copyImages(ctx context.Context, dstRegistry registr
 			return fmt.Errorf("error with repository %s: %v", host, err)
 		}
 
-		artifact := registry.NewArtifact(image.Registry(), image.Repository(), image.Version(), image.Digest())
+		artifact := registry.NewArtifact(image.Registry, image.Repository, image.Tag, image.Digest)
 		log.Println(dstRegistry.Destination(artifact))
 		if c.dryRun {
 			continue

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -107,8 +107,11 @@ func (or *OCIRegistryClient) FetchBlob(ctx context.Context, srcStorage orasregis
 }
 
 // CopyGraph copy manifest and all blobs to destination.
-func (or *OCIRegistryClient) CopyGraph(ctx context.Context, srcStorage orasregistry.Repository, srcRef string, dstStorage orasregistry.Repository, dstRef string) error {
-	copyOptions := oras.CopyOptions{}
-	_, err := oras.Copy(ctx, srcStorage, srcRef, dstStorage, dstRef, copyOptions)
-	return err
+func (or *OCIRegistryClient) CopyGraph(ctx context.Context, srcStorage orasregistry.Repository, srcRef string, dstStorage orasregistry.Repository, dstRef string) (ocispec.Descriptor, error) {
+	return oras.Copy(ctx, srcStorage, srcRef, dstStorage, dstRef, oras.CopyOptions{})
+}
+
+// Tag an image.
+func (or *OCIRegistryClient) Tag(ctx context.Context, dstStorage orasregistry.Repository, desc ocispec.Descriptor, tag string) error {
+	return dstStorage.Tag(ctx, desc, tag)
 }

--- a/pkg/registry/copy.go
+++ b/pkg/registry/copy.go
@@ -17,10 +17,16 @@ func Copy(ctx context.Context, srcClient StorageClient, dstClient StorageClient,
 		return fmt.Errorf("repository destination: %v", err)
 	}
 
-	err = srcClient.CopyGraph(ctx, srcStorage, image.VersionedImage(), dstStorage, dstClient.Destination(image))
+	desc, err := srcClient.CopyGraph(ctx, srcStorage, image.VersionedImage(), dstStorage, dstClient.Destination(image))
 	if err != nil {
 		return fmt.Errorf("registry copy: %v", err)
 	}
 
+	if len(image.Tag) > 0 {
+		err = dstClient.Tag(ctx, dstStorage, desc, image.Tag)
+		if err != nil {
+			return fmt.Errorf("image tag: %v", err)
+		}
+	}
 	return nil
 }

--- a/pkg/registry/copy_test.go
+++ b/pkg/registry/copy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/eks-anywhere/pkg/registry"
@@ -18,6 +19,12 @@ var srcArtifact = registry.Artifact{
 	Digest:     "sha256:6efe21500abbfbb6b3e37b80dd5dea0b11a0d1b145e84298fee5d7784a77e967",
 }
 
+var expectedSrcRef = srcArtifact.VersionedImage()
+
+var desc = ocispec.Descriptor{
+	URLs: []string{expectedSrcRef},
+}
+
 func TestCopy(t *testing.T) {
 	srcClient := mocks.NewMockStorageClient(gomock.NewController(t))
 	dstClient := mocks.NewMockStorageClient(gomock.NewController(t))
@@ -27,9 +34,9 @@ func TestCopy(t *testing.T) {
 
 	srcClient.EXPECT().GetStorage(ctx, srcArtifact).Return(&mockSrcRepo, nil)
 	dstClient.EXPECT().GetStorage(ctx, srcArtifact).Return(&mockDstRepo, nil)
-	dstClient.EXPECT().Destination(srcArtifact).Return(srcArtifact.VersionedImage())
-	expectedSrcRef := srcArtifact.VersionedImage()
-	srcClient.EXPECT().CopyGraph(ctx, &mockSrcRepo, expectedSrcRef, &mockDstRepo, expectedSrcRef).Return(nil)
+	dstClient.EXPECT().Destination(srcArtifact).Return(expectedSrcRef)
+	srcClient.EXPECT().CopyGraph(ctx, &mockSrcRepo, expectedSrcRef, &mockDstRepo, expectedSrcRef).Return(desc, nil)
+	dstClient.EXPECT().Tag(ctx, &mockDstRepo, desc, srcArtifact.Tag).Return(nil)
 
 	err := registry.Copy(ctx, srcClient, dstClient, srcArtifact)
 	assert.NoError(t, err)
@@ -46,7 +53,7 @@ func TestCopyCopyGraphError(t *testing.T) {
 	dstClient.EXPECT().GetStorage(ctx, srcArtifact).Return(&mockDstRepo, nil)
 	dstClient.EXPECT().Destination(srcArtifact).Return(srcArtifact.VersionedImage())
 	expectedSrcRef := srcArtifact.VersionedImage()
-	srcClient.EXPECT().CopyGraph(ctx, &mockSrcRepo, expectedSrcRef, &mockDstRepo, expectedSrcRef).Return(fmt.Errorf("oops"))
+	srcClient.EXPECT().CopyGraph(ctx, &mockSrcRepo, expectedSrcRef, &mockDstRepo, expectedSrcRef).Return(desc, fmt.Errorf("oops"))
 
 	err := registry.Copy(ctx, srcClient, dstClient, srcArtifact)
 	assert.EqualError(t, err, "registry copy: oops")

--- a/pkg/registry/mocks/storage.go
+++ b/pkg/registry/mocks/storage.go
@@ -38,11 +38,12 @@ func (m *MockStorageClient) EXPECT() *MockStorageClientMockRecorder {
 }
 
 // CopyGraph mocks base method.
-func (m *MockStorageClient) CopyGraph(ctx context.Context, srcStorage registry0.Repository, srcRef string, dstStorage registry0.Repository, dstRef string) error {
+func (m *MockStorageClient) CopyGraph(ctx context.Context, srcStorage registry0.Repository, srcRef string, dstStorage registry0.Repository, dstRef string) (v1.Descriptor, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyGraph", ctx, srcStorage, srcRef, dstStorage, dstRef)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(v1.Descriptor)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CopyGraph indicates an expected call of CopyGraph.
@@ -150,4 +151,18 @@ func (m *MockStorageClient) SetProject(project string) {
 func (mr *MockStorageClientMockRecorder) SetProject(project interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProject", reflect.TypeOf((*MockStorageClient)(nil).SetProject), project)
+}
+
+// Tag mocks base method.
+func (m *MockStorageClient) Tag(ctx context.Context, dstStorage registry0.Repository, desc v1.Descriptor, tag string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Tag", ctx, dstStorage, desc, tag)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Tag indicates an expected call of Tag.
+func (mr *MockStorageClientMockRecorder) Tag(ctx, dstStorage, desc, tag interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockStorageClient)(nil).Tag), ctx, dstStorage, desc, tag)
 }

--- a/pkg/registry/storage.go
+++ b/pkg/registry/storage.go
@@ -36,5 +36,6 @@ type StorageClient interface {
 	Destination(image Artifact) string
 	FetchBytes(ctx context.Context, srcStorage orasregistry.Repository, artifact Artifact) (ocispec.Descriptor, []byte, error)
 	FetchBlob(ctx context.Context, srcStorage orasregistry.Repository, descriptor ocispec.Descriptor) ([]byte, error)
-	CopyGraph(ctx context.Context, srcStorage orasregistry.Repository, srcRef string, dstStorage orasregistry.Repository, dstRef string) error
+	CopyGraph(ctx context.Context, srcStorage orasregistry.Repository, srcRef string, dstStorage orasregistry.Repository, dstRef string) (ocispec.Descriptor, error)
+	Tag(ctx context.Context, dstStorage orasregistry.Repository, desc ocispec.Descriptor, tag string) error
 }


### PR DESCRIPTION
This change tags the helm charts with the versions were are in the package bundle. It seems a lot of work just for that, but we'll want to use this to tag the other images as well once those versions are available.

![Screen Shot 2023-01-23 at 14 56 50](https://user-images.githubusercontent.com/104113/214159025-fa04b5e2-f1eb-40c5-8b6b-368d98b8ca24.png)

