### PR TITLE
Added airgapped instructions to the docs

### DIFF
--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -115,7 +115,7 @@ EKS Anywhere supports airgapped installation for creating clusters using a regis
 For airgapped installation to work, the Admin machine must have:
 
 * Temporary access to the internet to download images and artifacts
-* Ample space (50 GB or more) to store artifacts locally
+* Ample space (80 GB or more) to store artifacts locally
 
 
 To create a cluster in an airgapped environment, perform the following:

--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -101,6 +101,62 @@ You can verify your installed version with
 eksctl anywhere version
 ```
 
+## Prepare for airgapped deployments (optional)
+
+When creating an EKS Anywhere cluster, there may be times where you need to do so in an airgapped
+environment.
+In this type of environment, cluster nodes are connected to the Admin Machine, but not to the
+internet.
+In order to download images and artifacts, however, the Admin machine needs to be temporarily
+connected to the internet.
+
+An airgapped environment is especially important if you require the most secure networks.
+EKS Anywhere supports airgapped installation for creating clusters using a registry mirror.
+For airgapped installation to work, the Admin machine must have:
+
+* Temporary access to the internet to download images and artifacts
+* Ample space (50 GB or more) to store artifacts locally
+
+
+To create a cluster in an airgapped environment, perform the following:
+
+1. Download the artifacts and images that will be used by the cluster nodes to the Admin machine using the following command:
+   ```bash
+   eksctl anywhere download artifacts
+   ```
+   A compressed file `eks-anywhere-downloads.tar.gz` will be downloaded.
+
+1. To decompress this file, use the following command:
+   ```bash
+   tar -xvf eks-anywhere-downloads.tar.gz
+   ```
+   This will create an eks-anywhere-downloads folder that we’ll be using later.
+
+1. In order for the next command to run smoothly, ensure that Docker has been preinstalled. Then run the following:
+   ```bash
+   eksctl anywhere download images -o images.tar
+   ```
+
+   **For the remaining steps, the Admin machine no longer needs to be connected to the internet or the bastion host.**
+
+1. Next, you will need to set up a local registry mirror to host the downloaded EKS Anywhere contents. In order to set one up, refer to [Registry Mirror configuration.]({{< relref "/docs/reference/clusterspec/optional/registrymirror.md" >}})
+
+1. Now that you’ve configured your local registry mirror, you will need to import images to the local registry mirror using the following command (be sure to replace <registryUrl> with the url of the local registry mirror you created in step 4):
+   ```bash
+   eksctl anywhere import images -i images.tar -r <registryUrl> \
+      -- bundles ./anywhere-downloads/bundle-release.yaml
+   ```
+You are now ready to deploy a cluster by following instructions to [Create local cluster]({{< relref "/docs/getting-started/local-environment/" >}}) or  [Create production cluster.]({{< relref "/docs/getting-started/production-environment/" >}}) See text below for specific provider instructions.
+
+### For Bare Metal (Tinkerbell)
+You will need to have hookOS and its OS artifacts downloaded and served locally from an http file server.
+You will also need to modify the [hookImagesURLPath]({{< relref "../../reference/clusterspec/baremetal/#hookimagesurlpath" >}}) and the [osImageURL]({{< relref "../../reference/clusterspec/baremetal/#osimageurl" >}}) in the cluster configuration files.
+Ensure that structure of the files is set up as described in [hookImagesURLPath.]({{< relref "../../reference/clusterspec/baremetal/#hookimagesurlpath" >}})
+
+### For vSphere
+If you are using the vSphere provider, be sure that the requirements in the
+[Prerequisite checklist]({{< relref "../../reference/vsphere/vsphere-prereq" >}}) have been met.
+
 ## Deploy a cluster
 
 Once you have the tools installed you can deploy a local cluster or production cluster in the next steps.

--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -132,24 +132,24 @@ To create a cluster in an airgapped environment, perform the following:
    ```
    This will create an eks-anywhere-downloads folder that we’ll be using later.
 
-1. In order for the next command to run smoothly, ensure that Docker has been preinstalled. Then run the following:
+1. In order for the next command to run smoothly, ensure that Docker has been pre-installed and is running. Then run the following:
    ```bash
    eksctl anywhere download images -o images.tar
    ```
 
    **For the remaining steps, the Admin machine no longer needs to be connected to the internet or the bastion host.**
 
