### PR TITLE
docs: Clarify caCertContent documentation

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/optional/registrymirror.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/registrymirror.md
@@ -43,7 +43,8 @@ spec:
 * __Example__: ```port: 443```
 ### __caCertContent__ (optional)
 * __Description__: Certificate Authority (CA) Certificate for the private registry . When using 
-  self-signed certificates it is necessary to pass this parameter in the cluster spec.<br/>
+  self-signed certificates it is necessary to pass this parameter in the cluster spec. This __must__ be the individual public CA cert used to sign the registry certificate. This will be added to the cluster nodes so that they are able to pull images from the private registry.
+
   It is also possible to configure CACertContent by exporting an environment variable:<br/>
   `export EKSA_REGISTRY_MIRROR_CA="/path/to/certificate-file"`
 * __Type__: string


### PR DESCRIPTION
The registry mirror caCertContent __must__ be a singular ca cert, and it must be the cert used to sign the registry mirror cert.

*Issue #, if available:*

*Description of changes:*
Updating the registry mirror documentation about ca cert usage.

*Testing (if applicable):*
Markdown preview

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

