### PR TITLE
Update go-lint version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.0
+          version: v1.51.2
           only-new-issues: true
           # Disable package caching to avoid a double cache with setup-go.
           skip-pkg-cache: true


### PR DESCRIPTION
This version works on mac with 1.20. The old version OOMs.