-1. Next, you will need to set up a local registry mirror to host the downloaded EKS Anywhere contents. In order to set one up, refer to [Registry Mirror configuration.]({{< relref "/docs/reference/clusterspec/optional/registrymirror.md" >}})
+1. Next, you will need to set up a local registry mirror to host the downloaded EKS Anywhere images. In order to set one up, refer to [Registry Mirror configuration.]({{< relref "/docs/reference/clusterspec/optional/registrymirror.md" >}})
 
 1. Now that you’ve configured your local registry mirror, you will need to import images to the local registry mirror using the following command (be sure to replace <registryUrl> with the url of the local registry mirror you created in step 4):
    ```bash
    eksctl anywhere import images -i images.tar -r <registryUrl> \
-      -- bundles ./anywhere-downloads/bundle-release.yaml
+      -- bundles ./eks-anywhere-downloads/bundle-release.yaml
    ```
 You are now ready to deploy a cluster by following instructions to [Create local cluster]({{< relref "/docs/getting-started/local-environment/" >}}) or  [Create production cluster.]({{< relref "/docs/getting-started/production-environment/" >}}) See text below for specific provider instructions.
 
 ### For Bare Metal (Tinkerbell)
-You will need to have hookOS and its OS artifacts downloaded and served locally from an http file server.
+You will need to have hookOS and its OS artifacts downloaded and served locally from an HTTP file server.
 You will also need to modify the [hookImagesURLPath]({{< relref "../../reference/clusterspec/baremetal/#hookimagesurlpath" >}}) and the [osImageURL]({{< relref "../../reference/clusterspec/baremetal/#osimageurl" >}}) in the cluster configuration files.
 Ensure that structure of the files is set up as described in [hookImagesURLPath.]({{< relref "../../reference/clusterspec/baremetal/#hookimagesurlpath" >}})
 

--- a/docs/content/en/docs/getting-started/local-environment/_index.md
+++ b/docs/content/en/docs/getting-started/local-environment/_index.md
@@ -88,13 +88,26 @@ To install the EKS Anywhere binaries and see system requirements please follow t
    export EKSA_AWS_SECRET_ACCESS_KEY="your*secret*key"
    export EKSA_AWS_REGION="us-west-2"
    ```
+   **NOTE**: The Amazon EKS Anywhere Curated Packages are only available to customers with the Amazon EKS Anywhere Enterprise Subscription. Due to this there might be some warnings in the CLI if proper authentication is not set up.
 
 1. Create Cluster:
 
-     **Note** The Amazon EKS Anywhere Curated Packages are only available to customers with the Amazon EKS Anywhere Enterprise Subscription. Due to this there might be some warnings in the CLI if proper authentication is not set up.
+   For a regular cluster create (with internet access), type the following:
+
       ```bash
-      eksctl anywhere create cluster -f $CLUSTER_NAME.yaml
+      eksctl anywhere create cluster \
+         # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
+         -f $CLUSTER_NAME.yaml
       ```
+   For an airgapped cluster create, follow [Preparation for airgapped deployments]({{< relref "../install/#preparation-for-airgapped-deployments-optional" >}}) instructions, then type the following:
+
+      ```bash
+      eksctl anywhere create cluster 
+         # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
+         -f $CLUSTER_NAME.yaml \
+         --bundles-override ./eks-anywhere-downloads/bundle-release.yaml
+      ```
+
      Example command output
       ```
       Performing setup and validations
@@ -120,7 +133,7 @@ To install the EKS Anywhere binaries and see system requirements please follow t
       secret/aws-secret created
       job.batch/eksa-auth-refresher created
       ```
-      **Note** to install curated packages during cluster creation, use `--install-packages packages.yaml` flag  
+      **NOTE**: to install curated packages during cluster creation, use `--install-packages packages.yaml` flag  
    
 1. Use the cluster
 
@@ -157,7 +170,7 @@ To install the EKS Anywhere binaries and see system requirements please follow t
    Verify the test application in the [deploy test application section]({{< relref "../../tasks/workload/test-app" >}}).
 
 ## Create management/workload clusters
-To try the recommended EKS Anywhere [topology]({{< relref "../../concepts/cluster-topologies" >}}), you can create a management cluster and one or more workload clusters on the same Docker provider.
+To try the recommended EKS Anywhere [topology,]({{< relref "../../concepts/cluster-topologies" >}}) you can create a management cluster and one or more workload clusters on the same Docker provider.
 
 ### Prerequisite Checklist
 
@@ -249,13 +262,23 @@ To install the EKS Anywhere binaries and see system requirements please follow t
    export EKSA_AWS_SECRET_ACCESS_KEY="your*secret*key"  
    ```
 
-1. Create cluster
+1. Create cluster:
 
