### PR TITLE
Validate control plane endpoint with pods and services CIDR blocks

### DIFF
--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -2130,6 +2130,39 @@ func TestValidateNetworking(t *testing.T) {
 			},
 		},
 		{
+			name:    "both pods CIDR block and service CIDR block do not conflict with control plane endpoint",
+			wantErr: nil,
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: SnowDatacenterKind,
+					},
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						Endpoint: &Endpoint{
+							Host: "192.168.1.10",
+						},
+					},
+					ClusterNetwork: ClusterNetwork{
+						Pods: Pods{
+							CidrBlocks: []string{
+								"10.1.0.0/16",
+							},
+						},
+						Services: Services{
+							CidrBlocks: []string{
+								"10.96.0.0/12",
+							},
+						},
+						Nodes: &Nodes{
+							CIDRMaskSize: nodeCidrMaskSize,
+						},
+						CNI:       Cilium,
+						CNIConfig: nil,
+					},
+				},
+			},
+		},
+		{
 			name:    "invalid pods CIDR block",
 			wantErr: fmt.Errorf("invalid CIDR block format for Pods: {[1.2.3]}. Please specify a valid CIDR block for pod subnet"),
 			cluster: &Cluster{
@@ -2155,6 +2188,39 @@ func TestValidateNetworking(t *testing.T) {
 			},
 		},
 		{
+			name:    "pods CIDR block conflicts with control plane endpoint",
+			wantErr: fmt.Errorf("control plane endpoint 192.168.1.10 conflicts with pods CIDR block 192.168.1.0/24"),
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: SnowDatacenterKind,
+					},
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						Endpoint: &Endpoint{
+							Host: "192.168.1.10",
+						},
+					},
+					ClusterNetwork: ClusterNetwork{
+						Pods: Pods{
+							CidrBlocks: []string{
+								"192.168.1.0/24",
+							},
+						},
+						Services: Services{
+							CidrBlocks: []string{
+								"1.2.3.4/6",
+							},
+						},
+						Nodes: &Nodes{
+							CIDRMaskSize: nodeCidrMaskSize,
+						},
+						CNI:       Cilium,
+						CNIConfig: nil,
+					},
+				},
+			},
+		},
+		{
 			name:    "invalid services CIDR block",
 			wantErr: fmt.Errorf("invalid CIDR block for Services: {[1.2.3]}. Please specify a valid CIDR block for service subnet"),
 			cluster: &Cluster{
@@ -2168,6 +2234,72 @@ func TestValidateNetworking(t *testing.T) {
 						Services: Services{
 							CidrBlocks: []string{
 								"1.2.3",
+							},
+						},
+						Nodes: &Nodes{
+							CIDRMaskSize: nodeCidrMaskSize,
+						},
+						CNI:       Cilium,
+						CNIConfig: nil,
+					},
+				},
+			},
+		},
+		{
+			name:    "services CIDR block conflicts with control plane endpoint",
+			wantErr: fmt.Errorf("control plane endpoint 192.168.1.10 conflicts with services CIDR block 192.168.1.0/24"),
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: SnowDatacenterKind,
+					},
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						Endpoint: &Endpoint{
+							Host: "192.168.1.10",
+						},
+					},
+					ClusterNetwork: ClusterNetwork{
+						Pods: Pods{
+							CidrBlocks: []string{
+								"1.2.3.4/6",
+							},
+						},
+						Services: Services{
+							CidrBlocks: []string{
+								"192.168.1.0/24",
+							},
+						},
+						Nodes: &Nodes{
+							CIDRMaskSize: nodeCidrMaskSize,
+						},
+						CNI:       Cilium,
+						CNIConfig: nil,
+					},
+				},
+			},
+		},
+		{
+			name:    "control plane endpoint is invalid",
+			wantErr: fmt.Errorf("control plane endpoint 192.168.1 is invalid"),
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: SnowDatacenterKind,
+					},
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						Endpoint: &Endpoint{
+							Host: "192.168.1",
+						},
+					},
+					ClusterNetwork: ClusterNetwork{
+						Pods: Pods{
+							CidrBlocks: []string{
+								"1.2.3.4/6",
+							},
+						},
+						Services: Services{
+							CidrBlocks: []string{
+								"10.1.0.0/24",
 							},
 						},
 						Nodes: &Nodes{


### PR DESCRIPTION
*Issue #, if available:*
if either pod cidr or service cidr conflicts with control plane endpoint, cluster provision will fail after installing cilium

*Description of changes:*
check if pod cidr or service cidr has conflicts with control plane endpoint in preflight validation.

*Testing (if applicable):*
built new eksa binary, and tested, worked as expected
```
# with incorrect configs
[ec2-user@ip-34-223-14-233 ~]$ eksctl anywhere create cluster -f eksa-cluster.yaml -v6  --force-cleanup
2023-02-01T00:55:19.266Z	V4	Logger init completed	{"vlevel": 6}
Error: the cluster config file provided is invalid: control plane endpoint 192.168.1.245 conflicts with pods CIDR block 192.168.1.0/16
[ec2-user@ip-34-223-14-233 ~]$ vim eksa-cluster.yaml
[ec2-user@ip-34-223-14-233 ~]$ eksctl anywhere create cluster -f eksa-cluster.yaml -v6  --force-cleanup
2023-02-01T00:55:50.963Z	V4	Logger init completed	{"vlevel": 6}
Error: the cluster config file provided is invalid: control plane endpoint 192.168.1.245 conflicts with services CIDR block 192.168.1.0/12
[ec2-user@ip-34-223-14-233 ~]$ vim eksa-cluster.yaml
[ec2-user@ip-34-223-14-233 ~]$ eksctl anywhere create cluster -f eksa-cluster.yaml -v6  --force-cleanup
2023-02-01T00:56:22.731Z	V4	Logger init completed	{"vlevel": 6}
Error: the cluster config file provided is invalid: control plane endpoint 192.168.1 is invalid
[ec2-user@ip-34-223-14-233 ~]$

# with correct configs
[ec2-user@ip-34-223-14-233 ~]$ eksctl anywhere create cluster -f eksa-cluster.yaml -v6  --force-cleanup
2023-02-01T01:01:28.500Z	V4	Logger init completed	{"vlevel": 6}
2023-02-01T01:01:28.503Z	V6	Executing command	{"cmd": "/usr/bin/docker version --format {{.Client.Version}}"}
2023-02-01T01:01:28.545Z	V6	Executing command	{"cmd": "/usr/bin/docker info --format '{{json .MemTotal}}'"}
2023-02-01T01:01:28.823Z	V4	Reading bundles manifest	{"url": "https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/bundle-release.yaml"}
2023-02-01T01:01:29.088Z	V5	Retrier:	{"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2023-02-01T01:01:29.088Z	V2	Pulling docker image	{"image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.14.0-eks-a-v0.0.0-dev-build.5584"}
2023-02-01T01:01:29.088Z	V6	Executing command	{"cmd": "/usr/bin/docker pull public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.14.0-eks-a-v0.0.0-dev-build.5584"}
2023-02-01T01:01:34.866Z	V5	Retry execution successful	{"retries": 1, "duration": "5.77799287s"}
2023-02-01T01:01:34.866Z	V3	Initializing long running container	{"name": "eksa_1675213289088629918", "image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.14.0-eks-a-v0.0.0-dev-build.5584"}
2023-02-01T01:01:34.866Z	V6	Executing command	{"cmd": "/usr/bin/docker run -d --name eksa_1675213289088629918 --network host -w /home/ec2-user -v /var/run/docker.sock:/var/run/docker.sock -v /home/ec2-user:/home/ec2-user -v /home/ec2-user:/home/ec2-user --entrypoint sleep public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.14.0-eks-a-v0.0.0-dev-build.5584 infinity"}
Error: fetching aws credentials from env: env 'EKSA_AWS_CREDENTIALS_FILE' is not set or is empty
[ec2-user@ip-34-223-14-233 ~]$
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

