### PR TITLE
Implement Tinkerbell reconcile CP

### DIFF
--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -41,6 +41,7 @@ const (
 	capiPackage         = "sigs.k8s.io/cluster-api"
 	capdPackage         = "sigs.k8s.io/cluster-api/test"
 	capvPackage         = "sigs.k8s.io/cluster-api-provider-vsphere"
+	captPackage         = "github.com/tinkerbell/cluster-api-provider-tinkerbell"
 	etcdProviderPackage = "github.com/aws/etcdadm-controller"
 )
 
@@ -69,6 +70,7 @@ var packages = []moduleWithCRD{
 		withAdditionalCustomCRDPath("bootstrap/kubeadm/config/crd/bases"),
 		withAdditionalCustomCRDPath("controlplane/kubeadm/config/crd/bases"),
 	),
+	mustBuildModuleWithCRDs(captPackage),
 	mustBuildModuleWithCRDs(capvPackage),
 	mustBuildModuleWithCRDs(capdPackage,
 		withMainCustomCRDPath("infrastructure/docker/config/crd/bases"),

--- a/manager/main.go
+++ b/manager/main.go
@@ -9,6 +9,7 @@ import (
 	etcdv1 "github.com/aws/etcdadm-controller/api/v1beta1"
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
+	tinkerbellv1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/api/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -54,6 +55,7 @@ func init() {
 	utilruntime.Must(eksdv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(snowv1.AddToScheme(scheme))
 	utilruntime.Must(addonsv1.AddToScheme(scheme))
+	utilruntime.Must(tinkerbellv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/pkg/clients/kubernetes/scheme.go
+++ b/pkg/clients/kubernetes/scheme.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	etcdv1 "github.com/aws/etcdadm-controller/api/v1beta1"
+	tinkerbellv1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/api/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	cloudstackv1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta2"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
@@ -32,6 +33,7 @@ var schemeAdders = []schemeAdder{
 	vspherev1.AddToScheme,
 	etcdv1.AddToScheme,
 	addonsv1.AddToScheme,
+	tinkerbellv1.AddToScheme,
 }
 
 func addToScheme(scheme *runtime.Scheme, schemeAdders ...schemeAdder) error {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,12 +1,14 @@
 package features
 
+// These are environment variables used as flags to enable/disable features.
 const (
-	CloudStackKubeVipDisabledEnvVar = "CLOUDSTACK_KUBE_VIP_DISABLED"
-	FullLifecycleAPIEnvVar          = "FULL_LIFECYCLE_API"
-	FullLifecycleGate               = "FullLifecycleAPI"
-	CheckpointEnabledEnvVar         = "CHECKPOINT_ENABLED"
-	UseNewWorkflowsEnvVar           = "USE_NEW_WORKFLOWS"
-	K8s125SupportEnvVar             = "K8S_1_25_SUPPORT"
+	CloudStackKubeVipDisabledEnvVar             = "CLOUDSTACK_KUBE_VIP_DISABLED"
+	FullLifecycleAPIEnvVar                      = "FULL_LIFECYCLE_API"
+	FullLifecycleGate                           = "FullLifecycleAPI"
+	CheckpointEnabledEnvVar                     = "CHECKPOINT_ENABLED"
+	UseNewWorkflowsEnvVar                       = "USE_NEW_WORKFLOWS"
+	K8s125SupportEnvVar                         = "K8S_1_25_SUPPORT"
+	TinkerbellUseDiskExtractorDefaultDiskEnvVar = "TINKERBELL_DISK_EXTRACTOR_DISABLED"
 )
 
 func FeedGates(featureGates []string) {
@@ -60,5 +62,13 @@ func K8s125Support() Feature {
 	return Feature{
 		Name:     "Kubernetes version 1.25 support",
 		IsActive: globalFeatures.isActiveForEnvVar(K8s125SupportEnvVar),
+	}
+}
+
+// TinkerbellUseDiskExtractorDefaultDisk is a flag that forces the diskExtractor to use /dev/sda disk by default.
+func TinkerbellUseDiskExtractorDefaultDisk() Feature {
+	return Feature{
+		Name:     "Use a default disk /dev/sda when using the diskExtractor",
+		IsActive: globalFeatures.isActiveForEnvVar(TinkerbellUseDiskExtractorDefaultDiskEnvVar),
 	}
 }

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -77,3 +77,11 @@ func TestWithK8s125FeatureFlag(t *testing.T) {
 	g.Expect(os.Setenv(K8s125SupportEnvVar, "true")).To(Succeed())
 	g.Expect(IsActive(K8s125Support())).To(BeTrue())
 }
+
+func TestWithTinkerbellUseDiskExtractorDefaultDiskFlag(t *testing.T) {
+	g := NewWithT(t)
+	setupContext(t)
+
+	g.Expect(os.Setenv(TinkerbellUseDiskExtractorDefaultDiskEnvVar, "true")).To(Succeed())
+	g.Expect(IsActive(TinkerbellUseDiskExtractorDefaultDisk())).To(BeTrue())
+}

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
@@ -10,6 +10,7 @@ import (
 
 	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/features"
 )
 
 // DiskExtractor represents a hardware labels and map it with the appropriate disk given in the hardware csv file.
@@ -79,6 +80,12 @@ func (d *DiskExtractor) InsertProvisionedHardwareDisks(hardware *tinkv1alpha1.Ha
 // GetDisk returns the disk cached for selector. If selector has no disk cached ErrDiskNotFound
 // is returned.
 func (d *DiskExtractor) GetDisk(selector eksav1alpha1.HardwareSelector) (string, error) {
+	// TODO: To be removed with the diskExtractor logic. For now this is a temporary solution
+	// while having to use the diskExtractor in the controller.
+	if features.TinkerbellUseDiskExtractorDefaultDisk().IsActive() {
+		return "/dev/sda", nil
+	}
+
 	key, err := serializeHardwareSelector(selector)
 	if err != nil {
 		return "", err

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware_test.go
@@ -9,6 +9,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
 )
 
@@ -268,4 +269,17 @@ func TestDiskExtractorNoDiskFound(t *testing.T) {
 
 	_, err = diskExtractor.GetDisk(hardwareSelector)
 	g.Expect(err).To(gomega.MatchError(hardware.ErrDiskNotFound{}))
+}
+
+// TODO: remove after diskExtractor has been refactored and removed.
+func TestDiskExtractorUseDefaultDisk(t *testing.T) {
+	features.ClearCache()
+	t.Setenv(features.TinkerbellUseDiskExtractorDefaultDiskEnvVar, "true")
+	g := gomega.NewWithT(t)
+	diskExtractor := hardware.NewDiskExtractor()
+	hardwareSelector := eksav1alpha1.HardwareSelector{}
+
+	disk, err := diskExtractor.GetDisk(hardwareSelector)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(disk).To(gomega.Equal("/dev/sda"))
 }

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -160,6 +160,7 @@ func TestReconcilerReconcileControlPlaneSuccess(t *testing.T) {
 		c.Name = workloadClusterName
 	})
 	tt.ShouldEventuallyExist(tt.ctx, capiCluster)
+	tt.ShouldEventuallyNotExist(tt.ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "registry-credentials", Namespace: constants.EksaSystemNamespace}})
 }
 
 func TestReconcilerReconcileControlPlaneSuccessRegistryMirrorAuthentication(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR implements the Tinkerbell Cluster Reconciler phase: `ReconcileControlPlane`.

Additionally, a `TinkerbellUseDiskExtractorDefaultDisk` flag has been added that forces the diskExtractor to use `/dev/sda` disk by default as discussed. This is temporary until the diskExtractor logic can be removed from the reconciler.

*Testing (if applicable):*
Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

