### PR TITLE
Add a design proposal on adding CredentialRef to NutanixDatacenter

### DIFF
--- a/designs/nutanix-datacenterconfig-credentialref.md
+++ b/designs/nutanix-datacenterconfig-credentialref.md
@@ -1,0 +1,51 @@
+# Nutanix Datacenter Config Credential Reference
+
+## Introduction
+
+**Problem:** When a management cluster and a workload cluster are present on two different Nutanix Prism Central instances,
+using same credentials to authenticate to both instances is not possible. To remedy this, we need to associate credentials
+with corresponding Nutanix Datacenter Configs.
+
+## Overview of Solution
+With this feature, a user can specify credentials reference (i.e. Name and Namespace of the secret containing the credentials)
+in the Nutanix Datacenter Config. This info will be fetched and used to authenticate to the Nutanix Prism Central instance
+when creating the workload cluster.
+
+### Solution Details
+Extend the `NutanixDatacenterConfig` CRD to include a new field `credentialRef` storing name, namespace, and kind (similar to how
+`credentialsRef` is defined in the `NutanixCluster` CRD).
+
+```go
+// NutanixDatacenterConfigSpec defines the desired state of NutanixDatacenterConfig.
+type NutanixDatacenterConfigSpec struct {
+    ...
+    // CredentialRef is the reference to the secret that contains the credentials
+    // for the Nutanix Prism Central
+    // +optional
+    CredentialRef *NutanixCredentialReference `json:"credentialRef,omitempty"`
+}
+
+// NutanixCredentialKind is the kind of the Nutanix credential
+type NutanixCredentialKind string
+
+// NutanixCredentialReference is the reference to the secret that contains the credentials
+// +kubebuilder:object:generate=true
+type NutanixCredentialReference struct {
+    // Kind of the Nutanix credential
+    // +kubebuilder:validation:Enum=Secret
+    Kind NutanixCredentialKind `json:"kind"`
+    // Name of the credential.
+    // +kubebuilder:validation:Required
+    // +kubebuilder:validation:MinLength=1
+    Name string `json:"name"`
+    // namespace of the credential.
+    // +optional
+    Namespace string `json:"namespace"`
+}
+```
+
+When creating a workload cluster, the `NutanixDatacenterConfig` referenced in the `Cluster` CRD will be fetched and
+the `credentialRef` field will be used to fetch the secret to get the credentials needed to authenticate with Prism Central
+to create resources needed for the cluster. If the `credentialRef` field is not present, the credentials from the
+cluster (i.e. eksa-system/cluster-name) will be used as default to preserve existing behaviour.
+

--- a/designs/nutanix-datacenterconfig-credentialref.md
+++ b/designs/nutanix-datacenterconfig-credentialref.md
@@ -28,11 +28,6 @@ type NutanixDatacenterConfigSpec struct {
     CredentialRef *Ref `json:"credentialRef,omitempty"`
 }
 
