### PR TITLE
Clarify image-builder supports building AMIs with non-gp3 volumes

### DIFF
--- a/docs/content/en/docs/reference/artifacts.md
+++ b/docs/content/en/docs/reference/artifacts.md
@@ -487,7 +487,7 @@ These steps use `image-builder` to create an Ubuntu-based Amazon Machine Image (
      "root_device_name": "<The device name used by EC2 for the root EBS volume attached to the instance>",
      "subnet_id": "<The ID of the subnet where Packer will launch the EC2 instance. This field is required when using a non-default VPC>",
      "volume_size": "<The size of the root EBS volume in GiB>",
-     "volume_type": "<The type of root EBS volume. Currently only gp3 is supported>",
+     "volume_type": "<The type of root EBS volume, such as gp2, gp3, io1, etc.>"
    }
    ```
 1. To create an Ubuntu-based image, run `image-builder` with the following options:


### PR DESCRIPTION
Prior to the changes in aws/eks-anywhere-build-tooling#1996, we could only build AMIs attached with `gp3` EBS volumes due to a hardcoding issue in kubernetes-sigs/image-builder. Now we can build AMIs with any type of EBS volume.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

