### PR TITLE
Fixing panic errors for tinkerbell FLC

### DIFF
--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -308,7 +308,7 @@ func (f *Factory) withSnowClusterReconciler() *Factory {
 }
 
 func (f *Factory) withTinkerbellClusterReconciler() *Factory {
-	f.withCNIReconciler().withTracker()
+	f.withCNIReconciler().withTracker().withIPValidator()
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.tinkerbellClusterReconciler != nil {

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig.go
@@ -119,5 +119,9 @@ func validateTinkerbellMachineConfig(config *TinkerbellMachineConfig) error {
 		)
 	}
 
+	if len(config.Spec.Users) == 0 {
+		return fmt.Errorf("TinkerbellMachineConfig: missing spec.Users: %s", config.Name)
+	}
+
 	return nil
 }

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
@@ -108,16 +108,21 @@ func validateImmutableFieldsTinkerbellMachineConfig(new, old *TinkerbellMachineC
 		allErrs = append(allErrs, field.Forbidden(specPath.Child("OSFamily"), "field is immutable"))
 	}
 
+	if len(new.Spec.Users) != len(old.Spec.Users) {
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("Users"), "field is immutable"))
+		return allErrs
+	}
+
+	if new.Spec.Users[0].Name != old.Spec.Users[0].Name {
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("Users[0].Name"), "field is immutable"))
+	}
+
 	if len(new.Spec.Users[0].SshAuthorizedKeys) != len(old.Spec.Users[0].SshAuthorizedKeys) {
 		allErrs = append(allErrs, field.Forbidden(specPath.Child("Users[0].SshAuthorizedKeys"), "field is immutable"))
 	}
 
 	if len(new.Spec.Users[0].SshAuthorizedKeys) > 0 && (new.Spec.Users[0].SshAuthorizedKeys[0] != old.Spec.Users[0].SshAuthorizedKeys[0]) {
 		allErrs = append(allErrs, field.Forbidden(specPath.Child("Users[0].SshAuthorizedKeys[0]"), "field is immutable"))
-	}
-
-	if new.Spec.Users[0].Name != old.Spec.Users[0].Name {
-		allErrs = append(allErrs, field.Forbidden(specPath.Child("Users[0].Name"), "field is immutable"))
 	}
 
 	if !reflect.DeepEqual(new.Spec.HardwareSelector, old.Spec.HardwareSelector) {

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
@@ -110,7 +110,6 @@ func validateImmutableFieldsTinkerbellMachineConfig(new, old *TinkerbellMachineC
 
 	if len(new.Spec.Users) != len(old.Spec.Users) {
 		allErrs = append(allErrs, field.Forbidden(specPath.Child("Users"), "field is immutable"))
-		return allErrs
 	}
 
 	if new.Spec.Users[0].Name != old.Spec.Users[0].Name {

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
@@ -108,7 +108,11 @@ func validateImmutableFieldsTinkerbellMachineConfig(new, old *TinkerbellMachineC
 		allErrs = append(allErrs, field.Forbidden(specPath.Child("OSFamily"), "field is immutable"))
 	}
 
-	if new.Spec.Users[0].SshAuthorizedKeys[0] != old.Spec.Users[0].SshAuthorizedKeys[0] {
+	if len(new.Spec.Users[0].SshAuthorizedKeys) != len(old.Spec.Users[0].SshAuthorizedKeys) {
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("Users[0].SshAuthorizedKeys"), "field is immutable"))
+	}
+
+	if len(new.Spec.Users[0].SshAuthorizedKeys) > 0 && (new.Spec.Users[0].SshAuthorizedKeys[0] != old.Spec.Users[0].SshAuthorizedKeys[0]) {
 		allErrs = append(allErrs, field.Forbidden(specPath.Child("Users[0].SshAuthorizedKeys[0]"), "field is immutable"))
 	}
 

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook_test.go
@@ -50,6 +50,21 @@ func TestTinkerbellMachineConfig_ValidateUpdateFailOSFamily(t *testing.T) {
 	g.Expect(HaveField("spec.OSFamily", err))
 }
 
+func TestTinkerbellMachineConfig_ValidateUpdateFailLenSshAuthorizedKeys(t *testing.T) {
+	machineConfigOld := createTinkerbellMachineConfig()
+	machineConfigNew := createTinkerbellMachineConfig(func(mc *TinkerbellMachineConfig) {
+		mc.Spec.Users = []UserConfiguration{{
+			Name:              "mySshUsername",
+			SshAuthorizedKeys: []string{},
+		}}
+	})
+
+	g := NewWithT(t)
+	err := machineConfigNew.ValidateUpdate(machineConfigOld)
+	g.Expect(err).NotTo(BeNil())
+	g.Expect(HaveField("Users[0].SshAuthorizedKeys", err))
+}
+
 func TestTinkerbellMachineConfig_ValidateUpdateFailSshAuthorizedKeys(t *testing.T) {
 	machineConfigOld := createTinkerbellMachineConfig()
 	machineConfigNew := createTinkerbellMachineConfig(func(mc *TinkerbellMachineConfig) {

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook_test.go
@@ -22,6 +22,15 @@ func TestTinkerbellMachineConfig_ValidateCreateFail(t *testing.T) {
 	g.Expect(machineConfig.ValidateCreate()).NotTo(Succeed())
 }
 
+func TestTinkerbellMachineConfig_ValidateCreateFailNoUsers(t *testing.T) {
+	machineConfig := createTinkerbellMachineConfig(func(mc *TinkerbellMachineConfig) {
+		mc.Spec.Users = []UserConfiguration{}
+	})
+
+	g := NewWithT(t)
+	g.Expect(machineConfig.ValidateCreate()).NotTo(Succeed())
+}
+
 func TestTinkerbellMachineConfig_ValidateUpdateSucceed(t *testing.T) {
 	machineConfigOld := createTinkerbellMachineConfig()
 	machineConfigNew := machineConfigOld.DeepCopy()

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook_test.go
@@ -80,6 +80,27 @@ func TestTinkerbellMachineConfig_ValidateUpdateFailSshAuthorizedKeys(t *testing.
 	g.Expect(HaveField("Users[0].SshAuthorizedKeys[0]", err))
 }
 
+func TestTinkerbellMachineConfig_ValidateUpdateFailUsersLen(t *testing.T) {
+	machineConfigOld := createTinkerbellMachineConfig()
+	machineConfigNew := createTinkerbellMachineConfig(func(mc *TinkerbellMachineConfig) {
+		mc.Spec.Users = []UserConfiguration{
+			{
+				Name:              "mySshUsername1",
+				SshAuthorizedKeys: []string{"mySshAuthorizedKey"},
+			},
+			{
+				Name:              "mySshUsername2",
+				SshAuthorizedKeys: []string{"mySshAuthorizedKey"},
+			},
+		}
+	})
+
+	g := NewWithT(t)
+	err := machineConfigNew.ValidateUpdate(machineConfigOld)
+	g.Expect(err).NotTo(BeNil())
+	g.Expect(HaveField("Users", err))
+}
+
 func TestTinkerbellMachineConfig_ValidateUpdateFailUsers(t *testing.T) {
 	machineConfigOld := createTinkerbellMachineConfig()
 	machineConfigNew := createTinkerbellMachineConfig(func(mc *TinkerbellMachineConfig) {

--- a/pkg/providers/tinkerbell/assert_test.go
+++ b/pkg/providers/tinkerbell/assert_test.go
@@ -39,6 +39,9 @@ func TestAssertMachineConfigsValid_InvalidFails(t *testing.T) {
 				"baz": "qux",
 			}
 		},
+		"MissingUsers": func(clusterSpec *tinkerbell.ClusterSpec) {
+			clusterSpec.ControlPlaneMachineConfig().Spec.Users = []eksav1alpha1.UserConfiguration{}
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			g := gomega.NewWithT(t)

--- a/pkg/providers/tinkerbell/cluster_spec_builder_test.go
+++ b/pkg/providers/tinkerbell/cluster_spec_builder_test.go
@@ -91,6 +91,11 @@ func (b ValidClusterSpecBuilder) Build() *tinkerbell.ClusterSpec {
 				Spec: v1alpha1.TinkerbellMachineConfigSpec{
 					HardwareSelector: v1alpha1.HardwareSelector{"type": "cp"},
 					OSFamily:         v1alpha1.Ubuntu,
+					Users: []v1alpha1.UserConfiguration{
+						{
+							Name: "ec2-user",
+						},
+					},
 				},
 			},
 			b.ExternalEtcdMachineName: {
@@ -101,6 +106,11 @@ func (b ValidClusterSpecBuilder) Build() *tinkerbell.ClusterSpec {
 				Spec: v1alpha1.TinkerbellMachineConfigSpec{
 					HardwareSelector: v1alpha1.HardwareSelector{"type": "etcd"},
 					OSFamily:         v1alpha1.Ubuntu,
+					Users: []v1alpha1.UserConfiguration{
+						{
+							Name: "ec2-user",
+						},
+					},
 				},
 			},
 			b.WorkerNodeGroupMachineName: {
@@ -111,6 +121,11 @@ func (b ValidClusterSpecBuilder) Build() *tinkerbell.ClusterSpec {
 				Spec: v1alpha1.TinkerbellMachineConfigSpec{
 					HardwareSelector: v1alpha1.HardwareSelector{"type": "worker"},
 					OSFamily:         v1alpha1.Ubuntu,
+					Users: []v1alpha1.UserConfiguration{
+						{
+							Name: "ec2-user",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
*Description of changes:*
Ran into `Index out of bound` and `invalid memory address or nil pointer dereference [recovered]` errors when testing the controller for tinkerbell. Added fixes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

