### PR TITLE
set a default region for PackageControllerClient

### DIFF
--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -64,6 +64,7 @@ func NewPackageControllerClient(chartInstaller ChartInstaller, kubectl KubectlRu
 		chartInstaller: chartInstaller,
 		kubectl:        kubectl,
 		registryMirror: registryMirror,
+		eksaRegion:     eksaDefaultRegion,
 	}
 
 	for _, o := range options {
@@ -148,7 +149,9 @@ func (pc *PackageControllerClient) GetCuratedPackagesRegistries() (sourceRegistr
 			defaultImageRegistry = gatedOCINamespace
 		}
 	} else {
-		defaultImageRegistry = strings.ReplaceAll(defaultImageRegistry, eksaDefaultRegion, pc.eksaRegion)
+		if pc.eksaRegion != eksaDefaultRegion {
+			defaultImageRegistry = strings.ReplaceAll(defaultImageRegistry, eksaDefaultRegion, pc.eksaRegion)
+		}
 	}
 	return sourceRegistry, defaultRegistry, defaultImageRegistry
 }
@@ -371,8 +374,6 @@ func WithEksaRegion(eksaRegion string) func(client *PackageControllerClient) {
 	return func(config *PackageControllerClient) {
 		if eksaRegion != "" {
 			config.eksaRegion = eksaRegion
-		} else {
-			config.eksaRegion = eksaDefaultRegion
 		}
 	}
 }

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -912,6 +912,40 @@ func TestGetPackageControllerConfigurationNothing(t *testing.T) {
 	g.Expect(err).To(BeNil())
 }
 
+func TestGetCuratedPackagesRegistriesDefaultRegion(t *testing.T) {
+	clusterSpec := v1alpha1.ClusterSpec{
+		Packages: &v1alpha1.PackageConfiguration{
+			Disable: true,
+		},
+	}
+	chart := &artifactsv1.Image{
+		Name: "test_controller",
+		URI:  "test_registry/eks-anywhere/eks-anywhere-packages:v1",
+	}
+	g := NewWithT(t)
+	cluster := cluster.Spec{Config: &cluster.Config{Cluster: &v1alpha1.Cluster{Spec: clusterSpec}}}
+	sut := curatedpackages.NewPackageControllerClient(nil, nil, "billy", "", chart, nil, curatedpackages.WithClusterSpec(&cluster))
+	_, _, img := sut.GetCuratedPackagesRegistries()
+	g.Expect(img).To(Equal("783794618700.dkr.ecr.us-west-2.amazonaws.com"))
+}
+
+func TestGetCuratedPackagesRegistriesCustomRegion(t *testing.T) {
+	clusterSpec := v1alpha1.ClusterSpec{
+		Packages: &v1alpha1.PackageConfiguration{
+			Disable: true,
+		},
+	}
+	chart := &artifactsv1.Image{
+		Name: "test_controller",
+		URI:  "test_registry/eks-anywhere/eks-anywhere-packages:v1",
+	}
+	g := NewWithT(t)
+	cluster := cluster.Spec{Config: &cluster.Config{Cluster: &v1alpha1.Cluster{Spec: clusterSpec}}}
+	sut := curatedpackages.NewPackageControllerClient(nil, nil, "billy", "", chart, nil, curatedpackages.WithClusterSpec(&cluster), curatedpackages.WithEksaRegion("test"))
+	_, _, img := sut.GetCuratedPackagesRegistries()
+	g.Expect(img).To(Equal("783794618700.dkr.ecr.test.amazonaws.com"))
+}
+
 func TestGetPackageControllerConfigurationError(t *testing.T) {
 	clusterSpec := v1alpha1.ClusterSpec{
 		Packages: &v1alpha1.PackageConfiguration{

--- a/pkg/curatedpackages/testdata/values_empty.yaml
+++ b/pkg/curatedpackages/testdata/values_empty.yaml
@@ -7,4 +7,4 @@ registryMirrorSecret:
 awsSecret:
   id: ""
   secret: ""
-  region: ""
+  region: "dXMtd2VzdC0y"

--- a/pkg/curatedpackages/testdata/values_empty_awssecret.yaml
+++ b/pkg/curatedpackages/testdata/values_empty_awssecret.yaml
@@ -7,4 +7,4 @@ registryMirrorSecret:
 awsSecret:
   id: ""
   secret: ""
-  region: ""
+  region: "dXMtd2VzdC0y"


### PR DESCRIPTION
As the region setting is optional, it can't be assumed to be set, as was happening in places.

Since it seems safe to have a default value set, and there was a default value already defined, I've gone ahead and set it.

Now things can assume the value of the eksaRegion field is a non-zero value.

