### PR TITLE
Move logs to a subfolder

### DIFF
--- a/cmd/eksctl-anywhere/cmd/root.go
+++ b/cmd/eksctl-anywhere/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -44,8 +45,14 @@ func rootPersistentPreRun(cmd *cobra.Command, args []string) {
 }
 
 func initLogger() error {
-	outputFilePath := fmt.Sprintf("./eksa-cli-%s.log", time.Now().Format("2006-01-02T15_04_05"))
-	if err := logger.InitZap(logger.ZapOpts{
+	logsFolder := filepath.Join(".", "eksa-cli-logs")
+	err := os.MkdirAll(logsFolder, 0o750)
+	if err != nil {
+		return fmt.Errorf("failed to create logs folder: %v", err)
+	}
+
+	outputFilePath := filepath.Join(".", "eksa-cli-logs", fmt.Sprintf("%s.log", time.Now().Format("2006-01-02T15_04_05")))
+	if err = logger.InitZap(logger.ZapOpts{
 		Level:          viper.GetInt("verbosity"),
 		OutputFilePath: outputFilePath,
 	}); err != nil {


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* Many Users have a lot failed runs, and each failed run creates a log file in the working directory. So a user can get a bloated folder quite easily. To mitigate the issue, all failed logs are now saved in a subfolder of the working directory.

*Testing (if applicable):* 
1. make eks-a
2. eksa download artifacts, ctrl-c, and logs are saved in eksa-cli-logs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

