### PR TITLE
Decouple a unit test from its environment

### DIFF
--- a/pkg/clustermanager/eksa_installer_test.go
+++ b/pkg/clustermanager/eksa_installer_test.go
@@ -2,6 +2,7 @@ package clustermanager_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -252,6 +253,7 @@ func TestSetManagerFlags(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			os.Unsetenv(features.FullLifecycleAPIEnvVar)
 			features.ClearCache()
 			for _, e := range tt.featureEnvVars {
 				t.Setenv(e, "true")


### PR DESCRIPTION
Having this variable set would cause test failures, as the "noflags" variant of the test would assume that the value was unset.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

