### PR TITLE
adding cleanup phase to tinkerbell reconciler

### DIFF
--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -81,6 +81,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, log logr.Logger, cluster *an
 		r.ValidateHardware,
 		r.ValidateDatacenterConfig,
 		r.ValidateRufioMachines,
+		r.CleanupStatusAfterValidate,
 		r.ReconcileControlPlane,
 		r.CheckControlPlaneReady,
 		r.ReconcileCNI,
@@ -91,6 +92,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, log logr.Logger, cluster *an
 // ValidateControlPlaneIP passes the cluster spec from tinkerbellScope to the IP Validator.
 func (r *Reconciler) ValidateControlPlaneIP(ctx context.Context, log logr.Logger, tinkerbellScope *Scope) (controller.Result, error) {
 	return r.ipValidator.ValidateControlPlaneIP(ctx, log, tinkerbellScope.ClusterSpec)
+}
+
+// CleanupStatusAfterValidate removes errors from the cluster status with the tinkerbellScope.
+func (r *Reconciler) CleanupStatusAfterValidate(ctx context.Context, log logr.Logger, tinkerbellScope *Scope) (controller.Result, error) {
+	return clusters.CleanupStatusAfterValidate(ctx, log, tinkerbellScope.ClusterSpec)
 }
 
 // ValidateClusterSpec performs a set of assertions on a cluster spec.


### PR DESCRIPTION
*Issue #, if available:*
[1207](https://github.com/aws/eks-anywhere-internal/issues/1207)

*Description of changes:*
Calling CleanupStatusAfterValidate to clear Tinkerbell cluster status if validations pass.

*Testing (if applicable):*
existing unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

