### PR TITLE
Changing logic for removing hardware from catalogue

### DIFF
--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware.go
@@ -51,24 +51,28 @@ func (c *Catalogue) InsertHardware(hardware *tinkv1alpha1.Hardware) error {
 func (c *Catalogue) RemoveHardwares(hardware []tinkv1alpha1.Hardware) error {
 	m := make(map[string]bool, len(hardware))
 	for _, hw := range hardware {
-		m[hw.Name+":"+hw.Namespace] = true
+		m[getRemoveKey(hw)] = true
 	}
 
 	diff := []*tinkv1alpha1.Hardware{}
 	for i, hw := range c.hardware {
-		key := hw.Name + ":" + hw.Namespace
+		key := getRemoveKey(*hw)
 		if _, ok := m[key]; !ok {
 			diff = append(diff, c.hardware[i])
 		} else {
 			if err := c.hardwareIndex.Remove(c.hardware[i]); err != nil {
 				return err
 			}
-			delete(m, key)
 		}
 	}
 
 	c.hardware = diff
 	return nil
+}
+
+// getRemoveKey returns key used to search and remove hardware.
+func getRemoveKey(hardware tinkv1alpha1.Hardware) string {
+	return hardware.Name + ":" + hardware.Namespace
 }
 
 // AllHardware retrieves a copy of the catalogued Hardware instances.

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware_test.go
@@ -51,6 +51,43 @@ func TestCatalogue_Hardwares_Remove(t *testing.T) {
 	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(1))
 }
 
+func TestCatalogue_Hardwares_RemoveDuplicates(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+
+	err := catalogue.InsertHardware(&v1alpha1.Hardware{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "hw1",
+			Namespace: "namespace",
+		},
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	err = catalogue.InsertHardware(&v1alpha1.Hardware{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "hw2",
+			Namespace: "namespace",
+		},
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	err = catalogue.InsertHardware(&v1alpha1.Hardware{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "hw2",
+			Namespace: "namespace",
+		},
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(catalogue.RemoveHardwares([]v1alpha1.Hardware{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "hw2",
+				Namespace: "namespace",
+			},
+		},
+	})).ToNot(gomega.HaveOccurred())
+	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(1))
+}
+
 func TestCatalogue_Hardwares_RemoveExtraHw(t *testing.T) {
 	g := gomega.NewWithT(t)
 

--- a/pkg/providers/tinkerbell/hardware/catalogue_hardware_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_hardware_test.go
@@ -51,7 +51,7 @@ func TestCatalogue_Hardwares_Remove(t *testing.T) {
 	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(1))
 }
 
-func TestCatalogue_Hardware_RemoveFail(t *testing.T) {
+func TestCatalogue_Hardwares_RemoveExtraHw(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	catalogue := hardware.NewCatalogue()
@@ -63,19 +63,81 @@ func TestCatalogue_Hardware_RemoveFail(t *testing.T) {
 		},
 	})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(catalogue.RemoveHardware(&v1alpha1.Hardware{
+	err = catalogue.InsertHardware(&v1alpha1.Hardware{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "hw2",
 			Namespace: "namespace",
 		},
-	}, 1)).To(gomega.HaveOccurred())
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	err = catalogue.InsertHardware(&v1alpha1.Hardware{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "hw3",
+			Namespace: "namespace",
+		},
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(catalogue.RemoveHardwares([]v1alpha1.Hardware{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "hw2",
+				Namespace: "namespace",
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "hw3",
+				Namespace: "namespace",
+			},
+		},
+	})).ToNot(gomega.HaveOccurred())
 	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(1))
-	g.Expect(catalogue.RemoveHardware(&v1alpha1.Hardware{
+}
+
+func TestCatalogue_Hardwares_RemoveNothing(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+
+	err := catalogue.InsertHardware(&v1alpha1.Hardware{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "hw2",
+			Name:      "hw1",
 			Namespace: "namespace",
 		},
-	}, 2)).To(gomega.HaveOccurred())
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(catalogue.RemoveHardwares([]v1alpha1.Hardware{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "hw2",
+				Namespace: "namespace",
+			},
+		},
+	})).ToNot(gomega.HaveOccurred())
+	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(1))
+}
+
+func TestCatalogue_Hardwares_RemoveEverything(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	catalogue := hardware.NewCatalogue()
+
+	err := catalogue.InsertHardware(&v1alpha1.Hardware{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "hw1",
+			Namespace: "namespace",
+		},
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(catalogue.RemoveHardwares([]v1alpha1.Hardware{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "hw1",
+				Namespace: "namespace",
+			},
+		},
+	})).ToNot(gomega.HaveOccurred())
+	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(0))
 }
 
 func TestCatalogue_Hardware_UnknownIndexErrors(t *testing.T) {


### PR DESCRIPTION
*Description of changes:*
`Removehardwares` was throwing an index out of bound panic because we were reducing the length of the `catalogue.Hardware` in-place. 
Fixed by storing a diff list and replacing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

