### PR TITLE
Use correct field name when fetching EKS-A CLI URL

### DIFF
--- a/release/scripts/github-bundle-release.sh
+++ b/release/scripts/github-bundle-release.sh
@@ -39,7 +39,7 @@ done
 
 for os in darwin linux; do
     for arch in amd64 arm64; do
-        EKSA_CLI_URI=$(yq e ".spec.releases[0].eksABinary.$os.$arch.uri" $ARTIFACTS_DIR/$DATE_YYYYMMDD-eks-a-release.yaml)
+        EKSA_CLI_URI=$(yq e ".spec.releases[0].eksACLI.$os.$arch.uri" $ARTIFACTS_DIR/$DATE_YYYYMMDD-eks-a-release.yaml)
         wget $EKSA_CLI_URI -O $ARTIFACTS_DIR/$(basename $EKSA_CLI_URI)
     done
 done


### PR DESCRIPTION
Use correct field name when fetching EKS-A CLI URL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

