### PR TITLE
Refactor aws client for future easier unit testing

### DIFF
--- a/pkg/aws/ec2_test.go
+++ b/pkg/aws/ec2_test.go
@@ -29,7 +29,7 @@ func newEC2Test(t *testing.T) *ec2Test {
 		WithT:  NewWithT(t),
 		ctx:    ctx,
 		ec2:    ec2,
-		client: aws.NewClientFromEC2(ec2),
+		client: aws.NewClient(aws.WithEC2(ec2)),
 	}
 }
 

--- a/pkg/aws/snow.go
+++ b/pkg/aws/snow.go
@@ -37,7 +37,7 @@ func BuildClients(ctx context.Context) (Clients, error) {
 		if err != nil {
 			return nil, fmt.Errorf("setting up aws client: %v", err)
 		}
-		deviceClientMap[ip] = NewClient(ctx, config)
+		deviceClientMap[ip] = NewClientFromConfig(config)
 	}
 	return deviceClientMap, nil
 }

--- a/pkg/aws/snowballdevice_test.go
+++ b/pkg/aws/snowballdevice_test.go
@@ -29,7 +29,7 @@ func newSnowballDeviceTest(t *testing.T) *snowballDeviceTest {
 		WithT:          NewWithT(t),
 		ctx:            ctx,
 		snowballDevice: sbd,
-		client:         aws.NewClientFromSnowball(sbd),
+		client:         aws.NewClient(aws.WithSnowballDevice(sbd)),
 	}
 }
 

--- a/pkg/providers/snow/reconciler/clientbuilder.go
+++ b/pkg/providers/snow/reconciler/clientbuilder.go
@@ -78,7 +78,7 @@ func createAwsClients(ctx context.Context, credentials []byte, certificates []by
 		if err != nil {
 			return nil, errors.Wrap(err, "setting up aws client")
 		}
-		deviceClientMap[ip] = aws.NewClient(ctx, clientCfg)
+		deviceClientMap[ip] = aws.NewClientFromConfig(clientCfg)
 	}
 
 	return deviceClientMap, nil


### PR DESCRIPTION
*Issue #, if available:*

Prepare for including an IMDSv2 for checking instance ip. https://github.com/aws/eks-anywhere/issues/4844 

*Description of changes:*

Add `ClientOpt` for easier aws client testing. Avoid to add a `NewClientFromXXX` testing method every time we add a new client.

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

