### PR TITLE
Fix registry mirror e2e for tinkerbell

### DIFF
--- a/internal/test/e2e/registryMirror.go
+++ b/internal/test/e2e/registryMirror.go
@@ -37,6 +37,10 @@ func (e *E2ESession) setupRegistryMirrorEnv(testRegex string) error {
 		endpoint = e.testEnvVars[e2etests.RegistryEndpointTinkerbellVar]
 		port = e.testEnvVars[e2etests.RegistryPortTinkerbellVar]
 		caCert = e.testEnvVars[e2etests.RegistryCACertTinkerbellVar]
+
+		if err := e.mountRegistryCert(caCert, net.JoinHostPort(endpoint, port)); err != nil {
+			return err
+		}
 	}
 
 	// Since Authenticated tests needs to use separate harbor registries.


### PR DESCRIPTION
*Description of changes:*
Fix registry mirror tests to mount proper ca certs for tinkerbell tests

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

