### PR TITLE
Add Secret registry mapping when generating Tinkerbell CP Spec

### DIFF
--- a/pkg/providers/tinkerbell/controlplane.go
+++ b/pkg/providers/tinkerbell/controlplane.go
@@ -111,6 +111,15 @@ func newControlPlaneParser(logger logr.Logger) (*yamlutil.Parser, *controlPlaneB
 		return nil, nil, errors.Wrap(err, "building tinkerbell control plane parser")
 	}
 
+	err = parser.RegisterMappings(
+		yamlutil.NewMapping(constants.SecretKind, func() yamlutil.APIObject {
+			return &corev1.Secret{}
+		}),
+	)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "registering tinkerbell control plane mappings in parser")
+	}
+
 	builder := &controlPlaneBuilder{
 		BaseBuilder:  baseBuilder,
 		ControlPlane: &ControlPlane{},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds registers a Secret Kind mapping to the control plane parse which seems to be missing when generating Tinker-bell CP Spec.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

