### PR TITLE
Skip external ETCD e2e test for tinkerbell

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -67,3 +67,4 @@ skipped_tests:
 - TestTinkerbellUpgradeMulticlusterWorkloadClusterK8sUpgrade
 - TestTinkerbellUpgradeMulticlusterWorkloadClusterWorkerScaleDown
 - TestTinkerbellUpgradeMulticlusterWorkloadClusterWorkerScaleup
+- TestTinkerbellKubernetes125UbuntuExternalEtcdSimpleFlow


### PR DESCRIPTION
*Description of changes:*
Skipping external ETCD e2e test for tinkerbell as of now since we don't support external ETCD for tinkerbell.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

