### PR TITLE
Fix vsphere registry auth e2e tests

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -932,7 +932,7 @@ func TestVSphereKubernetes125BottlerocketRegistryMirrorAndCert(t *testing.T) {
 	runRegistryMirrorConfigFlow(test)
 }
 
-func TestVsphereKubernetes125UbuntuAuthenticatedRegistryMirror(t *testing.T) {
+func TestVSphereKubernetes125UbuntuAuthenticatedRegistryMirror(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithUbuntu125(), framework.WithPrivateNetwork()),
@@ -945,7 +945,7 @@ func TestVsphereKubernetes125UbuntuAuthenticatedRegistryMirror(t *testing.T) {
 	runRegistryMirrorConfigFlow(test)
 }
 
-func TestVsphereKubernetes125BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
+func TestVSphereKubernetes125BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewVSphere(t, framework.WithBottleRocket125(), framework.WithPrivateNetwork()),


### PR DESCRIPTION
*Description of changes:*
Fixes capitalization for vsphere authenticated registry e2e tests from #5061 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


