### PR TITLE
Make testdata files mutable only by API changes

### DIFF
--- a/release/pkg/assets/tagger/tagger.go
+++ b/release/pkg/assets/tagger/tagger.go
@@ -30,7 +30,7 @@ func BuildToolingGitTagAssigner(rc *releasetypes.ReleaseConfig, gitTagPath, over
 	if overrideBranch != "" {
 		branchName = overrideBranch
 	}
-	gitTag, err := filereader.ReadGitTag(gitTagPath, rc.BuildRepoSource, branchName)
+	gitTag, err := filereader.ReadGitTag(gitTagPath, rc.BuildRepoSource, branchName, rc.DryRun)
 	if err != nil {
 		return "", errors.Cause(err)
 	}

--- a/release/pkg/bundles/cilium.go
+++ b/release/pkg/bundles/cilium.go
@@ -40,7 +40,7 @@ func GetCiliumBundle(r *releasetypes.ReleaseConfig) (anywherev1alpha1.CiliumBund
 	artifacts := r.BundleArtifactsTable["cilium"]
 
 	ciliumContainerRegistry := "public.ecr.aws/isovalent"
-	ciliumGitTag, err := filereader.ReadGitTag(constants.CiliumProjectPath, r.BuildRepoSource, r.BuildRepoBranchName)
+	ciliumGitTag, err := filereader.ReadGitTag(constants.CiliumProjectPath, r.BuildRepoSource, r.BuildRepoBranchName, r.DryRun)
 	if err != nil {
 		return anywherev1alpha1.CiliumBundle{}, errors.Cause(err)
 	}

--- a/release/pkg/bundles/eksa.go
+++ b/release/pkg/bundles/eksa.go
@@ -79,7 +79,7 @@ func GetEksaBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]string
 	} else {
 		componentChecksum = version.GenerateComponentHash(artifactHashes, r.DryRun)
 	}
-	version, err := version.BuildComponentVersion(version.NewCliVersioner(r.ReleaseVersion, r.CliRepoSource), componentChecksum)
+	version, err := version.BuildComponentVersion(version.NewCliVersioner(r), componentChecksum)
 	if err != nil {
 		return anywherev1alpha1.EksaBundle{}, errors.Wrapf(err, "failed generating version for eksa bundle")
 	}

