### PR TITLE
Nutanix Full Cluster lifecycle support

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_nutanixdatacenterconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_nutanixdatacenterconfigs.yaml
@@ -68,7 +68,6 @@ spec:
                 type: boolean
               port:
                 description: Port is the Port of Nutanix Prism Central
-                minimum: 9440
                 type: integer
             required:
             - endpoint

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -6693,6 +6693,27 @@ webhooks:
     service:
       name: eksa-webhook-service
       namespace: eksa-system
+      path: /validate-anywhere-eks-amazonaws-com-v1alpha1-nutanixmachineconfig
+  failurePolicy: Fail
+  name: validation.nutanixmachineconfig.anywhere.amazonaws.com
+  rules:
+  - apiGroups:
+    - anywhere.eks.amazonaws.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - nutanixmachineconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: eksa-webhook-service
+      namespace: eksa-system
       path: /validate-anywhere-eks-amazonaws-com-v1alpha1-oidcconfig
   failurePolicy: Fail
   name: validation.oidcconfig.anywhere.amazonaws.com

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4425,7 +4425,6 @@ spec:
                 type: boolean
               port:
                 description: Port is the Port of Nutanix Prism Central
-                minimum: 9440
                 type: integer
             required:
             - endpoint
@@ -6120,6 +6119,10 @@ rules:
   - dockerclusters/status
   - dockermachinetemplates
   - dockermachinetemplates/status
+  - nutanixclusters
+  - nutanixclusters/status
+  - nutanixmachinetemplates
+  - nutanixmachinetemplates/status
   verbs:
   - get
   - list

--- a/config/rbac/manager_extraroles_patch.yaml
+++ b/config/rbac/manager_extraroles_patch.yaml
@@ -89,6 +89,10 @@
       - dockerclusters/status
       - dockermachinetemplates
       - dockermachinetemplates/status
+      - nutanixclusters
+      - nutanixclusters/status
+      - nutanixmachinetemplates
+      - nutanixmachinetemplates/status
     verbs:
       - get
       - list

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -315,6 +315,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-anywhere-eks-amazonaws-com-v1alpha1-nutanixmachineconfig
+  failurePolicy: Fail
+  name: validation.nutanixmachineconfig.anywhere.amazonaws.com
+  rules:
+  - apiGroups:
+    - anywhere.eks.amazonaws.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - nutanixmachineconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-anywhere-eks-amazonaws-com-v1alpha1-oidcconfig
   failurePolicy: Fail
   name: validation.oidcconfig.anywhere.amazonaws.com

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -145,21 +145,25 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) 
 			&source.Kind{Type: &anywherev1.NutanixDatacenterConfig{}},
 			handler.EnqueueRequestsFromMapFunc(childObjectHandler),
 		).
+		Watches(
+			&source.Kind{Type: &anywherev1.NutanixMachineConfig{}},
+			handler.EnqueueRequestsFromMapFunc(childObjectHandler),
+		).
 		Complete(r)
 }
 
 // Reconcile reconciles a cluster object.
-// +kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=clusters;snowmachineconfigs;snowippools;vspheredatacenterconfigs;vspheremachineconfigs;dockerdatacenterconfigs;tinkerbellmachineconfigs;tinkerbelldatacenterconfigs;cloudstackdatacenterconfigs;cloudstackmachineconfigs;nutanixdatacenterconfigs;bundles;awsiamconfigs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=clusters;snowmachineconfigs;snowippools;vspheredatacenterconfigs;vspheremachineconfigs;dockerdatacenterconfigs;tinkerbellmachineconfigs;tinkerbelldatacenterconfigs;cloudstackdatacenterconfigs;cloudstackmachineconfigs;nutanixdatacenterconfigs;nutanixmachineconfigs;bundles;awsiamconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=oidcconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=awsiamconfigs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=clusters/status;snowmachineconfigs/status;snowippools/status;vspheredatacenterconfigs/status;vspheremachineconfigs/status;dockerdatacenterconfigs/status;cloudstackdatacenterconfigs/status;cloudstackmachineconfigs/status;nutanixdatacenterconfigs/status;bundles/status;awsiamconfigs/status;tinkerbelldatacenterconfigs/status;tinkerbellmachineconfigs/status,verbs=;get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=clusters/finalizers;snowmachineconfigs/finalizers;snowippools/finalizers;vspheredatacenterconfigs/finalizers;vspheremachineconfigs/finalizers;dockerdatacenterconfigs/finalizers;cloudstackdatacenterconfigs/finalizers;cloudstackmachineconfigs/finalizers;nutanixdatacenterconfigs/finalizers;bundles/finalizers;awsiamconfigs/finalizers;tinkerbelldatacenterconfigs/finalizers;tinkerbellmachineconfigs/finalizers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=clusters/status;snowmachineconfigs/status;snowippools/status;vspheredatacenterconfigs/status;vspheremachineconfigs/status;dockerdatacenterconfigs/status;cloudstackdatacenterconfigs/status;cloudstackmachineconfigs/status;nutanixdatacenterconfigs/status;nutanixmachineconfigs/status;bundles/status;awsiamconfigs/status;tinkerbelldatacenterconfigs/status;tinkerbellmachineconfigs/status,verbs=;get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=clusters/finalizers;snowmachineconfigs/finalizers;snowippools/finalizers;vspheredatacenterconfigs/finalizers;vspheremachineconfigs/finalizers;dockerdatacenterconfigs/finalizers;cloudstackdatacenterconfigs/finalizers;cloudstackmachineconfigs/finalizers;nutanixdatacenterconfigs/finalizers;nutanixmachineconfigs/finalizers;bundles/finalizers;awsiamconfigs/finalizers;tinkerbelldatacenterconfigs/finalizers;tinkerbellmachineconfigs/finalizers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=addons.cluster.x-k8s.io,resources=clusterresourcesets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=test,resources=test,verbs=get;list;watch;create;update;patch;delete;kill
 // +kubebuilder:rbac:groups=distro.eks.amazonaws.com,resources=releases,verbs=get;list;watch
-// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awssnowclusters;awssnowmachinetemplates;awssnowippools;vsphereclusters;vspheremachinetemplates;dockerclusters;dockermachinetemplates;tinkerbellclusters;tinkerbellmachinetemplates;cloudstackclusters;cloudstackmachinetemplates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awssnowclusters;awssnowmachinetemplates;awssnowippools;vsphereclusters;vspheremachinetemplates;dockerclusters;dockermachinetemplates;tinkerbellclusters;tinkerbellmachinetemplates;cloudstackclusters;cloudstackmachinetemplates;nutanixclusters;nutanixmachinetemplates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",namespace=eksa-system,resources=secrets,verbs=delete;
 // +kubebuilder:rbac:groups=tinkerbell.org,resources=hardware;hardware/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=bmc.tinkerbell.org,resources=machines;machines/status,verbs=get;list;watch

