### PR TITLE
Remove hard coded Tinkerbell provider version

### DIFF
--- a/release/pkg/bundles/tinkerbell.go
+++ b/release/pkg/bundles/tinkerbell.go
@@ -119,10 +119,6 @@ func GetTinkerbellBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]
 		return anywherev1alpha1.TinkerbellBundle{}, errors.Wrapf(err, "Error getting version for cluster-api-provider-tinkerbell")
 	}
 
-	// TODO: remove these 2 lines when CAPT releases a new git tag
-	_ = version
-	version = "v0.1.0"
-
 	bundle := anywherev1alpha1.TinkerbellBundle{
 		Version:              version,
 		ClusterAPIController: bundleImageArtifacts["cluster-api-provider-tinkerbell"],

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -348,7 +348,7 @@ spec:
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.6/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -357,7 +357,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc5-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -368,11 +368,11 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.6/metadata.yaml
-      version: v1.0.6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/metadata.yaml
+      version: v1.0.5-rc5+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -381,7 +381,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc5-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -392,8 +392,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.5/metadata.yaml
-      version: v1.0.5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/metadata.yaml
+      version: v1.0.4-rc5+abcdef1
     flux:
       helmController:
         arch:
@@ -478,7 +478,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.3-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -487,7 +487,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.3-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -496,8 +496,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.1-eks-a-v0.0.0-dev-build.1
-      version: v0.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.3-eks-a-v0.0.0-dev-build.1
+      version: v0.3.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -731,7 +731,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
-      version: v0.1.0
+      version: v0.4.0+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -843,7 +843,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-21-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-22-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -1030,13 +1030,13 @@ spec:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ami image for EKS-D 1-22-21 release
-          name: bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Ami image for EKS-D 1-22-22 release
+          name: bottlerocket-v1.22.17-eks-d-1-22-22-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ami/1-22/1-22-21/bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ami/1-22/1-22-22/bottlerocket-v1.22.17-eks-d-1-22-22-eks-a-v0.0.0-dev-build.0-amd64.img.gz
       channel: 1-22
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
       crictl:
@@ -1075,32 +1075,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.17-eks-d-1-22-22-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.22.17
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-21.yaml
-      name: kubernetes-1-22-eks-21
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-22.yaml
+      name: kubernetes-1-22-eks-22
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-22-21 release
-          name: bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-22-22 release
+          name: bottlerocket-v1.22.17-eks-d-1-22-22-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-22/1-22-21/bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-22/1-22-22/bottlerocket-v1.22.17-eks-d-1-22-22-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-22-21 release
-          name: bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-22-22 release
+          name: bottlerocket-v1.22.17-eks-d-1-22-22-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-22/1-22-21/bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-22/1-22-22/bottlerocket-v1.22.17-eks-d-1-22-22-eks-a-v0.0.0-dev-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -1134,7 +1134,7 @@ spec:
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.6/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1143,7 +1143,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc5-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1154,11 +1154,11 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.6/metadata.yaml
-      version: v1.0.6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/metadata.yaml
+      version: v1.0.5-rc5+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1167,7 +1167,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc5-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1178,8 +1178,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.5/metadata.yaml
-      version: v1.0.5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/metadata.yaml
+      version: v1.0.4-rc5+abcdef1
     flux:
       helmController:
         arch:
@@ -1264,7 +1264,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.3-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -1273,7 +1273,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.3-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -1282,8 +1282,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.1-eks-a-v0.0.0-dev-build.1
-      version: v0.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.3-eks-a-v0.0.0-dev-build.1
+      version: v0.3.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -1293,7 +1293,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-22-21-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-22-22-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/infrastructure-components.yaml
       kubeVip:
@@ -1517,7 +1517,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
-      version: v0.1.0
+      version: v0.4.0+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -1629,7 +1629,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-16-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-17-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -1816,13 +1816,13 @@ spec:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ami image for EKS-D 1-23-16 release
-          name: bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Ami image for EKS-D 1-23-17 release
+          name: bottlerocket-v1.23.16-eks-d-1-23-17-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ami/1-23/1-23-16/bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ami/1-23/1-23-17/bottlerocket-v1.23.16-eks-d-1-23-17-eks-a-v0.0.0-dev-build.0-amd64.img.gz
       channel: 1-23
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
       crictl:
@@ -1861,32 +1861,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.16-eks-d-1-23-17-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.23.16
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-16.yaml
-      name: kubernetes-1-23-eks-16
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-17.yaml
+      name: kubernetes-1-23-eks-17
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-23-16 release
-          name: bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-23-17 release
+          name: bottlerocket-v1.23.16-eks-d-1-23-17-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-23/1-23-16/bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-23/1-23-17/bottlerocket-v1.23.16-eks-d-1-23-17-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-23-16 release
-          name: bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-23-17 release
+          name: bottlerocket-v1.23.16-eks-d-1-23-17-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-23/1-23-16/bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-23/1-23-17/bottlerocket-v1.23.16-eks-d-1-23-17-eks-a-v0.0.0-dev-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -1920,7 +1920,7 @@ spec:
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.6/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1929,7 +1929,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc5-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1940,11 +1940,11 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.6/metadata.yaml
-      version: v1.0.6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/metadata.yaml
+      version: v1.0.5-rc5+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1953,7 +1953,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc5-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1964,8 +1964,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.5/metadata.yaml
-      version: v1.0.5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/metadata.yaml
+      version: v1.0.4-rc5+abcdef1
     flux:
       helmController:
         arch:
@@ -2050,7 +2050,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.3-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -2059,7 +2059,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.3-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2068,8 +2068,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.1-eks-a-v0.0.0-dev-build.1
-      version: v0.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.3-eks-a-v0.0.0-dev-build.1
+      version: v0.3.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -2079,7 +2079,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-23-16-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-23-17-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/infrastructure-components.yaml
       kubeVip:
@@ -2303,7 +2303,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
-      version: v0.1.0
+      version: v0.4.0+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -2415,7 +2415,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-24-11-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-24-12-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -2602,13 +2602,13 @@ spec:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ami image for EKS-D 1-24-11 release
-          name: bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Ami image for EKS-D 1-24-12 release
+          name: bottlerocket-v1.24.10-eks-d-1-24-12-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ami/1-24/1-24-11/bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ami/1-24/1-24-12/bottlerocket-v1.24.10-eks-d-1-24-12-eks-a-v0.0.0-dev-build.0-amd64.img.gz
       channel: 1-24
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
       crictl:
@@ -2647,32 +2647,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.24.10-eks-d-1-24-12-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.24.10
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-24/kubernetes-1-24-eks-11.yaml
-      name: kubernetes-1-24-eks-11
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-24/kubernetes-1-24-eks-12.yaml
+      name: kubernetes-1-24-eks-12
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-24-11 release
-          name: bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-24-12 release
+          name: bottlerocket-v1.24.10-eks-d-1-24-12-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-24/1-24-11/bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-24/1-24-12/bottlerocket-v1.24.10-eks-d-1-24-12-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-24-11 release
-          name: bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-24-12 release
+          name: bottlerocket-v1.24.10-eks-d-1-24-12-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-24/1-24-11/bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-24/1-24-12/bottlerocket-v1.24.10-eks-d-1-24-12-eks-a-v0.0.0-dev-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -2706,7 +2706,7 @@ spec:
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.6/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2715,7 +2715,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc5-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2726,11 +2726,11 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.6/metadata.yaml
-      version: v1.0.6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/metadata.yaml
+      version: v1.0.5-rc5+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2739,7 +2739,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc5-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2750,8 +2750,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.5/metadata.yaml
-      version: v1.0.5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/metadata.yaml
+      version: v1.0.4-rc5+abcdef1
     flux:
       helmController:
         arch:
@@ -2836,7 +2836,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.3-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -2845,7 +2845,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.3-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2854,8 +2854,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.1-eks-a-v0.0.0-dev-build.1
-      version: v0.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.3-eks-a-v0.0.0-dev-build.1
+      version: v0.3.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -2865,7 +2865,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-24-11-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-24-12-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/infrastructure-components.yaml
       kubeVip:
@@ -3089,7 +3089,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
-      version: v0.1.0
+      version: v0.4.0+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -3201,7 +3201,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-25-7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-25-8-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -3424,10 +3424,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.25.6-eks-d-1-25-7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.25.6-eks-d-1-25-8-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.25.6
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-25/kubernetes-1-25-eks-7.yaml
-      name: kubernetes-1-25-eks-7
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-25/kubernetes-1-25-eks-8.yaml
+      name: kubernetes-1-25-eks-8
       ova:
         bottlerocket: {}
       raw:
@@ -3465,7 +3465,7 @@ spec:
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.6/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -3474,7 +3474,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc5-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3485,11 +3485,11 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.6/metadata.yaml
-      version: v1.0.6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/metadata.yaml
+      version: v1.0.5-rc5+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -3498,7 +3498,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc5-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3509,8 +3509,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.5/metadata.yaml
-      version: v1.0.5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/metadata.yaml
+      version: v1.0.4-rc5+abcdef1
     flux:
       helmController:
         arch:
@@ -3595,7 +3595,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.3-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -3604,7 +3604,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.3-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -3613,8 +3613,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.1-eks-a-v0.0.0-dev-build.1
-      version: v0.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.3-eks-a-v0.0.0-dev-build.1
+      version: v0.3.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -3624,7 +3624,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-25-7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-25-8-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/infrastructure-components.yaml
       kubeVip:
@@ -3848,7 +3848,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
-      version: v0.1.0
+      version: v0.4.0+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -3960,7 +3960,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-26-3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-26-4-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -4183,10 +4183,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.26.1-eks-d-1-26-3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.26.1-eks-d-1-26-4-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.26.1
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-26/kubernetes-1-26-eks-3.yaml
-      name: kubernetes-1-26-eks-3
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-26/kubernetes-1-26-eks-4.yaml
+      name: kubernetes-1-26-eks-4
       ova:
         bottlerocket: {}
       raw:
@@ -4224,7 +4224,7 @@ spec:
       version: v0.0.0-dev+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.6/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -4233,7 +4233,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.6-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc5-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -4244,11 +4244,11 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.6/metadata.yaml
-      version: v1.0.6+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc5/metadata.yaml
+      version: v1.0.5-rc5+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.5/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -4257,7 +4257,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc5-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -4268,8 +4268,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.0-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.5/metadata.yaml
-      version: v1.0.5+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc5/metadata.yaml
+      version: v1.0.4-rc5+abcdef1
     flux:
       helmController:
         arch:
@@ -4354,7 +4354,7 @@ spec:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.3-eks-a-v0.0.0-dev-build.1
       packageController:
         arch:
         - amd64
@@ -4363,7 +4363,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.3-eks-a-v0.0.0-dev-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -4372,8 +4372,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.1-eks-a-v0.0.0-dev-build.1
-      version: v0.3.1+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.3-eks-a-v0.0.0-dev-build.1
+      version: v0.3.3+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -4383,7 +4383,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-26-3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-26-4-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/infrastructure-components.yaml
       kubeVip:
@@ -4607,7 +4607,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-build.1
-      version: v0.1.0
+      version: v0.4.0+abcdef1
     vSphere:
       clusterAPIController:
         arch:

--- a/release/pkg/test/testdata/release-0.14-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.14-bundle-release.yaml
@@ -731,7 +731,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.1.0
+      version: 9e9c2a397288908f73a4f499ac00aaf96d15deb6+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -843,7 +843,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-21-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-22-eks-a-v0.0.0-dev-release-0.14-build.1
     certManager:
       acmesolver:
         arch:
@@ -1030,13 +1030,13 @@ spec:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ami image for EKS-D 1-22-21 release
-          name: bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          description: Bottlerocket Ami image for EKS-D 1-22-22 release
+          name: bottlerocket-v1.22.17-eks-d-1-22-22-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ami/1-22/1-22-21/bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ami/1-22/1-22-22/bottlerocket-v1.22.17-eks-d-1-22-22-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
       channel: 1-22
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
       crictl:
@@ -1075,32 +1075,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.17-eks-d-1-22-22-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVersion: v1.22.17
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-21.yaml
-      name: kubernetes-1-22-eks-21
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-22.yaml
+      name: kubernetes-1-22-eks-22
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-22-21 release
-          name: bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-22-22 release
+          name: bottlerocket-v1.22.17-eks-d-1-22-22-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ova/1-22/1-22-21/bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ova/1-22/1-22-22/bottlerocket-v1.22.17-eks-d-1-22-22-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-22-21 release
-          name: bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-22-22 release
+          name: bottlerocket-v1.22.17-eks-d-1-22-22-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/raw/1-22/1-22-21/bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/raw/1-22/1-22-22/bottlerocket-v1.22.17-eks-d-1-22-22-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -1293,7 +1293,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-22-21-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-22-22-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/infrastructure-components.yaml
       kubeVip:
@@ -1517,7 +1517,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.1.0
+      version: 9e9c2a397288908f73a4f499ac00aaf96d15deb6+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -1629,7 +1629,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-16-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-17-eks-a-v0.0.0-dev-release-0.14-build.1
     certManager:
       acmesolver:
         arch:
@@ -1816,13 +1816,13 @@ spec:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ami image for EKS-D 1-23-16 release
-          name: bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          description: Bottlerocket Ami image for EKS-D 1-23-17 release
+          name: bottlerocket-v1.23.16-eks-d-1-23-17-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ami/1-23/1-23-16/bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ami/1-23/1-23-17/bottlerocket-v1.23.16-eks-d-1-23-17-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
       channel: 1-23
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
       crictl:
@@ -1861,32 +1861,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.16-eks-d-1-23-17-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVersion: v1.23.16
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-16.yaml
-      name: kubernetes-1-23-eks-16
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-17.yaml
+      name: kubernetes-1-23-eks-17
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-23-16 release
-          name: bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-23-17 release
+          name: bottlerocket-v1.23.16-eks-d-1-23-17-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ova/1-23/1-23-16/bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ova/1-23/1-23-17/bottlerocket-v1.23.16-eks-d-1-23-17-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-23-16 release
-          name: bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-23-17 release
+          name: bottlerocket-v1.23.16-eks-d-1-23-17-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/raw/1-23/1-23-16/bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/raw/1-23/1-23-17/bottlerocket-v1.23.16-eks-d-1-23-17-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -2079,7 +2079,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-23-16-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-23-17-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/infrastructure-components.yaml
       kubeVip:
@@ -2303,7 +2303,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.1.0
+      version: 9e9c2a397288908f73a4f499ac00aaf96d15deb6+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -2415,7 +2415,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-24-11-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-24-12-eks-a-v0.0.0-dev-release-0.14-build.1
     certManager:
       acmesolver:
         arch:
@@ -2602,13 +2602,13 @@ spec:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ami image for EKS-D 1-24-11 release
-          name: bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          description: Bottlerocket Ami image for EKS-D 1-24-12 release
+          name: bottlerocket-v1.24.10-eks-d-1-24-12-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ami/1-24/1-24-11/bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ami/1-24/1-24-12/bottlerocket-v1.24.10-eks-d-1-24-12-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
       channel: 1-24
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
       crictl:
@@ -2647,32 +2647,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.24.10-eks-d-1-24-12-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVersion: v1.24.10
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-24/kubernetes-1-24-eks-11.yaml
-      name: kubernetes-1-24-eks-11
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-24/kubernetes-1-24-eks-12.yaml
+      name: kubernetes-1-24-eks-12
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-24-11 release
-          name: bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-24-12 release
+          name: bottlerocket-v1.24.10-eks-d-1-24-12-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ova/1-24/1-24-11/bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ova/1-24/1-24-12/bottlerocket-v1.24.10-eks-d-1-24-12-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-24-11 release
-          name: bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-24-12 release
+          name: bottlerocket-v1.24.10-eks-d-1-24-12-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/raw/1-24/1-24-11/bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/raw/1-24/1-24-12/bottlerocket-v1.24.10-eks-d-1-24-12-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -2865,7 +2865,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-24-11-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-24-12-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/infrastructure-components.yaml
       kubeVip:
@@ -3089,7 +3089,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.1.0
+      version: 9e9c2a397288908f73a4f499ac00aaf96d15deb6+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -3201,7 +3201,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-25-7-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-25-8-eks-a-v0.0.0-dev-release-0.14-build.1
     certManager:
       acmesolver:
         arch:
@@ -3424,10 +3424,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.25.6-eks-d-1-25-7-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.25.6-eks-d-1-25-8-eks-a-v0.0.0-dev-release-0.14-build.1
       kubeVersion: v1.25.6
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-25/kubernetes-1-25-eks-7.yaml
-      name: kubernetes-1-25-eks-7
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-25/kubernetes-1-25-eks-8.yaml
+      name: kubernetes-1-25-eks-8
       ova:
         bottlerocket: {}
       raw:
@@ -3624,7 +3624,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-25-7-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-25-8-eks-a-v0.0.0-dev-release-0.14-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/infrastructure-components.yaml
       kubeVip:
@@ -3848,7 +3848,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.1.0
+      version: 9e9c2a397288908f73a4f499ac00aaf96d15deb6+abcdef1
     vSphere:
       clusterAPIController:
         arch:


### PR DESCRIPTION
The hard coded version populates the version key for CAPT in the bundle. It is used by EKS-A to determine if there's a change in the provider and if a new version needs rolling out. Because we always use the same version number, we never roll out the updated CAPT and consequently CAPT fails to launch correctly. This occurs during an upgrade from a v0.14 cluster to main only as that's the first time we've updated CAPT.