### PR TITLE
Update Tinkerbell reconciler tests to use fake client

### DIFF
--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -70,7 +70,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 
 func TestReconcilerValidateDatacenterConfigSuccess(t *testing.T) {
 	tt := newReconcilerTest(t)
-	tt.createAllObjs()
+	tt.withFakeClient()
 
 	result, err := tt.reconciler().ValidateDatacenterConfig(tt.ctx, test.NewNullLogger(), tt.buildScope())
 
@@ -82,7 +82,7 @@ func TestReconcilerValidateDatacenterConfigSuccess(t *testing.T) {
 func TestReconcilerValidateDatacenterConfigMissingManagementCluster(t *testing.T) {
 	tt := newReconcilerTest(t)
 	tt.cluster.Spec.ManagementCluster.Name = "nonexistent-management-cluster"
-	tt.createAllObjs()
+	tt.withFakeClient()
 
 	result, err := tt.reconciler().ValidateDatacenterConfig(tt.ctx, test.NewNullLogger(), tt.buildScope())
 
@@ -95,7 +95,7 @@ func TestReconcilerValidateDatacenterConfigMissingManagementCluster(t *testing.T
 func TestReconcilerValidateDatacenterConfigMissingManagementDatacenter(t *testing.T) {
 	tt := newReconcilerTest(t)
 	tt.managementCluster.Spec.DatacenterRef.Name = "nonexistent-datacenter"
-	tt.createAllObjs()
+	tt.withFakeClient()
 
 	result, err := tt.reconciler().ValidateDatacenterConfig(tt.ctx, test.NewNullLogger(), tt.buildScope())
 
@@ -113,7 +113,7 @@ func TestReconcilerValidateDatacenterConfigIpMismatch(t *testing.T) {
 	})
 	tt.managementCluster.Spec.DatacenterRef.Name = managementDatacenterConfig.Name
 	tt.eksaSupportObjs = append(tt.eksaSupportObjs, managementDatacenterConfig)
-	tt.createAllObjs()
+	tt.withFakeClient()
 
 	result, err := tt.reconciler().ValidateDatacenterConfig(tt.ctx, test.NewNullLogger(), tt.buildScope())
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Have been seeing intermittent test failures during test coverage for Tinkerbell Datacenter reconciler tests. This updates them to use the fake client to reduce failure points.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

