### PR TITLE
Fixing AssertionsForScaleUpDown currentSpec references

### DIFF
--- a/pkg/providers/tinkerbell/assert_test.go
+++ b/pkg/providers/tinkerbell/assert_test.go
@@ -466,7 +466,6 @@ func TestValidatableClusterWorkerNodeGroupConfigs(t *testing.T) {
 
 	g.Expect(workerConfigs[0].MachineDeploymentName).To(gomega.Equal("cluster-worker-node-group-0"))
 	g.Expect(workerConfigs[0].Replicas).To(gomega.Equal(1))
-	g.Expect(workerConfigs[0].HardwareSelector).To(gomega.Equal(eksav1alpha1.HardwareSelector{"type": "worker"}))
 }
 
 func TestValidatableTinkerbellCAPIControlPlaneReplicaCount(t *testing.T) {
@@ -494,7 +493,6 @@ func TestValidatableTinkerbellCAPIWorkerNodeGroupConfigs(t *testing.T) {
 
 	g.Expect(workerConfigs[0].MachineDeploymentName).To(gomega.Equal("cluster-worker-node-group-0"))
 	g.Expect(workerConfigs[0].Replicas).To(gomega.Equal(1))
-	g.Expect(workerConfigs[0].HardwareSelector).To(gomega.Equal(eksav1alpha1.HardwareSelector{"type": "worker"}))
 }
 
 func TestAssertionsForScaleUpDown_Success(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
AssertionsForScaleUpDown() was calling the current/old spec hardware selector which is not available in the CLI upgrade workflow causing a nil pointer exception in CLI upgrades and E2E tests.

This removes the call for hardware selector and updates AssertionsForScaleUpDown() to use the same desired clusterSpec that was previously being referenced.

*Testing (if applicable):*
Manually ran CLI upgrade workflow with no changes in spec. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

