### PR TITLE
Cleanup registry mirror artifacts after the tests for Tinkerbell

### DIFF
--- a/test/e2e/registrymirror.go
+++ b/test/e2e/registrymirror.go
@@ -29,4 +29,5 @@ func runTinkerbellRegistryMirrorFlow(test *framework.ClusterE2ETest) {
 	test.StopIfFailed()
 	test.DeleteCluster()
 	test.ValidateHardwareDecommissioned()
+	test.CleanupDownloadedArtifactsAndImages()
 }

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -636,6 +636,12 @@ func (e *ClusterE2ETest) ExtractDownloadedArtifacts(opts ...CommandOpt) {
 	e.Run("tar", "-xf", defaultDownloadArtifactsOutputLocation)
 }
 
+// CleanupDownloadedArtifactsAndImages cleans up the downloaded artifacts and images.
+func (e *ClusterE2ETest) CleanupDownloadedArtifactsAndImages(opts ...CommandOpt) {
+	e.T.Log("Cleaning up downloaded artifacts and images")
+	e.Run("rm", "-rf", defaultDownloadArtifactsOutputLocation, defaultDownloadImagesOutputLocation)
+}
+
 // DownloadImages runs the EKS-A `download images` command with appropriate args.
 func (e *ClusterE2ETest) DownloadImages(opts ...CommandOpt) {
 	downloadImagesArgs := []string{"download", "images", "-o", defaultDownloadImagesOutputLocation}


### PR DESCRIPTION
*Description of changes:*
Add a cleanup step in tinkerbell registry mirror tests to cleanup the downloaded artifacts after the tests complete.
This is needed so the next set of tests don't run out of disk space.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

