### PR TITLE
docs: Make managementCluster defintion obvious

### DIFF
--- a/docs/content/en/docs/getting-started/production-environment/baremetal-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/baremetal-getstarted.md
@@ -123,7 +123,21 @@ Follow these steps if you want to use your initial cluster to create and manage 
    ```
 
    Refer to the initial config described earlier for the required and optional settings.
-   Ensure workload cluster object names (`Cluster`, `TinkerbellDatacenterConfig`, `TinkerbellMachineConfig`, etc.) are distinct from management cluster object names. Be sure to set the `managementCluster` field to identify the name of the management cluster. Keep the tinkerbellIP of workload cluster the same as tinkerbellIP of the management cluster.
+   Ensure workload cluster object names (`Cluster`, `TinkerbellDatacenterConfig`, `TinkerbellMachineConfig`, etc.) are distinct from management cluster object names. Keep the tinkerbellIP of workload cluster the same as tinkerbellIP of the management cluster.
+
+1. Be sure to set the `managementCluster` field to identify the name of the management cluster.
+
+   For example, the management cluster, _mgmt_ is defined for our workload cluster _w01_ as follows:
+
+   ```yaml
+   apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+   kind: Cluster
+   metadata:
+     name: w01
+   spec:
+     managementCluster:
+       name: mgmt
+   ```
 
 1. Set License Environment Variable
 

--- a/docs/content/en/docs/getting-started/production-environment/cloudstack-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/cloudstack-getstarted.md
@@ -188,7 +188,20 @@ Follow these steps if you want to use your initial cluster to create and manage 
    Refer to the initial config described earlier for the required and optional settings. In particular:
 
    * Ensure workload cluster object names (`Cluster`, `CloudDatacenterConfig`, `CloudStackMachineConfig`, etc.) are distinct from management cluster object names.
-   * Be sure to set the `managementCluster` field to identify the name of the management cluster.
+
+1. Be sure to set the `managementCluster` field to identify the name of the management cluster.
+
+   For example, the management cluster, _mgmt_ is defined for our workload cluster _w01_ as follows:
+
+   ```yaml
+   apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+   kind: Cluster
+   metadata:
+     name: w01
+   spec:
+     managementCluster:
+       name: mgmt
+   ```
 
 1. Set License Environment Variable
 

--- a/docs/content/en/docs/getting-started/production-environment/nutanix-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/nutanix-getstarted.md
@@ -168,7 +168,21 @@ Follow these steps if you want to use your initial cluster to create and manage 
    ```
 
    Refer to the initial config described earlier for the required and optional settings.
-   Ensure workload cluster object names (`Cluster`, `NutanixDatacenterConfig`, `NutanixMachineConfig`, etc.) are distinct from management cluster object names. Be sure to set the `managementCluster` field to identify the name of the management cluster.
+   Ensure workload cluster object names (`Cluster`, `NutanixDatacenterConfig`, `NutanixMachineConfig`, etc.) are distinct from management cluster object names.
+
+1. Be sure to set the `managementCluster` field to identify the name of the management cluster.
+
+   For example, the management cluster, _mgmt_ is defined for our workload cluster _w01_ as follows:
+
+   ```yaml
+   apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+   kind: Cluster
+   metadata:
+     name: w01
+   spec:
+     managementCluster:
+       name: mgmt
+   ```
 
 1. Set License Environment Variable
 

--- a/docs/content/en/docs/getting-started/production-environment/snow-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/snow-getstarted.md
@@ -162,7 +162,21 @@ Follow these steps if you want to use your initial cluster to create and manage 
 
    Refer to the initial config described earlier for the required and optional settings.
 
-   >**NOTE**: Ensure workload cluster object names (`Cluster`, `SnowDatacenterConfig`, `SnowMachineConfig`, etc.) are distinct from management cluster object names. Be sure to set the `managementCluster` field to identify the name of the management cluster.
+   >**NOTE**: Ensure workload cluster object names (`Cluster`, `SnowDatacenterConfig`, `SnowMachineConfig`, etc.) are distinct from management cluster object names.
+
+1. Be sure to set the `managementCluster` field to identify the name of the management cluster.
+
+   For example, the management cluster, _mgmt_ is defined for our workload cluster _w01_ as follows:
+
+   ```yaml
+   apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+   kind: Cluster
+   metadata:
+     name: w01
+   spec:
+     managementCluster:
+       name: mgmt
+   ```
 
 1. Set License Environment Variable
 

--- a/docs/content/en/docs/getting-started/production-environment/vsphere-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/vsphere-getstarted.md
@@ -170,7 +170,21 @@ Follow these steps if you want to use your initial cluster to create and manage 
 
    Refer to the initial config described earlier for the required and optional settings.
 
-   >**NOTE**: Ensure workload cluster object names (`Cluster`, `VSphereDatacenterConfig`, `VSphereMachineConfig`, etc.) are distinct from management cluster object names. Be sure to set the `managementCluster` field to identify the name of the management cluster.
+   >**NOTE**: Ensure workload cluster object names (`Cluster`, `vSphereDatacenterConfig`, `vSphereMachineConfig`, etc.) are distinct from management cluster object names.
+
+1. Be sure to set the `managementCluster` field to identify the name of the management cluster.
+
+   For example, the management cluster, _mgmt_ is defined for our workload cluster _w01_ as follows:
+
+   ```yaml
+   apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+   kind: Cluster
+   metadata:
+     name: w01
+   spec:
+     managementCluster:
+       name: mgmt
+   ```
 
 1. Set License Environment Variable
 


### PR DESCRIPTION
managementCluster is a critical field for workload clusters. It was only defined as the last sentence in a note here. Let's make it more obvious.

*Issue #, if available:*
None
*Description of changes:*
managementCluster is a critical field for workload clusters. It was only defined as the last sentence in a note here. Let's make it more obvious.

*Testing (if applicable):*
Markdown preview

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

