### PR TITLE
Feature: Add unmanaged CNI for FLC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ GO ?= $(GO_VERSION)/go
 GO_TEST ?= $(GO) test
 # A regular expression defining what packages to exclude from the unit-test recipe.
 UNIT_TEST_PACKAGE_EXCLUSION_REGEX ?=mocks$
+UNIT_TEST_PACKAGES ?= $$($(GO) list ./... | grep -vE "$(UNIT_TEST_PACKAGE_EXCLUSION_REGEX)")
 
 ## ensure local execution uses the 'main' branch bundle
 BRANCH_NAME?=main
@@ -422,7 +423,7 @@ unit-test: ## Run unit tests
 unit-test: $(SETUP_ENVTEST) 
 unit-test: KUBEBUILDER_ASSETS ?= $(shell $(SETUP_ENVTEST) use --use-env -p path --arch $(GO_ARCH) $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))
 unit-test:
-	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" $(GO_TEST) $$($(GO) list ./... | grep -vE "$(UNIT_TEST_PACKAGE_EXCLUSION_REGEX)") -cover -tags "$(BUILD_TAGS)" $(GO_TEST_FLAGS)
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" $(GO_TEST) $(UNIT_TEST_PACKAGES) -cover -tags "$(BUILD_TAGS)" $(GO_TEST_FLAGS)
 
 
 # unit-test-patch is a convenience target that restricts test runs to modified

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -205,6 +205,21 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 			field.Forbidden(specPath.Child("clusterNetwork", "dns"), "field is immutable"))
 	}
 
+	// We don't want users to be able to toggle off SkipUpgrade until we've understood the
+	// implications so we are temporarily disallowing it.
+
+	oCNI := old.Spec.ClusterNetwork.CNIConfig
+	nCNI := new.Spec.ClusterNetwork.CNIConfig
+	if oCNI != nil && oCNI.Cilium != nil && !oCNI.Cilium.IsManaged() && nCNI.Cilium.IsManaged() {
+		allErrs = append(
+			allErrs,
+			field.Forbidden(
+				specPath.Child("clusterNetwork", "cniConfig", "cilium", "skipUpgrade"),
+				"cannot toggle off skipUpgrade once enabled",
+			),
+		)
+	}
+
 	if !new.Spec.ClusterNetwork.Nodes.Equal(old.Spec.ClusterNetwork.Nodes) {
 		allErrs = append(
 			allErrs,

--- a/pkg/networking/cilium/installation.go
+++ b/pkg/networking/cilium/installation.go
@@ -1,6 +1,8 @@
 package cilium
 
 import (
+	"strings"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -12,9 +14,15 @@ type Installation struct {
 	ConfigMap *corev1.ConfigMap
 }
 
-// Installed determines if all Cilium components are present.
-// If the ConfigMap doesn't exist we still considered Cilium is installed.
-// The installation might not be complete but it can be functional.
+// Installed determines if all EKS-A Embedded Cilium components are present. It identifies
+// EKS-A Embedded Cilium by the image name. If the ConfigMap doesn't exist we still considered
+// Cilium is installed. The installation might not be complete but it can be functional.
 func (i Installation) Installed() bool {
-	return i.DaemonSet != nil && i.Operator != nil
+	var isEKSACilium bool
+	if i.DaemonSet != nil {
+		for _, c := range i.DaemonSet.Spec.Template.Spec.Containers {
+			isEKSACilium = isEKSACilium || strings.Contains(c.Image, "eksa")
+		}
+	}
+	return i.DaemonSet != nil && i.Operator != nil && isEKSACilium
 }

--- a/pkg/networking/cilium/installation_test.go
+++ b/pkg/networking/cilium/installation_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/aws/eks-anywhere/pkg/networking/cilium"
 )
@@ -18,14 +19,42 @@ func TestInstallationInstalled(t *testing.T) {
 		{
 			name: "installed",
 			installation: cilium.Installation{
-				DaemonSet: &appsv1.DaemonSet{},
-				Operator:  &appsv1.Deployment{},
+				DaemonSet: &appsv1.DaemonSet{
+					Spec: appsv1.DaemonSetSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{Image: "cilium-eksa"},
+								},
+							},
+						},
+					},
+				},
+				Operator: &appsv1.Deployment{},
 			},
 			want: true,
 		},
 		{
 			name: "ds not installed",
 			installation: cilium.Installation{
+				Operator: &appsv1.Deployment{},
+			},
+			want: false,
+		},
+		{
+			name: "ds not installed with eksa cilium",
+			installation: cilium.Installation{
+				DaemonSet: &appsv1.DaemonSet{
+					Spec: appsv1.DaemonSetSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{Image: "cilium"},
+								},
+							},
+						},
+					},
+				},
 				Operator: &appsv1.Deployment{},
 			},
 			want: false,

--- a/pkg/networking/cilium/reconciler/marker.go
+++ b/pkg/networking/cilium/reconciler/marker.go
@@ -1,0 +1,27 @@
+package reconciler
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
+)
+
+// EKSACiliumInstalledAnnotation indicates a cluster has previously been observed to have
+// EKS-A Cilium installed irrespective of whether its still installed.
+const EKSACiliumInstalledAnnotation = "anywhere.eks.amazonaws.com/eksa-cilium"
+
+// ciliumWasInstalled checks cluster for the EKSACiliumInstalledAnnotation.
+func ciliumWasInstalled(ctx context.Context, cluster *v1alpha1.Cluster) bool {
+	if cluster.Annotations == nil {
+		return false
+	}
+	_, ok := cluster.Annotations[EKSACiliumInstalledAnnotation]
+	return ok
+}
+
+// markCiliumInstalled populates the EKSACiliumInstalledAnnotation on cluster. It may trigger
+// anothe reconciliation event.
+func markCiliumInstalled(ctx context.Context, cluster *v1alpha1.Cluster) {
+	clientutil.AddAnnotation(cluster, EKSACiliumInstalledAnnotation, "")
+}


### PR DESCRIPTION
This PR adds the business logic for Full Lifecycle Controller handling of the Cilium `skipUpgrade` flag in the EKS-A API.

The change relies on an annotation populated whenever we observe EKS-A Embedded Cilium is installed in the cluster. Using the annotation combined with the skip flag, we can determine if we need to install Cilium (for successful cluster creation) or treat the CNI as unmanaged and do nothing.

An edge case exists where a user may have uninstalled EKS-A Embedded Cilium and toggled skip on. In that case, we cannot identify if Cilium was ever installed and consequently will try to install it. Users can work around the problem by manually populating the annotation.

**Manual Tested Scenarios**

* Create a workload cluster and observe EKS-A Cilium installed and annotation present.
* Create a workload cluster, then remove the annotation and observe its put back.
* Create a workload cluster, uninstall Cilium and remove annotation and observe both are installed/put back.
* Create a workload cluster with skip enabled and observe EKS-A Cilium installed but then skipped in future reconciliation.
* Create a workload cluster, enable skip, remove the annotation and observe the annotation get reapplied.
* Create a workload cluster, enable skip, uninstall Cilium and install OSS Cilium and observe upgrades skipped.
* Create a workload cluster, enable skip, remove the annotation, remove Cilium and observe Cilium get reinstalled and the annotation reapplied (this is a bork case that requires a workaround if the user doesn't want Cilium to be reinstalled).