### PR TITLE
Check Control Plane is ready during Tinkerbell reconciliation

### DIFF
--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -62,6 +62,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, log logr.Logger, cluster *an
 		r.ipValidator.ValidateControlPlaneIP,
 		r.ValidateClusterSpec,
 		r.ReconcileControlPlane,
+		r.CheckControlPlaneReady,
 		r.ReconcileCNI,
 	).Run(ctx, log, clusterSpec)
 }
@@ -93,6 +94,13 @@ func (r *Reconciler) ReconcileControlPlane(ctx context.Context, log logr.Logger,
 	}
 
 	return clusters.ReconcileControlPlane(ctx, r.client, toClientControlPlane(cp))
+}
+
+// CheckControlPlaneReady checks whether the control plane for an eks-a cluster is ready or not.
+// Requeues with the appropriate wait times whenever the cluster is not ready yet.
+func (r *Reconciler) CheckControlPlaneReady(ctx context.Context, log logr.Logger, clusterSpec *c.Spec) (controller.Result, error) {
+	log = log.WithValues("phase", "checkControlPlaneReady")
+	return clusters.CheckControlPlaneReady(ctx, r.client, log, clusterSpec.Cluster)
 }
 
 // ReconcileWorkerNodes validates the cluster definition and reconciles the worker nodes

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -339,7 +339,6 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 	ipValidator := tinkerbellreconcilermocks.NewMockIPValidator(ctrl)
 
 	bundle := test.Bundle()
-	// secret := registryCredentialSecret()
 
 	managementCluster := tinkerbellCluster(func(c *anywherev1.Cluster) {
 		c.Name = "management-cluster"
@@ -417,7 +416,6 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 			workloadClusterDatacenter,
 			bundle,
 			test.EksdRelease(),
-			// secret,
 		},
 		cluster:                   cluster,
 		datacenterConfig:          workloadClusterDatacenter,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds CheckControlPlaneReady reconciliation phase to the Tinkerbell reconciler

*Testing (if applicable):*
Tested sufficiently by `TestReconcilerReconcileSuccess` and the tests in `pkg/controller/clusters/clusterapi_test.go`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

