### PR TITLE
Introduce --no-timeouts flag in create and upgrade CLI (#5151)

### DIFF
--- a/cmd/eksctl-anywhere/cmd/constants.go
+++ b/cmd/eksctl-anywhere/cmd/constants.go
@@ -8,6 +8,7 @@ const (
 	perMachineWaitTimeoutFlag   = "per-machine-wait-timeout"
 	unhealthyMachineTimeoutFlag = "unhealthy-machine-timeout"
 	nodeStartupTimeoutFlag      = "node-startup-timeout"
+	noTimeoutsFlag              = "no-timeouts"
 )
 
 type Operation int

--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -113,7 +113,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		return err
 	}
 
-	clusterManagerOpts, err := buildClusterManagerOpts(cc.timeoutOptions)
+	clusterManagerTimeoutOpts, err := buildClusterManagerOpts(cc.timeoutOptions)
 	if err != nil {
 		return fmt.Errorf("failed to build cluster manager opts: %v", err)
 	}
@@ -121,7 +121,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 	factory := dependencies.ForSpec(ctx, clusterSpec).WithExecutableMountDirs(dirs...).
 		WithBootstrapper().
 		WithCliConfig(cliConfig).
-		WithClusterManager(clusterSpec.Cluster, clusterManagerOpts...).
+		WithClusterManager(clusterSpec.Cluster, clusterManagerTimeoutOpts).
 		WithProvider(cc.fileName, clusterSpec.Cluster, cc.skipIpCheck, cc.hardwareCSVPath, cc.forceClean, cc.tinkerbellBootstrapIP).
 		WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -93,7 +93,7 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).WithExecutableMountDirs(dirs...).
 		WithBootstrapper().
 		WithCliConfig(cliConfig).
-		WithClusterManager(clusterSpec.Cluster).
+		WithClusterManager(clusterSpec.Cluster, nil).
 		WithProvider(dc.fileName, clusterSpec.Cluster, cc.skipIpCheck, dc.hardwareFileName, false, dc.tinkerbellBootstrapIP).
 		WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().

--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/clustermanager"
 	"github.com/aws/eks-anywhere/pkg/config"
