### PR TITLE
Increase TLS Handshake timeout for reading data from URLs

### DIFF
--- a/pkg/files/reader.go
+++ b/pkg/files/reader.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 )
 
 const (
@@ -43,10 +44,15 @@ func WithEKSAUserAgent(eksAComponent, version string) ReaderOpt {
 }
 
 func NewReader(opts ...ReaderOpt) *Reader {
+	transport := &http.Transport{
+		TLSHandshakeTimeout: 60 * time.Second,
+	}
 	r := &Reader{
-		embedFS:    embed.FS{},
-		httpClient: &http.Client{},
-		userAgent:  eksaUserAgent("unknown", "no-version"),
+		embedFS: embed.FS{},
+		httpClient: &http.Client{
+			Transport: transport,
+		},
+		userAgent: eksaUserAgent("unknown", "no-version"),
 	}
 
 	for _, o := range opts {


### PR DESCRIPTION
Sometimes during cluster creation, we encounter TLS handshake timeout errors like below
```
Error: initializing capi resources in cluster: can't load infrastructure bundle for manifest https://anywhere-assets.eks.amazonaws.com/releases/bundles/27/artifacts/cert-manager/manifests/v1.9.1/cert-manager.yaml: failed to load manifest: failed reading file from url [https://anywhere-assets.eks.amazonaws.com/releases/bundles/27/artifacts/cert-manager/manifests/v1.9.1/cert-manager.yaml]: Get "https://anywhere-assets.eks.amazonaws.com/releases/bundles/27/artifacts/cert-manager/manifests/v1.9.1/cert-manager.yaml": net/http: TLS handshake timeout
```
The default TLS handshake timeout is 10 seconds, bumping it to 60 seconds (which is a very generous amount).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

