### PR TITLE
MetalLB tests for multiple k8s versions

### DIFF
--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/test/framework"
-	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -197,7 +196,7 @@ func TestDockerKubernetes124CuratedPackagesAdotSimpleFlow(t *testing.T) {
 }
 
 func TestDockerCuratedPackagesMetalLB(t *testing.T) {
-	suite.Run(t, new(Suite))
+	RunMetalLBDockerTests(t)
 }
 
 // AWS IAM Auth


### PR DESCRIPTION
*Description of changes:* Add e2e for 1.25 and also test 1.24

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

