### PR TITLE
Replace ioutil with os/io since ioutil is deprecated

### DIFF
--- a/cmd/eksctl-anywhere/cmd/downloadartifacts.go
+++ b/cmd/eksctl-anywhere/cmd/downloadartifacts.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -120,7 +119,7 @@ func downloadArtifacts(context context.Context, opts *downloadArtifactsOptions) 
 		return fmt.Errorf("marshaling bundle-release.yaml: %v", err)
 	}
 	bundleReleaseFilePath := filepath.Join(opts.downloadDir, "bundle-release.yaml")
-	if err = ioutil.WriteFile(bundleReleaseFilePath, bundleReleaseContent, 0o644); err != nil {
+	if err = os.WriteFile(bundleReleaseFilePath, bundleReleaseContent, 0o644); err != nil {
 		return err
 	}
 
@@ -161,7 +160,7 @@ func downloadArtifact(filePath, artifactUri string, reader *files.Reader) error 
 	if err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(filePath, contents, 0o644); err != nil {
+	if err = os.WriteFile(filePath, contents, 0o644); err != nil {
 		return err
 	}
 

--- a/internal/pkg/oidc/token.go
+++ b/internal/pkg/oidc/token.go
@@ -4,7 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	jose "gopkg.in/square/go-jose.v2"
@@ -85,7 +85,7 @@ func WithSubject(subject string) JWTOpt {
 }
 
 func (o *oidcTokenClaim) generateToken() (string, error) {
-	keyContent, err := ioutil.ReadFile(o.keyFile)
+	keyContent, err := os.ReadFile(o.keyFile)
 	if err != nil {
 		return "", fmt.Errorf("could not read key file: %v", err)
 	}

--- a/internal/test/files.go
+++ b/internal/test/files.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -61,7 +60,7 @@ func contentEqualToFile(gotContent []byte, wantFile string) (bool, error) {
 		return false, nil
 	}
 
-	fileContent, err := ioutil.ReadFile(wantFile)
+	fileContent, err := os.ReadFile(wantFile)
 	if err != nil {
 		return false, err
 	}
@@ -85,7 +84,7 @@ func computeDiffBetweenContentAndFile(content []byte, file string) (string, erro
 
 func processUpdate(t *testing.T, filePath, content string) {
 	if *UpdateGoldenFiles {
-		if err := ioutil.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
 			t.Fatalf("failed to update golden file %s: %v", filePath, err)
 		}
 		log.Printf("Golden file updated: %s", filePath)
@@ -93,7 +92,7 @@ func processUpdate(t *testing.T, filePath, content string) {
 }
 
 func ReadFileAsBytes(t *testing.T, file string) []byte {
-	bytesRead, err := ioutil.ReadFile(file)
+	bytesRead, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatalf("File [%s] reading error in test: %v", file, err)
 	}
@@ -106,7 +105,7 @@ func ReadFile(t *testing.T, file string) string {
 }
 
 func NewWriter(t *testing.T) (dir string, writer filewriter.FileWriter) {
-	dir, err := ioutil.TempDir(".", SanitizePath(t.Name())+"-")
+	dir, err := os.MkdirTemp(".", SanitizePath(t.Name())+"-")
 	if err != nil {
 		t.Fatalf("error setting up folder for test: %v", err)
 	}

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -16,7 +15,7 @@ import (
 //
 // The file is automatically closed and removed when the test ends.
 func WithFakeFile(t *testing.T) (f *os.File) {
-	f, err := ioutil.TempFile(t.TempDir(), "fake-file")
+	f, err := os.CreateTemp(t.TempDir(), "fake-file")
 	if err != nil {
 		t.Fatalf("opening throwaway file: %s", err)
 	}

--- a/pkg/api/v1alpha1/cloudstackmachineconfig.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,7 +50,7 @@ func (c *CloudStackMachineConfigGenerate) Name() string {
 
 func GetCloudStackMachineConfigs(fileName string) (map[string]*CloudStackMachineConfig, error) {
 	configs := make(map[string]*CloudStackMachineConfig)
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read file due to: %v", err)
 	}

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -260,7 +260,7 @@ func ValidateClusterConfigContent(clusterConfig *Cluster) error {
 // ParseClusterConfig unmarshalls an API object implementing the KindAccessor interface
 // from a multiobject yaml file in disk. It doesn't set defaults nor validates the object.
 func ParseClusterConfig(fileName string, clusterConfig KindAccessor) error {
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
 		return fmt.Errorf("unable to read file due to: %v", err)
 	}

--- a/pkg/api/v1alpha1/cluster_defaults.go
+++ b/pkg/api/v1alpha1/cluster_defaults.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/aws/eks-anywhere/pkg/constants"
@@ -35,7 +34,7 @@ func setRegistryMirrorConfigDefaults(clusterConfig *Cluster) error {
 	}
 	if clusterConfig.Spec.RegistryMirrorConfiguration.CACertContent == "" {
 		if caCert, set := os.LookupEnv(RegistryMirrorCAKey); set && len(caCert) > 0 {
-			content, err := ioutil.ReadFile(caCert)
+			content, err := os.ReadFile(caCert)
 			if err != nil {
 				return fmt.Errorf("reading the cert file %s: %v", caCert, err)
 			}

--- a/pkg/api/v1alpha1/nutanixmachineconfig.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -111,7 +111,7 @@ func (c *NutanixMachineConfigGenerate) Name() string {
 
 func GetNutanixMachineConfigs(fileName string) (map[string]*NutanixMachineConfig, error) {
 	configs := make(map[string]*NutanixMachineConfig)
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read file due to: %v", err)
 	}

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,7 +57,7 @@ func (c *TinkerbellMachineConfigGenerate) Name() string {
 
 func GetTinkerbellMachineConfigs(fileName string) (map[string]*TinkerbellMachineConfig, error) {
 	configs := make(map[string]*TinkerbellMachineConfig)
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read file due to: %v", err)
 	}

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,7 +68,7 @@ func (c *TinkerbellTemplateConfigGenerate) Name() string {
 
 func GetTinkerbellTemplateConfig(fileName string) (map[string]*TinkerbellTemplateConfig, error) {
 	templates := make(map[string]*TinkerbellTemplateConfig)
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read file due to: %v", err)
 	}

--- a/pkg/api/v1alpha1/vspheremachineconfig.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig.go
@@ -2,8 +2,8 @@ package v1alpha1
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,7 +59,7 @@ func (c *VSphereMachineConfigGenerate) Name() string {
 
 func GetVSphereMachineConfigs(fileName string) (map[string]*VSphereMachineConfig, error) {
 	configs := make(map[string]*VSphereMachineConfig)
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read file due to: %v", err)
 	}

--- a/pkg/aws/creds.go
+++ b/pkg/aws/creds.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"regexp"
@@ -45,7 +44,7 @@ func EncodeFileFromEnv(envKey string) (string, error) {
 		return "", err
 	}
 
-	content, err := ioutil.ReadFile(filePath)
+	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", fmt.Errorf("unable to read file due to: %v", err)
 	}

--- a/pkg/cluster/load.go
+++ b/pkg/cluster/load.go
@@ -2,7 +2,7 @@ package cluster
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"sigs.k8s.io/yaml"
 
@@ -21,7 +21,7 @@ func LoadManagement(kubeconfig string) (*types.Cluster, error) {
 	if kubeconfig == "" {
 		return nil, nil
 	}
-	kubeConfigBytes, err := ioutil.ReadFile(kubeconfig)
+	kubeConfigBytes, err := os.ReadFile(kubeconfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -147,7 +146,7 @@ func writeInfrastructureBundle(clusterSpec *cluster.Spec, rootFolder string, bun
 			return fmt.Errorf("can't load infrastructure bundle for manifest %s: %v", manifest.URI, err)
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(infraFolder, m.Filename), m.Content, 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(infraFolder, m.Filename), m.Content, 0o644); err != nil {
 			return fmt.Errorf("generating file for infrastructure bundle %s: %v", m.Filename, err)
 		}
 	}

--- a/pkg/executables/govc_test.go
+++ b/pkg/executables/govc_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -177,7 +176,7 @@ func (dt *deployTemplateTest) assertDeployTemplateError(t *testing.T) {
 func (dt *deployTemplateTest) assertDeployOptsMatches(t *testing.T) {
 	g := NewWithT(t)
 
-	actual, err := ioutil.ReadFile(filepath.Join(dt.dir, executables.DeployOptsFile))
+	actual, err := os.ReadFile(filepath.Join(dt.dir, executables.DeployOptsFile))
 	if err != nil {
 		t.Fatalf("failed to read deploy options file: %v", err)
 	}

--- a/pkg/executables/kind.go
+++ b/pkg/executables/kind.go
@@ -6,7 +6,6 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -201,7 +200,7 @@ func (k *Kind) setupExecConfig(clusterSpec *cluster.Spec) error {
 			if err := os.MkdirAll(path, os.ModePerm); err != nil {
 				return err
 			}
-			if err := ioutil.WriteFile(filepath.Join(path, "ca.crt"), []byte(registryMirror.CACertContent), 0o644); err != nil {
+			if err := os.WriteFile(filepath.Join(path, "ca.crt"), []byte(registryMirror.CACertContent), 0o644); err != nil {
 				return errors.New("error writing the registry certification file")
 			}
 			k.execConfig.RegistryCACertPath = filepath.Join(clusterSpec.Cluster.Name, "generated", "certs.d")

--- a/pkg/files/reader.go
+++ b/pkg/files/reader.go
@@ -3,9 +3,10 @@ package files
 import (
 	"embed"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 )
 
@@ -84,7 +85,7 @@ func (r *Reader) readHttpFile(uri string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed reading file from url [%s]: %v", uri, err)
 	}
@@ -102,7 +103,7 @@ func (r *Reader) readEmbedFile(url *url.URL) ([]byte, error) {
 }
 
 func readLocalFile(filename string) ([]byte, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed reading local file [%s]: %v", filename, err)
 	}

--- a/pkg/filewriter/tmp_writer_test.go
+++ b/pkg/filewriter/tmp_writer_test.go
@@ -1,7 +1,6 @@
 package filewriter_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -77,7 +76,7 @@ func TestTmpWriterWriteValid(t *testing.T) {
 				t.Errorf("tmpWriter.Write() = %v, want to end with %v", gotPath, tt.fileName)
 			}
 
-			content, err := ioutil.ReadFile(gotPath)
+			content, err := os.ReadFile(gotPath)
 			if err != nil {
 				t.Fatalf("error reading written file: %v", err)
 			}

--- a/pkg/filewriter/writer.go
+++ b/pkg/filewriter/writer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -30,7 +29,7 @@ func (w *writer) Write(fileName string, content []byte, opts ...FileOptionsFunc)
 	o := buildOptions(w, opts)
 
 	filePath := filepath.Join(o.BasePath, fileName)
-	err := ioutil.WriteFile(filePath, content, o.Permissions)
+	err := os.WriteFile(filePath, content, o.Permissions)
 	if err != nil {
 		return "", fmt.Errorf("writing to file [%s]: %v", filePath, err)
 	}

--- a/pkg/git/factory/gitfactory.go
+++ b/pkg/git/factory/gitfactory.go
@@ -3,7 +3,6 @@ package gitfactory
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -140,7 +139,7 @@ func getSignerFromPrivateKeyFile(privateKeyFile string, passphrase string) (ssh.
 	var signer ssh.Signer
 	var err error
 
-	sshKey, err := ioutil.ReadFile(privateKeyFile)
+	sshKey, err := os.ReadFile(privateKeyFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gitops/flux/upgrader_test.go
+++ b/pkg/gitops/flux/upgrader_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -211,7 +211,7 @@ func setupTestFiles(t *testing.T, writer filewriter.FileWriter) error {
 	if err != nil {
 		return fmt.Errorf("failed to create test eksa-system directory: %v", err)
 	}
-	eksaContent, err := ioutil.ReadFile("./testdata/cluster-config-default-path-management.yaml")
+	eksaContent, err := os.ReadFile("./testdata/cluster-config-default-path-management.yaml")
 	if err != nil {
 		return fmt.Errorf("File [%s] reading error in test: %v", "cluster-config-default-path-management.yaml", err)
 	}

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -90,7 +90,7 @@ func unmarshalYamlToObject(t *testing.T, filepath string) map[string]interface{}
 
 func processUpdate(t *testing.T, goldenFilePath, generatedFilePath string) {
 	if *test.UpdateGoldenFiles {
-		if err := ioutil.WriteFile(goldenFilePath, test.ReadFileAsBytes(t, generatedFilePath), 0o644); err != nil {
+		if err := os.WriteFile(goldenFilePath, test.ReadFileAsBytes(t, generatedFilePath), 0o644); err != nil {
 			t.Fatalf("failed to update golden file %s: %v", goldenFilePath, err)
 		}
 		log.Printf("Golden file updated: %s", goldenFilePath)

--- a/pkg/providers/vsphere/setupuser/validator.go
+++ b/pkg/providers/vsphere/setupuser/validator.go
@@ -3,7 +3,7 @@ package setupuser
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -66,7 +66,7 @@ func GenerateConfig(ctx context.Context, filepath string) (*VSphereSetupUserConf
 }
 
 func readConfig(ctx context.Context, filepath string) (*VSphereSetupUserConfig, error) {
-	file, err := ioutil.ReadFile(filepath)
+	file, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %s, err = %v", filepath, err)
 	}

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -201,7 +200,7 @@ var releaseCmd = &cobra.Command{
 			fmt.Printf("\n%s\n", string(bundleManifest))
 
 			if !dryRun {
-				err = ioutil.WriteFile(bundleReleaseManifestFile, bundleManifest, 0o644)
+				err = os.WriteFile(bundleReleaseManifestFile, bundleManifest, 0o644)
 				if err != nil {
 					fmt.Printf("Error writing bundles manifest file to disk: %v\n", err)
 					os.Exit(1)
@@ -272,7 +271,7 @@ var releaseCmd = &cobra.Command{
 			}
 
 			// Push the manifest file and other artifacts to release locations
-			err = ioutil.WriteFile(eksAReleaseManifestFile, releaseManifest, 0o644)
+			err = os.WriteFile(eksAReleaseManifestFile, releaseManifest, 0o644)
 			if err != nil {
 				fmt.Printf("Error writing EKS-A release manifest file to disk: %v\n", err)
 				os.Exit(1)

--- a/release/pkg/filereader/file_reader.go
+++ b/release/pkg/filereader/file_reader.go
@@ -16,7 +16,7 @@ package filereader
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -77,7 +77,7 @@ func ReadShaSums(filename string, r *releasetypes.ReleaseConfig) (string, string
 }
 
 func readShaFile(filename string) (string, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return "", errors.Cause(err)
 	}
@@ -88,7 +88,7 @@ func readShaFile(filename string) (string, error) {
 }
 
 func ReadFileContentsTrimmed(filename string) (string, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return "", errors.Cause(err)
 	}
@@ -100,7 +100,7 @@ func ReadEksDReleases(r *releasetypes.ReleaseConfig) (*EksDLatestReleases, error
 	eksDLatestReleases := &EksDLatestReleases{}
 	eksDReleaseFilePath := filepath.Join(r.BuildRepoSource, "EKSD_LATEST_RELEASES")
 
-	eksDReleaseFile, err := ioutil.ReadFile(eksDReleaseFilePath)
+	eksDReleaseFile, err := os.ReadFile(eksDReleaseFilePath)
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
@@ -115,7 +115,7 @@ func GetSupportedK8sVersions(r *releasetypes.ReleaseConfig) ([]string, error) {
 	// Read the eks-d latest release file to get all the releases
 	releaseFilePath := filepath.Join(r.BuildRepoSource, constants.ReleaseFolderName, "SUPPORTED_RELEASE_BRANCHES")
 
-	releaseFile, err := ioutil.ReadFile(releaseFilePath)
+	releaseFile, err := os.ReadFile(releaseFilePath)
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
@@ -134,7 +134,7 @@ func GetBottlerocketSupportedK8sVersionsByFormat(r *releasetypes.ReleaseConfig, 
 	bottlerocketReleasesFilename := "BOTTLEROCKET_RELEASES"
 	bottlerocketReleasesFilePath := filepath.Join(r.BuildRepoSource, constants.ImageBuilderProjectPath, bottlerocketReleasesFilename)
 
-	bottlerocketReleasesFileContents, err := ioutil.ReadFile(bottlerocketReleasesFilePath)
+	bottlerocketReleasesFileContents, err := os.ReadFile(bottlerocketReleasesFilePath)
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
@@ -157,7 +157,7 @@ func GetBottlerocketSupportedK8sVersionsByFormat(r *releasetypes.ReleaseConfig, 
 func GetBottlerocketContainerMetadata(r *releasetypes.ReleaseConfig, filename string) (string, string, error) {
 	var bottlerocketContainerMetadataMap map[string]interface{}
 	bottlerocketContainerMetadataFilePath := filepath.Join(r.BuildRepoSource, constants.ImageBuilderProjectPath, filename)
-	metadata, err := ioutil.ReadFile(bottlerocketContainerMetadataFilePath)
+	metadata, err := os.ReadFile(bottlerocketContainerMetadataFilePath)
 	if err != nil {
 		return "", "", errors.Cause(err)
 	}
@@ -202,7 +202,7 @@ func GetCurrentEksADevReleaseVersion(releaseVersion string, r *releasetypes.Rele
 			}
 
 			// Check if current version and latest version are the same semver
-			latestBuildS3, err := ioutil.ReadFile(tempFileName)
+			latestBuildS3, err := os.ReadFile(tempFileName)
 			if err != nil {
 				return "", errors.Cause(err)
 			}
@@ -329,7 +329,7 @@ func ReadHttpFile(uri string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed reading file from url [%s]", uri)
 	}

--- a/release/pkg/helm/helm.go
+++ b/release/pkg/helm/helm.go
@@ -16,7 +16,6 @@ package helm
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -348,7 +347,7 @@ func (helmrequires *Requires) validateHelmRequiresNotEmpty() error {
 
 // parseHelmRequires will attempt to unpack the requires.yaml into the Go struct `Requires`.
 func parseHelmRequires(fileName string, helmrequires *Requires) error {
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
 		return fmt.Errorf("unable to read file due to: %v", err)
 	}
@@ -392,7 +391,7 @@ func ValidateHelmChart(fileName string) (*chart.Metadata, error) {
 
 // parseHelmChart will attempt to unpack the Chart.yaml into the Go struct `Chart`.
 func parseHelmChart(fileName string, helmChart *chart.Metadata) error {
-	content, err := ioutil.ReadFile(fileName)
+	content, err := os.ReadFile(fileName)
 	if err != nil {
 		return fmt.Errorf("unable to read file due to: %v", err)
 	}
@@ -415,7 +414,7 @@ func OverwriteChartYaml(filename string, helmChart *chart.Metadata) error {
 		return fmt.Errorf("unable to Marshal %v\nyamlData: %s\n %v", helmChart, yamlData, err)
 	}
 
-	err = ioutil.WriteFile(filename, yamlData, 0o644)
+	err = os.WriteFile(filename, yamlData, 0o644)
 	if err != nil {
 		return err
 	}
@@ -437,7 +436,7 @@ func OverWriteChartValuesImageTag(filename string, tagMap map[string]string) err
 	if err != nil {
 		return fmt.Errorf("unable to Marshal %v\nyamlData: %s\n %v", values, yamlData, err)
 	}
-	err = ioutil.WriteFile(valuesFile, yamlData, 0o644)
+	err = os.WriteFile(valuesFile, yamlData, 0o644)
 	if err != nil {
 		return err
 	}
@@ -456,7 +455,7 @@ func OverWriteChartValuesImageSha(filename string, shaMap map[string]anywherev1a
 	if err != nil {
 		return fmt.Errorf("unable to Marshal %v\nyamlData: %s\n %v", values, yamlData, err)
 	}
-	err = ioutil.WriteFile(valuesFile, yamlData, 0o644)
+	err = os.WriteFile(valuesFile, yamlData, 0o644)
 	if err != nil {
 		return err
 	}

--- a/release/pkg/operations/bundle_release_test.go
+++ b/release/pkg/operations/bundle_release_test.go
@@ -17,7 +17,6 @@ package operations
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -157,7 +156,7 @@ func TestGenerateBundleManifest(t *testing.T) {
 
 			expectedBundleManifestFile := filepath.Join(gitRoot, releaseFolder, testdataFolder, fmt.Sprintf("%s-bundle-release.yaml", tt.buildRepoBranchName))
 			generatedBundleManifestFile := filepath.Join(generatedBundlePath, fmt.Sprintf("%s-dry-run-bundle-release.yaml", tt.buildRepoBranchName))
-			err = ioutil.WriteFile(generatedBundleManifestFile, bundleManifest, 0o644)
+			err = os.WriteFile(generatedBundleManifestFile, bundleManifest, 0o644)
 			if err != nil {
 				t.Fatalf("Error writing bundles manifest file to disk: %v\n", err)
 			}

--- a/release/pkg/operations/rename.go
+++ b/release/pkg/operations/rename.go
@@ -16,7 +16,6 @@ package operations
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -82,7 +81,7 @@ func RenameArtifacts(r *releasetypes.ReleaseConfig, artifacts map[string][]relea
 				}
 
 				for _, imageTagOverride := range manifestArtifact.ImageTagOverrides {
-					manifestFileContents, err := ioutil.ReadFile(newArtifactFile)
+					manifestFileContents, err := os.ReadFile(newArtifactFile)
 					if err != nil {
 						return errors.Cause(err)
 					}
@@ -90,7 +89,7 @@ func RenameArtifacts(r *releasetypes.ReleaseConfig, artifacts map[string][]relea
 					compiledRegex := regexp.MustCompile(regex)
 					fmt.Printf("Overriding image to %s in manifest %s\n", imageTagOverride.ReleaseUri, newArtifactFile)
 					updatedManifestFileContents := compiledRegex.ReplaceAllString(string(manifestFileContents), imageTagOverride.ReleaseUri)
-					err = ioutil.WriteFile(newArtifactFile, []byte(updatedManifestFileContents), 0o644)
+					err = os.WriteFile(newArtifactFile, []byte(updatedManifestFileContents), 0o644)
 					if err != nil {
 						return errors.Cause(err)
 					}

--- a/release/pkg/test/files.go
+++ b/release/pkg/test/files.go
@@ -15,7 +15,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"testing"
 
@@ -30,7 +30,7 @@ func CheckFilesEquals(t *testing.T, actualPath, expectedPath string, update bool
 	}
 
 	if update {
-		err = ioutil.WriteFile(expectedPath, []byte(actualContent), 0o644)
+		err = os.WriteFile(expectedPath, []byte(actualContent), 0o644)
 		if err != nil {
 			t.Fatalf("Error updating testdata bundle: %v\n", err)
 		}
@@ -56,7 +56,7 @@ func CheckFilesEquals(t *testing.T, actualPath, expectedPath string, update bool
 }
 
 func readFile(filepath string) (string, error) {
-	data, err := ioutil.ReadFile(filepath)
+	data, err := os.ReadFile(filepath)
 	if err != nil {
 		return "", err
 	}

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -324,7 +324,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -333,9 +333,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -344,7 +344,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -1110,7 +1110,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -1119,9 +1119,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1130,7 +1130,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -1896,7 +1896,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -1905,9 +1905,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1916,7 +1916,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -2682,7 +2682,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -2691,9 +2691,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -2702,7 +2702,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -3441,7 +3441,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -3450,9 +3450,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -3461,7 +3461,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -4200,7 +4200,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-build.1
       clusterController:
         arch:
         - amd64
@@ -4209,9 +4209,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -4220,7 +4220,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:

--- a/release/pkg/test/testdata/release-0.14-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.14-bundle-release.yaml
@@ -37,18 +37,18 @@ spec:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:bf56c9712189f5fc65d35544e2a84d3a7a1a2c05f2840fab54c57e8a3f8b57a4
+        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:a8f8f30ed6bd3f4848cf79d19f6c31d60b9c898649e7ee1d3081dac4a36421a7
+        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
       kubeadmBootstrap:
         arch:
         - amd64
@@ -324,7 +324,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterController:
         arch:
         - amd64
@@ -333,9 +333,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -344,7 +344,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       version: v0.0.0-dev-release-0.14+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -823,18 +823,18 @@ spec:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:bf56c9712189f5fc65d35544e2a84d3a7a1a2c05f2840fab54c57e8a3f8b57a4
+        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:a8f8f30ed6bd3f4848cf79d19f6c31d60b9c898649e7ee1d3081dac4a36421a7
+        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
       kubeadmBootstrap:
         arch:
         - amd64
@@ -1110,7 +1110,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterController:
         arch:
         - amd64
@@ -1119,9 +1119,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1130,7 +1130,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       version: v0.0.0-dev-release-0.14+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -1609,18 +1609,18 @@ spec:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:bf56c9712189f5fc65d35544e2a84d3a7a1a2c05f2840fab54c57e8a3f8b57a4
+        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:a8f8f30ed6bd3f4848cf79d19f6c31d60b9c898649e7ee1d3081dac4a36421a7
+        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
       kubeadmBootstrap:
         arch:
         - amd64
@@ -1896,7 +1896,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterController:
         arch:
         - amd64
@@ -1905,9 +1905,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1916,7 +1916,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       version: v0.0.0-dev-release-0.14+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -2395,18 +2395,18 @@ spec:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:bf56c9712189f5fc65d35544e2a84d3a7a1a2c05f2840fab54c57e8a3f8b57a4
+        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:a8f8f30ed6bd3f4848cf79d19f6c31d60b9c898649e7ee1d3081dac4a36421a7
+        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
       kubeadmBootstrap:
         arch:
         - amd64
@@ -2682,7 +2682,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterController:
         arch:
         - amd64
@@ -2691,9 +2691,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -2702,7 +2702,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       version: v0.0.0-dev-release-0.14+build.0+abcdef1
     etcdadmBootstrap:
       components:
@@ -3181,18 +3181,18 @@ spec:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:bf56c9712189f5fc65d35544e2a84d3a7a1a2c05f2840fab54c57e8a3f8b57a4
+        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:a8f8f30ed6bd3f4848cf79d19f6c31d60b9c898649e7ee1d3081dac4a36421a7
+        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.6.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
       kubeadmBootstrap:
         arch:
         - amd64
@@ -3441,7 +3441,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       clusterController:
         arch:
         - amd64
@@ -3450,9 +3450,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.1/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.14.2/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -3461,7 +3461,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.14.2-eks-a-v0.0.0-dev-release-0.14-build.1
       version: v0.0.0-dev-release-0.14+build.0+abcdef1
     etcdadmBootstrap:
       components:

--- a/release/pkg/version/version.go
+++ b/release/pkg/version/version.go
@@ -19,7 +19,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -129,7 +129,7 @@ func GenerateManifestHash(r *releasetypes.ReleaseConfig, manifestArtifact *relea
 		return FakeComponentChecksum, nil
 	}
 
-	manifestContents, err := ioutil.ReadFile(filepath.Join(manifestArtifact.ArtifactPath, manifestArtifact.ReleaseName))
+	manifestContents, err := os.ReadFile(filepath.Join(manifestArtifact.ArtifactPath, manifestArtifact.ReleaseName))
 	if err != nil {
 		return "", errors.Wrapf(err, "failed reading manifest contents from [%s]", manifestArtifact.ArtifactPath)
 	}

--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/filewriter/writer.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/filewriter/writer.go
@@ -3,7 +3,6 @@ package filewriter
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -42,7 +41,7 @@ func (t *writer) Write(fileName string, content []byte, f ...FileOptionsFunc) (s
 		currentDir = t.dir
 	}
 	filePath := filepath.Join(currentDir, fileName)
-	err := ioutil.WriteFile(filePath, content, op.Permissions)
+	err := os.WriteFile(filePath, content, op.Permissions)
 	if err != nil {
 		return "", fmt.Errorf("writing to file [%s]: %v", filePath, err)
 	}
@@ -68,7 +67,7 @@ func (t *writer) WriteTestArtifactsS3ToFile(key string, data []byte) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(p, data, os.ModePerm)
+	err = os.WriteFile(p, data, os.ModePerm)
 	if err != nil {
 		return err
 	}

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -8,7 +8,6 @@ import (
 	_ "embed"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -621,7 +620,7 @@ func (e *ClusterE2ETest) createCluster(opts ...CommandOpt) {
 	if err != nil {
 		e.T.Fatal(err)
 	}
-	b, err := ioutil.ReadAll(file)
+	b, err := io.ReadAll(file)
 	if err != nil {
 		e.T.Fatal(err)
 	}

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -640,11 +639,11 @@ func (e *ClusterE2ETest) validateGitopsRepoContent(gitTools *gitfactory.GitTools
 	if err != nil {
 		e.T.Errorf("Error checking out branch: %v", err)
 	}
-	gitFile, err := ioutil.ReadFile(gitFilePath)
+	gitFile, err := os.ReadFile(gitFilePath)
 	if err != nil {
 		e.T.Errorf("Error opening file from the original repo directory: %v", err)
 	}
-	localFile, err := ioutil.ReadFile(localFilePath)
+	localFile, err := os.ReadFile(localFilePath)
 	if err != nil {
 		e.T.Errorf("Error opening file from the newly created repo directory: %v", err)
 	}


### PR DESCRIPTION
*Description of changes:*
Replace `ioutil` with `os`/`io` since `ioutil` is deprecated since go 1.16

More details about `ioutils` deprecation here: https://pkg.go.dev/io/ioutil#pkg-overview

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

