### PR TITLE
Validate Mgmt Cluster Bundles Version on Upgrade

### DIFF
--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -79,3 +79,27 @@ func ValidateK8s126Support(clusterSpec *cluster.Spec) error {
 	}
 	return nil
 }
+
+// ValidateManagementClusterBundlesVersion checks if management cluster's bundle version
+// is greater than or equal to the bundle version used to upgrade a workload cluster.
+func ValidateManagementClusterBundlesVersion(ctx context.Context, k KubectlClient, mgmtCluster *types.Cluster, workload *cluster.Spec) error {
+	cluster, err := k.GetEksaCluster(ctx, mgmtCluster, mgmtCluster.Name)
+	if err != nil {
+		return err
+	}
+
+	if cluster.Spec.BundlesRef == nil {
+		return fmt.Errorf("management cluster bundlesRef cannot be nil")
+	}
+
+	mgmtBundles, err := k.GetBundles(ctx, mgmtCluster.KubeconfigFile, cluster.Spec.BundlesRef.Name, cluster.Spec.BundlesRef.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if mgmtBundles.Spec.Number < workload.Bundles.Spec.Number {
+		return fmt.Errorf("cannot upgrade workload cluster with bundle spec.number %d while management cluster %s is on older bundle spec.number %d", workload.Bundles.Spec.Number, mgmtCluster.Name, mgmtBundles.Spec.Number)
+	}
+
+	return nil
+}

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -13,10 +13,12 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/mocks"
+	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 type clusterTest struct {
@@ -231,4 +233,107 @@ func TestValidateK8s126SupportActive(t *testing.T) {
 	features.ClearCache()
 	os.Setenv(features.K8s126SupportEnvVar, "true")
 	tt.Expect(validations.ValidateK8s126Support(tt.clusterSpec)).To(Succeed())
+}
+
+func TestValidateManagementClusterBundlesVersion(t *testing.T) {
+	type testParam struct {
+		mgmtBundlesName   string
+		mgmtBundlesNumber int
+		wkBundlesName     string
+		wkBundlesNumber   int
+		wantErr           string
+		errGetEksaCluster error
+		errGetBundles     error
+	}
+
+	testParams := []testParam{
+		{
+			mgmtBundlesName:   "bundles-28",
+			mgmtBundlesNumber: 28,
+			wkBundlesName:     "bundles-27",
+			wkBundlesNumber:   27,
+			wantErr:           "",
+		},
+		{
+			mgmtBundlesName:   "bundles-28",
+			mgmtBundlesNumber: 28,
+			wkBundlesName:     "bundles-29",
+			wkBundlesNumber:   29,
+			wantErr:           "cannot upgrade workload cluster with bundle spec.number 29 while management cluster management-cluster is on older bundle spec.number 28",
+		},
+		{
+			mgmtBundlesName:   "bundles-28",
+			mgmtBundlesNumber: 28,
+			wkBundlesName:     "bundles-27",
+			wkBundlesNumber:   27,
+			wantErr:           "failed to reach cluster",
+			errGetEksaCluster: errors.New("failed to reach cluster"),
+		},
+		{
+			mgmtBundlesName:   "bundles-28",
+			mgmtBundlesNumber: 28,
+			wkBundlesName:     "bundles-27",
+			wkBundlesNumber:   27,
+			wantErr:           "failed to reach cluster",
+			errGetBundles:     errors.New("failed to reach cluster"),
+		},
+	}
+
+	for _, p := range testParams {
+		tt := newTest(t, withKubectl())
+		mgmtName := "management-cluster"
+		mgmtCluster := managementCluster(mgmtName)
+		mgmtClusterObject := anywhereCluster(mgmtName)
+
+		mgmtClusterObject.Spec.BundlesRef = &anywherev1.BundlesRef{
+			Name:      p.mgmtBundlesName,
+			Namespace: constants.EksaSystemNamespace,
+		}
+
+		tt.clusterSpec.Config.Cluster.Spec.BundlesRef = &anywherev1.BundlesRef{
+			Name:      p.wkBundlesName,
+			Namespace: constants.EksaSystemNamespace,
+		}
+		wkBundle := &releasev1alpha1.Bundles{
+			Spec: releasev1alpha1.BundlesSpec{
+				Number: p.wkBundlesNumber,
+			},
+		}
+		tt.clusterSpec.Bundles = wkBundle
+
+		mgmtBundle := &releasev1alpha1.Bundles{
+			Spec: releasev1alpha1.BundlesSpec{
+				Number: p.mgmtBundlesNumber,
+			},
+		}
+
+		ctx := context.Background()
+		tt.kubectl.EXPECT().GetEksaCluster(ctx, mgmtCluster, mgmtCluster.Name).Return(mgmtClusterObject, p.errGetEksaCluster)
+		if p.errGetEksaCluster == nil {
+			tt.kubectl.EXPECT().GetBundles(ctx, mgmtCluster.KubeconfigFile, mgmtClusterObject.Spec.BundlesRef.Name, mgmtClusterObject.Spec.BundlesRef.Namespace).Return(mgmtBundle, p.errGetBundles)
+		}
+
+		if p.wantErr == "" {
+			err := validations.ValidateManagementClusterBundlesVersion(ctx, tt.kubectl, mgmtCluster, tt.clusterSpec)
+			tt.Expect(err).To(BeNil())
+		} else {
+			err := validations.ValidateManagementClusterBundlesVersion(ctx, tt.kubectl, mgmtCluster, tt.clusterSpec)
+			tt.Expect(err.Error()).To(Equal(p.wantErr))
+		}
+	}
+}
+
+func TestValidateManagementClusterBundlesVersionMissingBundlesRef(t *testing.T) {
+	tt := newTest(t, withKubectl())
+	wantErr := "management cluster bundlesRef cannot be nil"
+	mgmtName := "management-cluster"
+	mgmtCluster := managementCluster(mgmtName)
+	mgmtClusterObject := anywhereCluster(mgmtName)
+
+	mgmtClusterObject.Spec.BundlesRef = nil
+	ctx := context.Background()
+	tt.kubectl.EXPECT().GetEksaCluster(ctx, mgmtCluster, mgmtCluster.Name).Return(mgmtClusterObject, nil)
+
+	err := validations.ValidateManagementClusterBundlesVersion(ctx, tt.kubectl, mgmtCluster, tt.clusterSpec)
+	tt.Expect(err.Error()).To(Equal(wantErr))
 }

--- a/pkg/validations/kubectl.go
+++ b/pkg/validations/kubectl.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/executables"
 	mockexecutables "github.com/aws/eks-anywhere/pkg/executables/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
+	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 type KubectlClient interface {
@@ -22,6 +23,7 @@ type KubectlClient interface {
 	Version(ctx context.Context, cluster *types.Cluster) (*executables.VersionResponse, error)
 	GetClusters(ctx context.Context, cluster *types.Cluster) ([]types.CAPICluster, error)
 	GetEksaCluster(ctx context.Context, cluster *types.Cluster, clusterName string) (*v1alpha1.Cluster, error)
+	GetBundles(ctx context.Context, kubeconfigFile, name, namespace string) (*releasev1alpha1.Bundles, error)
 	GetEksaGitOpsConfig(ctx context.Context, gitOpsConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.GitOpsConfig, error)
 	GetEksaFluxConfig(ctx context.Context, fluxConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.FluxConfig, error)
 	GetEksaOIDCConfig(ctx context.Context, oidcConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.OIDCConfig, error)

--- a/pkg/validations/mocks/kubectl.go
+++ b/pkg/validations/mocks/kubectl.go
@@ -11,6 +11,7 @@ import (
 	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	executables "github.com/aws/eks-anywhere/pkg/executables"
 	types "github.com/aws/eks-anywhere/pkg/types"
+	v1alpha10 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	gomock "github.com/golang/mock/gomock"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -36,6 +37,21 @@ func NewMockKubectlClient(ctrl *gomock.Controller) *MockKubectlClient {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockKubectlClient) EXPECT() *MockKubectlClientMockRecorder {
 	return m.recorder
+}
+
+// GetBundles mocks base method.
+func (m *MockKubectlClient) GetBundles(ctx context.Context, kubeconfigFile, name, namespace string) (*v1alpha10.Bundles, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBundles", ctx, kubeconfigFile, name, namespace)
+	ret0, _ := ret[0].(*v1alpha10.Bundles)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBundles indicates an expected call of GetBundles.
+func (mr *MockKubectlClientMockRecorder) GetBundles(ctx, kubeconfigFile, name, namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundles", reflect.TypeOf((*MockKubectlClient)(nil).GetBundles), ctx, kubeconfigFile, name, namespace)
 }
 
 // GetClusters mocks base method.

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -94,5 +94,17 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 			}
 		},
 	}
+
+	if u.Opts.Spec.Cluster.IsManaged() {
+		upgradeValidations = append(
+			upgradeValidations,
+			func() *validations.ValidationResult {
+				return &validations.ValidationResult{
+					Name:        "validate management cluster bundle version compatibility",
+					Remediation: fmt.Sprintf("upgrade management cluster %s before upgrading workload cluster %s", u.Opts.Spec.Cluster.ManagedBy(), u.Opts.WorkloadCluster.Name),
+					Err:         validations.ValidateManagementClusterBundlesVersion(ctx, k, u.Opts.ManagementCluster, u.Opts.Spec),
+				}
+			})
+	}
 	return upgradeValidations
 }

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/config"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	filewritermocks "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
@@ -25,6 +27,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/mocks"
 	"github.com/aws/eks-anywhere/pkg/validations/upgradevalidations"
+	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 const (
@@ -1135,6 +1138,10 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 				"noproxy2",
 			},
 		}
+		s.Cluster.Spec.BundlesRef = &anywherev1.BundlesRef{
+			Name:      "bundles-28",
+			Namespace: constants.EksaSystemNamespace,
+		}
 
 		s.GitOpsConfig = defaultGitOps
 		s.OIDCConfig = defaultOIDC
@@ -1177,6 +1184,11 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 					GitVersion: tc.clusterVersion,
 				},
 			}
