### PR TITLE
Tinkerbell Upgrade CAPI Comparator

### DIFF
--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -133,7 +133,7 @@ func KubeadmControlPlane(clusterSpec *cluster.Spec, infrastructureObject APIObje
 			Kind:       kubeadmControlPlaneKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      KubeadmControlPlaneName(clusterSpec),
+			Name:      KubeadmControlPlaneName(clusterSpec.Cluster),
 			Namespace: constants.EksaSystemNamespace,
 		},
 		Spec: controlplanev1.KubeadmControlPlaneSpec{

--- a/pkg/clusterapi/name.go
+++ b/pkg/clusterapi/name.go
@@ -72,8 +72,9 @@ func DefaultObjectName(baseName string) string {
 	return ObjectName(baseName, 1)
 }
 
-func KubeadmControlPlaneName(clusterSpec *cluster.Spec) string {
-	return clusterSpec.Cluster.GetName()
+// KubeadmControlPlaneName generates the kubeadmControlPlane name for an EKSA Cluster.
+func KubeadmControlPlaneName(cluster *v1alpha1.Cluster) string {
+	return cluster.GetName()
 }
 
 // EtcdClusterName sets the default EtcdCluster object name.
@@ -110,7 +111,7 @@ func WorkerMachineTemplateName(clusterSpec *cluster.Spec, workerNodeGroupConfig 
 }
 
 func ControlPlaneMachineHealthCheckName(clusterSpec *cluster.Spec) string {
-	return fmt.Sprintf("%s-kcp-unhealthy", KubeadmControlPlaneName(clusterSpec))
+	return fmt.Sprintf("%s-kcp-unhealthy", KubeadmControlPlaneName(clusterSpec.Cluster))
 }
 
 func WorkerMachineHealthCheckName(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) string {

--- a/pkg/clusterapi/name_test.go
+++ b/pkg/clusterapi/name_test.go
@@ -133,7 +133,7 @@ func TestKubeadmControlPlaneName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := newApiBuilerTest(t)
-			g.Expect(clusterapi.KubeadmControlPlaneName(g.clusterSpec)).To(Equal(tt.want))
+			g.Expect(clusterapi.KubeadmControlPlaneName(g.clusterSpec.Cluster)).To(Equal(tt.want))
 		})
 	}
 }

--- a/pkg/controller/clusterapi.go
+++ b/pkg/controller/clusterapi.go
@@ -6,6 +6,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -40,4 +41,23 @@ func CapiClusterObjectKey(cluster *anywherev1.Cluster) client.ObjectKey {
 		Name:      clusterapi.ClusterName(cluster),
 		Namespace: constants.EksaSystemNamespace,
 	}
+}
+
+// GetKubeadmControlPlane reads a cluster-api KubeadmControlPlane for an eks-a cluster using a kube client
+// If the KubeadmControlPlane is not found, the method returns (nil, nil).
+func GetKubeadmControlPlane(ctx context.Context, client client.Client, cluster *anywherev1.Cluster) (*controlplanev1.KubeadmControlPlane, error) {
+	kubeadmControlPlaneName := clusterapi.KubeadmControlPlaneName(cluster)
+
+	kubeadmControlPlane := &controlplanev1.KubeadmControlPlane{}
+	key := types.NamespacedName{Namespace: constants.EksaSystemNamespace, Name: kubeadmControlPlaneName}
+
+	err := client.Get(ctx, key, kubeadmControlPlane)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return kubeadmControlPlane, nil
 }

--- a/pkg/controller/clusterapi_test.go
+++ b/pkg/controller/clusterapi_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	_ "github.com/aws/eks-anywhere/internal/test/envtest"
@@ -46,6 +47,36 @@ func TestGetCAPIClusterError(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("no kind is registered for the type")))
 }
 
