### PR TITLE
Support linking VM resources with Projects on Nutanix

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_nutanixmachineconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_nutanixmachineconfigs.yaml
@@ -88,6 +88,27 @@ spec:
                 x-kubernetes-int-or-string: true
               osFamily:
                 type: string
+              project:
+                description: Project is an optional property that specifies the Prism
+                  Central project so that machine resources can be linked to it. The
+                  project identifier (uuid or name) can be obtained from the Prism
+                  Central console or using the Prism Central API.
+                properties:
+                  name:
+                    description: name is the resource name in the PC
+                    type: string
+                  type:
+                    description: Type is the identifier type to use for this resource.
+                    enum:
+                    - uuid
+                    - name
+                    type: string
+                  uuid:
+                    description: uuid is the UUID of the resource in the PC.
+                    type: string
+                required:
+                - type
+                type: object
               subnet:
                 description: subnet is to identify the cluster's network subnet to
                   use for the Machine's VM The cluster identifier (uuid or name) can

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4534,6 +4534,27 @@ spec:
                 x-kubernetes-int-or-string: true
               osFamily:
                 type: string
+              project:
+                description: Project is an optional property that specifies the Prism
+                  Central project so that machine resources can be linked to it. The
+                  project identifier (uuid or name) can be obtained from the Prism
+                  Central console or using the Prism Central API.
+                properties:
+                  name:
+                    description: name is the resource name in the PC
+                    type: string
+                  type:
+                    description: Type is the identifier type to use for this resource.
+                    enum:
+                    - uuid
+                    - name
+                    type: string
+                  uuid:
+                    description: uuid is the UUID of the resource in the PC.
+                    type: string
+                required:
+                - type
+                type: object
               subnet:
                 description: subnet is to identify the cluster's network subnet to
                   use for the Machine's VM The cluster identifier (uuid or name) can

--- a/pkg/api/v1alpha1/nutanixmachineconfig.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig.go
@@ -223,6 +223,12 @@ func validateNutanixReferences(c *NutanixMachineConfig) error {
 		return err
 	}
 