+	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
@@ -28,6 +29,7 @@ type timeoutOptions struct {
 	perMachineWaitTimeout   string
 	unhealthyMachineTimeout string
 	nodeStartupTimeout      string
+	noTimeouts              bool
 }
 
 func applyTimeoutFlags(flagSet *pflag.FlagSet, t *timeoutOptions) {
@@ -45,9 +47,11 @@ func applyTimeoutFlags(flagSet *pflag.FlagSet, t *timeoutOptions) {
 
 	flagSet.StringVar(&t.nodeStartupTimeout, nodeStartupTimeoutFlag, clustermanager.DefaultNodeStartupTimeout.String(), "Override the default node startup timeout (10m) ")
 	markFlagHidden(flagSet, nodeStartupTimeoutFlag)
+
+	flagSet.BoolVar(&t.noTimeouts, noTimeoutsFlag, false, "Disable timeout for all wait operations")
 }
 
-func buildClusterManagerOpts(t timeoutOptions) ([]clustermanager.ClusterManagerOpt, error) {
+func buildClusterManagerOpts(t timeoutOptions) (*dependencies.ClusterManagerTimeoutOptions, error) {
 	cpWaitTimeout, err := time.ParseDuration(t.cpWaitTimeout)
 	if err != nil {
 		return nil, fmt.Errorf(timeoutErrorTemplate, cpWaitTimeoutFlag, err)
@@ -73,12 +77,13 @@ func buildClusterManagerOpts(t timeoutOptions) ([]clustermanager.ClusterManagerO
 		return nil, fmt.Errorf(timeoutErrorTemplate, nodeStartupTimeoutFlag, err)
 	}
 
-	return []clustermanager.ClusterManagerOpt{
-		clustermanager.WithControlPlaneWaitTimeout(cpWaitTimeout),
-		clustermanager.WithExternalEtcdWaitTimeout(externalEtcdWaitTimeout),
-		clustermanager.WithMachineMaxWait(perMachineWaitTimeout),
-		clustermanager.WithUnhealthyMachineTimeout(unhealthyMachineTimeout),
-		clustermanager.WithNodeStartupTimeout(nodeStartupTimeout),
+	return &dependencies.ClusterManagerTimeoutOptions{
+		ControlPlaneWait:     cpWaitTimeout,
+		ExternalEtcdWait:     externalEtcdWaitTimeout,
+		MachineWait:          perMachineWaitTimeout,
+		UnhealthyMachineWait: unhealthyMachineTimeout,
+		NodeStartupWait:      nodeStartupTimeout,
+		NoTimeouts:           t.noTimeouts,
 	}, nil
 }
 

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -91,7 +91,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(cmd *cobra.Command) error {
 		return err
 	}
 
-	clusterManagerOpts, err := buildClusterManagerOpts(uc.timeoutOptions)
+	clusterManagerTimeoutOpts, err := buildClusterManagerOpts(uc.timeoutOptions)
 	if err != nil {
 		return fmt.Errorf("failed to build cluster manager opts: %v", err)
 	}
@@ -99,7 +99,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(cmd *cobra.Command) error {
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).WithExecutableMountDirs(dirs...).
 		WithBootstrapper().
 		WithCliConfig(cliConfig).
-		WithClusterManager(clusterSpec.Cluster, clusterManagerOpts...).
+		WithClusterManager(clusterSpec.Cluster, clusterManagerTimeoutOpts).
 		WithProvider(uc.fileName, clusterSpec.Cluster, cc.skipIpCheck, uc.hardwareCSVPath, uc.forceClean, uc.tinkerbellBootstrapIP).
 		WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().

--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -77,7 +77,7 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 	}
 
 	deps, err := dependencies.ForSpec(ctx, newClusterSpec).
-		WithClusterManager(newClusterSpec.Cluster).
+		WithClusterManager(newClusterSpec.Cluster, nil).
 		WithProvider(uc.fileName, newClusterSpec.Cluster, false, uc.hardwareCSVPath, uc.forceClean, uc.tinkerbellBootstrapIP).
 		WithGitOpsFlux(newClusterSpec.Cluster, newClusterSpec.FluxConfig, nil).
 		WithCAPIManager().

--- a/pkg/clustermanager/client.go
+++ b/pkg/clustermanager/client.go
@@ -28,10 +28,10 @@ func NewClient(clusterClient ClusterClient) *client {
 	return &client{ClusterClient: clusterClient}
 }
 
-func (c *client) waitForDeployments(ctx context.Context, deploymentsByNamespace map[string][]string, cluster *types.Cluster) error {
+func (c *client) waitForDeployments(ctx context.Context, deploymentsByNamespace map[string][]string, cluster *types.Cluster, timeout string) error {
 	for namespace, deployments := range deploymentsByNamespace {
 		for _, deployment := range deployments {
-			err := c.WaitForDeployment(ctx, cluster, deploymentWaitStr, "Available", deployment, namespace)
+			err := c.WaitForDeployment(ctx, cluster, timeout, "Available", deployment, namespace)
 			if err != nil {
 				return fmt.Errorf("waiting for %s in namespace %s: %v", deployment, namespace, err)
 			}

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"reflect"
 	"strings"
 	"time"
@@ -43,13 +44,18 @@ const (
 	defaultBackOffPeriod   = 5 * time.Second
 	machineBackoff         = 1 * time.Second
 	defaultMachinesMinWait = 30 * time.Minute
-	moveCAPIWait           = 15 * time.Minute
+
 	// DefaultMaxWaitPerMachine is the default max time the cluster manager will wait per a machine.
 	DefaultMaxWaitPerMachine = 10 * time.Minute
-	clusterWaitStr           = "60m"
+	// DefaultClusterWait is the default max time the cluster manager will wait for the capi cluster to be in ready state.
+	DefaultClusterWait = 60 * time.Minute
 	// DefaultControlPlaneWait is the default time the cluster manager will wait for the control plane to be ready.
-	DefaultControlPlaneWait   = 60 * time.Minute
-	deploymentWaitStr         = "30m"
+	DefaultControlPlaneWait = 60 * time.Minute
+	// DefaultControlPlaneWaitAfterMove is the default max time the cluster manager will wait for the control plane to be in ready state after the capi move operation.
+	DefaultControlPlaneWaitAfterMove = 15 * time.Minute
+	// DefaultDeploymentWait is the default max time the cluster manager will wait for the deployment to be available.
+	DefaultDeploymentWait = 30 * time.Minute
+
 	controlPlaneInProgressStr = "1m"
 	etcdInProgressStr         = "1m"
 	// DefaultEtcdWait is the default time the cluster manager will wait for ectd to be ready.
@@ -63,20 +69,24 @@ const (
 var eksaClusterResourceType = fmt.Sprintf("clusters.%s", v1alpha1.GroupVersion.Group)
 
 type ClusterManager struct {
-	eksaComponents          EKSAComponents
-	clusterClient           *RetrierClient
-	writer                  filewriter.FileWriter
-	networking              Networking
-	diagnosticsFactory      diagnostics.DiagnosticBundleFactory
-	Retrier                 *retrier.Retrier
-	machineMaxWait          time.Duration
-	machineBackoff          time.Duration
-	machinesMinWait         time.Duration
-	awsIamAuth              AwsIamAuth
-	controlPlaneWaitTimeout time.Duration
-	externalEtcdWaitTimeout time.Duration
-	unhealthyMachineTimeout time.Duration
-	nodeStartupTimeout      time.Duration
+	eksaComponents     EKSAComponents
+	clusterClient      *RetrierClient
+	Retrier            *retrier.Retrier
+	writer             filewriter.FileWriter
+	networking         Networking
+	diagnosticsFactory diagnostics.DiagnosticBundleFactory
+	awsIamAuth         AwsIamAuth
+
+	machineMaxWait                   time.Duration
+	machineBackoff                   time.Duration
+	machinesMinWait                  time.Duration
+	controlPlaneWaitTimeout          time.Duration
+	controlPlaneWaitAfterMoveTimeout time.Duration
+	externalEtcdWaitTimeout          time.Duration
+	unhealthyMachineTimeout          time.Duration
+	nodeStartupTimeout               time.Duration
+	clusterWaitTimeout               time.Duration
+	deploymentWaitTimeout            time.Duration
 }
 
 type ClusterClient interface {
@@ -154,20 +164,23 @@ func DefaultRetrier() *retrier.Retrier {
 // New constructs a new ClusterManager.
 func New(clusterClient *RetrierClient, networking Networking, writer filewriter.FileWriter, diagnosticBundleFactory diagnostics.DiagnosticBundleFactory, awsIamAuth AwsIamAuth, eksaComponents EKSAComponents, opts ...ClusterManagerOpt) *ClusterManager {
 	c := &ClusterManager{
-		eksaComponents:          eksaComponents,
-		clusterClient:           clusterClient,
-		writer:                  writer,
-		networking:              networking,
-		Retrier:                 DefaultRetrier(),
-		diagnosticsFactory:      diagnosticBundleFactory,
-		machineMaxWait:          DefaultMaxWaitPerMachine,
-		machineBackoff:          machineBackoff,
-		machinesMinWait:         defaultMachinesMinWait,
-		awsIamAuth:              awsIamAuth,
-		controlPlaneWaitTimeout: DefaultControlPlaneWait,
-		externalEtcdWaitTimeout: DefaultEtcdWait,
-		unhealthyMachineTimeout: DefaultUnhealthyMachineTimeout,
-		nodeStartupTimeout:      DefaultNodeStartupTimeout,
+		eksaComponents:                   eksaComponents,
+		clusterClient:                    clusterClient,
+		writer:                           writer,
+		networking:                       networking,
+		Retrier:                          DefaultRetrier(),
+		diagnosticsFactory:               diagnosticBundleFactory,
+		machineMaxWait:                   DefaultMaxWaitPerMachine,
+		machineBackoff:                   machineBackoff,
+		machinesMinWait:                  defaultMachinesMinWait,
+		awsIamAuth:                       awsIamAuth,
+		controlPlaneWaitTimeout:          DefaultControlPlaneWait,
+		controlPlaneWaitAfterMoveTimeout: DefaultControlPlaneWaitAfterMove,
+		externalEtcdWaitTimeout:          DefaultEtcdWait,
+		unhealthyMachineTimeout:          DefaultUnhealthyMachineTimeout,
+		nodeStartupTimeout:               DefaultNodeStartupTimeout,
+		clusterWaitTimeout:               DefaultClusterWait,
+		deploymentWaitTimeout:            DefaultDeploymentWait,
 	}
 
 	for _, o := range opts {
@@ -228,6 +241,24 @@ func WithRetrier(retrier *retrier.Retrier) ClusterManagerOpt {
 	}
 }
 
+// WithNoTimeouts disables the timeout for all the waits and retries in cluster manager.
+func WithNoTimeouts() ClusterManagerOpt {
+	return func(c *ClusterManager) {
+		noTimeoutRetrier := retrier.NewWithNoTimeout()
+		maxTime := time.Duration(math.MaxInt64)
+
+		c.Retrier = noTimeoutRetrier
+		c.machineMaxWait = maxTime
+		c.controlPlaneWaitTimeout = maxTime
+		c.controlPlaneWaitAfterMoveTimeout = maxTime
+		c.externalEtcdWaitTimeout = maxTime
+		c.unhealthyMachineTimeout = maxTime
+		c.nodeStartupTimeout = maxTime
+		c.clusterWaitTimeout = maxTime
+		c.deploymentWaitTimeout = maxTime
+	}
+}
+
 func (c *ClusterManager) MoveCAPI(ctx context.Context, from, to *types.Cluster, clusterName string, clusterSpec *cluster.Spec, checkers ...types.NodeReadyChecker) error {
 	logger.V(3).Info("Waiting for management machines to be ready before move")
 	labels := []string{clusterv1.MachineControlPlaneLabelName, clusterv1.MachineDeploymentLabelName}
@@ -236,7 +267,7 @@ func (c *ClusterManager) MoveCAPI(ctx context.Context, from, to *types.Cluster, 
 	}
 
 	logger.V(3).Info("Waiting for all clusters to be ready before move")
-	if err := c.waitForAllClustersReady(ctx, from, clusterWaitStr); err != nil {
+	if err := c.waitForAllClustersReady(ctx, from, c.clusterWaitTimeout.String()); err != nil {
 		return err
 	}
 
@@ -246,7 +277,7 @@ func (c *ClusterManager) MoveCAPI(ctx context.Context, from, to *types.Cluster, 
 	}
 
 	logger.V(3).Info("Waiting for control planes to be ready after move")
-	err = c.waitForAllControlPlanes(ctx, to, moveCAPIWait)
+	err = c.waitForAllControlPlanes(ctx, to, c.controlPlaneWaitAfterMoveTimeout)
 	if err != nil {
 		return err
 	}
@@ -653,19 +684,19 @@ func (c *ClusterManager) InstallCAPI(ctx context.Context, clusterSpec *cluster.S
 }
 
 func (c *ClusterManager) waitForCAPI(ctx context.Context, cluster *types.Cluster, provider providers.Provider, externalEtcdTopology bool) error {
-	err := c.clusterClient.waitForDeployments(ctx, internal.CAPIDeployments, cluster)
+	err := c.clusterClient.waitForDeployments(ctx, internal.CAPIDeployments, cluster, c.deploymentWaitTimeout.String())
 	if err != nil {
 		return err
 	}
 
 	if externalEtcdTopology {
-		err := c.clusterClient.waitForDeployments(ctx, internal.ExternalEtcdDeployments, cluster)
+		err := c.clusterClient.waitForDeployments(ctx, internal.ExternalEtcdDeployments, cluster, c.deploymentWaitTimeout.String())
 		if err != nil {
 			return err
 		}
 	}
 
-	err = c.clusterClient.waitForDeployments(ctx, provider.GetDeployments(), cluster)
+	err = c.clusterClient.waitForDeployments(ctx, provider.GetDeployments(), cluster, c.deploymentWaitTimeout.String())
 	if err != nil {
 		return err
 	}

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -38,6 +39,7 @@ var (
 	eksaVSphereDatacenterResourceType = fmt.Sprintf("vspheredatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaVSphereMachineResourceType    = fmt.Sprintf("vspheremachineconfigs.%s", v1alpha1.GroupVersion.Group)
 	expectedPauseAnnotation           = map[string]string{"anywhere.eks.amazonaws.com/paused": "true"}
+	maxTime                           = time.Duration(math.MaxInt64)
 )
 
 func TestClusterManagerInstallNetworkingSuccess(t *testing.T) {
@@ -132,14 +134,14 @@ func TestClusterManagerCAPIWaitForDeploymentStackedEtcd(t *testing.T) {
 	m.client.EXPECT().InitInfrastructure(ctx, clusterSpecStackedEtcd, clusterObj, m.provider)
 	for namespace, deployments := range internal.CAPIDeployments {
 		for _, deployment := range deployments {
-			m.client.EXPECT().WaitForDeployment(ctx, clusterObj, "30m", "Available", deployment, namespace)
+			m.client.EXPECT().WaitForDeployment(ctx, clusterObj, "30m0s", "Available", deployment, namespace)
 		}
 	}
 	providerDeployments := map[string][]string{}
 	m.provider.EXPECT().GetDeployments().Return(providerDeployments)
 	for namespace, deployments := range providerDeployments {
 		for _, deployment := range deployments {
-			m.client.EXPECT().WaitForDeployment(ctx, clusterObj, "30m", "Available", deployment, namespace)
+			m.client.EXPECT().WaitForDeployment(ctx, clusterObj, "30m0s", "Available", deployment, namespace)
 		}
 	}
 	if err := c.InstallCAPI(ctx, clusterSpecStackedEtcd, clusterObj, m.provider); err != nil {
@@ -157,19 +159,19 @@ func TestClusterManagerCAPIWaitForDeploymentExternalEtcd(t *testing.T) {
 	m.client.EXPECT().InitInfrastructure(ctx, clusterSpecExternalEtcd, clusterObj, m.provider)
 	for namespace, deployments := range internal.CAPIDeployments {
 		for _, deployment := range deployments {
-			m.client.EXPECT().WaitForDeployment(ctx, clusterObj, "30m", "Available", deployment, namespace)
+			m.client.EXPECT().WaitForDeployment(ctx, clusterObj, "30m0s", "Available", deployment, namespace)
 		}
 	}
 	for namespace, deployments := range internal.ExternalEtcdDeployments {
 		for _, deployment := range deployments {
-			m.client.EXPECT().WaitForDeployment(ctx, clusterObj, "30m", "Available", deployment, namespace)
+			m.client.EXPECT().WaitForDeployment(ctx, clusterObj, "30m0s", "Available", deployment, namespace)
 		}
 	}
 	providerDeployments := map[string][]string{}
 	m.provider.EXPECT().GetDeployments().Return(providerDeployments)
 	for namespace, deployments := range providerDeployments {
 		for _, deployment := range deployments {
-			m.client.EXPECT().WaitForDeployment(ctx, clusterObj, "30m", "Available", deployment, namespace)
+			m.client.EXPECT().WaitForDeployment(ctx, clusterObj, "30m0s", "Available", deployment, namespace)
 		}
 	}
 	if err := c.InstallCAPI(ctx, clusterSpecExternalEtcd, clusterObj, m.provider); err != nil {
@@ -520,7 +522,7 @@ func TestClusterManagerUpgradeSelfManagedClusterSuccess(t *testing.T) {
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
 	tt.mocks.client.EXPECT().GetMachineDeployment(tt.ctx, "cluster-name-md-0", gomock.AssignableToTypeOf(executables.WithKubeconfig(mCluster.KubeconfigFile)), gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace))).Return(&mds[0], nil)
 	tt.mocks.client.EXPECT().DeleteOldWorkerNodeGroup(tt.ctx, &mds[0], mCluster.KubeconfigFile)
-	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, wCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, wCluster, "30m0s", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, wCluster.Name).Return(nil)
 	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, wCluster.Name, mCluster.KubeconfigFile).Return(0, 0, nil)
 	tt.mocks.provider.EXPECT().GetDeployments()
@@ -576,7 +578,7 @@ func TestClusterManagerUpgradeSelfManagedClusterWithUnstackedEtcdSuccess(t *test
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
 	tt.mocks.client.EXPECT().GetMachineDeployment(tt.ctx, "cluster-name-md-0", gomock.AssignableToTypeOf(executables.WithKubeconfig(mCluster.KubeconfigFile)), gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace))).Return(&mds[0], nil)
 	tt.mocks.client.EXPECT().DeleteOldWorkerNodeGroup(tt.ctx, &mds[0], mCluster.KubeconfigFile)
-	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, wCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(8)
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, wCluster, "30m0s", "Available", gomock.Any(), gomock.Any()).MaxTimes(8)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, wCluster.Name).Return(nil)
 	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, wCluster.Name, mCluster.KubeconfigFile).Return(0, 0, nil)
 	tt.mocks.provider.EXPECT().GetDeployments()
@@ -632,7 +634,7 @@ func TestClusterManagerUpgradeSelfManagedClusterWithUnstackedEtcdTimeoutNotReady
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
 	tt.mocks.client.EXPECT().GetMachineDeployment(tt.ctx, "cluster-name-md-0", gomock.AssignableToTypeOf(executables.WithKubeconfig(mCluster.KubeconfigFile)), gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace))).Return(&mds[0], nil)
 	tt.mocks.client.EXPECT().DeleteOldWorkerNodeGroup(tt.ctx, &mds[0], mCluster.KubeconfigFile)
-	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, wCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(8)
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, wCluster, "30m0s", "Available", gomock.Any(), gomock.Any()).MaxTimes(8)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, wCluster.Name).Return(nil)
 	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, wCluster.Name, mCluster.KubeconfigFile).Return(0, 0, nil)
 	tt.mocks.provider.EXPECT().GetDeployments()
@@ -743,7 +745,7 @@ func TestClusterManagerUpgradeWorkloadClusterSuccess(t *testing.T) {
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
 	tt.mocks.client.EXPECT().GetMachineDeployment(tt.ctx, "cluster-name-md-0", gomock.AssignableToTypeOf(executables.WithKubeconfig(mCluster.KubeconfigFile)), gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace))).Return(&mds[0], nil)
 	tt.mocks.client.EXPECT().DeleteOldWorkerNodeGroup(tt.ctx, &mds[0], mCluster.KubeconfigFile)
-	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m0s", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, mCluster.Name).Return(nil)
 	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Return(0, 0, nil)
 	tt.mocks.provider.EXPECT().GetDeployments()
@@ -792,7 +794,7 @@ func TestClusterManagerUpgradeWorkloadClusterInstallStorageClassSuccess(t *testi
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
 	tt.mocks.client.EXPECT().GetMachineDeployment(tt.ctx, "cluster-name-md-0", gomock.AssignableToTypeOf(executables.WithKubeconfig(mCluster.KubeconfigFile)), gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace))).Return(&mds[0], nil)
 	tt.mocks.client.EXPECT().DeleteOldWorkerNodeGroup(tt.ctx, &mds[0], mCluster.KubeconfigFile)
-	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m0s", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, mCluster.Name).Return(nil)
 	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Return(0, 0, nil)
 	tt.mocks.provider.EXPECT().GetDeployments()
@@ -847,7 +849,7 @@ func TestClusterManagerUpgradeWorkloadClusterInstallStorageClassError(t *testing
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
 	tt.mocks.client.EXPECT().GetMachineDeployment(tt.ctx, "cluster-name-md-0", gomock.AssignableToTypeOf(executables.WithKubeconfig(mCluster.KubeconfigFile)), gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace))).Return(&mds[0], nil)
 	tt.mocks.client.EXPECT().DeleteOldWorkerNodeGroup(tt.ctx, &mds[0], mCluster.KubeconfigFile)
-	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m0s", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, mCluster.Name).Return(nil)
 	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Return(0, 0, nil)
 	tt.mocks.provider.EXPECT().GetDeployments()
@@ -904,7 +906,7 @@ func TestClusterManagerUpgradeWorkloadClusterAWSIamConfigSuccess(t *testing.T) {
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
 	tt.mocks.client.EXPECT().GetMachineDeployment(tt.ctx, "cluster-name-md-0", gomock.AssignableToTypeOf(executables.WithKubeconfig(mCluster.KubeconfigFile)), gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace))).Return(&mds[0], nil)
 	tt.mocks.client.EXPECT().DeleteOldWorkerNodeGroup(tt.ctx, &mds[0], mCluster.KubeconfigFile)
-	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m0s", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, mCluster.Name).Return(nil)
 	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Return(0, 0, nil)
 	tt.mocks.provider.EXPECT().GetDeployments()
@@ -954,7 +956,7 @@ func TestClusterManagerUpgradeCloudStackWorkloadClusterSuccess(t *testing.T) {
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
 	tt.mocks.client.EXPECT().GetMachineDeployment(tt.ctx, "cluster-name-md-0", gomock.AssignableToTypeOf(executables.WithKubeconfig(mCluster.KubeconfigFile)), gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace))).Return(&mds[0], nil)
 	tt.mocks.client.EXPECT().DeleteOldWorkerNodeGroup(tt.ctx, &mds[0], mCluster.KubeconfigFile)
-	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m0s", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, mCluster.Name).Return(nil)
 	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Return(0, 0, nil)
 	tt.mocks.provider.EXPECT().GetDeployments()
@@ -1003,7 +1005,7 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForMDReadyErrorOnce(t *testing.
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
 	tt.mocks.client.EXPECT().GetMachineDeployment(tt.ctx, "cluster-name-md-0", gomock.AssignableToTypeOf(executables.WithKubeconfig(mCluster.KubeconfigFile)), gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace))).Return(&mds[0], nil)
 	tt.mocks.client.EXPECT().DeleteOldWorkerNodeGroup(tt.ctx, &mds[0], mCluster.KubeconfigFile)
-	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m0s", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, mCluster.Name).Return(nil)
 	// Fail once
 	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Times(1).Return(0, 0, errors.New("error counting MD replicas"))
@@ -1055,7 +1057,7 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForMDReadyUnreadyOnce(t *testin
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
 	tt.mocks.client.EXPECT().GetMachineDeployment(tt.ctx, "cluster-name-md-0", gomock.AssignableToTypeOf(executables.WithKubeconfig(mCluster.KubeconfigFile)), gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace))).Return(&mds[0], nil)
 	tt.mocks.client.EXPECT().DeleteOldWorkerNodeGroup(tt.ctx, &mds[0], mCluster.KubeconfigFile)
-	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m0s", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, mCluster.Name).Return(nil)
 	// Return 0 and 1 for ready and total replicas once
 	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, mCluster.Name, mCluster.KubeconfigFile).Times(1).Return(0, 1, nil)
@@ -1142,7 +1144,7 @@ func TestClusterManagerUpgradeWorkloadClusterGetMachineDeploymentError(t *testin
 	).Return(kcp, nil)
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil)
 	tt.mocks.client.EXPECT().GetMachineDeployment(tt.ctx, "cluster-name-md-0", gomock.AssignableToTypeOf(executables.WithKubeconfig(mCluster.KubeconfigFile)), gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace))).Return(nil, errors.New("get md err"))
