### PR TITLE
merge the chartInstaller and chartUninstaller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -575,7 +575,7 @@ mocks: ## Generate mocks
 	${MOCKGEN} -destination=pkg/curatedpackages/mocks/bundlemanager.go -package=mocks -source "pkg/curatedpackages/bundlemanager.go" Manager
 	${MOCKGEN} -destination=pkg/clients/kubernetes/mocks/kubectl.go -package=mocks -source "pkg/clients/kubernetes/unauth.go"
 	${MOCKGEN} -destination=pkg/clients/kubernetes/mocks/kubeconfig.go -package=mocks -source "pkg/clients/kubernetes/kubeconfig.go"
-	${MOCKGEN} -destination=pkg/curatedpackages/mocks/installer.go -package=mocks -source "pkg/curatedpackages/packagecontrollerclient.go" ChartInstaller ChartUninstaller ClientBuilder
+	${MOCKGEN} -destination=pkg/curatedpackages/mocks/installer.go -package=mocks -source "pkg/curatedpackages/packagecontrollerclient.go" ChartManager ClientBuilder
 	${MOCKGEN} -destination=pkg/curatedpackages/mocks/kube_client.go -package=mocks -mock_names Client=MockKubeClient sigs.k8s.io/controller-runtime/pkg/client Client
 	${MOCKGEN} -destination=pkg/cluster/mocks/client_builder.go -package=mocks -source "pkg/cluster/client_builder.go"
 	${MOCKGEN} -destination=controllers/mocks/factory.go -package=mocks "github.com/aws/eks-anywhere/controllers" Manager

--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -436,7 +436,7 @@ func (f *Factory) withPackageControllerClient() *Factory {
 		if f.packageControllerClient != nil {
 			return nil
 		}
-		f.packageControllerClient = curatedpackages.NewPackageControllerClientFullLifecycle(f.logger, f.deps.Helm, f.deps.Helm, f.deps.Kubectl, f.tracker)
+		f.packageControllerClient = curatedpackages.NewPackageControllerClientFullLifecycle(f.logger, f.deps.Helm, f.deps.Kubectl, f.tracker)
 		return nil
 	})
 

--- a/pkg/curatedpackages/mocks/installer.go
+++ b/pkg/curatedpackages/mocks/installer.go
@@ -125,6 +125,57 @@ func (mr *MockChartUninstallerMockRecorder) Delete(ctx, kubeconfigFilePath, inst
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockChartUninstaller)(nil).Delete), ctx, kubeconfigFilePath, installName, namespace)
 }
 
+// MockChartManager is a mock of ChartManager interface.
+type MockChartManager struct {
+	ctrl     *gomock.Controller
+	recorder *MockChartManagerMockRecorder
+}
+
+// MockChartManagerMockRecorder is the mock recorder for MockChartManager.
+type MockChartManagerMockRecorder struct {
+	mock *MockChartManager
+}
+
+// NewMockChartManager creates a new mock instance.
+func NewMockChartManager(ctrl *gomock.Controller) *MockChartManager {
+	mock := &MockChartManager{ctrl: ctrl}
+	mock.recorder = &MockChartManagerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockChartManager) EXPECT() *MockChartManagerMockRecorder {
+	return m.recorder
+}
+
+// Delete mocks base method.
+func (m *MockChartManager) Delete(ctx context.Context, kubeconfigFilePath, installName, namespace string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, kubeconfigFilePath, installName, namespace)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockChartManagerMockRecorder) Delete(ctx, kubeconfigFilePath, installName, namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockChartManager)(nil).Delete), ctx, kubeconfigFilePath, installName, namespace)
+}
+
+// InstallChart mocks base method.
+func (m *MockChartManager) InstallChart(ctx context.Context, chart, ociURI, version, kubeconfigFilePath, namespace, valueFilePath string, skipCRDs bool, values []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallChart", ctx, chart, ociURI, version, kubeconfigFilePath, namespace, valueFilePath, skipCRDs, values)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallChart indicates an expected call of InstallChart.
+func (mr *MockChartManagerMockRecorder) InstallChart(ctx, chart, ociURI, version, kubeconfigFilePath, namespace, valueFilePath, skipCRDs, values interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallChart", reflect.TypeOf((*MockChartManager)(nil).InstallChart), ctx, chart, ociURI, version, kubeconfigFilePath, namespace, valueFilePath, skipCRDs, values)
+}
+
 // MockKubeDeleter is a mock of KubeDeleter interface.
 type MockKubeDeleter struct {
 	ctrl     *gomock.Controller

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -1049,8 +1049,7 @@ func (f *Factory) WithPackageControllerClient(spec *cluster.Spec, kubeConfig str
 			return err
 		}
 		f.dependencies.PackageControllerClient = curatedpackages.NewPackageControllerClient(
-			f.dependencies.Helm, // installer
-			f.dependencies.Helm, // uninstaller (sometimes these need to be different)
+			f.dependencies.Helm,
 			f.dependencies.Kubectl,
 			spec.Cluster.Name,
 			mgmtKubeConfig,


### PR DESCRIPTION
During development of curated packages support via full cluster lifecycle, these interfaces required different helm executable instantiations, but that requirement was removed, so now these can merge down into the same interface.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

