### PR TITLE
Create secrets for workload clusters

### DIFF
--- a/pkg/curatedpackages/config/packagebundlecontroller.yaml
+++ b/pkg/curatedpackages/config/packagebundlecontroller.yaml
@@ -1,9 +1,0 @@
-apiVersion: packages.eks.amazonaws.com/v1alpha1
-kind: PackageBundleController
-metadata:
-  name: {{.clusterName}}
-  namespace: {{.namespace}}
-spec:
-  logLevel: 4
-  defaultRegistry: {{.defaultRegistry}}
-  defaultImageRegistry: {{.defaultImageRegistry}}

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -21,9 +21,6 @@ import (
 //go:embed config/secrets.yaml
 var secretsValueYaml string
 
-//go:embed config/packagebundlecontroller.yaml
-var packageBundleControllerYaml string
-
 const (
 	eksaDefaultRegion = "us-west-2"
 	cronJobName       = "cronjob/cron-ecr-renew"
@@ -83,16 +80,9 @@ func NewPackageControllerClient(chartInstaller ChartInstaller, kubectl KubectlRu
 // In case the cluster is a workload cluster, it performs the following actions:
 //   - Creation of package bundle controller (PBC) custom resource in management cluster
 func (pc *PackageControllerClient) EnableCuratedPackages(ctx context.Context) error {
-	sourceRegistry, defaultRegistry, defaultImageRegistry := pc.GetCuratedPackagesRegistries()
-	// When the management cluster name and current cluster name are different,
-	// it indicates that we are trying to install the controller on a workload cluster.
-	// Instead of installing the controller, install packagebundlecontroller resource.
-	if pc.managementClusterName != pc.clusterName {
-		return pc.InstallPBCResources(ctx, defaultRegistry, defaultImageRegistry)
-	}
-
 	ociURI := fmt.Sprintf("%s%s", "oci://", pc.registryMirror.ReplaceRegistry(pc.chart.Image()))
 	clusterName := fmt.Sprintf("clusterName=%s", pc.clusterName)
+	sourceRegistry, defaultRegistry, defaultImageRegistry := pc.GetCuratedPackagesRegistries()
 	sourceRegistry = fmt.Sprintf("sourceRegistry=%s", sourceRegistry)
 	defaultRegistry = fmt.Sprintf("defaultRegistry=%s", defaultRegistry)
 	defaultImageRegistry = fmt.Sprintf("defaultImageRegistry=%s", defaultImageRegistry)
@@ -109,6 +99,9 @@ func (pc *PackageControllerClient) EnableCuratedPackages(ctx context.Context) er
 	}
 	if (pc.eksaSecretAccessKey == "" || pc.eksaAccessKeyID == "") && pc.registryMirror == nil {
 		values = append(values, "cronjob.suspend=true")
+	}
+	if pc.managementClusterName != pc.clusterName {
+		values = append(values, "workloadOnly=true")
 	}
 
 	var err error
@@ -191,32 +184,6 @@ func (pc *PackageControllerClient) generateHelmOverrideValues() ([]byte, error) 
 		return []byte{}, err
 	}
 	return result, nil
-}
-
-// InstallPBCResources installs Curated Packages Bundle Controller Custom Resource
-// This method is used only for Workload clusters
-// Please refer to this documentation: https://github.com/aws/eks-anywhere-packages/blob/main/docs/design/remote-management.md
-func (pc *PackageControllerClient) InstallPBCResources(ctx context.Context, defaultRegistry, defaultImageRegistry string) error {
-	templateValues := map[string]string{
-		"clusterName":          pc.clusterName,
-		"namespace":            constants.EksaPackagesName,
-		"defaultRegistry":      defaultRegistry,
-		"defaultImageRegistry": defaultImageRegistry,
-	}
-
-	result, err := templater.Execute(packageBundleControllerYaml, templateValues)
-	if err != nil {
-		return fmt.Errorf("replacing template values %v", err)
-	}
-
-	params := []string{"create", "-f", "-", "--kubeconfig", pc.kubeConfig}
-	stdOut, err := pc.kubectl.ExecuteFromYaml(ctx, result, params...)
-	if err != nil {
-		return fmt.Errorf("creating package bundle controller custom resource%v", err)
-	}
-
-	fmt.Print(&stdOut)
-	return nil
 }
 
 // packageBundleControllerResource is the name of the package bundle controller

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -100,9 +100,6 @@ func (pc *PackageControllerClient) EnableCuratedPackages(ctx context.Context) er
 	if (pc.eksaSecretAccessKey == "" || pc.eksaAccessKeyID == "") && pc.registryMirror == nil {
 		values = append(values, "cronjob.suspend=true")
 	}
-	if pc.managementClusterName != pc.clusterName {
-		values = append(values, "workloadOnly=true")
-	}
 
 	var err error
 	var valueFilePath string
@@ -110,7 +107,13 @@ func (pc *PackageControllerClient) EnableCuratedPackages(ctx context.Context) er
 		return err
 	}
 
