### PR TITLE
Tinkerbell: patch missing mount paths for BottleRocket upgrade

### DIFF
--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -98,6 +98,29 @@ spec:
             name: awsiamcert
             readOnly: false
 {{- end}}
+{{- /*
+  BottleRocket uses different host paths for kubeconfigs requiring host mount path overwrites for
+  the scheduler and controller-manager static pods.
+*/}}
+{{- if ( eq .format "bottlerocket" ) }}
+      controllerManager:
+        extraVolumes:
+        - hostPath: /var/lib/kubeadm/controller-manager.conf
+          mountPath: /etc/kubernetes/controller-manager.conf
+          name: kubeconfig
+          pathType: File
+          readOnly: true
+{{- end }}
+{{- if ( eq .format "bottlerocket" ) }}
+      scheduler:
+        extraVolumes:
+        - hostPath: /var/lib/kubeadm/scheduler.conf
+          mountPath: /etc/kubernetes/scheduler.conf
+          name: kubeconfig
+          pathType: File
+          readOnly: true
+      certificatesDir: /var/lib/kubeadm/pki
+{{- end }}
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_cp.yaml
@@ -48,6 +48,21 @@ spec:
       apiServer:
         extraArgs:
           feature-gates: ServiceLoadBalancerClass=true
+      controllerManager:
+        extraVolumes:
+        - hostPath: /var/lib/kubeadm/controller-manager.conf
+          mountPath: /etc/kubernetes/controller-manager.conf
+          name: kubeconfig
+          pathType: File
+          readOnly: true
+      scheduler:
+        extraVolumes:
+        - hostPath: /var/lib/kubeadm/scheduler.conf
+          mountPath: /etc/kubernetes/scheduler.conf
+          name: kubeconfig
+          pathType: File
+          readOnly: true
+      certificatesDir: /var/lib/kubeadm/pki
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_minimal_registry_mirror.yaml
@@ -50,6 +50,21 @@ spec:
       apiServer:
         extraArgs:
           feature-gates: ServiceLoadBalancerClass=true
+      controllerManager:
+        extraVolumes:
+        - hostPath: /var/lib/kubeadm/controller-manager.conf
+          mountPath: /etc/kubernetes/controller-manager.conf
+          name: kubeconfig
+          pathType: File
+          readOnly: true
+      scheduler:
+        extraVolumes:
+        - hostPath: /var/lib/kubeadm/scheduler.conf
+          mountPath: /etc/kubernetes/scheduler.conf
+          name: kubeconfig
+          pathType: File
+          readOnly: true
+      certificatesDir: /var/lib/kubeadm/pki
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_auth.yaml
@@ -68,6 +68,21 @@ spec:
       apiServer:
         extraArgs:
           feature-gates: ServiceLoadBalancerClass=true
+      controllerManager:
+        extraVolumes:
+        - hostPath: /var/lib/kubeadm/controller-manager.conf
+          mountPath: /etc/kubernetes/controller-manager.conf
+          name: kubeconfig
+          pathType: File
+          readOnly: true
+      scheduler:
+        extraVolumes:
+        - hostPath: /var/lib/kubeadm/scheduler.conf
+          mountPath: /etc/kubernetes/scheduler.conf
+          name: kubeconfig
+          pathType: File
+          readOnly: true
+      certificatesDir: /var/lib/kubeadm/pki
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_cert.yaml
@@ -68,6 +68,21 @@ spec:
       apiServer:
         extraArgs:
           feature-gates: ServiceLoadBalancerClass=true
+      controllerManager:
+        extraVolumes:
+        - hostPath: /var/lib/kubeadm/controller-manager.conf
+          mountPath: /etc/kubernetes/controller-manager.conf
+          name: kubeconfig
+          pathType: File
+          readOnly: true
+      scheduler:
+        extraVolumes:
+        - hostPath: /var/lib/kubeadm/scheduler.conf
+          mountPath: /etc/kubernetes/scheduler.conf
+          name: kubeconfig
+          pathType: File
+          readOnly: true
+      certificatesDir: /var/lib/kubeadm/pki
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:


### PR DESCRIPTION
When using BottleRocket we are required to alter kubeconfig paths that are mounted into the scheduler and controller-manager containers launched by the kubelet. This is because BottleRocket uses different paths.

Other providers patch using the YAML template ensuring new nodes created during an upgrade have the correct host mount paths.