### PR TITLE
Document e2e Build Flag Configuration in Quick Start

### DIFF
--- a/docs/developer/local-quickstart.md
+++ b/docs/developer/local-quickstart.md
@@ -58,3 +58,18 @@ If using VSCode, you can use the following as a `launch.json` configuration:
     ]
 }
 ```
+
+## Building e2e Tests
+
+Building e2e tests requires adding build tags. You can read more about what they are and how they work here.
+
+If using vscode, add this to your `.vscode/settings.json` file:
+```
+{
+    ...
+    "go.buildFlags": [
+        "-tags=e2e,all_providers"
+    ],
+    ...
+}
+```


### PR DESCRIPTION
*Description of changes:*
Small documentation note for configuring e2e build flags.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->