### PR TITLE
adding tinkerbell e2e clusterAPI test

### DIFF
--- a/test/e2e/multicluster.go
+++ b/test/e2e/multicluster.go
@@ -47,6 +47,22 @@ func runTinkerbellWorkloadClusterFlow(test *framework.MulticlusterE2ETest) {
 	test.DeleteTinkerbellManagementCluster()
 }
 
+func runTinkerbellWorkloadClusterAPIFlow(test *framework.MulticlusterE2ETest) {
+	test.CreateTinkerbellManagementCluster()
+	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
+		w.GenerateClusterConfig()
+		w.WaitForAvailableHardware()
+		w.PowerOffHardware()
+		w.ApplyClusterManifest()
+		w.WaitForKubeconfig()
+		w.ValidateClusterState()
+		w.DeleteClusterWithKubectl()
+		w.ValidateClusterDelete()
+		w.ValidateHardwareDecommissioned()
+	})
+	test.DeleteTinkerbellManagementCluster()
+}
+
 func runSimpleWorkloadUpgradeFlowForBareMetal(test *framework.MulticlusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.CreateTinkerbellManagementCluster()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -189,6 +189,33 @@ func TestTinkerbellKubernetes125UbuntuWorkloadCluster(t *testing.T) {
 	runTinkerbellWorkloadClusterFlow(test)
 }
 
+func TestTinkerbellKubernetes125UbuntuWorkloadClusterAPI(t *testing.T) {
+	provider := framework.NewTinkerbell(t, framework.WithUbuntu125Tinkerbell())
+	managementCluster := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
+		framework.WithControlPlaneHardware(2),
+		framework.WithWorkerHardware(2),
+	)
+	test := framework.NewMulticlusterE2ETest(
+		t,
+		managementCluster,
+	)
+	test.WithWorkloadClusters(
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterName(test.NewWorkloadClusterName()),
+			framework.WithClusterFiller(
+				api.WithKubernetesVersion(v1alpha1.Kube125),
+				api.WithManagementCluster(managementCluster.ClusterName),
+			),
+		),
+	)
+	runTinkerbellWorkloadClusterAPIFlow(test)
+}
+
 func TestTinkerbellKubernetes125BottlerocketWorkloadClusterSimpleFlow(t *testing.T) {
 	provider := framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell())
 	test := framework.NewMulticlusterE2ETest(
@@ -207,6 +234,33 @@ func TestTinkerbellKubernetes125BottlerocketWorkloadClusterSimpleFlow(t *testing
 		),
 	)
 	runTinkerbellWorkloadClusterFlow(test)
+}
+
+func TestTinkerbellKubernetes125BottlerocketWorkloadClusterAPI(t *testing.T) {
+	provider := framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell())
+	managementCluster := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
+		framework.WithControlPlaneHardware(2),
+		framework.WithWorkerHardware(2),
+	)
+	test := framework.NewMulticlusterE2ETest(
+		t,
+		managementCluster,
+	)
+	test.WithWorkloadClusters(
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterName(test.NewWorkloadClusterName()),
+			framework.WithClusterFiller(
+				api.WithKubernetesVersion(v1alpha1.Kube125),
+				api.WithManagementCluster(managementCluster.ClusterName),
+			),
+		),
+	)
+	runTinkerbellWorkloadClusterAPIFlow(test)
 }
 
 func TestTinkerbellKubernetes125UbuntuSingleNodeWorkloadCluster(t *testing.T) {
@@ -237,6 +291,39 @@ func TestTinkerbellKubernetes125UbuntuSingleNodeWorkloadCluster(t *testing.T) {
 	runTinkerbellWorkloadClusterFlow(test)
 }
 
+func TestTinkerbellKubernetes125UbuntuSingleNodeWorkloadClusterAPI(t *testing.T) {
+	provider := framework.NewTinkerbell(t, framework.WithUbuntu125Tinkerbell())
+	managementCluster := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube125),
+			api.WithEtcdCountIfExternal(0),
+			api.RemoveAllWorkerNodeGroups(),
+		),
+		framework.WithControlPlaneHardware(2),
+		framework.WithWorkerHardware(0),
+	)
+	test := framework.NewMulticlusterE2ETest(
+		t,
+		managementCluster,
+	)
+	test.WithWorkloadClusters(
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterName(test.NewWorkloadClusterName()),
+			framework.WithClusterFiller(
+				api.WithKubernetesVersion(v1alpha1.Kube125),
+				api.WithManagementCluster(managementCluster.ClusterName),
+				api.WithEtcdCountIfExternal(0),
+				api.RemoveAllWorkerNodeGroups(),
+			),
+		),
+	)
+	runTinkerbellWorkloadClusterAPIFlow(test)
+}
+
 func TestTinkerbellKubernetes125BottlerocketSingleNodeWorkloadCluster(t *testing.T) {
 	provider := framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell())
 	test := framework.NewMulticlusterE2ETest(
@@ -263,6 +350,39 @@ func TestTinkerbellKubernetes125BottlerocketSingleNodeWorkloadCluster(t *testing
 		),
 	)
 	runTinkerbellWorkloadClusterFlow(test)
+}
+
+func TestTinkerbellKubernetes125BottlerocketSingleNodeWorkloadClusterAPI(t *testing.T) {
+	provider := framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell())
+	managementCluster := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube125),
+			api.WithEtcdCountIfExternal(0),
+			api.RemoveAllWorkerNodeGroups(),
+		),
+		framework.WithControlPlaneHardware(2),
+		framework.WithWorkerHardware(0),
+	)
+	test := framework.NewMulticlusterE2ETest(
+		t,
+		managementCluster,
+	)
+	test.WithWorkloadClusters(
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterName(test.NewWorkloadClusterName()),
+			framework.WithClusterFiller(
+				api.WithKubernetesVersion(v1alpha1.Kube125),
+				api.WithManagementCluster(managementCluster.ClusterName),
+				api.WithEtcdCountIfExternal(0),
+				api.RemoveAllWorkerNodeGroups(),
+			),
+		),
+	)
+	runTinkerbellWorkloadClusterAPIFlow(test)
 }
 
 func TestTinkerbellKubernetes125BottlerocketWorkloadClusterSkipPowerActions(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
[1064](https://github.com/aws/eks-anywhere-internal/issues/1064)

*Description of changes:*
Adding E2E create/delete test for Tinkerbell Cluster API

*Testing (if applicable):*
added e2e test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

