### PR TITLE
Remove unsupported fields in snow doc

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/snow.md
+++ b/docs/content/en/docs/reference/clusterspec/snow.md
@@ -250,9 +250,6 @@ Refers to a `SnowIPPool` object which provides a range of ip addresses. When spe
 ### containersVolume (optional)
 Configuration option for customizing containers data storage volume.
 
-### containersVolume.deviceName (optional)
-Name of the device for the containers data storage volume.
-
 ### containersVolume.size
 Size of the storage device in Gi.
 
@@ -260,18 +257,6 @@ This field is required for BottleRocket OS and the size must be no smaller than 
 
 ### containersVolume.type (optional)
 Type of the volume. For example: `gp2`, `io1`.
-
-### containersVolume.iops (optional)
-Number of IOPS requested for the disk.
-
-### containersVolume.encrypted (optional)
-Whether the volume should be encrypted or not.
-
-### containersVolume.encryptionKey (optional)
-KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.
-
-If `encrypted` is set and `encryptionKey` is omitted, the default AWS key will be used.
-The key must already exist and be accessible by the Snow controller.
 
 ## SnowIPPool Fields
 


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/eks-anywhere/issues/1111

*Description of changes:*

Remove containersVolume fields that are not supported in CAPAS yet. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

