### PR TITLE
Propagate cluster taints and labels for CAPX clusters

### DIFF
--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -185,6 +185,17 @@ spec:
           # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
           #cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+{{- if .controlPlaneTaints }}
+        taints:
+{{- range .controlPlaneTaints}}
+          - key: {{ .Key }}
+            value: {{ .Value }}
+            effect: {{ .Effect }}
+{{- if .TimeAdded }}
+            timeAdded: {{ .TimeAdded }}
+{{- end }}
+{{- end }}
+{{- end }}
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -194,6 +205,17 @@ spec:
           anonymous-auth: "false"
 {{- if .kubeletExtraArgs }}
 {{ .kubeletExtraArgs.ToYaml | indent 10 }}
+{{- end }}
+{{- if .controlPlaneTaints }}
+        taints:
+{{- range .controlPlaneTaints}}
+          - key: {{ .Key }}
+            value: {{ .Value }}
+            effect: {{ .Effect }}
+{{- if .TimeAdded }}
+            timeAdded: {{ .TimeAdded }}
+{{- end }}
+{{- end }}
 {{- end }}
         name: "{{`{{ ds.meta_data.hostname }}`}}"
     users:
@@ -240,7 +262,7 @@ spec:
 {{ else if (eq .imageIDType "uuid") }}
         type: uuid
         uuid: "{{.imageUUID}}"
-{{ end }}
+{{- end }}
       cluster:
 {{- if (eq .nutanixPEClusterIDType "name") }}
         type: name
@@ -248,7 +270,7 @@ spec:
 {{- else if (eq .nutanixPEClusterIDType "uuid") }}
         type: uuid
         uuid: "{{.nutanixPEClusterUUID}}"
-{{ end }}
+{{- end }}
       subnet:
 {{- if (eq .subnetIDType "name") }}
         - type: name

--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -185,6 +185,9 @@ spec:
           # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
           #cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+{{- if .kubeletExtraArgs }}
+{{ .kubeletExtraArgs.ToYaml | indent 10 }}
+{{- end }}
 {{- if .controlPlaneTaints }}
         taints:
 {{- range .controlPlaneTaints}}

--- a/pkg/providers/nutanix/config/md-template.yaml
+++ b/pkg/providers/nutanix/config/md-template.yaml
@@ -105,6 +105,17 @@ spec:
 {{- if .kubeletExtraArgs }}
 {{ .kubeletExtraArgs.ToYaml | indent 12 }}
 {{- end }}
