### PR TITLE
Backup CAPI objects of management cluster

### DIFF
--- a/cmd/eksctl-anywhere/cmd/root.go
+++ b/cmd/eksctl-anywhere/cmd/root.go
@@ -24,7 +24,6 @@ var rootCmd = &cobra.Command{
 		if outputFilePath == "" {
 			return
 		}
-
 		if err := os.Remove(outputFilePath); err != nil {
 			fmt.Printf("Failed to cleanup log file %s: %s", outputFilePath, err)
 		}

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -103,6 +103,20 @@ func (mr *MockClusterClientMockRecorder) ApplyKubeSpecFromBytesWithNamespace(arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyKubeSpecFromBytesWithNamespace", reflect.TypeOf((*MockClusterClient)(nil).ApplyKubeSpecFromBytesWithNamespace), arg0, arg1, arg2, arg3)
 }
 
+// BackupManagement mocks base method.
+func (m *MockClusterClient) BackupManagement(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BackupManagement", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BackupManagement indicates an expected call of BackupManagement.
+func (mr *MockClusterClientMockRecorder) BackupManagement(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupManagement", reflect.TypeOf((*MockClusterClient)(nil).BackupManagement), arg0, arg1, arg2)
+}
+
 // CountMachineDeploymentReplicasReady mocks base method.
 func (m *MockClusterClient) CountMachineDeploymentReplicasReady(arg0 context.Context, arg1, arg2 string) (int, int, error) {
 	m.ctrl.T.Helper()

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -176,6 +176,26 @@ func clusterctlMoveRetryPolicy(totalRetries int, err error) (retry bool, wait ti
 	return false, 0
 }
 
+// BackupManagement save CAPI resources of a workload cluster before moving it to the bootstrap cluster during upgrade.
+func (c *Clusterctl) BackupManagement(ctx context.Context, cluster *types.Cluster, managementStatePath string) error {
+	filePath := filepath.Join(".", cluster.Name, managementStatePath)
+	err := os.MkdirAll(filePath, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("could not create backup file for CAPI objects: %v", err)
+	}
+
+	_, err = c.Execute(
+		ctx, "move",
+		"--to-directory", filePath,
+		"--kubeconfig", cluster.KubeconfigFile,
+		"--namespace", constants.EksaSystemNamespace,
+	)
+	if err != nil {
+		return fmt.Errorf("failed taking backup of CAPI objects: %v", err)
+	}
+	return nil
+}
+
 func (c *Clusterctl) MoveManagement(ctx context.Context, from, to *types.Cluster) error {
 	params := []string{"move", "--to-kubeconfig", to.KubeconfigFile, "--namespace", constants.EksaSystemNamespace}
 	if from.KubeconfigFile != "" {

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -217,6 +217,61 @@ func TestClusterctlInitInfrastructureInvalidClusterNameError(t *testing.T) {
 	}
 }
 
+func TestClusterctlBackupManagement(t *testing.T) {
+	managementClusterState := fmt.Sprintf("cluster-state-backup-%s", time.Now().Format("2006-01-02T15_04_05"))
+	clusterName := "cluster"
+
+	tests := []struct {
+		testName     string
+		cluster      *types.Cluster
+		wantMoveArgs []interface{}
+	}{
+		{
+			testName: "backup success",
+			cluster: &types.Cluster{
+				Name:           clusterName,
+				KubeconfigFile: "cluster.kubeconfig",
+			},
+			wantMoveArgs: []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", clusterName, managementClusterState), "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace},
+		},
+		{
+			testName: "no kubeconfig file",
+			cluster: &types.Cluster{
+				Name: clusterName,
+			},
+			wantMoveArgs: []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", clusterName, managementClusterState), "--kubeconfig", "", "--namespace", constants.EksaSystemNamespace},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			tc := newClusterctlTest(t)
+			tc.e.EXPECT().Execute(tc.ctx, tt.wantMoveArgs...)
+
+			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState); err != nil {
+				t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestClusterctlBackupManagementFailed(t *testing.T) {
+	managementClusterState := fmt.Sprintf("cluster-state-backup-%s", time.Now().Format("2006-01-02T15_04_05"))
+	tt := newClusterctlTest(t)
+
+	cluster := &types.Cluster{
+		Name:           "cluster",
+		KubeconfigFile: "cluster.kubeconfig",
+	}
+
+	wantMoveArgs := []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", cluster.Name, managementClusterState), "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}
+
+	tt.e.EXPECT().Execute(tt.ctx, wantMoveArgs...).Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
+	if err := tt.clusterctl.BackupManagement(tt.ctx, cluster, managementClusterState); err == nil {
+		t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
+	}
+}
+
 func TestClusterctlMoveManagement(t *testing.T) {
 	tests := []struct {
 		testName     string

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -27,24 +27,25 @@ type Task interface {
 
 // Command context maintains the mutable and shared entities.
 type CommandContext struct {
-	Bootstrapper       interfaces.Bootstrapper
-	Provider           providers.Provider
-	ClusterManager     interfaces.ClusterManager
-	GitOpsManager      interfaces.GitOpsManager
-	Validations        interfaces.Validator
-	Writer             filewriter.FileWriter
-	EksdInstaller      interfaces.EksdInstaller
-	PackageInstaller   interfaces.PackageInstaller
-	EksdUpgrader       interfaces.EksdUpgrader
-	CAPIManager        interfaces.CAPIManager
-	ClusterSpec        *cluster.Spec
-	CurrentClusterSpec *cluster.Spec
-	UpgradeChangeDiff  *types.ChangeDiff
-	BootstrapCluster   *types.Cluster
-	ManagementCluster  *types.Cluster
-	WorkloadCluster    *types.Cluster
-	Profiler           *Profiler
-	OriginalError      error
+	Bootstrapper              interfaces.Bootstrapper
+	Provider                  providers.Provider
+	ClusterManager            interfaces.ClusterManager
+	GitOpsManager             interfaces.GitOpsManager
+	Validations               interfaces.Validator
+	Writer                    filewriter.FileWriter
+	EksdInstaller             interfaces.EksdInstaller
+	PackageInstaller          interfaces.PackageInstaller
+	EksdUpgrader              interfaces.EksdUpgrader
+	CAPIManager               interfaces.CAPIManager
+	ClusterSpec               *cluster.Spec
+	CurrentClusterSpec        *cluster.Spec
+	UpgradeChangeDiff         *types.ChangeDiff
+	BootstrapCluster          *types.Cluster
+	ManagementCluster         *types.Cluster
+	WorkloadCluster           *types.Cluster
+	Profiler                  *Profiler
+	OriginalError             error
+	ManagementClusterStateDir string
 }
 
 func (c *CommandContext) SetError(err error) {
@@ -127,6 +128,7 @@ func (tr *taskRunner) RunTask(ctx context.Context, commandContext *CommandContex
 	var checkpointInfo CheckpointInfo
 	var err error
 
+	commandContext.ManagementClusterStateDir = fmt.Sprintf("cluster-state-backup-%s", time.Now().Format("2006-01-02T15_04_05"))
 	commandContext.Profiler = &Profiler{
 		metrics: make(map[string]map[string]time.Duration),
 		starts:  make(map[string]map[string]time.Time),

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -17,6 +17,7 @@ type Bootstrapper interface {
 }
 
 type ClusterManager interface {
+	BackupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath string) error
 	MoveCAPI(ctx context.Context, from, to *types.Cluster, clusterName string, clusterSpec *cluster.Spec, checkers ...types.NodeReadyChecker) error
 	CreateWorkloadCluster(ctx context.Context, managementCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) (*types.Cluster, error)
 	RunPostCreateWorkloadCluster(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec) error

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -111,6 +111,20 @@ func (mr *MockClusterManagerMockRecorder) ApplyBundles(arg0, arg1, arg2 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyBundles", reflect.TypeOf((*MockClusterManager)(nil).ApplyBundles), arg0, arg1, arg2)
 }
 
+// BackupCAPI mocks base method.
+func (m *MockClusterManager) BackupCAPI(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BackupCAPI", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BackupCAPI indicates an expected call of BackupCAPI.
+func (mr *MockClusterManagerMockRecorder) BackupCAPI(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupCAPI", reflect.TypeOf((*MockClusterManager)(nil).BackupCAPI), arg0, arg1, arg2)
+}
+
 // CreateAwsIamAuthCaSecret mocks base method.
 func (m *MockClusterManager) CreateAwsIamAuthCaSecret(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 
@@ -22,26 +23,27 @@ import (
 )
 
 type upgradeTestSetup struct {
-	t                  *testing.T
-	bootstrapper       *mocks.MockBootstrapper
-	clusterManager     *mocks.MockClusterManager
-	gitOpsManager      *mocks.MockGitOpsManager
-	provider           *providermocks.MockProvider
-	writer             *writermocks.MockFileWriter
-	validator          *mocks.MockValidator
-	eksdInstaller      *mocks.MockEksdInstaller
-	eksdUpgrader       *mocks.MockEksdUpgrader
-	capiManager        *mocks.MockCAPIManager
-	datacenterConfig   providers.DatacenterConfig
-	machineConfigs     []providers.MachineConfig
-	workflow           *workflows.Upgrade
-	ctx                context.Context
-	newClusterSpec     *cluster.Spec
-	currentClusterSpec *cluster.Spec
-	forceCleanup       bool
-	bootstrapCluster   *types.Cluster
-	workloadCluster    *types.Cluster
-	managementCluster  *types.Cluster
+	t                   *testing.T
+	bootstrapper        *mocks.MockBootstrapper
+	clusterManager      *mocks.MockClusterManager
+	gitOpsManager       *mocks.MockGitOpsManager
+	provider            *providermocks.MockProvider
+	writer              *writermocks.MockFileWriter
+	validator           *mocks.MockValidator
+	eksdInstaller       *mocks.MockEksdInstaller
+	eksdUpgrader        *mocks.MockEksdUpgrader
+	capiManager         *mocks.MockCAPIManager
+	datacenterConfig    providers.DatacenterConfig
+	machineConfigs      []providers.MachineConfig
+	workflow            *workflows.Upgrade
+	ctx                 context.Context
+	newClusterSpec      *cluster.Spec
+	currentClusterSpec  *cluster.Spec
+	forceCleanup        bool
+	bootstrapCluster    *types.Cluster
+	workloadCluster     *types.Cluster
+	managementCluster   *types.Cluster
+	managementStatePath string
 }
 
 func newUpgradeTest(t *testing.T) *upgradeTestSetup {
@@ -65,22 +67,23 @@ func newUpgradeTest(t *testing.T) *upgradeTestSetup {
 	}
 
 	return &upgradeTestSetup{
-		t:                t,
-		bootstrapper:     bootstrapper,
-		clusterManager:   clusterManager,
-		gitOpsManager:    gitOpsManager,
-		provider:         provider,
-		writer:           writer,
-		validator:        validator,
-		eksdInstaller:    eksdInstaller,
-		eksdUpgrader:     eksdUpgrader,
-		capiManager:      capiUpgrader,
-		datacenterConfig: datacenterConfig,
-		machineConfigs:   machineConfigs,
-		workflow:         workflow,
-		ctx:              context.Background(),
-		newClusterSpec:   test.NewClusterSpec(func(s *cluster.Spec) { s.Cluster.Name = "cluster-name" }),
-		workloadCluster:  &types.Cluster{Name: "workload"},
+		t:                   t,
+		bootstrapper:        bootstrapper,
+		clusterManager:      clusterManager,
+		gitOpsManager:       gitOpsManager,
+		provider:            provider,
+		writer:              writer,
+		validator:           validator,
+		eksdInstaller:       eksdInstaller,
+		eksdUpgrader:        eksdUpgrader,
+		capiManager:         capiUpgrader,
+		datacenterConfig:    datacenterConfig,
+		machineConfigs:      machineConfigs,
+		workflow:            workflow,
+		ctx:                 context.Background(),
+		newClusterSpec:      test.NewClusterSpec(func(s *cluster.Spec) { s.Cluster.Name = "cluster-name" }),
+		workloadCluster:     &types.Cluster{Name: "workload"},
+		managementStatePath: fmt.Sprintf("cluster-state-backup-%s", time.Now().Format("2006-01-02T15_04_05")),
 	}
 }
 
@@ -234,12 +237,19 @@ func (c *upgradeTestSetup) expectUpgradeWorkloadToReturn(managementCluster *type
 
 func (c *upgradeTestSetup) expectMoveManagementToBootstrap() {
 	gomock.InOrder(
+		c.clusterManager.EXPECT().BackupCAPI(c.ctx, c.managementCluster, c.managementStatePath),
 		c.clusterManager.EXPECT().MoveCAPI(
 			c.ctx, c.managementCluster, c.bootstrapCluster, gomock.Any(), c.newClusterSpec, gomock.Any(),
 		),
 		c.provider.EXPECT().PostMoveManagementToBootstrap(
 			c.ctx, c.bootstrapCluster,
 		),
+	)
+}
+
+func (c *upgradeTestSetup) expectBackupManagementToBootstrapFailed() {
+	gomock.InOrder(
+		c.clusterManager.EXPECT().BackupCAPI(c.ctx, c.managementCluster, c.managementStatePath).Return(fmt.Errorf("backup management failed")),
 	)
 }
 
@@ -501,6 +511,29 @@ func TestUpgradeRunFailedUpgrade(t *testing.T) {
 	test.expectCreateBootstrap()
 	test.expectMoveManagementToBootstrap()
 	test.expectUpgradeWorkloadToReturn(test.bootstrapCluster, test.workloadCluster, errors.New("failed upgrading"))
+	test.expectSaveLogs(test.workloadCluster)
+	test.expectWriteCheckpointFile()
+	test.expectPreCoreComponentsUpgrade()
+
+	err := test.run()
+	if err == nil {
+		t.Fatal("Upgrade.Run() err = nil, want err not nil")
+	}
+}
+
+func TestUpgradeRunFailedBackupManagementUpgrade(t *testing.T) {
+	test := newUpgradeSelfManagedClusterTest(t)
+	test.expectSetup()
+	test.expectPreflightValidationsToPass()
+	test.expectUpdateSecrets(test.workloadCluster)
+	test.expectEnsureEtcdCAPIComponentsExistTask(test.workloadCluster)
+	test.expectUpgradeCoreComponents(test.workloadCluster, test.workloadCluster)
+	test.expectProviderNoUpgradeNeeded(test.workloadCluster)
+	test.expectVerifyClusterSpecChanged(test.workloadCluster)
+	test.expectPauseEKSAControllerReconcile(test.workloadCluster)
+	test.expectPauseGitOpsReconcile(test.workloadCluster)
+	test.expectCreateBootstrap()
+	test.expectBackupManagementToBootstrapFailed()
 	test.expectSaveLogs(test.workloadCluster)
 	test.expectWriteCheckpointFile()
 	test.expectPreCoreComponentsUpgrade()


### PR DESCRIPTION
*Description of changes:*
Backup CAPI objects before moving from management cluster to bootstrap cluster during upgrade

*Testing (if applicable):*
I have tested this feature by create/upgrade/delete of management and workload cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