-	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m0s", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, mCluster.Name).Return(nil)
 	tt.mocks.writer.EXPECT().Write(mgmtClusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
 	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, mCluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
@@ -1182,7 +1184,7 @@ func TestClusterManagerUpgradeWorkloadClusterRemoveOldWorkerNodeGroupsError(t *t
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil)
 	tt.mocks.client.EXPECT().GetMachineDeployment(tt.ctx, "cluster-name-md-0", gomock.AssignableToTypeOf(executables.WithKubeconfig(mCluster.KubeconfigFile)), gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace))).Return(&mds[0], nil)
 	tt.mocks.client.EXPECT().DeleteOldWorkerNodeGroup(tt.ctx, &mds[0], mCluster.KubeconfigFile).Return(errors.New("delete wng error"))
-	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, mCluster, "30m0s", "Available", gomock.Any(), gomock.Any()).MaxTimes(10)
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, mCluster.Name).Return(nil)
 	tt.mocks.writer.EXPECT().Write(mgmtClusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
 	tt.mocks.client.EXPECT().GetEksaOIDCConfig(tt.ctx, tt.clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, mCluster.KubeconfigFile, tt.clusterSpec.Cluster.Namespace).Return(nil, nil)
@@ -1273,7 +1275,7 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForCAPITimeout(t *testing.T) {
 	tt.mocks.client.EXPECT().GetMachines(tt.ctx, mCluster, mCluster.Name).Return([]types.Machine{}, nil).Times(2)
 	tt.mocks.client.EXPECT().GetMachineDeployment(tt.ctx, "cluster-name-md-0", gomock.AssignableToTypeOf(executables.WithKubeconfig(mCluster.KubeconfigFile)), gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace))).Return(&mds[0], nil)
 	tt.mocks.client.EXPECT().DeleteOldWorkerNodeGroup(tt.ctx, &mds[0], mCluster.KubeconfigFile)
