### PR TITLE
Update eksa objects in cluster for skipped upgrade

### DIFF
--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -401,6 +401,8 @@ func TestSkipUpgradeRunSuccess(t *testing.T) {
 	test.expectVerifyClusterSpecNoChanges()
 	test.expectDatacenterConfig()
 	test.expectMachineConfigs()
+	test.expectCreateEKSAResources(test.workloadCluster)
+	test.expectInstallEksdManifest(test.workloadCluster)
 	test.expectResumeEKSAControllerReconcile(test.workloadCluster)
 	test.expectUpdateGitEksaSpec()
 	test.expectForceReconcileGitRepo(test.workloadCluster)


### PR DESCRIPTION
*Description of changes:*
This makes sure that even when a rolling upgrade is not needed, the eks-a objects reflect the latest state driven by the CLI. This includes new Bundles.

Before this, if there was a new Bundles that updated dependencies like CAPI or eks-a controller but didn't require a rolling upgrade, we didn't create the new Bundles in the cluster or update the cluster object to reference it. It's quite an edge case since most new Bundles come with new eks-d releases, which do trigger a rolling upgrade, so this probably never happened in prod.

*Testing (if applicable):*
Verified this works with docker provider and a new Bundles that only updates capi and cert-manager.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

