### PR TITLE
Remove 1.25 flag & add 1.26 flag for 0.14 branch

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -653,6 +653,7 @@ const (
 	Kube123 KubernetesVersion = "1.23"
 	Kube124 KubernetesVersion = "1.24"
 	Kube125 KubernetesVersion = "1.25"
+	Kube126 KubernetesVersion = "1.26"
 )
 
 type CNI string

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -7,7 +7,7 @@ const (
 	FullLifecycleGate               = "FullLifecycleAPI"
 	CheckpointEnabledEnvVar         = "CHECKPOINT_ENABLED"
 	UseNewWorkflowsEnvVar           = "USE_NEW_WORKFLOWS"
-	K8s125SupportEnvVar             = "K8S_1_25_SUPPORT"
+	K8s126SupportEnvVar             = "K8S_1_26_SUPPORT"
 )
 
 func FeedGates(featureGates []string) {
@@ -56,10 +56,10 @@ func UseNewWorkflows() Feature {
 	}
 }
 
-// K8s125Support is the feature flag for Kubernetes 1.25 support.
-func K8s125Support() Feature {
+// K8s126Support is the feature flag for Kubernetes 1.26 support.
+func K8s126Support() Feature {
 	return Feature{
-		Name:     "Kubernetes version 1.25 support",
-		IsActive: globalFeatures.isActiveForEnvVar(K8s125SupportEnvVar),
+		Name:     "Kubernetes version 1.26 support",
+		IsActive: globalFeatures.isActiveForEnvVar(K8s126SupportEnvVar),
 	}
 }

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -70,10 +70,10 @@ func TestIsActiveWithFeatureGatesTrue(t *testing.T) {
 	g.Expect(IsActive(fakeFeatureWithGate())).To(BeTrue())
 }
 
-func TestWithK8s125FeatureFlag(t *testing.T) {
+func TestWithK8s126FeatureFlag(t *testing.T) {
 	g := NewWithT(t)
 	setupContext(t)
 
-	g.Expect(os.Setenv(K8s125SupportEnvVar, "true")).To(Succeed())
-	g.Expect(IsActive(K8s125Support())).To(BeTrue())
+	g.Expect(os.Setenv(K8s126SupportEnvVar, "true")).To(Succeed())
+	g.Expect(IsActive(K8s126Support())).To(BeTrue())
 }

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -70,11 +70,11 @@ func ValidateManagementClusterName(ctx context.Context, k KubectlClient, mgmtClu
 	return nil
 }
 
-// ValidateK8s125Support checks if the 1.25 feature flag is set when using k8s 1.25.
-func ValidateK8s125Support(clusterSpec *cluster.Spec) error {
-	if !features.IsActive(features.K8s125Support()) {
-		if clusterSpec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube125 {
-			return fmt.Errorf("kubernetes version %s is not enabled. Please set the env variable %v", v1alpha1.Kube125, features.K8s125SupportEnvVar)
+// ValidateK8s126Support checks if the 1.26 feature flag is set when using k8s 1.26.
+func ValidateK8s126Support(clusterSpec *cluster.Spec) error {
+	if !features.IsActive(features.K8s126Support()) {
+		if clusterSpec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube126 {
+			return fmt.Errorf("kubernetes version %s is not enabled. Please set the env variable %v", v1alpha1.Kube126, features.K8s126SupportEnvVar)
 		}
 	}
 	return nil

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -218,17 +218,17 @@ func anywhereCluster(name string) *anywherev1.Cluster {
 	}
 }
 
-func TestValidateK8s125Support(t *testing.T) {
+func TestValidateK8s126Support(t *testing.T) {
 	tt := newTest(t)
-	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube125
-	tt.Expect(validations.ValidateK8s125Support(tt.clusterSpec)).To(
-		MatchError(ContainSubstring("kubernetes version 1.25 is not enabled. Please set the env variable K8S_1_25_SUPPORT")))
+	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube126
+	tt.Expect(validations.ValidateK8s126Support(tt.clusterSpec)).To(
+		MatchError(ContainSubstring("kubernetes version 1.26 is not enabled. Please set the env variable K8S_1_26_SUPPORT")))
 }
 
-func TestValidateK8s125SupportActive(t *testing.T) {
+func TestValidateK8s126SupportActive(t *testing.T) {
 	tt := newTest(t)
-	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube125
+	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube126
 	features.ClearCache()
-	os.Setenv(features.K8s125SupportEnvVar, "true")
-	tt.Expect(validations.ValidateK8s125Support(tt.clusterSpec)).To(Succeed())
+	os.Setenv(features.K8s126SupportEnvVar, "true")
+	tt.Expect(validations.ValidateK8s126Support(tt.clusterSpec)).To(Succeed())
 }

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -46,9 +46,9 @@ func (v *CreateValidations) BuildValidations(ctx context.Context) []validations.
 		},
 		func() *validations.ValidationResult {
 			return &validations.ValidationResult{
-				Name:        "validate kubernetes version 1.25 support",
-				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s125SupportEnvVar),
-				Err:         validations.ValidateK8s125Support(v.Opts.Spec),
+				Name:        "validate kubernetes version 1.26 support",
+				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s126SupportEnvVar),
+				Err:         validations.ValidateK8s126Support(v.Opts.Spec),
 				Silent:      true,
 			}
 		},

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -67,9 +67,9 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) (err erro
 			Err:         ValidateImmutableFields(ctx, k, targetCluster, u.Opts.Spec, u.Opts.Provider),
 		},
 		{
-			Name:        "validate kubernetes version 1.25 support",
-			Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s125SupportEnvVar),
-			Err:         validations.ValidateK8s125Support(u.Opts.Spec),
+			Name:        "validate kubernetes version 1.26 support",
+			Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s126SupportEnvVar),
+			Err:         validations.ValidateK8s126Support(u.Opts.Spec),
 			Silent:      true,
 		},
 	}

