### PR TITLE
Support nonRootVolumes option in snowMachineConfig

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_snowmachineconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_snowmachineconfigs.yaml
@@ -130,6 +130,47 @@ spec:
                     minItems: 1
                     type: array
                 type: object
+              nonRootVolumes:
+                description: NonRootVolumes provides the configuration options for
+                  the non root storage volumes.
+                items:
+                  description: 'Volume encapsulates the configuration options for
+                    the storage device TODO: Trim the fields that do not apply for
+                    Snow.'
+                  properties:
+                    deviceName:
+                      description: Device name
+                      type: string
+                    encrypted:
+                      description: Encrypted is whether the volume should be encrypted
+                        or not.
+                      type: boolean
+                    encryptionKey:
+                      description: EncryptionKey is the KMS key to use to encrypt
+                        the volume. Can be either a KMS key ID or ARN. If Encrypted
+                        is set and this is omitted, the default AWS key will be used.
+                        The key must already exist and be accessible by the controller.
+                      type: string
+                    iops:
+                      description: IOPS is the number of IOPS requested for the disk.
+                        Not applicable to all types.
+                      format: int64
+                      type: integer
+                    size:
+                      description: Size specifies size (in Gi) of the storage device.
+                        Must be greater than the image snapshot size or 8 (whichever
+                        is greater).
+                      format: int64
+                      minimum: 8
+                      type: integer
+                    type:
+                      description: Type is the type of the volume (e.g. gp2, io1,
+                        etc...).
+                      type: string
+                  required:
+                  - size
+                  type: object
+                type: array
               osFamily:
                 description: 'OSFamily is the node instance OS. Valid values: "bottlerocket"
                   and "ubuntu".'

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -5088,6 +5088,47 @@ spec:
                     minItems: 1
                     type: array
                 type: object
+              nonRootVolumes:
+                description: NonRootVolumes provides the configuration options for
+                  the non root storage volumes.
+                items:
+                  description: 'Volume encapsulates the configuration options for
+                    the storage device TODO: Trim the fields that do not apply for
+                    Snow.'
+                  properties:
+                    deviceName:
+                      description: Device name
+                      type: string
+                    encrypted:
+                      description: Encrypted is whether the volume should be encrypted
+                        or not.
+                      type: boolean
+                    encryptionKey:
+                      description: EncryptionKey is the KMS key to use to encrypt
+                        the volume. Can be either a KMS key ID or ARN. If Encrypted
+                        is set and this is omitted, the default AWS key will be used.
+                        The key must already exist and be accessible by the controller.
+                      type: string
+                    iops:
+                      description: IOPS is the number of IOPS requested for the disk.
+                        Not applicable to all types.
+                      format: int64
+                      type: integer
+                    size:
+                      description: Size specifies size (in Gi) of the storage device.
+                        Must be greater than the image snapshot size or 8 (whichever
+                        is greater).
+                      format: int64
+                      minimum: 8
+                      type: integer
+                    type:
+                      description: Type is the type of the volume (e.g. gp2, io1,
+                        etc...).
+                      type: string
+                  required:
+                  - size
+                  type: object
+                type: array
               osFamily:
                 description: 'OSFamily is the node instance OS. Valid values: "bottlerocket"
                   and "ubuntu".'

--- a/pkg/api/v1alpha1/snowmachineconfig_test.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_test.go
@@ -437,6 +437,68 @@ func TestSnowMachineConfigValidate(t *testing.T) {
 			},
 			wantErr: "SnowMachineConfig Network.DirectNetworkInterfaces list must contain one and only one primary DNI",
 		},
