### PR TITLE
Modified error msg check for unit test

### DIFF
--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -283,7 +284,7 @@ func (r *Reconciler) ValidateHardware(ctx context.Context, log logr.Logger, tink
 
 	if err := v.Validate(tinkClusterSpec); err != nil {
 		log.Error(err, "Hardware validation failure")
-		failureMessage := err.Error()
+		failureMessage := fmt.Errorf("hardware validation failure: %v", err).Error()
 		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
 
 		return controller.ResultWithReturn(), nil

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -497,7 +497,7 @@ func TestReconcilerValidateHardwareNoHardware(t *testing.T) {
 
 	tt.Expect(err).To(BeNil(), "error should be nil to prevent requeue")
 	tt.Expect(result).To(Equal(controller.Result{Result: &reconcile.Result{}}), "result should stop reconciliation")
-	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("minimum hardware count not met"))
+	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("hardware validation failure"))
 }
 
 func TestReconcilerValidateRufioMachinesFail(t *testing.T) {

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -497,7 +497,7 @@ func TestReconcilerValidateHardwareNoHardware(t *testing.T) {
 
 	tt.Expect(err).To(BeNil(), "error should be nil to prevent requeue")
 	tt.Expect(result).To(Equal(controller.Result{Result: &reconcile.Result{}}), "result should stop reconciliation")
-	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("minimum hardware count not met for selector '{\"type\":\"cp\"}': have 0, require 1"))
+	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("minimum hardware count not met"))
 }
 
 func TestReconcilerValidateRufioMachinesFail(t *testing.T) {


### PR DESCRIPTION
*Issue #5147*

*Description of changes:*
The unit test `TestReconcilerValidateHardwareNoHardware` is flaky because it checks for an error string and the error string depends on the order of a Map.

https://github.com/aws/eks-anywhere/blob/main/pkg/providers/tinkerbell/validate.go#L136

The requirements object is a map and it swaps its order of objects, so sometimes the worker node condition gets checked first and we are looking for the control plane condition in the unit test error message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

