### PR TITLE
Tinkerbell doesn't support external etcd

### DIFF
--- a/controllers/resource/template.go
+++ b/controllers/resource/template.go
@@ -316,7 +316,7 @@ func (r *TinkerbellTemplate) TemplateResources(ctx context.Context, eksaCluster 
 	for _, wnConfig := range workerTmc {
 		workerNodeGroupMachineSpecs[wnConfig.Name] = wnConfig.Spec
 	}
-	templateBuilder := tinkerbell.NewTemplateBuilder(&tdc.Spec, &cpTmc.Spec, &etcdTmc.Spec, hardware.NewDiskExtractor(), workerNodeGroupMachineSpecs, tdc.Spec.TinkerbellIP, r.now)
+	templateBuilder := tinkerbell.NewTemplateBuilder(&tdc.Spec, &cpTmc.Spec, hardware.NewDiskExtractor(), workerNodeGroupMachineSpecs, tdc.Spec.TinkerbellIP, r.now)
 	cp, err := r.ControlPlane(ctx, eksaCluster)
 	if err != nil {
 		return nil, err

--- a/pkg/providers/tinkerbell/controlplane.go
+++ b/pkg/providers/tinkerbell/controlplane.go
@@ -22,13 +22,13 @@ type BaseControlPlane = clusterapi.ControlPlane[*tinkerbellv1.TinkerbellCluster,
 // ControlPlane holds the Tinkerbell specific objects for a CAPI Tinkerbell control plane.
 type ControlPlane struct {
 	BaseControlPlane
-	Secrets *corev1.Secret
+	Secret *corev1.Secret
 }
 
 // Objects returns the control plane objects associated with the Tinkerbell cluster.
 func (p ControlPlane) Objects() []kubernetes.Object {
 	o := p.BaseControlPlane.Objects()
-	o = append(o, p.Secrets)
+	o = append(o, p.Secret)
 
 	return o
 }
@@ -84,7 +84,7 @@ func (b *controlPlaneBuilder) BuildFromParsed(lookup yamlutil.ObjectLookup) erro
 	b.ControlPlane.BaseControlPlane = *b.BaseBuilder.ControlPlane
 	for _, obj := range lookup {
 		if obj.GetObjectKind().GroupVersionKind().Kind == constants.SecretKind {
-			b.ControlPlane.Secrets = obj.(*corev1.Secret)
+			b.ControlPlane.Secret = obj.(*corev1.Secret)
 		}
 	}
 

--- a/pkg/providers/tinkerbell/controlplane_test.go
+++ b/pkg/providers/tinkerbell/controlplane_test.go
@@ -36,7 +36,7 @@ func TestControlPlaneObjects(t *testing.T) {
 					KubeadmControlPlane:         kubeadmControlPlane(),
 					ControlPlaneMachineTemplate: tinkerbellMachineTemplate("controlplane-machinetemplate"),
 				},
-				Secrets: secret(),
+				Secret: secret(),
 			},
 			expected: []kubernetes.Object{
 				capiCluster(),

--- a/pkg/providers/tinkerbell/template_test.go
+++ b/pkg/providers/tinkerbell/template_test.go
@@ -52,9 +52,4 @@ func TestGenerateTemplateBuilder(t *testing.T) {
 	gotWorkerNodeGroupMachineSpec, err := getWorkerNodeGroupMachineSpec(clusterSpec, diskExtractor)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(gotWorkerNodeGroupMachineSpec).To(Equal(expectedWorkerNodeGroupMachineSpec))
-
-	gotEtcdMachineSpec, err := getEtcdMachineSpec(clusterSpec, diskExtractor)
-	var expectedEtcdMachineSpec *v1alpha1.TinkerbellMachineConfigSpec
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(gotEtcdMachineSpec).To(Equal(expectedEtcdMachineSpec))
 }

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -147,7 +147,6 @@ func NewProvider(
 			datacenterSpec:              &datacenterConfig.Spec,
 			controlPlaneMachineSpec:     controlPlaneMachineSpec,
 			WorkerNodeGroupMachineSpecs: workerNodeGroupMachineSpecs,
-			etcdMachineSpec:             etcdMachineSpec,
 			diskExtractor:               diskExtractor,
 			tinkerbellIp:                tinkerbellIp,
 			now:                         now,


### PR DESCRIPTION
*Issue #, if available:*
- Remove the logic that build tinkerbell template on etcd.
- Secret in control plane should be singular.

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

