### PR TITLE
move validation

### DIFF
--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -7,14 +7,15 @@ import (
 	"net"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 	"github.com/aws/eks-anywhere/pkg/types"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 type Validator struct {
@@ -226,6 +227,7 @@ func (v *Validator) setDefaultAndValidateControlPlaneHostPort(cloudStackClusterS
 	return nil
 }
 
+// ValidateSecretsUnchanged checks the secret to see if it has not been changed
 func (v *Validator) ValidateSecretsUnchanged(ctx context.Context, cluster *types.Cluster, execConfig *decoder.CloudStackExecConfig, client ProviderKubectlClient) error {
 	for _, profile := range execConfig.Profiles {
 		secret, err := client.GetSecretFromNamespace(ctx, cluster.KubeconfigFile, profile.Name, constants.EksaSystemNamespace)

--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -227,7 +227,7 @@ func (v *Validator) setDefaultAndValidateControlPlaneHostPort(cloudStackClusterS
 	return nil
 }
 
-// ValidateSecretsUnchanged checks the secret to see if it has not been changed
+// ValidateSecretsUnchanged checks the secret to see if it has not been changed.
 func (v *Validator) ValidateSecretsUnchanged(ctx context.Context, cluster *types.Cluster, execConfig *decoder.CloudStackExecConfig, client ProviderKubectlClient) error {
 	for _, profile := range execConfig.Profiles {
 		secret, err := client.GetSecretFromNamespace(ctx, cluster.KubeconfigFile, profile.Name, constants.EksaSystemNamespace)

--- a/pkg/providers/cloudstack/validator_mocks.go
+++ b/pkg/providers/cloudstack/validator_mocks.go
@@ -9,6 +9,8 @@ import (
 	reflect "reflect"
 
 	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	decoder "github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
+	types "github.com/aws/eks-anywhere/pkg/types"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -75,4 +77,18 @@ func (m *MockProviderValidator) ValidateControlPlaneEndpointUniqueness(arg0 stri
 func (mr *MockProviderValidatorMockRecorder) ValidateControlPlaneEndpointUniqueness(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateControlPlaneEndpointUniqueness", reflect.TypeOf((*MockProviderValidator)(nil).ValidateControlPlaneEndpointUniqueness), arg0)
+}
+
+// ValidateSecretsUnchanged mocks base method.
+func (m *MockProviderValidator) ValidateSecretsUnchanged(arg0 context.Context, arg1 *types.Cluster, arg2 *decoder.CloudStackExecConfig, arg3 ProviderKubectlClient) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateSecretsUnchanged", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateSecretsUnchanged indicates an expected call of ValidateSecretsUnchanged.
+func (mr *MockProviderValidatorMockRecorder) ValidateSecretsUnchanged(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateSecretsUnchanged", reflect.TypeOf((*MockProviderValidator)(nil).ValidateSecretsUnchanged), arg0, arg1, arg2, arg3)
 }

--- a/pkg/providers/cloudstack/validator_registry.go
+++ b/pkg/providers/cloudstack/validator_registry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
+	"github.com/aws/eks-anywhere/pkg/types"
 )
 
 // ValidatorRegistry exposes a single method for retrieving the CloudStack validator, and abstracts away how they are injected.
@@ -32,6 +33,7 @@ type ProviderValidator interface {
 	ValidateCloudStackDatacenterConfig(ctx context.Context, datacenterConfig *anywherev1.CloudStackDatacenterConfig) error
 	ValidateClusterMachineConfigs(ctx context.Context, cloudStackClusterSpec *Spec) error
 	ValidateControlPlaneEndpointUniqueness(endpoint string) error
+	ValidateSecretsUnchanged(ctx context.Context, cluster *types.Cluster, execConfig *decoder.CloudStackExecConfig, client ProviderKubectlClient) error
 }
 
 // NewValidatorFactory initializes a factory for the CloudStack provider validator.

--- a/pkg/providers/cloudstack/validator_test.go
+++ b/pkg/providers/cloudstack/validator_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"

--- a/pkg/providers/cloudstack/validator_test.go
+++ b/pkg/providers/cloudstack/validator_test.go
@@ -479,7 +479,7 @@ func TestValidateMachineConfigsWithAffinity(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestValidateSecretsUnchangedOnSecretUnchanged(t *testing.T) {
+func TestValidateSecretsUnchangedSuccess(t *testing.T) {
 	ctx := context.Background()
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
@@ -495,7 +495,7 @@ func TestValidateSecretsUnchangedOnSecretUnchanged(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestValidateSecretsUnchangedOnSecretChanged(t *testing.T) {
+func TestValidateSecretsUnchangedFailureSecretChanged(t *testing.T) {
 	ctx := context.Background()
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
@@ -514,7 +514,7 @@ func TestValidateSecretsUnchangedOnSecretChanged(t *testing.T) {
 	thenErrorExpected(t, "profile 'global' is different from the secret", err)
 }
 
-func TestValidateSecretsUnchangedOnGetSecretFailure(t *testing.T) {
+func TestValidateSecretsUnchangedFailureGettingSecret(t *testing.T) {
 	ctx := context.Background()
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
@@ -530,7 +530,7 @@ func TestValidateSecretsUnchangedOnGetSecretFailure(t *testing.T) {
 	thenErrorExpected(t, "getting secret for profile global: test-error", err)
 }
 
-func TestValidateSecretsUnchangedOnSecretNotFound(t *testing.T) {
+func TestValidateSecretsUnchangedFailureSecretNotFound(t *testing.T) {
 	ctx := context.Background()
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
moved validateSecretsUnchanged from cloudstack.go to validator.go

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