-	if err := pc.chartInstaller.InstallChart(ctx, pc.chart.Name, ociURI, pc.chart.Tag(), pc.kubeConfig, "", valueFilePath, values); err != nil {
+	chartName := pc.chart.Name
+	if pc.managementClusterName != pc.clusterName {
+		values = append(values, "workloadOnly=true")
+		chartName = chartName + "-" + pc.clusterName
+	}
+
+	if err := pc.chartInstaller.InstallChart(ctx, chartName, ociURI, pc.chart.Tag(), pc.kubeConfig, "", valueFilePath, values); err != nil {
 		return err
 	}
 

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -231,7 +231,7 @@ func TestEnableCuratedPackagesSucceedInWorkloadCluster(t *testing.T) {
 			values = append(values, "cronjob.suspend=true")
 		}
 		values = append(values, "workloadOnly=true")
-		tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chart.Name, ociURI, tt.chart.Tag(), tt.kubeConfig, "", valueFilePath, values).Return(nil)
+		tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chart.Name+"-billy", ociURI, tt.chart.Tag(), tt.kubeConfig, "", valueFilePath, values).Return(nil)
 		any := gomock.Any()
 		tt.kubectl.EXPECT().
 			GetObject(any, any, any, any, any, any).
@@ -421,7 +421,6 @@ func TestEnableCuratedPackagesFailNoActiveBundle(t *testing.T) {
 		}
 	}
 }
-
 
 func TestEnableCuratedPackagesSuccessWhenCronJobFails(t *testing.T) {
 	for _, tt := range newPackageControllerTests(t) {

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -1,7 +1,6 @@
 package curatedpackages_test
 
 import (
-	"bytes"
 	"context"
 	_ "embed"
 	"errors"
@@ -25,12 +24,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/registrymirror"
 	artifactsv1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
-
-//go:embed testdata/packagebundlectrl_test.yaml
-var packageBundleControllerTest string
-
-//go:embed testdata/packagebundlectrl_registrymirror.yaml
-var packageBundleControllerTestWithMirror string
 
 const valueFileName = "values.yaml"
 
@@ -216,16 +209,34 @@ func TestEnableCuratedPackagesSucceedInWorkloadCluster(t *testing.T) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartInstaller, tt.kubectl, tt.clusterName, tt.kubeConfig, tt.chart,
 			tt.registryMirror,
-			curatedpackages.WithManagementClusterName("mgmt"),
+			curatedpackages.WithEksaSecretAccessKey(tt.eksaAccessKey),
 			curatedpackages.WithEksaRegion("us-west-2"),
+			curatedpackages.WithEksaAccessKeyId(tt.eksaAccessID),
+			curatedpackages.WithManagementClusterName("mgmt"),
+			curatedpackages.WithValuesFileWriter(tt.writer),
 		)
-
-		params := []string{"create", "-f", "-", "--kubeconfig", tt.kubeConfig}
+		clusterName := fmt.Sprintf("clusterName=%s", "billy")
+		valueFilePath := filepath.Join("billy", filewriter.DefaultTmpFolder, valueFileName)
+		ociURI := fmt.Sprintf("%s%s", "oci://", tt.registryMirror.ReplaceRegistry(tt.chart.Image()))
+		sourceRegistry, defaultRegistry, defaultImageRegistry := tt.command.GetCuratedPackagesRegistries()
+		sourceRegistry = fmt.Sprintf("sourceRegistry=%s", sourceRegistry)
+		defaultRegistry = fmt.Sprintf("defaultRegistry=%s", defaultRegistry)
+		defaultImageRegistry = fmt.Sprintf("defaultImageRegistry=%s", defaultImageRegistry)
 		if tt.registryMirror != nil {
-			tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, []byte(packageBundleControllerTestWithMirror), params).Return(bytes.Buffer{}, nil)
-		} else {
-			tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, []byte(packageBundleControllerTest), params).Return(bytes.Buffer{}, nil)
+			t.Setenv("REGISTRY_USERNAME", "username")
+			t.Setenv("REGISTRY_PASSWORD", "password")
 		}
+		values := []string{sourceRegistry, defaultRegistry, defaultImageRegistry, clusterName}
+		if (tt.eksaAccessID == "" || tt.eksaAccessKey == "") && tt.registryMirror == nil {
+			values = append(values, "cronjob.suspend=true")
+		}
+		values = append(values, "workloadOnly=true")
+		tt.chartInstaller.EXPECT().InstallChart(tt.ctx, tt.chart.Name, ociURI, tt.chart.Tag(), tt.kubeConfig, "", valueFilePath, values).Return(nil)
+		any := gomock.Any()
+		tt.kubectl.EXPECT().
+			GetObject(any, any, any, any, any, any).
+			DoAndReturn(getPBCSuccess(t)).
+			AnyTimes()
 
 		err := tt.command.EnableCuratedPackages(tt.ctx)
 		tt.Expect(err).To(BeNil())
