### PR TITLE
Add validation for HookImagesURLPath for proxy configuration

### DIFF
--- a/pkg/providers/tinkerbell/assert_test.go
+++ b/pkg/providers/tinkerbell/assert_test.go
@@ -286,6 +286,44 @@ func TestAssertPortsNotInUse_Fails(t *testing.T) {
 	g.Expect(assertion(clusterSpec)).ToNot(gomega.Succeed())
 }
 
+func TestAssertAssertHookImageURLProxyNonAirgappedURLSuccess(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec.Cluster.Spec.ProxyConfiguration = &eksav1alpha1.ProxyConfiguration{
+		HttpProxy:  "2.3.4.5",
+		HttpsProxy: "2.3.4.5",
+	}
+
+	clusterSpec.DatacenterConfig.Spec.HookImagesURLPath = "https://anywhere.eks.amazonaws.com/"
+	g.Expect(tinkerbell.AssertHookRetrievableWithoutProxy(clusterSpec)).To(gomega.Succeed())
+}
+
+func TestAssertAssertHookRetrievableWithoutProxyURLNotProvided(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec.Cluster.Spec.ProxyConfiguration = &eksav1alpha1.ProxyConfiguration{
+		HttpProxy:  "2.3.4.5",
+		HttpsProxy: "2.3.4.5",
+	}
+
+	g.Expect(tinkerbell.AssertHookRetrievableWithoutProxy(clusterSpec)).ToNot(gomega.Succeed())
+}
+
+func TestAssertAssertHookRetrievableWithoutProxyURLUnreachable(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	clusterSpec := NewDefaultValidClusterSpecBuilder().Build()
+	clusterSpec.Cluster.Spec.ProxyConfiguration = &eksav1alpha1.ProxyConfiguration{
+		HttpProxy:  "2.3.4.5",
+		HttpsProxy: "2.3.4.5",
+	}
+
+	clusterSpec.DatacenterConfig.Spec.HookImagesURLPath = "https://test.com"
+	g.Expect(tinkerbell.AssertHookRetrievableWithoutProxy(clusterSpec)).ToNot(gomega.Succeed())
+}
+
 func TestMinimumHardwareAvailableAssertionForCreate_SufficientSucceeds(t *testing.T) {
 	g := gomega.NewWithT(t)
 

--- a/pkg/providers/tinkerbell/cluster.go
+++ b/pkg/providers/tinkerbell/cluster.go
@@ -109,6 +109,7 @@ func NewClusterSpecValidator(assertions ...ClusterSpecAssertion) *ClusterSpecVal
 		AssertMachineConfigNamespaceMatchesDatacenterConfig,
 		AssertOsFamilyValid,
 		AssertTinkerbellIPAndControlPlaneIPNotSame,
+		AssertHookRetrievableWithoutProxy,
 	)
 	v.Register(assertions...)
 	return &v

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_proxy.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_proxy.yaml
@@ -51,6 +51,7 @@ metadata:
   namespace: test-namespace
 spec:
   tinkerbellIP: "2.3.4.5"
+  hookImagesURLPath: "https://anywhere.eks.amazonaws.com/"
   osImageURL: "https://ubuntu.gz"
 
 ---


### PR DESCRIPTION
*Description of changes:*
Add validation for HookImagesURLPath if proxy configuration is specified in cluster config file. Hook image need to be hosted locally and should be accessible without using proxy if proxy is specified. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