+{{- if .workerNodeGroupTaints }}
+          taints:
+ {{- range .workerNodeGroupTaints}}
+            - key: {{ .Key }}
+              value: {{ .Value }}
+              effect: {{ .Effect }}
+ {{- if .TimeAdded }}
+              timeAdded: {{ .TimeAdded }}
+ {{- end }}
+ {{- end }}
+ {{- end }}
           name: '{{`{{ ds.meta_data.hostname }}`}}'
       users:
         - name: "{{.workerSshUsername}}"

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -161,6 +161,7 @@ func buildTemplateMapCP(
 		"controlPlaneReplicas":         clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Count,
 		"controlPlaneSshAuthorizedKey": controlPlaneMachineSpec.Users[0].SshAuthorizedKeys[0],
 		"controlPlaneSshUsername":      controlPlaneMachineSpec.Users[0].Name,
+		"controlPlaneTaints":           clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints,
 		"eksaSystemNamespace":          constants.EksaSystemNamespace,
 		"format":                       format,
 		"podCidrs":                     clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks,
@@ -264,6 +265,7 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupMachineSpec v1
 		"subnetName":             workerNodeGroupMachineSpec.Subnet.Name,
 		"subnetUUID":             workerNodeGroupMachineSpec.Subnet.UUID,
 		"workerNodeGroupName":    fmt.Sprintf("%s-%s", clusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name),
+		"workerNodeGroupTaints":  workerNodeGroupConfiguration.Taints,
 	}
 
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {

--- a/pkg/providers/nutanix/template_test.go
+++ b/pkg/providers/nutanix/template_test.go
@@ -243,6 +243,40 @@ func TestNewNutanixTemplateBuilderProject(t *testing.T) {
 	assert.Equal(t, expectedWorkersSpec, workerSpec)
 }
 
+func TestNewNutanixTemplateBuilderNodeTaintsAndLabels(t *testing.T) {
+	dcConf, machineConf, workerConfs := minimalNutanixConfigSpec(t)
+
+	t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+	t.Setenv(constants.EksaNutanixPasswordKey, "password")
+	creds := GetCredsFromEnv()
+	builder := NewNutanixTemplateBuilder(&dcConf.Spec, &machineConf.Spec, &machineConf.Spec, workerConfs, creds, time.Now)
+	assert.NotNil(t, builder)
+
+	buildSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster-node-taints-labels.yaml")
+
+	cpSpec, err := builder.GenerateCAPISpecControlPlane(buildSpec)
+	assert.NoError(t, err)
+	assert.NotNil(t, cpSpec)
+
+	expectedControlPlaneSpec, err := os.ReadFile("testdata/expected_results_node_taints_labels.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, expectedControlPlaneSpec, cpSpec)
+
+	workloadTemplateNames := map[string]string{
+		"eksa-unit-test": "eksa-unit-test",
+	}
+	kubeadmconfigTemplateNames := map[string]string{
+		"eksa-unit-test": "eksa-unit-test",
+	}
+	workerSpec, err := builder.GenerateCAPISpecWorkers(buildSpec, workloadTemplateNames, kubeadmconfigTemplateNames)
+	assert.NoError(t, err)
+	assert.NotNil(t, workerSpec)
+
+	expectedWorkersSpec, err := os.ReadFile("testdata/expected_results_node_taints_labels_md.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, expectedWorkersSpec, workerSpec)
+}
+
 func minimalNutanixConfigSpec(t *testing.T) (*anywherev1.NutanixDatacenterConfig, *anywherev1.NutanixMachineConfig, map[string]anywherev1.NutanixMachineConfigSpec) {
 	dcConf := &anywherev1.NutanixDatacenterConfig{}
 	err := yaml.Unmarshal([]byte(nutanixDatacenterConfigSpec), dcConf)

--- a/pkg/providers/nutanix/testdata/eksa-cluster-node-taints-labels.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-node-taints-labels.yaml
@@ -1,0 +1,89 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  kubernetesVersion: "1.19"
+  controlPlaneConfiguration:
+    name: eksa-unit-test
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+    taints:
+      - key: key1
+        value: val1
+        effect: PreferNoSchedule
+    labels:
+      key1-cp: value1-cp
+      key2-cp: value2-cp
+  workerNodeGroupConfigurations:
+    - count: 4
+      name: eksa-unit-test
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: NutanixMachineConfig
+      taints:
+        - key: key1
+          value: val1
+          effect: PreferNoSchedule
+      labels:
+        key1-md: value1-md
+        key2-md: value2-md
+  externalEtcdConfiguration:
+    name: eksa-unit-test
+    count: 3
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  datacenterRef:
+    kind: NutanixDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440
+  credentialRef:
+    kind: Secret
+    name: "nutanix-credentials"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"

--- a/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
@@ -139,6 +139,8 @@ spec:
           # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
           #cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          node-labels: key1-cp=value1-cp,key2-cp=value2-cp
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints:
           - key: key1
             value: val1

--- a/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
@@ -1,0 +1,202 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixCluster
+metadata:
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  prismCentral:
+    address: "prism.nutanix.com"
+    port: 9440
+    insecure: false
+    credentialRef:
+      name: "capx-eksa-unit-test"
+      kind: Secret
+  controlPlaneEndpoint:
+    host: "test-ip"
+    port: 6443
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: "eksa-unit-test"
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: [10.96.0.0/12]
+    pods:
+      cidrBlocks: [192.168.0.0/16]
+    serviceDomain: "cluster.local"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: "eksa-unit-test"
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: NutanixCluster
+    name: "eksa-unit-test"
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  replicas: 3
+  version: "v1.19.8-eks-1-19-4"
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: NutanixMachineTemplate
+      name: "<no value>"
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      imageRepository: "public.ecr.aws/eks-distro/kubernetes"
+      apiServer:
+        certSANs:
+          - localhost
+          - 127.0.0.1
+          - 0.0.0.0
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+      dns:
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.8.0-eks-1-19-4
+      etcd:
+        external:
+          endpoints: []
+          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
+          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
+          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
+    files:
+    - content: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          creationTimestamp: null
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+            - name: kube-vip
+              image: 
+              imagePullPolicy: IfNotPresent
+              args:
+                - manager
+              env:
+                - name: vip_arp
+                  value: "true"
+                - name: address
+                  value: "test-ip"
+                - name: port
+                  value: "6443"
+                - name: vip_cidr
+                  value: "32"
+                - name: cp_enable
+                  value: "true"
+                - name: cp_namespace
+                  value: kube-system
+                - name: vip_ddns
+                  value: "false"
+                - name: vip_leaderelection
+                  value: "true"
+                - name: vip_leaseduration
+                  value: "15"
+                - name: vip_renewdeadline
+                  value: "10"
+                - name: vip_retryperiod
+                  value: "2"
+                - name: svc_enable
+                  value: "false"
+                - name: lb_enable
+                  value: "false"
+              securityContext:
+                capabilities:
+                  add:
+                    - NET_ADMIN
+                    - SYS_TIME
+                    - NET_RAW
+              volumeMounts:
+                - mountPath: /etc/kubernetes/admin.conf
+                  name: kubeconfig
+              resources: {}
+          hostNetwork: true
+          volumes:
+            - name: kubeconfig
+              hostPath:
+                type: FileOrCreate
+                path: /etc/kubernetes/admin.conf
+        status: {}
+      owner: root:root
+      path: /etc/kubernetes/manifests/kube-vip.yaml
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+          # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+          #cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+        taints:
+          - key: key1
+            value: val1
+            effect: PreferNoSchedule
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          cloud-provider: external
+          read-only-port: "0"
+          anonymous-auth: "false"
+          node-labels: key1-cp=value1-cp,key2-cp=value2-cp
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        taints:
+          - key: key1
+            value: val1
+            effect: PreferNoSchedule
+        name: "{{ ds.meta_data.hostname }}"
+    users:
+      - name: "mySshUsername"
+        lockPassword: false
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        sshAuthorizedKeys:
+          - "mySshAuthorizedKey"
+    preKubeadmCommands:
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
+      # This section should be removed once these packages are added to the image builder process
+      - apt update
+      - apt install -y nfs-common open-iscsi
+      - systemctl enable --now iscsid
+    postKubeadmCommands:
+      - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
+    useExperimentalRetryJoin: true
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "<no value>"
+  namespace: "eksa-system"
+spec:
+  template:
+    spec:
+      providerID: "nutanix://eksa-unit-test-m1"
+      vcpusPerSocket: 1
+      vcpuSockets: 4
+      memorySize: 8Gi
+      systemDiskSize: 40Gi
+      image:
+        type: name
+        name: "prism-image"
+
+      cluster:
+        type: name
+        name: "prism-cluster"
+      subnet:
+        - type: name
+          name: "prism-subnet"
+---

--- a/pkg/providers/nutanix/testdata/expected_results_node_taints_labels_md.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_node_taints_labels_md.yaml
@@ -1,0 +1,85 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: "eksa-unit-test"
+  name: "eksa-unit-test-eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  clusterName: "eksa-unit-test"
+  replicas: 4
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: "eksa-unit-test"
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: "eksa-unit-test"
+      clusterName: "eksa-unit-test"
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: NutanixMachineTemplate
+        name: "eksa-unit-test"
+      version: "v1.19.8-eks-1-19-4"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  template:
+    spec:
+      providerID: "nutanix://eksa-unit-test-m1"
+      vcpusPerSocket: 1
+      vcpuSockets: 4
+      memorySize: 8Gi
+      systemDiskSize: 40Gi
+      image:
+        type: name
+        name: "prism-image"
+
+      cluster:
+        type: name
+        name: "prism-cluster"
+      subnet:
+        - type: name
+          name: "prism-subnet"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  template:
+    spec:
+      preKubeadmCommands:
+        - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+            # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+            #cgroup-driver: cgroupfs
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            node-labels: key1-md=value1-md,key2-md=value2-md
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          taints:
+            - key: key1
+              value: val1
+              effect: PreferNoSchedule
+          name: '{{ ds.meta_data.hostname }}'
+      users:
+        - name: "mySshUsername"
+          lockPassword: false
+          sudo: ALL=(ALL) NOPASSWD:ALL
+          sshAuthorizedKeys:
+            - "mySshAuthorizedKey"
+
+---

--- a/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
@@ -142,6 +142,7 @@ spec:
           # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
           #cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock

--- a/pkg/providers/nutanix/testdata/expected_results_project.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_project.yaml
@@ -139,6 +139,7 @@ spec:
           # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
           #cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
@@ -175,6 +175,7 @@ spec:
           # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
           #cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock


### PR DESCRIPTION
Ensure taints and labels are passed on for both controlplane and worker nodes for Nutanix provider.

**How has this been tested?**
- Created a cluster spec with `taints` and `labels` present in `controlPlaneConfiguration` and `workerNodeGroupConfigurations`
```
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: Cluster
metadata:
  name: eksa-sid
spec:
  ...
  controlPlaneConfiguration:
    ...
    taints:
      - key: key1
        value: val1
        effect: PreferNoSchedule
    labels:
      key1-cp: value1-cp
      key2-cp: value2-cp
  workerNodeGroupConfigurations:
  ...
    taints:
      - key: key1
        value: val1
        effect: PreferNoSchedule
    labels:
      key1-md: value1-md
      key2-md: value2-md
```
- Created a cluster with the above cluster spec successfully
```
$ bin/eksctl-anywhere create cluster -f eksa-sid.yaml --force-cleanup -v 10  --bundles-override ./bundle-release.yaml
...
2023-03-16T22:19:48.323+0100	V0	🎉 Cluster created!
```
- Validate that taints and labels defined in cluster spec are present on the nodes
```
$ kubectl get nodes -o wide
NAME                            STATUS   ROLES           AGE     VERSION               INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
eksa-sid-gd5fb                  Ready    control-plane   8m36s   v1.24.6-eks-4360b32   10.40.142.62    <none>        Ubuntu 20.04.5 LTS   5.4.0-132-generic   containerd://1.5.9
eksa-sid-kkjxf                  Ready    control-plane   4m7s    v1.24.6-eks-4360b32   10.40.142.128   <none>        Ubuntu 20.04.5 LTS   5.4.0-132-generic   containerd://1.5.9
eksa-sid-md-0-b799798f8-h862r   Ready    <none>          9m19s   v1.24.6-eks-4360b32   10.40.142.224   <none>        Ubuntu 20.04.5 LTS   5.4.0-132-generic   containerd://1.5.9
eksa-sid-md-0-b799798f8-m9p5p   Ready    <none>          9m16s   v1.24.6-eks-4360b32   10.40.142.233   <none>        Ubuntu 20.04.5 LTS   5.4.0-132-generic   containerd://1.5.9
eksa-sid-md-0-b799798f8-zn5lb   Ready    <none>          9m29s   v1.24.6-eks-4360b32   10.40.142.202   <none>        Ubuntu 20.04.5 LTS   5.4.0-132-generic   containerd://1.5.9
eksa-sid-zqqq6                  Ready    control-plane   11m     v1.24.6-eks-4360b32   10.40.142.36    <none>        Ubuntu 20.04.5 LTS   5.4.0-132-generic   containerd://1.5.9

$ kubectl get nodes eksa-sid-gd5fb -o yaml | yq .spec.taints
- effect: PreferNoSchedule
  key: key1
  value: val1
- effect: NoSchedule
  key: node.cloudprovider.kubernetes.io/uninitialized
  value: "true"

$ kubectl get nodes eksa-sid-gd5fb -o yaml | yq .metadata.labels
beta.kubernetes.io/arch: amd64
beta.kubernetes.io/os: linux
key1-cp: value1-cp
key2-cp: value2-cp
kubernetes.io/arch: amd64
kubernetes.io/hostname: eksa-sid-gd5fb
kubernetes.io/os: linux
node-role.kubernetes.io/control-plane: ""
node.kubernetes.io/exclude-from-external-load-balancers: ""

$ kubectl get nodes eksa-sid-md-0-b799798f8-h862r -o yaml | yq .spec.taints
- effect: PreferNoSchedule
  key: key1
  value: val1

$ kubectl get nodes eksa-sid-md-0-b799798f8-h862r -o yaml | yq .metadata.labels
beta.kubernetes.io/arch: amd64
beta.kubernetes.io/os: linux
key1-md: value1-md
key2-md: value2-md
kubernetes.io/arch: amd64
kubernetes.io/hostname: eksa-sid-md-0-b799798f8-h862r
kubernetes.io/os: linux
```

Full install logs @ https://app.warp.dev/block/0qC7v0uLcY7arneov6tESt