--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -232,7 +232,6 @@ func (f *Factory) withNutanixClusterReconciler() *Factory {
 		f.nutanixClusterReconciler = nutanixreconciler.New(
 			f.manager.GetClient(),
 			f.deps.NutanixValidator,
-			f.deps.NutanixDefaulter,
 			f.cniReconciler,
 			f.tracker,
 			f.ipValidator,

--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -18,6 +18,7 @@ import (
 	ciliumreconciler "github.com/aws/eks-anywhere/pkg/networking/cilium/reconciler"
 	cnireconciler "github.com/aws/eks-anywhere/pkg/networking/reconciler"
 	dockerreconciler "github.com/aws/eks-anywhere/pkg/providers/docker/reconciler"
+	nutanixreconciler "github.com/aws/eks-anywhere/pkg/providers/nutanix/reconciler"
 	"github.com/aws/eks-anywhere/pkg/providers/snow"
 	snowreconciler "github.com/aws/eks-anywhere/pkg/providers/snow/reconciler"
 	tinkerbellreconciler "github.com/aws/eks-anywhere/pkg/providers/tinkerbell/reconciler"
@@ -38,6 +39,7 @@ type Factory struct {
 	vsphereClusterReconciler    *vspherereconciler.Reconciler
 	tinkerbellClusterReconciler *tinkerbellreconciler.Reconciler
 	snowClusterReconciler       *snowreconciler.Reconciler
+	nutanixClusterReconciler    *nutanixreconciler.Reconciler
 	cniReconciler               *cnireconciler.Reconciler
 	ipValidator                 *clusters.IPValidator
 	awsIamConfigReconciler      *awsiamconfigreconciler.Reconciler
@@ -218,6 +220,31 @@ func (f *Factory) WithNutanixDatacenterReconciler() *Factory {
 	return f
 }
 
+// withNutanixClusterReconciler adds the NutanixClusterReconciler to the controller factory.
+func (f *Factory) withNutanixClusterReconciler() *Factory {
+	f.dependencyFactory.WithNutanixDefaulter().WithNutanixValidator()
+	f.withTracker().withCNIReconciler().withIPValidator()
+	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
+		if f.nutanixClusterReconciler != nil {
+			return nil
+		}
+
+		f.nutanixClusterReconciler = nutanixreconciler.New(
+			f.manager.GetClient(),
+			f.deps.NutanixValidator,
+			f.deps.NutanixDefaulter,
+			f.cniReconciler,
+			f.tracker,
+			f.ipValidator,
+		)
+		f.registryBuilder.Add(anywherev1.NutanixDatacenterKind, f.nutanixClusterReconciler)
+
+		return nil
+	})
+
+	return f
+}
+
 func (f *Factory) withTracker() *Factory {
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.tracker != nil {
@@ -248,6 +275,7 @@ const (
 	snowProviderName       = "snow"
 	vSphereProviderName    = "vsphere"
 	tinkerbellProviderName = "tinkerbell"
+	nutanixProviderName    = "nutanix"
 )
 
 func (f *Factory) WithProviderClusterReconcilerRegistry(capiProviders []clusterctlv1.Provider) *Factory {
@@ -267,6 +295,8 @@ func (f *Factory) WithProviderClusterReconcilerRegistry(capiProviders []clusterc
 			f.withVSphereClusterReconciler()
 		case tinkerbellProviderName:
 			f.withTinkerbellClusterReconciler()
+		case nutanixProviderName:
+			f.withNutanixClusterReconciler()
 		default:
 			f.logger.Info("Found unknown CAPI provider, ignoring", "providerName", p.ProviderName)
 		}

--- a/controllers/factory_test.go
+++ b/controllers/factory_test.go
@@ -92,6 +92,38 @@ func TestFactoryBuildAllCloudStackReconciler(t *testing.T) {
 	g.Expect(reconcilers.CloudStackDatacenterReconciler).NotTo(BeNil())
 }
 
+func TestFactoryBuildAllNutanixReconciler(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	logger := nullLog()
+	ctrl := gomock.NewController(t)
+	manager := mocks.NewMockManager(ctrl)
+	manager.EXPECT().GetClient().AnyTimes()
+	manager.EXPECT().GetScheme().AnyTimes()
+
+	f := controllers.NewFactory(logger, manager).
+		WithNutanixDatacenterReconciler().
+		WithClusterReconciler([]clusterctlv1.Provider{
+			{
+				Type:         string(clusterctlv1.InfrastructureProviderType),
+				ProviderName: "nutanix",
+			},
+		})
+
+	// testing idempotence
+	f.WithNutanixDatacenterReconciler().
+		WithClusterReconciler([]clusterctlv1.Provider{
+			{
+				Type:         string(clusterctlv1.InfrastructureProviderType),
+				ProviderName: "nutanix",
+			},
+		})
+
+	reconcilers, err := f.Build(ctx)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(reconcilers.NutanixDatacenterReconciler).NotTo(BeNil())
+}
+
 func TestFactoryBuildClusterReconciler(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,8 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v35 v35.3.0
 	github.com/google/uuid v1.3.0
-	github.com/nutanix-cloud-native/prism-go-client v0.3.0
+	github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.1.3
+	github.com/nutanix-cloud-native/prism-go-client v0.3.4
 	github.com/onsi/gomega v1.24.1
 	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/pkg/errors v0.9.1
@@ -60,7 +61,7 @@ require (
 	sigs.k8s.io/cluster-api v1.3.3
 	sigs.k8s.io/cluster-api-provider-cloudstack v0.4.8-rc1
 	sigs.k8s.io/cluster-api-provider-vsphere v1.0.1
-	sigs.k8s.io/cluster-api/test v1.0.0
+	sigs.k8s.io/cluster-api/test v1.3.3
 	sigs.k8s.io/controller-runtime v0.13.1
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -129,6 +130,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -783,6 +783,7 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v1.2.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
@@ -1019,8 +1020,10 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nutanix-cloud-native/prism-go-client v0.3.0 h1:4N6L8qLpEl7Y4jKmhGQNk+fMVYLc9FZCINApfuhrA+4=
-github.com/nutanix-cloud-native/prism-go-client v0.3.0/go.mod h1:mwZsRrdiXVDtz8G1+Z79wbVHIJ41LB44xRN13/HlGPM=
+github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.1.3 h1:BnHg7FgoOcecfaNx/yZU6rYDpbYWRGMWoAz8k1sMUpI=
+github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.1.3/go.mod h1:fxiK+DI0D7Y+bPJOCGvbiUbYmPoiyxgxvJYDDhL1qzo=
+github.com/nutanix-cloud-native/prism-go-client v0.3.4 h1:bHY3VPrHHYnbRtkpGaKK+2ZmvUjNVRC55CYZbXIfnOk=
+github.com/nutanix-cloud-native/prism-go-client v0.3.4/go.mod h1:tTIH02E6o6AWSShr98QChoxuZl+jBhkXFixom9+fd1Y=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -2241,8 +2244,9 @@ sigs.k8s.io/cluster-api-provider-cloudstack v0.4.8-rc1 h1:dTmmeLggoXt4oAlvT+g02p
 sigs.k8s.io/cluster-api-provider-cloudstack v0.4.8-rc1/go.mod h1:b7l5H1Rb5tdpczy3MW/sGP+wM0E9HWdl0obBMxIq0q4=
 sigs.k8s.io/cluster-api-provider-vsphere v1.0.1 h1:qs7zSFkAL9tU8tHob7bmrEWfKsOU5JaskpeSIYrhQCc=
 sigs.k8s.io/cluster-api-provider-vsphere v1.0.1/go.mod h1:Z6MDQcZjX5DUcEFStotBptj2fMR4vgCVPAnw6inIY20=
-sigs.k8s.io/cluster-api/test v1.0.0 h1:PeWOLXtDGYMmzXwGX+NtH7Xxx6BtS83DT7vKzITY5X0=
 sigs.k8s.io/cluster-api/test v1.0.0/go.mod h1:8WQozDv62x2qHkCB1wTUeFjuwawuHKUTh8IMH5hePQs=
+sigs.k8s.io/cluster-api/test v1.3.3 h1:AzX6zWneNOv3umK9PnhON5kjt2MJaw0jvFl39ReWL28=
+sigs.k8s.io/cluster-api/test v1.3.3/go.mod h1:HKkh1O4lALo51GsXVIJ1rQNyLRE+CbEVcA+f/1gU5Rw=
 sigs.k8s.io/controller-runtime v0.5.0/go.mod h1:REiJzC7Y00U+2YkMbT8wxgrsX5USpXKGhb2sCtAXiT8=
 sigs.k8s.io/controller-runtime v0.10.2/go.mod h1:CQp8eyUQZ/Q7PJvnIrB6/hgfTC1kBkGylwsLgOQi1WY=
 sigs.k8s.io/controller-runtime v0.11.1/go.mod h1:KKwLiTooNGu+JmLZGn9Sl3Gjmfj66eMbCQznLP5zcqA=

--- a/manager/main.go
+++ b/manager/main.go
@@ -8,6 +8,7 @@ import (
 	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	etcdv1 "github.com/aws/etcdadm-controller/api/v1beta1"
 	"github.com/go-logr/logr"
+	nutanixv1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 	"github.com/spf13/pflag"
 	tinkerbellv1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/api/v1beta1"
 	rufiov1alpha1 "github.com/tinkerbell/rufio/api/v1alpha1"
@@ -60,6 +61,7 @@ func init() {
 	utilruntime.Must(tinkerbellv1.AddToScheme(scheme))
 	utilruntime.Must(tinkv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(rufiov1alpha1.AddToScheme(scheme))
+	utilruntime.Must(nutanixv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 
@@ -316,6 +318,10 @@ func setupTinkerbellWebhooks(setupLog logr.Logger, mgr ctrl.Manager) {
 func setupNutanixWebhooks(setupLog logr.Logger, mgr ctrl.Manager) {
 	if err := (&anywherev1.NutanixDatacenterConfig{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", WEBHOOK, anywherev1.NutanixDatacenterKind)
+		os.Exit(1)
+	}
+	if err := (&anywherev1.NutanixMachineConfig{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", WEBHOOK, anywherev1.NutanixMachineConfig{})
 		os.Exit(1)
 	}
 }

--- a/manager/main.go
+++ b/manager/main.go
@@ -321,7 +321,7 @@ func setupNutanixWebhooks(setupLog logr.Logger, mgr ctrl.Manager) {
 		os.Exit(1)
 	}
 	if err := (&anywherev1.NutanixMachineConfig{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", WEBHOOK, anywherev1.NutanixMachineConfig{})
+		setupLog.Error(err, "unable to create webhook", WEBHOOK, anywherev1.NutanixMachineConfigKind)
 		os.Exit(1)
 	}
 }

--- a/pkg/api/v1alpha1/nutanixdatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/nutanixdatacenterconfig_types.go
@@ -22,7 +22,7 @@ type NutanixDatacenterConfigSpec struct {
 
 	// Port is the Port of Nutanix Prism Central
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Minimum=9440
+	// +kubebuilder:validation:Default=9440
 	Port int `json:"port"`
 
 	// AdditionalTrustBundle is the optional PEM-encoded certificate bundle for

--- a/pkg/api/v1alpha1/nutanixdatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/nutanixdatacenterconfig_webhook.go
@@ -108,6 +108,11 @@ func validateImmutableFieldsNutanixDatacenterConfig(new, old *NutanixDatacenterC
 	var allErrs field.ErrorList
 	specPath := field.NewPath("spec")
 
+	if old.IsReconcilePaused() {
+		nutanixmachineconfiglog.Info("Reconciliation is paused")
+		return nil
+	}
+
 	if new.Spec.Endpoint != old.Spec.Endpoint {
 		allErrs = append(allErrs, field.Forbidden(specPath.Child("endpoint"), "field is immutable"))
 	}

--- a/pkg/api/v1alpha1/nutanixmachineconfig.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig.go
@@ -191,11 +191,11 @@ func validateNutanixMachineConfig(c *NutanixMachineConfig) error {
 }
 
 func validateMinimumNutanixMachineSpecs(c *NutanixMachineConfig) error {
-	if c.Spec.VCPUSockets <= defaultNutanixVCPUSockets {
+	if c.Spec.VCPUSockets < defaultNutanixVCPUSockets {
 		return fmt.Errorf("NutanixMachineConfig: vcpu sockets must be greater than or equal to %d", defaultNutanixVCPUSockets)
 	}
 
-	if c.Spec.VCPUsPerSocket <= defaultNutanixVCPUsPerSocket {
+	if c.Spec.VCPUsPerSocket < defaultNutanixVCPUsPerSocket {
 		return fmt.Errorf("NutanixMachineConfig: vcpu per socket must be greater than or equal to %d", defaultNutanixVCPUsPerSocket)
 	}
 

--- a/pkg/api/v1alpha1/nutanixmachineconfig.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig.go
@@ -161,3 +161,81 @@ func setNutanixMachineConfigDefaults(machineConfig *NutanixMachineConfig) {
 		machineConfig.Spec.OSFamily = defaultNutanixOSFamily
 	}
 }
+
+func validateNutanixMachineConfig(c *NutanixMachineConfig) error {
+	if err := validateObjectMeta(c.ObjectMeta); err != nil {
+		return fmt.Errorf("NutanixMachineConfig: %v", err)
+	}
+
+	if err := validateNutanixReferences(c); err != nil {
+		return fmt.Errorf("NutanixMachineConfig: %v", err)
+	}
+
+	if err := validateMinimumNutanixMachineSpecs(c); err != nil {
+		return fmt.Errorf("NutanixMachineConfig: %v", err)
+	}
+
+	if c.Spec.OSFamily != Ubuntu {
+		return fmt.Errorf(
+			"NutanixMachineConfig: unsupported spec.osFamily (%v); Please use one of the following: %s",
+			c.Spec.OSFamily,
+			Ubuntu,
+		)
+	}
+
+	if len(c.Spec.Users) <= 0 {
+		return fmt.Errorf("NutanixMachineConfig: missing spec.Users: %s", c.Name)
+	}
+
+	return nil
+}
+
+func validateMinimumNutanixMachineSpecs(c *NutanixMachineConfig) error {
+	if c.Spec.VCPUSockets <= defaultNutanixVCPUSockets {
+		return fmt.Errorf("NutanixMachineConfig: vcpu sockets must be greater than or equal to %d", defaultNutanixVCPUSockets)
+	}
+
+	if c.Spec.VCPUsPerSocket <= defaultNutanixVCPUsPerSocket {
+		return fmt.Errorf("NutanixMachineConfig: vcpu per socket must be greater than or equal to %d", defaultNutanixVCPUsPerSocket)
+	}
+
+	if c.Spec.MemorySize.Cmp(resource.MustParse(defaultNutanixMemorySizeGi)) < 0 {
+		return fmt.Errorf("NutanixMachineConfig: memory size must be greater than or equal to %s", defaultNutanixMemorySizeGi)
+	}
+
+	if c.Spec.SystemDiskSize.Cmp(resource.MustParse(defaultNutanixSystemDiskSizeGi)) < 0 {
+		return fmt.Errorf("NutanixMachineConfig: system disk size must be greater than %s", defaultNutanixSystemDiskSizeGi)
+	}
+
+	return nil
+}
+
+func validateNutanixReferences(c *NutanixMachineConfig) error {
+	if err := validateNutanixResourceReference(&c.Spec.Subnet, "subnet", c.Name); err != nil {
+		return err
+	}
+
+	if err := validateNutanixResourceReference(&c.Spec.Cluster, "cluster", c.Name); err != nil {
+		return err
+	}
+
+	if err := validateNutanixResourceReference(&c.Spec.Image, "image", c.Name); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateNutanixResourceReference(i *NutanixResourceIdentifier, resource string, mcName string) error {
+	if i.Type != NutanixIdentifierName && i.Type != NutanixIdentifierUUID {
+		return fmt.Errorf("NutanixMachineConfig: invalid identifier type for %s: %s", resource, i.Type)
+	}
+
+	if i.Type == NutanixIdentifierName && i.Name == nil {
+		return fmt.Errorf("NutanixMachineConfig: missing %s name: %s", resource, mcName)
+	} else if i.Type == NutanixIdentifierUUID && i.UUID == nil {
+		return fmt.Errorf("NutanixMachineConfig: missing %s UUID: %s", resource, mcName)
+	}
+
+	return nil
+}

--- a/pkg/api/v1alpha1/nutanixmachineconfig_test.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_test.go
@@ -126,6 +126,7 @@ func TestGetNutanixMachineConfigsValidConfig(t *testing.T) {
 				assert.True(t, machineConf.IsEtcd())
 
 				assert.False(t, machineConf.IsManaged())
+				machineConf.Annotations = nil
 				machineConf.SetManagedBy(machineConfName)
 				assert.True(t, machineConf.IsManaged())
 

--- a/pkg/api/v1alpha1/nutanixmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_webhook.go
@@ -1,0 +1,108 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"reflect"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+var nutanixmachineconfiglog = logf.Log.WithName("nutanixmachineconfig-resource")
+
+// SetupWebhookWithManager sets up and registers the webhook with the manager.
+func (in *NutanixMachineConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(in).
+		Complete()
+}
+
+var _ webhook.Validator = &NutanixMachineConfig{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+func (in *NutanixMachineConfig) ValidateCreate() error {
+	nutanixmachineconfiglog.Info("validate create", "name", in.Name)
+
+	if in.IsReconcilePaused() {
+		nutanixmachineconfiglog.Info("NutanixMachineConfig is paused, so allowing create", "name", in.Name)
+		return nil
+	}
+
+	if err := in.Validate(); err != nil {
+		return apierrors.NewInvalid(
+			GroupVersion.WithKind(NutanixMachineConfigKind).GroupKind(),
+			in.Name,
+			field.ErrorList{
+				field.Invalid(field.NewPath("spec"), in.Spec, err.Error()),
+			},
+		)
+	}
+
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (in *NutanixMachineConfig) ValidateUpdate(old runtime.Object) error {
+	nutanixmachineconfiglog.Info("validate update", "name", in.Name)
+
+	oldNutanixMachineConfig, ok := old.(*NutanixMachineConfig)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a NutanixMachineConfig but got a %T", old))
+	}
+
+	if oldNutanixMachineConfig.IsReconcilePaused() {
+		nutanixmachineconfiglog.Info("NutanixMachineConfig is paused, so allowing create", "name", in.Name)
+		return nil
+	}
+
+	var allErrs field.ErrorList
+	allErrs = append(allErrs, validateImmutableFieldsNutantixMachineConfig(in, oldNutanixMachineConfig)...)
+
+	if err := in.Validate(); err != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec"), in.Spec, err.Error()))
+	}
+
+	if len(allErrs) > 0 {
+		return apierrors.NewInvalid(
+			GroupVersion.WithKind(NutanixMachineConfigKind).GroupKind(),
+			in.Name,
+			allErrs,
+		)
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+func (in *NutanixMachineConfig) ValidateDelete() error {
+	nutanixmachineconfiglog.Info("validate delete", "name", in.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil
+}
+
+func validateImmutableFieldsNutantixMachineConfig(new, old *NutanixMachineConfig) field.ErrorList {
+	var allErrs field.ErrorList
+	specPath := field.NewPath("spec")
+	if new.Spec.OSFamily != old.Spec.OSFamily {
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("OSFamily"), "field is immutable"))
+	}
+
+	if !reflect.DeepEqual(new.Spec.Cluster, old.Spec.Cluster) {
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("Cluster"), "field is immutable"))
+	}
+
+	if !reflect.DeepEqual(new.Spec.Subnet, old.Spec.Subnet) {
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("Subnet"), "field is immutable"))
+	}
+
+	if !reflect.DeepEqual(new.Spec.Image, old.Spec.Image) {
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("Image"), "field is immutable"))
+	}
+
+	return allErrs
+}

--- a/pkg/api/v1alpha1/nutanixmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_webhook_test.go
@@ -1,0 +1,253 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/features"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
+)
+
+func nutanixMachineConfig() *v1alpha1.NutanixMachineConfig {
+	return &v1alpha1.NutanixMachineConfig{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-nmc",
+		},
+		Spec: v1alpha1.NutanixMachineConfigSpec{
+			OSFamily:       v1alpha1.Ubuntu,
+			VCPUsPerSocket: 2,
+			VCPUSockets:    4,
+			MemorySize:     resource.MustParse("8Gi"),
+			Image: v1alpha1.NutanixResourceIdentifier{
+				Type: v1alpha1.NutanixIdentifierName,
+				Name: ptr.String("ubuntu-image"),
+			},
+			Cluster: v1alpha1.NutanixResourceIdentifier{
+				Type: v1alpha1.NutanixIdentifierName,
+				Name: ptr.String("cluster-1"),
+			},
+			Subnet: v1alpha1.NutanixResourceIdentifier{
+				Type: v1alpha1.NutanixIdentifierName,
+				Name: ptr.String("subnet-1"),
+			},
+			SystemDiskSize: resource.MustParse("100Gi"),
+			Users: []v1alpha1.UserConfiguration{
+				{
+					Name: "test-user",
+				},
+			},
+		},
+	}
+}
+
+func TestNutanixMachineConfigWebhooksValidateCreateReconcilePaused(t *testing.T) {
+	g := NewWithT(t)
+	conf := nutanixMachineConfig()
+	conf.Annotations = map[string]string{
+		"anywhere.eks.amazonaws.com/paused": "true",
+	}
+	g.Expect(conf.ValidateCreate()).To(Succeed())
+}
+
+func TestValidateCreate_Valid(t *testing.T) {
+	g := NewWithT(t)
+	config := nutanixMachineConfig()
+	g.Expect(config.ValidateCreate()).To(Succeed())
+}
+
+func TestValidateCreate_Invalid(t *testing.T) {
+	g := NewWithT(t)
+	tests := []struct {
+		name string
+		fn   func(*v1alpha1.NutanixMachineConfig)
+	}{
+		{
+			name: "invalid name",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Name = ""
+			},
+		},
+		{
+			name: "invalid os family",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.OSFamily = "invalid"
+			},
+		},
+		{
+			name: "invalid vcpus per socket",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.VCPUsPerSocket = 0
+			},
+		},
+		{
+			name: "invalid vcpus sockets",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.VCPUSockets = 0
+			},
+		},
+		{
+			name: "invalid memory size",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.MemorySize = resource.MustParse("0Gi")
+			},
+		},
+		{
+			name: "invalid image type",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.Image.Type = "invalid"
+			},
+		},
+		{
+			name: "invalid image name",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.Image.Name = nil
+			},
+		},
+		{
+			name: "invalid cluster type",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.Cluster.Type = "invalid"
+			},
+		},
+		{
+			name: "invalid cluster name",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.Cluster.Name = nil
+			},
+		},
+		{
+			name: "invalid subnet type",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.Subnet.Type = "invalid"
+			},
+		},
+		{
+			name: "invalid subnet name",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.Subnet.Name = nil
+			},
+		},
+		{
+			name: "invalid system disk size",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.SystemDiskSize = resource.MustParse("0Gi")
+			},
+		},
+		{
+			name: "no user",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.Users = []v1alpha1.UserConfiguration{}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := nutanixMachineConfig()
+			tt.fn(config)
+			err := config.ValidateCreate()
+			g.Expect(err).To(HaveOccurred(), "expected error for %s", tt.name)
+		})
+	}
+}
+
+func TestNutanixMachineConfigWebhooksValidateUpdateReconcilePaused(t *testing.T) {
+	g := NewWithT(t)
+	oldConfig := nutanixMachineConfig()
+	newConfig := nutanixMachineConfig()
+	oldConfig.Annotations = map[string]string{
+		"anywhere.eks.amazonaws.com/paused": "true",
+	}
+	g.Expect(newConfig.ValidateUpdate(oldConfig)).To(Succeed())
+}
+
+func TestValidateUpdate_Valid(t *testing.T) {
+	g := NewWithT(t)
+	oldConfig := nutanixMachineConfig()
+	newConfig := nutanixMachineConfig()
+	newConfig.Spec.VCPUSockets = 8
+	g.Expect(newConfig.ValidateUpdate(oldConfig)).To(Succeed())
+}
+
+func TestValidateUpdate_Invalid(t *testing.T) {
+	g := NewWithT(t)
+	tests := []struct {
+		name string
+		fn   func(new *v1alpha1.NutanixMachineConfig)
+	}{
+		{
+			name: "different os family",
+			fn: func(new *v1alpha1.NutanixMachineConfig) {
+				new.Spec.OSFamily = v1alpha1.Bottlerocket
+			},
+		},
+		{
+			name: "different cluster",
+			fn: func(new *v1alpha1.NutanixMachineConfig) {
+				new.Spec.Cluster = v1alpha1.NutanixResourceIdentifier{
+					Type: v1alpha1.NutanixIdentifierName,
+					Name: ptr.String("cluster-2"),
+				}
+			},
+		},
+		{
+			name: "different subnet",
+			fn: func(new *v1alpha1.NutanixMachineConfig) {
+				new.Spec.Subnet = v1alpha1.NutanixResourceIdentifier{
+					Type: v1alpha1.NutanixIdentifierName,
+					Name: ptr.String("subnet-2"),
+				}
+			},
+		},
+		{
+			name: "different image",
+			fn: func(new *v1alpha1.NutanixMachineConfig) {
+				new.Spec.Image = v1alpha1.NutanixResourceIdentifier{
+					Type: v1alpha1.NutanixIdentifierName,
+					Name: ptr.String("image-2"),
+				}
+			},
+		},
+		{
+			name: "invalid vcpus per socket",
+			fn: func(new *v1alpha1.NutanixMachineConfig) {
+				new.Spec.VCPUsPerSocket = 0
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldConfig := nutanixMachineConfig()
+			newConfig := nutanixMachineConfig()
+			tt.fn(newConfig)
+			err := newConfig.ValidateUpdate(oldConfig)
+			g.Expect(err).To(HaveOccurred(), "expected error for %s", tt.name)
+		})
+	}
+}
+
+func TestValidateUpdate_OldObjectNotMachineConfig(t *testing.T) {
+	g := NewWithT(t)
+	oldConfig := nutanixDatacenterConfig()
+	newConfig := nutanixMachineConfig()
+	err := newConfig.ValidateUpdate(oldConfig)
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestNutanixMachineConfigSetupWebhookWithManager(t *testing.T) {
+	t.Setenv(features.FullLifecycleAPIEnvVar, "true")
+	g := NewWithT(t)
+	conf := nutanixMachineConfig()
+	g.Expect(conf.SetupWebhookWithManager(env.Manager())).To(Succeed())
+}
+
+func TestNutanixMachineConfigWebhooksValidateDelete(t *testing.T) {
+	g := NewWithT(t)
+	config := nutanixMachineConfig()
+	g.Expect(config.ValidateDelete()).To(Succeed())
+}

--- a/pkg/cluster/build.go
+++ b/pkg/cluster/build.go
@@ -14,6 +14,8 @@ func NewDefaultConfigClientBuilder() *ConfigClientBuilder {
 		getSnowDatacenter,
 		getSnowMachineConfigsAndIPPools,
 		getSnowIdentitySecret,
+		getNutanixDatacenter,
+		getNutanixMachineConfigs,
 		getOIDC,
 		getAWSIam,
 		getGitOps,

--- a/pkg/cluster/nutanix.go
+++ b/pkg/cluster/nutanix.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"context"
+
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
@@ -65,4 +67,43 @@ func processNutanixMachineConfig(c *Config, objects ObjectLookup, machineRef *an
 	}
 
 	c.NutanixMachineConfigs[m.GetName()] = m.(*anywherev1.NutanixMachineConfig)
+}
+
+func getNutanixDatacenter(ctx context.Context, client Client, c *Config) error {
+	if c.Cluster.Spec.DatacenterRef.Kind != anywherev1.NutanixDatacenterKind {
+		return nil
+	}
+
+	datacenter := &anywherev1.NutanixDatacenterConfig{}
+	if err := client.Get(ctx, c.Cluster.Spec.DatacenterRef.Name, c.Cluster.Namespace, datacenter); err != nil {
+		return err
+	}
+
+	c.NutanixDatacenter = datacenter
+	return nil
+}
+
+func getNutanixMachineConfigs(ctx context.Context, client Client, c *Config) error {
+	if c.Cluster.Spec.DatacenterRef.Kind != anywherev1.NutanixDatacenterKind {
+		return nil
+	}
+
+	if c.NutanixMachineConfigs == nil {
+		c.NutanixMachineConfigs = map[string]*anywherev1.NutanixMachineConfig{}
+	}
+
+	for _, machineConfigRef := range c.Cluster.MachineConfigRefs() {
+		if machineConfigRef.Kind != anywherev1.NutanixMachineConfigKind {
+			continue
+		}
+
+		machineConfig := &anywherev1.NutanixMachineConfig{}
+		if err := client.Get(ctx, machineConfigRef.Name, c.Cluster.Namespace, machineConfig); err != nil {
+			return err
+		}
+
+		c.NutanixMachineConfigs[machineConfig.GetName()] = machineConfig
+	}
+
+	return nil
 }

--- a/pkg/cluster/nutanix_test.go
+++ b/pkg/cluster/nutanix_test.go
@@ -1,15 +1,19 @@
 package cluster
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster/mocks"
 )
 
 //go:embed testdata/nutanix/eksa-cluster.yaml
