### PR TITLE
Update packagecontroller install command for registry mirror

### DIFF
--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/registrymirror"
 	"github.com/aws/eks-anywhere/pkg/version"
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
@@ -38,6 +39,7 @@ func NewDependenciesForPackages(ctx context.Context, opts ...PackageOpt) (*depen
 		WithManifestReader().
 		WithKubectl().
 		WithHelm(executables.WithInsecure()).
+		WithRegistryMirror(registrymirror.FromCluster(config.spec.Cluster)).
 		WithCuratedPackagesRegistry(config.registryName, config.kubeVersion, version.Get()).
 		WithPackageControllerClient(config.spec, config.kubeConfig).
 		Build(ctx)


### PR DESCRIPTION
Uses registry mirror for package controller install if specified in cluster spec.

