### PR TITLE
Add omitempty to HostOSConfig fields

### DIFF
--- a/pkg/api/v1alpha1/hostosconfig_types.go
+++ b/pkg/api/v1alpha1/hostosconfig_types.go
@@ -5,10 +5,10 @@ import "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 // HostOSConfiguration defines the configuration settings on the host OS.
 type HostOSConfiguration struct {
 	// +optional
-	NTPConfiguration *NTPConfiguration `json:"ntpConfiguration"`
+	NTPConfiguration *NTPConfiguration `json:"ntpConfiguration,omitempty"`
 
 	// +optional
-	BottlerocketConfiguration *BottlerocketConfiguration `json:"bottlerocketConfiguration"`
+	BottlerocketConfiguration *BottlerocketConfiguration `json:"bottlerocketConfiguration,omitempty"`
 }
 
 // NTPConfiguration defines the NTP configuration on the host OS.
@@ -22,5 +22,5 @@ type NTPConfiguration struct {
 type BottlerocketConfiguration struct {
 	// Kubernetes defines the Kubernetes settings on the host OS.
 	// +optional
-	Kubernetes *v1beta1.BottlerocketKubernetesSettings `json:"kubernetes"`
+	Kubernetes *v1beta1.BottlerocketKubernetesSettings `json:"kubernetes,omitempty"`
 }


### PR DESCRIPTION
*Description of changes:*
Add omitempty to HostOSConfig fields as they are optional

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

