### PR TITLE
Attempt at fix for dev helm chart in dev bundles

### DIFF
--- a/release/pkg/bundles/package-controller.go
+++ b/release/pkg/bundles/package-controller.go
@@ -23,6 +23,7 @@ import (
 	anywherev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	"github.com/aws/eks-anywhere/release/pkg/aws/ecr"
 	"github.com/aws/eks-anywhere/release/pkg/constants"
+	"github.com/aws/eks-anywhere/release/pkg/helm"
 	releasetypes "github.com/aws/eks-anywhere/release/pkg/types"
 	bundleutils "github.com/aws/eks-anywhere/release/pkg/util/bundles"
 	"github.com/aws/eks-anywhere/release/pkg/version"
@@ -37,8 +38,8 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]st
 
 	var sourceBranch string
 	var componentChecksum string
-	var Helmtag, Imagetag string
-	var Helmsha, Imagesha string
+	var Helmtag, Imagetag, Tokentag string
+	var Helmsha, Imagesha, TokenSha string
 	var err error
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	artifactHashes := []string{}
@@ -51,6 +52,10 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]st
 			fmt.Printf("Error getting dev version helm tag EKS Anywhere package controller, using latest version %v", err)
 		}
 		Imagetag, Imagesha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.ECR.EcrClient, "eks-anywhere-packages", "v0.0.0", true)
+		if err != nil {
+			fmt.Printf("Error getting dev version Image tag EKS Anywhere package controller, using latest version %v", err)
+		}
+		Tokentag, TokenSha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.ECR.EcrClient, "ecr-token-refresher", "v0.0.0", true)
 		if err != nil {
 			fmt.Printf("Error getting dev version Image tag EKS Anywhere package controller, using latest version %v", err)
 		}
@@ -76,9 +81,12 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]st
 					}
 				} else {
 					Digest := imageDigests[imageArtifact.ReleaseImageURI]
-					if r.DevRelease && Imagesha != "" && Imagetag != "" {
+					if strings.HasSuffix(imageArtifact.AssetName, "eks-anywhere-packages") && r.DevRelease && TokenSha != "" && Tokentag != "" {
 						Digest = Imagesha
 						imageArtifact.ReleaseImageURI = replaceTag(imageArtifact.ReleaseImageURI, Imagetag)
+					} else if strings.HasSuffix(imageArtifact.AssetName, "ecr-token-refresher") && r.DevRelease && Imagesha != "" && Imagetag != "" {
+						Digest = TokenSha
+						imageArtifact.ReleaseImageURI = replaceTag(imageArtifact.ReleaseImageURI, Tokentag)
 					}
 					bundleImageArtifact = anywherev1alpha1.Image{
 						Name:        imageArtifact.AssetName,
@@ -91,6 +99,37 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]st
 				}
 				bundleImageArtifacts[imageArtifact.AssetName] = bundleImageArtifact
 				artifactHashes = append(artifactHashes, bundleImageArtifact.ImageDigest)
+			}
+		}
+	}
+
+	if !r.DryRun && r.DevRelease && r.BuildRepoBranchName == "main" {
+		for _, componentName := range sortedComponentNames {
+			for _, artifact := range artifacts[componentName] {
+				if artifact.Image != nil {
+					imageArtifact := artifact.Image
+					sourceBranch = imageArtifact.SourcedFromBranch
+					if strings.HasSuffix(imageArtifact.AssetName, "helm") {
+						trimmedAsset := strings.TrimSuffix(artifact.Image.AssetName, "-helm")
+						fmt.Printf("trimmedAsset=%v\n\n", trimmedAsset)
+						helmDriver, err := helm.NewHelm()
+						if err != nil {
+							return anywherev1alpha1.PackageBundle{}, errors.Wrap(err, "creating helm client")
+						}
+						fmt.Printf("Modifying helm chart for %s\n", trimmedAsset)
+						helmDest, err := helm.GetHelmDest(helmDriver, r, imageArtifact.ReleaseImageURI, trimmedAsset)
+						if err != nil {
+							return anywherev1alpha1.PackageBundle{}, errors.Wrap(err, "getting Helm destination:")
+						}
+						fmt.Printf("helmDest=%v\n", helmDest)
+						fmt.Printf("Pulled helm chart locally to %s\n", helmDest)
+						fmt.Printf("r.sourceClients")
+						err = helm.ModifyAndPushChartYaml(*imageArtifact, r, helmDriver, helmDest, artifacts, bundleImageArtifacts)
+						if err != nil {
+							return anywherev1alpha1.PackageBundle{}, errors.Wrap(err, "modifying Chart.yaml and pushing Helm chart to destination:")
+						}
+					}
+				}
 			}
 		}
 	}

