### PR TITLE
Add missing Snow E2E tests to skip list

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -24,10 +24,12 @@ skipped_tests:
 - TestNutanixKubernetes122UbuntuWorkerNodeScaleUp1To3
 - TestNutanixKubernetes122UbuntuWorkerNodeScaleUp2To5
 # Snow
+- TestSnowKubernetes125UbuntuAWSIamAuth
 - TestSnowKubernetes124To125AWSIamAuthUpgrade
 - TestSnowKubernetes123UbuntuLabelsUpgradeFlow
 - TestSnowKubernetes123UbuntuRemoveWorkerNodeGroups
 - TestSnowKubernetes125OIDC
+- TestSnowKubernetes125UbuntuProxyConfig
 - TestSnowKubernetes122SimpleFlow
 - TestSnowKubernetes123SimpleFlow
 - TestSnowKubernetes124SimpleFlow
@@ -37,6 +39,7 @@ skipped_tests:
 - TestSnowKubernetes124UbuntuTo125Upgrade
 - TestSnowKubernetes122BottlerocketTo123Upgrade
 - TestSnowKubernetes123BottlerocketTo124Upgrade
+- TestSnowKubernetes124BottlerocketTo125Upgrade
 - TestSnowKubernetes122To123BottlerocketStaticIPUpgrade
 - TestSnowKubernetes123To124BottlerocketStaticIPUpgrade
 - TestSnowMulticlusterWorkloadClusterAPI


### PR DESCRIPTION
Some Snow tests were missing from the skip list, which caused them to run in CI and fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