--- a/test/e2e/awsiam_test.go
+++ b/test/e2e/awsiam_test.go
@@ -83,7 +83,6 @@ func TestDockerKubernetes125AWSIamAuth(t *testing.T) {
 		framework.NewDocker(t),
 		framework.WithAWSIam(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runAWSIamAuthFlow(test)
 }
@@ -134,7 +133,6 @@ func TestVSphereKubernetes125AWSIamAuth(t *testing.T) {
 		framework.NewVSphere(t, framework.WithUbuntu125()),
 		framework.WithAWSIam(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runAWSIamAuthFlow(test)
 }
@@ -192,7 +190,6 @@ func TestVSphereKubernetes124To125AWSIamAuthUpgrade(t *testing.T) {
 		v1alpha1.Kube125,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		provider.WithProviderUpgrade(provider.Ubuntu125Template()),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 }
 

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -77,7 +77,6 @@ func TestDockerKubernetes125ThreeWorkersConformanceFlow(t *testing.T) {
 		framework.NewDocker(t),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runConformanceFlow(test)
 }
@@ -128,7 +127,6 @@ func TestVSphereKubernetes125ThreeWorkersConformanceFlow(t *testing.T) {
 		framework.NewVSphere(t, framework.WithUbuntu125()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runConformanceFlow(test)
 }

--- a/test/e2e/flux_test.go
+++ b/test/e2e/flux_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -41,7 +40,6 @@ func TestDockerKubernetes125GithubFlux(t *testing.T) {
 		framework.NewDocker(t),
 		framework.WithFluxGithub(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runFluxFlow(test)
 }
@@ -51,7 +49,6 @@ func TestDockerKubernetes125GitFlux(t *testing.T) {
 		framework.NewDocker(t),
 		framework.WithFluxGit(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runFluxFlow(test)
 }
@@ -85,7 +82,6 @@ func TestVSphereKubernetes125FluxLegacy(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runFluxFlow(test)
 }
@@ -98,7 +94,6 @@ func TestVSphereKubernetes125GithubFlux(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runFluxFlow(test)
 }
@@ -111,7 +106,6 @@ func TestVSphereKubernetes125GitFlux(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runFluxFlow(test)
 }
@@ -159,7 +153,6 @@ func TestVSphereKubernetes125ThreeReplicasThreeWorkersFluxLegacy(t *testing.T) {
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
 		framework.WithFluxLegacy(),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runFluxFlow(test)
 }
@@ -175,7 +168,6 @@ func TestDockerKubernetes125GitopsOptionsFluxLegacy(t *testing.T) {
 			api.WithFluxNamespace(fluxUserProvidedNamespace),
 			api.WithFluxConfigurationPath(fluxUserProvidedPath),
 		),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runFluxFlow(test)
 }
@@ -192,7 +184,6 @@ func TestVSphereKubernetes125GitopsOptionsFluxLegacy(t *testing.T) {
 			api.WithFluxNamespace(fluxUserProvidedNamespace),
 			api.WithFluxConfigurationPath(fluxUserProvidedPath),
 		),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runFluxFlow(test)
 }
@@ -212,7 +203,6 @@ func TestVSphereKubernetes124To125FluxUpgradeLegacy(t *testing.T) {
 		v1alpha1.Kube125,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		provider.WithProviderUpgrade(provider.Ubuntu125Template()),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 }
 
@@ -231,7 +221,6 @@ func TestVSphereKubernetes124To125GitFluxUpgrade(t *testing.T) {
 		v1alpha1.Kube125,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		provider.WithProviderUpgrade(provider.Ubuntu125Template()),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 }
 

--- a/test/e2e/labels_test.go
+++ b/test/e2e/labels_test.go
@@ -51,7 +51,6 @@ func TestDockerKubernetes125Labels(t *testing.T) {
 			api.WithWorkerNodeGroup(worker2, api.WithCount(1),
 				api.WithLabel(key2, val2)),
 		),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 
 	runLabelsUpgradeFlow(
@@ -78,7 +77,6 @@ func TestVSphereKubernetes125Labels(t *testing.T) {
 			api.WithControlPlaneCount(1),
 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 		),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 
 	runLabelsUpgradeFlow(

--- a/test/e2e/oidc_test.go
+++ b/test/e2e/oidc_test.go
@@ -83,7 +83,6 @@ func TestDockerKubernetes125OIDC(t *testing.T) {
 		framework.NewDocker(t),
 		framework.WithOIDC(),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runOIDCFlow(test)
 }
@@ -176,7 +175,6 @@ func TestVSphereKubernetes125OIDC(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runOIDCFlow(test)
 }
@@ -197,7 +195,6 @@ func TestVSphereKubernetes124To125OIDCUpgrade(t *testing.T) {
 		v1alpha1.Kube125,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		provider.WithProviderUpgrade(provider.Ubuntu125Template()),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 }
 

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -28,7 +28,6 @@ func TestVSphereKubernetes125UbuntuProxyConfig(t *testing.T) {
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runProxyConfigFlow(test)
 }

--- a/test/e2e/registry_mirror_test.go
+++ b/test/e2e/registry_mirror_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -41,7 +40,6 @@ func TestVSphereKubernetes125UbuntuRegistryMirrorAndCert(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runRegistryMirrorConfigFlow(test)
 }

--- a/test/e2e/simpleflow_test.go
+++ b/test/e2e/simpleflow_test.go
@@ -88,7 +88,6 @@ func TestDockerKubernetes125SimpleFlow(t *testing.T) {
 		t,
 		framework.NewDocker(t),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
-		framework.WithEnvVar("K8S_1_25_SUPPORT", "true"),
 	)
 	runSimpleFlow(test)
 }
@@ -134,7 +133,6 @@ func TestVSphereKubernetes125SimpleFlow(t *testing.T) {
 		t,
 		framework.NewVSphere(t, framework.WithUbuntu125()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
-		framework.WithEnvVar("K8S_1_25_SUPPORT", "true"),
 	)
 	runSimpleFlow(test)
 }
@@ -326,7 +324,6 @@ func TestTinkerbellKubernetes125SimpleFlow(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		framework.WithControlPlaneHardware(1),
 		framework.WithWorkerHardware(1),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runTinkerbellSimpleFlow(test)
 }
@@ -382,7 +379,6 @@ func TestTinkerbellKubernetes125RedHatSimpleFlow(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		framework.WithControlPlaneHardware(1),
 		framework.WithWorkerHardware(1),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runTinkerbellSimpleFlow(test)
 }

--- a/test/e2e/stackedetcd_test.go
+++ b/test/e2e/stackedetcd_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -68,8 +67,7 @@ func TestVSphereKubernetes125StackedEtcdUbuntu(t *testing.T) {
 		framework.NewVSphere(t, framework.WithUbuntu125()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"))
+		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
 	runStackedEtcdFlow(test)
 }
 

--- a/test/e2e/taints_test.go
+++ b/test/e2e/taints_test.go
@@ -47,7 +47,6 @@ func TestDockerKubernetes125Taints(t *testing.T) {
 			api.WithWorkerNodeGroup(worker1, api.WithCount(1)),
 			api.WithWorkerNodeGroup(worker2, api.WithTaint(framework.PreferNoScheduleTaint()), api.WithCount(1)),
 		),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 
 	runTaintsUpgradeFlow(
@@ -74,7 +73,6 @@ func TestVSphereKubernetes125Taints(t *testing.T) {
 			api.WithControlPlaneCount(1),
 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 		),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 
 	runTaintsUpgradeFlow(

--- a/test/e2e/upgrade_from_latest_test.go
+++ b/test/e2e/upgrade_from_latest_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	"github.com/aws/eks-anywhere/test/framework"
 )
@@ -314,7 +313,6 @@ func TestVSphereKubernetes124To125UbuntuUpgradeFromLatestMinorRelease(t *testing
 			provider.Ubuntu125Template(), // Set the template so it doesn't get autoimported
 		),
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(anywherev1.Kube125)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 }
 
@@ -391,7 +389,6 @@ func TestDockerKubernetes124to125UpgradeFromLatestMinorRelease(t *testing.T) {
 		release,
 		anywherev1.Kube125,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(anywherev1.Kube125)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 }
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -124,7 +124,6 @@ func TestVSphereKubernetes124UbuntuTo125Upgrade(t *testing.T) {
 		v1alpha1.Kube125,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		provider.WithProviderUpgrade(provider.Ubuntu125Template()),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 }
 
@@ -144,7 +143,6 @@ func TestVSphereKubernetes124UbuntuTo125UpgradeCiliumPolicyEnforcementMode(t *te
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
 		provider.WithProviderUpgrade(provider.Ubuntu125Template()),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 }
 
@@ -159,7 +157,6 @@ func TestVSphereKubernetes124UbuntuTo125MultipleFieldsUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube125,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube125)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 		provider.WithProviderUpgrade(
 			provider.Ubuntu125Template(),
 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
@@ -191,7 +188,6 @@ func TestVSphereKubernetes124UbuntuTo125WithFluxLegacyUpgrade(t *testing.T) {
 		v1alpha1.Kube125,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		provider.WithProviderUpgrade(provider.Ubuntu125Template()),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 }
 
@@ -213,7 +209,6 @@ func TestVSphereKubernetes124UbuntuTo125DifferentNamespaceWithFluxLegacyUpgrade(
 		v1alpha1.Kube125,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		provider.WithProviderUpgrade(provider.Ubuntu125Template()),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 }
 
@@ -225,7 +220,6 @@ func TestVSphereKubernetes125UbuntuControlPlaneNodeUpgrade(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runSimpleUpgradeFlow(
 		test,
@@ -242,7 +236,6 @@ func TestVSphereKubernetes125UbuntuWorkerNodeUpgrade(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runSimpleUpgradeFlow(
 		test,
@@ -375,7 +368,6 @@ func TestDockerKubernetes124To125StackedEtcdUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube125,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube125)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 }
 
@@ -391,7 +383,6 @@ func TestDockerKubernetes124To125ExternalEtcdUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube125,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube125)),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 }
 
@@ -724,7 +715,6 @@ func TestTinkerbellKubernetes125UbuntuWorkerNodeUpgrade(t *testing.T) {
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
 		framework.WithControlPlaneHardware(1),
 		framework.WithWorkerHardware(2),
-		framework.WithEnvVar(features.K8s125SupportEnvVar, "true"),
 	)
 	runSimpleUpgradeFlowForBareMetal(
 		test,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removing 1.25 feature flag & adding 1.26 feature flag manually for 0.14 since the e2e test structure changed drastically since adding the feature flag, but there is not real need to backport all of those implementations to this branch 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

