### PR TITLE
Increase max retries when trying to build cluster validator

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1673,7 +1673,7 @@ func (e *ClusterE2ETest) CombinedAutoScalerMetricServerTest(autoscalerName strin
 func (e *ClusterE2ETest) ValidateClusterState() {
 	e.T.Logf("Validating cluster %s", e.ClusterName)
 	ctx := context.Background()
-	err := retrier.Retry(12, 5*time.Second, func() error {
+	err := retrier.Retry(60, 5*time.Second, func() error {
 		return e.buildClusterValidator(ctx)
 	})
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The API e2e tests seem to be failing to connect to the kubeapi server sometimes when building the cluster validator client. This PR increases the max retries assuming it just needs more time to be ready.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

