### PR TITLE
Tinkerbell Scaling Upgrade Validation

### DIFF
--- a/pkg/providers/tinkerbell/assert_test.go
+++ b/pkg/providers/tinkerbell/assert_test.go
@@ -8,10 +8,16 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/onsi/gomega"
+	"github.com/tinkerbell/cluster-api-provider-tinkerbell/api/v1beta1"
+	tinkerbellv1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/api/v1beta1"
 	"github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
 	eksav1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/networkutils/mocks"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
@@ -416,6 +422,81 @@ func TestMinimumHardwareAvailableAssertionForCreate_InsufficientFailsWithoutExte
 	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }
 
+func TestHardwareSelectorWorker(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	g.Expect(tinkerbell.HardwareSelector(*machineTemplate())).To(gomega.Equal(eksav1alpha1.HardwareSelector{"type": "worker"}))
+}
+
+func TestHardwareSelectorNil(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	machineTemplate := machineTemplate(func(mt *tinkerbellv1.TinkerbellMachineTemplate) {
+		mt.Spec.Template.Spec.HardwareAffinity.Required = []tinkerbellv1.HardwareAffinityTerm{}
+	})
+
+	g.Expect(tinkerbell.HardwareSelector(*machineTemplate)).To(gomega.BeNil())
+}
+
+func TestValidatableClusterControlPlaneReplicaCount(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	validatableCluster := &tinkerbell.ValidatableTinkerbellClusterSpec{clusterSpec}
+
+	g.Expect(validatableCluster.ControlPlaneReplicaCount()).To(gomega.Equal(1))
+}
+
+func TestValidatableClusterControlPlaneHardwareSelector(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	validatableCluster := &tinkerbell.ValidatableTinkerbellClusterSpec{clusterSpec}
+
+	g.Expect(validatableCluster.ControlPlaneHardwareSelector()).To(gomega.Equal(eksav1alpha1.HardwareSelector{"type": "cp"}))
+}
+
+func TestValidatableClusterWorkerNodeGroupConfigs(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	validatableCluster := &tinkerbell.ValidatableTinkerbellClusterSpec{clusterSpec}
+
+	workerConfigs := validatableCluster.WorkerNodeHardwareGroups()
+
+	g.Expect(workerConfigs[0].MachineDeploymentName).To(gomega.Equal("cluster-worker-node-group-0"))
+	g.Expect(workerConfigs[0].Replicas).To(gomega.Equal(1))
+	g.Expect(workerConfigs[0].HardwareSelector).To(gomega.Equal(eksav1alpha1.HardwareSelector{"type": "worker"}))
+}
+
+func TestValidatableTinkerbellCAPIControlPlaneReplicaCount(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	validatableCAPI := validatableTinkerbellCAPI()
+
+	g.Expect(validatableCAPI.ControlPlaneReplicaCount()).To(gomega.Equal(1))
+}
+
+func TestValidatableTinkerbellCAPIControlPlaneHardwareSelector(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	validatableCAPI := validatableTinkerbellCAPI()
+
+	g.Expect(validatableCAPI.ControlPlaneHardwareSelector()).To(gomega.Equal(eksav1alpha1.HardwareSelector{"type": "cp"}))
+}
+
+func TestValidatableTinkerbellCAPIWorkerNodeGroupConfigs(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	validatableCAPI := validatableTinkerbellCAPI()
+
+	workerConfigs := validatableCAPI.WorkerNodeHardwareGroups()
+
+	g.Expect(workerConfigs[0].MachineDeploymentName).To(gomega.Equal("cluster-worker-node-group-0"))
+	g.Expect(workerConfigs[0].Replicas).To(gomega.Equal(1))
+	g.Expect(workerConfigs[0].HardwareSelector).To(gomega.Equal(eksav1alpha1.HardwareSelector{"type": "worker"}))
+}
+
 func TestAssertionsForScaleUpDown_Success(t *testing.T) {
 	g := gomega.NewWithT(t)
 
@@ -423,10 +504,94 @@ func TestAssertionsForScaleUpDown_Success(t *testing.T) {
 	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
 	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
 
-	assertion := tinkerbell.AssertionsForScaleUpDown(catalogue, clusterSpec.Spec, true)
+	assertion := tinkerbell.AssertionsForScaleUpDown(catalogue, &tinkerbell.ValidatableTinkerbellClusterSpec{clusterSpec}, true)
 	newClusterSpec := NewDefaultValidClusterSpecBuilder().Build()
 	newClusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+
 	g.Expect(assertion(newClusterSpec)).To(gomega.Succeed())
+}
+
+func TestAssertionsForScaleUpDown_CAPISuccess(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+	tinkerbellCAPI := validatableTinkerbellCAPI()
+
+	assertion := tinkerbell.AssertionsForScaleUpDown(catalogue, tinkerbellCAPI, false)
+	newClusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	newClusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+
+	check := &tinkerbell.ValidatableTinkerbellClusterSpec{newClusterSpec}
+	t.Log(tinkerbellCAPI.WorkerNodeHardwareGroups()[0].MachineDeploymentName)
+	t.Log(check.WorkerNodeHardwareGroups()[0].MachineDeploymentName)
+
+	g.Expect(assertion(newClusterSpec)).To(gomega.Succeed())
+}
+
+func TestAssertionsForScaleUpDown_ScaleUpControlPlaneSuccess(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+	_ = catalogue.InsertHardware(&v1alpha1.Hardware{ObjectMeta: metav1.ObjectMeta{
+		Labels: map[string]string{"type": "cp"},
+	}})
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+
+	assertion := tinkerbell.AssertionsForScaleUpDown(catalogue, &tinkerbell.ValidatableTinkerbellClusterSpec{clusterSpec}, false)
+	newClusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	newClusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+	newClusterSpec.Cluster.Spec.ControlPlaneConfiguration.Count = 2
+
+	g.Expect(assertion(newClusterSpec)).To(gomega.Succeed())
+}
+
+func TestAssertionsForScaleUpDown_ScaleUpWorkerSuccess(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+	_ = catalogue.InsertHardware(&v1alpha1.Hardware{ObjectMeta: metav1.ObjectMeta{
+		Labels: map[string]string{"type": "worker"},
+	}})
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+
+	assertion := tinkerbell.AssertionsForScaleUpDown(catalogue, &tinkerbell.ValidatableTinkerbellClusterSpec{clusterSpec}, false)
+	newClusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	newClusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+	newClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(2)
+
+	g.Expect(assertion(newClusterSpec)).To(gomega.Succeed())
+}
+
+func TestAssertionsForScaleUpDown_AddWorkerSuccess(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+	_ = catalogue.InsertHardware(&v1alpha1.Hardware{ObjectMeta: metav1.ObjectMeta{
+		Labels: map[string]string{"type": "worker"},
+	}})
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+	clusterSpec.Spec.Cluster.Spec.WorkerNodeGroupConfigurations = []eksav1alpha1.WorkerNodeGroupConfiguration{}
+
+	assertion := tinkerbell.AssertionsForScaleUpDown(catalogue, &tinkerbell.ValidatableTinkerbellClusterSpec{clusterSpec}, false)
+	newClusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	newClusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+
+	g.Expect(assertion(newClusterSpec)).To(gomega.Succeed())
+}
+
+func TestAssertionsForScaleUpDown_ExternalEtcdErrorFails(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+
+	assertion := tinkerbell.AssertionsForScaleUpDown(catalogue, &tinkerbell.ValidatableTinkerbellClusterSpec{clusterSpec}, true)
+	newClusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+
+	g.Expect(assertion(newClusterSpec)).To(gomega.MatchError(gomega.ContainSubstring("scale up/down not supported for external etcd")))
 }
 
 func TestAssertionsForScaleUpDown_FailsScaleUpAndRollingError(t *testing.T) {
@@ -436,7 +601,7 @@ func TestAssertionsForScaleUpDown_FailsScaleUpAndRollingError(t *testing.T) {
 	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
 	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
 
-	assertion := tinkerbell.AssertionsForScaleUpDown(catalogue, clusterSpec.Spec, true)
+	assertion := tinkerbell.AssertionsForScaleUpDown(catalogue, &tinkerbell.ValidatableTinkerbellClusterSpec{clusterSpec}, true)
 	newClusterSpec := NewDefaultValidClusterSpecBuilder().Build()
 	newClusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
 	newClusterSpec.WorkerNodeGroupConfigurations()[0].Count = ptr.Int(2)
@@ -504,4 +669,42 @@ func mergeHardwareSelectors(m1, m2 map[string]string) map[string]string {
 		m1[name] = value
 	}
 	return m1
+}
+
+func validatableTinkerbellCAPI() *tinkerbell.ValidatableTinkerbellCAPI {
+	return &tinkerbell.ValidatableTinkerbellCAPI{
+		ControlPlane: &tinkerbell.ControlPlane{
+			BaseControlPlane: tinkerbell.BaseControlPlane{
+				KubeadmControlPlane: &controlplanev1.KubeadmControlPlane{
+					Spec: controlplanev1.KubeadmControlPlaneSpec{
+						Replicas: ptr.Int32(1),
+						Version:  "1.22",
+					},
+				},
+				ControlPlaneMachineTemplate: machineTemplate(
+					func(tmt *v1beta1.TinkerbellMachineTemplate) {
+						tmt.Spec.Template.Spec.HardwareAffinity.Required = []tinkerbellv1.HardwareAffinityTerm{
+							{
+								LabelSelector: metav1.LabelSelector{MatchLabels: map[string]string{"type": "cp"}},
+							},
+						}
+					},
+				),
+			},
+		},
+		Workers: workers(),
+	}
+}
+
+func workers() *tinkerbell.Workers {
+	return &tinkerbell.Workers{
+		Groups: []clusterapi.WorkerGroup[*v1beta1.TinkerbellMachineTemplate]{
+			{
+				MachineDeployment: machineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.Name = "cluster-worker-node-group-0"
+				}),
+				ProviderMachineTemplate: machineTemplate(),
+			},
+		},
+	}
 }