+	if c.Spec.Project != nil {
+		if err := validateNutanixResourceReference(c.Spec.Project, "project", c.Name); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/api/v1alpha1/nutanixmachineconfig_types.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_types.go
@@ -42,6 +42,11 @@ type NutanixMachineConfigSpec struct {
 	// or using the Prism Central API.
 	// +kubebuilder:validation:Required
 	Subnet NutanixResourceIdentifier `json:"subnet"`
+	// Project is an optional property that specifies the Prism Central project so that machine resources
+	// can be linked to it. The project identifier (uuid or name) can be obtained from the Prism Central console
+	// or using the Prism Central API.
+	// +optional
+	Project *NutanixResourceIdentifier `json:"project,omitempty"`
 
 	// systemDiskSize is size (in Quantity format) of the system disk of the VM
 	// The minimum systemDiskSize is 20Gi bytes

--- a/pkg/api/v1alpha1/nutanixmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_webhook.go
@@ -56,7 +56,7 @@ func (in *NutanixMachineConfig) ValidateUpdate(old runtime.Object) error {
 	}
 
 	if oldNutanixMachineConfig.IsReconcilePaused() {
-		nutanixmachineconfiglog.Info("NutanixMachineConfig is paused, so allowing create", "name", in.Name)
+		nutanixmachineconfiglog.Info("NutanixMachineConfig is paused, so allowing update", "name", in.Name)
 		if len(allErrs) > 0 {
 			return apierrors.NewInvalid(
 				GroupVersion.WithKind(NutanixMachineConfigKind).GroupKind(),

--- a/pkg/api/v1alpha1/nutanixmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_webhook_test.go
@@ -34,6 +34,10 @@ func nutanixMachineConfig() *v1alpha1.NutanixMachineConfig {
 				Type: v1alpha1.NutanixIdentifierName,
 				Name: ptr.String("subnet-1"),
 			},
+			Project: &v1alpha1.NutanixResourceIdentifier{
+				Type: v1alpha1.NutanixIdentifierName,
+				Name: ptr.String("project-1"),
+			},
 			SystemDiskSize: resource.MustParse("100Gi"),
 			Users: []v1alpha1.UserConfiguration{
 				{

--- a/pkg/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha1/zz_generated.deepcopy.go
@@ -1630,6 +1630,11 @@ func (in *NutanixMachineConfigSpec) DeepCopyInto(out *NutanixMachineConfigSpec) 
 	in.Image.DeepCopyInto(&out.Image)
 	in.Cluster.DeepCopyInto(&out.Cluster)
 	in.Subnet.DeepCopyInto(&out.Subnet)
+	if in.Project != nil {
+		in, out := &in.Project, &out.Project
+		*out = new(NutanixResourceIdentifier)
+		(*in).DeepCopyInto(*out)
+	}
 	out.SystemDiskSize = in.SystemDiskSize.DeepCopy()
 }
 

--- a/pkg/providers/nutanix/client.go
+++ b/pkg/providers/nutanix/client.go
@@ -13,5 +13,7 @@ type Client interface {
 	ListImage(ctx context.Context, getEntitiesRequest *v3.DSMetadata) (*v3.ImageListIntentResponse, error)
 	GetCluster(ctx context.Context, uuid string) (*v3.ClusterIntentResponse, error)
 	ListCluster(ctx context.Context, getEntitiesRequest *v3.DSMetadata) (*v3.ClusterListIntentResponse, error)
+	GetProject(ctx context.Context, uuid string) (*v3.Project, error)
+	ListProject(ctx context.Context, getEntitiesRequest *v3.DSMetadata) (*v3.ProjectListResponse, error)
 	GetCurrentLoggedInUser(ctx context.Context) (*v3.UserIntentResponse, error)
 }

--- a/pkg/providers/nutanix/config/md-template.yaml
+++ b/pkg/providers/nutanix/config/md-template.yaml
@@ -69,6 +69,16 @@ spec:
         - type: uuid
           uuid: "{{.subnetUUID}}"
 {{ end }}
+{{- if .projectIDType}}
+      project:
+{{- if (eq .projectIDType "name") }}
+        type: name
+        name: "{{.projectName}}"
+{{- else if (eq .projectIDType "uuid") }}
+        type: uuid
+        uuid: "{{.projectUUID}}"
+{{ end }}
+{{ end }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/pkg/providers/nutanix/mocks/client.go
+++ b/pkg/providers/nutanix/mocks/client.go
@@ -80,6 +80,21 @@ func (mr *MockClientMockRecorder) GetImage(ctx, uuid interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImage", reflect.TypeOf((*MockClient)(nil).GetImage), ctx, uuid)
 }
 
+// GetProject mocks base method.
+func (m *MockClient) GetProject(ctx context.Context, uuid string) (*v3.Project, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProject", ctx, uuid)
+	ret0, _ := ret[0].(*v3.Project)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProject indicates an expected call of GetProject.
+func (mr *MockClientMockRecorder) GetProject(ctx, uuid interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockClient)(nil).GetProject), ctx, uuid)
+}
+
 // GetSubnet mocks base method.
 func (m *MockClient) GetSubnet(ctx context.Context, uuid string) (*v3.SubnetIntentResponse, error) {
 	m.ctrl.T.Helper()
@@ -123,6 +138,21 @@ func (m *MockClient) ListImage(ctx context.Context, getEntitiesRequest *v3.DSMet
 func (mr *MockClientMockRecorder) ListImage(ctx, getEntitiesRequest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImage", reflect.TypeOf((*MockClient)(nil).ListImage), ctx, getEntitiesRequest)
+}
+
+// ListProject mocks base method.
+func (m *MockClient) ListProject(ctx context.Context, getEntitiesRequest *v3.DSMetadata) (*v3.ProjectListResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListProject", ctx, getEntitiesRequest)
+	ret0, _ := ret[0].(*v3.ProjectListResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListProject indicates an expected call of ListProject.
+func (mr *MockClientMockRecorder) ListProject(ctx, getEntitiesRequest interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProject", reflect.TypeOf((*MockClient)(nil).ListProject), ctx, getEntitiesRequest)
 }
 
 // ListSubnet mocks base method.

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -224,6 +224,12 @@ func buildTemplateMapCP(
 		values["etcdSshUsername"] = etcdMachineSpec.Users[0].Name
 	}
 
+	if controlPlaneMachineSpec.Project != nil {
+		values["projectIDType"] = controlPlaneMachineSpec.Project.Type
+		values["projectName"] = controlPlaneMachineSpec.Project.Name
+		values["projectUUID"] = controlPlaneMachineSpec.Project.UUID
+	}
+
 	return values, nil
 }
 
@@ -279,6 +285,12 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupMachineSpec v1
 			values["registryUsername"] = username
 			values["registryPassword"] = password
 		}
+	}
+
+	if workerNodeGroupMachineSpec.Project != nil {
+		values["projectIDType"] = workerNodeGroupMachineSpec.Project.Type
+		values["projectName"] = workerNodeGroupMachineSpec.Project.Name
+		values["projectUUID"] = workerNodeGroupMachineSpec.Project.UUID
 	}
 
 	return values, nil

--- a/pkg/providers/nutanix/template_test.go
+++ b/pkg/providers/nutanix/template_test.go
@@ -25,6 +25,9 @@ var nutanixDatacenterConfigSpec string
 //go:embed testdata/machineConfig.yaml
 var nutanixMachineConfigSpec string
 
+//go:embed testdata/machineConfig_project.yaml
+var nutanixMachineConfigSpecWithProject string
+
 func fakemarshal(v interface{}) ([]byte, error) {
 	return []byte{}, errors.New("marshalling failed")
 }
@@ -198,6 +201,46 @@ func TestNewNutanixTemplateBuilderRegistryMirrorConfigNoRegistryCredsSet(t *test
 	}
 	_, err = builder.GenerateCAPISpecWorkers(buildSpec, workloadTemplateNames, kubeadmconfigTemplateNames)
 	assert.Error(t, err)
+}
+
+func TestNewNutanixTemplateBuilderProject(t *testing.T) {
+	t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+	t.Setenv(constants.EksaNutanixPasswordKey, "password")
+	creds := GetCredsFromEnv()
+
+	dcConf, _, _ := minimalNutanixConfigSpec(t)
+	machineConf := &anywherev1.NutanixMachineConfig{}
+	err := yaml.Unmarshal([]byte(nutanixMachineConfigSpecWithProject), machineConf)
+	require.NoError(t, err)
+
+	workerConfs := map[string]anywherev1.NutanixMachineConfigSpec{
+		"eksa-unit-test": machineConf.Spec,
+	}
+	builder := NewNutanixTemplateBuilder(&dcConf.Spec, &machineConf.Spec, &machineConf.Spec, workerConfs, creds, time.Now)
+	assert.NotNil(t, builder)
+
+	buildSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster-project.yaml")
+	cpSpec, err := builder.GenerateCAPISpecControlPlane(buildSpec)
+	assert.NoError(t, err)
+	assert.NotNil(t, cpSpec)
+
+	expectedControlPlaneSpec, err := os.ReadFile("testdata/expected_results_project.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, expectedControlPlaneSpec, cpSpec)
+
+	workloadTemplateNames := map[string]string{
+		"eksa-unit-test": "eksa-unit-test",
+	}
+	kubeadmconfigTemplateNames := map[string]string{
+		"eksa-unit-test": "eksa-unit-test",
+	}
+	workerSpec, err := builder.GenerateCAPISpecWorkers(buildSpec, workloadTemplateNames, kubeadmconfigTemplateNames)
+	assert.NoError(t, err)
+	assert.NotNil(t, workerSpec)
+
+	expectedWorkersSpec, err := os.ReadFile("testdata/expected_results_project_md.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, expectedWorkersSpec, workerSpec)
 }
 
 func minimalNutanixConfigSpec(t *testing.T) (*anywherev1.NutanixDatacenterConfig, *anywherev1.NutanixMachineConfig, map[string]anywherev1.NutanixMachineConfigSpec) {

--- a/pkg/providers/nutanix/testdata/eksa-cluster-project.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-project.yaml
@@ -1,0 +1,79 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  kubernetesVersion: "1.19"
+  controlPlaneConfiguration:
+    name: eksa-unit-test
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  workerNodeGroupConfigurations:
+    - count: 4
+      name: eksa-unit-test
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: NutanixMachineConfig
+  externalEtcdConfiguration:
+    name: eksa-unit-test
+    count: 3
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  datacenterRef:
+    kind: NutanixDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440
+  credentialRef:
+    kind: Secret
+    name: "nutanix-credentials"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  project:
+    type: "name"
+    name: "prism-project"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---

--- a/pkg/providers/nutanix/testdata/expected_results_project.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_project.yaml
@@ -1,92 +1,76 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: NutanixCluster
 metadata:
-  name: "{{.clusterName}}"
-  namespace: "{{.eksaSystemNamespace}}"
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
 spec:
   prismCentral:
-{{- if .nutanixAdditionalTrustBundle }}
-    additionalTrustBundle:
-      kind: String
-      data: |
-{{ .nutanixAdditionalTrustBundle | indent 8 }}
-{{- end }}
-    address: "{{.nutanixEndpoint}}"
-    port: {{.nutanixPort}}
-    insecure: {{.nutanixInsecure}}
+    address: "prism.nutanix.com"
+    port: 9440
+    insecure: false
     credentialRef:
-      name: "{{.secretName}}"
+      name: "capx-eksa-unit-test"
       kind: Secret
   controlPlaneEndpoint:
-    host: "{{.controlPlaneEndpointIp}}"
+    host: "test-ip"
     port: 6443
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: "{{.clusterName}}"
-  name: "{{.clusterName}}"
-  namespace: "{{.eksaSystemNamespace}}"
+    cluster.x-k8s.io/cluster-name: "eksa-unit-test"
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
 spec:
   clusterNetwork:
     services:
-      cidrBlocks: {{.serviceCidrs}}
+      cidrBlocks: [10.96.0.0/12]
     pods:
-      cidrBlocks: {{.podCidrs}}
+      cidrBlocks: [192.168.0.0/16]
     serviceDomain: "cluster.local"
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane
-    name: "{{.clusterName}}"
+    name: "eksa-unit-test"
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: NutanixCluster
-    name: "{{.clusterName}}"
+    name: "eksa-unit-test"
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
-  name: "{{.clusterName}}"
-  namespace: "{{.eksaSystemNamespace}}"
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
 spec:
-  replicas: {{.controlPlaneReplicas}}
-  version: "{{.kubernetesVersion}}"
+  replicas: 3
+  version: "v1.19.8-eks-1-19-4"
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
-      name: "{{.controlPlaneTemplateName}}"
+      name: "<no value>"
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: "{{.kubernetesRepository}}"
+      imageRepository: "public.ecr.aws/eks-distro/kubernetes"
       apiServer:
         certSANs:
           - localhost
           - 127.0.0.1
           - 0.0.0.0
-{{- if .apiServerExtraArgs }}
-        extraArgs:
-{{ .apiServerExtraArgs.ToYaml | indent 10 }}
-{{- end }}
       controllerManager:
         extraArgs:
           enable-hostpath-provisioner: "true"
       dns:
-        imageRepository: {{.corednsRepository}}
-        imageTag: {{.corednsVersion}}
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.8.0-eks-1-19-4
       etcd:
-{{- if .externalEtcd }}
         external:
           endpoints: []
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
-{{- else }}
-        local:
-          imageRepository: {{.etcdRepository}}
-          imageTag: {{.etcdImageTag}}
-{{- end }}
     files:
     - content: |
         apiVersion: v1
@@ -98,7 +82,7 @@ spec:
         spec:
           containers:
             - name: kube-vip
-              image: {{.kubeVipImage}}
+              image: 
               imagePullPolicy: IfNotPresent
               args:
                 - manager
@@ -106,7 +90,7 @@ spec:
                 - name: vip_arp
                   value: "true"
                 - name: address
-                  value: "{{.controlPlaneEndpointIp}}"
+                  value: "test-ip"
                 - name: port
                   value: "6443"
                 - name: vip_cidr
@@ -126,9 +110,9 @@ spec:
                 - name: vip_retryperiod
                   value: "2"
                 - name: svc_enable
-                  value: "{{.kubeVipSvcEnable}}"
+                  value: "false"
                 - name: lb_enable
-                  value: "{{.kubeVipLBEnable}}"
+                  value: "false"
               securityContext:
                 capabilities:
                   add:
@@ -148,36 +132,6 @@ spec:
         status: {}
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
-{{- if .registryCACert }}
-    - content: |
-{{ .registryCACert | indent 8 }}
-      owner: root:root
-      path: "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-{{- end }}
-{{- if .registryMirrorMap }}
-    - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          {{- range $orig, $mirror := .registryMirrorMap }}
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
-            endpoint = ["https://{{ $mirror }}"]
-          {{- end }}
-{{- if or .registryCACert .insecureSkip }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
-{{- if .registryCACert }}
-            ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-{{- end }}
-{{- if .insecureSkip }}
-            insecure_skip_verify = {{ .insecureSkip }}
-{{- end }}
-{{- end }}
-{{- if .registryAuth }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".auth]
-            username = "{{.registryUsername}}"
-            password = "{{.registryPassword}}"
-{{- end }}
-      owner: root:root
-      path: "/etc/containerd/config_append.toml"
-{{- end }}
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -192,26 +146,19 @@ spec:
           cloud-provider: external
           read-only-port: "0"
           anonymous-auth: "false"
-{{- if .kubeletExtraArgs }}
-{{ .kubeletExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-        name: "{{`{{ ds.meta_data.hostname }}`}}"
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: "{{ ds.meta_data.hostname }}"
     users:
-      - name: "{{.controlPlaneSshUsername }}"
+      - name: "mySshUsername"
         lockPassword: false
         sudo: ALL=(ALL) NOPASSWD:ALL
         sshAuthorizedKeys:
-          - "{{.controlPlaneSshAuthorizedKey}}"
+          - "mySshAuthorizedKey"
     preKubeadmCommands:
-{{- if and .registryMirrorMap }}
-      - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
-      - sudo systemctl daemon-reload
-      - sudo systemctl restart containerd
-{{- end }}
-      - hostnamectl set-hostname "{{`{{ ds.meta_data.hostname }}`}}"
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >> /etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
       # This section should be removed once these packages are added to the image builder process
       - apt update
       - apt install -y nfs-common open-iscsi
@@ -223,60 +170,28 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: NutanixMachineTemplate
 metadata:
-  name: "{{.controlPlaneTemplateName}}"
-  namespace: "{{.eksaSystemNamespace}}"
+  name: "<no value>"
+  namespace: "eksa-system"
 spec:
   template:
     spec:
-      providerID: "nutanix://{{.clusterName}}-m1"
-      vcpusPerSocket: {{.vcpusPerSocket}}
-      vcpuSockets: {{.vcpuSockets}}
-      memorySize: {{.memorySize}}
-      systemDiskSize: {{.systemDiskSize}}
+      providerID: "nutanix://eksa-unit-test-m1"
+      vcpusPerSocket: 1
+      vcpuSockets: 4
+      memorySize: 8Gi
+      systemDiskSize: 40Gi
       image:
-{{- if (eq .imageIDType "name") }}
         type: name
-        name: "{{.imageName}}"
-{{ else if (eq .imageIDType "uuid") }}
-        type: uuid
-        uuid: "{{.imageUUID}}"
-{{ end }}
+        name: "prism-image"
+
       cluster:
-{{- if (eq .nutanixPEClusterIDType "name") }}
         type: name
-        name: "{{.nutanixPEClusterName}}"
-{{- else if (eq .nutanixPEClusterIDType "uuid") }}
-        type: uuid
-        uuid: "{{.nutanixPEClusterUUID}}"
-{{ end }}
+        name: "prism-cluster"
       subnet:
-{{- if (eq .subnetIDType "name") }}
         - type: name
-          name: "{{.subnetName}}"
-{{- else if (eq .subnetIDType "uuid") }}
-        - type: uuid
-          uuid: "{{.subnetUUID}}"
-{{ end }}
-{{- if .projectIDType}}
+          name: "prism-subnet"
       project:
-{{- if (eq .projectIDType "name") }}
         type: name
-        name: "{{.projectName}}"
-{{- else if (eq .projectIDType "uuid") }}
-        type: uuid
-        uuid: "{{.projectUUID}}"
-{{ end }}
-{{ end }}
+        name: "prism-project"
+
 ---
-{{- if .registryAuth }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: registry-credentials
-  namespace: {{.eksaSystemNamespace}}
-  labels:
-    clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "{{.registryUsername}}"
-  password: "{{.registryPassword}}"
-{{- end }}

--- a/pkg/providers/nutanix/testdata/expected_results_project_md.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_project_md.yaml
@@ -1,0 +1,84 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: "eksa-unit-test"
+  name: "eksa-unit-test-eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  clusterName: "eksa-unit-test"
+  replicas: 4
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: "eksa-unit-test"
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: "eksa-unit-test"
+      clusterName: "eksa-unit-test"
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: NutanixMachineTemplate
+        name: "eksa-unit-test"
+      version: "v1.19.8-eks-1-19-4"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  template:
+    spec:
+      providerID: "nutanix://eksa-unit-test-m1"
+      vcpusPerSocket: 1
+      vcpuSockets: 4
+      memorySize: 8Gi
+      systemDiskSize: 40Gi
+      image:
+        type: name
+        name: "prism-image"
+
+      cluster:
+        type: name
+        name: "prism-cluster"
+      subnet:
+        - type: name
+          name: "prism-subnet"
+      project:
+        type: name
+        name: "prism-project"
+
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  template:
+    spec:
+      preKubeadmCommands:
+        - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+            # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+            #cgroup-driver: cgroupfs
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          name: '{{ ds.meta_data.hostname }}'
+      users:
+        - name: "mySshUsername"
+          lockPassword: false
+          sudo: ALL=(ALL) NOPASSWD:ALL
+          sshAuthorizedKeys:
+            - "mySshAuthorizedKey"
+
+---

--- a/pkg/providers/nutanix/testdata/machineConfig_project.yaml
+++ b/pkg/providers/nutanix/testdata/machineConfig_project.yaml
@@ -1,0 +1,27 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  project:
+    type: "name"
+    name: "prism-project"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"

--- a/pkg/providers/nutanix/validator.go
+++ b/pkg/providers/nutanix/validator.go
@@ -191,7 +191,7 @@ func (v *Validator) ValidateMachineConfig(ctx context.Context, client Client, co
 	}
 
 	if config.Spec.Project != nil {
-		if err := v.validateProjectConfig(ctx, *config.Spec.Project); err != nil {
+		if err := v.validateProjectConfig(ctx, client, *config.Spec.Project); err != nil {
 			return err
 		}
 	}
@@ -280,14 +280,14 @@ func (v *Validator) validateSubnetConfig(ctx context.Context, client Client, ide
 	return nil
 }
 
-func (v *Validator) validateProjectConfig(ctx context.Context, identifier anywherev1.NutanixResourceIdentifier) error {
+func (v *Validator) validateProjectConfig(ctx context.Context, client Client, identifier anywherev1.NutanixResourceIdentifier) error {
 	switch identifier.Type {
 	case anywherev1.NutanixIdentifierName:
 		if identifier.Name == nil || *identifier.Name == "" {
 			return fmt.Errorf("missing project name")
 		}
 		projectName := *identifier.Name
-		if _, err := findProjectUUIDByName(ctx, v.client, projectName); err != nil {
+		if _, err := findProjectUUIDByName(ctx, client, projectName); err != nil {
 			return fmt.Errorf("failed to find project with name %q: %v", projectName, err)
 		}
 	case anywherev1.NutanixIdentifierUUID:
@@ -295,7 +295,7 @@ func (v *Validator) validateProjectConfig(ctx context.Context, identifier anywhe
 			return fmt.Errorf("missing project uuid")
 		}
 		projectUUID := *identifier.UUID
-		if _, err := v.client.GetProject(ctx, projectUUID); err != nil {
+		if _, err := client.GetProject(ctx, projectUUID); err != nil {
 			return fmt.Errorf("failed to find project with uuid %s: %v", projectUUID, err)
 		}
 	default:

--- a/pkg/providers/nutanix/validator_test.go
+++ b/pkg/providers/nutanix/validator_test.go
@@ -372,7 +372,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 					Type: anywherev1.NutanixIdentifierName,
 					Name: nil,
 				}
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "missing project name",
 		},
@@ -386,7 +387,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 					Type: anywherev1.NutanixIdentifierUUID,
 					UUID: nil,
 				}
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "missing project uuid",
 		},
@@ -400,7 +402,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 					Type: "notatype",
 					UUID: nil,
 				}
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "invalid project identifier type",
 		},
@@ -415,7 +418,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 					Type: anywherev1.NutanixIdentifierName,
 					Name: ptr.String("notaproject"),
 				}
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "failed to find project by name",
 		},
@@ -430,7 +434,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 					Type: anywherev1.NutanixIdentifierName,
 					Name: ptr.String("notaproject"),
 				}
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "failed to find project by name",
 		},
@@ -447,7 +452,8 @@ func TestNutanixValidatorValidateMachineConfig(t *testing.T) {
 					Type: anywherev1.NutanixIdentifierName,
 					Name: ptr.String("project"),
 				}
-				return NewValidator(mockClient, validator, &http.Client{Transport: transport})
+				clientCache := &ClientCache{clients: map[string]Client{"test": mockClient}}
+				return NewValidator(clientCache, validator, &http.Client{Transport: transport})
 			},
 			expectedError: "found more than one (2) project with name",
 		},


### PR DESCRIPTION
These changes allow specifying an optional project in the NutanixMachineConfig
which, when specified, is propagated to the corresponding NutanixMachineTemplate
property. 

**How has this been tested?**
- Used a bundle-release.yaml with eksa-components.yaml and cluster-controller image overridden to
the ones corresponding to the changes in this PR.
- Set the `project` property in `NutanixMachineConfig` manifests to `my-project`: A project that already exists in Prism Central
```
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: NutanixMachineConfig
metadata:
  name: eksa-sid-cp
spec:
  ...
  project:
    name: my-project
    type: name
  ...

---
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: NutanixMachineConfig
metadata:
  name: eksa-sid
spec:
  ...
  project:
    name: my-project
    type: name
  ...
```
- Created a cluster successfully
```
$ bin/eksctl-anywhere create cluster -f ./${CLUSTER_NAME}.yaml --force-cleanup -v 10  --bundles-override ./bundle-release-project.yaml
...
2023-03-15T23:00:00.450+0100	V0	🎉 Cluster created!
```
- Check the names of the machines in the created cluster
```
$ kubectl get machines -A
NAMESPACE     NAME                             CLUSTER    NODENAME                         PROVIDERID                                       PHASE     AGE   VERSION
eksa-system   eksa-sid-22rsp                   eksa-sid   eksa-sid-22rsp                   nutanix://33182ce4-e87e-4145-93f5-9441157c6e00   Running   21m   v1.24.10-eks-1-24-12
eksa-system   eksa-sid-476bp                   eksa-sid   eksa-sid-476bp                   nutanix://d82e1a2e-7c65-4f90-bfe8-5d3a28934e21   Running   21m   v1.24.10-eks-1-24-12
eksa-system   eksa-sid-bkvlk                   eksa-sid   eksa-sid-bkvlk                   nutanix://62754b9a-258b-4efb-bf2c-ff9d8de880c0   Running   21m   v1.24.10-eks-1-24-12
eksa-system   eksa-sid-md-0-85b84bd54d-2l4gb   eksa-sid   eksa-sid-md-0-85b84bd54d-2l4gb   nutanix://47989010-bd02-45be-abf0-4fd5fd3c668c   Running   21m   v1.24.10-eks-1-24-12
eksa-system   eksa-sid-md-0-85b84bd54d-hx9st   eksa-sid   eksa-sid-md-0-85b84bd54d-hx9st   nutanix://69494499-4c38-48a4-bc92-9aff8d89ca8c   Running   21m   v1.24.10-eks-1-24-12
eksa-system   eksa-sid-md-0-85b84bd54d-rsndq   eksa-sid   eksa-sid-md-0-85b84bd54d-rsndq   nutanix://0aa24440-e038-4ab8-8b55-df3900aec941   Running   21m   v1.24.10-eks-1-24-12
```
- Verify on Prism Central that the VMs corresponding to the machines above are linked to the `my-project` project.
![2023-03-15 at 23 06](https://user-images.githubusercontent.com/6081171/225456613-696bd320-f2cb-47c7-99d5-cd37cae5d407.png)


Full install logs: https://app.warp.dev/block/ZQ5t4rdhmUL0GCNQZ2JqNW