-	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, wCluster, "30m", "Available", gomock.Any(), gomock.Any()).Return(errors.New("time out"))
+	tt.mocks.client.EXPECT().WaitForDeployment(tt.ctx, wCluster, "30m0s", "Available", gomock.Any(), gomock.Any()).Return(errors.New("time out"))
 	tt.mocks.client.EXPECT().ValidateControlPlaneNodes(tt.ctx, mCluster, wCluster.Name).Return(nil)
 	tt.mocks.client.EXPECT().CountMachineDeploymentReplicasReady(tt.ctx, wCluster.Name, mCluster.KubeconfigFile).Return(0, 0, nil)
 	tt.mocks.writer.EXPECT().Write(clusterName+"-eks-a-cluster.yaml", gomock.Any(), gomock.Not(gomock.Nil()))
@@ -1327,7 +1329,7 @@ func TestClusterManagerMoveCAPISuccess(t *testing.T) {
 	).Return(mds, nil)
 	m.client.EXPECT().GetMachines(ctx, from, to.Name)
 	m.client.EXPECT().GetClusters(ctx, from).Return(clustersNotReady, nil)
-	m.client.EXPECT().WaitForClusterReady(ctx, from, "60m", capiClusterName)
+	m.client.EXPECT().WaitForClusterReady(ctx, from, "1h0m0s", capiClusterName)
 	m.client.EXPECT().MoveManagement(ctx, from, to)
 	m.client.EXPECT().GetClusters(ctx, to).Return(clustersReady, nil)
 	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "15m0s", capiClusterName)