+func TestGetKubeadmControlPlaneSuccess(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	eksaCluster := eksaCluster()
+	kubeadmControlPlane := kubeadmControlPlane()
+	client := fake.NewClientBuilder().WithObjects(eksaCluster, kubeadmControlPlane).Build()
+
+	g.Expect(controller.GetKubeadmControlPlane(ctx, client, eksaCluster)).To(Equal(kubeadmControlPlane))
+}
+
+func TestGetKubeadmControlPlaneMissingKubeadmControlPlane(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	eksaCluster := eksaCluster()
+	client := fake.NewClientBuilder().WithObjects(eksaCluster).Build()
+
+	g.Expect(controller.GetKubeadmControlPlane(ctx, client, eksaCluster)).To(BeNil())
+}
+
+func TestGetKubeadmControlPlaneError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	eksaCluster := eksaCluster()
+	// This should make the client fail because CRDs are not registered
+	client := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+
+	_, err := controller.GetKubeadmControlPlane(ctx, client, eksaCluster)
+	g.Expect(err).To(MatchError(ContainSubstring("no kind is registered for the type")))
+}
+
 func TestGetCapiClusterObjectKey(t *testing.T) {
 	g := NewWithT(t)
 	eksaCluster := eksaCluster()
@@ -76,6 +107,19 @@ func capiCluster() *clusterv1.Cluster {
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Cluster",
 			APIVersion: clusterv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: "eksa-system",
+		},
+	}
+}
+
+func kubeadmControlPlane() *controlplanev1.KubeadmControlPlane {
+	return &controlplanev1.KubeadmControlPlane{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeadmControlPlane",
+			APIVersion: controlplanev1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-cluster",

--- a/pkg/providers/tinkerbell/comparator.go
+++ b/pkg/providers/tinkerbell/comparator.go
@@ -1,0 +1,51 @@
+package tinkerbell
+
+import (
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+)
+
+// Versionable enables kubernetes version retrieval.
+type Versionable interface {
+	Version() string
+}
+
+// Replicable enables replica number retrieval.
+type Replicable interface {
+	Replicas() int
+}
+
+// KubeadmControlPlane wraps the KubeadmControlPlane to enable Comparator functions.
+type KubeadmControlPlane struct {
+	*controlplanev1.KubeadmControlPlane
+}
+
+// Version retrieves KubeadmControlPlane replicas.
+func (k *KubeadmControlPlane) Version() string {
+	return k.Spec.Version
+}
+
+// Replicas retrieves KubeadmControlPlane replicas.
+func (k *KubeadmControlPlane) Replicas() int {
+	return int(*k.Spec.Replicas)
+}
+
+// MachineDeployment implements Replicable by decorating a MachineDeployment.
+type MachineDeployment struct {
+	*clusterv1.MachineDeployment
+}
+
+// Replicas retrieves MachineDeployment replicas.
+func (m *MachineDeployment) Replicas() int {
+	return int(*m.Spec.Replicas)
+}
+
+// HasKubernetesVersionChange detects kubernetes version has changed between two Comparator objects.
+func HasKubernetesVersionChange(current Versionable, desired Versionable) bool {
+	return current.Version() != desired.Version()
+}
+
+// ReplicasDiff returns the difference in replica count between new and old Comparator objects.
+func ReplicasDiff(current Replicable, desired Replicable) int {
+	return desired.Replicas() - current.Replicas()
+}

--- a/pkg/providers/tinkerbell/comparator_test.go
+++ b/pkg/providers/tinkerbell/comparator_test.go
@@ -1,0 +1,106 @@
+package tinkerbell_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
+)
+
+func TestKubeadmControlPlaneReplicas(t *testing.T) {
+	g := NewWithT(t)
+
+	KCPComparator := &tinkerbell.KubeadmControlPlane{comparatorKubeadmControlPlane()}
+
+	g.Expect(KCPComparator.Replicas()).To(Equal(1))
+}
+
+func TestKubeadmControlPlaneVersion(t *testing.T) {
+	g := NewWithT(t)
+
+	KCPComparator := &tinkerbell.KubeadmControlPlane{comparatorKubeadmControlPlane()}
+
+	g.Expect(KCPComparator.Version()).To(Equal("1.22"))
+}
+
+func TestMachineDeploymentReplicas(t *testing.T) {
+	g := NewWithT(t)
+
+	MDComparator := &tinkerbell.MachineDeployment{comparatorMachineDeployment()}
+
+	g.Expect(MDComparator.Replicas()).To(Equal(1))
+}
+
+func TestKubernetesVersionChangeFalse(t *testing.T) {
+	g := NewWithT(t)
+
+	oldComparator := &testComparable{version: "1.22"}
+	newComparator := &testComparable{version: "1.22"}
+
+	g.Expect(tinkerbell.HasKubernetesVersionChange(oldComparator, newComparator)).To(Equal(false))
+}
+
+func TestKubernetesVersionChangeTrue(t *testing.T) {
+	g := NewWithT(t)
+
+	oldComparator := &testComparable{version: "1.22"}
+	newComparator := &testComparable{version: "1.23"}
+
+	g.Expect(tinkerbell.HasKubernetesVersionChange(oldComparator, newComparator)).To(Equal(true))
+}
+
+func TestReplicasChangeUnchanged(t *testing.T) {
+	g := NewWithT(t)
+
+	oldComparator := &testComparable{replicas: 1}
+	newComparator := &testComparable{replicas: 1}
+
+	g.Expect(tinkerbell.ReplicasDiff(oldComparator, newComparator)).To(Equal(0))
+}
+
+func TestReplicasChangeChanged(t *testing.T) {
+	g := NewWithT(t)
+
+	oldComparator := &testComparable{replicas: 1}
+	newComparator := &testComparable{replicas: 3}
+
+	g.Expect(tinkerbell.ReplicasDiff(oldComparator, newComparator)).To(Equal(2))
+}
+
+func comparatorKubeadmControlPlane() *controlplanev1.KubeadmControlPlane {
+	k := &controlplanev1.KubeadmControlPlane{
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			Replicas: ptr.Int32(1),
+			Version:  "1.22",
+		},
+	}
+
+	return k
+}
+
+func comparatorMachineDeployment() *clusterv1.MachineDeployment {
+	m := &clusterv1.MachineDeployment{
+		Spec: clusterv1.MachineDeploymentSpec{
+			Replicas: ptr.Int32(1),
+		},
+	}
+
+	return m
+}
+
+type testComparable struct {
+	version  string
+	replicas int
+}
+
+func (t *testComparable) Version() string {
+	return t.version
+}
+
+func (t *testComparable) Replicas() int {
+	return t.replicas
+}


### PR DESCRIPTION
*Issue #, if available:*
[Design Doc](https://quip-amazon.com/tPdvA2zEwdd7/Tinkerbell-Cluster-Upgrade) 
[Custom comparator for CAPI spec for Upgrade#1042](https://github.com/aws/eks-anywhere-internal/issues/1042)

*Description of changes:*
This implements comparator functions for CAPI objects to help detect Tinkerbell rolling/scaling upgrades.

*Testing (if applicable):*
added unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