@@ -411,59 +422,6 @@ func TestEnableCuratedPackagesFailNoActiveBundle(t *testing.T) {
 	}
 }
 
-func TestPbcCreationSuccess(t *testing.T) {
-	for _, tt := range newPackageControllerTests(t) {
-		tt.eksaRegion = "us-west-2"
-		tt.command = curatedpackages.NewPackageControllerClient(
-			tt.chartInstaller, tt.kubectl, "billy", tt.kubeConfig, tt.chart,
-			tt.registryMirror,
-			curatedpackages.WithEksaSecretAccessKey(tt.eksaAccessKey),
-			curatedpackages.WithEksaRegion(tt.eksaRegion),
-			curatedpackages.WithEksaAccessKeyId(tt.eksaAccessID),
-			curatedpackages.WithManagementClusterName(tt.clusterName),
-			curatedpackages.WithValuesFileWriter(tt.writer),
-		)
-
-		_, defaultRegistry, defaultImageRegistry := tt.command.GetCuratedPackagesRegistries()
-		params := []string{"create", "-f", "-", "--kubeconfig", tt.kubeConfig}
-
-		if tt.registryMirror != nil {
-			tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, []byte(packageBundleControllerTestWithMirror), params).Return(bytes.Buffer{}, nil)
-		} else {
-			tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, []byte(packageBundleControllerTest), params).Return(bytes.Buffer{}, nil)
-		}
-
-		err := tt.command.InstallPBCResources(tt.ctx, defaultRegistry, defaultImageRegistry)
-		tt.Expect(err).To(BeNil())
-	}
-}
-
-func TestPbcCreationFail(t *testing.T) {
-	for _, tt := range newPackageControllerTests(t) {
-		tt.eksaRegion = "us-west-2"
-		tt.command = curatedpackages.NewPackageControllerClient(
-			tt.chartInstaller, tt.kubectl, "billy", tt.kubeConfig, tt.chart,
-			tt.registryMirror,
-			curatedpackages.WithEksaSecretAccessKey(tt.eksaAccessKey),
-			curatedpackages.WithEksaRegion(tt.eksaRegion),
-			curatedpackages.WithEksaAccessKeyId(tt.eksaAccessID),
-			curatedpackages.WithManagementClusterName(tt.clusterName),
-			curatedpackages.WithValuesFileWriter(tt.writer),
-		)
-
-		_, defaultRegistry, defaultImageRegistry := tt.command.GetCuratedPackagesRegistries()
-		params := []string{"create", "-f", "-", "--kubeconfig", tt.kubeConfig}
-
-		if tt.registryMirror != nil {
-			tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, []byte(packageBundleControllerTestWithMirror), params).Return(bytes.Buffer{}, errors.New("creating pbc"))
-		} else {
-			tt.kubectl.EXPECT().ExecuteFromYaml(tt.ctx, []byte(packageBundleControllerTest), params).Return(bytes.Buffer{}, errors.New("creating pbc"))
-		}
-
-		err := tt.command.InstallPBCResources(tt.ctx, defaultRegistry, defaultImageRegistry)
-		tt.Expect(err).NotTo(BeNil())
-	}
-}
 
 func TestEnableCuratedPackagesSuccessWhenCronJobFails(t *testing.T) {
 	for _, tt := range newPackageControllerTests(t) {

--- a/pkg/curatedpackages/testdata/packagebundlectrl_registrymirror.yaml
+++ b/pkg/curatedpackages/testdata/packagebundlectrl_registrymirror.yaml
@@ -1,9 +1,0 @@
-apiVersion: packages.eks.amazonaws.com/v1alpha1
-kind: PackageBundleController
-metadata:
-  name: billy
-  namespace: eksa-packages
-spec:
-  logLevel: 4
-  defaultRegistry: 1.2.3.4:443/public/eks-anywhere
-  defaultImageRegistry: 1.2.3.4:443/private

--- a/pkg/curatedpackages/testdata/packagebundlectrl_test.yaml
+++ b/pkg/curatedpackages/testdata/packagebundlectrl_test.yaml
@@ -1,9 +1,0 @@
-apiVersion: packages.eks.amazonaws.com/v1alpha1
-kind: PackageBundleController
-metadata:
-  name: billy
-  namespace: eksa-packages
-spec:
-  logLevel: 4
-  defaultRegistry: public.ecr.aws/eks-anywhere
-  defaultImageRegistry: 783794618700.dkr.ecr.us-west-2.amazonaws.com


### PR DESCRIPTION
Use helm chart to create credential secrets and PackageBundleController for workload clusters