@@ -1453,7 +1455,7 @@ func TestClusterManagerMoveCAPIErrorWaitForClusterReady(t *testing.T) {
 	capiClusterName := "capi-cluster"
 	clusters := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}}}
 	m.client.EXPECT().GetClusters(ctx, from).Return(clusters, nil)
-	m.client.EXPECT().WaitForClusterReady(ctx, from, "60m", capiClusterName).Return(errors.New("error waitinf for cluster to be ready"))
+	m.client.EXPECT().WaitForClusterReady(ctx, from, "1h0m0s", capiClusterName).Return(errors.New("error waitinf for cluster to be ready"))
 
 	if err := c.MoveCAPI(ctx, from, to, from.Name, clusterSpec); err == nil {
 		t.Error("ClusterManager.MoveCAPI() error = nil, wantErr not nil")
@@ -1764,6 +1766,15 @@ func TestInstallMachineHealthChecksWithTimeoutOverride(t *testing.T) {
 	if err := tt.clusterManager.InstallMachineHealthChecks(ctx, tt.clusterSpec, tt.cluster); err != nil {
 		t.Errorf("ClusterManager.InstallMachineHealthChecks() error = %v, wantErr nil", err)
 	}
+}
+
+func TestInstallMachineHealthChecksWithNoTimeout(t *testing.T) {
+	tt := newTest(t, clustermanager.WithNoTimeouts())
+	tt.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Name = "worker-1"
+	wantMHC := expectedMachineHealthCheck(maxTime, maxTime)
+	tt.mocks.client.EXPECT().ApplyKubeSpecFromBytes(tt.ctx, tt.cluster, wantMHC)
+
+	tt.Expect(tt.clusterManager.InstallMachineHealthChecks(tt.ctx, tt.clusterSpec, tt.cluster)).To(Succeed())
 }
 
 func TestInstallMachineHealthChecksApplyError(t *testing.T) {

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -51,6 +51,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers/validator"
 	"github.com/aws/eks-anywhere/pkg/providers/vsphere"
 	"github.com/aws/eks-anywhere/pkg/registrymirror"
+	"github.com/aws/eks-anywhere/pkg/retrier"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/version"
 	"github.com/aws/eks-anywhere/pkg/workflow/task/workload"
@@ -824,7 +825,43 @@ type clusterManagerClient struct {
 	*executables.Kubectl
 }
 
-func (f *Factory) WithClusterManager(clusterConfig *v1alpha1.Cluster, opts ...clustermanager.ClusterManagerOpt) *Factory {
+// ClusterManagerTimeoutOptions maintains the timeout options for cluster manager.
+type ClusterManagerTimeoutOptions struct {
+	NoTimeouts bool
+
+	ControlPlaneWait, ExternalEtcdWait, MachineWait, UnhealthyMachineWait, NodeStartupWait time.Duration
+}
+
+func eksaInstallerOpts(timeoutOpts *ClusterManagerTimeoutOptions) []clustermanager.EKSAInstallerOpt {
+	if timeoutOpts == nil || !timeoutOpts.NoTimeouts {
+		return nil
+	}
+
+	return []clustermanager.EKSAInstallerOpt{clustermanager.WithEKSAInstallerNoTimeouts()}
+}
+
+func clusterManagerOpts(timeoutOpts *ClusterManagerTimeoutOptions) []clustermanager.ClusterManagerOpt {
+	if timeoutOpts == nil {
+		return nil
+	}
+
+	o := []clustermanager.ClusterManagerOpt{
+		clustermanager.WithControlPlaneWaitTimeout(timeoutOpts.ControlPlaneWait),
+		clustermanager.WithExternalEtcdWaitTimeout(timeoutOpts.ExternalEtcdWait),
+		clustermanager.WithMachineMaxWait(timeoutOpts.MachineWait),
+		clustermanager.WithUnhealthyMachineTimeout(timeoutOpts.UnhealthyMachineWait),
+		clustermanager.WithNodeStartupTimeout(timeoutOpts.NodeStartupWait),
+	}
+
+	if timeoutOpts.NoTimeouts {
+		o = append(o, clustermanager.WithNoTimeouts())
+	}
+
+	return o
+}
+
+// WithClusterManager builds a cluster manager based on the cluster config and timeout options.
+func (f *Factory) WithClusterManager(clusterConfig *v1alpha1.Cluster, timeoutOpts *ClusterManagerTimeoutOptions) *Factory {
 	f.WithClusterctl().WithKubectl().WithNetworking(clusterConfig).WithWriter().WithDiagnosticBundleFactory().WithAwsIamAuth()
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
@@ -832,14 +869,22 @@ func (f *Factory) WithClusterManager(clusterConfig *v1alpha1.Cluster, opts ...cl
 			return nil
 		}
 
+		var r *retrier.Retrier
+		if timeoutOpts != nil && timeoutOpts.NoTimeouts {
+			r = retrier.NewWithNoTimeout()
+		} else {
+			r = clustermanager.DefaultRetrier()
+		}
+
 		client := clustermanager.NewRetrierClient(
 			&clusterManagerClient{
 				f.dependencies.Clusterctl,
 				f.dependencies.Kubectl,
 			},
-			clustermanager.DefaultRetrier(),
+			r,
 		)
-		installer := clustermanager.NewEKSAInstaller(client)
+
+		installer := clustermanager.NewEKSAInstaller(client, eksaInstallerOpts(timeoutOpts)...)
 
 		f.dependencies.ClusterManager = clustermanager.New(
 			client,
@@ -848,7 +893,7 @@ func (f *Factory) WithClusterManager(clusterConfig *v1alpha1.Cluster, opts ...cl
 			f.dependencies.DignosticCollectorFactory,
 			f.dependencies.AwsIamAuth,
 			installer,
-			opts...,
+			clusterManagerOpts(timeoutOpts)...,
 		)
 		return nil
 	})

--- a/pkg/retrier/retrier.go
+++ b/pkg/retrier/retrier.go
@@ -40,6 +40,11 @@ func NewWithMaxRetries(maxRetries int, backOffPeriod time.Duration) *Retrier {
 	return New(time.Duration(math.MaxInt64), WithMaxRetries(maxRetries, backOffPeriod))
 }
 
+// NewWithNoTimeout creates a new retrier with no global timeout and infinite retries.
+func NewWithNoTimeout() *Retrier {
+	return New(time.Duration(math.MaxInt64))
+}
+
 // WithMaxRetries sets a retry policy that will retry up to maxRetries times
 // with a wait time between retries of backOffPeriod.
 func WithMaxRetries(maxRetries int, backOffPeriod time.Duration) RetrierOpt {

--- a/pkg/retrier/retrier_test.go
+++ b/pkg/retrier/retrier_test.go
@@ -51,6 +51,18 @@ func TestNewWithMaxRetriesSuccessAfterRetries(t *testing.T) {
 	}
 }
 
+func TestNewWithNoTimeout(t *testing.T) {
+	r := retrier.NewWithNoTimeout()
+	fn := func() error {
+		return nil
+	}
+
+	err := r.Retry(fn)
+	if err != nil {
+		t.Fatalf("Retrier.Retry() error = %v, want nil", err)
+	}
+}
+
 func TestRetry(t *testing.T) {
 	wantRetries := 5
 	gotRetries := 0


### PR DESCRIPTION
*Issue #, if available:*

Backport #5151 

*Description of changes:*

*Testing (if applicable):*

Manual testing on docker provider w create/upgrade --no-timeouts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