--- a/release/pkg/constants/constants.go
+++ b/release/pkg/constants/constants.go
@@ -22,6 +22,7 @@ const (
 	SuccessIcon              = "✅"
 	FakeComponentChecksum    = "abcdef1"
 	FakeGitCommit            = "0123456789abcdef0123456789abcdef01234567"
+	FakeGitTag               = "v1.2.3"
 	ReleaseFolderName        = "release"
 	EksDReleaseComponentsUrl = "https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml"
 	YamlSeparator            = "\n---\n"

--- a/release/pkg/filereader/file_reader.go
+++ b/release/pkg/filereader/file_reader.go
@@ -337,7 +337,10 @@ func ReadHttpFile(uri string) ([]byte, error) {
 	return data, nil
 }
 
-func ReadGitTag(projectPath, gitRootPath, branch string) (string, error) {
+func ReadGitTag(projectPath, gitRootPath, branch string, dryRun bool) (string, error) {
+	if dryRun {
+		return constants.FakeGitTag, nil
+	}
 	_, err := git.CheckoutRepo(gitRootPath, branch)
 	if err != nil {
 		return "", fmt.Errorf("error reading git tag: %v", err)

--- a/release/pkg/images/images.go
+++ b/release/pkg/images/images.go
@@ -175,7 +175,7 @@ func GetSourceImageURI(r *releasetypes.ReleaseConfig, name, repoName string, tag
 						if hasSeparateTagPerReleaseBranch {
 							gitTagPath = filepath.Join(tagOptions["projectPath"], tagOptions["eksDReleaseChannel"])
 						}
-						gitTagFromMain, err = filereader.ReadGitTag(gitTagPath, r.BuildRepoSource, "main")
+						gitTagFromMain, err = filereader.ReadGitTag(gitTagPath, r.BuildRepoSource, "main", r.DryRun)
 						if err != nil {
 							return "", "", errors.Cause(err)
 						}

--- a/release/pkg/operations/download.go
+++ b/release/pkg/operations/download.go
@@ -72,7 +72,7 @@ func DownloadArtifacts(r *releasetypes.ReleaseConfig, eksArtifacts map[string][]
 						if strings.Contains(sourceS3Key, "eksctl-anywhere") {
 							latestSourceS3PrefixFromMain = strings.NewReplacer(r.CliRepoBranchName, "latest").Replace(sourceS3Prefix)
 						} else {
-							gitTagFromMain, err := filereader.ReadGitTag(artifact.Archive.ProjectPath, r.BuildRepoSource, "main")
+							gitTagFromMain, err := filereader.ReadGitTag(artifact.Archive.ProjectPath, r.BuildRepoSource, "main", r.DryRun)
 							if err != nil {
 								return errors.Cause(err)
 							}
@@ -121,7 +121,7 @@ func DownloadArtifacts(r *releasetypes.ReleaseConfig, eksArtifacts map[string][]
 							if strings.Contains(sourceS3Key, "eksctl-anywhere") {
 								latestSourceS3PrefixFromMain = strings.NewReplacer(r.CliRepoBranchName, "latest").Replace(sourceS3Prefix)
 							} else {
-								gitTagFromMain, err := filereader.ReadGitTag(artifact.Archive.ProjectPath, r.BuildRepoSource, "main")
+								gitTagFromMain, err := filereader.ReadGitTag(artifact.Archive.ProjectPath, r.BuildRepoSource, "main", r.DryRun)
 								if err != nil {
 									return errors.Cause(err)
 								}
@@ -158,7 +158,7 @@ func DownloadArtifacts(r *releasetypes.ReleaseConfig, eksArtifacts map[string][]
 				if err != nil {
 					if r.BuildRepoBranchName != "main" {
 						fmt.Printf("Artifact corresponding to %s branch not found for %s manifest. Using artifact from main\n", r.BuildRepoBranchName, sourceS3Key)
-						gitTagFromMain, err := filereader.ReadGitTag(artifact.Manifest.ProjectPath, r.BuildRepoSource, "main")
+						gitTagFromMain, err := filereader.ReadGitTag(artifact.Manifest.ProjectPath, r.BuildRepoSource, "main", r.DryRun)
 						if err != nil {
 							return errors.Cause(err)
 						}

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -10,7 +10,7 @@ spec:
   versionsBundles:
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.3.3/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -19,7 +19,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -28,10 +28,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     bottlerocketHostContainers:
       admin:
         arch:
@@ -67,7 +67,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.2.3-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -76,7 +76,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.2.3-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -85,7 +85,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       ctl:
         arch:
         - amd64
@@ -94,10 +94,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.2.3-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.11.0/cert-manager.yaml
-      version: v1.11.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.2.3/cert-manager.yaml
+      version: v1.2.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -106,7 +106,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.2.3-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -115,14 +115,14 @@ spec:
         imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.2.3
       helmChart:
         description: Helm chart for cilium-chart
         imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.2.3
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.2.3/cilium.yaml
       operator:
         arch:
         - amd64
@@ -130,8 +130,8 @@ spec:
         imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.2.3
+      version: v1.2.3
     cloudStack:
       clusterAPIController:
         arch:
@@ -141,9 +141,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -152,7 +152,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -161,13 +161,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.3.3/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.3/core-components.yaml
       controller:
         arch:
         - amd64
@@ -176,7 +176,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -185,13 +185,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.3.3/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -200,7 +200,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -209,15 +209,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -226,7 +226,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -235,10 +235,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     eksD:
       ami:
         bottlerocket:
@@ -261,7 +261,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.2.3/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -270,7 +270,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/v1.2.3/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
       imagebuilder:
         arch:
@@ -280,7 +280,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v1.2.3/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -324,7 +324,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -333,9 +333,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -344,11 +344,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-build.1
-      version: v0.0.0-dev+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -357,7 +357,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -366,13 +366,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/metadata.yaml
-      version: v1.0.5-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -381,7 +381,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -390,10 +390,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/metadata.yaml
-      version: v1.0.4-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     flux:
       helmController:
         arch:
@@ -403,7 +403,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kustomizeController:
         arch:
         - amd64
@@ -412,7 +412,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       notificationController:
         arch:
         - amd64
@@ -421,7 +421,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       sourceController:
         arch:
         - amd64
@@ -430,8 +430,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-build.1
-      version: v0.31.3+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     haproxy:
       image:
         arch:
@@ -441,11 +441,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v1.2.3-eks-a-v0.0.0-dev-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v1.2.3/kindnetd.yaml
+      version: v1.2.3+abcdef1
     kubeVersion: "1.21"
     nutanix:
       clusterAPIController:
@@ -456,11 +456,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -469,16 +469,16 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/metadata.yaml
-      version: v1.1.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:1.2.3-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -487,7 +487,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v1.2.3-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -496,8 +496,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-build.1
-      version: v0.2.30+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -509,7 +509,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-21-26-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -518,7 +518,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -527,10 +527,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
-      version: v0.1.22+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -540,11 +540,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.4.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -553,7 +553,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: envoy
         os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -562,9 +562,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -575,7 +575,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:v1.2.3-eks-a-v0.0.0-dev-build.1
           imageToDisk:
             arch:
             - amd64
@@ -584,7 +584,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:v1.2.3-eks-a-v0.0.0-dev-build.1
           kexec:
             arch:
             - amd64
@@ -593,7 +593,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:v1.2.3-eks-a-v0.0.0-dev-build.1
           ociToDisk:
             arch:
             - amd64
@@ -602,7 +602,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:v1.2.3-eks-a-v0.0.0-dev-build.1
           reboot:
             arch:
             - amd64
@@ -611,7 +611,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:v1.2.3-eks-a-v0.0.0-dev-build.1
           writeFile:
             arch:
             - amd64
@@ -620,7 +620,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:v1.2.3-eks-a-v0.0.0-dev-build.1
         boots:
           arch:
           - amd64
@@ -629,7 +629,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.8.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v1.2.3-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
@@ -638,7 +638,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.10.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v1.2.3-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -648,7 +648,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:v1.2.3-eks-a-v0.0.0-dev-build.1
           docker:
             arch:
             - amd64
@@ -657,18 +657,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:v1.2.3-eks-a-v0.0.0-dev-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -677,18 +677,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:v1.2.3-eks-a-v0.0.0-dev-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -697,7 +697,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v0.2.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v1.2.3-eks-a-v0.0.0-dev-build.1
         tink:
           tinkController:
             arch:
@@ -707,7 +707,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
           tinkServer:
             arch:
             - amd64
@@ -716,7 +716,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v1.2.3-eks-a-v0.0.0-dev-build.1
           tinkWorker:
             arch:
             - amd64
@@ -725,12 +725,12 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v1.2.3-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:1.2.3-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -741,11 +741,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -754,7 +754,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -763,7 +763,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -772,7 +772,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -781,9 +781,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.21.3-eks-d-1-21-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.2.3-eks-d-1-21-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -792,11 +792,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.1
-      version: v1.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.3.3/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -805,7 +805,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -814,10 +814,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     bottlerocketHostContainers:
       admin:
         arch:
@@ -853,7 +853,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.2.3-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -862,7 +862,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.2.3-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -871,7 +871,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       ctl:
         arch:
         - amd64
@@ -880,10 +880,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.2.3-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.11.0/cert-manager.yaml
-      version: v1.11.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.2.3/cert-manager.yaml
+      version: v1.2.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -892,7 +892,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.2.3-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -901,14 +901,14 @@ spec:
         imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.2.3
       helmChart:
         description: Helm chart for cilium-chart
         imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.2.3
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.2.3/cilium.yaml
       operator:
         arch:
         - amd64
@@ -916,8 +916,8 @@ spec:
         imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.2.3
+      version: v1.2.3
     cloudStack:
       clusterAPIController:
         arch:
@@ -927,9 +927,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -938,7 +938,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -947,13 +947,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.3.3/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.3/core-components.yaml
       controller:
         arch:
         - amd64
@@ -962,7 +962,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -971,13 +971,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.3.3/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -986,7 +986,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -995,15 +995,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -1012,7 +1012,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -1021,10 +1021,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     eksD:
       ami:
         bottlerocket:
@@ -1047,7 +1047,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.2.3/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -1056,7 +1056,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/v1.2.3/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
       imagebuilder:
         arch:
@@ -1066,7 +1066,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v1.2.3/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -1110,7 +1110,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -1119,9 +1119,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1130,11 +1130,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-build.1
-      version: v0.0.0-dev+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1143,7 +1143,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1152,13 +1152,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/metadata.yaml
-      version: v1.0.5-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1167,7 +1167,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1176,10 +1176,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/metadata.yaml
-      version: v1.0.4-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     flux:
       helmController:
         arch:
@@ -1189,7 +1189,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kustomizeController:
         arch:
         - amd64
@@ -1198,7 +1198,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       notificationController:
         arch:
         - amd64
@@ -1207,7 +1207,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       sourceController:
         arch:
         - amd64
@@ -1216,8 +1216,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-build.1
-      version: v0.31.3+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     haproxy:
       image:
         arch:
@@ -1227,11 +1227,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v1.2.3-eks-a-v0.0.0-dev-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v1.2.3/kindnetd.yaml
+      version: v1.2.3+abcdef1
     kubeVersion: "1.22"
     nutanix:
       clusterAPIController:
@@ -1242,11 +1242,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -1255,16 +1255,16 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/metadata.yaml
-      version: v1.1.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:1.2.3-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1273,7 +1273,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v1.2.3-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1282,8 +1282,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-build.1
-      version: v0.2.30+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -1295,7 +1295,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-22-19-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -1304,7 +1304,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -1313,10 +1313,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
-      version: v0.1.22+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -1326,11 +1326,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.4.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -1339,7 +1339,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: envoy
         os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -1348,9 +1348,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -1361,7 +1361,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:v1.2.3-eks-a-v0.0.0-dev-build.1
           imageToDisk:
             arch:
             - amd64
@@ -1370,7 +1370,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:v1.2.3-eks-a-v0.0.0-dev-build.1
           kexec:
             arch:
             - amd64
@@ -1379,7 +1379,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:v1.2.3-eks-a-v0.0.0-dev-build.1
           ociToDisk:
             arch:
             - amd64
@@ -1388,7 +1388,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:v1.2.3-eks-a-v0.0.0-dev-build.1
           reboot:
             arch:
             - amd64
@@ -1397,7 +1397,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:v1.2.3-eks-a-v0.0.0-dev-build.1
           writeFile:
             arch:
             - amd64
@@ -1406,7 +1406,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:v1.2.3-eks-a-v0.0.0-dev-build.1
         boots:
           arch:
           - amd64
@@ -1415,7 +1415,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.8.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v1.2.3-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
@@ -1424,7 +1424,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.10.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v1.2.3-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -1434,7 +1434,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:v1.2.3-eks-a-v0.0.0-dev-build.1
           docker:
             arch:
             - amd64
@@ -1443,18 +1443,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:v1.2.3-eks-a-v0.0.0-dev-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -1463,18 +1463,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:v1.2.3-eks-a-v0.0.0-dev-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -1483,7 +1483,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v0.2.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v1.2.3-eks-a-v0.0.0-dev-build.1
         tink:
           tinkController:
             arch:
@@ -1493,7 +1493,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
           tinkServer:
             arch:
             - amd64
@@ -1502,7 +1502,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v1.2.3-eks-a-v0.0.0-dev-build.1
           tinkWorker:
             arch:
             - amd64
@@ -1511,12 +1511,12 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v1.2.3-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:1.2.3-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -1527,11 +1527,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -1540,7 +1540,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1549,7 +1549,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -1558,7 +1558,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -1567,9 +1567,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.22.6-eks-d-1-22-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.2.3-eks-d-1-22-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -1578,11 +1578,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.1
-      version: v1.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.3.3/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1591,7 +1591,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1600,10 +1600,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     bottlerocketHostContainers:
       admin:
         arch:
@@ -1639,7 +1639,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.2.3-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -1648,7 +1648,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.2.3-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -1657,7 +1657,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       ctl:
         arch:
         - amd64
@@ -1666,10 +1666,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.2.3-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.11.0/cert-manager.yaml
-      version: v1.11.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.2.3/cert-manager.yaml
+      version: v1.2.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -1678,7 +1678,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.2.3-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -1687,14 +1687,14 @@ spec:
         imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.2.3
       helmChart:
         description: Helm chart for cilium-chart
         imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.2.3
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.2.3/cilium.yaml
       operator:
         arch:
         - amd64
@@ -1702,8 +1702,8 @@ spec:
         imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.2.3
+      version: v1.2.3
     cloudStack:
       clusterAPIController:
         arch:
@@ -1713,9 +1713,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -1724,7 +1724,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -1733,13 +1733,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.3.3/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.3/core-components.yaml
       controller:
         arch:
         - amd64
@@ -1748,7 +1748,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1757,13 +1757,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.3.3/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -1772,7 +1772,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1781,15 +1781,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -1798,7 +1798,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -1807,10 +1807,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     eksD:
       ami:
         bottlerocket:
@@ -1833,7 +1833,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.2.3/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -1842,7 +1842,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/v1.2.3/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
       imagebuilder:
         arch:
@@ -1852,7 +1852,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v1.2.3/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -1896,7 +1896,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -1905,9 +1905,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1916,11 +1916,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-build.1
-      version: v0.0.0-dev+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1929,7 +1929,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1938,13 +1938,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/metadata.yaml
-      version: v1.0.5-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1953,7 +1953,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1962,10 +1962,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/metadata.yaml
-      version: v1.0.4-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     flux:
       helmController:
         arch:
@@ -1975,7 +1975,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kustomizeController:
         arch:
         - amd64
@@ -1984,7 +1984,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       notificationController:
         arch:
         - amd64
@@ -1993,7 +1993,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       sourceController:
         arch:
         - amd64
@@ -2002,8 +2002,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-build.1
-      version: v0.31.3+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     haproxy:
       image:
         arch:
@@ -2013,11 +2013,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v1.2.3-eks-a-v0.0.0-dev-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v1.2.3/kindnetd.yaml
+      version: v1.2.3+abcdef1
     kubeVersion: "1.23"
     nutanix:
       clusterAPIController:
@@ -2028,11 +2028,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2041,16 +2041,16 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/metadata.yaml
-      version: v1.1.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:1.2.3-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -2059,7 +2059,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v1.2.3-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2068,8 +2068,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-build.1
-      version: v0.2.30+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -2081,7 +2081,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-23-14-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2090,7 +2090,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -2099,10 +2099,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
-      version: v0.1.22+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -2112,11 +2112,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.4.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -2125,7 +2125,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: envoy
         os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -2134,9 +2134,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -2147,7 +2147,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:v1.2.3-eks-a-v0.0.0-dev-build.1
           imageToDisk:
             arch:
             - amd64
@@ -2156,7 +2156,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:v1.2.3-eks-a-v0.0.0-dev-build.1
           kexec:
             arch:
             - amd64
@@ -2165,7 +2165,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:v1.2.3-eks-a-v0.0.0-dev-build.1
           ociToDisk:
             arch:
             - amd64
@@ -2174,7 +2174,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:v1.2.3-eks-a-v0.0.0-dev-build.1
           reboot:
             arch:
             - amd64
@@ -2183,7 +2183,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:v1.2.3-eks-a-v0.0.0-dev-build.1
           writeFile:
             arch:
             - amd64
@@ -2192,7 +2192,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:v1.2.3-eks-a-v0.0.0-dev-build.1
         boots:
           arch:
           - amd64
@@ -2201,7 +2201,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.8.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v1.2.3-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
@@ -2210,7 +2210,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.10.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v1.2.3-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -2220,7 +2220,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:v1.2.3-eks-a-v0.0.0-dev-build.1
           docker:
             arch:
             - amd64
@@ -2229,18 +2229,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:v1.2.3-eks-a-v0.0.0-dev-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -2249,18 +2249,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:v1.2.3-eks-a-v0.0.0-dev-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -2269,7 +2269,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v0.2.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v1.2.3-eks-a-v0.0.0-dev-build.1
         tink:
           tinkController:
             arch:
@@ -2279,7 +2279,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
           tinkServer:
             arch:
             - amd64
@@ -2288,7 +2288,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v1.2.3-eks-a-v0.0.0-dev-build.1
           tinkWorker:
             arch:
             - amd64
@@ -2297,12 +2297,12 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v1.2.3-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:1.2.3-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -2313,11 +2313,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -2326,7 +2326,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2335,7 +2335,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -2344,7 +2344,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -2353,9 +2353,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.23.1-eks-d-1-23-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.2.3-eks-d-1-23-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -2364,11 +2364,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.1
-      version: v1.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.3.3/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2377,7 +2377,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2386,10 +2386,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     bottlerocketHostContainers:
       admin:
         arch:
@@ -2425,7 +2425,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.2.3-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -2434,7 +2434,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.2.3-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -2443,7 +2443,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       ctl:
         arch:
         - amd64
@@ -2452,10 +2452,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.2.3-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.11.0/cert-manager.yaml
-      version: v1.11.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.2.3/cert-manager.yaml
+      version: v1.2.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -2464,7 +2464,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.2.3-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -2473,14 +2473,14 @@ spec:
         imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.2.3
       helmChart:
         description: Helm chart for cilium-chart
         imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.2.3
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.2.3/cilium.yaml
       operator:
         arch:
         - amd64
@@ -2488,8 +2488,8 @@ spec:
         imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.2.3
+      version: v1.2.3
     cloudStack:
       clusterAPIController:
         arch:
@@ -2499,9 +2499,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -2510,7 +2510,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -2519,13 +2519,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.3.3/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.3/core-components.yaml
       controller:
         arch:
         - amd64
@@ -2534,7 +2534,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2543,13 +2543,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.3.3/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -2558,7 +2558,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2567,15 +2567,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -2584,7 +2584,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -2593,10 +2593,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     eksD:
       ami:
         bottlerocket:
@@ -2619,7 +2619,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.2.3/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -2628,7 +2628,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/v1.2.3/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
       imagebuilder:
         arch:
@@ -2638,7 +2638,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v1.2.3/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -2682,7 +2682,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -2691,9 +2691,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -2702,11 +2702,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-build.1
-      version: v0.0.0-dev+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2715,7 +2715,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2724,13 +2724,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/metadata.yaml
-      version: v1.0.5-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2739,7 +2739,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2748,10 +2748,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/metadata.yaml
-      version: v1.0.4-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     flux:
       helmController:
         arch:
@@ -2761,7 +2761,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kustomizeController:
         arch:
         - amd64
@@ -2770,7 +2770,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       notificationController:
         arch:
         - amd64
@@ -2779,7 +2779,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       sourceController:
         arch:
         - amd64
@@ -2788,8 +2788,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-build.1
-      version: v0.31.3+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     haproxy:
       image:
         arch:
@@ -2799,11 +2799,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v1.2.3-eks-a-v0.0.0-dev-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v1.2.3/kindnetd.yaml
+      version: v1.2.3+abcdef1
     kubeVersion: "1.24"
     nutanix:
       clusterAPIController:
@@ -2814,11 +2814,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2827,16 +2827,16 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/metadata.yaml
-      version: v1.1.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:1.2.3-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -2845,7 +2845,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v1.2.3-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2854,8 +2854,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-build.1
-      version: v0.2.30+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -2867,7 +2867,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-24-9-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2876,7 +2876,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -2885,10 +2885,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
-      version: v0.1.22+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -2898,11 +2898,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.4.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -2911,7 +2911,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: envoy
         os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -2920,9 +2920,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -2933,7 +2933,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:v1.2.3-eks-a-v0.0.0-dev-build.1
           imageToDisk:
             arch:
             - amd64
@@ -2942,7 +2942,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:v1.2.3-eks-a-v0.0.0-dev-build.1
           kexec:
             arch:
             - amd64
@@ -2951,7 +2951,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:v1.2.3-eks-a-v0.0.0-dev-build.1
           ociToDisk:
             arch:
             - amd64
@@ -2960,7 +2960,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:v1.2.3-eks-a-v0.0.0-dev-build.1
           reboot:
             arch:
             - amd64
@@ -2969,7 +2969,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:v1.2.3-eks-a-v0.0.0-dev-build.1
           writeFile:
             arch:
             - amd64
@@ -2978,7 +2978,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:v1.2.3-eks-a-v0.0.0-dev-build.1
         boots:
           arch:
           - amd64
@@ -2987,7 +2987,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.8.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v1.2.3-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
@@ -2996,7 +2996,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.10.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v1.2.3-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -3006,7 +3006,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:v1.2.3-eks-a-v0.0.0-dev-build.1
           docker:
             arch:
             - amd64
@@ -3015,18 +3015,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:v1.2.3-eks-a-v0.0.0-dev-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -3035,18 +3035,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:v1.2.3-eks-a-v0.0.0-dev-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -3055,7 +3055,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v0.2.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v1.2.3-eks-a-v0.0.0-dev-build.1
         tink:
           tinkController:
             arch:
@@ -3065,7 +3065,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
           tinkServer:
             arch:
             - amd64
@@ -3074,7 +3074,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v1.2.3-eks-a-v0.0.0-dev-build.1
           tinkWorker:
             arch:
             - amd64
@@ -3083,12 +3083,12 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v1.2.3-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:1.2.3-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -3099,11 +3099,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -3112,7 +3112,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3121,7 +3121,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -3130,7 +3130,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -3139,9 +3139,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.24.1-eks-d-1-24-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.2.3-eks-d-1-24-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -3150,11 +3150,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.1
-      version: v1.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.3.3/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -3163,7 +3163,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3172,10 +3172,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     bottlerocketHostContainers:
       admin:
         arch:
@@ -3211,7 +3211,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.2.3-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -3220,7 +3220,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.2.3-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -3229,7 +3229,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       ctl:
         arch:
         - amd64
@@ -3238,10 +3238,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.2.3-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.11.0/cert-manager.yaml
-      version: v1.11.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.2.3/cert-manager.yaml
+      version: v1.2.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -3250,7 +3250,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.2.3-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -3259,14 +3259,14 @@ spec:
         imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.2.3
       helmChart:
         description: Helm chart for cilium-chart
         imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.2.3
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.2.3/cilium.yaml
       operator:
         arch:
         - amd64
@@ -3274,8 +3274,8 @@ spec:
         imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.2.3
+      version: v1.2.3
     cloudStack:
       clusterAPIController:
         arch:
@@ -3285,9 +3285,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -3296,7 +3296,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -3305,13 +3305,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.3.3/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.3/core-components.yaml
       controller:
         arch:
         - amd64
@@ -3320,7 +3320,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3329,13 +3329,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.3.3/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -3344,7 +3344,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3353,15 +3353,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -3370,7 +3370,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -3379,10 +3379,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     eksD:
       ami:
         bottlerocket: {}
@@ -3396,7 +3396,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.2.3/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -3405,7 +3405,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/v1.2.3/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
       imagebuilder:
         arch:
@@ -3415,7 +3415,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v1.2.3/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -3441,7 +3441,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -3450,9 +3450,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -3461,11 +3461,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-build.1
-      version: v0.0.0-dev+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -3474,7 +3474,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3483,13 +3483,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/metadata.yaml
-      version: v1.0.5-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -3498,7 +3498,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3507,10 +3507,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/metadata.yaml
-      version: v1.0.4-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     flux:
       helmController:
         arch:
@@ -3520,7 +3520,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kustomizeController:
         arch:
         - amd64
@@ -3529,7 +3529,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       notificationController:
         arch:
         - amd64
@@ -3538,7 +3538,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       sourceController:
         arch:
         - amd64
@@ -3547,8 +3547,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-build.1
-      version: v0.31.3+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     haproxy:
       image:
         arch:
@@ -3558,11 +3558,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v1.2.3-eks-a-v0.0.0-dev-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v1.2.3/kindnetd.yaml
+      version: v1.2.3+abcdef1
     kubeVersion: "1.25"
     nutanix:
       clusterAPIController:
@@ -3573,11 +3573,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -3586,16 +3586,16 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/metadata.yaml
-      version: v1.1.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:1.2.3-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -3604,7 +3604,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v1.2.3-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -3613,8 +3613,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-build.1
-      version: v0.2.30+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -3626,7 +3626,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-25-5-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -3635,7 +3635,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -3644,10 +3644,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
-      version: v0.1.22+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -3657,11 +3657,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.4.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -3670,7 +3670,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: envoy
         os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -3679,9 +3679,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -3692,7 +3692,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:v1.2.3-eks-a-v0.0.0-dev-build.1
           imageToDisk:
             arch:
             - amd64
@@ -3701,7 +3701,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:v1.2.3-eks-a-v0.0.0-dev-build.1
           kexec:
             arch:
             - amd64
@@ -3710,7 +3710,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:v1.2.3-eks-a-v0.0.0-dev-build.1
           ociToDisk:
             arch:
             - amd64
@@ -3719,7 +3719,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:v1.2.3-eks-a-v0.0.0-dev-build.1
           reboot:
             arch:
             - amd64
@@ -3728,7 +3728,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:v1.2.3-eks-a-v0.0.0-dev-build.1
           writeFile:
             arch:
             - amd64
@@ -3737,7 +3737,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:v1.2.3-eks-a-v0.0.0-dev-build.1
         boots:
           arch:
           - amd64
@@ -3746,7 +3746,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.8.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v1.2.3-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
@@ -3755,7 +3755,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.10.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v1.2.3-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -3765,7 +3765,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:v1.2.3-eks-a-v0.0.0-dev-build.1
           docker:
             arch:
             - amd64
@@ -3774,18 +3774,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:v1.2.3-eks-a-v0.0.0-dev-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -3794,18 +3794,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:v1.2.3-eks-a-v0.0.0-dev-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -3814,7 +3814,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v0.2.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v1.2.3-eks-a-v0.0.0-dev-build.1
         tink:
           tinkController:
             arch:
@@ -3824,7 +3824,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
           tinkServer:
             arch:
             - amd64
@@ -3833,7 +3833,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v1.2.3-eks-a-v0.0.0-dev-build.1
           tinkWorker:
             arch:
             - amd64
@@ -3842,12 +3842,12 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v1.2.3-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:1.2.3-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -3858,11 +3858,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -3871,7 +3871,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3880,7 +3880,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -3889,7 +3889,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -3898,9 +3898,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.25.0-eks-d-1-25-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.2.3-eks-d-1-25-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -3909,11 +3909,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.1
-      version: v1.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.3.3/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -3922,7 +3922,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3931,10 +3931,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     bottlerocketHostContainers:
       admin:
         arch:
@@ -3970,7 +3970,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.2.3-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -3979,7 +3979,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.2.3-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -3988,7 +3988,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       ctl:
         arch:
         - amd64
@@ -3997,10 +3997,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.2.3-eks-a-v0.0.0-dev-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.11.0/cert-manager.yaml
-      version: v1.11.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.2.3/cert-manager.yaml
+      version: v1.2.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -4009,7 +4009,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.11.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.2.3-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -4018,14 +4018,14 @@ spec:
         imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.2.3
       helmChart:
         description: Helm chart for cilium-chart
         imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.2.3
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.2.3/cilium.yaml
       operator:
         arch:
         - amd64
@@ -4033,8 +4033,8 @@ spec:
         imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.2.3
+      version: v1.2.3
     cloudStack:
       clusterAPIController:
         arch:
@@ -4044,9 +4044,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -4055,7 +4055,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -4064,13 +4064,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.3.3/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.3/core-components.yaml
       controller:
         arch:
         - amd64
@@ -4079,7 +4079,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -4088,13 +4088,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.3.3/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -4103,7 +4103,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -4112,15 +4112,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -4129,7 +4129,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -4138,10 +4138,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.3.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.3.3/metadata.yaml
-      version: v1.3.3+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     eksD:
       ami:
         bottlerocket: {}
@@ -4155,7 +4155,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.2.3/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -4164,7 +4164,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm/v1.2.3/etcdadm-v0.0.0-dev-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
       imagebuilder:
         arch:
@@ -4174,7 +4174,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v1.2.3/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -4200,7 +4200,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -4209,9 +4209,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -4220,11 +4220,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-build.1
-      version: v0.0.0-dev+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -4233,7 +4233,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -4242,13 +4242,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/metadata.yaml
-      version: v1.0.5-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -4257,7 +4257,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -4266,10 +4266,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/metadata.yaml
-      version: v1.0.4-rc5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     flux:
       helmController:
         arch:
@@ -4279,7 +4279,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       kustomizeController:
         arch:
         - amd64
@@ -4288,7 +4288,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       notificationController:
         arch:
         - amd64
@@ -4297,7 +4297,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
       sourceController:
         arch:
         - amd64
@@ -4306,8 +4306,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-build.1
-      version: v0.31.3+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     haproxy:
       image:
         arch:
@@ -4317,11 +4317,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v1.2.3-eks-a-v0.0.0-dev-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v1.2.3/kindnetd.yaml
+      version: v1.2.3+abcdef1
     kubeVersion: "1.26"
     nutanix:
       clusterAPIController:
@@ -4332,11 +4332,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -4345,16 +4345,16 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.1/metadata.yaml
-      version: v1.1.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:1.2.3-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -4363,7 +4363,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v1.2.3-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -4372,8 +4372,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-build.1
-      version: v0.2.30+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -4385,7 +4385,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-26-1-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -4394,7 +4394,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -4403,10 +4403,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
-      version: v0.1.22+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -4416,11 +4416,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.4.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -4429,7 +4429,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: envoy
         os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -4438,9 +4438,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -4451,7 +4451,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:v1.2.3-eks-a-v0.0.0-dev-build.1
           imageToDisk:
             arch:
             - amd64
@@ -4460,7 +4460,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:v1.2.3-eks-a-v0.0.0-dev-build.1
           kexec:
             arch:
             - amd64
@@ -4469,7 +4469,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:v1.2.3-eks-a-v0.0.0-dev-build.1
           ociToDisk:
             arch:
             - amd64
@@ -4478,7 +4478,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:v1.2.3-eks-a-v0.0.0-dev-build.1
           reboot:
             arch:
             - amd64
@@ -4487,7 +4487,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:v1.2.3-eks-a-v0.0.0-dev-build.1
           writeFile:
             arch:
             - amd64
@@ -4496,7 +4496,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:v1.2.3-eks-a-v0.0.0-dev-build.1
         boots:
           arch:
           - amd64
@@ -4505,7 +4505,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.8.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v1.2.3-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
@@ -4514,7 +4514,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.10.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v1.2.3-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -4524,7 +4524,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:v1.2.3-eks-a-v0.0.0-dev-build.1
           docker:
             arch:
             - amd64
@@ -4533,18 +4533,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:v1.2.3-eks-a-v0.0.0-dev-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -4553,18 +4553,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:03a67729d895635fe3c612e4feca3400b9336cc9-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:v1.2.3-eks-a-v0.0.0-dev-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/03a67729d895635fe3c612e4feca3400b9336cc9/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/hook/v1.2.3/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -4573,7 +4573,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v0.2.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v1.2.3-eks-a-v0.0.0-dev-build.1
         tink:
           tinkController:
             arch:
@@ -4583,7 +4583,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v1.2.3-eks-a-v0.0.0-dev-build.1
           tinkServer:
             arch:
             - amd64
@@ -4592,7 +4592,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v1.2.3-eks-a-v0.0.0-dev-build.1
           tinkWorker:
             arch:
             - amd64
@@ -4601,12 +4601,12 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.8.0-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v1.2.3-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:1.2.3-eks-a-v0.0.0-dev-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -4617,11 +4617,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.2.3-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -4630,7 +4630,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -4639,7 +4639,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -4648,7 +4648,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -4657,9 +4657,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.25.0-eks-d-1-26-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.2.3-eks-d-1-26-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -4668,6 +4668,6 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.1
-      version: v1.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v1.2.3-eks-a-v0.0.0-dev-build.1
+      version: v1.2.3+abcdef1
 status: {}

--- a/release/pkg/test/testdata/release-0.14-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.14-bundle-release.yaml
@@ -10,7 +10,7 @@ spec:
   versionsBundles:
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -19,7 +19,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -28,27 +28,27 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     bottlerocketHostContainers:
       admin:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:bf56c9712189f5fc65d35544e2a84d3a7a1a2c05f2840fab54c57e8a3f8b57a4
+        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:a8f8f30ed6bd3f4848cf79d19f6c31d60b9c898649e7ee1d3081dac4a36421a7
+        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
       kubeadmBootstrap:
         arch:
         - amd64
@@ -67,7 +67,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       cainjector:
         arch:
         - amd64
@@ -76,7 +76,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       controller:
         arch:
         - amd64
@@ -85,7 +85,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       ctl:
         arch:
         - amd64
@@ -94,10 +94,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
-      version: v1.9.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.2.3/cert-manager.yaml
+      version: v1.2.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -106,7 +106,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
     cilium:
       cilium:
         arch:
@@ -115,14 +115,14 @@ spec:
         imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.2.3
       helmChart:
         description: Helm chart for cilium-chart
         imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.2.3
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.2.3/cilium.yaml
       operator:
         arch:
         - amd64
@@ -130,8 +130,8 @@ spec:
         imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.2.3
+      version: v1.2.3
     cloudStack:
       clusterAPIController:
         arch:
@@ -141,9 +141,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -152,7 +152,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -161,13 +161,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.3/core-components.yaml
       controller:
         arch:
         - amd64
@@ -176,7 +176,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -185,13 +185,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -200,7 +200,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -209,15 +209,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -226,7 +226,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -235,10 +235,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     eksD:
       ami:
         bottlerocket:
@@ -261,7 +261,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.2.3/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -270,7 +270,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/v1.2.3/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
       imagebuilder:
         arch:
@@ -280,7 +280,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/v1.2.3/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -324,7 +324,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterController:
         arch:
         - amd64
@@ -333,9 +333,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -344,11 +344,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.0.0-dev-release-0.14+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -357,7 +357,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -366,13 +366,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/metadata.yaml
-      version: v1.0.5-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -381,7 +381,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -390,10 +390,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/metadata.yaml
-      version: v1.0.4-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     flux:
       helmController:
         arch:
@@ -403,7 +403,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kustomizeController:
         arch:
         - amd64
@@ -412,7 +412,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       notificationController:
         arch:
         - amd64
@@ -421,7 +421,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       sourceController:
         arch:
         - amd64
@@ -430,8 +430,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.31.3+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     haproxy:
       image:
         arch:
@@ -441,11 +441,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v1.2.3/kindnetd.yaml
+      version: v1.2.3+abcdef1
     kubeVersion: "1.21"
     nutanix:
       clusterAPIController:
@@ -456,11 +456,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -469,16 +469,16 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/metadata.yaml
-      version: v1.1.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       packageController:
         arch:
         - amd64
@@ -487,7 +487,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -496,8 +496,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.30+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -509,7 +509,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-21-26-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -518,7 +518,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -527,10 +527,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
-      version: v0.1.22+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -540,11 +540,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -553,7 +553,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: envoy
         os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -562,9 +562,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -575,7 +575,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           imageToDisk:
             arch:
             - amd64
@@ -584,7 +584,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           kexec:
             arch:
             - amd64
@@ -593,7 +593,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           ociToDisk:
             arch:
             - amd64
@@ -602,7 +602,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           reboot:
             arch:
             - amd64
@@ -611,7 +611,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           writeFile:
             arch:
             - amd64
@@ -620,7 +620,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         boots:
           arch:
           - amd64
@@ -629,7 +629,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:79b1d9acb65dfd0527b44800eddbdcf6b751c8d8-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         hegel:
           arch:
           - amd64
@@ -638,7 +638,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         hook:
           bootkit:
             arch:
@@ -648,7 +648,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           docker:
             arch:
             - amd64
@@ -657,18 +657,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -677,18 +677,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -697,7 +697,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         tink:
           tinkController:
             arch:
@@ -707,7 +707,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           tinkServer:
             arch:
             - amd64
@@ -716,7 +716,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           tinkWorker:
             arch:
             - amd64
@@ -725,12 +725,12 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -741,11 +741,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -754,7 +754,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -763,7 +763,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -772,7 +772,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -781,9 +781,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.21.3-eks-d-1-21-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.2.3-eks-d-1-21-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -792,11 +792,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v1.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -805,7 +805,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -814,27 +814,27 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     bottlerocketHostContainers:
       admin:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:bf56c9712189f5fc65d35544e2a84d3a7a1a2c05f2840fab54c57e8a3f8b57a4
+        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:a8f8f30ed6bd3f4848cf79d19f6c31d60b9c898649e7ee1d3081dac4a36421a7
+        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
       kubeadmBootstrap:
         arch:
         - amd64
@@ -853,7 +853,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       cainjector:
         arch:
         - amd64
@@ -862,7 +862,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       controller:
         arch:
         - amd64
@@ -871,7 +871,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       ctl:
         arch:
         - amd64
@@ -880,10 +880,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
-      version: v1.9.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.2.3/cert-manager.yaml
+      version: v1.2.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -892,7 +892,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
     cilium:
       cilium:
         arch:
@@ -901,14 +901,14 @@ spec:
         imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.2.3
       helmChart:
         description: Helm chart for cilium-chart
         imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.2.3
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.2.3/cilium.yaml
       operator:
         arch:
         - amd64
@@ -916,8 +916,8 @@ spec:
         imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.2.3
+      version: v1.2.3
     cloudStack:
       clusterAPIController:
         arch:
@@ -927,9 +927,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -938,7 +938,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -947,13 +947,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.3/core-components.yaml
       controller:
         arch:
         - amd64
@@ -962,7 +962,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -971,13 +971,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -986,7 +986,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -995,15 +995,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -1012,7 +1012,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -1021,10 +1021,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     eksD:
       ami:
         bottlerocket:
@@ -1047,7 +1047,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.2.3/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -1056,7 +1056,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/v1.2.3/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
       imagebuilder:
         arch:
@@ -1066,7 +1066,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/v1.2.3/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -1110,7 +1110,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterController:
         arch:
         - amd64
@@ -1119,9 +1119,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1130,11 +1130,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.0.0-dev-release-0.14+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1143,7 +1143,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1152,13 +1152,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/metadata.yaml
-      version: v1.0.5-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1167,7 +1167,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1176,10 +1176,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/metadata.yaml
-      version: v1.0.4-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     flux:
       helmController:
         arch:
@@ -1189,7 +1189,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kustomizeController:
         arch:
         - amd64
@@ -1198,7 +1198,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       notificationController:
         arch:
         - amd64
@@ -1207,7 +1207,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       sourceController:
         arch:
         - amd64
@@ -1216,8 +1216,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.31.3+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     haproxy:
       image:
         arch:
@@ -1227,11 +1227,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v1.2.3/kindnetd.yaml
+      version: v1.2.3+abcdef1
     kubeVersion: "1.22"
     nutanix:
       clusterAPIController:
@@ -1242,11 +1242,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -1255,16 +1255,16 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/metadata.yaml
-      version: v1.1.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       packageController:
         arch:
         - amd64
@@ -1273,7 +1273,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1282,8 +1282,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.30+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -1295,7 +1295,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-22-19-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -1304,7 +1304,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -1313,10 +1313,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
-      version: v0.1.22+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -1326,11 +1326,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -1339,7 +1339,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: envoy
         os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -1348,9 +1348,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -1361,7 +1361,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           imageToDisk:
             arch:
             - amd64
@@ -1370,7 +1370,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           kexec:
             arch:
             - amd64
@@ -1379,7 +1379,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           ociToDisk:
             arch:
             - amd64
@@ -1388,7 +1388,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           reboot:
             arch:
             - amd64
@@ -1397,7 +1397,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           writeFile:
             arch:
             - amd64
@@ -1406,7 +1406,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         boots:
           arch:
           - amd64
@@ -1415,7 +1415,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:79b1d9acb65dfd0527b44800eddbdcf6b751c8d8-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         hegel:
           arch:
           - amd64
@@ -1424,7 +1424,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         hook:
           bootkit:
             arch:
@@ -1434,7 +1434,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           docker:
             arch:
             - amd64
@@ -1443,18 +1443,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -1463,18 +1463,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -1483,7 +1483,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         tink:
           tinkController:
             arch:
@@ -1493,7 +1493,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           tinkServer:
             arch:
             - amd64
@@ -1502,7 +1502,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           tinkWorker:
             arch:
             - amd64
@@ -1511,12 +1511,12 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -1527,11 +1527,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -1540,7 +1540,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1549,7 +1549,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -1558,7 +1558,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -1567,9 +1567,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.22.6-eks-d-1-22-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.2.3-eks-d-1-22-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -1578,11 +1578,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v1.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1591,7 +1591,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1600,27 +1600,27 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     bottlerocketHostContainers:
       admin:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:bf56c9712189f5fc65d35544e2a84d3a7a1a2c05f2840fab54c57e8a3f8b57a4
+        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:a8f8f30ed6bd3f4848cf79d19f6c31d60b9c898649e7ee1d3081dac4a36421a7
+        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
       kubeadmBootstrap:
         arch:
         - amd64
@@ -1639,7 +1639,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       cainjector:
         arch:
         - amd64
@@ -1648,7 +1648,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       controller:
         arch:
         - amd64
@@ -1657,7 +1657,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       ctl:
         arch:
         - amd64
@@ -1666,10 +1666,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
-      version: v1.9.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.2.3/cert-manager.yaml
+      version: v1.2.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -1678,7 +1678,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
     cilium:
       cilium:
         arch:
@@ -1687,14 +1687,14 @@ spec:
         imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.2.3
       helmChart:
         description: Helm chart for cilium-chart
         imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.2.3
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.2.3/cilium.yaml
       operator:
         arch:
         - amd64
@@ -1702,8 +1702,8 @@ spec:
         imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.2.3
+      version: v1.2.3
     cloudStack:
       clusterAPIController:
         arch:
@@ -1713,9 +1713,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -1724,7 +1724,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -1733,13 +1733,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.3/core-components.yaml
       controller:
         arch:
         - amd64
@@ -1748,7 +1748,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1757,13 +1757,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -1772,7 +1772,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1781,15 +1781,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -1798,7 +1798,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -1807,10 +1807,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     eksD:
       ami:
         bottlerocket:
@@ -1833,7 +1833,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.2.3/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -1842,7 +1842,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/v1.2.3/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
       imagebuilder:
         arch:
@@ -1852,7 +1852,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/v1.2.3/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -1896,7 +1896,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterController:
         arch:
         - amd64
@@ -1905,9 +1905,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1916,11 +1916,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.0.0-dev-release-0.14+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1929,7 +1929,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1938,13 +1938,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/metadata.yaml
-      version: v1.0.5-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1953,7 +1953,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1962,10 +1962,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/metadata.yaml
-      version: v1.0.4-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     flux:
       helmController:
         arch:
@@ -1975,7 +1975,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kustomizeController:
         arch:
         - amd64
@@ -1984,7 +1984,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       notificationController:
         arch:
         - amd64
@@ -1993,7 +1993,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       sourceController:
         arch:
         - amd64
@@ -2002,8 +2002,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.31.3+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     haproxy:
       image:
         arch:
@@ -2013,11 +2013,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v1.2.3/kindnetd.yaml
+      version: v1.2.3+abcdef1
     kubeVersion: "1.23"
     nutanix:
       clusterAPIController:
@@ -2028,11 +2028,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2041,16 +2041,16 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/metadata.yaml
-      version: v1.1.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       packageController:
         arch:
         - amd64
@@ -2059,7 +2059,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2068,8 +2068,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.30+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -2081,7 +2081,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-23-14-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2090,7 +2090,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -2099,10 +2099,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
-      version: v0.1.22+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -2112,11 +2112,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -2125,7 +2125,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: envoy
         os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -2134,9 +2134,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -2147,7 +2147,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           imageToDisk:
             arch:
             - amd64
@@ -2156,7 +2156,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           kexec:
             arch:
             - amd64
@@ -2165,7 +2165,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           ociToDisk:
             arch:
             - amd64
@@ -2174,7 +2174,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           reboot:
             arch:
             - amd64
@@ -2183,7 +2183,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           writeFile:
             arch:
             - amd64
@@ -2192,7 +2192,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         boots:
           arch:
           - amd64
@@ -2201,7 +2201,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:79b1d9acb65dfd0527b44800eddbdcf6b751c8d8-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         hegel:
           arch:
           - amd64
@@ -2210,7 +2210,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         hook:
           bootkit:
             arch:
@@ -2220,7 +2220,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           docker:
             arch:
             - amd64
@@ -2229,18 +2229,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -2249,18 +2249,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -2269,7 +2269,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         tink:
           tinkController:
             arch:
@@ -2279,7 +2279,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           tinkServer:
             arch:
             - amd64
@@ -2288,7 +2288,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           tinkWorker:
             arch:
             - amd64
@@ -2297,12 +2297,12 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -2313,11 +2313,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -2326,7 +2326,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2335,7 +2335,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -2344,7 +2344,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -2353,9 +2353,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.23.1-eks-d-1-23-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.2.3-eks-d-1-23-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -2364,11 +2364,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v1.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2377,7 +2377,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2386,27 +2386,27 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     bottlerocketHostContainers:
       admin:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:bf56c9712189f5fc65d35544e2a84d3a7a1a2c05f2840fab54c57e8a3f8b57a4
+        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:a8f8f30ed6bd3f4848cf79d19f6c31d60b9c898649e7ee1d3081dac4a36421a7
+        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
       kubeadmBootstrap:
         arch:
         - amd64
@@ -2425,7 +2425,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       cainjector:
         arch:
         - amd64
@@ -2434,7 +2434,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       controller:
         arch:
         - amd64
@@ -2443,7 +2443,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       ctl:
         arch:
         - amd64
@@ -2452,10 +2452,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
-      version: v1.9.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.2.3/cert-manager.yaml
+      version: v1.2.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -2464,7 +2464,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
     cilium:
       cilium:
         arch:
@@ -2473,14 +2473,14 @@ spec:
         imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.2.3
       helmChart:
         description: Helm chart for cilium-chart
         imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.2.3
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.2.3/cilium.yaml
       operator:
         arch:
         - amd64
@@ -2488,8 +2488,8 @@ spec:
         imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.2.3
+      version: v1.2.3
     cloudStack:
       clusterAPIController:
         arch:
@@ -2499,9 +2499,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -2510,7 +2510,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -2519,13 +2519,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.3/core-components.yaml
       controller:
         arch:
         - amd64
@@ -2534,7 +2534,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2543,13 +2543,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -2558,7 +2558,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2567,15 +2567,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -2584,7 +2584,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -2593,10 +2593,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     eksD:
       ami:
         bottlerocket:
@@ -2619,7 +2619,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.2.3/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -2628,7 +2628,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/v1.2.3/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
       imagebuilder:
         arch:
@@ -2638,7 +2638,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/v1.2.3/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -2682,7 +2682,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterController:
         arch:
         - amd64
@@ -2691,9 +2691,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -2702,11 +2702,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.0.0-dev-release-0.14+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2715,7 +2715,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2724,13 +2724,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/metadata.yaml
-      version: v1.0.5-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2739,7 +2739,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2748,10 +2748,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/metadata.yaml
-      version: v1.0.4-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     flux:
       helmController:
         arch:
@@ -2761,7 +2761,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kustomizeController:
         arch:
         - amd64
@@ -2770,7 +2770,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       notificationController:
         arch:
         - amd64
@@ -2779,7 +2779,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       sourceController:
         arch:
         - amd64
@@ -2788,8 +2788,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.31.3+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     haproxy:
       image:
         arch:
@@ -2799,11 +2799,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v1.2.3/kindnetd.yaml
+      version: v1.2.3+abcdef1
     kubeVersion: "1.24"
     nutanix:
       clusterAPIController:
@@ -2814,11 +2814,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2827,16 +2827,16 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/metadata.yaml
-      version: v1.1.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       packageController:
         arch:
         - amd64
@@ -2845,7 +2845,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2854,8 +2854,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.30+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -2867,7 +2867,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-24-9-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2876,7 +2876,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -2885,10 +2885,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
-      version: v0.1.22+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -2898,11 +2898,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -2911,7 +2911,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: envoy
         os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -2920,9 +2920,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -2933,7 +2933,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           imageToDisk:
             arch:
             - amd64
@@ -2942,7 +2942,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           kexec:
             arch:
             - amd64
@@ -2951,7 +2951,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           ociToDisk:
             arch:
             - amd64
@@ -2960,7 +2960,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           reboot:
             arch:
             - amd64
@@ -2969,7 +2969,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           writeFile:
             arch:
             - amd64
@@ -2978,7 +2978,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         boots:
           arch:
           - amd64
@@ -2987,7 +2987,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:79b1d9acb65dfd0527b44800eddbdcf6b751c8d8-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         hegel:
           arch:
           - amd64
@@ -2996,7 +2996,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         hook:
           bootkit:
             arch:
@@ -3006,7 +3006,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           docker:
             arch:
             - amd64
@@ -3015,18 +3015,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -3035,18 +3035,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -3055,7 +3055,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         tink:
           tinkController:
             arch:
@@ -3065,7 +3065,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           tinkServer:
             arch:
             - amd64
@@ -3074,7 +3074,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           tinkWorker:
             arch:
             - amd64
@@ -3083,12 +3083,12 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -3099,11 +3099,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -3112,7 +3112,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3121,7 +3121,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -3130,7 +3130,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -3139,9 +3139,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.24.1-eks-d-1-24-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.2.3-eks-d-1-24-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -3150,11 +3150,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v1.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -3163,7 +3163,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3172,27 +3172,27 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     bottlerocketHostContainers:
       admin:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:bf56c9712189f5fc65d35544e2a84d3a7a1a2c05f2840fab54c57e8a3f8b57a4
+        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:a8f8f30ed6bd3f4848cf79d19f6c31d60b9c898649e7ee1d3081dac4a36421a7
+        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
       kubeadmBootstrap:
         arch:
         - amd64
@@ -3211,7 +3211,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       cainjector:
         arch:
         - amd64
@@ -3220,7 +3220,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       controller:
         arch:
         - amd64
@@ -3229,7 +3229,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       ctl:
         arch:
         - amd64
@@ -3238,10 +3238,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
-      version: v1.9.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.2.3/cert-manager.yaml
+      version: v1.2.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -3250,7 +3250,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
     cilium:
       cilium:
         arch:
@@ -3259,14 +3259,14 @@ spec:
         imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.2.3
       helmChart:
         description: Helm chart for cilium-chart
         imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.2.3
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.2.3/cilium.yaml
       operator:
         arch:
         - amd64
@@ -3274,8 +3274,8 @@ spec:
         imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.2.3
+      version: v1.2.3
     cloudStack:
       clusterAPIController:
         arch:
@@ -3285,9 +3285,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -3296,7 +3296,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -3305,13 +3305,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.3/core-components.yaml
       controller:
         arch:
         - amd64
@@ -3320,7 +3320,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3329,13 +3329,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -3344,7 +3344,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3353,15 +3353,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -3370,7 +3370,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -3379,10 +3379,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     eksD:
       ami:
         bottlerocket: {}
@@ -3396,7 +3396,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.2.3/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -3405,7 +3405,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/v1.2.3/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
       imagebuilder:
         arch:
@@ -3415,7 +3415,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/v1.2.3/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -3441,7 +3441,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterController:
         arch:
         - amd64
@@ -3450,9 +3450,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -3461,11 +3461,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.0.0-dev-release-0.14+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -3474,7 +3474,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3483,13 +3483,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/metadata.yaml
-      version: v1.0.5-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -3498,7 +3498,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3507,10 +3507,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/metadata.yaml
-      version: v1.0.4-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     flux:
       helmController:
         arch:
@@ -3520,7 +3520,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kustomizeController:
         arch:
         - amd64
@@ -3529,7 +3529,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       notificationController:
         arch:
         - amd64
@@ -3538,7 +3538,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       sourceController:
         arch:
         - amd64
@@ -3547,8 +3547,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.31.3+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     haproxy:
       image:
         arch:
@@ -3558,11 +3558,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v1.2.3/kindnetd.yaml
+      version: v1.2.3+abcdef1
     kubeVersion: "1.25"
     nutanix:
       clusterAPIController:
@@ -3573,11 +3573,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -3586,16 +3586,16 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/metadata.yaml
-      version: v1.1.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       packageController:
         arch:
         - amd64
@@ -3604,7 +3604,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -3613,8 +3613,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.30+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -3626,7 +3626,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-25-5-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -3635,7 +3635,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -3644,10 +3644,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.22-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.22/metadata.yaml
-      version: v0.1.22+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v1.2.3/metadata.yaml
+      version: v1.2.3+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -3657,11 +3657,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -3670,7 +3670,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: envoy
         os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -3679,9 +3679,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v1.2.3/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -3692,7 +3692,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           imageToDisk:
             arch:
             - amd64
@@ -3701,7 +3701,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           kexec:
             arch:
             - amd64
@@ -3710,7 +3710,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           ociToDisk:
             arch:
             - amd64
@@ -3719,7 +3719,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           reboot:
             arch:
             - amd64
@@ -3728,7 +3728,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           writeFile:
             arch:
             - amd64
@@ -3737,7 +3737,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         boots:
           arch:
           - amd64
@@ -3746,7 +3746,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:79b1d9acb65dfd0527b44800eddbdcf6b751c8d8-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         hegel:
           arch:
           - amd64
@@ -3755,7 +3755,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         hook:
           bootkit:
             arch:
@@ -3765,7 +3765,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           docker:
             arch:
             - amd64
@@ -3774,18 +3774,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -3794,18 +3794,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/v1.2.3/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -3814,7 +3814,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         tink:
           tinkController:
             arch:
@@ -3824,7 +3824,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           tinkServer:
             arch:
             - amd64
@@ -3833,7 +3833,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
           tinkWorker:
             arch:
             - amd64
@@ -3842,12 +3842,12 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       version: v0.1.0
     vSphere:
       clusterAPIController:
@@ -3858,11 +3858,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/infrastructure-components.yaml
       driver:
         arch:
         - amd64
@@ -3871,7 +3871,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-driver
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3880,7 +3880,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVip:
         arch:
         - amd64
@@ -3889,7 +3889,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
       manager:
         arch:
         - amd64
@@ -3898,9 +3898,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.25.0-eks-d-1-25-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.2.3-eks-d-1-25-eks-a-v0.0.0-dev-release-0.14-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.2.3/metadata.yaml
       syncer:
         arch:
         - amd64
@@ -3909,6 +3909,6 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: vsphere-csi-syncer
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v1.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v1.2.3-eks-a-v0.0.0-dev-release-0.14-build.1
+      version: v1.2.3+abcdef1
 status: {}

--- a/release/pkg/util/bundles/bundles.go
+++ b/release/pkg/util/bundles/bundles.go
@@ -38,7 +38,7 @@ func SortArtifactsMap(m map[string][]releasetypes.Artifact) []string {
 }
 
 func getKubeRbacProxyImageAttributes(r *releasetypes.ReleaseConfig) (string, string, map[string]string, error) {
-	gitTag, err := filereader.ReadGitTag(constants.KubeRbacProxyProjectPath, r.BuildRepoSource, r.BuildRepoBranchName)
+	gitTag, err := filereader.ReadGitTag(constants.KubeRbacProxyProjectPath, r.BuildRepoSource, r.BuildRepoBranchName, r.DryRun)
 	if err != nil {
 		return "", "", nil, errors.Cause(err)
 	}

--- a/release/pkg/version/version.go
+++ b/release/pkg/version/version.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/aws/eks-anywhere/release/pkg/constants"
 	"github.com/aws/eks-anywhere/release/pkg/filereader"
 	"github.com/aws/eks-anywhere/release/pkg/git"
 	releasetypes "github.com/aws/eks-anywhere/release/pkg/types"
@@ -93,22 +94,27 @@ func NewMultiProjectVersionerWithGITTAG(repoSource, pathToRootFolder, pathToMain
 }
 
 func (v *VersionerWithGITTAG) patchVersion() (string, error) {
-	return filereader.ReadGitTag(v.folderWithGITTAG, v.releaseConfig.BuildRepoSource, v.sourcedFromBranch)
+	return filereader.ReadGitTag(v.folderWithGITTAG, v.releaseConfig.BuildRepoSource, v.sourcedFromBranch, v.releaseConfig.DryRun)
 }
 
 type cliVersioner struct {
 	Versioner
 	cliVersion string
+	dryRun     bool
 }
 
-func NewCliVersioner(cliVersion, pathToProject string) *cliVersioner {
+func NewCliVersioner(releaseConfig *releasetypes.ReleaseConfig) *cliVersioner {
 	return &cliVersioner{
-		cliVersion: cliVersion,
-		Versioner:  Versioner{pathToProject: pathToProject},
+		cliVersion: releaseConfig.ReleaseVersion,
+		Versioner:  Versioner{pathToProject: releaseConfig.CliRepoSource},
+		dryRun:     releaseConfig.DryRun,
 	}
 }
 
 func (v *cliVersioner) patchVersion() (string, error) {
+	if v.dryRun {
+		return constants.FakeGitTag, nil
+	}
 	return v.cliVersion, nil
 }
 


### PR DESCRIPTION
Make testdata files mutable only by API changes, and not by version changes in the build-tooling repo. This makes the tests self-contained.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