@@ -53,4 +57,43 @@ func TestValidateNutanixEntry(t *testing.T) {
 
 	err = cm.Validate(config)
 	assert.NoError(t, err)
+}
+
+func TestNutanixConfigClientBuilder(t *testing.T) {
+	clusterConf := &anywherev1.Cluster{}
+	err := yaml.Unmarshal([]byte(nutanixClusterConfigSpec), clusterConf)
+	require.NoError(t, err)
+
+	expectedDCConf := &anywherev1.NutanixDatacenterConfig{}
+	err = yaml.Unmarshal([]byte(nutanixDatacenterConfigSpec), expectedDCConf)
+	require.NoError(t, err)
+
+	expectedMachineConf := &anywherev1.NutanixMachineConfig{}
+	err = yaml.Unmarshal([]byte(nutanixMachineConfigSpec), expectedMachineConf)
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	m := mocks.NewMockClient(ctrl)
+
+	m.EXPECT().Get(gomock.Any(), clusterConf.Spec.DatacenterRef.Name, gomock.Any(), &anywherev1.NutanixDatacenterConfig{}).
+		DoAndReturn(func(ctx context.Context, name, namespace string, obj client.Object) error {
+			expectedDCConf.DeepCopyInto(obj.(*anywherev1.NutanixDatacenterConfig))
+			return nil
+		})
+
+	m.EXPECT().Get(gomock.Any(), clusterConf.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, gomock.Any(), &anywherev1.NutanixMachineConfig{}).
+		DoAndReturn(func(ctx context.Context, name, namespace string, obj client.Object) error {
+			expectedMachineConf.DeepCopyInto(obj.(*anywherev1.NutanixMachineConfig))
+			return nil
+		})
+
+	ccb := NewConfigClientBuilder().Register(
+		getNutanixDatacenter,
+		getNutanixMachineConfigs,
+	)
+	conf, err := ccb.Build(context.TODO(), m, clusterConf)
+	assert.NoError(t, err)
+	assert.NotNil(t, conf)
+	assert.Equal(t, expectedDCConf, conf.NutanixDatacenter)
+	assert.Equal(t, expectedMachineConf, conf.NutanixMachineConfig(clusterConf.Spec.ControlPlaneConfiguration.MachineGroupRef.Name))
 }

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -132,7 +132,6 @@ func TestFactoryBuildWithProviderNutanix(t *testing.T) {
 			WithLocalExecutables().
 			WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
 			WithNutanixValidator().
-			WithNutanixDefaulter().
 			Build(context.Background())
 
 		tt.Expect(err).To(BeNil())

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -120,26 +120,6 @@ func TestFactoryBuildWithProviderNutanix(t *testing.T) {
 			name:              "nutanix provider valid config with additional trust bundle",
 			clusterConfigFile: "testdata/nutanix/cluster_nutanix_with_trust_bundle.yaml",
 		},
-		{
-			name:              "nutanix provider valid config with invalid additional trust bundle",
-			clusterConfigFile: "testdata/nutanix/cluster_nutanix_with_invalid_trust_bundle.yaml",
-			expectError:       true,
-		},
-		{
-			name:              "nutanix provider valid config with empty additional trust bundle",
-			clusterConfigFile: "testdata/nutanix/cluster_nutanix_with_empty_trust_bundle.yaml",
-			expectError:       true,
-		},
-		{
-			name:              "nutanix provider missing datacenter config",
-			clusterConfigFile: "testdata/nutanix/cluster_nutanix_without_dc.yaml",
-			expectError:       true,
-		},
-		{
-			name:              "nutanix provider missing machine config",
-			clusterConfigFile: "testdata/nutanix/cluster_nutanix_without_mc.yaml",
-			expectError:       true,
-		},
 	}
 
 	t.Setenv(constants.EksaNutanixUsernameKey, "test")
