### PR TITLE
Make labels and taints immutable for Tinkerbell

### DIFF
--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -188,7 +188,7 @@ func (r *Reconciler) DetectOperation(ctx context.Context, log logr.Logger, tinke
 	case wantVersionChange:
 		op = K8sVersionUpgradeOperation
 	}
-	log.V(5).Info("Operation detected", "operation", op)
+	log.Info("Operation detected", "operation", op)
 	return op, nil
 }
 
@@ -226,7 +226,7 @@ func (r *Reconciler) OmitMachineTemplate(ctx context.Context, log logr.Logger, t
 	if o == ScaleOperation || o == NoChange {
 		tinkerbell.OmitTinkerbellCPMachineTemplate(tinkerbellScope.ControlPlane)
 		tinkerbell.OmitTinkerbellWorkersMachineTemplate(tinkerbellScope.Workers)
-		log.V(5).Info("Machine Template omitted")
+		log.Info("Machine Template omitted")
 	}
 	return controller.Result{}, nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make labels and taints immutable for Tinkerbell
*Testing (if applicable):*
- unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

