### PR TITLE
Add rm vms command for Nutanix in eks-a-tool

### DIFF
--- a/cmd/eks-a-tool/cmd/nutanix.go
+++ b/cmd/eks-a-tool/cmd/nutanix.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var nutanixCmd = &cobra.Command{
+	Use:   "nutanix",
+	Short: "Nutanix commands",
+	Long:  "Use eks-a-tool nutanix to run nutanix utilities",
+}
+
+func init() {
+	rootCmd.AddCommand(nutanixCmd)
+}

--- a/cmd/eks-a-tool/cmd/nutanixrm.go
+++ b/cmd/eks-a-tool/cmd/nutanixrm.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var nutanixRmCmd = &cobra.Command{
+	Use:   "rm",
+	Short: "Nutanix rm commands",
+	Long:  "Use eks-a-tool nutanix rm to run nutanix rm utilities",
+}
+
+func init() {
+	nutanixCmd.AddCommand(nutanixRmCmd)
+}

--- a/cmd/eks-a-tool/cmd/nutanixrmvms.go
+++ b/cmd/eks-a-tool/cmd/nutanixrmvms.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/aws/eks-anywhere/internal/test/cleanup"
+	"github.com/aws/eks-anywhere/pkg/validations"
+)
+
+const (
+	endpointFlag     = "endpoint"
+	portFlag         = "port"
+	insecureFlag     = "insecure"
+	ignoreErrorsFlag = "ignoreErrors"
+)
+
+var nutanixRmVmsCmd = &cobra.Command{
+	Use:    "vms <cluster-name>",
+	PreRun: prerunCmdBindFlags,
+	Short:  "Nutanix rmvms command",
+	Long:   "This command removes vms associated with a cluster name",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		clusterName, err := validations.ValidateClusterNameArg(args)
+		if err != nil {
+			return err
+		}
+		insecure := false
+		if viper.IsSet(insecureFlag) {
+			insecure = true
+		}
+		err = cleanup.NutanixTestResourcesCleanup(cmd.Context(), clusterName, viper.GetString(endpointFlag), viper.GetString(portFlag), insecure, viper.GetBool(ignoreErrorsFlag))
+		if err != nil {
+			log.Fatalf("Error removing vms: %v", err)
+		}
+		return nil
+	},
+}
+
+func init() {
+	nutanixRmCmd.AddCommand(nutanixRmVmsCmd)
+
+	nutanixRmVmsCmd.Flags().StringP(endpointFlag, "e", "", "specify Nutanix Prism endpoint (REQUIRED)")
+	nutanixRmVmsCmd.Flags().StringP(portFlag, "p", "9440", "specify Nutanix Prism port (default: 9440)")
+	nutanixRmVmsCmd.Flags().StringP(insecureFlag, "k", "false", "skip TLS when contacting Prism APIs (default: false)")
+	nutanixRmVmsCmd.Flags().String(ignoreErrorsFlag, "true", "ignore APIs errors when deleting VMs (default: true)")
+
+	if err := nutanixRmVmsCmd.MarkFlagRequired(endpointFlag); err != nil {
+		log.Fatalf("Marking flag '%s' as required", endpointFlag)
+	}
+}


### PR DESCRIPTION
*Description of changes:*
Adds `eks-a-tool nutanix rm vms <cluster-name>` command to easily cleanup Nutanix VMs 

*Testing (if applicable):*
```bash
$ make eks-a-tool

$ export EKSA_NUTANIX_USERNAME="..."
$ export EKSA_NUTANIX_PASSWORD="..."

$ ./bin/eks-a-tool nutanix rm vms main --endpoint pc.nutanix.local --insecure true -v 4
2023-01-30T12:03:27.181-0800    V4      Logger init completed   {"vlevel": 4}
2023-01-30T12:03:56.382-0800    V4      Deleting Nutanix VM     {"Name": "main-i-0b1f1-7aedd81-control-plane-template-1674779404886-88x88", "UUID:": "4836cc45-467a-45cc-97f0-f1f05d4c24d9"}
2023-01-30T12:03:56.907-0800    V4      Deleting Nutanix VM     {"Name": "main-i-05c46-a8ce162-control-plane-template-1674779490983-fdgd9", "UUID:": "34e3f7ac-c9a2-4d9a-b80c-5c416ef9715b"}
2023-01-30T12:03:57.412-0800    V4      Deleting Nutanix VM     {"Name": "main-i-08010-c7e25a6-control-plane-template-1674779501323-52t2n", "UUID:": "2f422afe-74ae-4c33-8116-371d121bba06"}
2023-01-30T12:03:57.895-0800    V4      Deleting Nutanix VM     {"Name": "main-i-0b1f1-7aedd81-md-0-1674779404886-l9nn4", "UUID:": "c6e9fbd0-8a02-4286-b434-0c99942b921a"}
2023-01-30T12:03:58.504-0800    V4      Deleting Nutanix VM     {"Name": "main-i-05fb6-32693f6-control-plane-template-1674779640224-j5chd", "UUID:": "1dee3198-28cd-4b37-b47c-e0f03458df17"}
2023-01-30T12:03:59.024-0800    V4      Deleting Nutanix VM     {"Name": "main-i-05c46-a8ce162-md-0-1674779490984-5rvgb", "UUID:": "5409ee4c-da23-4c66-9c51-1db30f9569f5"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

