### PR TITLE
Tinkerbell proxy related changes for hook bootkit

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -304,9 +304,6 @@ func (s *Installer) getBootsEnv(bundle releasev1alpha1.TinkerbellStackBundle, ti
 	if s.proxyConfig != nil {
 		noProxy := strings.Join(s.proxyConfig.NoProxy, ",")
 		extraKernelArgs = fmt.Sprintf("%s HTTP_PROXY=%s HTTPS_PROXY=%s NO_PROXY=%s", extraKernelArgs, s.proxyConfig.HttpProxy, s.proxyConfig.HttpsProxy, noProxy)
-		bootsEnv["HTTP_PROXY"] = s.proxyConfig.HttpProxy
-		bootsEnv["HTTPS_PROXY"] = s.proxyConfig.HttpsProxy
-		bootsEnv["NO_PROXY"] = noProxy
 	}
 	bootsEnv["BOOTS_EXTRA_KERNEL_ARGS"] = extraKernelArgs
 

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
@@ -1,0 +1,45 @@
+boots:
+  args:
+  - -dhcp-addr=0.0.0.0:67
+  - -osie-path-override=https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
+  deploy: true
+  env:
+  - name: TINKERBELL_TLS
+    value: "false"
+  - name: TINKERBELL_GRPC_AUTHORITY
+    value: 1.2.3.4:42113
+  - name: HTTP_PROXY
+    value: "1.2.3.4:3128"
+  - name: HTTP_PROXY
+    value: "1.2.3.4:3128"
+  - name: BOOTS_EXTRA_KERNEL_ARGS
+    value: tink_worker_image=1.2.3.4:443/custom/eks-anywhere/tink-worker:latest insecure_registries=1.2.3.4:443
+  - name: DATA_MODEL_VERSION
+    value: kubernetes
+  image: public.ecr.aws/eks-anywhere/boots:latest
+createNamespace: false
+envoy:
+  deploy: false
+  externalIp: 1.2.3.4
+  image: public.ecr.aws/eks-anywhere/envoy:latest
+hegel:
+  env:
+  - name: HEGEL_TRUSTED_PROXIES
+    value: 192.168.0.0/16
+  image: public.ecr.aws/eks-anywhere/hegel:latest
+  port:
+    hostPortEnabled: false
+kubevip:
+  deploy: false
+  image: public.ecr.aws/eks-anywhere/kube-vip:latest
+namespace: eksa-system
+rufio:
+  image: public.ecr.aws/eks-anywhere/rufio:latest
+tinkController:
+  image: public.ecr.aws/eks-anywhere/tink-controller:latest
+tinkServer:
+  args:
+  - --tls=false
+  image: public.ecr.aws/eks-anywhere/tink-server:latest
+  port:
+    hostPortEnabled: false

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -593,7 +593,7 @@ func generateTemplateBuilder(clusterSpec *cluster.Spec) (providers.TemplateBuild
 }
 
 // GenerateNoProxyList generates NOPROXY list for tinkerbell provider based on HTTP_PROXY, HTTPS_PROXY, NOPROXY and tinkerbellIP.
-func GenerateNoProxyList(clusterSpec *v1alpha1.Cluster, datacenterSpec v1alpha1.TinkerbellDatacenterConfigSpec, tinkerbellIp string) []string {
+func GenerateNoProxyList(clusterSpec *v1alpha1.Cluster, datacenterSpec v1alpha1.TinkerbellDatacenterConfigSpec, tinkerbellIP string) []string {
 	capacity := len(clusterSpec.Spec.ClusterNetwork.Pods.CidrBlocks) +
 		len(clusterSpec.Spec.ClusterNetwork.Services.CidrBlocks) +
 		len(clusterSpec.Spec.ProxyConfiguration.NoProxy) + 4
@@ -607,7 +607,7 @@ func GenerateNoProxyList(clusterSpec *v1alpha1.Cluster, datacenterSpec v1alpha1.
 	noProxyList = append(noProxyList,
 		clusterSpec.Spec.ControlPlaneConfiguration.Endpoint.Host,
 		datacenterSpec.TinkerbellIP,
-		tinkerbellIp,
+		tinkerbellIP,
 	)
 
 	return noProxyList

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_proxy.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_proxy.yaml
@@ -50,7 +50,7 @@ metadata:
   name: test
   namespace: test-namespace
 spec:
-  tinkerbellIP: "5.6.7.8"
+  tinkerbellIP: "2.3.4.5"
   osImageURL: "https://ubuntu.gz"
 
 ---

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_proxy.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_proxy.yaml
@@ -117,7 +117,7 @@ spec:
           [Service]
           Environment="HTTP_PROXY=1.1.1.1:8080"
           Environment="HTTPS_PROXY=1.1.1.1:8443"
-          Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,localhost,127.0.0.1,.svc,1.2.3.4,5.6.7.8"
+          Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,localhost,127.0.0.1,.svc,1.2.3.4,2.3.4.5,5.6.7.8"
         owner: root:root
         path: /etc/systemd/system/containerd.service.d/http-proxy.conf
     preKubeadmCommands:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_proxy.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_proxy.yaml
@@ -165,7 +165,7 @@ spec:
             [Service]
             Environment="HTTP_PROXY=1.1.1.1:8080"
             Environment="HTTPS_PROXY=1.1.1.1:8443"
-            Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,localhost,127.0.0.1,.svc,1.2.3.4,5.6.7.8"
+            Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,localhost,127.0.0.1,.svc,1.2.3.4,2.3.4.5,5.6.7.8"
           owner: root:root
           path: /etc/systemd/system/containerd.service.d/http-proxy.conf
       preKubeadmCommands:

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -131,11 +131,22 @@ func NewProvider(
 		}
 	}
 
+	var proxyConfig *v1alpha1.ProxyConfiguration
+	if clusterConfig.Spec.ProxyConfiguration != nil {
+		proxyConfig = &v1alpha1.ProxyConfiguration{
+			HttpProxy:  clusterConfig.Spec.ProxyConfiguration.HttpProxy,
+			HttpsProxy: clusterConfig.Spec.ProxyConfiguration.HttpsProxy,
+			NoProxy:    GenerateNoProxyList(clusterConfig, datacenterConfig.Spec, tinkerbellIP),
+		}
+	} else {
+		proxyConfig = nil
+	}
+
 	return &Provider{
 		clusterConfig:         clusterConfig,
 		datacenterConfig:      datacenterConfig,
 		machineConfigs:        machineConfigs,
-		stackInstaller:        stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace, clusterConfig.Spec.ClusterNetwork.Pods.CidrBlocks[0], registrymirror.FromCluster(clusterConfig)),
+		stackInstaller:        stack.NewInstaller(docker, writer, helm, constants.EksaSystemNamespace, clusterConfig.Spec.ClusterNetwork.Pods.CidrBlocks[0], registrymirror.FromCluster(clusterConfig), proxyConfig),
 		providerKubectlClient: providerKubectlClient,
 		templateBuilder: &TemplateBuilder{
 			datacenterSpec:              &datacenterConfig.Spec,


### PR DESCRIPTION
*Description of changes:*
This PR passes proxy variables to tinkerbell stack where hook bootkit grabs the variables and set those as environment variables for tink-worker and other action images. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

