### PR TITLE
Add registry mirror insecure skip verify support feature flag to enable for all providers.

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
 )
@@ -723,8 +724,10 @@ func validateMirrorConfig(clusterConfig *Cluster) error {
 		return fmt.Errorf("registry mirror port %s is invalid, please provide a valid port", clusterConfig.Spec.RegistryMirrorConfiguration.Port)
 	}
 
-	if clusterConfig.Spec.RegistryMirrorConfiguration.InsecureSkipVerify && clusterConfig.Spec.DatacenterRef.Kind != SnowDatacenterKind {
-		return errors.New("insecureSkipVerify is only supported for snow provider")
+	if !features.RegistryMirrorInsecureSkipVerifySupport().IsActive() {
+		if clusterConfig.Spec.RegistryMirrorConfiguration.InsecureSkipVerify && clusterConfig.Spec.DatacenterRef.Kind != SnowDatacenterKind {
+			return errors.New("insecureSkipVerify is only supported for snow provider")
+		}
 	}
 
 	mirrorCount := 0

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -2628,7 +2628,7 @@ func TestValidateMirrorConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			features.ClearCache()
 			if tt.insecureSkipVerifySupport {
-				os.Setenv("REGISTRY_MIRROR_INSECURE_SKIP_VERIFY_SUPPORT", "true")
+				os.Setenv(features.RegistryMirrrorInsecureSkipVerifySupportEnvVar, "true")
 			}
 			g := NewWithT(t)
 			err := validateMirrorConfig(tt.cluster)
@@ -2638,7 +2638,7 @@ func TestValidateMirrorConfig(t *testing.T) {
 				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
 			}
 			if tt.insecureSkipVerifySupport {
-				os.Unsetenv("REGISTRY_MIRROR_INSECURE_SKIP_VERIFY_SUPPORT")
+				os.Unsetenv(features.RegistryMirrrorInsecureSkipVerifySupportEnvVar)
 			}
 		})
 	}

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
@@ -2477,9 +2479,10 @@ func TestValidateCNIConfig(t *testing.T) {
 
 func TestValidateMirrorConfig(t *testing.T) {
 	tests := []struct {
-		name    string
-		wantErr string
-		cluster *Cluster
+		name                      string
+		wantErr                   string
+		cluster                   *Cluster
+		insecureSkipVerifySupport bool
 	}{
 		{
 			name:    "registry mirror not specified",
@@ -2588,6 +2591,23 @@ func TestValidateMirrorConfig(t *testing.T) {
 			},
 		},
 		{
+			name:    "insecureSkipVerify on non snow provider with support env enabled",
+			wantErr: "",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					RegistryMirrorConfiguration: &RegistryMirrorConfiguration{
+						Endpoint:           "1.2.3.4",
+						Port:               "443",
+						InsecureSkipVerify: true,
+					},
+					DatacenterRef: Ref{
+						Kind: "nonsnow",
+					},
+				},
+			},
+			insecureSkipVerifySupport: true,
+		},
+		{
 			name:    "insecureSkipVerify on snow provider",
 			wantErr: "",
 			cluster: &Cluster{
@@ -2606,12 +2626,19 @@ func TestValidateMirrorConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			features.ClearCache()
+			if tt.insecureSkipVerifySupport {
+				os.Setenv("REGISTRY_MIRROR_INSECURE_SKIP_VERIFY_SUPPORT", "true")
+			}
 			g := NewWithT(t)
 			err := validateMirrorConfig(tt.cluster)
 			if tt.wantErr == "" {
 				g.Expect(err).To(BeNil())
 			} else {
 				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			}
+			if tt.insecureSkipVerifySupport {
+				os.Unsetenv("REGISTRY_MIRROR_INSECURE_SKIP_VERIFY_SUPPORT")
 			}
 		})
 	}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -2,12 +2,13 @@ package features
 
 // These are environment variables used as flags to enable/disable features.
 const (
-	CloudStackKubeVipDisabledEnvVar = "CLOUDSTACK_KUBE_VIP_DISABLED"
-	FullLifecycleAPIEnvVar          = "FULL_LIFECYCLE_API"
-	FullLifecycleGate               = "FullLifecycleAPI"
-	CheckpointEnabledEnvVar         = "CHECKPOINT_ENABLED"
-	UseNewWorkflowsEnvVar           = "USE_NEW_WORKFLOWS"
-	K8s126SupportEnvVar             = "K8S_1_26_SUPPORT"
+	CloudStackKubeVipDisabledEnvVar                = "CLOUDSTACK_KUBE_VIP_DISABLED"
+	FullLifecycleAPIEnvVar                         = "FULL_LIFECYCLE_API"
+	FullLifecycleGate                              = "FullLifecycleAPI"
+	CheckpointEnabledEnvVar                        = "CHECKPOINT_ENABLED"
+	UseNewWorkflowsEnvVar                          = "USE_NEW_WORKFLOWS"
+	K8s126SupportEnvVar                            = "K8S_1_26_SUPPORT"
+	RegistryMirrrorInsecureSkipVerifySupportEnvVar = "REGISTRY_MIRROR_INSECURE_SKIP_VERIFY_SUPPORT"
 )
 
 func FeedGates(featureGates []string) {
@@ -61,5 +62,13 @@ func K8s126Support() Feature {
 	return Feature{
 		Name:     "Kubernetes version 1.26 support",
 		IsActive: globalFeatures.isActiveForEnvVar(K8s126SupportEnvVar),
+	}
+}
+
+// RegistryMirrorInsecureSkipVerifySupport is a feature flag that enables registry mirror InsecureSkipVerify option support for all providers to pass preflight validations.
+func RegistryMirrorInsecureSkipVerifySupport() Feature {
+	return Feature{
+		Name:     "Insecure skip verify supported for all providers",
+		IsActive: globalFeatures.isActiveForEnvVar(RegistryMirrrorInsecureSkipVerifySupportEnvVar),
 	}
 }

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -77,3 +77,11 @@ func TestWithK8s126FeatureFlag(t *testing.T) {
 	g.Expect(os.Setenv(K8s126SupportEnvVar, "true")).To(Succeed())
 	g.Expect(IsActive(K8s126Support())).To(BeTrue())
 }
+
+func TestWithRegistryMirrorInsecureSkipVerifySupportFeatureFlag(t *testing.T) {
+	g := NewWithT(t)
+	setupContext(t)
+
+	g.Expect(os.Setenv(RegistryMirrrorInsecureSkipVerifySupportEnvVar, "true")).To(Succeed())
+	g.Expect(IsActive(RegistryMirrorInsecureSkipVerifySupport())).To(BeTrue())
+}


### PR DESCRIPTION
…ll providers

*Issue #, if available:*

*Description of changes:*
This validation currently blocks during preflight for unsupported providers. Use of flag this flag is to temporarily block support for registryMirror InsecureSkipVerify option is added for all providers.

Also, want to get this so that it will being binary built into the controller image which currently has the code enforcing insecureSkipVerify for only Snow compiled into it. So, this will allow for easier local testing.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

