### PR TITLE
Replace snow instance type exact match with regex validation

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_snowmachineconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_snowmachineconfigs.yaml
@@ -81,9 +81,7 @@ spec:
                   type: string
                 type: array
               instanceType:
-                description: 'InstanceType is the type of instance to create. Valid
-                  values: "sbe-c.large" (default), "sbe-c.xlarge", "sbe-c.2xlarge"
-                  and "sbe-c.4xlarge".'
+                description: InstanceType is the type of instance to create.
                 type: string
               network:
                 description: Network provides the custom network setting for the machine.

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4960,9 +4960,7 @@ spec:
                   type: string
                 type: array
               instanceType:
-                description: 'InstanceType is the type of instance to create. Valid
-                  values: "sbe-c.large" (default), "sbe-c.xlarge", "sbe-c.2xlarge"
-                  and "sbe-c.4xlarge".'
+                description: InstanceType is the type of instance to create.
                 type: string
               network:
                 description: Network provides the custom network setting for the machine.

--- a/internal/pkg/api/snow.go
+++ b/internal/pkg/api/snow.go
@@ -47,7 +47,8 @@ func WithSnowAMIIDForAllMachines(id string) SnowFiller {
 	}
 }
 
-func WithSnowInstanceTypeForAllMachines(instanceType anywherev1.SnowInstanceType) SnowFiller {
+// WithSnowInstanceTypeForAllMachines specifies an instance type for all the snow machine configs.
+func WithSnowInstanceTypeForAllMachines(instanceType string) SnowFiller {
 	return func(config SnowConfig) {
 		for _, m := range config.machineConfigs {
 			m.Spec.InstanceType = instanceType

--- a/internal/pkg/api/snowmachines.go
+++ b/internal/pkg/api/snowmachines.go
@@ -29,7 +29,8 @@ func WithSnowAMIID(id string) SnowMachineConfigFiller {
 	}
 }
 
-func WithSnowInstanceType(instanceType anywherev1.SnowInstanceType) SnowMachineConfigFiller {
+// WithSnowInstanceType specifies an instance type for the snow machine config.
+func WithSnowInstanceType(instanceType string) SnowMachineConfigFiller {
 	return func(m *anywherev1.SnowMachineConfig) {
 		m.Spec.InstanceType = instanceType
 	}

--- a/pkg/api/v1alpha1/snowmachineconfig_test.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_test.go
@@ -130,7 +130,7 @@ func TestSnowMachineConfigValidate(t *testing.T) {
 			name: "valid without ami",
 			obj: &SnowMachineConfig{
 				Spec: SnowMachineConfigSpec{
-					InstanceType:             DefaultSnowInstanceType,
+					InstanceType:             "sbe-c.4xlarge",
 					PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
 					Devices:                  []string{"1.2.3.4"},
 					OSFamily:                 Ubuntu,
@@ -151,11 +151,11 @@ func TestSnowMachineConfigValidate(t *testing.T) {
 			wantErr: "",
 		},
 		{
-			name: "invalid instance type",
+			name: "invalid instance type sbe-g.largex",
 			obj: &SnowMachineConfig{
 				Spec: SnowMachineConfigSpec{
 					AMIID:                    "ami-1",
-					InstanceType:             "invalid-instance-type",
+					InstanceType:             "sbe-g.largex",
 					PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
 					Devices:                  []string{"1.2.3.4"},
 					OSFamily:                 Bottlerocket,
@@ -173,14 +173,64 @@ func TestSnowMachineConfigValidate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "InstanceType invalid-instance-type is not supported, please use one of the following: sbe-c.large, sbe-c.xlarge, sbe-c.2xlarge, sbe-c.4xlarge, sbe-c.8xlarge, sbe-c.12xlarge, sbe-c.16xlarge, sbe-c.24xlarge",
+			wantErr: "SnowMachineConfig InstanceType sbe-g.largex is not supported",
+		},
+		{
+			name: "invalid instance type sbe-c-xlarge",
+			obj: &SnowMachineConfig{
+				Spec: SnowMachineConfigSpec{
+					AMIID:                    "ami-1",
+					InstanceType:             "sbe-c-large",
+					PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
+					Devices:                  []string{"1.2.3.4"},
+					OSFamily:                 Bottlerocket,
+					Network: SnowNetwork{
+						DirectNetworkInterfaces: []SnowDirectNetworkInterface{
+							{
+								Index:   1,
+								DHCP:    true,
+								Primary: true,
+							},
+						},
+					},
+					ContainersVolume: &snowv1.Volume{
+						Size: 25,
+					},
+				},
+			},
+			wantErr: "SnowMachineConfig InstanceType sbe-c-large is not supported",
+		},
+		{
+			name: "invalid instance type sbe-c.elarge",
+			obj: &SnowMachineConfig{
+				Spec: SnowMachineConfigSpec{
+					AMIID:                    "ami-1",
+					InstanceType:             "sbe-c.elarge",
+					PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
+					Devices:                  []string{"1.2.3.4"},
+					OSFamily:                 Bottlerocket,
+					Network: SnowNetwork{
+						DirectNetworkInterfaces: []SnowDirectNetworkInterface{
+							{
+								Index:   1,
+								DHCP:    true,
+								Primary: true,
+							},
+						},
+					},
+					ContainersVolume: &snowv1.Volume{
+						Size: 25,
+					},
+				},
+			},
+			wantErr: "SnowMachineConfig InstanceType sbe-c.elarge is not supported",
 		},
 		{
 			name: "invalid physical network connector",
 			obj: &SnowMachineConfig{
 				Spec: SnowMachineConfigSpec{
 					AMIID:                    "ami-1",
-					InstanceType:             DefaultSnowInstanceType,
+					InstanceType:             "sbe-c.64xlarge",
 					PhysicalNetworkConnector: "invalid-physical-network",
 					Devices:                  []string{"1.2.3.4"},
 					OSFamily:                 Bottlerocket,
@@ -205,7 +255,7 @@ func TestSnowMachineConfigValidate(t *testing.T) {
 			obj: &SnowMachineConfig{
 				Spec: SnowMachineConfigSpec{
 					AMIID:                    "ami-1",
-					InstanceType:             DefaultSnowInstanceType,
+					InstanceType:             "sbe-g.large",
 					PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
 					OSFamily:                 Bottlerocket,
 					Network: SnowNetwork{

--- a/pkg/api/v1alpha1/snowmachineconfig_types.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_types.go
@@ -11,20 +11,9 @@ const (
 	SFPPlus PhysicalNetworkConnectorType = "SFP_PLUS"
 	QSFP    PhysicalNetworkConnectorType = "QSFP"
 	RJ45    PhysicalNetworkConnectorType = "RJ45"
-
-	SbeCLarge    SnowInstanceType = "sbe-c.large"
-	SbeCXLarge   SnowInstanceType = "sbe-c.xlarge"
-	SbeC2XLarge  SnowInstanceType = "sbe-c.2xlarge"
-	SbeC4XLarge  SnowInstanceType = "sbe-c.4xlarge"
-	SbeC8XLarge  SnowInstanceType = "sbe-c.8xlarge"
-	SbeC12XLarge SnowInstanceType = "sbe-c.12xlarge"
-	SbeC16XLarge SnowInstanceType = "sbe-c.16xlarge"
-	SbeC24XLarge SnowInstanceType = "sbe-c.24xlarge"
 )
 
 type PhysicalNetworkConnectorType string
-
-type SnowInstanceType string
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 // Important: Run "make generate" to regenerate code after modifying this file
@@ -37,8 +26,7 @@ type SnowMachineConfigSpec struct {
 	AMIID string `json:"amiID,omitempty"`
 
 	// InstanceType is the type of instance to create.
-	// Valid values: "sbe-c.large" (default), "sbe-c.xlarge", "sbe-c.2xlarge" and "sbe-c.4xlarge".
-	InstanceType SnowInstanceType `json:"instanceType,omitempty"`
+	InstanceType string `json:"instanceType,omitempty"`
 
 	// PhysicalNetworkConnector is the physical network connector type to use for creating direct network interfaces (DNI).
 	// Valid values: "SFP_PLUS" (default), "QSFP" and "RJ45".

--- a/pkg/api/v1alpha1/snowmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_webhook_test.go
@@ -25,7 +25,7 @@ func TestSnowMachineConfigValidateCreateNoAMI(t *testing.T) {
 
 	sOld := snowMachineConfig()
 	sOld.Spec.SshKeyName = "testKey"
-	sOld.Spec.InstanceType = v1alpha1.SbeCLarge
+	sOld.Spec.InstanceType = v1alpha1.DefaultSnowInstanceType
 	sOld.Spec.PhysicalNetworkConnector = v1alpha1.SFPPlus
 	sOld.Spec.Devices = []string{"1.2.3.4"}
 	sOld.Spec.OSFamily = v1alpha1.Bottlerocket
@@ -58,7 +58,7 @@ func TestSnowMachineConfigValidateCreateInvalidInstanceType(t *testing.T) {
 func TestSnowMachineConfigValidateCreateEmptySSHKeyName(t *testing.T) {
 	g := NewWithT(t)
 	s := snowMachineConfig()
-	s.Spec.InstanceType = v1alpha1.SbeCLarge
+	s.Spec.InstanceType = v1alpha1.DefaultSnowInstanceType
 	s.Spec.PhysicalNetworkConnector = v1alpha1.SFPPlus
 	s.Spec.Devices = []string{"1.2.3.4"}
 	s.Spec.OSFamily = v1alpha1.Ubuntu
@@ -80,7 +80,7 @@ func TestSnowMachineConfigValidateCreate(t *testing.T) {
 	sOld := snowMachineConfig()
 	sOld.Spec.AMIID = "testAMI"
 	sOld.Spec.SshKeyName = "testKey"
-	sOld.Spec.InstanceType = v1alpha1.SbeCLarge
+	sOld.Spec.InstanceType = v1alpha1.DefaultSnowInstanceType
 	sOld.Spec.PhysicalNetworkConnector = v1alpha1.SFPPlus
 	sOld.Spec.Devices = []string{"1.2.3.4"}
 	sOld.Spec.OSFamily = v1alpha1.Bottlerocket
@@ -107,7 +107,7 @@ func TestSnowMachineConfigValidateUpdate(t *testing.T) {
 	sNew := sOld.DeepCopy()
 	sNew.Spec.AMIID = "testAMI"
 	sNew.Spec.SshKeyName = "testKey"
-	sNew.Spec.InstanceType = v1alpha1.SbeCLarge
+	sNew.Spec.InstanceType = v1alpha1.DefaultSnowInstanceType
 	sNew.Spec.PhysicalNetworkConnector = v1alpha1.SFPPlus
 	sNew.Spec.Devices = []string{"1.2.3.4"}
 	sNew.Spec.OSFamily = v1alpha1.Bottlerocket
@@ -134,7 +134,7 @@ func TestSnowMachineConfigValidateUpdateNoDevices(t *testing.T) {
 	sNew := sOld.DeepCopy()
 	sNew.Spec.AMIID = "testAMI"
 	sNew.Spec.SshKeyName = "testKey"
-	sNew.Spec.InstanceType = v1alpha1.SbeCLarge
+	sNew.Spec.InstanceType = v1alpha1.DefaultSnowInstanceType
 	sNew.Spec.PhysicalNetworkConnector = v1alpha1.SFPPlus
 	sNew.Spec.OSFamily = v1alpha1.Bottlerocket
 
@@ -147,7 +147,7 @@ func TestSnowMachineConfigValidateUpdateEmptySSHKeyName(t *testing.T) {
 	sOld := snowMachineConfig()
 	sNew := sOld.DeepCopy()
 	sNew.Spec.AMIID = "testAMI"
-	sNew.Spec.InstanceType = v1alpha1.SbeCLarge
+	sNew.Spec.InstanceType = v1alpha1.DefaultSnowInstanceType
 	sNew.Spec.PhysicalNetworkConnector = v1alpha1.SFPPlus
 	sNew.Spec.OSFamily = v1alpha1.Bottlerocket
 

--- a/pkg/providers/snow/validator.go
+++ b/pkg/providers/snow/validator.go
@@ -167,7 +167,7 @@ func (v *Validator) ValidateInstanceType(ctx context.Context, m *v1alpha1.SnowMa
 			return fmt.Errorf("credentials not found for device [%s]", ip)
 		}
 
-		if err := validateInstanceTypeInDevice(ctx, client, string(m.Spec.InstanceType), ip); err != nil {
+		if err := validateInstanceTypeInDevice(ctx, client, m.Spec.InstanceType, ip); err != nil {
 			return err
 		}
 	}

--- a/test/e2e/snow_test.go
+++ b/test/e2e/snow_test.go
@@ -212,7 +212,7 @@ func TestSnowKubernetes124To125UbuntuMultipleFieldsUpgrade(t *testing.T) {
 			api.WithWorkerNodeCount(2),
 		),
 		provider.WithProviderUpgrade(
-			api.WithSnowInstanceTypeForAllMachines(v1alpha1.SbeCXLarge),
+			api.WithSnowInstanceTypeForAllMachines("sbe-c.xlarge"),
 			api.WithSnowPhysicalNetworkConnectorForAllMachines(v1alpha1.QSFP),
 		),
 		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),


### PR DESCRIPTION
*Issue #, if available:*

#4889 and #4891 introduced new snow instance type validation where we fetch the instance type metadata dynamically from aws go SDK `DescribeInstanceTypes` and see if the instance type specified in each `SnowMachineConfig` is within the supported instance type list and is valid.

*Description of changes:*

This PR removes the exact match of the snow instance type in API context unaware validation, and replace it with regex, which is more flexible and will support newer instance type in the future.

*Testing (if applicable):*

Unit tests + manual e2e


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