-const (
-    // RefKindSecret is the kind of the credential that corresponds to a Kubernetes Secret
-    RefKindSecret = "Secret"
-)
-
 func (in *NutanixDatacenterConfig) Validate() error {
     ...
     if in.Spec.CredentialRef != nil && in.Spec.CredentialRef.Kind != RefKindSecret {
@@ -44,8 +39,13 @@ func (in *NutanixDatacenterConfig) Validate() error {
 
 When creating a workload cluster, the `NutanixDatacenterConfig` referenced in the `Cluster` CRD will be fetched and
 the `credentialRef` field will be used to fetch the secret to get the credentials needed to authenticate with Prism Central
-to create resources needed for the cluster. If the `credentialRef` field is not present when creating a workload cluster,
-validation webhook will return a validation failure. During management cluster creation, we can fetch the secrets from the
-environment, create the secret manifests in `eksa-system` as we do now, and add the `credentialRef` to the corresponding
-`NutanixDatacenterConfig` if not present. This will allow us to assume that `credentialRef` will always be set in the
-`NutanixDatacenterConfig` in all cases.
+to create resources needed for the cluster. If the `credentialRef` field is not present when creating a nutanix datacenter config, a
+mutation webhook will add the `credentialRef` field to the `NutanixDatacenterConfig` with the `nutanix-credentials` as the
+credentialRef. If credentialRef is not set appropriately, validation webhook will return a validation failure. 
+During management cluster creation, we can fetch the secrets from the environment, create the secret manifests in `eksa-system`
+as we do now, and add the `credentialRef` to the corresponding `NutanixDatacenterConfig` if not present. This will allow
+us to assume that `credentialRef` will always be set in the `NutanixDatacenterConfig` in all cases. We will continue to
+create a cluster-specific secret for CAPX provider named after the cluster name as we have been doing so far. This way
+from a users perspective secrets can be shared across clusters at a EKS-A level, but at a CAPX level, each cluster will have
+its own decoupled secret. This will allow us to handle the format changes (if any) for the CAPX secret in the future. In future,
+we will also add support for watching the referenced secrets and use `OwnerReferences` to link back secrets to Clusters.

--- a/designs/nutanix-datacenterconfig-credentialref.md
+++ b/designs/nutanix-datacenterconfig-credentialref.md
@@ -23,7 +23,6 @@ type NutanixDatacenterConfigSpec struct {
     ...
     // CredentialRef is the reference to the secret name that contains the credentials
     // for the Nutanix Prism Central. The namespace for the secret is assumed to be a constant i.e. eksa-system.
-    // +kubebuilder:validation:Optional
     // +optional
     CredentialRef *Ref `json:"credentialRef,omitempty"`
 }

--- a/designs/nutanix-datacenterconfig-credentialref.md
+++ b/designs/nutanix-datacenterconfig-credentialref.md
@@ -39,13 +39,20 @@ func (in *NutanixDatacenterConfig) Validate() error {
 
 When creating a workload cluster, the `NutanixDatacenterConfig` referenced in the `Cluster` CRD will be fetched and
 the `credentialRef` field will be used to fetch the secret to get the credentials needed to authenticate with Prism Central
-to create resources needed for the cluster. If the `credentialRef` field is not present when creating a nutanix datacenter config, a
-mutation webhook will add the `credentialRef` field to the `NutanixDatacenterConfig` with the `nutanix-credentials` as the
-credentialRef. If credentialRef is not set appropriately, validation webhook will return a validation failure. 
+to create resources needed for the cluster.
+
+When creating a NutanixDatacenterConfig, if the `credentialRef` field is not present the validation webhook will return
+a validation failure. When updating an existing NutanixDatacenterConfig the validation webhook will only return a validation
+failure if the `credentialRef` field is being removed and set to nil.
+
 During management cluster creation, we can fetch the secrets from the environment, create the secret manifests in `eksa-system`
 as we do now, and add the `credentialRef` to the corresponding `NutanixDatacenterConfig` if not present. This will allow
-us to assume that `credentialRef` will always be set in the `NutanixDatacenterConfig` in all cases. We will continue to
-create a cluster-specific secret for CAPX provider named after the cluster name as we have been doing so far. This way
+us to assume that `credentialRef` will always be set in the `NutanixDatacenterConfig` in all cases.
+
+The NutanixDatacenterReconciler and the NutanixClusterReconciler can ensure the credentialRef is set in the NutanixDatacenterConfig.
+If the `credentialRef` is not set, the reconcilers can set them and return and the future iterations will have the credentialRef set.
+
+We will continue to create a cluster-specific secret for CAPX provider named after the cluster name as we have been doing so far. This way
 from a users perspective secrets can be shared across clusters at a EKS-A level, but at a CAPX level, each cluster will have
 its own decoupled secret. This will allow us to handle the format changes (if any) for the CAPX secret in the future. In future,
 we will also add support for watching the referenced secrets and use `OwnerReferences` to link back secrets to Clusters.


### PR DESCRIPTION
The CredentialRef property will allow to transparently link credentials for a Prism Central with its corresponding EKS-A abstraction: NutanixDatacenter.