### PR TITLE
Add bundles override flag for list and download commands

### DIFF
--- a/cmd/eksctl-anywhere/cmd/checkimages.go
+++ b/cmd/eksctl-anywhere/cmd/checkimages.go
@@ -48,13 +48,13 @@ var checkImagesCommand = &cobra.Command{
 	},
 }
 
-func checkImages(context context.Context, spec string) error {
-	images, err := getImages(spec)
+func checkImages(context context.Context, clusterSpecPath string) error {
+	images, err := getImages(clusterSpecPath, "")
 	if err != nil {
 		return err
 	}
 
-	clusterSpec, err := readAndValidateClusterSpec(spec, version.Get())
+	clusterSpec, err := readAndValidateClusterSpec(clusterSpecPath, version.Get())
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -11,8 +11,12 @@ import (
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
-func getImages(spec string) ([]v1alpha1.Image, error) {
-	clusterSpec, err := readAndValidateClusterSpec(spec, version.Get())
+func getImages(clusterSpecPath, bundlesOverride string) ([]v1alpha1.Image, error) {
+	var specOpts []cluster.SpecOpt
+	if bundlesOverride != "" {
+		specOpts = append(specOpts, cluster.WithOverrideBundlesManifest(bundlesOverride))
+	}
+	clusterSpec, err := readAndValidateClusterSpec(clusterSpecPath, version.Get(), specOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/eksctl-anywhere/cmd/importimages.go
+++ b/cmd/eksctl-anywhere/cmd/importimages.go
@@ -54,13 +54,14 @@ var importImagesCmdDeprecated = &cobra.Command{
 	},
 }
 
-func importImages(ctx context.Context, spec string) error {
+//gocyclo:ignore
+func importImages(ctx context.Context, clusterSpecPath string) error {
 	registryUsername := os.Getenv("REGISTRY_USERNAME")
 	registryPassword := os.Getenv("REGISTRY_PASSWORD")
 	if registryUsername == "" || registryPassword == "" {
 		return fmt.Errorf("username or password not set. Provide REGISTRY_USERNAME and REGISTRY_PASSWORD for importing helm charts (e.g. cilium)")
 	}
-	clusterSpec, err := readAndValidateClusterSpec(spec, version.Get())
+	clusterSpec, err := readAndValidateClusterSpec(clusterSpecPath, version.Get())
 	if err != nil {
 		return err
 	}
@@ -88,7 +89,7 @@ func importImages(ctx context.Context, spec string) error {
 		return fmt.Errorf("registry mirror port %s is invalid, please provide a valid port", clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Port)
 	}
 
-	images, err := getImages(spec)
+	images, err := getImages(clusterSpecPath, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/internal/commands/artifacts/download.go
+++ b/cmd/eksctl-anywhere/cmd/internal/commands/artifacts/download.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/aws/eks-anywhere/pkg/files"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
 	"github.com/aws/eks-anywhere/pkg/version"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
@@ -34,6 +36,7 @@ type Packager interface {
 
 type Download struct {
 	Reader                   Reader
+	FileReader               *files.Reader
 	Version                  version.Info
 	BundlesImagesDownloader  ImageMover
 	EksaToolsImageDownloader ImageMover
@@ -42,15 +45,26 @@ type Download struct {
 	TmpDowloadFolder         string
 	DstFile                  string
 	ManifestDownloader       ManifestDownloader
+	BundlesOverride          string
 }
 
 func (d Download) Run(ctx context.Context) error {
 	if err := os.MkdirAll(d.TmpDowloadFolder, os.ModePerm); err != nil {
 		return fmt.Errorf("creating tmp artifact download folder: %v", err)
 	}
-	b, err := d.Reader.ReadBundlesForVersion(d.Version.GitVersion)
-	if err != nil {
-		return fmt.Errorf("downloading images: %v", err)
+
+	var b *releasev1.Bundles
+	var err error
+	if d.BundlesOverride != "" {
+		b, err = bundles.Read(d.FileReader, d.BundlesOverride)
+		if err != nil {
+			return fmt.Errorf("reading bundles override: %v", err)
+		}
+	} else {
+		b, err = d.Reader.ReadBundlesForVersion(d.Version.GitVersion)
+		if err != nil {
+			return fmt.Errorf("reading bundles for version %s: %v", d.Version.GitVersion, err)
+		}
 	}
 
 	toolsImage := b.DefaultEksAToolsImage().VersionedImage()

--- a/cmd/eksctl-anywhere/cmd/listimages.go
+++ b/cmd/eksctl-anywhere/cmd/listimages.go
@@ -12,6 +12,7 @@ import (
 
 type listImagesOptions struct {
 	fileName string
+	bundlesOverride string
 }
 
 var lio = &listImagesOptions{}
@@ -19,10 +20,7 @@ var lio = &listImagesOptions{}
 func init() {
 	listCmd.AddCommand(listImagesCommand)
 	listImagesCommand.Flags().StringVarP(&lio.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
-	err := listImagesCommand.MarkFlagRequired("filename")
-	if err != nil {
-		log.Fatalf("Error marking filename flag as required: %v", err)
-	}
+	listImagesCommand.Flags().StringVarP(&lio.bundlesOverride, "bundles-override", "", "", "Override default Bundles manifest (not recommended)")
 }
 
 var listImagesCommand = &cobra.Command{
@@ -39,12 +37,12 @@ var listImagesCommand = &cobra.Command{
 	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return listImages(cmd.Context(), lio.fileName)
+		return listImages(cmd.Context(), lio.fileName, lio.bundlesOverride)
 	},
 }
 
-func listImages(context context.Context, spec string) error {
-	images, err := getImages(spec)
+func listImages(context context.Context, clusterSpecPath, bundlesOverride string) error {
+	images, err := getImages(clusterSpecPath, bundlesOverride)
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/listovas.go
+++ b/cmd/eksctl-anywhere/cmd/listovas.go
@@ -14,11 +14,13 @@ import (
 	"sigs.k8s.io/yaml"
 
 	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/version"
 )
 
 type listOvasOptions struct {
 	fileName string
+	bundlesOverride string
 }
 
 type listOvasOutput struct {
@@ -32,6 +34,7 @@ var listOvaOpts = &listOvasOptions{}
 func init() {
 	listCmd.AddCommand(listOvasCmd)
 	listOvasCmd.Flags().StringVarP(&listOvaOpts.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
+	listOvasCmd.Flags().StringVarP(&listOvaOpts.bundlesOverride, "bundles-override", "", "", "Override default Bundles manifest (not recommended)")
 	err := listOvasCmd.MarkFlagRequired("filename")
 	if err != nil {
 		log.Fatalf("Error marking filename flag as required: %v", err)
@@ -45,15 +48,19 @@ var listOvasCmd = &cobra.Command{
 	PreRunE:      preRunListOvasCmd,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := listOvas(cmd.Context(), listOvaOpts.fileName); err != nil {
+		if err := listOvas(cmd.Context(), listOvaOpts.fileName, listOvaOpts.bundlesOverride); err != nil {
 			return err
 		}
 		return nil
 	},
 }
 
-func listOvas(context context.Context, spec string) error {
-	clusterSpec, err := readAndValidateClusterSpec(spec, version.Get())
+func listOvas(context context.Context, clusterSpecPath, bundlesOverride string) error {
+	var specOpts []cluster.SpecOpt
+	if bundlesOverride != "" {
+		specOpts = append(specOpts, cluster.WithOverrideBundlesManifest(bundlesOverride))
+	}
+	clusterSpec, err := readAndValidateClusterSpec(clusterSpecPath, version.Get(), specOpts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adding bundles override to EKS-A `list` and `download` command sets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