@@ -151,16 +131,13 @@ func TestFactoryBuildWithProviderNutanix(t *testing.T) {
 		deps, err := dependencies.NewFactory().
 			WithLocalExecutables().
 			WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+			WithNutanixValidator().
+			WithNutanixDefaulter().
 			Build(context.Background())
 
-		if tc.expectError {
-			tt.Expect(err).NotTo(BeNil())
-			tt.Expect(deps).To(BeNil())
-		} else {
-			tt.Expect(err).To(BeNil())
-			tt.Expect(deps.Provider).NotTo(BeNil())
-			tt.Expect(deps.NutanixPrismClient).NotTo(BeNil())
-		}
+		tt.Expect(err).To(BeNil())
+		tt.Expect(deps.Provider).NotTo(BeNil())
+		tt.Expect(deps.NutanixClientCache).NotTo(BeNil())
 	}
 }
 

--- a/pkg/providers/nutanix/clientcache.go
+++ b/pkg/providers/nutanix/clientcache.go
@@ -4,6 +4,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"net"
+	"strconv"
 
 	prismgoclient "github.com/nutanix-cloud-native/prism-go-client"
 	"github.com/nutanix-cloud-native/prism-go-client/environment/credentials"
@@ -45,7 +47,7 @@ func (cb *ClientCache) GetNutanixClient(datacenterConfig *anywherev1.NutanixData
 
 	endpoint := datacenterConfig.Spec.Endpoint
 	port := datacenterConfig.Spec.Port
-	url := fmt.Sprintf("%s:%d", endpoint, port)
+	url := net.JoinHostPort(endpoint, strconv.Itoa(port))
 	nutanixCreds := prismgoclient.Credentials{
 		URL:      url,
 		Username: creds.PrismCentral.Username,

--- a/pkg/providers/nutanix/clientcache.go
+++ b/pkg/providers/nutanix/clientcache.go
@@ -1,0 +1,65 @@
+package nutanix
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	prismgoclient "github.com/nutanix-cloud-native/prism-go-client"
+	"github.com/nutanix-cloud-native/prism-go-client/environment/credentials"
+	v3 "github.com/nutanix-cloud-native/prism-go-client/v3"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+// ClientCache is a map of NutanixDatacenterConfig name to Nutanix client.
+type ClientCache struct {
+	clients map[string]Client
+}
+
+// NewClientCache returns a new ClientCache.
+func NewClientCache() *ClientCache {
+	return &ClientCache{
+		clients: make(map[string]Client),
+	}
+}
+
+// GetNutanixClient returns a Nutanix client for the given NutanixDatacenterConfig.
+func (cb *ClientCache) GetNutanixClient(datacenterConfig *anywherev1.NutanixDatacenterConfig, creds credentials.BasicAuthCredential) (Client, error) {
+	if client, ok := cb.clients[datacenterConfig.Name]; ok {
+		return client, nil
+	}
+
+	clientOpts := make([]v3.ClientOption, 0)
+	if datacenterConfig.Spec.AdditionalTrustBundle != "" {
+		block, _ := pem.Decode([]byte(datacenterConfig.Spec.AdditionalTrustBundle))
+		certs, err := x509.ParseCertificates(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse additional trust bundle %s: %v", datacenterConfig.Spec.AdditionalTrustBundle, err)
+		}
+		if len(certs) == 0 {
+			return nil, fmt.Errorf("unable to extract certs from the addtional trust bundle %s", datacenterConfig.Spec.AdditionalTrustBundle)
+		}
+		clientOpts = append(clientOpts, v3.WithCertificate(certs[0]))
+	}
+
+	endpoint := datacenterConfig.Spec.Endpoint
+	port := datacenterConfig.Spec.Port
+	url := fmt.Sprintf("%s:%d", endpoint, port)
+	nutanixCreds := prismgoclient.Credentials{
+		URL:      url,
+		Username: creds.PrismCentral.Username,
+		Password: creds.PrismCentral.Password,
+		Endpoint: endpoint,
+		Port:     fmt.Sprintf("%d", port),
+		Insecure: datacenterConfig.Spec.Insecure,
+	}
+
+	client, err := v3.NewV3Client(nutanixCreds, clientOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating nutanix client: %v", err)
+	}
+
+	cb.clients[datacenterConfig.Name] = client.V3
+	return client.V3, nil
+}

--- a/pkg/providers/nutanix/clientcache_test.go
+++ b/pkg/providers/nutanix/clientcache_test.go
@@ -1,0 +1,24 @@
+package nutanix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
+)
+
+func TestNewClientCache(t *testing.T) {
+	cc := NewClientCache()
+	dcConf := &anywherev1.NutanixDatacenterConfig{}
+	err := yaml.Unmarshal([]byte(nutanixDatacenterConfigSpecWithTrustBundle), dcConf)
+	require.NoError(t, err)
+	t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+	t.Setenv(constants.EksaNutanixPasswordKey, "password")
+	c, err := cc.GetNutanixClient(dcConf, GetCredsFromEnv())
+	assert.NoError(t, err)
+	assert.NotNil(t, c)
+}

--- a/pkg/providers/nutanix/controlplane.go
+++ b/pkg/providers/nutanix/controlplane.go
@@ -51,17 +51,12 @@ func ControlPlaneSpec(ctx context.Context, logger logr.Logger, client kubernetes
 	ndcs := spec.NutanixDatacenter.Spec
 	machineConfigs := spec.NutanixMachineConfigs
 	controlPlaneMachineSpec, etcdMachineSpec := getControlPlaneMachineSpecs(machineConfigs, &spec.Cluster.Spec.ControlPlaneConfiguration, spec.Cluster.Spec.ExternalEtcdConfiguration)
-
-	wnmcs := make(map[string]v1alpha1.NutanixMachineConfigSpec)
 	for _, machineConfig := range machineConfigs {
 		machineConfig.SetDefaults()
 	}
 
 	creds := GetCredsFromEnv()
-	templateBuilder := NewNutanixTemplateBuilder(&ndcs, controlPlaneMachineSpec, etcdMachineSpec, wnmcs, creds, time.Now)
-	for _, workerNodeGroupConfiguration := range spec.Cluster.Spec.WorkerNodeGroupConfigurations {
-		templateBuilder.workerNodeGroupMachineSpecs[workerNodeGroupConfiguration.MachineGroupRef.Name] = machineConfigs[workerNodeGroupConfiguration.MachineGroupRef.Name].Spec
-	}
+	templateBuilder := NewNutanixTemplateBuilder(&ndcs, controlPlaneMachineSpec, etcdMachineSpec, nil, creds, time.Now)
 
 	controlPlaneYaml, err := generateControlPlaneYAML(templateBuilder, spec)
 	if err != nil {

--- a/pkg/providers/nutanix/controlplane.go
+++ b/pkg/providers/nutanix/controlplane.go
@@ -1,0 +1,145 @@
+package nutanix
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	nutanixv1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	yamlcapi "github.com/aws/eks-anywhere/pkg/clusterapi/yaml"
+	"github.com/aws/eks-anywhere/pkg/yamlutil"
+)
+
+// BaseControlPlane represents a CAPI Nutanix control plane.
+type BaseControlPlane = clusterapi.ControlPlane[*nutanixv1.NutanixCluster, *nutanixv1.NutanixMachineTemplate]
+
+// ControlPlane holds the Nutanix specific objects for a CAPI Nutanix control plane.
+type ControlPlane struct {
+	BaseControlPlane
+}
+
+// Objects returns the control plane objects associated with the Nutanix cluster.
+func (p ControlPlane) Objects() []kubernetes.Object {
+	o := p.BaseControlPlane.Objects()
+	return o
+}
+
+// ControlPlaneBuilder defines the builder for all objects in the CAPI Nutanix control plane.
+type ControlPlaneBuilder struct {
+	BaseBuilder  *yamlcapi.ControlPlaneBuilder[*nutanixv1.NutanixCluster, *nutanixv1.NutanixMachineTemplate]
+	ControlPlane *ControlPlane
+}
+
+// BuildFromParsed implements the base yamlcapi.BuildFromParsed and processes any additional objects for the Nutanix control plane.
+func (b *ControlPlaneBuilder) BuildFromParsed(lookup yamlutil.ObjectLookup) error {
+	if err := b.BaseBuilder.BuildFromParsed(lookup); err != nil {
+		return err
+	}
+
+	b.ControlPlane.BaseControlPlane = *b.BaseBuilder.ControlPlane
+	return nil
+}
+
+// ControlPlaneSpec builds a nutanix ControlPlane definition based on an eks-a cluster spec.
+func ControlPlaneSpec(ctx context.Context, logger logr.Logger, client kubernetes.Client, spec *cluster.Spec) (*ControlPlane, error) {
+	ndcs := spec.NutanixDatacenter.Spec
+	machineConfigs := spec.NutanixMachineConfigs
+	controlPlaneMachineSpec, etcdMachineSpec := getControlPlaneMachineSpecs(machineConfigs, &spec.Cluster.Spec.ControlPlaneConfiguration, spec.Cluster.Spec.ExternalEtcdConfiguration)
+
+	wnmcs := make(map[string]v1alpha1.NutanixMachineConfigSpec)
+	for _, machineConfig := range machineConfigs {
+		machineConfig.SetDefaults()
+	}
+
+	creds := GetCredsFromEnv()
+	templateBuilder := NewNutanixTemplateBuilder(&ndcs, controlPlaneMachineSpec, etcdMachineSpec, wnmcs, creds, time.Now)
+	for _, workerNodeGroupConfiguration := range spec.Cluster.Spec.WorkerNodeGroupConfigurations {
+		templateBuilder.workerNodeGroupMachineSpecs[workerNodeGroupConfiguration.MachineGroupRef.Name] = machineConfigs[workerNodeGroupConfiguration.MachineGroupRef.Name].Spec
+	}
+
+	controlPlaneYaml, err := generateControlPlaneYAML(templateBuilder, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	cp, err := parseControlPlaneYAML(logger, controlPlaneYaml)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cp.UpdateImmutableObjectNames(ctx, client, getMachineTemplate, machineTemplateEquals); err != nil {
+		return nil, err
+	}
+
+	return cp, nil
+}
+
+func getControlPlaneMachineSpecs(machineConfigs map[string]*v1alpha1.NutanixMachineConfig, controlPlaneConfig *v1alpha1.ControlPlaneConfiguration, externalEtcdConfig *v1alpha1.ExternalEtcdConfiguration) (*v1alpha1.NutanixMachineConfigSpec, *v1alpha1.NutanixMachineConfigSpec) {
+	var controlPlaneMachineSpec, etcdMachineSpec *v1alpha1.NutanixMachineConfigSpec
+	if controlPlaneConfig.MachineGroupRef != nil && machineConfigs[controlPlaneConfig.MachineGroupRef.Name] != nil {
+		controlPlaneMachineSpec = &machineConfigs[controlPlaneConfig.MachineGroupRef.Name].Spec
+	}
+
+	if externalEtcdConfig != nil && externalEtcdConfig.MachineGroupRef != nil && machineConfigs[externalEtcdConfig.MachineGroupRef.Name] != nil {
+		etcdMachineSpec = &machineConfigs[externalEtcdConfig.MachineGroupRef.Name].Spec
+	}
+
+	return controlPlaneMachineSpec, etcdMachineSpec
+}
+
+func generateControlPlaneYAML(templateBuilder *TemplateBuilder, spec *cluster.Spec) ([]byte, error) {
+	return templateBuilder.GenerateCAPISpecControlPlane(
+		spec,
+		func(values map[string]interface{}) {
+			values["controlPlaneTemplateName"] = clusterapi.ControlPlaneMachineTemplateName(spec.Cluster)
+			values["etcdTemplateName"] = clusterapi.EtcdMachineTemplateName(spec.Cluster)
+		},
+	)
+}
+
+func parseControlPlaneYAML(logger logr.Logger, controlPlaneYAML []byte) (*ControlPlane, error) {
+	parser, builder, err := newControlPlaneParser(logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := parser.Parse(controlPlaneYAML, builder); err != nil {
+		return nil, err
+	}
+
+	return builder.ControlPlane, nil
+}
+
+func newControlPlaneParser(logger logr.Logger) (*yamlutil.Parser, *ControlPlaneBuilder, error) {
+	parser, baseBuilder, err := yamlcapi.NewControlPlaneParserAndBuilder(
+		logger,
+		yamlutil.NewMapping(
+			"NutanixCluster",
+			func() *nutanixv1.NutanixCluster {
+				return &nutanixv1.NutanixCluster{}
+			},
+		),
+		yamlutil.NewMapping(
+			"NutanixMachineTemplate",
+			func() *nutanixv1.NutanixMachineTemplate {
+				return &nutanixv1.NutanixMachineTemplate{}
+			},
+		),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed building nutanix control plane parser: %w", err)
+	}
+
+	builder := &ControlPlaneBuilder{
+		BaseBuilder:  baseBuilder,
+		ControlPlane: &ControlPlane{},
+	}
+
+	return parser, builder, nil
+}

--- a/pkg/providers/nutanix/controlplane_test.go
+++ b/pkg/providers/nutanix/controlplane_test.go
@@ -1,0 +1,22 @@
+package nutanix
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/constants"
+)
+
+func TestControlPlaneSpec(t *testing.T) {
+	t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+	t.Setenv(constants.EksaNutanixPasswordKey, "password")
+	logger := test.NewNullLogger()
+	client := test.NewFakeKubeClient()
+	spec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
+	cp, err := ControlPlaneSpec(context.TODO(), logger, client, spec)
+	assert.NoError(t, err)
+	assert.NotNil(t, cp)
+}

--- a/pkg/providers/nutanix/reconciler/reconciler.go
+++ b/pkg/providers/nutanix/reconciler/reconciler.go
@@ -1,0 +1,249 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"github.com/nutanix-cloud-native/prism-go-client/environment/credentials"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/controller"
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
+	"github.com/aws/eks-anywhere/pkg/controller/clusters"
+	"github.com/aws/eks-anywhere/pkg/controller/serverside"
+	"github.com/aws/eks-anywhere/pkg/providers/nutanix"
+)
+
+// CNIReconciler is an interface for reconciling CNI in the Tinkerbell cluster reconciler.
+type CNIReconciler interface {
+	Reconcile(ctx context.Context, logger logr.Logger, client client.Client, spec *cluster.Spec) (controller.Result, error)
+}
+
+// RemoteClientRegistry is an interface that defines methods for remote clients.
+type RemoteClientRegistry interface {
+	GetClient(ctx context.Context, cluster client.ObjectKey) (client.Client, error)
+}
+
+// IPValidator is an interface that defines methods to validate the control plane IP.
+type IPValidator interface {
+	ValidateControlPlaneIP(ctx context.Context, log logr.Logger, spec *cluster.Spec) (controller.Result, error)
+}
+
+// Reconciler reconciles a Nutanix cluster.
+type Reconciler struct {
+	client               client.Client
+	validator            *nutanix.Validator
+	defaulter            *nutanix.Defaulter
+	cniReconciler        CNIReconciler
+	remoteClientRegistry RemoteClientRegistry
+	ipValidator          IPValidator
+	*serverside.ObjectApplier
+}
+
+// New defines a new Nutanix reconciler.
+func New(client client.Client, validator *nutanix.Validator, defaulter *nutanix.Defaulter, cniReconciler CNIReconciler, registry RemoteClientRegistry, ipValidator IPValidator) *Reconciler {
+	return &Reconciler{
+		client:               client,
+		validator:            validator,
+		defaulter:            defaulter,
+		cniReconciler:        cniReconciler,
+		remoteClientRegistry: registry,
+		ipValidator:          ipValidator,
+		ObjectApplier:        serverside.NewObjectApplier(client),
+	}
+}
+
+func getSecret(ctx context.Context, kubectl client.Client, secretName, secretNS string) (*apiv1.Secret, error) {
+	secret := &apiv1.Secret{}
+	secretKey := client.ObjectKey{
+		Namespace: secretNS,
+		Name:      secretName,
+	}
+	if err := kubectl.Get(ctx, secretKey, secret); err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
+// GetNutanixCredsFromSecret returns the Nutanix credentials from a secret.
+func GetNutanixCredsFromSecret(ctx context.Context, kubectl client.Client, secretName, secretNS string) (credentials.BasicAuthCredential, error) {
+	secret, err := getSecret(ctx, kubectl, secretName, secretNS)
+	if err != nil {
+		return credentials.BasicAuthCredential{}, fmt.Errorf("failed getting nutanix credentials secret: %v", err)
+	}
+
+	creds, err := credentials.ParseCredentials(secret.Data["credentials"])
+	if err != nil {
+		return credentials.BasicAuthCredential{}, fmt.Errorf("failed parsing nutanix credentials: %v", err)
+	}
+
+	return credentials.BasicAuthCredential{PrismCentral: credentials.PrismCentralBasicAuth{
+		BasicAuth: credentials.BasicAuth{
+			Username: creds.Username,
+			Password: creds.Password,
+		},
+	}}, nil
+}
+
+func (r *Reconciler) reconcileClusterSecret(ctx context.Context, log logr.Logger, c *cluster.Spec) (controller.Result, error) {
+	eksaSecret := &apiv1.Secret{}
+	eksaSecretKey := client.ObjectKey{
+		Namespace: constants.EksaSystemNamespace,
+		Name:      nutanix.EKSASecretName(c),
+	}
+
+	if err := r.client.Get(ctx, eksaSecretKey, eksaSecret); err != nil {
+		log.Error(err, "Failed to get EKS-A secret %s/%s", constants.EksaSystemNamespace, c.NutanixDatacenter.Spec.CredentialRef.Name)
+		return controller.Result{}, err
+	}
+
+	capxSecret := &apiv1.Secret{}
+	capxSecretKey := client.ObjectKey{
+		Namespace: constants.EksaSystemNamespace,
+		Name:      nutanix.CAPXSecretName(c),
+	}
+	if err := r.client.Get(ctx, capxSecretKey, capxSecret); err == nil {
+		if reflect.DeepEqual(eksaSecret.Data, capxSecret.Data) {
+			return controller.Result{}, nil
+		}
+		capxSecret.Data = eksaSecret.Data
+		if err := r.client.Update(ctx, capxSecret); err != nil {
+			log.Error(err, "Failed to update CAPX secret %s/%s", constants.EksaSystemNamespace, c.Cluster.Name)
+			return controller.Result{}, err
+		}
+		return controller.Result{}, nil
+	}
+
+	capxSecret = &apiv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.EksaSystemNamespace,
+			Name:      nutanix.CAPXSecretName(c),
+		},
+		Data: eksaSecret.Data,
+	}
+	if err := r.client.Create(ctx, capxSecret); err != nil {
+		log.Error(err, "Failed to create CAPX secret %s/%s", constants.EksaSystemNamespace, c.Cluster.Name)
+		return controller.Result{}, err
+	}
+
+	return controller.Result{}, nil
+}
+
+// Reconcile reconciles the cluster to the desired state.
+func (r *Reconciler) Reconcile(ctx context.Context, log logr.Logger, c *anywherev1.Cluster) (controller.Result, error) {
+	log = log.WithValues("provider", "nutanix")
+	clusterSpec, err := cluster.BuildSpec(ctx, clientutil.NewKubeClient(r.client), c)
+	if err != nil {
+		return controller.Result{}, err
+	}
+
+	return controller.NewPhaseRunner[*cluster.Spec]().Register(
+		r.reconcileClusterSecret,
+		r.ipValidator.ValidateControlPlaneIP,
+		r.ValidateClusterSpec,
+		clusters.CleanupStatusAfterValidate,
+		r.ReconcileControlPlane,
+		r.CheckControlPlaneReady,
+		r.ReconcileCNI,
+		r.ReconcileWorkers,
+	).Run(ctx, log, clusterSpec)
+}
+
+// ReconcileCNI reconciles the CNI to the desired state.
+func (r *Reconciler) ReconcileCNI(ctx context.Context, log logr.Logger, clusterSpec *cluster.Spec) (controller.Result, error) {
+	log = log.WithValues("phase", "reconcileCNI")
+
+	c, err := r.remoteClientRegistry.GetClient(ctx, controller.CapiClusterObjectKey(clusterSpec.Cluster))
+	if err != nil {
+		return controller.Result{}, err
+	}
+
+	return r.cniReconciler.Reconcile(ctx, log, c, clusterSpec)
+}
+
+// ValidateClusterSpec performs additional, context-aware validations on the cluster spec.
+func (r *Reconciler) ValidateClusterSpec(ctx context.Context, log logr.Logger, clusterSpec *cluster.Spec) (controller.Result, error) {
+	fmt.Println("Validating cluster spec")
+	fmt.Printf("%+v", clusterSpec.Config.Cluster.Spec.DatacenterRef)
+	log = log.WithValues("phase", "validateClusterSpec")
+
+	creds, err := GetNutanixCredsFromSecret(ctx, r.client, clusterSpec.NutanixDatacenter.Spec.CredentialRef.Name, "eksa-system")
+	if err != nil {
+		return controller.Result{}, err
+	}
+
+	if err := r.validator.ValidateClusterSpec(ctx, clusterSpec, creds); err != nil {
+		log.Error(err, "Invalid cluster spec")
+		failureMessage := err.Error()
+		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
+		return controller.ResultWithReturn(), nil
+	}
+
+	return controller.Result{}, nil
+}
+
+// ReconcileControlPlane reconciles the control plane to the desired state.
+func (r *Reconciler) ReconcileControlPlane(ctx context.Context, log logr.Logger, clusterSpec *cluster.Spec) (controller.Result, error) {
+	log = log.WithValues("phase", "reconcileControlPlane")
+
+	cp, err := nutanix.ControlPlaneSpec(ctx, log, clientutil.NewKubeClient(r.client), clusterSpec)
+	if err != nil {
+		return controller.Result{}, err
+	}
+
+	return clusters.ReconcileControlPlane(ctx, r.client, toClientControlPlane(cp))
+}
+
+func toClientControlPlane(cp *nutanix.ControlPlane) *clusters.ControlPlane {
+	return &clusters.ControlPlane{
+		Cluster:                     cp.Cluster,
+		ProviderCluster:             cp.ProviderCluster,
+		KubeadmControlPlane:         cp.KubeadmControlPlane,
+		ControlPlaneMachineTemplate: cp.ControlPlaneMachineTemplate,
+		EtcdCluster:                 cp.EtcdCluster,
+		EtcdMachineTemplate:         cp.EtcdMachineTemplate,
+	}
+}
+
+// ReconcileWorkerNodes reconciles the worker nodes to the desired state.
+func (r *Reconciler) ReconcileWorkerNodes(ctx context.Context, log logr.Logger, eksCluster *anywherev1.Cluster) (controller.Result, error) {
+	log = log.WithValues("provider", "nutanix", "reconcile type", "workers")
+	clusterSpec, err := cluster.BuildSpec(ctx, clientutil.NewKubeClient(r.client), eksCluster)
+	if err != nil {
+		return controller.Result{}, err
+	}
+
+	return controller.NewPhaseRunner[*cluster.Spec]().Register(
+		r.ValidateClusterSpec,
+		r.ReconcileWorkers,
+	).Run(ctx, log, clusterSpec)
+}
+
+// ReconcileWorkers reconciles the workers to the desired state.
+func (r *Reconciler) ReconcileWorkers(ctx context.Context, log logr.Logger, spec *cluster.Spec) (controller.Result, error) {
+	if spec.NutanixDatacenter == nil {
+		return controller.Result{}, nil
+	}
+	log = log.WithValues("phase", "reconcileWorkers")
+	log.Info("Applying worker CAPI objects")
+	w, err := nutanix.WorkersSpec(ctx, log, clientutil.NewKubeClient(r.client), spec)
+	if err != nil {
+		return controller.Result{}, err
+	}
+
+	return clusters.ReconcileWorkersForEKSA(ctx, log, r.client, spec.Cluster, clusters.ToWorkers(w))
+}
+
+// CheckControlPlaneReady checks whether the control plane for an eks-a cluster is ready or not.
+// Requeues with the appropriate wait times whenever the cluster is not ready yet.
+func (r *Reconciler) CheckControlPlaneReady(ctx context.Context, log logr.Logger, clusterSpec *cluster.Spec) (controller.Result, error) {
+	log = log.WithValues("phase", "checkControlPlaneReady")
+	return clusters.CheckControlPlaneReady(ctx, r.client, log, clusterSpec.Cluster)
+}

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -98,20 +98,24 @@ func (ntb *TemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, w
 // GenerateCAPISpecSecret generates the secret containing the credentials for the nutanix prism central and is used by the
 // CAPX controller. The secret is named after the cluster name.
 func (ntb *TemplateBuilder) GenerateCAPISpecSecret(clusterSpec *cluster.Spec, buildOptions ...providers.BuildMapOption) (content []byte, err error) {
-	return ntb.generateSpecSecret(capxSecretName(clusterSpec), ntb.creds, buildOptions...)
+	return ntb.generateSpecSecret(CAPXSecretName(clusterSpec), ntb.creds, buildOptions...)
 }
 
-func capxSecretName(spec *cluster.Spec) string {
+// CAPXSecretName returns the name of the secret containing the credentials for the nutanix prism central and is used by the
+// CAPX controller.
+func CAPXSecretName(spec *cluster.Spec) string {
 	return fmt.Sprintf("capx-%s", spec.Cluster.Name)
 }
 
 // GenerateEKSASpecSecret generates the secret containing the credentials for the nutanix prism central and is used by the
 // EKS-A controller. The secret is named nutanix-credentials.
 func (ntb *TemplateBuilder) GenerateEKSASpecSecret(clusterSpec *cluster.Spec, buildOptions ...providers.BuildMapOption) (content []byte, err error) {
-	return ntb.generateSpecSecret(eksaSecretName(clusterSpec), ntb.creds, buildOptions...)
+	return ntb.generateSpecSecret(EKSASecretName(clusterSpec), ntb.creds, buildOptions...)
 }
 
-func eksaSecretName(spec *cluster.Spec) string {
+// EKSASecretName returns the name of the secret containing the credentials for the nutanix prism central and is used by the
+// EKS-Anywhere controller.
+func EKSASecretName(spec *cluster.Spec) string {
 	return spec.NutanixDatacenter.Spec.CredentialRef.Name
 }
 
@@ -187,7 +191,7 @@ func buildTemplateMapCP(
 		"nutanixPEClusterIDType":       controlPlaneMachineSpec.Cluster.Type,
 		"nutanixPEClusterName":         controlPlaneMachineSpec.Cluster.Name,
 		"nutanixPEClusterUUID":         controlPlaneMachineSpec.Cluster.UUID,
-		"secretName":                   capxSecretName(clusterSpec),
+		"secretName":                   CAPXSecretName(clusterSpec),
 		"subnetIDType":                 controlPlaneMachineSpec.Subnet.Type,
 		"subnetName":                   controlPlaneMachineSpec.Subnet.Name,
 		"subnetUUID":                   controlPlaneMachineSpec.Subnet.UUID,

--- a/pkg/providers/nutanix/testdata/eksa-cluster-multiple-worker-md.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-multiple-worker-md.yaml
@@ -1,0 +1,80 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  kubernetesVersion: "1.19"
+  controlPlaneConfiguration:
+    name: eksa-unit-test
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  workerNodeGroupConfigurations:
+    - count: 4
+      name: eksa-unit-test-0
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: NutanixMachineConfig
+    - count: 4
+      name: eksa-unit-test-1
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: NutanixMachineConfig
+  externalEtcdConfiguration:
+    name: eksa-unit-test
+    count: 3
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  datacenterRef:
+    kind: NutanixDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440
+  credentialRef:
+    name: "nutanix-credentials"
+    kind: Secret
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"

--- a/pkg/providers/nutanix/validator.go
+++ b/pkg/providers/nutanix/validator.go
@@ -45,7 +45,7 @@ func NewValidator(clientCache *ClientCache, certValidator crypto.TlsValidator, h
 
 // ValidateClusterSpec validates the cluster spec.
 func (v *Validator) ValidateClusterSpec(ctx context.Context, spec *cluster.Spec, creds credentials.BasicAuthCredential) error {
-	fmt.Printf("ValidateClusterSpec for Nutanix datacenter %s\n", spec.NutanixDatacenter.Name)
+	logger.Info("ValidateClusterSpec for Nutanix datacenter", spec.NutanixDatacenter.Name)
 	client, err := v.clientCache.GetNutanixClient(spec.NutanixDatacenter, creds)
 	if err != nil {
 		return err

--- a/pkg/providers/nutanix/validator_test.go
+++ b/pkg/providers/nutanix/validator_test.go
@@ -106,7 +106,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 			name: "invalid vcpu sockets",
 			setup: func(machineConf *anywherev1.NutanixMachineConfig, mockClient *mocknutanix.MockClient, validator *mockCrypto.MockTlsValidator, transport *mocknutanix.MockRoundTripper) *Validator {
 				machineConf.Spec.VCPUSockets = 0
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "vCPU sockets 0 must be greater than or equal to 1",
 		},
@@ -114,7 +115,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 			name: "invalid vcpus per socket",
 			setup: func(machineConf *anywherev1.NutanixMachineConfig, mockClient *mocknutanix.MockClient, validator *mockCrypto.MockTlsValidator, transport *mocknutanix.MockRoundTripper) *Validator {
 				machineConf.Spec.VCPUsPerSocket = 0
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "vCPUs per socket 0 must be greater than or equal to 1",
 		},
@@ -122,7 +124,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 			name: "memory size less than min required",
 			setup: func(machineConf *anywherev1.NutanixMachineConfig, mockClient *mocknutanix.MockClient, validator *mockCrypto.MockTlsValidator, transport *mocknutanix.MockRoundTripper) *Validator {
 				machineConf.Spec.MemorySize = resource.MustParse("100Mi")
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "MemorySize must be greater than or equal to 2048Mi",
 		},
@@ -130,7 +133,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 			name: "invalid system size",
 			setup: func(machineConf *anywherev1.NutanixMachineConfig, mockClient *mocknutanix.MockClient, validator *mockCrypto.MockTlsValidator, transport *mocknutanix.MockRoundTripper) *Validator {
 				machineConf.Spec.SystemDiskSize = resource.MustParse("100Mi")
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "SystemDiskSize must be greater than or equal to 20Gi",
 		},
@@ -138,7 +142,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 			name: "empty cluster name",
 			setup: func(machineConf *anywherev1.NutanixMachineConfig, mockClient *mocknutanix.MockClient, validator *mockCrypto.MockTlsValidator, transport *mocknutanix.MockRoundTripper) *Validator {
 				machineConf.Spec.Cluster.Name = nil
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "missing cluster name",
 		},
@@ -147,7 +152,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 			setup: func(machineConf *anywherev1.NutanixMachineConfig, mockClient *mocknutanix.MockClient, validator *mockCrypto.MockTlsValidator, transport *mocknutanix.MockRoundTripper) *Validator {
 				machineConf.Spec.Cluster.Type = anywherev1.NutanixIdentifierUUID
 				machineConf.Spec.Cluster.UUID = nil
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "missing cluster uuid",
 		},
@@ -155,7 +161,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 			name: "invalid cluster identifier type",
 			setup: func(machineConf *anywherev1.NutanixMachineConfig, mockClient *mocknutanix.MockClient, validator *mockCrypto.MockTlsValidator, transport *mocknutanix.MockRoundTripper) *Validator {
 				machineConf.Spec.Cluster.Type = "notanidentifier"
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "invalid cluster identifier type",
 		},
@@ -163,7 +170,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 			name: "list cluster request failed",
 			setup: func(machineConf *anywherev1.NutanixMachineConfig, mockClient *mocknutanix.MockClient, validator *mockCrypto.MockTlsValidator, transport *mocknutanix.MockRoundTripper) *Validator {
 				mockClient.EXPECT().ListCluster(gomock.Any(), gomock.Any()).Return(nil, errors.New("cluster not found"))
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "failed to find cluster by name",
 		},
@@ -171,7 +179,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 			name: "list cluster request did not find match",
 			setup: func(machineConf *anywherev1.NutanixMachineConfig, mockClient *mocknutanix.MockClient, validator *mockCrypto.MockTlsValidator, transport *mocknutanix.MockRoundTripper) *Validator {
 				mockClient.EXPECT().ListCluster(gomock.Any(), gomock.Any()).Return(&v3.ClusterListIntentResponse{}, nil)
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "failed to find cluster by name",
 		},
@@ -181,7 +190,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 				clusters := fakeClusterList()
 				clusters.Entities = append(clusters.Entities, clusters.Entities[0])
 				mockClient.EXPECT().ListCluster(gomock.Any(), gomock.Any()).Return(clusters, nil)
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "found more than one (2) cluster with name",
 		},
@@ -190,7 +200,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 			setup: func(machineConf *anywherev1.NutanixMachineConfig, mockClient *mocknutanix.MockClient, validator *mockCrypto.MockTlsValidator, transport *mocknutanix.MockRoundTripper) *Validator {
 				mockClient.EXPECT().ListCluster(gomock.Any(), gomock.Any()).Return(fakeClusterList(), nil)
 				machineConf.Spec.Subnet.Name = nil
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "missing subnet name",
 		},
@@ -200,7 +211,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 				mockClient.EXPECT().ListCluster(gomock.Any(), gomock.Any()).Return(fakeClusterList(), nil)
 				machineConf.Spec.Subnet.Type = anywherev1.NutanixIdentifierUUID
 				machineConf.Spec.Subnet.UUID = nil
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "missing subnet uuid",
 		},
@@ -209,7 +221,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 			setup: func(machineConf *anywherev1.NutanixMachineConfig, mockClient *mocknutanix.MockClient, validator *mockCrypto.MockTlsValidator, transport *mocknutanix.MockRoundTripper) *Validator {
 				mockClient.EXPECT().ListCluster(gomock.Any(), gomock.Any()).Return(fakeClusterList(), nil)
 				machineConf.Spec.Subnet.Type = "notanidentifier"
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "invalid subnet identifier type",
 		},
@@ -218,7 +231,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 			setup: func(machineConf *anywherev1.NutanixMachineConfig, mockClient *mocknutanix.MockClient, validator *mockCrypto.MockTlsValidator, transport *mocknutanix.MockRoundTripper) *Validator {
 				mockClient.EXPECT().ListCluster(gomock.Any(), gomock.Any()).Return(fakeClusterList(), nil)
 				mockClient.EXPECT().ListSubnet(gomock.Any(), gomock.Any()).Return(nil, errors.New("subnet not found"))
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "failed to find subnet by name",
 		},
@@ -227,7 +241,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 			setup: func(machineConf *anywherev1.NutanixMachineConfig, mockClient *mocknutanix.MockClient, validator *mockCrypto.MockTlsValidator, transport *mocknutanix.MockRoundTripper) *Validator {
 				mockClient.EXPECT().ListCluster(gomock.Any(), gomock.Any()).Return(fakeClusterList(), nil)
 				mockClient.EXPECT().ListSubnet(gomock.Any(), gomock.Any()).Return(&v3.SubnetListIntentResponse{}, nil)
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "failed to find subnet by name",
 		},
@@ -238,7 +253,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 				subnets := fakeSubnetList()
 				subnets.Entities = append(subnets.Entities, subnets.Entities[0])
 				mockClient.EXPECT().ListSubnet(gomock.Any(), gomock.Any()).Return(subnets, nil)
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "found more than one (2) subnet with name",
 		},
@@ -248,7 +264,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 				mockClient.EXPECT().ListCluster(gomock.Any(), gomock.Any()).Return(fakeClusterList(), nil)
 				mockClient.EXPECT().ListSubnet(gomock.Any(), gomock.Any()).Return(fakeSubnetList(), nil)
 				machineConf.Spec.Image.Name = nil
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "missing image name",
 		},
@@ -259,7 +276,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 				mockClient.EXPECT().ListSubnet(gomock.Any(), gomock.Any()).Return(fakeSubnetList(), nil)
 				machineConf.Spec.Image.Type = anywherev1.NutanixIdentifierUUID
 				machineConf.Spec.Image.UUID = nil
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "missing image uuid",
 		},
@@ -269,7 +287,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 				mockClient.EXPECT().ListCluster(gomock.Any(), gomock.Any()).Return(fakeClusterList(), nil)
 				mockClient.EXPECT().ListSubnet(gomock.Any(), gomock.Any()).Return(fakeSubnetList(), nil)
 				machineConf.Spec.Image.Type = "notanidentifier"
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "invalid image identifier type",
 		},
@@ -279,7 +298,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 				mockClient.EXPECT().ListCluster(gomock.Any(), gomock.Any()).Return(fakeClusterList(), nil)
 				mockClient.EXPECT().ListSubnet(gomock.Any(), gomock.Any()).Return(fakeSubnetList(), nil)
 				mockClient.EXPECT().ListImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("image not found"))
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "failed to find image by name",
 		},
