### PR TITLE
Add snow instance type validation in CLI preflight

### DIFF
--- a/pkg/aws/snowballdevice.go
+++ b/pkg/aws/snowballdevice.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -25,6 +26,19 @@ func (c *Client) IsSnowballDeviceUnlocked(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("describing snowball device: %v", err)
 	}
 	return out.UnlockStatus.State == types.UnlockStatusStateUnlocked, nil
+}
+
+// SnowballDeviceType returns the snowball device type by calling the describe-device api.
+func (c *Client) SnowballDeviceType(ctx context.Context) (string, error) {
+	out, err := c.snowballDevice.DescribeDevice(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("describing snowball device: %v", err)
+	}
+	deviceType := out.DeviceType
+	if deviceType == nil {
+		return "", errors.New("snowball device type not found")
+	}
+	return *deviceType, nil
 }
 
 func (c *Client) SnowballDeviceSoftwareVersion(ctx context.Context) (string, error) {

--- a/pkg/aws/snowballdevice_test.go
+++ b/pkg/aws/snowballdevice_test.go
@@ -86,3 +86,33 @@ func TestSnowballDeviceSoftwareVersionDescribeDeviceSoftwareError(t *testing.T) 
 	g.Expect(err).NotTo(Succeed())
 	g.Expect(got).To(Equal(""))
 }
+
+func TestSnowballDeviceTypeSuccess(t *testing.T) {
+	g := newSnowballDeviceTest(t)
+	deviceType := "device-type"
+	out := &snowballdevice.DescribeDeviceOutput{
+		DeviceType: &deviceType,
+	}
+	g.snowballDevice.EXPECT().DescribeDevice(g.ctx, nil).Return(out, nil)
+	got, err := g.client.SnowballDeviceType(g.ctx)
+	g.Expect(err).To(Succeed())
+	g.Expect(got).To(Equal(deviceType))
+}
+
+func TestSnowballDeviceTypeDescribeDeviceError(t *testing.T) {
+	g := newSnowballDeviceTest(t)
+	g.snowballDevice.EXPECT().DescribeDevice(g.ctx, nil).Return(nil, errors.New("error"))
+	got, err := g.client.SnowballDeviceType(g.ctx)
+	g.Expect(err).NotTo(Succeed())
+	g.Expect(got).To(Equal(""))
+}
+
+func TestSnowballDeviceTypeNotFoundError(t *testing.T) {
+	g := newSnowballDeviceTest(t)
+	out := &snowballdevice.DescribeDeviceOutput{
+		DeviceType: nil,
+	}
+	g.snowballDevice.EXPECT().DescribeDevice(g.ctx, nil).Return(out, nil)
+	_, err := g.client.SnowballDeviceType(g.ctx)
+	g.Expect(err).To(MatchError(ContainSubstring("snowball device type not found")))
+}

--- a/pkg/providers/snow/aws.go
+++ b/pkg/providers/snow/aws.go
@@ -11,6 +11,7 @@ type AwsClient interface {
 	EC2KeyNameExists(ctx context.Context, keyName string) (bool, error)
 	EC2ImportKeyPair(ctx context.Context, keyName string, keyMaterial []byte) error
 	IsSnowballDeviceUnlocked(ctx context.Context) (bool, error)
+	SnowballDeviceType(ctx context.Context) (string, error)
 	SnowballDeviceSoftwareVersion(ctx context.Context) (string, error)
 }
 

--- a/pkg/providers/snow/entry.go
+++ b/pkg/providers/snow/entry.go
@@ -73,6 +73,14 @@ func (cm *ConfigManager) snowEntry(ctx context.Context) *cluster.ConfigManagerEn
 			},
 			func(c *cluster.Config) error {
 				for _, m := range c.SnowMachineConfigs {
+					if err := cm.validator.ValidateInstanceType(ctx, m); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			func(c *cluster.Config) error {
+				for _, m := range c.SnowMachineConfigs {
 					if err := cm.validator.ValidateDeviceSoftware(ctx, m); err != nil {
 						return err
 					}

--- a/pkg/providers/snow/mocks/aws.go
+++ b/pkg/providers/snow/mocks/aws.go
@@ -108,6 +108,21 @@ func (mr *MockAwsClientMockRecorder) SnowballDeviceSoftwareVersion(ctx interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SnowballDeviceSoftwareVersion", reflect.TypeOf((*MockAwsClient)(nil).SnowballDeviceSoftwareVersion), ctx)
 }
 
+// SnowballDeviceType mocks base method.
+func (m *MockAwsClient) SnowballDeviceType(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SnowballDeviceType", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SnowballDeviceType indicates an expected call of SnowballDeviceType.
+func (mr *MockAwsClientMockRecorder) SnowballDeviceType(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SnowballDeviceType", reflect.TypeOf((*MockAwsClient)(nil).SnowballDeviceType), ctx)
+}
+
 // MockLocalIMDSClient is a mock of LocalIMDSClient interface.
 type MockLocalIMDSClient struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/eks-anywhere/issues/4880

*Description of changes:*

Some snow instance types are only supported in specific snow device type. Add validation in CLI to check it.

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

