### PR TITLE
Wait for control plane ready before using kubeconfig for validations in API e2e tests

### DIFF
--- a/test/framework/workload.go
+++ b/test/framework/workload.go
@@ -63,6 +63,11 @@ func (w *WorkloadCluster) WaitForKubeconfig() {
 	if err != nil {
 		w.T.Fatalf("Failed waiting for cluster kubeconfig: %s", err)
 	}
+
+	w.T.Logf("Waiting for workload cluster %s control plane to be ready", w.ClusterName)
+	if err := w.KubectlClient.WaitForControlPlaneReady(ctx, w.managementCluster(), "10m", w.ClusterName); err != nil {
+		w.T.Errorf("Failed waiting for control plane ready: %s", err)
+	}
 }
 
 // ValidateClusterDelete verifies the cluster has been deleted.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some of the API tests are failing while trying to create the cluster client, because `connect: no route to host` after waiting for the kubeconfig. This PR adds a wait for the control plane to be ready after waiting for the kubeconfig, since there may be a delay there.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

