### PR TITLE
updating phase runner to accept generic objects

### DIFF
--- a/pkg/controller/runner.go
+++ b/pkg/controller/runner.go
@@ -4,34 +4,32 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-
-	"github.com/aws/eks-anywhere/pkg/cluster"
 )
 
 // Phase represents a generic reconciliation phase for a cluster spec.
-type Phase func(ctx context.Context, log logr.Logger, clusterSpec *cluster.Spec) (Result, error)
+type Phase[O any] func(ctx context.Context, log logr.Logger, obj O) (Result, error)
 
 // PhaseRunner allows to execute Phases in order.
-type PhaseRunner struct {
-	phases []Phase
+type PhaseRunner[O any] struct {
+	phases []Phase[O]
 }
 
 // NewPhaseRunner creates a new PhaseRunner without any Phases.
-func NewPhaseRunner() PhaseRunner {
-	return PhaseRunner{}
+func NewPhaseRunner[O any]() PhaseRunner[O] {
+	return PhaseRunner[O]{}
 }
 
 // Register adds a phase to the runnner.
-func (r PhaseRunner) Register(phases ...Phase) PhaseRunner {
+func (r PhaseRunner[O]) Register(phases ...Phase[O]) PhaseRunner[O] {
 	r.phases = append(r.phases, phases...)
 	return r
 }
 
 // Run will execute phases in the order they were registered until a phase
 // returns an error or a Result that requests to an interruption.
-func (r PhaseRunner) Run(ctx context.Context, log logr.Logger, clusterSpec *cluster.Spec) (Result, error) {
+func (r PhaseRunner[O]) Run(ctx context.Context, log logr.Logger, obj O) (Result, error) {
 	for _, p := range r.phases {
-		if r, err := p(ctx, log, clusterSpec); r.Return() {
+		if r, err := p(ctx, log, obj); r.Return() {
 			return r, nil
 		} else if err != nil {
 			return Result{}, err

--- a/pkg/controller/runner_test.go
+++ b/pkg/controller/runner_test.go
@@ -19,7 +19,7 @@ func TestPhaseRunnerRunError(t *testing.T) {
 	ctx := context.Background()
 	phase1 := newPhase()
 	phase3 := newPhase()
-	r := controller.NewPhaseRunner().Register(
+	r := controller.NewPhaseRunner[*cluster.Spec]().Register(
 		phase1.run,
 		phaseReturnError,
 		phase3.run,
@@ -36,7 +36,7 @@ func TestPhaseRunnerRunRequeue(t *testing.T) {
 	ctx := context.Background()
 	phase1 := newPhase()
 	phase3 := newPhase()
-	r := controller.NewPhaseRunner().Register(
+	r := controller.NewPhaseRunner[*cluster.Spec]().Register(
 		phase1.run,
 		phaseReturnRequeue,
 		phase3.run,
@@ -55,7 +55,7 @@ func TestPhaseRunnerRunAllPhasesFinished(t *testing.T) {
 	phase1 := newPhase()
 	phase2 := newPhase()
 	phase3 := newPhase()
-	r := controller.NewPhaseRunner().Register(
+	r := controller.NewPhaseRunner[*cluster.Spec]().Register(
 		phase1.run,
 		phase2.run,
 		phase3.run,

--- a/pkg/providers/docker/reconciler/reconciler.go
+++ b/pkg/providers/docker/reconciler/reconciler.go
@@ -52,7 +52,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, log logr.Logger, c *anywhere
 		return controller.Result{}, err
 	}
 
-	return controller.NewPhaseRunner().Register(
+	return controller.NewPhaseRunner[*cluster.Spec]().Register(
 		r.ReconcileControlPlane,
 		r.CheckControlPlaneReady,
 		r.ReconcileCNI,
@@ -87,7 +87,7 @@ func (r *Reconciler) ReconcileWorkerNodes(ctx context.Context, log logr.Logger, 
 		return controller.Result{}, errors.Wrap(err, "building cluster Spec for worker node reconcile")
 	}
 
-	return controller.NewPhaseRunner().Register(
+	return controller.NewPhaseRunner[*cluster.Spec]().Register(
 		r.ReconcileWorkers,
 	).Run(ctx, log, clusterSpec)
 }

--- a/pkg/providers/snow/reconciler/reconciler.go
+++ b/pkg/providers/snow/reconciler/reconciler.go
@@ -57,7 +57,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, log logr.Logger, c *anywhere
 		return controller.Result{}, err
 	}
 
-	return controller.NewPhaseRunner().Register(
+	return controller.NewPhaseRunner[*cluster.Spec]().Register(
 		r.ipValidator.ValidateControlPlaneIP,
 		r.ValidateMachineConfigs,
 		clusters.CleanupStatusAfterValidate,
@@ -77,7 +77,7 @@ func (r *Reconciler) ReconcileWorkerNodes(ctx context.Context, log logr.Logger, 
 		return controller.Result{}, err
 	}
 
-	return controller.NewPhaseRunner().Register(
+	return controller.NewPhaseRunner[*cluster.Spec]().Register(
 		r.ValidateMachineConfigs,
 		r.ReconcileWorkers,
 	).Run(ctx, log, clusterSpec)

--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -163,7 +163,7 @@ func (r *Reconciler) ValidateDatacenterConfig(ctx context.Context, log logr.Logg
 	clusterSpec := tinkerbellScope.ClusterSpec
 	log = log.WithValues("phase", "validateDatacenterConfig")
 
-	if err := r.validateTinkerbellIPMatch(ctx, NewScope(clusterSpec)); err != nil {
+	if err := r.validateTinkerbellIPMatch(ctx, clusterSpec); err != nil {
 		log.Error(err, "Invalid TinkerbellDatacenterConfig")
 		failureMessage := err.Error()
 		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
@@ -186,8 +186,7 @@ func (r *Reconciler) ReconcileCNI(ctx context.Context, log logr.Logger, tinkerbe
 	return r.cniReconciler.Reconcile(ctx, log, client, clusterSpec)
 }
 
-func (r *Reconciler) validateTinkerbellIPMatch(ctx context.Context, tinkerbellScope *Scope) error {
-	clusterSpec := tinkerbellScope.ClusterSpec
+func (r *Reconciler) validateTinkerbellIPMatch(ctx context.Context, clusterSpec *c.Spec) error {
 	if clusterSpec.Cluster.IsManaged() {
 
 		// for workload cluster tinkerbell IP must match management cluster tinkerbell IP

--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -40,7 +40,8 @@ type Scope struct {
 // NewScope creates a new Tinkerbell Reconciler Scope.
 func NewScope(clusterSpec *c.Spec) *Scope {
 	return &Scope{
-		ClusterSpec: clusterSpec,
+		ClusterSpec:      clusterSpec,
+		isRollingUpgrade: false,
 	}
 }
 

--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -33,7 +33,8 @@ type IPValidator interface {
 
 // Scope object for Tinkerbell reconciler.
 type Scope struct {
-	ClusterSpec *c.Spec
+	ClusterSpec      *c.Spec
+	isRollingUpgrade bool
 }
 
 // NewScope creates a new Tinkerbell Reconciler Scope.

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -53,7 +53,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 	logger := test.NewNullLogger()
 	remoteClient := env.Client()
 
-	tt.ipValidator.EXPECT().ValidateControlPlaneIP(tt.ctx, logger, tt.buildScope()).Return(controller.Result{}, nil)
+	tt.ipValidator.EXPECT().ValidateControlPlaneIP(tt.ctx, logger, tt.buildSpec()).Return(controller.Result{}, nil)
 
 	tt.remoteClientRegistry.EXPECT().GetClient(
 		tt.ctx, client.ObjectKey{Name: workloadClusterName, Namespace: constants.EksaSystemNamespace},
@@ -128,14 +128,14 @@ func TestReconcileCNISuccess(t *testing.T) {
 
 	logger := test.NewNullLogger()
 	remoteClient := fake.NewClientBuilder().Build()
-	spec := tt.buildScope()
+	scope := tt.buildScope()
 
 	tt.remoteClientRegistry.EXPECT().GetClient(
 		tt.ctx, client.ObjectKey{Name: workloadClusterName, Namespace: constants.EksaSystemNamespace},
 	).Return(remoteClient, nil)
-	tt.cniReconciler.EXPECT().Reconcile(tt.ctx, logger, remoteClient, spec)
+	tt.cniReconciler.EXPECT().Reconcile(tt.ctx, logger, remoteClient, scope.ClusterSpec)
 
-	result, err := tt.reconciler().ReconcileCNI(tt.ctx, logger, spec)
+	result, err := tt.reconciler().ReconcileCNI(tt.ctx, logger, scope)
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())

--- a/pkg/providers/vsphere/reconciler/reconciler.go
+++ b/pkg/providers/vsphere/reconciler/reconciler.go
@@ -102,7 +102,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, log logr.Logger, cluster *an
 		return controller.Result{}, err
 	}
 
-	return controller.NewPhaseRunner().Register(
+	return controller.NewPhaseRunner[*c.Spec]().Register(
 		r.ipValidator.ValidateControlPlaneIP,
 		r.ValidateDatacenterConfig,
 		r.ValidateMachineConfigs,
@@ -124,7 +124,7 @@ func (r *Reconciler) ReconcileWorkerNodes(ctx context.Context, log logr.Logger, 
 		return controller.Result{}, err
 	}
 
-	return controller.NewPhaseRunner().Register(
+	return controller.NewPhaseRunner[*c.Spec]().Register(
 		r.ValidateDatacenterConfig,
 		r.ValidateMachineConfigs,
 		r.ReconcileWorkers,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Tinkerbell upgrade validations require comparisons between the desired Cluster Spec state and the existing current state pulled from the CAPI objects at multiple phases of the reconciler. Caching the result of our comparisons and/or the desired CAPI state earlier on will allow us to reference these objects in later phases without repeatedly retrieving the CAPI state and running our comparisons.

The phase runner currently runs off the Cluster Spec object. We propose allowing the object type to be specified as needed to allow custom fields and values outside of Cluster Spec to be stored, referenced and modified in different phases - while being constrained to the scope of the `reconciler.Reconcile()` function for thread safety.

This update enables phase runner to accept a specifiable type instead of the previous `*cluster.Spec` type as well as introduces the `Scope` struct for Tinkerbell to store our additional information

*Testing (if applicable):*
Existing automated unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

