### PR TITLE
Add function remove doubletagged images

### DIFF
--- a/release/pkg/aws/ecr/ecr.go
+++ b/release/pkg/aws/ecr/ecr.go
@@ -119,6 +119,18 @@ func FilterECRRepoByTagPrefix(ecrClient *ecr.ECR, repoName, prefix string, hasTa
 	} else {
 		filteredImageDetails = imageTagFilterWithout(imageDetails, prefix)
 	}
+
+	// Filter out any tags that don't match our prefix for doubletagged scenarios
+	for _, detail := range filteredImageDetails {
+		if len(detail.ImageTags) > 0 {
+			for j, tag := range detail.ImageTags {
+				if !strings.HasPrefix(*tag, prefix) {
+					detail.ImageTags = removeStringSlice(detail.ImageTags, *detail.ImageTags[j])
+				}
+			}
+		}
+	}
+
 	// In case we don't find any tag substring matches, we still want to populate the bundle with the latest version.
 	if len(filteredImageDetails) < 1 {
 		filteredImageDetails = imageDetails
@@ -200,4 +212,14 @@ func GetLatestImageSha(ecrClient *ecr.ECR, repoName string) (string, error) {
 		return "", fmt.Errorf("error no images found")
 	}
 	return *latest.ImageTags[0], nil
+}
+
+// removeStringSlice removes a named string from a slice, without knowing it's index or it being ordered.
+func removeStringSlice(l []*string, item string) []*string {
+	for i, other := range l {
+		if *other == item {
+			return append(l[:i], l[i+1:]...)
+		}
+	}
+	return l
 }

--- a/release/pkg/aws/ecr/ecr.go
+++ b/release/pkg/aws/ecr/ecr.go
@@ -122,11 +122,9 @@ func FilterECRRepoByTagPrefix(ecrClient *ecr.ECR, repoName, prefix string, hasTa
 
 	// Filter out any tags that don't match our prefix for doubletagged scenarios
 	for _, detail := range filteredImageDetails {
-		if len(detail.ImageTags) > 0 {
-			for j, tag := range detail.ImageTags {
-				if !strings.HasPrefix(*tag, prefix) {
-					detail.ImageTags = removeStringSlice(detail.ImageTags, *detail.ImageTags[j])
-				}
+		for _, tag := range detail.ImageTags {
+			if tag != nil && !strings.HasPrefix(*tag, prefix) {
+				detail.ImageTags = removeStringSlice(detail.ImageTags, *tag)
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Description of changes:*

Sometimes when the image details gets checked it will multiple tags.

`["0.0.0.abcde", "latest"]`

This would technically pass the filter requirement where we are looking for the presence of the of the prefix `0.0.0` however it might return back the tag of latest for the actual bundle.

This function will check the slice once a match has been made, and remove out an items from the slice which also don't match the prefix requirement.

var newSlice []string
newSlice = removeStringSlice(["0.0.0.abcde", "latest"] "latest")

`["0.0.0.abcde", "latest"]`  becomes.... `["0.0.0.abcde"]` 



Last PR was using `*detail.ImageTags[j]` which would get index out of length error, so changed function to not utilize index.