@@ -289,7 +309,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 				mockClient.EXPECT().ListCluster(gomock.Any(), gomock.Any()).Return(fakeClusterList(), nil)
 				mockClient.EXPECT().ListSubnet(gomock.Any(), gomock.Any()).Return(fakeSubnetList(), nil)
 				mockClient.EXPECT().ListImage(gomock.Any(), gomock.Any()).Return(&v3.ImageListIntentResponse{}, nil)
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "failed to find image by name",
 		},
@@ -301,7 +322,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 				images := fakeImageList()
 				images.Entities = append(images.Entities, images.Entities[0])
 				mockClient.EXPECT().ListImage(gomock.Any(), gomock.Any()).Return(images, nil)
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "found more than one (2) image with name",
 		},
@@ -319,7 +341,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 				mockClient.EXPECT().ListCluster(gomock.Any(), gomock.Any()).Return(clusters, nil)
 				mockClient.EXPECT().ListSubnet(gomock.Any(), gomock.Any()).Return(fakeSubnetList(), nil)
 				mockClient.EXPECT().ListImage(gomock.Any(), gomock.Any()).Return(fakeImageList(), nil)
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "",
 		},
@@ -333,7 +356,7 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 
 			mockClient := mocknutanix.NewMockClient(ctrl)
 			validator := tc.setup(machineConfig, mockClient, mockCrypto.NewMockTlsValidator(ctrl), mocknutanix.NewMockRoundTripper(ctrl))