+		{
+			name: "invalid nonRootVolumes, device name empty",
+			obj: &SnowMachineConfig{
+				Spec: SnowMachineConfigSpec{
+					AMIID:                    "ami-1",
+					InstanceType:             DefaultSnowInstanceType,
+					PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
+					Devices:                  []string{"1.2.3.4"},
+					OSFamily:                 Bottlerocket,
+					Network: SnowNetwork{
+						DirectNetworkInterfaces: []SnowDirectNetworkInterface{
+							{
+								Index:   1,
+								DHCP:    true,
+								Primary: true,
+							},
+						},
+					},
+					ContainersVolume: &snowv1.Volume{
+						Size: 25,
+					},
+					NonRootVolumes: []*snowv1.Volume{
+						{
+							DeviceName: "",
+							Size:       25,
+						},
+					},
+				},
+			},
+			wantErr: "SnowMachineConfig NonRootVolumes[0].DeviceName must be specified",
+		},
+		{
+			name: "invalid nonRootVolumes, device name prefix /dev/sda",
+			obj: &SnowMachineConfig{
+				Spec: SnowMachineConfigSpec{
+					AMIID:                    "ami-1",
+					InstanceType:             DefaultSnowInstanceType,
+					PhysicalNetworkConnector: DefaultSnowPhysicalNetworkConnectorType,
+					Devices:                  []string{"1.2.3.4"},
+					OSFamily:                 Bottlerocket,
+					Network: SnowNetwork{
+						DirectNetworkInterfaces: []SnowDirectNetworkInterface{
+							{
+								Index:   1,
+								DHCP:    true,
+								Primary: true,
+							},
+						},
+					},
+					ContainersVolume: &snowv1.Volume{
+						Size: 25,
+					},
+					NonRootVolumes: []*snowv1.Volume{
+						{
+							DeviceName: "/dev/sda1",
+							Size:       25,
+						},
+					},
+				},
+			},
+			wantErr: "SnowMachineConfig NonRootVolumes[0].DeviceName [/dev/sda1] is invalid. Device name with prefix /dev/sda* is reserved for root volume and containers volume, please use another name",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/api/v1alpha1/snowmachineconfig_types.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_types.go
@@ -41,6 +41,9 @@ type SnowMachineConfigSpec struct {
 	// ContainersVolume provides the configuration options for the containers data storage volume.
 	ContainersVolume *snowv1.Volume `json:"containersVolume,omitempty"`
 
+	// NonRootVolumes provides the configuration options for the non root storage volumes.
+	NonRootVolumes []*snowv1.Volume `json:"nonRootVolumes,omitempty"`
+
 	// OSFamily is the node instance OS.
 	// Valid values: "bottlerocket" and "ubuntu".
 	OSFamily OSFamily `json:"osFamily,omitempty"`

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -308,6 +308,7 @@ func MachineTemplate(name string, machineConfig *v1alpha1.SnowMachineConfig, cap
 					PhysicalNetworkConnectorType: &networkConnector,
 					Devices:                      machineConfig.Spec.Devices,
 					ContainersVolume:             machineConfig.Spec.ContainersVolume,
+					NonRootVolumes:               machineConfig.Spec.NonRootVolumes,
 					Network: snowv1.AWSSnowNetwork{
 						DirectNetworkInterfaces: dnis,
 					},

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -848,10 +848,18 @@ func wantSnowIPPool() *snowv1.AWSSnowIPPool {
 
 func TestSnowMachineTemplate(t *testing.T) {
 	tt := newApiBuilerTest(t)
-	got := snow.MachineTemplate("snow-test-control-plane-1", tt.machineConfigs["test-cp"], nil)
+	mc := tt.machineConfigs["test-cp"]
+	mc.Spec.NonRootVolumes = []*snowv1.Volume{
+		{
+			DeviceName: "/dev/sdc",
+			Size:       10,
+		},
+	}
+	got := snow.MachineTemplate("snow-test-control-plane-1", mc, nil)
 	want := wantSnowMachineTemplate()
 	want.SetName("snow-test-control-plane-1")
 	want.Spec.Template.Spec.InstanceType = "sbe-c.large"
+	want.Spec.Template.Spec.NonRootVolumes = mc.Spec.NonRootVolumes
 	tt.Expect(got).To(Equal(want))
 }
 


### PR DESCRIPTION
*Issue #, if available:*

Resolves #5199 

*Description of changes:*

Add nonRootVolumes option for snow provider. Related CAPAS PR: https://github.com/aws/cluster-api-provider-aws-snow/pull/127

This allows user to add non root volumes which can be used to setup CSI and persistent storage.

*Testing (if applicable):*

Unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

