### PR TITLE
Add e2e validation for package controller package installation

### DIFF
--- a/test/e2e/curatedpackages.go
+++ b/test/e2e/curatedpackages.go
@@ -21,6 +21,14 @@ import (
 
 func runCuratedPackageInstall(test *framework.ClusterE2ETest) {
 	test.SetPackageBundleActive()
+	err := WaitForPackageToBeInstalled(test, context.Background(), "eks-anywhere-packages", 3*time.Minute)
+	if err != nil {
+		test.T.Fatalf("packages controller not in installed state: %s", err)
+	}
+	err = WaitForPackageToBeInstalled(test, context.Background(), "eks-anywhere-packages-crds", 3*time.Minute)
+	if err != nil {
+		test.T.Fatalf("packages controller crds not in installed state: %s", err)
+	}
 	packageName := "hello-eks-anywhere"
 	packagePrefix := "test"
 	packageFile := test.BuildPackageConfigFile(packageName, packagePrefix, EksaPackagesNamespace)


### PR DESCRIPTION
*Description of changes:*
Test package controller package in regular e2e packages tests

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

