### PR TITLE
Validate pod cidr mask size with the default value of node cidr size

### DIFF
--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -1996,7 +1996,7 @@ func TestValidateNetworking(t *testing.T) {
 					ClusterNetwork: ClusterNetwork{
 						Pods: Pods{
 							CidrBlocks: []string{
-								"1.2.3.4/6",
+								"1.2.3.4/8",
 							},
 						},
 						Services: Services{
@@ -2018,7 +2018,7 @@ func TestValidateNetworking(t *testing.T) {
 					ClusterNetwork: ClusterNetwork{
 						Pods: Pods{
 							CidrBlocks: []string{
-								"1.2.3.4/6",
+								"1.2.3.4/8",
 							},
 						},
 						Services: Services{
@@ -2040,7 +2040,7 @@ func TestValidateNetworking(t *testing.T) {
 					ClusterNetwork: ClusterNetwork{
 						Pods: Pods{
 							CidrBlocks: []string{
-								"1.2.3.4/6",
+								"1.2.3.4/8",
 							},
 						},
 						Services: Services{
@@ -2081,7 +2081,7 @@ func TestValidateNetworking(t *testing.T) {
 		},
 		{
 			name:    "node cidr mask size invalid",
-			wantErr: fmt.Errorf("the size of pod subnet with mask 30 is smaller than the size of node subnet with mask 28"),
+			wantErr: fmt.Errorf("the size of pod subnet with mask 30 is smaller than or equal to the size of node subnet with mask 28"),
 			cluster: &Cluster{
 				Spec: ClusterSpec{
 					ClusterNetwork: ClusterNetwork{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -28,6 +28,7 @@ const (
 	EtcdadmControllerProviderName           = "bootstrap-etcdadm-controller"
 	DefaultHttpsPort                        = "443"
 	DefaultWorkerNodeGroupName              = "md-0"
+	DefaultNodeCidrMaskSize                 = 24
 
 	VSphereProviderName    = "vsphere"
 	DockerProviderName     = "docker"


### PR DESCRIPTION
*Description of changes:*
We do have a validation where if a user specify node cidr mask size in `clusterNetwork` field, it validates against pod cidr blocks. With this PR, we will validate pod cidr block size against node cidr mask size with the default value too so we can validate user config data before it fails at the later stage.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

