### PR TITLE
Remove Full Cluster Lifecycle feature gate for Nutanix

### DIFF
--- a/pkg/api/v1alpha1/nutanixdatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/nutanixdatacenterconfig_webhook.go
@@ -9,8 +9,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
-	"github.com/aws/eks-anywhere/pkg/features"
 )
 
 // nutanixdatacenterconfiglog is for logging in this package.
@@ -33,10 +31,6 @@ func (r *NutanixDatacenterConfig) ValidateCreate() error {
 	if r.IsReconcilePaused() {
 		nutanixdatacenterconfiglog.Info("NutanixDatacenterConfig is paused, allowing create", "name", r.Name)
 		return nil
-	}
-
-	if !features.IsActive(features.FullLifecycleAPI()) {
-		return apierrors.NewBadRequest("Creating new NutanixDatacenterConfig on existing cluster is not supported")
 	}
 
 	if r.Spec.CredentialRef == nil {

--- a/pkg/api/v1alpha1/nutanixdatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/nutanixdatacenterconfig_webhook_test.go
@@ -10,11 +10,9 @@ import (
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 )
 
 func TestNutanixDatacenterConfigWebhooksValidateCreate(t *testing.T) {
-	t.Setenv(features.FullLifecycleAPIEnvVar, "true")
 	g := NewWithT(t)
 	dcConf := nutanixDatacenterConfig()
 	g.Expect(dcConf.ValidateCreate()).To(Succeed())
@@ -30,7 +28,6 @@ func TestNutanixDatacenterConfigWebhooksValidateCreateReconcilePaused(t *testing
 }
 
 func TestNutanixDatacenterConfigWebhookValidateCreateNoCredentialRef(t *testing.T) {
-	t.Setenv(features.FullLifecycleAPIEnvVar, "true")
 	g := NewWithT(t)
 	dcConf := nutanixDatacenterConfig()
 	dcConf.Spec.CredentialRef = nil
@@ -38,7 +35,6 @@ func TestNutanixDatacenterConfigWebhookValidateCreateNoCredentialRef(t *testing.
 }
 
 func TestNutanixDatacenterConfigWebhooksValidateCreateValidaitonFailure(t *testing.T) {
-	t.Setenv(features.FullLifecycleAPIEnvVar, "true")
 	g := NewWithT(t)
 	dcConf := nutanixDatacenterConfig()
 	dcConf.Spec.Endpoint = ""
@@ -46,7 +42,6 @@ func TestNutanixDatacenterConfigWebhooksValidateCreateValidaitonFailure(t *testi
 }
 
 func TestNutanixDatacenterConfigWebhooksValidateUpdate(t *testing.T) {
-	t.Setenv(features.FullLifecycleAPIEnvVar, "true")
 	g := NewWithT(t)
 	dcConf := nutanixDatacenterConfig()
 	g.Expect(dcConf.ValidateCreate()).To(Succeed())
@@ -68,7 +63,6 @@ func TestNutanixDatacenterConfigWebhooksValidateUpdateReconcilePaused(t *testing
 }
 
 func TestNutanixDatacenterConfigWebhooksValidateUpdateValidationFailure(t *testing.T) {
-	t.Setenv(features.FullLifecycleAPIEnvVar, "true")
 	g := NewWithT(t)
 	dcConf := nutanixDatacenterConfig()
 	g.Expect(dcConf.ValidateCreate()).To(Succeed())
@@ -78,7 +72,6 @@ func TestNutanixDatacenterConfigWebhooksValidateUpdateValidationFailure(t *testi
 }
 
 func TestNutanixDatacenterConfigWebhooksValidateUpdateInvalidOldObject(t *testing.T) {
-	t.Setenv(features.FullLifecycleAPIEnvVar, "true")
 	g := NewWithT(t)
 	newConf := nutanixDatacenterConfig()
 	newConf.Spec.CredentialRef = nil
@@ -86,7 +79,6 @@ func TestNutanixDatacenterConfigWebhooksValidateUpdateInvalidOldObject(t *testin
 }
 
 func TestNutanixDatacenterConfigWebhooksValidateUpdateCredentialRefRemoved(t *testing.T) {
-	t.Setenv(features.FullLifecycleAPIEnvVar, "true")
 	g := NewWithT(t)
 	oldConf := nutanixDatacenterConfig()
 	g.Expect(oldConf.ValidateCreate()).To(Succeed())
@@ -96,7 +88,6 @@ func TestNutanixDatacenterConfigWebhooksValidateUpdateCredentialRefRemoved(t *te
 }
 
 func TestNutanixDatacenterConfigWebhooksValidateDelete(t *testing.T) {
-	t.Setenv(features.FullLifecycleAPIEnvVar, "true")
 	g := NewWithT(t)
 	dcConf := nutanixDatacenterConfig()
 	g.Expect(dcConf.ValidateCreate()).To(Succeed())
@@ -104,7 +95,6 @@ func TestNutanixDatacenterConfigWebhooksValidateDelete(t *testing.T) {
 }
 
 func TestNutanixDatacenterConfigSetupWebhookWithManager(t *testing.T) {
-	t.Setenv(features.FullLifecycleAPIEnvVar, "true")
 	g := NewWithT(t)
 	dcConf := nutanixDatacenterConfig()
 	g.Expect(dcConf.SetupWebhookWithManager(env.Manager())).To(Succeed())

--- a/pkg/clustermanager/eksa_installer.go
+++ b/pkg/clustermanager/eksa_installer.go
@@ -176,7 +176,8 @@ func fullLifeCycleControllerForProvider(cluster *anywherev1.Cluster) bool {
 	// from the logic that drives the gates.
 	return cluster.Spec.DatacenterRef.Kind == anywherev1.VSphereDatacenterKind ||
 		cluster.Spec.DatacenterRef.Kind == anywherev1.DockerDatacenterKind ||
-		cluster.Spec.DatacenterRef.Kind == anywherev1.SnowDatacenterKind
+		cluster.Spec.DatacenterRef.Kind == anywherev1.SnowDatacenterKind ||
+		cluster.Spec.DatacenterRef.Kind == anywherev1.NutanixDatacenterKind
 }
 
 func (g *EKSAComponentGenerator) parseEKSAComponentsSpec(spec *cluster.Spec) (*eksaComponents, error) {

--- a/pkg/clustermanager/eksa_installer_test.go
+++ b/pkg/clustermanager/eksa_installer_test.go
@@ -251,6 +251,18 @@ func TestSetManagerFlags(t *testing.T) {
 			}),
 		},
 		{
+			name:       "full lifecycle, nutanix",
+			deployment: deployment(),
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Spec.DatacenterRef.Kind = anywherev1.NutanixDatacenterKind
+			}),
+			want: deployment(func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Containers[0].Args = []string{
+					"--feature-gates=FullLifecycleAPI=true",
+				}
+			}),
+		},
+		{
 			name:           "full lifecycle, feature flag enabled",
 			deployment:     deployment(),
 			spec:           test.NewClusterSpec(),


### PR DESCRIPTION
This ensures user doesn't have to set FULL_LIFECYCLE_API to true manually to use full cluster lifecycle features on Nutanix.