### PR TITLE
Add validation to check for empty ssh keys

### DIFF
--- a/pkg/api/v1alpha1/tinkerbellmachineconfig.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig.go
@@ -123,6 +123,10 @@ func validateTinkerbellMachineConfig(config *TinkerbellMachineConfig) error {
 		return fmt.Errorf("TinkerbellMachineConfig: missing spec.Users: %s", config.Name)
 	}
 
+	if len(config.Spec.Users[0].SshAuthorizedKeys) == 0 || config.Spec.Users[0].SshAuthorizedKeys[0] == "" {
+		return fmt.Errorf("TinkerbellMachineConfig: missing spec.Users[0].SshAuthorizedKeys: %s for user %s. Please specify a ssh authorized key", config.Name, config.Spec.Users[0])
+	}
+
 	if err := validateHostOSConfig(config.Spec.HostOSConfiguration); err != nil {
 		return fmt.Errorf("HostOSConfiguration is invalid for TinkerbellMachineConfig %s: %v", config.Name, err)
 	}

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook_test.go
@@ -21,7 +21,7 @@ func TestTinkerbellMachineConfigValidateCreateFail(t *testing.T) {
 	})
 
 	g := NewWithT(t)
-	g.Expect(machineConfig.ValidateCreate()).NotTo(Succeed())
+	g.Expect(machineConfig.ValidateCreate()).To(MatchError(ContainSubstring("TinkerbellMachineConfig: missing spec.hardwareSelector: tinkerbellmachineconfig")))
 }
 
 func TestTinkerbellMachineConfigValidateCreateFailNoUsers(t *testing.T) {
@@ -30,7 +30,34 @@ func TestTinkerbellMachineConfigValidateCreateFailNoUsers(t *testing.T) {
 	})
 
 	g := NewWithT(t)
-	g.Expect(machineConfig.ValidateCreate()).NotTo(Succeed())
+	g.Expect(machineConfig.ValidateCreate()).To(MatchError(ContainSubstring("TinkerbellMachineConfig: missing spec.Users: tinkerbellmachineconfig")))
+}
+
+func TestTinkerbellMachineConfigValidateCreateFailNoSSHkeys(t *testing.T) {
+	machineConfig := v1alpha1.CreateTinkerbellMachineConfig(func(mc *v1alpha1.TinkerbellMachineConfig) {
+		mc.Spec.Users = []v1alpha1.UserConfiguration{
+			{
+				Name: "test",
+			},
+		}
+	})
+
+	g := NewWithT(t)
+	g.Expect(machineConfig.ValidateCreate()).To(MatchError(ContainSubstring("Please specify a ssh authorized key")))
+}
+
+func TestTinkerbellMachineConfigValidateCreateFailEmptySSHkeys(t *testing.T) {
+	machineConfig := v1alpha1.CreateTinkerbellMachineConfig(func(mc *v1alpha1.TinkerbellMachineConfig) {
+		mc.Spec.Users = []v1alpha1.UserConfiguration{
+			{
+				Name:              "test",
+				SshAuthorizedKeys: []string{},
+			},
+		}
+	})
+
+	g := NewWithT(t)
+	g.Expect(machineConfig.ValidateCreate()).To(MatchError(ContainSubstring("Please specify a ssh authorized key")))
 }
 
 func TestTinkerbellMachineConfigValidateUpdateSucceed(t *testing.T) {

--- a/pkg/providers/tinkerbell/cluster_spec_builder_test.go
+++ b/pkg/providers/tinkerbell/cluster_spec_builder_test.go
@@ -94,6 +94,9 @@ func (b ValidClusterSpecBuilder) Build() *tinkerbell.ClusterSpec {
 					Users: []v1alpha1.UserConfiguration{
 						{
 							Name: "ec2-user",
+							SshAuthorizedKeys: []string{
+								"test-rsa ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+							},
 						},
 					},
 				},
@@ -109,6 +112,9 @@ func (b ValidClusterSpecBuilder) Build() *tinkerbell.ClusterSpec {
 					Users: []v1alpha1.UserConfiguration{
 						{
 							Name: "ec2-user",
+							SshAuthorizedKeys: []string{
+								"test-rsa ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+							},
 						},
 					},
 				},
@@ -124,6 +130,9 @@ func (b ValidClusterSpecBuilder) Build() *tinkerbell.ClusterSpec {
 					Users: []v1alpha1.UserConfiguration{
 						{
 							Name: "ec2-user",
+							SshAuthorizedKeys: []string{
+								"test-rsa ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+							},
 						},
 					},
 				},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add validation to check for empty ssh keys
*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

