### PR TITLE
Add docs for hostOSConfig

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/baremetal.md
+++ b/docs/content/en/docs/reference/clusterspec/baremetal.md
@@ -10,6 +10,7 @@ This is a generic template with detailed descriptions below for reference.
 The following additional optional configuration can also be included:
 
 * [CNI]({{< relref "optional/cni.md" >}})
+* [Host OS Config]({{< relref "optional/hostOSConfig.md" >}})
 
 To generate your own cluster configuration, follow instructions from the Bare Metal [Create production cluster]({{< relref "../../getting-started/production-environment/" >}}) section and modify it using descriptions below.
 For information on how to add cluster configuration settings to this file for advanced node configuration, see [Advanced Bare Metal cluster configuration]({{< relref "#advanced-bare-metal-cluster-configuration" >}}).

--- a/docs/content/en/docs/reference/clusterspec/baremetal.md
+++ b/docs/content/en/docs/reference/clusterspec/baremetal.md
@@ -279,6 +279,10 @@ ssh -i <private-key-file> <user>@<machine-IP>
 
 The default is generating a key in your `$(pwd)/<cluster-name>` folder when not specifying a value.
 
+### hostOSConfig (optional)
+Optional host OS configurations for the EKS Anywhere Kubernetes nodes.
+More information in the [Host OS Configuration]({{< relref "./optional/hostOSConfig.md" >}}) section.
+
 ## Advanced Bare Metal cluster configuration
 
 When you generate a Bare Metal cluster configuration, the `TinkerbellTemplateConfig` is kept internally and not shown in the generated configuration file.

--- a/docs/content/en/docs/reference/clusterspec/optional/hostOSConfig.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/hostOSConfig.md
@@ -50,7 +50,7 @@ Top level object used for host OS configurations.
 <br>
 
   * #### `bottlerocketConfiguration`
-    Key used for configuring Bottlerocket specific settings on EKS Anywhere cluster nodes. These settings are _only valid_ for Bottlerocket.
+    Key used for configuring Bottlerocket-specific settings on EKS Anywhere cluster nodes. These settings are _only valid_ for Bottlerocket.
 
     * ##### `kubernetes`
       Key used for configuring Bottlerocket Kubernetes settings.
@@ -59,7 +59,7 @@ Top level object used for host OS configurations.
         List of unsafe sysctls that should be enabled on the node.
 
       * ##### `clusterDNSIPs`
-        List of IPs of DNS service/s running in the kubernetes cluster.
+        List of IPs of DNS service(s) running in the kubernetes cluster.
 
       * ##### `maxPods`
         Maximum number of pods that can be scheduled on each node.

--- a/docs/content/en/docs/reference/clusterspec/optional/hostOSConfig.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/hostOSConfig.md
@@ -1,0 +1,65 @@
+---
+title: "Host OS Configuration"
+linkTitle: "Host OS Configuration"
+weight: 90
+description: >
+  EKS Anywhere cluster yaml specification for host OS configuration
+---
+
+## Host OS Configuration
+You can configure certain host OS settings through EKS Anywhere.
+
+{{% alert title="Note" color="primary" %}}
+Currently, these settings are only supported for vSphere and Tinkerbell providers.<br>
+Additionally, settings under `bottlerocketConfiguration` are only supported for `osFamily: bottlerocket`
+{{% /alert %}}
+
+The following cluster spec shows an example of how to configure host OS settings:
+```yaml
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig        # Replace "VSphereMachineConfig" with "TinkerbellMachineConfig" for Tinkerbell clusters
+metadata:
+  name: machine-config
+spec:
+  ...
+  hostOSConfiguration:
+    ntpConfiguration:
+      servers:
+        - time-a.ntp.local
+        - time-b.ntp.local
+    bottlerocketConfiguration:
+      kubernetes:
+        allowedUnsafeSysctls:
+          - "net.core.somaxconn"
+          - "net.ipv4.ip_local_port_range"
+        clusterDNSIPs:
+          - 10.96.0.10
+        maxPods: 100
+```
+
+## Host OS Configuration Spec Details
+### `hostOSConfiguration`
+Top level object used for host OS configurations.
+
+  * #### `ntpConfiguration`
+    Key used for configuring NTP servers on your EKS Anywhere cluster nodes.
+
+    * ##### `servers`
+      Servers is a list of NTP servers that should be configured on EKS Anywhere cluster nodes.
+
+<br>
+
+  * #### `bottlerocketConfiguration`
+    Key used for configuring Bottlerocket specific settings on EKS Anywhere cluster nodes. These settings are _only valid_ for Bottlerocket.
+
+    * ##### `kubernetes`
+      Key used for configuring Bottlerocket Kubernetes settings.
+
+      * ##### `allowedUnsafeSysctls`
+        List of unsafe sysctls that should be enabled on the node.
+
+      * ##### `clusterDNSIPs`
+        List of IPs of DNS service/s running in the kubernetes cluster.
+
+      * ##### `maxPods`
+        Maximum number of pods that can be scheduled on each node.

--- a/docs/content/en/docs/reference/clusterspec/vsphere.md
+++ b/docs/content/en/docs/reference/clusterspec/vsphere.md
@@ -107,6 +107,7 @@ The following additional optional configuration can also be included:
 * [gitops]({{< relref "optional/gitops.md" >}})
 * [proxy]({{< relref "optional/proxy.md" >}})
 * [Registry Mirror]({{< relref "optional/registrymirror.md" >}})
+* [Host OS Config]({{< relref "optional/hostOSConfig.md" >}})
 
 ## Cluster Fields
 

--- a/docs/content/en/docs/reference/clusterspec/vsphere.md
+++ b/docs/content/en/docs/reference/clusterspec/vsphere.md
@@ -353,6 +353,10 @@ Example:
   - urn:vmomi:InventoryServiceTag:8e0ce079-0675-47d6-8665-16ada4e6dabd:GLOBAL
 ```
 
+### hostOSConfig (optional)
+Optional host OS configurations for the EKS Anywhere Kubernetes nodes.
+More information in the [Host OS Configuration]({{< relref "./optional/hostOSConfig.md" >}}) section.
+
 ## Optional VSphere Credentials 
 Use the following environment variables to configure Cloud Provider and CSI Driver with different credentials.
 


### PR DESCRIPTION
*Description of changes:*
Add docs for hostOSConfig
Preview available here
https://anywhere-docs.abhnvp.people.aws.dev/docs/reference/clusterspec/optional/hostosconfig/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