--- a/pkg/providers/tinkerbell/cluster_spec_builder_test.go
+++ b/pkg/providers/tinkerbell/cluster_spec_builder_test.go
@@ -36,6 +36,9 @@ func (b ValidClusterSpecBuilder) Build() *tinkerbell.ClusterSpec {
 		Spec: &cluster.Spec{
 			Config: &cluster.Config{
 				Cluster: &v1alpha1.Cluster{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "cluster",
+					},
 					Spec: v1alpha1.ClusterSpec{
 						ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
 							Count: 1,
@@ -70,6 +73,8 @@ func (b ValidClusterSpecBuilder) Build() *tinkerbell.ClusterSpec {
 						},
 					},
 				},
+				TinkerbellDatacenter:     b.NewDefaultTinkerbellDatacenter(),
+				TinkerbellMachineConfigs: b.NewDefaultTinkerbellMachineConfigs(),
 			},
 		},
 		DatacenterConfig: &v1alpha1.TinkerbellDatacenterConfig{
@@ -147,4 +152,67 @@ func (b ValidClusterSpecBuilder) Build() *tinkerbell.ClusterSpec {
 	}
 
 	return spec
+}
+
+func (b ValidClusterSpecBuilder) NewDefaultTinkerbellDatacenter() *v1alpha1.TinkerbellDatacenterConfig {
+	return &v1alpha1.TinkerbellDatacenterConfig{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "datacenter-config",
+			Namespace: b.Namespace,
+		},
+		Spec: v1alpha1.TinkerbellDatacenterConfigSpec{
+			TinkerbellIP: "1.1.1.2",
+			OSImageURL:   "https://ubuntu.gz",
+		},
+	}
+}
+
+func (b ValidClusterSpecBuilder) NewDefaultTinkerbellMachineConfigs() map[string]*v1alpha1.TinkerbellMachineConfig {
+	return map[string]*v1alpha1.TinkerbellMachineConfig{
+		b.ControlPlaneMachineName: {
+			ObjectMeta: v1.ObjectMeta{
+				Name:      b.ControlPlaneMachineName,
+				Namespace: b.Namespace,
+			},
+			Spec: v1alpha1.TinkerbellMachineConfigSpec{
+				HardwareSelector: v1alpha1.HardwareSelector{"type": "cp"},
+				OSFamily:         v1alpha1.Ubuntu,
+				Users: []v1alpha1.UserConfiguration{
+					{
+						Name: "ec2-user",
+					},
+				},
+			},
+		},
+		b.ExternalEtcdMachineName: {
+			ObjectMeta: v1.ObjectMeta{
+				Name:      b.ExternalEtcdMachineName,
+				Namespace: b.Namespace,
+			},
+			Spec: v1alpha1.TinkerbellMachineConfigSpec{
+				HardwareSelector: v1alpha1.HardwareSelector{"type": "etcd"},
+				OSFamily:         v1alpha1.Ubuntu,
+				Users: []v1alpha1.UserConfiguration{
+					{
+						Name: "ec2-user",
+					},
+				},
+			},
+		},
+		b.WorkerNodeGroupMachineName: {
+			ObjectMeta: v1.ObjectMeta{
+				Name:      b.WorkerNodeGroupMachineName,
+				Namespace: b.Namespace,
+			},
+			Spec: v1alpha1.TinkerbellMachineConfigSpec{
+				HardwareSelector: v1alpha1.HardwareSelector{"type": "worker"},
+				OSFamily:         v1alpha1.Ubuntu,
+				Users: []v1alpha1.UserConfiguration{
+					{
+						Name: "ec2-user",
+					},
+				},
+			},
+		},
+	}
 }

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -155,7 +155,8 @@ func (p *Provider) validateAvailableHardwareForUpgrade(ctx context.Context, curr
 		rollingUpgrade = true
 	}
 
-	clusterSpecValidator.Register(AssertionsForScaleUpDown(p.catalogue, currentSpec, rollingUpgrade))
+	currentTinkerbellSpec := NewClusterSpec(currentSpec, currentSpec.TinkerbellMachineConfigs, currentSpec.TinkerbellDatacenter)
+	clusterSpecValidator.Register(AssertionsForScaleUpDown(p.catalogue, &ValidatableTinkerbellClusterSpec{currentTinkerbellSpec}, rollingUpgrade))
 
 	tinkerbellClusterSpec := NewClusterSpec(newClusterSpec, p.machineConfigs, p.datacenterConfig)
 


### PR DESCRIPTION
*Issue #, if available:*
[#1060](https://github.com/aws/eks-anywhere-internal/issues/1060)

*Description of changes:*
Tinkerbell `AssertionsForScaleUpDown()` requires both the current clusterSpec and the desired clusterSpec when run by the cluster validator. The Cluster Full Lifecycle controller does not have current state cluster spec and pulls CAPI state instead. `AssertionsForScaleUpDown` minimum hardware requirements must still be run for scaling upgrades with the Cluster Full Lifecycle Controller.  

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

