### PR TITLE
Fixing tink reconcile worker template omit and logs

### DIFF
--- a/pkg/controller/clusterapi.go
+++ b/pkg/controller/clusterapi.go
@@ -61,3 +61,20 @@ func GetKubeadmControlPlane(ctx context.Context, client client.Client, cluster *
 	}
 	return kubeadmControlPlane, nil
 }
+
+// GetMachineDeployment reads a cluster-api MachineDeployment for an eks-a cluster using a kube client.
+// If the MachineDeployment is not found, the method returns (nil, nil).
+func GetMachineDeployment(ctx context.Context, client client.Client, machineDeploymentName string) (*clusterv1.MachineDeployment, error) {
+	machineDeployment := &clusterv1.MachineDeployment{}
+	key := types.NamespacedName{Namespace: constants.EksaSystemNamespace, Name: machineDeploymentName}
+
+	err := client.Get(ctx, key, machineDeployment)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return machineDeployment, nil
+}

--- a/pkg/controller/clusterapi_test.go
+++ b/pkg/controller/clusterapi_test.go
@@ -77,6 +77,35 @@ func TestGetKubeadmControlPlaneError(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("no kind is registered for the type")))
 }
 
+func TestGetMachineDeploymentSuccess(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	eksaCluster := eksaCluster()
+	machineDeployment := machineDeployment()
+	client := fake.NewClientBuilder().WithObjects(eksaCluster, machineDeployment).Build()
+
+	g.Expect(controller.GetMachineDeployment(ctx, client, "my-cluster")).To(Equal(machineDeployment))
+}
+
+func TestGetMachineDeploymentMissingMD(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	eksaCluster := eksaCluster()
+	client := fake.NewClientBuilder().WithObjects(eksaCluster).Build()
+
+	g.Expect(controller.GetMachineDeployment(ctx, client, "test")).To(BeNil())
+}
+
+func TestGetMachineDeploymentError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	// This should make the client fail because CRDs are not registered
+	client := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+
+	_, err := controller.GetMachineDeployment(ctx, client, "test")
+	g.Expect(err).To(MatchError(ContainSubstring("no kind is registered for the type")))
+}
+
 func TestGetCapiClusterObjectKey(t *testing.T) {
 	g := NewWithT(t)
 	eksaCluster := eksaCluster()
@@ -120,6 +149,19 @@ func kubeadmControlPlane() *controlplanev1.KubeadmControlPlane {
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "KubeadmControlPlane",
 			APIVersion: controlplanev1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: "eksa-system",
+		},
+	}
+}
+
+func machineDeployment() *clusterv1.MachineDeployment {
+	return &clusterv1.MachineDeployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MachineDeployment",
+			APIVersion: clusterv1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-cluster",

--- a/pkg/controller/clusters/workers.go
+++ b/pkg/controller/clusters/workers.go
@@ -2,6 +2,7 @@ package clusters
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -46,11 +47,13 @@ type WorkerGroup struct {
 }
 
 func (g *WorkerGroup) objects() []client.Object {
-	return []client.Object{
-		g.KubeadmConfigTemplate,
-		g.MachineDeployment,
-		g.ProviderMachineTemplate,
+	objs := []client.Object{g.KubeadmConfigTemplate, g.MachineDeployment}
+
+	if !reflect.ValueOf(g.ProviderMachineTemplate).IsNil() {
+		objs = append(objs, g.ProviderMachineTemplate)
 	}
+
+	return objs
 }
 
 // ToWorkers converts the generic clusterapi Workers definition to the concrete one defined

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -525,19 +525,6 @@ func buildTemplateMapMD(
 	return values, nil
 }
 
-// OmitTinkerbellCPMachineTemplate omits control plane machine template on scale update.
-func OmitTinkerbellCPMachineTemplate(cp *ControlPlane) {
-	cp.ControlPlaneMachineTemplate = nil
-}
-
-// OmitTinkerbellWorkersMachineTemplate omits workers machine template on scale update.
-func OmitTinkerbellWorkersMachineTemplate(w *Workers) {
-	wg := w.Groups
-	for _, w := range wg {
-		w.ProviderMachineTemplate = nil
-	}
-}
-
 func omitTinkerbellMachineTemplate(inputSpec []byte) ([]byte, error) {
 	var outSpec []unstructured.Unstructured
 	resources := strings.Split(string(inputSpec), "---")


### PR DESCRIPTION
*Description of changes:*
The tinkerbell reconcile phase omitting worker node machine templates was setting `nil` to the loop iterator and not the scope object.
Added `nil` for the right objects and also added Nil checks when applying worker node spec.

*Testing (if applicable):*
Built the controller and tested changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

