### PR TITLE
Skip Nutanix 1.25 packages e2e tests

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -31,6 +31,9 @@ skipped_tests:
 - TestNutanixKubernetes122UbuntuWorkerNodeScaleDown5To2
 - TestNutanixKubernetes122UbuntuWorkerNodeScaleUp1To3
 - TestNutanixKubernetes122UbuntuWorkerNodeScaleUp2To5
+- TestNutanixKubernetes125CuratedPackagesClusterAutoscalerUbuntuSimpleFlow
+- TestNutanixKubernetes125CuratedPackagesEmissarySimpleFlow
+- TestNutanixKubernetes125CuratedPackagesSimpleFlow
 # Snow
 - TestSnowKubernetes121UbuntuAWSIamAuth
 - TestSnowKubernetes122To123AWSIamAuthUpgrade


### PR DESCRIPTION
*Description of changes:*
Skip Nutanix 1.25 packages e2e tests until 1.25 packages bundle is available. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

