### PR TITLE
Remove --tls=false when deploying Tinkerbell chart

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -162,7 +162,7 @@ func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 		},
 		tinkServer: map[string]interface{}{
 			image: bundle.TinkerbellStack.Tink.TinkServer.URI,
-			args:  []string{"--tls=false"},
+			args:  []string{},
 			port: map[string]bool{
 				hostPortEnabled: s.hostPort,
 			},
@@ -377,6 +377,7 @@ func (s *Installer) Upgrade(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 		},
 		tinkServer: map[string]interface{}{
 			image: bundle.TinkerbellStack.Tink.TinkServer.URI,
+			args:  []string{},
 		},
 		hegel: map[string]interface{}{
 			image: bundle.TinkerbellStack.Hegel.URI,


### PR DESCRIPTION
Upon merging https://github.com/aws/eks-anywhere-build-tooling/pull/1856, the TLS flag won't be required as part of values YAML and will be present in both create and upgrade.

This fixes the upgrade issue where the TLS flag is dropped because it was a values override that didn't get re-used from original deployment.