### PR TITLE
Clusterctl backup of management resources before moving to bootstrap

### DIFF
--- a/cmd/eksctl-anywhere/cmd/root.go
+++ b/cmd/eksctl-anywhere/cmd/root.go
@@ -23,7 +23,6 @@ var rootCmd = &cobra.Command{
 		if outputFilePath == "" {
 			return
 		}
-
 		if err := os.Remove(outputFilePath); err != nil {
 			fmt.Printf("Failed to cleanup log file %s: %s", outputFilePath, err)
 		}

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -40,6 +40,7 @@ var (
 	eksaVSphereMachineResourceType    = fmt.Sprintf("vspheremachineconfigs.%s", v1alpha1.GroupVersion.Group)
 	expectedPauseAnnotation           = map[string]string{"anywhere.eks.amazonaws.com/paused": "true"}
 	maxTime                           = time.Duration(math.MaxInt64)
+	managementStatePath               = fmt.Sprintf("cluster-state-backup-%s", time.Now().Format("2006-01-02T15_04_05"))
 )
 
 func TestClusterManagerInstallNetworkingSuccess(t *testing.T) {
@@ -1284,6 +1285,34 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForCAPITimeout(t *testing.T) {
 
 	if err := tt.clusterManager.UpgradeCluster(tt.ctx, mCluster, wCluster, tt.clusterSpec, tt.mocks.provider); err == nil {
 		t.Error("ClusterManager.UpgradeCluster() error = nil, wantErr not nil")
+	}
+}
+
+func TestClusterManagerBackupCAPISuccess(t *testing.T) {
+	from := &types.Cluster{
+		Name: "from-cluster",
+	}
+
+	ctx := context.Background()
+
+	c, m := newClusterManager(t)
+	m.client.EXPECT().BackupManagement(ctx, from, managementStatePath)
+
+	if err := c.BackupCAPI(ctx, from, managementStatePath); err != nil {
+		t.Errorf("ClusterManager.BackupCAPI() error = %v, wantErr nil", err)
+	}
+}
+
+func TestClusterManagerBackupCAPIError(t *testing.T) {
+	from := &types.Cluster{}
+
+	ctx := context.Background()
+
+	c, m := newClusterManager(t)
+	m.client.EXPECT().BackupManagement(ctx, from, managementStatePath).Return(errors.New("backing up CAPI resources"))
+
+	if err := c.BackupCAPI(ctx, from, managementStatePath); err == nil {
+		t.Errorf("ClusterManager.BackupCAPI() error = %v, wantErr nil", err)
 	}
 }
 

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -103,6 +103,20 @@ func (mr *MockClusterClientMockRecorder) ApplyKubeSpecFromBytesWithNamespace(arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyKubeSpecFromBytesWithNamespace", reflect.TypeOf((*MockClusterClient)(nil).ApplyKubeSpecFromBytesWithNamespace), arg0, arg1, arg2, arg3)
 }
 
+// BackupManagement mocks base method.
+func (m *MockClusterClient) BackupManagement(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BackupManagement", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BackupManagement indicates an expected call of BackupManagement.
+func (mr *MockClusterClientMockRecorder) BackupManagement(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupManagement", reflect.TypeOf((*MockClusterClient)(nil).BackupManagement), arg0, arg1, arg2)
+}
+
 // CountMachineDeploymentReplicasReady mocks base method.
 func (m *MockClusterClient) CountMachineDeploymentReplicasReady(arg0 context.Context, arg1, arg2 string) (int, int, error) {
 	m.ctrl.T.Helper()

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -172,6 +172,26 @@ func clusterctlMoveRetryPolicy(totalRetries int, err error) (retry bool, wait ti
 	return false, 0
 }
 
+// BackupManagement save CAPI resources of a workload cluster before moving it to the bootstrap cluster during upgrade.
+func (c *Clusterctl) BackupManagement(ctx context.Context, cluster *types.Cluster, managementStatePath string) error {
+	filePath := filepath.Join(".", cluster.Name, managementStatePath)
+	err := os.MkdirAll(filePath, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("could not create backup file for CAPI objects: %v", err)
+	}
+
+	_, err = c.Execute(
+		ctx, "move",
+		"--to-directory", filePath,
+		"--kubeconfig", cluster.KubeconfigFile,
+		"--namespace", constants.EksaSystemNamespace,
+	)
+	if err != nil {
+		return fmt.Errorf("failed taking backup of CAPI objects: %v", err)
+	}
+	return nil
+}
+
 func (c *Clusterctl) MoveManagement(ctx context.Context, from, to *types.Cluster) error {
 	params := []string{"move", "--to-kubeconfig", to.KubeconfigFile, "--namespace", constants.EksaSystemNamespace}
 	if from.KubeconfigFile != "" {

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -181,8 +181,8 @@ func (c *Clusterctl) BackupManagement(ctx context.Context, cluster *types.Cluste
 	}
 
 	_, err = c.Execute(
-		ctx, "move",
-		"--to-directory", filePath,
+		ctx, "backup",
+		"--directory", filePath,
 		"--kubeconfig", cluster.KubeconfigFile,
 		"--namespace", constants.EksaSystemNamespace,
 	)

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -244,6 +244,61 @@ func TestClusterctlInitInfrastructureInvalidClusterNameError(t *testing.T) {
 	}
 }
 
+func TestClusterctlBackupManagement(t *testing.T) {
+	managementClusterState := fmt.Sprintf("cluster-state-backup-%s", time.Now().Format("2006-01-02T15_04_05"))
+	clusterName := "cluster"
+
+	tests := []struct {
+		testName     string
+		cluster      *types.Cluster
+		wantMoveArgs []interface{}
+	}{
+		{
+			testName: "backup success",
+			cluster: &types.Cluster{
+				Name:           clusterName,
+				KubeconfigFile: "cluster.kubeconfig",
+			},
+			wantMoveArgs: []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", clusterName, managementClusterState), "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace},
+		},
+		{
+			testName: "no kubeconfig file",
+			cluster: &types.Cluster{
+				Name: clusterName,
+			},
+			wantMoveArgs: []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", clusterName, managementClusterState), "--kubeconfig", "", "--namespace", constants.EksaSystemNamespace},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			tc := newClusterctlTest(t)
+			tc.e.EXPECT().Execute(tc.ctx, tt.wantMoveArgs...)
+
+			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState); err != nil {
+				t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestClusterctlBackupManagementFailed(t *testing.T) {
+	managementClusterState := fmt.Sprintf("cluster-state-backup-%s", time.Now().Format("2006-01-02T15_04_05"))
+	tt := newClusterctlTest(t)
+
+	cluster := &types.Cluster{
+		Name:           "cluster",
+		KubeconfigFile: "cluster.kubeconfig",
+	}
+
+	wantMoveArgs := []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", cluster.Name, managementClusterState), "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}
+
+	tt.e.EXPECT().Execute(tt.ctx, wantMoveArgs...).Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
+	if err := tt.clusterctl.BackupManagement(tt.ctx, cluster, managementClusterState); err == nil {
+		t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
+	}
+}
+
 func TestClusterctlMoveManagement(t *testing.T) {
 	tests := []struct {
 		testName     string

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -259,14 +259,14 @@ func TestClusterctlBackupManagement(t *testing.T) {
 				Name:           clusterName,
 				KubeconfigFile: "cluster.kubeconfig",
 			},
-			wantMoveArgs: []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", clusterName, managementClusterState), "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace},
+			wantMoveArgs: []interface{}{"backup", "--directory", fmt.Sprintf("%s/%s", clusterName, managementClusterState), "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace},
 		},
 		{
 			testName: "no kubeconfig file",
 			cluster: &types.Cluster{
 				Name: clusterName,
 			},
-			wantMoveArgs: []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", clusterName, managementClusterState), "--kubeconfig", "", "--namespace", constants.EksaSystemNamespace},
+			wantMoveArgs: []interface{}{"backup", "--directory", fmt.Sprintf("%s/%s", clusterName, managementClusterState), "--kubeconfig", "", "--namespace", constants.EksaSystemNamespace},
 		},
 	}
 
@@ -291,7 +291,7 @@ func TestClusterctlBackupManagementFailed(t *testing.T) {
 		KubeconfigFile: "cluster.kubeconfig",
 	}
 
-	wantMoveArgs := []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", cluster.Name, managementClusterState), "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}
+	wantMoveArgs := []interface{}{"backup", "--directory", fmt.Sprintf("%s/%s", cluster.Name, managementClusterState), "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}
 
 	tt.e.EXPECT().Execute(tt.ctx, wantMoveArgs...).Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
 	if err := tt.clusterctl.BackupManagement(tt.ctx, cluster, managementClusterState); err == nil {

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -27,24 +27,25 @@ type Task interface {
 
 // Command context maintains the mutable and shared entities.
 type CommandContext struct {
-	Bootstrapper       interfaces.Bootstrapper
-	Provider           providers.Provider
-	ClusterManager     interfaces.ClusterManager
-	GitOpsManager      interfaces.GitOpsManager
-	Validations        interfaces.Validator
-	Writer             filewriter.FileWriter
-	EksdInstaller      interfaces.EksdInstaller
-	PackageInstaller   interfaces.PackageInstaller
-	EksdUpgrader       interfaces.EksdUpgrader
-	CAPIManager        interfaces.CAPIManager
-	ClusterSpec        *cluster.Spec
-	CurrentClusterSpec *cluster.Spec
-	UpgradeChangeDiff  *types.ChangeDiff
-	BootstrapCluster   *types.Cluster
-	ManagementCluster  *types.Cluster
-	WorkloadCluster    *types.Cluster
-	Profiler           *Profiler
-	OriginalError      error
+	Bootstrapper              interfaces.Bootstrapper
+	Provider                  providers.Provider
+	ClusterManager            interfaces.ClusterManager
+	GitOpsManager             interfaces.GitOpsManager
+	Validations               interfaces.Validator
+	Writer                    filewriter.FileWriter
+	EksdInstaller             interfaces.EksdInstaller
+	PackageInstaller          interfaces.PackageInstaller
+	EksdUpgrader              interfaces.EksdUpgrader
+	CAPIManager               interfaces.CAPIManager
+	ClusterSpec               *cluster.Spec
+	CurrentClusterSpec        *cluster.Spec
+	UpgradeChangeDiff         *types.ChangeDiff
+	BootstrapCluster          *types.Cluster
+	ManagementCluster         *types.Cluster
+	WorkloadCluster           *types.Cluster
+	Profiler                  *Profiler
+	OriginalError             error
+	ManagementClusterStateDir string
 }
 
 func (c *CommandContext) SetError(err error) {
@@ -127,6 +128,7 @@ func (tr *taskRunner) RunTask(ctx context.Context, commandContext *CommandContex
 	var checkpointInfo CheckpointInfo
 	var err error
 
+	commandContext.ManagementClusterStateDir = fmt.Sprintf("cluster-state-backup-%s", time.Now().Format("2006-01-02T15_04_05"))
 	commandContext.Profiler = &Profiler{
 		metrics: make(map[string]map[string]time.Duration),
 		starts:  make(map[string]map[string]time.Time),

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -17,6 +17,7 @@ type Bootstrapper interface {
 }
 
 type ClusterManager interface {
+	BackupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath string) error
 	MoveCAPI(ctx context.Context, from, to *types.Cluster, clusterName string, clusterSpec *cluster.Spec, checkers ...types.NodeReadyChecker) error
 	CreateWorkloadCluster(ctx context.Context, managementCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) (*types.Cluster, error)
 	RunPostCreateWorkloadCluster(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec) error

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -111,6 +111,20 @@ func (mr *MockClusterManagerMockRecorder) ApplyBundles(arg0, arg1, arg2 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyBundles", reflect.TypeOf((*MockClusterManager)(nil).ApplyBundles), arg0, arg1, arg2)
 }
 
+// BackupCAPI mocks base method.
+func (m *MockClusterManager) BackupCAPI(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BackupCAPI", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BackupCAPI indicates an expected call of BackupCAPI.
+func (mr *MockClusterManagerMockRecorder) BackupCAPI(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupCAPI", reflect.TypeOf((*MockClusterManager)(nil).BackupCAPI), arg0, arg1, arg2)
+}
+
 // CreateAwsIamAuthCaSecret mocks base method.
 func (m *MockClusterManager) CreateAwsIamAuthCaSecret(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -3,6 +3,8 @@ package workflows
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/clustermarshaller"
@@ -441,8 +443,15 @@ func (s *installCAPITask) Restore(ctx context.Context, commandContext *task.Comm
 }
 
 func (s *moveManagementToBootstrapTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("Backing up workload cluster's management resources before moving to bootstrap cluster")
+	err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.WorkloadCluster, commandContext.ManagementClusterStateDir)
+	if err != nil {
+		commandContext.SetError(err)
+		return &CollectDiagnosticsTask{}
+	}
+
 	logger.Info("Moving cluster management from workload to bootstrap cluster")
-	err := commandContext.ClusterManager.MoveCAPI(ctx, commandContext.WorkloadCluster, commandContext.BootstrapCluster, commandContext.WorkloadCluster.Name, commandContext.ClusterSpec, types.WithNodeRef(), types.WithNodeHealthy())
+	err = commandContext.ClusterManager.MoveCAPI(ctx, commandContext.WorkloadCluster, commandContext.BootstrapCluster, commandContext.WorkloadCluster.Name, commandContext.ClusterSpec, types.WithNodeRef(), types.WithNodeHealthy())
 	if err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}
@@ -660,6 +669,7 @@ func (s *deleteBootstrapClusterTask) Run(ctx context.Context, commandContext *ta
 		if err := commandContext.Bootstrapper.DeleteBootstrapCluster(ctx, commandContext.BootstrapCluster, constants.Upgrade, false); err != nil {
 			commandContext.SetError(err)
 		}
+
 		if commandContext.OriginalError == nil {
 			logger.MarkSuccess("Cluster upgraded!")
 		}
@@ -667,6 +677,11 @@ func (s *deleteBootstrapClusterTask) Run(ctx context.Context, commandContext *ta
 			// Cluster has been succesfully upgraded, bootstrap cluster successfully deleted
 			// We don't necessarily need to return with an error here and abort
 			logger.Info(fmt.Sprintf("%v", err))
+		}
+
+		capiObjectFile := filepath.Join(commandContext.BootstrapCluster.Name, commandContext.ManagementClusterStateDir)
+		if err := os.RemoveAll(capiObjectFile); err != nil {
+			logger.Info(fmt.Sprintf("management cluster CAPI backup file not found: %v", err))
 		}
 		return nil
 	}

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -526,7 +526,6 @@ func TestUpgradeRunFailedBackupManagementUpgrade(t *testing.T) {
 	test.expectBackupManagementToBootstrapFailed()
 	test.expectSaveLogs(test.workloadCluster)
 	test.expectWriteCheckpointFile()
-	test.expectPreCoreComponentsUpgrade()
 
 	err := test.run()
 	if err == nil {


### PR DESCRIPTION
*Description of changes:*
Backup CAPI objects before moving from management cluster to bootstrap during upgrade.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

