### PR TITLE
Require imdsv2 On Run Instance

### DIFF
--- a/internal/pkg/ec2/create.go
+++ b/internal/pkg/ec2/create.go
@@ -77,7 +77,8 @@ func CreateInstance(session *session.Session, amiId, key, tag, instanceProfileNa
 					},
 				},
 			},
-			UserData: aws.String(base64.StdEncoding.EncodeToString([]byte(dockerLogsUserData))),
+			UserData:        aws.String(base64.StdEncoding.EncodeToString([]byte(dockerLogsUserData))),
+			MetadataOptions: &ec2.InstanceMetadataOptionsRequest{HttpTokens: aws.String("required"), HttpPutResponseHopLimit: aws.Int64(int64(2))},
 		})
 
 		return err


### PR DESCRIPTION
When building images, require the ec2 instance executing to use imdsv2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->