### PR TITLE
Remove step to ValidateFlux in LatestMinorRelease tests

### DIFF
--- a/test/e2e/upgrade_from_latest.go
+++ b/test/e2e/upgrade_from_latest.go
@@ -30,7 +30,6 @@ func runUpgradeFromReleaseFlow(test *framework.ClusterE2ETest, latestRelease *re
 	test.WaitForControlPlaneReady()
 	test.UpgradeClusterWithNewConfig(clusterOpts)
 	test.ValidateCluster(wantVersion)
-	test.ValidateFlux()
 	test.StopIfFailed()
 	test.DeleteCluster()
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We don't use Gitops in any of LatestMinorRelease tests, so this validation was causing a nil pointer in all of the test runs. Removing this since it is unnecessary

*Testing (if applicable):*
```
--- PASS: TestDockerKubernetes122to123UpgradeFromLatestMinorRelease (1148.88s)
PASS
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

