### PR TITLE
Fix snow e2e error in release branch

### DIFF
--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -568,7 +568,7 @@ func TestSnowKubernetes122To123UbuntuMultipleFieldsUpgrade(t *testing.T) {
 		),
 		provider.WithProviderUpgrade(
 			framework.UpdateSnowUbuntuTemplate123Var(),
-			api.WithSnowInstanceTypeForAllMachines(v1alpha1.SbeCXLarge),
+			api.WithSnowInstanceTypeForAllMachines("sbe-c.large"),
 			api.WithSnowPhysicalNetworkConnectorForAllMachines(v1alpha1.QSFP),
 		),
 		framework.WithEnvVar(features.SnowProviderEnvVar, "true"),


### PR DESCRIPTION
*Issue #, if available:*

Some snow e2e changes are not cherry-picked to release 0.14 branch. Causing old snow e2e failing. 

*Description of changes:*

Since snow e2e tests are not running in CI, we only fix the instanceType to bypass the compile error.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

