### PR TITLE
Update calls to CreateManagementClusterWithConfig

### DIFF
--- a/test/e2e/curatedpackages.go
+++ b/test/e2e/curatedpackages.go
@@ -33,7 +33,7 @@ func runCuratedPackageInstallSimpleFlow(test *framework.ClusterE2ETest) {
 }
 
 func runCuratedPackageRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2ETest) {
-	test.CreateManagementCluster()
+	test.CreateManagementClusterWithConfig()
 	test.RunInWorkloadClusters(func(e *framework.WorkloadCluster) {
 		e.GenerateClusterConfig()
 		e.CreateCluster()

--- a/test/e2e/emissary.go
+++ b/test/e2e/emissary.go
@@ -31,7 +31,7 @@ func runCuratedPackageEmissaryInstallSimpleFlow(test *framework.ClusterE2ETest) 
 }
 
 func runCuratedPackageEmissaryRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2ETest) {
-	test.CreateManagementCluster()
+	test.CreateManagementClusterWithConfig()
 	test.RunInWorkloadClusters(func(e *framework.WorkloadCluster) {
 		e.GenerateClusterConfig()
 		e.CreateCluster()

--- a/test/e2e/multicluster.go
+++ b/test/e2e/multicluster.go
@@ -13,7 +13,7 @@ import (
 )
 
 func runWorkloadClusterFlow(test *framework.MulticlusterE2ETest) {
-	test.CreateManagementCluster()
+	test.CreateManagementClusterWithConfig()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
 		w.GenerateClusterConfig()
 		w.CreateCluster()
@@ -24,7 +24,7 @@ func runWorkloadClusterFlow(test *framework.MulticlusterE2ETest) {
 }
 
 func runWorkloadClusterFlowWithGitOps(test *framework.MulticlusterE2ETest, clusterOpts ...framework.ClusterE2ETestOpt) {
-	test.CreateManagementCluster()
+	test.CreateManagementClusterWithConfig()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
 		w.GenerateClusterConfig()
 		w.CreateCluster()


### PR DESCRIPTION
## Description of changes
This adds the cluster config generation prior to the actual CLI call to create the management cluster. This method was renamed and those changes were probably lost with the refactor to split the tests by provider.

This should fix the e2e failures we saw got flux tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

