### PR TITLE
Fix integer log for vsphere template defaulting

### DIFF
--- a/pkg/providers/vsphere/defaults.go
+++ b/pkg/providers/vsphere/defaults.go
@@ -117,7 +117,8 @@ func (d *Defaulter) setCloneModeAndDiskSizeDefaults(ctx context.Context, machine
 	minDiskSize := max(minDiskGib, templateDiskSize)
 
 	if machineConfig.Spec.DiskGiB < minDiskSize {
-		logger.Info("Warning: VSphereMachineConfig DiskGiB cannot be less than %s. Defaulting to %s.", minDiskSize, minDiskSize)
+		errStr := fmt.Sprintf("Warning: VSphereMachineConfig DiskGiB cannot be less than %v. Defaulting to %v.", minDiskSize, minDiskSize)
+		logger.Info(errStr)
 		machineConfig.Spec.DiskGiB = minDiskSize
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix the log message to show the defaults properly as it was showing as below before:
```
non-string key argument passed to logging, ignoring all later arguments	{"invalid key": 22}
Warning: VSphereMachineConfig DiskGiB cannot be less than %s. Defaulting to %s.
```

new:
```
Warning: VSphereMachineConfig DiskGiB cannot be less than 22. Defaulting to 22.
```

*Testing (if applicable):*
functional testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