-			err = validator.ValidateMachineConfig(context.Background(), machineConfig)
+			err = validator.ValidateMachineConfig(context.Background(), mockClient, machineConfig)
 			if tc.expectedError != "" {
 				assert.Contains(t, err.Error(), tc.expectedError)
 			} else {
@@ -399,7 +422,8 @@ func TestNutanixValidatorValidateDatacenterConfig(t *testing.T) {
 	mockTransport.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{}, nil).AnyTimes()
 
 	mockHTTPClient := &http.Client{Transport: mockTransport}
-	validator := NewValidator(mockClient, mockTLSValidator, mockHTTPClient)
+	clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+	validator := NewValidator(clientCache, mockTLSValidator, mockHTTPClient)
 	require.NotNil(t, validator)
 
 	for _, tc := range tests {
@@ -408,7 +432,7 @@ func TestNutanixValidatorValidateDatacenterConfig(t *testing.T) {
 			err := yaml.Unmarshal([]byte(tc.dcConfFile), dcConf)
 			require.NoError(t, err)
 
-			err = validator.ValidateDatacenterConfig(context.Background(), dcConf)
+			err = validator.ValidateDatacenterConfig(context.Background(), clientCache.clients["test"], dcConf)
 			if tc.expectErr {
 				assert.Error(t, err, tc.name)
 			} else {
@@ -442,7 +466,8 @@ func TestNutanixValidatorValidateDatacenterConfigWithInvalidCreds(t *testing.T) 
 	mockTransport.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{}, nil).AnyTimes()
 
 	mockHTTPClient := &http.Client{Transport: mockTransport}
-	validator := NewValidator(mockClient, mockTLSValidator, mockHTTPClient)
+	clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+	validator := NewValidator(clientCache, mockTLSValidator, mockHTTPClient)
 	require.NotNil(t, validator)
 
 	for _, tc := range tests {
@@ -451,7 +476,7 @@ func TestNutanixValidatorValidateDatacenterConfigWithInvalidCreds(t *testing.T) 
 			err := yaml.Unmarshal([]byte(tc.dcConfFile), dcConf)
 			require.NoError(t, err)
 
-			err = validator.ValidateDatacenterConfig(context.Background(), dcConf)
+			err = validator.ValidateDatacenterConfig(context.Background(), clientCache.clients["test"], dcConf)
 			if tc.expectErr {
 				assert.Error(t, err, tc.name)
 			} else {

--- a/pkg/providers/nutanix/workers.go
+++ b/pkg/providers/nutanix/workers.go
@@ -1,0 +1,136 @@
+package nutanix
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	capiyaml "github.com/aws/eks-anywhere/pkg/clusterapi/yaml"
+	"github.com/aws/eks-anywhere/pkg/providers/common"
+	"github.com/aws/eks-anywhere/pkg/yamlutil"
+)
+
+type (
+	// Workers represents the nutanix specific CAPI spec for worker nodes.
+	Workers        = clusterapi.Workers[*v1beta1.NutanixMachineTemplate]
+	workersBuilder = capiyaml.WorkersBuilder[*v1beta1.NutanixMachineTemplate]
+)
+
+// WorkersSpec generates a nutanix specific CAPI spec for an eks-a cluster worker nodes.
+// It talks to the cluster with a client to detect changes in immutable objects and generates new
+// names for them.
+func WorkersSpec(ctx context.Context, logger logr.Logger, client kubernetes.Client, spec *cluster.Spec) (*Workers, error) {
+	ndcs := spec.NutanixDatacenter.Spec
+	machineConfigs := spec.NutanixMachineConfigs
+	controlPlaneMachineSpec, etcdMachineSpec := getControlPlaneAndEtcdMachineSpecs(spec, machineConfigs)
+
+	wnmcs := make(map[string]v1alpha1.NutanixMachineConfigSpec, len(spec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	for _, machineConfig := range machineConfigs {
+		machineConfig.SetDefaults()
+	}
+
+	creds := GetCredsFromEnv()
+	templateBuilder := NewNutanixTemplateBuilder(&ndcs, controlPlaneMachineSpec, etcdMachineSpec, wnmcs, creds, time.Now)
+
+	workloadTemplateNames, kubeadmconfigTemplateNames := getTemplateNames(spec, templateBuilder, machineConfigs)
+
+	workersYaml, err := templateBuilder.GenerateCAPISpecWorkers(spec, workloadTemplateNames, kubeadmconfigTemplateNames)
+	if err != nil {
+		return nil, err
+	}
+
+	workers, err := parseWorkersYaml(logger, workersYaml)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nutanix CAPI workers yaml: %w", err)
+	}
+
+	if err = workers.UpdateImmutableObjectNames(ctx, client, getMachineTemplate, machineTemplateEquals); err != nil {
+		return nil, fmt.Errorf("updating nutanix worker immutable object names: %w", err)
+	}
+
+	return workers, nil
+}
+
+func getControlPlaneAndEtcdMachineSpecs(spec *cluster.Spec, machineConfigs map[string]*v1alpha1.NutanixMachineConfig) (*v1alpha1.NutanixMachineConfigSpec, *v1alpha1.NutanixMachineConfigSpec) {
+	var controlPlaneMachineSpec, etcdMachineSpec *v1alpha1.NutanixMachineConfigSpec
+
+	if spec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef != nil && machineConfigs[spec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name] != nil {
+		controlPlaneMachineSpec = &machineConfigs[spec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name].Spec
+	}
+
+	if spec.Cluster.Spec.ExternalEtcdConfiguration != nil {
+		if spec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef != nil && machineConfigs[spec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name] != nil {
+			etcdMachineSpec = &machineConfigs[spec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name].Spec
+		}
+	}
+
+	return controlPlaneMachineSpec, etcdMachineSpec
+}
+
+func getTemplateNames(spec *cluster.Spec, templateBuilder *TemplateBuilder, machineConfigs map[string]*v1alpha1.NutanixMachineConfig) (map[string]string, map[string]string) {
+	workloadTemplateNames := make(map[string]string, len(spec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	kubeadmconfigTemplateNames := make(map[string]string, len(spec.Cluster.Spec.WorkerNodeGroupConfigurations))
+
+	for _, workerNodeGroupConfiguration := range spec.Cluster.Spec.WorkerNodeGroupConfigurations {
+		workloadTemplateNames[workerNodeGroupConfiguration.Name] = common.WorkerMachineTemplateName(spec.Cluster.Name, workerNodeGroupConfiguration.Name, templateBuilder.now)
+		kubeadmconfigTemplateNames[workerNodeGroupConfiguration.Name] = common.KubeadmConfigTemplateName(spec.Cluster.Name, workerNodeGroupConfiguration.Name, templateBuilder.now)
+		templateBuilder.workerNodeGroupMachineSpecs[workerNodeGroupConfiguration.MachineGroupRef.Name] = machineConfigs[workerNodeGroupConfiguration.MachineGroupRef.Name].Spec
+	}
+
+	return workloadTemplateNames, kubeadmconfigTemplateNames
+}
+
+func parseWorkersYaml(logger logr.Logger, workersYaml []byte) (*Workers, error) {
+	parser, builder, err := newWorkersParserAndBuilder(logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = parser.Parse(workersYaml, builder); err != nil {
+		return nil, fmt.Errorf("parsing nutanix CAPI workers yaml: %w", err)
+	}
+
+	return builder.Workers, nil
+}
+
+func newWorkersParserAndBuilder(logger logr.Logger) (*yamlutil.Parser, *workersBuilder, error) {
+	parser, builder, err := capiyaml.NewWorkersParserAndBuilder(
+		logger,
+		machineTemplateMapping(),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("building nutanix workers parser and builder: %w", err)
+	}
+
+	return parser, builder, nil
+}
+
+func machineTemplateMapping() yamlutil.Mapping[*v1beta1.NutanixMachineTemplate] {
+	return yamlutil.NewMapping(
+		"NutanixMachineTemplate",
+		func() *v1beta1.NutanixMachineTemplate {
+			return &v1beta1.NutanixMachineTemplate{}
+		},
+	)
+}
+
+func getMachineTemplate(ctx context.Context, client kubernetes.Client, name, namespace string) (*v1beta1.NutanixMachineTemplate, error) {
+	m := &v1beta1.NutanixMachineTemplate{}
+	if err := client.Get(ctx, name, namespace, m); err != nil {
+		return nil, fmt.Errorf("reading nutanixMachineTemplate: %w", err)
+	}
+
+	return m, nil
+}
+
+func machineTemplateEquals(new, old *v1beta1.NutanixMachineTemplate) bool {
+	return equality.Semantic.DeepDerivative(new.Spec, old.Spec)
+}

--- a/pkg/providers/nutanix/workers_test.go
+++ b/pkg/providers/nutanix/workers_test.go
@@ -1,0 +1,24 @@
+package nutanix
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/constants"
+)
+
+func TestWorkersSpec(t *testing.T) {
+	t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+	t.Setenv(constants.EksaNutanixPasswordKey, "password")
+
+	logger := test.NewNullLogger()
+	client := test.NewFakeKubeClient()
+	spec := test.NewFullClusterSpec(t, "testdata/eksa-cluster-multiple-worker-md.yaml")
+	workers, err := WorkersSpec(context.TODO(), logger, client, spec)
+	require.NoError(t, err)
+	assert.Len(t, workers.Groups, 2)
+}


### PR DESCRIPTION
Adds Nutanix cluster reconciler for full cluster lifecycle support

**How is this being tested?**
- Deployed a cluster (based on changes from https://github.com/aws/eks-anywhere/pull/5114)
```
$ bin/eksctl-anywhere create cluster -f ./${CLUSTER_NAME}.yaml --force-cleanup -v 10  --bundles-override ./bundle-release.yaml
```
- Configured tilt to point to the custom image registry and Kubernetes context
```
{
  "default_registry": "public.ecr.aws/g7v6l0u0",
  "allowed_contexts": ["eksa-sid-admin@eksa-sid"]
}
```
- Deploy the updated controller
```
make run-controller
```
- Create a new cluster
```
$ kubectl apply -f workload.yaml

... after a while ...

$ kubectl get clusters -A
NAMESPACE   NAME            AGE
default     eksa-sid        71m
default     eksa-workload   66m

$ kubectl get machines -A
NAMESPACE     NAME                                           CLUSTER         NODENAME                                       PROVIDERID                                       PHASE     AGE     VERSION
eksa-system   eksa-sid-d9l9r                                 eksa-sid        eksa-sid-d9l9r                                 nutanix://ca6d985b-fc76-4421-9e08-ae75e5f41cd7   Running   72m     v1.24.10-eks-1-24-11
eksa-system   eksa-sid-fm5p4                                 eksa-sid        eksa-sid-fm5p4                                 nutanix://849fe9cb-87ae-46f7-b8e8-d680afcbac82   Running   72m     v1.24.10-eks-1-24-11
eksa-system   eksa-sid-md-0-58c74c847c-fczbg                 eksa-sid        eksa-sid-md-0-58c74c847c-fczbg                 nutanix://7b16e2cb-dfa6-4874-a36a-16605c460bbb   Running   72m     v1.24.10-eks-1-24-11
eksa-system   eksa-sid-md-0-58c74c847c-ndljw                 eksa-sid        eksa-sid-md-0-58c74c847c-ndljw                 nutanix://b1293345-ec1d-4625-827b-b9e753871d05   Running   72m     v1.24.10-eks-1-24-11
eksa-system   eksa-sid-md-0-58c74c847c-p7wjb                 eksa-sid        eksa-sid-md-0-58c74c847c-p7wjb                 nutanix://681975ef-7b89-486b-af89-1a16be653a46   Running   72m     v1.24.10-eks-1-24-11
eksa-system   eksa-sid-w26lc                                 eksa-sid        eksa-sid-w26lc                                 nutanix://080a25ef-a7c2-4516-b788-3156f689b4d2   Running   72m     v1.24.10-eks-1-24-11
eksa-system   eksa-workload-5prj7                            eksa-workload   eksa-workload-5prj7                            nutanix://e6f43da6-dca5-4d96-9971-02e05780bc99   Running   26m     v1.24.10-eks-1-24-11
eksa-system   eksa-workload-dh8lw                            eksa-workload   eksa-workload-dh8lw                            nutanix://77ef792d-628d-4280-8ae7-5575ccf6bf12   Running   34m     v1.24.10-eks-1-24-11
eksa-system   eksa-workload-ghjhp                            eksa-workload   eksa-workload-ghjhp                            nutanix://f19b4930-259d-4b0b-a779-f3537b27c196   Running   30m     v1.24.10-eks-1-24-11
eksa-system   eksa-workload-workload-md-0-6b54fc694b-b959d   eksa-workload   eksa-workload-workload-md-0-6b54fc694b-b959d   nutanix://dbeee9b8-badb-4e22-a2b1-4a5f41565f83   Running   8m31s   v1.24.10-eks-1-24-11
eksa-system   eksa-workload-workload-md-0-6b54fc694b-jdrs5   eksa-workload   eksa-workload-workload-md-0-6b54fc694b-jdrs5   nutanix://823ea7d6-e6fa-43c2-a23a-d3028aa9de9d   Running   8m31s   v1.24.10-eks-1-24-11
eksa-system   eksa-workload-workload-md-0-6b54fc694b-sjn9k   eksa-workload   eksa-workload-workload-md-0-6b54fc694b-sjn9k   nutanix://1595232c-f8a4-4a8f-92ed-ff2e23773683   Running   8m31s   v1.24.10-eks-1-24-11
```
- Delete the created cluster using kubectl delete
```
$ kubectl delete cluster eksa-workload
cluster.anywhere.eks.amazonaws.com "eksa-workload" deleted

$ kubectl get clusters -A

NAMESPACE   NAME       AGE
default     eksa-sid   73m

$ kubectl  get machines -A
NAMESPACE     NAME                             CLUSTER    NODENAME                         PROVIDERID                                       PHASE     AGE   VERSION
eksa-system   eksa-sid-d9l9r                   eksa-sid   eksa-sid-d9l9r                   nutanix://ca6d985b-fc76-4421-9e08-ae75e5f41cd7   Running   75m   v1.24.10-eks-1-24-11
eksa-system   eksa-sid-fm5p4                   eksa-sid   eksa-sid-fm5p4                   nutanix://849fe9cb-87ae-46f7-b8e8-d680afcbac82   Running   75m   v1.24.10-eks-1-24-11
eksa-system   eksa-sid-md-0-58c74c847c-fczbg   eksa-sid   eksa-sid-md-0-58c74c847c-fczbg   nutanix://7b16e2cb-dfa6-4874-a36a-16605c460bbb   Running   75m   v1.24.10-eks-1-24-11
eksa-system   eksa-sid-md-0-58c74c847c-ndljw   eksa-sid   eksa-sid-md-0-58c74c847c-ndljw   nutanix://b1293345-ec1d-4625-827b-b9e753871d05   Running   75m   v1.24.10-eks-1-24-11
eksa-system   eksa-sid-md-0-58c74c847c-p7wjb   eksa-sid   eksa-sid-md-0-58c74c847c-p7wjb   nutanix://681975ef-7b89-486b-af89-1a16be653a46   Running   75m   v1.24.10-eks-1-24-11
eksa-system   eksa-sid-w26lc                   eksa-sid   eksa-sid-w26lc                   nutanix://080a25ef-a7c2-4516-b788-3156f689b4d2   Running   75m   v1.24.10-eks-1-24-11
```

- Followed Terraform docs (https://github.com/aws/eks-anywhere/blob/728000b479a7e3bd3ffe41e84145fba1037ac4c5/docs/content/en/docs/tasks/cluster/cluster-terraform.md) and validated it works by updating replicas on control plane as well as creating a new workload cluster using terraform.

![2023-03-08 at 17 38](https://user-images.githubusercontent.com/6081171/225678984-10a8b7ab-3589-46a5-a13d-6b5830f0ae42.png)