### PR TITLE
Add `cleanup-vms` flag to nutanix e2e test

### DIFF
--- a/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
@@ -73,6 +73,7 @@ phases:
         -v 4
         --skip ${SKIPPED_TESTS}
         --bundles-override=${BUNDLES_OVERRIDE}
+        --cleanup-vms=true
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
         --baremetal-branch=${BAREMETAL_BRANCH}


### PR DESCRIPTION
*Description of changes:*
This should cleanup any leftover Nutanix VMs at the end of Nutanix e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