-   ```bash
-   eksctl anywhere create cluster \
-      # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
-      -f eksa-mgmt-cluster.yaml
-   ```
+   For a regular cluster create (with internet access), type the following:
+
+      ```bash
+      eksctl anywhere create cluster \ 
+         # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
+         -f $CLUSTER_NAME.yaml
+      ```
+   For an airgapped cluster create, follow [Preparation for airgapped deployments]({{< relref "../install/#preparation-for-airgapped-deployments-optional" >}}) instructions, then type the following:
+
+      ```bash
+      eksctl anywhere create cluster \
+         # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
+         -f $CLUSTER_NAME.yaml \
+         --bundles-override ./eks-anywhere-downloads/bundle-release.yaml
+      ```
 
 1. Once the cluster is created you can use it with the generated `KUBECONFIG` file in your local directory:
 
@@ -301,11 +324,22 @@ Follow these steps to have your management cluster create and manage separate wo
 
    * **Terraform**: See [Manage separate workload clusters with Terraform]({{< relref "../../tasks/cluster/cluster-terraform.md#manage-separate-workload-clusters-using-terraform" >}})
      
-   * **eksctl CLI**: Useful for temporary cluster configurations. To create a workload cluster with `eksctl`, run:
+   * **eksctl CLI**: Useful for temporary cluster configurations. To create a workload cluster with `eksctl`, do one of the following.
+     For a regular cluster create (with internet access), type the following:
+
       ```bash
       eksctl anywhere create cluster \
           -f eksa-w01-cluster.yaml  \
-          # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
+         # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
+          --kubeconfig mgmt/mgmt-eks-a-cluster.kubeconfig
+      ```
+     For an airgapped cluster create, follow [Preparation for airgapped deployments]({{< relref "../install/#preparation-for-airgapped-deployments-optional" >}}) instructions, then type the following:
+
+      ```bash
+      eksctl create cluster \
+         # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
+         -f $CLUSTER_NAME.yaml \
+         --bundles-override ./eks-anywhere-downloads/bundle-release.yaml \
           --kubeconfig mgmt/mgmt-eks-a-cluster.kubeconfig
       ```
       As noted earlier, adding the `--kubeconfig` option tells `eksctl` to use the management cluster identified by that kubeconfig file to create a different workload cluster.

--- a/docs/content/en/docs/getting-started/local-environment/_index.md
+++ b/docs/content/en/docs/getting-started/local-environment/_index.md
@@ -99,7 +99,7 @@ To install the EKS Anywhere binaries and see system requirements please follow t
          # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
          -f $CLUSTER_NAME.yaml
       ```
-   For an airgapped cluster create, follow [Preparation for airgapped deployments]({{< relref "../install/#preparation-for-airgapped-deployments-optional" >}}) instructions, then type the following:
+   For an airgapped cluster create, follow [Preparation for airgapped deployments]({{< relref "../install/#prepare-for-airgapped-deployments-optional" >}}) instructions, then type the following:
 
       ```bash
       eksctl anywhere create cluster 
@@ -271,7 +271,7 @@ To install the EKS Anywhere binaries and see system requirements please follow t
          # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
          -f $CLUSTER_NAME.yaml
       ```
-   For an airgapped cluster create, follow [Preparation for airgapped deployments]({{< relref "../install/#preparation-for-airgapped-deployments-optional" >}}) instructions, then type the following:
+   For an airgapped cluster create, follow [Preparation for airgapped deployments]({{< relref "../install/#prepare-for-airgapped-deployments-optional" >}}) instructions, then type the following:
 
       ```bash
       eksctl anywhere create cluster \
@@ -333,7 +333,7 @@ Follow these steps to have your management cluster create and manage separate wo
          # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
           --kubeconfig mgmt/mgmt-eks-a-cluster.kubeconfig
       ```
-     For an airgapped cluster create, follow [Preparation for airgapped deployments]({{< relref "../install/#preparation-for-airgapped-deployments-optional" >}}) instructions, then type the following:
+     For an airgapped cluster create, follow [Preparation for airgapped deployments]({{< relref "../install/#prepare-for-airgapped-deployments-optional" >}}) instructions, then type the following:
 
       ```bash
       eksctl create cluster \


### PR DESCRIPTION
*Description of changes:* Documentation on setting up EKS Anywhere cluster creation for an airgapped environment is added to the install page here.

A cluster create command for airgapped will need to be added to each provider. So far, I have just added it to the local environment (Docker) provider. I'd like to keep this PR on hold until that provider's content looks okay. Then I'll add it to the others.
