### PR TITLE
Remove duplicate retry when getting workload cluster kubeconfig

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -303,10 +303,8 @@ func (c *ClusterManager) CreateWorkloadCluster(ctx context.Context, managementCl
 
 	// Use a buffer to cache the kubeconfig.
 	var buf bytes.Buffer
-	err := c.Retrier.Retry(func() error {
-		return c.getWorkloadClusterKubeconfig(ctx, clusterName, managementCluster, &buf)
-	})
-	if err != nil {
+
+	if err := c.getWorkloadClusterKubeconfig(ctx, clusterName, managementCluster, &buf); err != nil {
 		return nil, fmt.Errorf("waiting for workload kubeconfig: %v", err)
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

The `getWorkloadClusterKubeconfig` method already contains the retry logic as `clusterClient` is a retryClient: https://github.com/aws/eks-anywhere/blob/main/pkg/clustermanager/cluster_manager.go#L397.

*Description of changes:*

Remove duplicate retry.

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

