### PR TITLE
Add AWS IMDSv2 client

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -10,7 +10,7 @@ import (
 
 // Client provides the single API client to make operations call to aws services.
 type Client struct {
-	ec2            EC2Client
+	ec2            *EC2
 	snowballDevice SnowballDeviceClient
 }
 
@@ -57,7 +57,7 @@ func LoadConfig(ctx context.Context, opts ...AwsConfigOpt) (aws.Config, error) {
 type ClientOpt func(*Client)
 
 // WithEC2 returns a ClientOpt that sets the ec2 client.
-func WithEC2(ec2 EC2Client) ClientOpt {
+func WithEC2(ec2 *EC2) ClientOpt {
 	return func(c *Client) {
 		c.ec2 = ec2
 	}

--- a/pkg/aws/mocks/ec2.go
+++ b/pkg/aws/mocks/ec2.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	imds "github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	ec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -93,4 +94,47 @@ func (mr *MockEC2ClientMockRecorder) ImportKeyPair(ctx, params interface{}, optF
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, params}, optFns...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportKeyPair", reflect.TypeOf((*MockEC2Client)(nil).ImportKeyPair), varargs...)
+}
+
+// MockIMDSClient is a mock of IMDSClient interface.
+type MockIMDSClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockIMDSClientMockRecorder
+}
+
+// MockIMDSClientMockRecorder is the mock recorder for MockIMDSClient.
+type MockIMDSClientMockRecorder struct {
+	mock *MockIMDSClient
+}
+
+// NewMockIMDSClient creates a new mock instance.
+func NewMockIMDSClient(ctrl *gomock.Controller) *MockIMDSClient {
+	mock := &MockIMDSClient{ctrl: ctrl}
+	mock.recorder = &MockIMDSClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockIMDSClient) EXPECT() *MockIMDSClientMockRecorder {
+	return m.recorder
+}
+
+// GetMetadata mocks base method.
+func (m *MockIMDSClient) GetMetadata(ctx context.Context, params *imds.GetMetadataInput, optFns ...func(*imds.Options)) (*imds.GetMetadataOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetMetadata", varargs...)
+	ret0, _ := ret[0].(*imds.GetMetadataOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMetadata indicates an expected call of GetMetadata.
+func (mr *MockIMDSClientMockRecorder) GetMetadata(ctx, params interface{}, optFns ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockIMDSClient)(nil).GetMetadata), varargs...)
 }


### PR DESCRIPTION
*Issue #, if available:*

Part 1 of https://github.com/aws/eks-anywhere/issues/4844

*Description of changes:*

Rewrite #4849 as aws go sdk v2 has an built-in imds client.

*Testing (if applicable):*
Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

