### PR TITLE
Remove temporary TinkerbellUseDiskExtractorDefault feature gate

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -2,13 +2,12 @@ package features
 
 // These are environment variables used as flags to enable/disable features.
 const (
-	CloudStackKubeVipDisabledEnvVar             = "CLOUDSTACK_KUBE_VIP_DISABLED"
-	FullLifecycleAPIEnvVar                      = "FULL_LIFECYCLE_API"
-	FullLifecycleGate                           = "FullLifecycleAPI"
-	CheckpointEnabledEnvVar                     = "CHECKPOINT_ENABLED"
-	UseNewWorkflowsEnvVar                       = "USE_NEW_WORKFLOWS"
-	K8s126SupportEnvVar                         = "K8S_1_26_SUPPORT"
-	TinkerbellUseDiskExtractorDefaultDiskEnvVar = "TINKERBELL_DISK_EXTRACTOR_DISABLED"
+	CloudStackKubeVipDisabledEnvVar = "CLOUDSTACK_KUBE_VIP_DISABLED"
+	FullLifecycleAPIEnvVar          = "FULL_LIFECYCLE_API"
+	FullLifecycleGate               = "FullLifecycleAPI"
+	CheckpointEnabledEnvVar         = "CHECKPOINT_ENABLED"
+	UseNewWorkflowsEnvVar           = "USE_NEW_WORKFLOWS"
+	K8s126SupportEnvVar             = "K8S_1_26_SUPPORT"
 )
 
 func FeedGates(featureGates []string) {
@@ -62,13 +61,5 @@ func K8s126Support() Feature {
 	return Feature{
 		Name:     "Kubernetes version 1.26 support",
 		IsActive: globalFeatures.isActiveForEnvVar(K8s126SupportEnvVar),
-	}
-}
-
-// TinkerbellUseDiskExtractorDefaultDisk is a flag that forces the diskExtractor to use /dev/sda disk by default.
-func TinkerbellUseDiskExtractorDefaultDisk() Feature {
-	return Feature{
-		Name:     "Use a default disk /dev/sda when using the diskExtractor",
-		IsActive: globalFeatures.isActiveForEnvVar(TinkerbellUseDiskExtractorDefaultDiskEnvVar),
 	}
 }

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -77,11 +77,3 @@ func TestWithK8s126FeatureFlag(t *testing.T) {
 	g.Expect(os.Setenv(K8s126SupportEnvVar, "true")).To(Succeed())
 	g.Expect(IsActive(K8s126Support())).To(BeTrue())
 }
-
-func TestWithTinkerbellUseDiskExtractorDefaultDiskFlag(t *testing.T) {
-	g := NewWithT(t)
-	setupContext(t)
-
-	g.Expect(os.Setenv(TinkerbellUseDiskExtractorDefaultDiskEnvVar, "true")).To(Succeed())
-	g.Expect(IsActive(TinkerbellUseDiskExtractorDefaultDisk())).To(BeTrue())
-}

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/controller"
 	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/reconciler"
 	tinkerbellreconcilermocks "github.com/aws/eks-anywhere/pkg/providers/tinkerbell/reconciler/mocks"
@@ -39,10 +38,6 @@ const (
 )
 
 func TestReconcilerReconcileSuccess(t *testing.T) {
-	// TODO: remove after diskExtractor has been refactored and removed.
-	features.ClearCache()
-	t.Setenv(features.TinkerbellUseDiskExtractorDefaultDiskEnvVar, "true")
-	//
 	tt := newReconcilerTest(t)
 
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
@@ -162,10 +157,6 @@ func TestReconcileCNIErrorClientRegistry(t *testing.T) {
 }
 
 func TestReconcilerReconcileControlPlaneSuccess(t *testing.T) {
-	// TODO: remove after diskExtractor has been refactored and removed.
-	features.ClearCache()
-	t.Setenv(features.TinkerbellUseDiskExtractorDefaultDiskEnvVar, "true")
-	//
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 	result, err := tt.reconciler().ReconcileControlPlane(tt.ctx, test.NewNullLogger(), tt.buildScope())
@@ -223,10 +214,6 @@ func TestReconcilerReconcileControlPlaneSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileControlPlaneSuccessRegistryMirrorAuthentication(t *testing.T) {
-	// TODO: remove after diskExtractor has been refactored and removed.
-	features.ClearCache()
-	t.Setenv(features.TinkerbellUseDiskExtractorDefaultDiskEnvVar, "true")
-	//
 	t.Setenv("REGISTRY_USERNAME", "username")
 	t.Setenv("REGISTRY_PASSWORD", "password")
 	tt := newReconcilerTest(t)
@@ -292,10 +279,6 @@ func TestReconcilerReconcileControlPlaneSuccessRegistryMirrorAuthentication(t *t
 }
 
 func TestReconcilerReconcileControlPlaneFailure(t *testing.T) {
-	// TODO: remove after diskExtractor has been refactored and removed.
-	features.ClearCache()
-	t.Setenv(features.TinkerbellUseDiskExtractorDefaultDiskEnvVar, "true")
-	//
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 	scope := tt.buildScope()
@@ -345,11 +328,6 @@ func TestReconcilerValidateClusterSpecInvalidOSFamily(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
-	// TODO: remove after diskExtractor has been refactored and removed.
-	features.ClearCache()
-	t.Setenv(features.TinkerbellUseDiskExtractorDefaultDiskEnvVar, "true")
-	//
-
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "mgmt-cluster"
 	tt.cluster.SetSelfManaged()
@@ -396,11 +374,6 @@ func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
-	// TODO: remove after diskExtractor has been refactored and removed.
-	features.ClearCache()
-	t.Setenv(features.TinkerbellUseDiskExtractorDefaultDiskEnvVar, "true")
-	//
-
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "mgmt-cluster"
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
@@ -444,11 +417,6 @@ func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkerNodesFailure(t *testing.T) {
-	// TODO: remove after diskExtractor has been refactored and removed.
-	features.ClearCache()
-	t.Setenv(features.TinkerbellUseDiskExtractorDefaultDiskEnvVar, "true")
-	//
-
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "mgmt-cluster"
 	tt.cluster.SetSelfManaged()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This was added to use a default disk for the diskExtractor for Tinkerbell temporary, so that we could continue to test the new  controller, meanwhile the diskExtractor was being refactored/removed. Now it's no longer necessary.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

