### PR TITLE
docs: Update IAM Roles for Service Accounts docs

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/cloudstack.md
+++ b/docs/content/en/docs/reference/clusterspec/cloudstack.md
@@ -9,7 +9,7 @@ This is a generic template with detailed descriptions below for reference.
 The following additional optional configuration can also be included:
 
 * [CNI]({{< relref "optional/cni.md" >}})
-* [IAM for pods]({{< relref "optional/irsa.md" >}})
+* [IAM Roles for Service Accounts]({{< relref "optional/irsa.md" >}})
 * [IAM Authenticator]({{< relref "optional/iamauth.md" >}})
 * [OIDC]({{< relref "optional/oidc.md" >}})
 * [GitOps]({{< relref "optional/gitops.md" >}})

--- a/docs/content/en/docs/reference/clusterspec/optional/irsa.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/irsa.md
@@ -1,6 +1,6 @@
 ---
-title: "IAM for Pods configuration"
-linkTitle: "IAM for pods"
+title: "IAM Roles for Service Accounts configuration"
+linkTitle: "IAM Roles for Serivce Accounts"
 weight: 20
 description: >
   EKS Anywhere cluster spec for Pod IAM (IRSA)
@@ -136,7 +136,7 @@ Set the remaining fields in [cluster spec]({{< relref "../vsphere/" >}}) as requ
 
 1. Set the $KUBECONFIG env var to the path of the EKS Anywhere cluster.
 
-1. Update `amazon-eks-pod-identity-webhook/deploy/auth.yaml` with `OIDC_IAM_ROLE` and other annotations as mentioned in sample below.
+1. Create `my-service-account.yaml` with `OIDC_IAM_ROLE` and other annotations as mentioned in sample below.
     ```yaml
     apiVersion: v1
     kind: ServiceAccount
@@ -157,11 +157,18 @@ Set the remaining fields in [cluster spec]({{< relref "../vsphere/" >}}) as requ
         eks.amazonaws.com/token-expiration: "86400"
     ```
 
-1. Run the following command:
+1. Run the following command to apply the manifests for the amazon-eks-pod-identity-webhook. The image used here will be pulled from docker.io. Optionally, the image can be imported into (or proxied through) your private registry. Change the IMAGE= argument here to your private registry if needed.
 
     ```bash
     make cluster-up IMAGE=amazon/amazon-eks-pod-identity-webhook:latest
     ```
+
+2. Finally, apply the `my-service-account.yaml` file to create your service account.
+
+    ```bash
+    kubectl apply -f my-service-account.yaml
+    ```
+
 1. You can validate IRSA by using test steps mentioned [here](https://anywhere.eks.amazonaws.com/docs/workshops/packages/adot/adot_amp_amg/#irsa-set-up-test). Ensure awscli pod is deployed in same namespace of ServiceAccount pod-identity-webhook.
 
 

--- a/docs/content/en/docs/reference/clusterspec/vsphere.md
+++ b/docs/content/en/docs/reference/clusterspec/vsphere.md
@@ -101,7 +101,7 @@ spec:
 The following additional optional configuration can also be included:
 
 * [CNI]({{< relref "optional/cni.md" >}})
-* [IAM for pods]({{< relref "optional/irsa.md" >}})
+* [IAM Roles for Service Accounts]({{< relref "optional/irsa.md" >}})
 * [IAM Authenticator]({{< relref "optional/iamauth.md" >}})
 * [OIDC]({{< relref "optional/oidc.md" >}})
 * [gitops]({{< relref "optional/gitops.md" >}})

--- a/docs/content/en/docs/workshops/provision/vsphere.md
+++ b/docs/content/en/docs/workshops/provision/vsphere.md
@@ -72,7 +72,7 @@ All steps listed below should be executed on the admin machine with reachability
          * [etcd]({{< relref "/docs/reference/clusterspec/optional/etcd" >}}) (comes by default with the generated config file) 
          * [proxy]({{< relref "/docs/reference/clusterspec/optional/proxy" >}}) 
          * [GitOps]({{< relref "/docs/reference/clusterspec/optional/gitops" >}}) 
-         * [IAM for Pods]({{< relref "/docs/reference/clusterspec/optional/irsa" >}}) 
+         * [IAM Roles for Service Accounts]({{< relref "/docs/reference/clusterspec/optional/irsa" >}}) 
          * [IAM Authenticator]({{< relref "/docs/reference/clusterspec/optional/iamauth" >}}) 
          * [container registry mirror]({{< relref "/docs/reference/clusterspec/optional/registrymirror" >}})
 
@@ -149,7 +149,7 @@ All steps listed below should be executed on the admin machine with reachability
 
    {{% alert title="Important" color="warning" %}}
 
-   If you plan to enable other compnents such as, GitOps, oidc, IAM for Pods, etc, Skip creating the cluster now and go ahead adding the configuration for those components to your generated config file first. Or you would need to receate the cluster again as mentioned above.
+   If you plan to enable other compnents such as, GitOps, oidc, IAM Roles for Service Accounts, etc, Skip creating the cluster now and go ahead adding the configuration for those components to your generated config file first. Or you would need to receate the cluster again as mentioned above.
 
    {{% /alert %}}
 
@@ -268,7 +268,7 @@ Follow these steps if you want to use your initial cluster to create and manage 
 
    {{% alert title="Important" color="warning" %}}
 
-   If you plan to enable other compnents such as oidc, IAM for Pods, etc, skip creating the cluster now and go ahead adding the configuration for those components to your generated config file first. Or you would need to receate the cluster again. If GitOps have been enabled on the initial/management cluster, you would not have the option to enable GitOps on the workload cluster, as the goal of using GitOps is to centrally manage all of your clusters. 
+   If you plan to enable other compnents such as oidc, IAM Roles for Service Accounts, etc, skip creating the cluster now and go ahead adding the configuration for those components to your generated config file first. Or you would need to receate the cluster again. If GitOps have been enabled on the initial/management cluster, you would not have the option to enable GitOps on the workload cluster, as the goal of using GitOps is to centrally manage all of your clusters. 
 
    {{% /alert %}}
 


### PR DESCRIPTION
1. Replace usage of "IAM for Pods" with "IAM Roles for Service Accounts", using the correct name for the feature.
2. Teak the irsa.md docs to clarify the installation of the webhook and creation of a service account.

*Testing (if applicable):*
Tested with `make server` to make sure no links were broken.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

