### PR TITLE
docs: Restrict the curated packages IAM example further

### DIFF
--- a/docs/content/en/docs/tasks/packages/_index.md
+++ b/docs/content/en/docs/tasks/packages/_index.md
@@ -13,14 +13,14 @@ For proper curated package support, make sure the cluster `kubernetes` version i
 
 ### Setup authentication to use curated-packages
 
-When you have been notified that your account has been given access to curated packages, create a user in your account with a policy that only allows ECR read access similar to this:
+When you have been notified that your account has been given access to curated packages, create an IAM user in your account with a policy that only allows ECR read access to the Curated Packages repository; similar to this:
 
 ```
 {
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "VisualEditor0",
+            "Sid": "ECRRead",
             "Effect": "Allow",
             "Action": [
                 "ecr:DescribeImageScanFindings",
@@ -28,13 +28,20 @@ When you have been notified that your account has been given access to curated p
                 "ecr:DescribeRegistry",
                 "ecr:DescribePullThroughCacheRules",
                 "ecr:DescribeImageReplicationStatus",
-                "ecr:GetAuthorizationToken",
                 "ecr:ListTagsForResource",
                 "ecr:ListImages",
                 "ecr:BatchGetImage",
                 "ecr:DescribeImages",
                 "ecr:DescribeRepositories",
                 "ecr:BatchCheckLayerAvailability"
+            ],
+            "Resource": "arn:aws:ecr:*:783794618700:repository/*"
+        },
+        {
+            "Sid": "ECRLogin",
+            "Effect": "Allow",
+            "Action": [
+                "ecr:GetAuthorizationToken"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
The current IAM policy example for curated packages is too open. It would allow the IAM User to pull from any repository anywhere, including any repository in the account. The intent is for this user to pull curated packages from the curated packages repository. This change in the policy example reflects that.

Note that the `ecr:GetAuthorizationToken` action does not have a resource, so its resource must be '*'.

*Issue #, if available:*
None

*Description of changes:*
See above.

*Testing (if applicable):*
Tested in AWS account with `aws ecr get-login-password --region us-east-1 |docker login --username AWS --password-stdin 783794618700.dkr.ecr.us-east-1.amazonaws.com` and `docker pull 783794618700.dkr.ecr.us-east-1.amazonaws.com/emissary-ingress/emissary:v3.3.0-cbf71de34d8bb5a72083f497d599da63e8b3837b`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

