### PR TITLE
Add pointer to Nutanix getting started guide

### DIFF
--- a/docs/content/en/docs/reference/nutanix/_index.md
+++ b/docs/content/en/docs/reference/nutanix/_index.md
@@ -5,3 +5,4 @@ weight: 20
 description: >
   Preparing a Nutanix Cloud Infrastructure provider for EKS Anywhere
 ---
+See [Create Nutanix production cluster]({{< relref "../../getting-started/production-environment/nutanix-getstarted.md" >}}) to learn how to set up EKS Anywhere on Nutanix. Documents below describe how to prepare your Nutanix environment.


### PR DESCRIPTION
*Description of changes:* I noticed an EKS Anywhere on Nutanix blog pointing to the Nutanix reference page instead of to the getting started guide. I added a pointer to the getting started guide in case someone lands on that reference page first.