+			bundlesResponse := &releasev1alpha1.Bundles{
+				Spec: releasev1alpha1.BundlesSpec{
+					Number: 28,
+				},
+			}
 
 			provider.EXPECT().DatacenterConfig(clusterSpec).Return(existingProviderSpec).MaxTimes(1)
 			provider.EXPECT().ValidateNewSpec(ctx, workloadCluster, clusterSpec).Return(nil).MaxTimes(1)
@@ -1187,6 +1199,10 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 			k.EXPECT().ValidateClustersCRD(ctx, workloadCluster).Return(tc.crdResponse)
 			k.EXPECT().GetClusters(ctx, workloadCluster).Return(tc.getClusterResponse, nil)
 			k.EXPECT().GetEksaCluster(ctx, workloadCluster, clusterSpec.Cluster.Name).Return(existingClusterSpec.Cluster, nil)
+			if opts.Spec.Cluster.IsManaged() {
+				k.EXPECT().GetEksaCluster(ctx, workloadCluster, workloadCluster.Name).Return(existingClusterSpec.Cluster, nil)
+				k.EXPECT().GetBundles(ctx, workloadCluster.KubeconfigFile, existingClusterSpec.Cluster.Spec.BundlesRef.Name, existingClusterSpec.Cluster.Spec.BundlesRef.Namespace).Return(bundlesResponse, nil)
+			}
 			k.EXPECT().GetEksaGitOpsConfig(ctx, clusterSpec.Cluster.Spec.GitOpsRef.Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.GitOpsConfig, nil).MaxTimes(1)
 			k.EXPECT().GetEksaOIDCConfig(ctx, clusterSpec.Cluster.Spec.IdentityProviderRefs[1].Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.OIDCConfig, nil).MaxTimes(1)
 			k.EXPECT().GetEksaAWSIamConfig(ctx, clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.AWSIamConfig, nil).MaxTimes(1)


### PR DESCRIPTION
Validates that the management cluster's bundle is the same version or newer than the bundle version used to upgrade a workload cluster.

*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/5105

*Description of changes:*
Validates that a management cluster's bundles rev >= the bundle used by CLI to upgrade a workload cluster.

*Testing (if applicable):*
Unit test and two manual tests:
- [x] upgrading workload cluster with a bundle manifest built in at build time that should fail validation
- [x] upgrading workload cluster with a bundles override that should fail the validation
- [x] upgrading workload cluster with a bundles override that should pass the validation

Example error:
```
2023-03-15T17:13:16.583-0400    V0      ❌ Validation failed    {"validation": "validate management cluster bundle version compatibility", "error": "cannot upgrade workload cluster with bundle 29 while management cluster mgmt-v-jwmeier is on older bundle 28", "remediation": "upgrade management cluster mgmt-v-jwmeier before upgrading workload cluster wk-v-jwmeier"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