--- a/release/pkg/operations/upload.go
+++ b/release/pkg/operations/upload.go
@@ -84,7 +84,7 @@ func UploadArtifacts(r *releasetypes.ReleaseConfig, eksArtifacts map[string][]re
 			if artifact.Image != nil {
 				// If the artifact is a helm chart, skip the skopeo copy. Instead, modify the Chart.yaml to match the release tag
 				// and then use Helm package and push commands to upload chart to ECR Public
-				if !r.DryRun && (strings.HasSuffix(artifact.Image.AssetName, "helm") || strings.HasSuffix(artifact.Image.AssetName, "chart")) {
+				if !r.DryRun && !r.DevRelease && (strings.HasSuffix(artifact.Image.AssetName, "helm") || strings.HasSuffix(artifact.Image.AssetName, "chart")) {
 					// Trim -helm on the packages helm chart, but don't need to trim tinkerbell chart since the AssetName is the same as the repoName
 					trimmedAsset := strings.TrimSuffix(artifact.Image.AssetName, "-helm")
 
@@ -100,7 +100,7 @@ func UploadArtifacts(r *releasetypes.ReleaseConfig, eksArtifacts map[string][]re
 					}
 
 					fmt.Printf("Pulled helm chart locally to %s\n", helmDest)
-					err = helm.ModifyAndPushChartYaml(*artifact.Image, r, helmDriver, helmDest, eksArtifacts)
+					err = helm.ModifyAndPushChartYaml(*artifact.Image, r, helmDriver, helmDest, eksArtifacts, nil)
 					if err != nil {
 						return fmt.Errorf("modifying Chart.yaml and pushing Helm chart to destination: %v", err)
 					}

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -478,7 +478,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.29-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -487,7 +487,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.29-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -496,8 +496,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.29-eks-a-v0.0.0-dev-build.1
-      version: v0.2.29+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-build.1
+      version: v0.2.30+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -509,7 +509,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-21-26-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -527,10 +527,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.21-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/metadata.yaml
-      version: v0.1.21+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
+      version: v0.1.22+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -730,7 +730,7 @@ spec:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.0-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -1264,7 +1264,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.29-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1273,7 +1273,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.29-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1282,8 +1282,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.29-eks-a-v0.0.0-dev-build.1
-      version: v0.2.29+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-build.1
+      version: v0.2.30+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -1295,7 +1295,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-22-19-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -1313,10 +1313,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.21-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/metadata.yaml
-      version: v0.1.21+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
+      version: v0.1.22+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -1516,7 +1516,7 @@ spec:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.0-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -2050,7 +2050,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.29-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -2059,7 +2059,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.29-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2068,8 +2068,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.29-eks-a-v0.0.0-dev-build.1
-      version: v0.2.29+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-build.1
+      version: v0.2.30+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -2081,7 +2081,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-23-14-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2099,10 +2099,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.21-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/metadata.yaml
-      version: v0.1.21+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
+      version: v0.1.22+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -2302,7 +2302,7 @@ spec:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.0-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -2836,7 +2836,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.29-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -2845,7 +2845,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.29-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2854,8 +2854,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.29-eks-a-v0.0.0-dev-build.1
-      version: v0.2.29+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-build.1
+      version: v0.2.30+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -2867,7 +2867,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-24-9-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2885,10 +2885,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.21-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/metadata.yaml
-      version: v0.1.21+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
+      version: v0.1.22+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -3088,7 +3088,7 @@ spec:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.0-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -3595,7 +3595,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.29-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -3604,7 +3604,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.29-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -3613,8 +3613,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.29-eks-a-v0.0.0-dev-build.1
-      version: v0.2.29+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-build.1
+      version: v0.2.30+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -3626,7 +3626,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-25-5-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -3644,10 +3644,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.21-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/metadata.yaml
-      version: v0.1.21+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
+      version: v0.1.22+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -3847,7 +3847,7 @@ spec:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.0-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -3899,6 +3899,765 @@ spec:
         name: cloud-provider-vsphere
         os: linux
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.25.0-eks-d-1-25-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+      syncer:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for vsphere-csi-syncer image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: vsphere-csi-syncer
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.1
+      version: v1.3.1+abcdef1
+  - bootstrap:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kubeadm-bootstrap-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kubeadm-bootstrap-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
+    bottlerocketHostContainers:
+      admin:
+        arch:
+        - amd64
+        description: Container image for bottlerocket-admin image
+        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
+        name: bottlerocket-admin
+        os: linux
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
+      control:
+        arch:
+        - amd64
+        description: Container image for bottlerocket-control image
+        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
+        name: bottlerocket-control
+        os: linux
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
+      kubeadmBootstrap:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for bottlerocket-bootstrap image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: bottlerocket-bootstrap
+        os: linux
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-26-1-eks-a-v0.0.0-dev-build.1
+    certManager:
+      acmesolver:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-acmesolver image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-acmesolver
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-build.1
+      cainjector:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-cainjector image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-cainjector
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-build.1
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-build.1
+      ctl:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-ctl image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-ctl
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-build.1
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
+      version: v1.9.1+abcdef1
+      webhook:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-webhook image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-webhook
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-build.1
+    cilium:
+      cilium:
+        arch:
+        - amd64
+        description: Container image for cilium image
+        imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
+        name: cilium
+        os: linux
+        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+      helmChart:
+        description: Helm chart for cilium-chart
+        imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
+        name: cilium-chart
+        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+      operator:
+        arch:
+        - amd64
+        description: Container image for operator-generic image
+        imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
+        name: operator-generic
+        os: linux
+        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
+      version: v1.11.10-eksa.2
+    cloudStack:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-cloudstack image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-cloudstack
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-build.1
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+      kubeRbacProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
+      version: v0.4.9-rc4+abcdef1
+    clusterAPI:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
+    controlPlane:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kubeadm-control-plane-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kubeadm-control-plane-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
+    docker:
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-docker image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-docker
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
+      version: v1.2.0+abcdef1
+    eksD:
+      ami:
+        bottlerocket: {}
+      channel: 1-26
+      components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+      crictl:
+        arch:
+        - amd64
+        description: cri-tools tarball for linux/amd64
+        name: cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+      etcdadm:
+        arch:
+        - amd64
+        description: etcdadm tarball for linux/amd64
+        name: etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
+      gitCommit: 0123456789abcdef0123456789abcdef01234567
+      imagebuilder:
+        arch:
+        - amd64
+        description: image-builder tarball for linux/amd64
+        name: image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+      kindNode:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kind-node image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kind-node
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.26.1-eks-d-1-26-1-eks-a-v0.0.0-dev-build.1
+      kubeVersion: v1.26.1
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-26/kubernetes-1-26-eks-1.yaml
+      name: kubernetes-1-26-eks-1
+      ova:
+        bottlerocket: {}
+      raw:
+        bottlerocket: {}
+    eksa:
+      cliTools:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-cli-tools image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-cli-tools
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-build.1
+      clusterController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-cluster-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-cluster-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-build.1
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+      diagnosticCollector:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-diagnostic-collector image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-diagnostic-collector
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-build.1
+      version: v0.0.0-dev+build.0+abcdef1
+    etcdadmBootstrap:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/bootstrap-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for etcdadm-bootstrap-provider image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: etcdadm-bootstrap-provider
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc4-eks-a-v0.0.0-dev-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/metadata.yaml
+      version: v1.0.5-rc4+abcdef1
+    etcdadmController:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/bootstrap-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for etcdadm-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: etcdadm-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc4-eks-a-v0.0.0-dev-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/metadata.yaml
+      version: v1.0.4-rc4+abcdef1
+    flux:
+      helmController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for helm-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: helm-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-build.1
+      kustomizeController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kustomize-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kustomize-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-build.1
+      notificationController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for notification-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: notification-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-build.1
+      sourceController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for source-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: source-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-build.1
+      version: v0.31.3+abcdef1
+    haproxy:
+      image:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for haproxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: haproxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-build.1
+    kindnetd:
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
+      version: v0.17.0+abcdef1
+    kubeVersion: "1.26"
+    nutanix:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-nutanix image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-nutanix
+        os: linux
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.1-eks-a-v0.0.0-dev-build.1
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/cluster-template.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/infrastructure-components.yaml
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/metadata.yaml
+      version: v1.1.1+abcdef1
+    packageController:
+      helmChart:
+        description: Helm chart for eks-anywhere-packages
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-packages
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-build.1
+      packageController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-packages image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-packages
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-build.1
+      tokenRefresher:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for ecr-token-refresher image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: ecr-token-refresher
+        os: linux
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-build.1
+      version: v0.2.30+abcdef1
+    snow:
+      bottlerocketBootstrapSnow:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for bottlerocket-bootstrap-snow image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: bottlerocket-bootstrap-snow
+        os: linux
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-26-1-eks-a-v0.0.0-dev-build.1
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-snow-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-snow-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
+      version: v0.1.22+abcdef1
+    tinkerbell:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-tinkerbell image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-tinkerbell
+        os: linux
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.4.0-eks-a-v0.0.0-dev-build.1
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/cluster-template.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/infrastructure-components.yaml
+      envoy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for envoy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: envoy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-build.1
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/metadata.yaml
+      tinkerbellStack:
+        actions:
+          cexec:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for cexec image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: cexec
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+          imageToDisk:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for image2disk image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: image2disk
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+          kexec:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for kexec image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: kexec
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+          ociToDisk:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for oci2disk image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: oci2disk
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+          reboot:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for reboot image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: reboot
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+          writeFile:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for writefile image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: writefile
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+        boots:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for boots image
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: boots
+          os: linux
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.8.1-eks-a-v0.0.0-dev-build.1
+        hegel:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for hegel image
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: hegel
+          os: linux
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.10.1-eks-a-v0.0.0-dev-build.1
+        hook:
+          bootkit:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-bootkit image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: hook-bootkit
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+          docker:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-docker image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: hook-docker
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+          initramfs:
+            amd:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/initramfs-x86_64
+            arm:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/initramfs-aarch64
+          kernel:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-kernel image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: hook-kernel
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+          vmlinuz:
+            amd:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/vmlinuz-x86_64
+            arm:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/vmlinuz-aarch64
+        rufio:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for rufio image
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: rufio
+          os: linux
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v0.2.1-eks-a-v0.0.0-dev-build.1
+        tink:
+          tinkController:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-controller image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: tink-controller
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.8.0-eks-a-v0.0.0-dev-build.1
+          tinkServer:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-server image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: tink-server
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.8.0-eks-a-v0.0.0-dev-build.1
+          tinkWorker:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-worker image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: tink-worker
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.8.0-eks-a-v0.0.0-dev-build.1
+        tinkerbellChart:
+          description: Helm chart for tinkerbell-chart
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: tinkerbell-chart
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
+      version: v0.1.0
+    vSphere:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-vsphere image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-vsphere
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-build.1
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+      driver:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for vsphere-csi-driver image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: vsphere-csi-driver
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cloud-provider-vsphere image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cloud-provider-vsphere
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.25.0-eks-d-1-26-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
       syncer:

--- a/release/pkg/test/testdata/release-0.14-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.14-bundle-release.yaml
@@ -478,7 +478,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
       packageController:
         arch:
         - amd64
@@ -487,7 +487,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -496,8 +496,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.29+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v0.2.30+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -509,7 +509,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-21-26-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -527,10 +527,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.21-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/metadata.yaml
-      version: v0.1.21+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
+      version: v0.1.22+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -1264,7 +1264,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
       packageController:
         arch:
         - amd64
@@ -1273,7 +1273,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1282,8 +1282,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.29+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v0.2.30+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -1295,7 +1295,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-22-19-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -1313,10 +1313,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.21-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/metadata.yaml
-      version: v0.1.21+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
+      version: v0.1.22+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -2050,7 +2050,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
       packageController:
         arch:
         - amd64
@@ -2059,7 +2059,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2068,8 +2068,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.29+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v0.2.30+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -2081,7 +2081,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-23-14-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2099,10 +2099,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.21-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/metadata.yaml
-      version: v0.1.21+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
+      version: v0.1.22+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -2836,7 +2836,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
       packageController:
         arch:
         - amd64
@@ -2845,7 +2845,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2854,8 +2854,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.29+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v0.2.30+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -2867,7 +2867,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-24-9-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2885,10 +2885,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.21-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/metadata.yaml
-      version: v0.1.21+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
+      version: v0.1.22+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -3595,7 +3595,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
       packageController:
         arch:
         - amd64
@@ -3604,7 +3604,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -3613,8 +3613,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.29-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.29+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v0.2.30+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -3626,7 +3626,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-25-5-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -3644,10 +3644,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.21-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.21/metadata.yaml
-      version: v0.1.21+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
+      version: v0.1.22+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Description of changes:*

This will do 3 things which should help with package controller image tag/sha mismatch from the bundle and the helm chart that is causing installation/e2e issues.

1. Will override the Image SHA in the values.yaml for the packages helm chart on dev bundles. This is the function `OverWriteChartValuesImageSha` on line 447 of `release/pkg/helm/helm.go`

2. Will lookup and use the correct latest version/sha of the Token Refresher in the Dev Bundle when running a dev Release. This is on lines 58-61, and 84-89 on  `release/pkg/bundles/package-controller.go`

3. Will override the Image Version and SHA in the values.yaml for the packages helm chart on dev bundles, and push the helm chart to Public ECR that will be used in the dev bundle. We are re-using logic we use to fix the Helm Chart in production by overwriting tags here. This can be found on lines 106-136 on `release/pkg/bundles/package-controller.go`



What this results in is the Helm Chart being referenced in the Dev Bundle getting it's `values.yaml` image tag/sha referenced being forced to the exact version referenced in the Dev Bundle which **Should** :crossed_fingers:  help fix the issues we've been seeing where installations fail due to image not being found.
