### PR TITLE
Confirm cancelling when user cancels (Ctrl+C) CLI execution

### DIFF
--- a/cmd/eksctl-anywhere/cmd/root.go
+++ b/cmd/eksctl-anywhere/cmd/root.go
@@ -3,15 +3,19 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/aws/eks-anywhere/pkg/console"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/signals"
 )
 
 var rootCmd = &cobra.Command{
@@ -38,24 +42,48 @@ func init() {
 }
 
 func rootPersistentPreRun(cmd *cobra.Command, args []string) {
-	if err := initLogger(); err != nil {
+	stdout := logger.NewPausableWriter(os.Stdout)
+
+	if err := initLogger(stdout); err != nil {
 		log.Fatal(err)
 	}
+
+	signals.On(func() {
+		resume := stdout.Pause()
+
+		fmt.Println("Warning: Terminating this operation may leave the cluster in an irrecoverable state.")
+		if console.Confirm("Are you sure you want to exit?", os.Stdout, os.Stdin) {
+			os.Exit(-1)
+		}
+
+		if err := resume(); err != nil {
+			// Logging the error may not alert the user because the logger may be borked.
+			// We can't terminate the program so instead we're writing to Stdout so the user is
+			// aware an issue has happened.
+			//
+			// We still log the error as other log sinks may be working.
+			logger.Error(err, "Resuming stdout logging")
+			fmt.Fprintf(os.Stderr, "Failed to resume stdout logging: %s", err)
+		}
+	}, syscall.SIGINT)
 }
 
-func initLogger() error {
+func initLogger(consoleWriter io.Writer) error {
 	logsFolder := filepath.Join(".", "eksa-cli-logs")
 	err := os.MkdirAll(logsFolder, 0o750)
 	if err != nil {
 		return fmt.Errorf("failed to create logs folder: %v", err)
 	}
+	filename := fmt.Sprintf("%s.log", time.Now().Format("2006-01-02T15_04_05"))
+	logFilePath := filepath.Join(".", "eksa-cli-logs", filename)
 
-	outputFilePath := filepath.Join(".", "eksa-cli-logs", fmt.Sprintf("%s.log", time.Now().Format("2006-01-02T15_04_05")))
-	if err = logger.Init(logger.Options{
+	err = logger.Init(logger.Options{
 		Level:          viper.GetInt("verbosity"),
-		OutputFilePath: outputFilePath,
-	}); err != nil {
-		return fmt.Errorf("root cmd: %v", err)
+		OutputFilePath: logFilePath,
+		Console:        consoleWriter,
+	})
+	if err != nil {
+		return fmt.Errorf("root cmd: init zap: %v", err)
 	}
 
 	return nil

--- a/cmd/eksctl-anywhere/main.go
+++ b/cmd/eksctl-anywhere/main.go
@@ -3,22 +3,12 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/aws/eks-anywhere/cmd/eksctl-anywhere/cmd"
 	"github.com/aws/eks-anywhere/pkg/eksctl"
-	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
 func main() {
-	sigChannel := make(chan os.Signal, 1)
-	signal.Notify(sigChannel, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigChannel
-		logger.Info("Warning: Terminating this operation may leave the cluster in an irrecoverable state")
-		os.Exit(-1)
-	}()
 	if eksctl.Enabled() {
 		err := eksctl.ValidateVersion()
 		if err != nil {

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -1,0 +1,23 @@
+package console
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+)
+
+// Confirm prompts the user with question expecting a Y/n response. If the user responds Y, it
+// returns true. All other responses return false.
+func Confirm(question string, out io.Writer, in io.Reader) bool {
+	fmt.Fprintf(out, "%v [Y/n]: ", question)
+	scanner := bufio.NewScanner(in)
+	for {
+		scanner.Scan()
+		if scanner.Err() != nil {
+			fmt.Fprintf(out, "An error occured while reading input, please try again (%v).", scanner.Err())
+			continue
+		}
+
+		return scanner.Text() == "Y"
+	}
+}

--- a/pkg/console/console_test.go
+++ b/pkg/console/console_test.go
@@ -1,0 +1,67 @@
+package console_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/aws/eks-anywhere/pkg/console"
+)
+
+func TestConfirm(t *testing.T) {
+	tests := []struct {
+		Name   string
+		Input  string
+		Result bool
+	}{
+		{
+			Name:   "UpperY",
+			Input:  "Y",
+			Result: true,
+		},
+		{
+			Name:  "LowerY",
+			Input: "y",
+		},
+		{
+			Name:  "UpperN",
+			Input: "y",
+		},
+		{
+			Name:  "WordStartingWithUpperY",
+			Input: "Yellow",
+		},
+		{
+			Name:  "WordStartingWithLowerY",
+			Input: "yellow",
+		},
+		{
+			Name:  "Word",
+			Input: "foobar",
+		},
+		{
+			Name:  "HighUTF8",
+			Input: "√",
+		},
+		{
+			Name:  "WordHighUTF8",
+			Input: "√¥†˙˚œ˚",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			var input, output bytes.Buffer
+
+			input.WriteString(tc.Input)
+
+			result := console.Confirm("My foo bar question?", &output, &input)
+
+			switch {
+			case tc.Result && !result:
+				t.Fatal("Expected true, received false")
+			case !tc.Result && result:
+				t.Fatal("Expected false, but got true")
+			}
+		})
+	}
+}

--- a/pkg/logger/init.go
+++ b/pkg/logger/init.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -43,12 +44,16 @@ func Init(opts Options) error {
 		return err
 	}
 
-	// Build the encoders and logger.
+	// Default to os.Stdout if no writer is provided.
+	if opts.Console == nil {
+		opts.Console = os.Stdout
+	}
 
+	// Build the encoders and logger.
 	fileEncoder := zapcore.NewJSONEncoder(encoderCfg)
 	consoleEncoder := zapcore.NewConsoleEncoder(encoderCfg)
 	core := zapcore.NewTee(
-		zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stdout), logrAtomicLevel(opts.Level)),
+		zapcore.NewCore(consoleEncoder, zapcore.AddSync(opts.Console), logrAtomicLevel(opts.Level)),
 		zapcore.NewCore(fileEncoder, logFile, logrAtomicLevel(MaxLogLevel)),
 	)
 	logger := zap.New(core)
@@ -69,6 +74,9 @@ type Options struct {
 	// OutputFilePath is an absolute file path. The file will be created if it doesn't exist.
 	// All logs available at level 9 will be written to the file.
 	OutputFilePath string
+
+	// Console is a Writer that represents the console. It defaults to os.Stdout.
+	Console io.Writer
 }
 
 // logrAtomicLevel creates a zapcore.AtomicLevel compatible with go-logr.

--- a/pkg/logger/pause.go
+++ b/pkg/logger/pause.go
@@ -1,0 +1,51 @@
+package logger
+
+import (
+	"bytes"
+	"io"
+	"sync"
+)
+
+// PausableWriter facilitates pausing output from the underlying writer and resuming it later.
+// It can be used with Init to control console output from the logger.
+type PausableWriter struct {
+	out io.Writer
+	mtx sync.Mutex
+}
+
+func (w *PausableWriter) Write(p []byte) (int, error) {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+	return w.out.Write(p)
+}
+
+// Pause will pause output to the underlying io.Writer and return a function that resumes output.
+// When resumed, all data received during the pause will be written to the underlying io.Writer.
+func (w *PausableWriter) Pause() func() error {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+
+	original := w.out
+
+	var buffer bytes.Buffer
+	w.out = &buffer
+
+	return func() error {
+		w.mtx.Lock()
+		defer w.mtx.Unlock()
+
+		// Always restore the original writer so we don't continually add to the buffer. This will
+		// ensure that even if we fail to copy buffered content to the original writer, we won't
+		// continue to buffer.
+		defer func() { w.out = original }()
+
+		// Copy the contents of the buffer to the destination before we reset the writer.
+		_, err := io.Copy(original, &buffer)
+		return err
+	}
+}
+
+// NewPausableWriter creates a new PausableWriter that will write to w.
+func NewPausableWriter(w io.Writer) *PausableWriter {
+	return &PausableWriter{out: w}
+}

--- a/pkg/logger/pause_test.go
+++ b/pkg/logger/pause_test.go
@@ -1,0 +1,40 @@
+package logger_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
+)
+
+func TestPausibleWriter(t *testing.T) {
+	var dst bytes.Buffer
+	sink := logger.NewPausableWriter(&dst)
+
+	_, err := sink.Write([]byte("hello"))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if dst.String() != "hello" {
+		t.Fatalf("Expected 'hello', got '%s'", dst.String())
+	}
+
+	resume := sink.Pause()
+
+	_, err = sink.Write([]byte("world"))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if dst.String() != "hello" {
+		t.Fatalf("Expected 'hello', got '%s'", dst.String())
+	}
+
+	err = resume()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if dst.String() != "helloworld" {
+		t.Fatalf("Expected 'helloworld'; got '%s'", dst.String())
+	}
+}

--- a/pkg/signals/signals.go
+++ b/pkg/signals/signals.go
@@ -1,0 +1,34 @@
+package signals
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+)
+
+// On registers a function to be called when one of sigs is received. If no sigs are provided On
+// is a noop. It returns a cancellation func that can be used to unregister the signals. The
+// cancellation func is idempotent.
+func On(fn func(), sigs ...os.Signal) func() {
+	if len(sigs) == 0 {
+		return func() {}
+	}
+
+	receive := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	signal.Notify(receive, sigs...)
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-receive:
+				fn()
+			}
+		}
+	}()
+
+	var once sync.Once
+	return func() { once.Do(func() { close(done) }) }
+}


### PR DESCRIPTION
_Depends on: #5206_

This PR changes the warning currently output when a user `Ctrl`+`C`s into an interactive Q&A asking the user to confirm they really want to cancel. The warning still exists in its original form but is followed by a question. If the user responds with anything other than a capital `Y` the program continues. This ensures the user has a combination keystroke (`Shift`+`Y`) mitigating the risk of entering the wrong thing.

While the question is posed, console logging is redirected to a buffer. If the user chooses to continue logging collected while paused is dumped to the console before resuming normal logging.

```
Warning: Terminating this operation may leave the cluster in an irrecoverable state.
Are you sure you want to exit? [Y/n]: Y
```

The logic is executed on every command as it is instrumented at the top level root cmd at a similar point to the original warning.

It maintains `SIGTERM` handling which models `SIGKILL` behavior. We should improve on this with a separate PR and attempt to perform a graceful shutdown making `SIGKILL` the only way to forcefully terminate a process (this aligns with unix expectations).
