### PR TITLE
Enabled registry mirror InsecureSkipVerify flag for Tinkerbell

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -725,10 +725,10 @@ func validateMirrorConfig(clusterConfig *Cluster) error {
 
 	if clusterConfig.Spec.RegistryMirrorConfiguration.InsecureSkipVerify {
 		switch clusterConfig.Spec.DatacenterRef.Kind {
-		case DockerDatacenterKind, NutanixDatacenterKind, VSphereDatacenterKind, SnowDatacenterKind:
+		case DockerDatacenterKind, NutanixDatacenterKind, VSphereDatacenterKind, TinkerbellDatacenterKind, SnowDatacenterKind:
 			break
 		default:
-			return fmt.Errorf("insecureSkipVerify is only supported for docker, nutanix, snow and vsphere providers")
+			return fmt.Errorf("insecureSkipVerify is only supported for docker, nutanix, snow, tinkerbell, and vsphere providers")
 		}
 	}
 

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -2573,7 +2573,7 @@ func TestValidateMirrorConfig(t *testing.T) {
 		},
 		{
 			name:    "insecureSkipVerify on an unsupported provider",
-			wantErr: "insecureSkipVerify is only supported for docker, nutanix, snow and vsphere providers",
+			wantErr: "insecureSkipVerify is only supported for docker, nutanix, snow, tinkerbell, and vsphere providers",
 			cluster: &Cluster{
 				Spec: ClusterSpec{
 					RegistryMirrorConfiguration: &RegistryMirrorConfiguration{

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -319,9 +319,14 @@ spec:
             [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
               endpoint = ["https://{{ $mirror }}"]
             {{- end }}
-            {{- if .registryCACert }}
+            {{- if or .registryCACert .insecureSkip }}
             [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
+            {{- if .registryCACert }}
               ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
+            {{- end }}
+            {{- if .insecureSkip }}
+              insecure_skip_verify = {{.insecureSkip}}
+            {{- end }}
             {{- end }}
             {{- if .registryAuth }}
             [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".auth]

--- a/pkg/providers/tinkerbell/config/template-md.yaml
+++ b/pkg/providers/tinkerbell/config/template-md.yaml
@@ -142,9 +142,14 @@ spec:
               [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
                 endpoint = ["https://{{ $mirror }}"]
               {{- end }}
-              {{- if .registryCACert }}
+              {{- if or .registryCACert .insecureSkip }}
               [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
+              {{- if .registryCACert }}
                 ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
+              {{- end }}
+              {{- if .insecureSkip }}
+                insecure_skip_verify = {{.insecureSkip}}
+              {{- end }}
               {{- end }}
               {{- if .registryAuth }}
               [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".auth]

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -566,6 +566,7 @@ func populateRegistryMirrorValues(clusterSpec *cluster.Spec, values map[string]i
 	registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 	values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 	values["mirrorBase"] = registryMirror.BaseRegistry
+	values["insecureSkip"] = registryMirror.InsecureSkipVerify
 	values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 	if len(registryMirror.CACertContent) > 0 {
 		values["registryCACert"] = registryMirror.CACertContent

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -439,6 +439,18 @@ func TestTinkerbellKubernetes125UbuntuRegistryMirror(t *testing.T) {
 	runTinkerbellRegistryMirrorFlow(test)
 }
 
+func TestTinkerbellKubernetes125UbuntuRegistryMirrorInsecureSkipVerify(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewTinkerbell(t, framework.WithUbuntu125Tinkerbell()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
+		framework.WithControlPlaneHardware(1),
+		framework.WithWorkerHardware(1),
+		framework.WithRegistryMirrorInsecureSkipVerify(constants.TinkerbellProviderName),
+	)
+	runTinkerbellRegistryMirrorFlow(test)
+}
+
 func TestTinkerbellKubernetes125BottlerocketRegistryMirror(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,


### PR DESCRIPTION
*Issue #, if available:*
#1647 following up on the introduction of InsecureSkipVerify flag, and introducing it to the other providers.

*Description of changes:*

Description of changes:
This PR adds InsecureSkipVerify option support for Tinkerbell.

Work on the other providers will continue in other PRs

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

