### PR TITLE
Validate snow instance type has at least 2 default vCPU

### DIFF
--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -74,16 +74,25 @@ func (c *Client) EC2ImportKeyPair(ctx context.Context, keyName string, keyMateri
 	return nil
 }
 
+// EC2InstanceType has the information of an ec2 instance type.
+type EC2InstanceType struct {
+	Name        string
+	DefaultVCPU *int32
+}
+
 // EC2InstanceTypes calls aws sdk ec2.DescribeInstanceTypes to get a list of supported instance type for a device.
-func (c *Client) EC2InstanceTypes(ctx context.Context) ([]string, error) {
+func (c *Client) EC2InstanceTypes(ctx context.Context) ([]EC2InstanceType, error) {
 	out, err := c.ec2.DescribeInstanceTypes(ctx, &ec2.DescribeInstanceTypesInput{})
 	if err != nil {
 		return nil, fmt.Errorf("describing ec2 instance type in device: %v", err)
 	}
 
-	instanceTypes := make([]string, 0, len(out.InstanceTypes))
+	instanceTypes := make([]EC2InstanceType, 0, len(out.InstanceTypes))
 	for _, it := range out.InstanceTypes {
-		instanceTypes = append(instanceTypes, string(it.InstanceType))
+		instanceTypes = append(instanceTypes, EC2InstanceType{
+			Name:        string(it.InstanceType),
+			DefaultVCPU: it.VCpuInfo.DefaultVCpus,
+		})
 	}
 	return instanceTypes, nil
 }

--- a/pkg/aws/ec2_test.go
+++ b/pkg/aws/ec2_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/aws"
 	"github.com/aws/eks-anywhere/pkg/aws/mocks"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 type ec2Test struct {
@@ -123,13 +124,28 @@ func TestEC2InstanceTypes(t *testing.T) {
 		InstanceTypes: []types.InstanceTypeInfo{
 			{
 				InstanceType: types.InstanceTypeC1Medium,
+				VCpuInfo: &types.VCpuInfo{
+					DefaultVCpus: ptr.Int32(8),
+				},
 			},
 			{
 				InstanceType: types.InstanceTypeA1Large,
+				VCpuInfo: &types.VCpuInfo{
+					DefaultVCpus: ptr.Int32(2),
+				},
 			},
 		},
 	}
-	want := []string{"c1.medium", "a1.large"}
+	want := []aws.EC2InstanceType{
+		{
+			Name:        "c1.medium",
+			DefaultVCPU: ptr.Int32(8),
+		},
+		{
+			Name:        "a1.large",
+			DefaultVCPU: ptr.Int32(2),
+		},
+	}
 	g.ec2.EXPECT().DescribeInstanceTypes(g.ctx, &ec2.DescribeInstanceTypesInput{}).Return(out, nil)
 	got, err := g.client.EC2InstanceTypes(g.ctx)
 	g.Expect(err).To(Succeed())

--- a/pkg/providers/snow/aws.go
+++ b/pkg/providers/snow/aws.go
@@ -10,7 +10,7 @@ type AwsClient interface {
 	EC2ImageExists(ctx context.Context, imageID string) (bool, error)
 	EC2KeyNameExists(ctx context.Context, keyName string) (bool, error)
 	EC2ImportKeyPair(ctx context.Context, keyName string, keyMaterial []byte) error
-	EC2InstanceTypes(ctx context.Context) ([]string, error)
+	EC2InstanceTypes(ctx context.Context) ([]aws.EC2InstanceType, error)
 	IsSnowballDeviceUnlocked(ctx context.Context) (bool, error)
 	SnowballDeviceSoftwareVersion(ctx context.Context) (string, error)
 }

--- a/pkg/providers/snow/mocks/aws.go
+++ b/pkg/providers/snow/mocks/aws.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	aws "github.com/aws/eks-anywhere/pkg/aws"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -64,10 +65,10 @@ func (mr *MockAwsClientMockRecorder) EC2ImportKeyPair(ctx, keyName, keyMaterial 
 }
 
 // EC2InstanceTypes mocks base method.
-func (m *MockAwsClient) EC2InstanceTypes(ctx context.Context) ([]string, error) {
+func (m *MockAwsClient) EC2InstanceTypes(ctx context.Context) ([]aws.EC2InstanceType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EC2InstanceTypes", ctx)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]aws.EC2InstanceType)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/aws"
 	kubemock "github.com/aws/eks-anywhere/pkg/clients/kubernetes/mocks"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
@@ -496,12 +497,25 @@ func wantEksaCredentialsSecretWithEnvCreds() *v1.Secret {
 	return secret
 }
 
+func supportedInstanceTypes() []aws.EC2InstanceType {
+	return []aws.EC2InstanceType{
+		{
+			Name:        "sbe-c.large",
+			DefaultVCPU: ptr.Int32(2),
+		},
+		{
+			Name:        "sbe-c.xlarge",
+			DefaultVCPU: ptr.Int32(4),
+		},
+	}
+}
+
 func TestSetupAndValidateCreateClusterSuccess(t *testing.T) {
 	tt := newSnowTest(t)
 	setupContext(t)
 	tt.aws.EXPECT().EC2ImageExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
 	tt.aws.EXPECT().EC2KeyNameExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
-	tt.aws.EXPECT().EC2InstanceTypes(tt.ctx).Return([]string{"sbe-c.large", "sbe-c.xlarge"}, nil).Times(4)
+	tt.aws.EXPECT().EC2InstanceTypes(tt.ctx).Return(supportedInstanceTypes(), nil).Times(4)
 	tt.aws.EXPECT().IsSnowballDeviceUnlocked(tt.ctx).Return(true, nil).Times(4)
 	tt.aws.EXPECT().SnowballDeviceSoftwareVersion(tt.ctx).Return("102", nil).Times(4)
 	tt.imds.EXPECT().EC2InstanceIP(tt.ctx).Return("1.2.3.5", nil)
@@ -516,7 +530,7 @@ func TestSetupAndValidateCreateClusterIMDSNotInitialized(t *testing.T) {
 	tt.provider = newProvider(tt.ctx, t, tt.kubeUnAuthClient, tt.aws, nil, tt.ctrl)
 	tt.aws.EXPECT().EC2ImageExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
 	tt.aws.EXPECT().EC2KeyNameExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
-	tt.aws.EXPECT().EC2InstanceTypes(tt.ctx).Return([]string{"sbe-c.large", "sbe-c.xlarge"}, nil).Times(4)
+	tt.aws.EXPECT().EC2InstanceTypes(tt.ctx).Return(supportedInstanceTypes(), nil).Times(4)
 	tt.aws.EXPECT().IsSnowballDeviceUnlocked(tt.ctx).Return(true, nil).Times(4)
 	tt.aws.EXPECT().SnowballDeviceSoftwareVersion(tt.ctx).Return("102", nil).Times(4)
 	err := tt.provider.SetupAndValidateCreateCluster(tt.ctx, tt.clusterSpec)
@@ -529,7 +543,7 @@ func TestSetupAndValidateCreateClusterCPIPInvalid(t *testing.T) {
 	setupContext(t)
 	tt.aws.EXPECT().EC2ImageExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
 	tt.aws.EXPECT().EC2KeyNameExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
-	tt.aws.EXPECT().EC2InstanceTypes(tt.ctx).Return([]string{"sbe-c.large", "sbe-c.xlarge"}, nil).Times(4)
+	tt.aws.EXPECT().EC2InstanceTypes(tt.ctx).Return(supportedInstanceTypes(), nil).Times(4)
 	tt.aws.EXPECT().IsSnowballDeviceUnlocked(tt.ctx).Return(true, nil).Times(4)
 	tt.aws.EXPECT().SnowballDeviceSoftwareVersion(tt.ctx).Return("102", nil).Times(4)
 	tt.imds.EXPECT().EC2InstanceIP(tt.ctx).Return("1.2.3.4", nil)
@@ -543,7 +557,7 @@ func TestSetupAndValidateCreateClusterGetInstanceIPError(t *testing.T) {
 	setupContext(t)
 	tt.aws.EXPECT().EC2ImageExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
 	tt.aws.EXPECT().EC2KeyNameExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
-	tt.aws.EXPECT().EC2InstanceTypes(tt.ctx).Return([]string{"sbe-c.large", "sbe-c.xlarge"}, nil).Times(4)
+	tt.aws.EXPECT().EC2InstanceTypes(tt.ctx).Return(supportedInstanceTypes(), nil).Times(4)
 	tt.aws.EXPECT().IsSnowballDeviceUnlocked(tt.ctx).Return(true, nil).Times(4)
 	tt.aws.EXPECT().SnowballDeviceSoftwareVersion(tt.ctx).Return("102", nil).Times(4)
 	tt.imds.EXPECT().EC2InstanceIP(tt.ctx).Return("", errors.New("fetch instance ip error"))
@@ -566,18 +580,47 @@ func TestSetupAndValidateCreateClusterGetEC2InstanceTypesError(t *testing.T) {
 	tt.Expect(err).To(MatchError(ContainSubstring("fetching supported instance types for device [1.2.3.4]: get instance types error")))
 }
 
-func TestSetupAndValidateCreateClusterInvalidInstanceTypeError(t *testing.T) {
+func TestSetupAndValidateCreateClusterUnsupportedInstanceTypeError(t *testing.T) {
 	tt := newSnowTest(t)
+	instanceTypes := []aws.EC2InstanceType{
+		{
+			Name: "new-instance-type",
+		},
+	}
 	setupContext(t)
 	tt.aws.EXPECT().EC2ImageExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
 	tt.aws.EXPECT().EC2KeyNameExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
-	tt.aws.EXPECT().EC2InstanceTypes(tt.ctx).Return([]string{"new-instance-type"}, nil)
+	tt.aws.EXPECT().EC2InstanceTypes(tt.ctx).Return(instanceTypes, nil)
 	tt.aws.EXPECT().IsSnowballDeviceUnlocked(tt.ctx).Return(true, nil).Times(4)
 	tt.aws.EXPECT().SnowballDeviceSoftwareVersion(tt.ctx).Return("102", nil).Times(4)
 	tt.imds.EXPECT().EC2InstanceIP(tt.ctx).Return("1.2.3.5", nil)
 	err := tt.provider.SetupAndValidateCreateCluster(tt.ctx, tt.clusterSpec)
 	tt.Expect(tt.clusterSpec.SnowCredentialsSecret).To(Equal(wantEksaCredentialsSecretWithEnvCreds()))
 	tt.Expect(err).To(MatchError(ContainSubstring("not supported in device [1.2.3.4]")))
+}
+
+func TestSetupAndValidateCreateClusterInstanceTypeVCPUError(t *testing.T) {
+	tt := newSnowTest(t)
+	instanceTypes := []aws.EC2InstanceType{
+		{
+			Name:        "sbe-c.large",
+			DefaultVCPU: ptr.Int32(1),
+		},
+		{
+			Name:        "sbe-c.xlarge",
+			DefaultVCPU: ptr.Int32(1),
+		},
+	}
+	setupContext(t)
+	tt.aws.EXPECT().EC2ImageExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
+	tt.aws.EXPECT().EC2KeyNameExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
+	tt.aws.EXPECT().EC2InstanceTypes(tt.ctx).Return(instanceTypes, nil)
+	tt.aws.EXPECT().IsSnowballDeviceUnlocked(tt.ctx).Return(true, nil).Times(4)
+	tt.aws.EXPECT().SnowballDeviceSoftwareVersion(tt.ctx).Return("102", nil).Times(4)
+	tt.imds.EXPECT().EC2InstanceIP(tt.ctx).Return("1.2.3.5", nil)
+	err := tt.provider.SetupAndValidateCreateCluster(tt.ctx, tt.clusterSpec)
+	tt.Expect(tt.clusterSpec.SnowCredentialsSecret).To(Equal(wantEksaCredentialsSecretWithEnvCreds()))
+	tt.Expect(err).To(MatchError(ContainSubstring("has 1 vCPU. Please choose an instance type with at least 2 default vCPU")))
 }
 
 func TestSetupAndValidateCreateClusterNoCredsEnv(t *testing.T) {
@@ -615,7 +658,7 @@ func TestSetupAndValidateUpgradeClusterSuccess(t *testing.T) {
 	setupContext(t)
 	tt.aws.EXPECT().EC2ImageExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
 	tt.aws.EXPECT().EC2KeyNameExists(tt.ctx, gomock.Any()).Return(true, nil).Times(4)
-	tt.aws.EXPECT().EC2InstanceTypes(tt.ctx).Return([]string{"sbe-c.large", "sbe-c.xlarge"}, nil).Times(4)
+	tt.aws.EXPECT().EC2InstanceTypes(tt.ctx).Return(supportedInstanceTypes(), nil).Times(4)
 	tt.aws.EXPECT().IsSnowballDeviceUnlocked(tt.ctx).Return(true, nil).Times(4)
 	tt.aws.EXPECT().SnowballDeviceSoftwareVersion(tt.ctx).Return("102", nil).Times(4)
 	tt.imds.EXPECT().EC2InstanceIP(tt.ctx).Return("1.2.3.5", nil)


### PR DESCRIPTION
*Issue #, if available:*

Add vCPU check for snow instance type as kubelet requires at least 2 vCPU.

*Description of changes:*

*Testing (if applicable):*

Unit tests + manual e2e

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

