### PR TITLE
Fixing metallb e2e test that keeps failing

### DIFF
--- a/test/e2e/metallb.go
+++ b/test/e2e/metallb.go
@@ -57,7 +57,6 @@ func (suite *Suite) TestPackagesMetalLB() {
 	suite.cluster.WithCluster(func(test *framework.ClusterE2ETest) {
 		kcfg := kubeconfig.FromClusterName(test.ClusterName)
 		cluster := suite.cluster.Cluster()
-		test.InstallCuratedPackagesController()
 		ctx := context.Background()
 		namespace := "metallb-system"
 		test.CreateNamespace(namespace)

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1056,30 +1056,6 @@ func (e *ClusterE2ETest) DeleteNamespace(namespace string) {
 	}
 }
 
-func (e *ClusterE2ETest) InstallCuratedPackagesController() {
-	kubeconfig := e.kubeconfigFilePath()
-	// TODO Add a test that installs the controller via the CLI.
-	ctx := context.Background()
-	charts, err := e.PackageConfig.HelmClient.ListCharts(ctx, kubeconfig)
-	if err != nil {
-		e.T.Fatalf("Unable to list charts: %v", err)
-	}
-	installed := false
-	for _, c := range charts {
-		if c == EksaPackagesInstallation {
-			installed = true
-			break
-		}
-	}
-	if !installed {
-		err = e.PackageConfig.HelmClient.InstallChart(ctx, e.PackageConfig.chartName, e.PackageConfig.chartURI, e.PackageConfig.chartVersion, kubeconfig, "eksa-packages", "", e.PackageConfig.chartValues)
-		if err != nil {
-			e.T.Fatalf("Unable to install %s helm chart on the cluster: %v",
-				e.PackageConfig.chartName, err)
-		}
-	}
-}
-
 // SetPackageBundleActive will set the current packagebundle to the active state.
 func (e *ClusterE2ETest) SetPackageBundleActive() {
 	kubeconfig := e.kubeconfigFilePath()


### PR DESCRIPTION
*Description of changes:*

The test was constantly failing due to a duplicate package controller installation, removed the extra call and the function since this was the only place it was actually used.

```
--- PASS: TestDockerCuratedPackagesMetalLB (652.64s)
    --- PASS: TestDockerCuratedPackagesMetalLB/TestPackagesMetalLB (647.85s)
        --- PASS: TestDockerCuratedPackagesMetalLB/TestPackagesMetalLB/Basic_installation (87.66s)
        --- PASS: TestDockerCuratedPackagesMetalLB/TestPackagesMetalLB/Address_pool_configuration (71.54s)
        --- PASS: TestDockerCuratedPackagesMetalLB/TestPackagesMetalLB/BGP_configuration (72.76s)
PASS
```