### PR TITLE
Autogenerate eksctl anywhere commands doc from code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,10 @@ build-cross-platform: eks-a-cross-platform
 eks-a-tool: ## Build eks-a-tool
 	$(GO) build -o bin/eks-a-tool github.com/aws/eks-anywhere/cmd/eks-a-tool
 
+.PHONY: docgen
+docgen: eks-a-tool ## generate eksctl anywhere commands doc from code
+	bin/eks-a-tool docgen
+
 .PHONY: eks-a-cluster-controller
 eks-a-cluster-controller: ## Build eks-a-cluster-controller
 	$(GO) build -ldflags "-s -w -buildid='' -extldflags -static" -o bin/manager ./manager

--- a/cmd/eks-a-tool/cmd/docgen.go
+++ b/cmd/eks-a-tool/cmd/docgen.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+
+	anywhere "github.com/aws/eks-anywhere/cmd/eksctl-anywhere/cmd"
+)
+
+const fmTemplate = `---
+title: "%s"
+linkTitle: "%s"
+---
+
+`
+
+var cmdDocPath string
+
+var docgenCmd = &cobra.Command{
+	Use:    "docgen",
+	Short:  "Generate the documentation for the CLI commands",
+	Long:   "Use eks-a-tool docgen to auto generate CLI commands documentation",
+	Hidden: true,
+	RunE:   docgenCmdRun,
+}
+
+func init() {
+	docgenCmd.Flags().StringVar(&cmdDocPath, "path", "./docs/content/en/docs/reference/eksctl", "Path to write the generated documentation to")
+	rootCmd.AddCommand(docgenCmd)
+}
+
+func docgenCmdRun(_ *cobra.Command, _ []string) error {
+	anywhereRootCmd := anywhere.RootCmd()
+	anywhereRootCmd.DisableAutoGenTag = true
+	if err := doc.GenMarkdownTreeCustom(anywhereRootCmd, cmdDocPath, filePrepender, linkHandler); err != nil {
+		return fmt.Errorf("error generating markdown doc from eksctl-anywhere root cmd: %v", err)
+	}
+	return nil
+}
+
+func filePrepender(filename string) string {
+	name := filepath.Base(filename)
+	base := strings.TrimSuffix(name, path.Ext(name))
+	title := strings.Replace(base, "_", " ", -1)
+	return fmt.Sprintf(fmTemplate, title, title)
+}
+
+func linkHandler(name string) string {
+	base := strings.TrimSuffix(name, path.Ext(name))
+	base = strings.Replace(base, "(", "", -1)
+	base = strings.Replace(base, ")", "", -1)
+	return "../" + strings.ToLower(base) + "/"
+}

--- a/cmd/eksctl-anywhere/cmd/root.go
+++ b/cmd/eksctl-anywhere/cmd/root.go
@@ -64,3 +64,8 @@ func initLogger() error {
 func Execute() error {
 	return rootCmd.ExecuteContext(context.Background())
 }
+
+// RootCmd returns the eksctl-anywhere root cmd.
+func RootCmd() *cobra.Command {
+	return rootCmd
+}

--- a/docs/content/en/docs/reference/eksctl/anywhere.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere.md
@@ -1,0 +1,38 @@
+---
+title: "anywhere"
+linkTitle: "anywhere"
+---
+
+## anywhere
+
+Amazon EKS Anywhere
+
+### Synopsis
+
+Use eksctl anywhere to build your own self-managing cluster on your hardware with the best of Amazon EKS
+
+### Options
+
+```
+  -h, --help            help for anywhere
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere apply](../anywhere_apply/)	 - Apply resources
+* [anywhere check-images](../anywhere_check-images/)	 - Check images used by EKS Anywhere do exist in the target registry
+* [anywhere copy](../anywhere_copy/)	 - Copy resources
+* [anywhere create](../anywhere_create/)	 - Create resources
+* [anywhere delete](../anywhere_delete/)	 - Delete resources
+* [anywhere describe](../anywhere_describe/)	 - Describe resources
+* [anywhere download](../anywhere_download/)	 - Download resources
+* [anywhere exp](../anywhere_exp/)	 - experimental commands
+* [anywhere generate](../anywhere_generate/)	 - Generate resources
+* [anywhere get](../anywhere_get/)	 - Get resources
+* [anywhere import](../anywhere_import/)	 - Import resources
+* [anywhere install](../anywhere_install/)	 - Install resources to the cluster
+* [anywhere list](../anywhere_list/)	 - List resources
+* [anywhere upgrade](../anywhere_upgrade/)	 - Upgrade resources
+* [anywhere version](../anywhere_version/)	 - Get the eksctl anywhere version
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_apply.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_apply.md
@@ -1,0 +1,30 @@
+---
+title: "anywhere apply"
+linkTitle: "anywhere apply"
+---
+
+## anywhere apply
+
+Apply resources
+
+### Synopsis
+
+Use eksctl anywhere apply to apply resources
+
+### Options
+
+```
+  -h, --help   help for apply
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+* [anywhere apply package(s)](../anywhere_apply_packages/)	 - Apply curated packages
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_apply_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_apply_package(s).md
@@ -1,0 +1,35 @@
+---
+title: "anywhere apply package(s)"
+linkTitle: "anywhere apply package(s)"
+---
+
+## anywhere apply package(s)
+
+Apply curated packages
+
+### Synopsis
+
+Apply Curated Packages Custom Resources to the cluster
+
+```
+anywhere apply package(s) [flags]
+```
+
+### Options
+
+```
+  -f, --filename string     Filename that contains curated packages custom resources to apply
+  -h, --help                help for package(s)
+      --kubeconfig string   Path to an optional kubeconfig file to use.
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere apply](../anywhere_apply/)	 - Apply resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_check-images.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_check-images.md
@@ -1,0 +1,34 @@
+---
+title: "anywhere check-images"
+linkTitle: "anywhere check-images"
+---
+
+## anywhere check-images
+
+Check images used by EKS Anywhere do exist in the target registry
+
+### Synopsis
+
+This command is used to check images used by EKS-Anywhere for cluster provisioning do exist in the target registry
+
+```
+anywhere check-images [flags]
+```
+
+### Options
+
+```
+  -f, --filename string   Filename that contains EKS-A cluster configuration
+  -h, --help              help for check-images
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_copy.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_copy.md
@@ -1,0 +1,30 @@
+---
+title: "anywhere copy"
+linkTitle: "anywhere copy"
+---
+
+## anywhere copy
+
+Copy resources
+
+### Synopsis
+
+Copy EKS Anywhere resources and artifacts
+
+### Options
+
+```
+  -h, --help   help for copy
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+* [anywhere copy packages](../anywhere_copy_packages/)	 - Copy curated package images and charts from a source to a destination
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_copy_packages.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_copy_packages.md
@@ -1,0 +1,39 @@
+---
+title: "anywhere copy packages"
+linkTitle: "anywhere copy packages"
+---
+
+## anywhere copy packages
+
+Copy curated package images and charts from a source to a destination
+
+### Synopsis
+
+Copy all the EKS Anywhere curated package images and helm charts from a source to a destination.
+
+```
+anywhere copy packages [flags]
+```
+
+### Options
+
+```
+      --aws-region string   Region to copy images from
+  -b, --bundle string       EKS-A bundle file to read artifact dependencies from
+      --dry-run             Dry run copy to print images that would be copied
+      --dst-cert string     TLS certificate for destination registry
+  -h, --help                help for packages
+      --insecure            Skip TLS verification while copying images and charts
+      --src-cert string     TLS certificate for source registry
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere copy](../anywhere_copy/)	 - Copy resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_create.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_create.md
@@ -1,0 +1,31 @@
+---
+title: "anywhere create"
+linkTitle: "anywhere create"
+---
+
+## anywhere create
+
+Create resources
+
+### Synopsis
+
+Use eksctl anywhere create to create resources, such as clusters
+
+### Options
+
+```
+  -h, --help   help for create
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+* [anywhere create cluster](../anywhere_create_cluster/)	 - Create workload cluster
+* [anywhere create package(s)](../anywhere_create_packages/)	 - Create curated packages
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_create_cluster.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_create_cluster.md
@@ -1,0 +1,42 @@
+---
+title: "anywhere create cluster"
+linkTitle: "anywhere create cluster"
+---
+
+## anywhere create cluster
+
+Create workload cluster
+
+### Synopsis
+
+This command is used to create workload clusters
+
+```
+anywhere create cluster -f <cluster-config-file> [flags]
+```
+
+### Options
+
+```
+      --bundles-override string          Override default Bundles manifest (not recommended)
+  -f, --filename string                  Filename that contains EKS-A cluster configuration
+      --force-cleanup                    Force deletion of previously created bootstrap cluster
+  -z, --hardware-csv string              Path to a CSV file containing hardware data.
+  -h, --help                             help for cluster
+      --install-packages string          Location of curated packages configuration files to install to the cluster
+      --kubeconfig string                Management cluster kubeconfig file
+      --no-timeouts                      Disable timeout for all wait operations
+      --skip-ip-check                    Skip check for whether cluster control plane ip is in use
+      --tinkerbell-bootstrap-ip string   Override the local tinkerbell IP in the bootstrap cluster
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere create](../anywhere_create/)	 - Create resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_create_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_create_package(s).md
@@ -1,0 +1,35 @@
+---
+title: "anywhere create package(s)"
+linkTitle: "anywhere create package(s)"
+---
+
+## anywhere create package(s)
+
+Create curated packages
+
+### Synopsis
+
+Create Curated Packages Custom Resources to the cluster
+
+```
+anywhere create package(s) [flags]
+```
+
+### Options
+
+```
+  -f, --filename string     Filename that contains curated packages custom resources to create
+  -h, --help                help for package(s)
+      --kubeconfig string   Path to an optional kubeconfig file to use.
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere create](../anywhere_create/)	 - Create resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_delete.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_delete.md
@@ -1,0 +1,31 @@
+---
+title: "anywhere delete"
+linkTitle: "anywhere delete"
+---
+
+## anywhere delete
+
+Delete resources
+
+### Synopsis
+
+Use eksctl anywhere delete to delete clusters
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+* [anywhere delete cluster](../anywhere_delete_cluster/)	 - Workload cluster
+* [anywhere delete package(s)](../anywhere_delete_packages/)	 - Delete package(s)
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_delete_cluster.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_delete_cluster.md
@@ -1,0 +1,38 @@
+---
+title: "anywhere delete cluster"
+linkTitle: "anywhere delete cluster"
+---
+
+## anywhere delete cluster
+
+Workload cluster
+
+### Synopsis
+
+This command is used to delete workload clusters created by eksctl anywhere
+
+```
+anywhere delete cluster (<cluster-name>|-f <config-file>) [flags]
+```
+
+### Options
+
+```
+      --bundles-override string   Override default Bundles manifest (not recommended)
+  -f, --filename string           Filename that contains EKS-A cluster configuration, required if <cluster-name> is not provided
+      --force-cleanup             Force deletion of previously created bootstrap cluster
+  -h, --help                      help for cluster
+      --kubeconfig string         kubeconfig file pointing to a management cluster
+  -w, --w-config string           Kubeconfig file to use when deleting a workload cluster
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere delete](../anywhere_delete/)	 - Delete resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_delete_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_delete_package(s).md
@@ -1,0 +1,35 @@
+---
+title: "anywhere delete package(s)"
+linkTitle: "anywhere delete package(s)"
+---
+
+## anywhere delete package(s)
+
+Delete package(s)
+
+### Synopsis
+
+This command is used to delete the curated packages custom resources installed in the cluster
+
+```
+anywhere delete package(s) [flags]
+```
+
+### Options
+
+```
+      --cluster string      Cluster for package deletion.
+  -h, --help                help for package(s)
+      --kubeconfig string   Path to an optional kubeconfig file to use.
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere delete](../anywhere_delete/)	 - Delete resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_describe.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_describe.md
@@ -1,0 +1,30 @@
+---
+title: "anywhere describe"
+linkTitle: "anywhere describe"
+---
+
+## anywhere describe
+
+Describe resources
+
+### Synopsis
+
+Use eksctl anywhere describe to show details of a specific resource or group of resources
+
+### Options
+
+```
+  -h, --help   help for describe
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+* [anywhere describe package(s)](../anywhere_describe_packages/)	 - Describe curated packages in the cluster
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_describe_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_describe_package(s).md
@@ -1,0 +1,31 @@
+---
+title: "anywhere describe package(s)"
+linkTitle: "anywhere describe package(s)"
+---
+
+## anywhere describe package(s)
+
+Describe curated packages in the cluster
+
+```
+anywhere describe package(s) [flags]
+```
+
+### Options
+
+```
+      --cluster string      Cluster to describe packages.
+  -h, --help                help for package(s)
+      --kubeconfig string   Path to an optional kubeconfig file to use.
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere describe](../anywhere_describe/)	 - Describe resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_download.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_download.md
@@ -1,0 +1,31 @@
+---
+title: "anywhere download"
+linkTitle: "anywhere download"
+---
+
+## anywhere download
+
+Download resources
+
+### Synopsis
+
+Use eksctl anywhere download to download artifacts (manifests, bundles) used by EKS Anywhere
+
+### Options
+
+```
+  -h, --help   help for download
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+* [anywhere download artifacts](../anywhere_download_artifacts/)	 - Download EKS Anywhere artifacts/manifests to a tarball on disk
+* [anywhere download images](../anywhere_download_images/)	 - Download all eks-a images to disk
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_download_artifacts.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_download_artifacts.md
@@ -1,0 +1,38 @@
+---
+title: "anywhere download artifacts"
+linkTitle: "anywhere download artifacts"
+---
+
+## anywhere download artifacts
+
+Download EKS Anywhere artifacts/manifests to a tarball on disk
+
+### Synopsis
+
+This command is used to download the S3 artifacts from an EKS Anywhere bundle manifest and package them into a tarball
+
+```
+anywhere download artifacts [flags]
+```
+
+### Options
+
+```
+      --bundles-override string   Override default Bundles manifest (not recommended)
+  -d, --download-dir string       Directory to download the artifacts to (default "eks-anywhere-downloads")
+      --dry-run                   Print the manifest URIs without downloading them
+  -f, --filename string           [Deprecated] Filename that contains EKS-A cluster configuration
+  -h, --help                      help for artifacts
+  -r, --retain-dir                Do not delete the download folder after creating a tarball
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere download](../anywhere_download/)	 - Download resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_download_images.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_download_images.md
@@ -1,0 +1,39 @@
+---
+title: "anywhere download images"
+linkTitle: "anywhere download images"
+---
+
+## anywhere download images
+
+Download all eks-a images to disk
+
+### Synopsis
+
+Creates a tarball containing all necessary images
+to create an eks-a cluster for any of the supported
+Kubernetes versions.
+
+```
+anywhere download images [flags]
+```
+
+### Options
+
+```
+      --bundles-override string   Override default Bundles manifest (not recommended)
+  -h, --help                      help for images
+      --include-packages          this flag no longer works, use copy packages instead (DEPRECATED: use copy packages command)
+      --insecure                  Flag to indicate skipping TLS verification while downloading helm charts
+  -o, --output string             Output tarball containing all downloaded images
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere download](../anywhere_download/)	 - Download resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_exp.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_exp.md
@@ -1,0 +1,31 @@
+---
+title: "anywhere exp"
+linkTitle: "anywhere exp"
+---
+
+## anywhere exp
+
+experimental commands
+
+### Synopsis
+
+Use eksctl anywhere experimental commands
+
+### Options
+
+```
+  -h, --help   help for exp
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+* [anywhere exp validate](../anywhere_exp_validate/)	 - Validate resource or action
+* [anywhere exp vsphere](../anywhere_exp_vsphere/)	 - Utility vsphere operations
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_exp_validate.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_exp_validate.md
@@ -1,0 +1,30 @@
+---
+title: "anywhere exp validate"
+linkTitle: "anywhere exp validate"
+---
+
+## anywhere exp validate
+
+Validate resource or action
+
+### Synopsis
+
+Use eksctl anywhere validate to validate a resource or action
+
+### Options
+
+```
+  -h, --help   help for validate
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere exp](../anywhere_exp/)	 - experimental commands
+* [anywhere exp validate create](../anywhere_exp_validate_create/)	 - Validate create resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_exp_validate_create.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_exp_validate_create.md
@@ -1,0 +1,30 @@
+---
+title: "anywhere exp validate create"
+linkTitle: "anywhere exp validate create"
+---
+
+## anywhere exp validate create
+
+Validate create resources
+
+### Synopsis
+
+Use eksctl anywhere validate create to validate the create action on resources, such as cluster
+
+### Options
+
+```
+  -h, --help   help for create
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere exp validate](../anywhere_exp_validate/)	 - Validate resource or action
+* [anywhere exp validate create cluster](../anywhere_exp_validate_create_cluster/)	 - Validate create cluster
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_exp_validate_create_cluster.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_exp_validate_create_cluster.md
@@ -1,0 +1,36 @@
+---
+title: "anywhere exp validate create cluster"
+linkTitle: "anywhere exp validate create cluster"
+---
+
+## anywhere exp validate create cluster
+
+Validate create cluster
+
+### Synopsis
+
+Use eksctl anywhere validate create cluster to validate the create cluster action
+
+```
+anywhere exp validate create cluster -f <cluster-config-file> [flags]
+```
+
+### Options
+
+```
+  -f, --filename string                  Filename that contains EKS-A cluster configuration
+  -z, --hardware-csv string              Path to a CSV file containing hardware data.
+  -h, --help                             help for cluster
+      --tinkerbell-bootstrap-ip string   Override the local tinkerbell IP in the bootstrap cluster
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere exp validate create](../anywhere_exp_validate_create/)	 - Validate create resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_exp_vsphere.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_exp_vsphere.md
@@ -1,0 +1,30 @@
+---
+title: "anywhere exp vsphere"
+linkTitle: "anywhere exp vsphere"
+---
+
+## anywhere exp vsphere
+
+Utility vsphere operations
+
+### Synopsis
+
+Use eksctl anywhere vsphere to perform utility operations on vsphere
+
+### Options
+
+```
+  -h, --help   help for vsphere
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere exp](../anywhere_exp/)	 - experimental commands
+* [anywhere exp vsphere setup](../anywhere_exp_vsphere_setup/)	 - Setup vSphere objects
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_exp_vsphere_setup.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_exp_vsphere_setup.md
@@ -1,0 +1,30 @@
+---
+title: "anywhere exp vsphere setup"
+linkTitle: "anywhere exp vsphere setup"
+---
+
+## anywhere exp vsphere setup
+
+Setup vSphere objects
+
+### Synopsis
+
+Use eksctl anywhere vsphere setup to configure vSphere objects
+
+### Options
+
+```
+  -h, --help   help for setup
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere exp vsphere](../anywhere_exp_vsphere/)	 - Utility vsphere operations
+* [anywhere exp vsphere setup user](../anywhere_exp_vsphere_setup_user/)	 - Setup vSphere user
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_exp_vsphere_setup_user.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_exp_vsphere_setup_user.md
@@ -1,0 +1,36 @@
+---
+title: "anywhere exp vsphere setup user"
+linkTitle: "anywhere exp vsphere setup user"
+---
+
+## anywhere exp vsphere setup user
+
+Setup vSphere user
+
+### Synopsis
+
+Use eksctl anywhere vsphere setup user to configure EKS Anywhere vSphere user
+
+```
+anywhere exp vsphere setup user -f <config-file> [flags]
+```
+
+### Options
+
+```
+  -f, --filename string   Filename containing vsphere setup configuration
+      --force             Force flag. When set, setup user will proceed even if the group and role objects already exist. Mutually exclusive with --password flag, as it expects the user to already exist. default: false
+  -h, --help              help for user
+  -p, --password string   Password for creating new user
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere exp vsphere setup](../anywhere_exp_vsphere_setup/)	 - Setup vSphere objects
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_generate.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_generate.md
@@ -1,0 +1,34 @@
+---
+title: "anywhere generate"
+linkTitle: "anywhere generate"
+---
+
+## anywhere generate
+
+Generate resources
+
+### Synopsis
+
+Use eksctl anywhere generate to generate resources, such as clusterconfig yaml
+
+### Options
+
+```
+  -h, --help   help for generate
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+* [anywhere generate clusterconfig](../anywhere_generate_clusterconfig/)	 - Generate cluster config
+* [anywhere generate hardware](../anywhere_generate_hardware/)	 - Generate hardware files
+* [anywhere generate packages](../anywhere_generate_packages/)	 - Generate package(s) configuration
+* [anywhere generate support-bundle](../anywhere_generate_support-bundle/)	 - Generate a support bundle
+* [anywhere generate support-bundle-config](../anywhere_generate_support-bundle-config/)	 - Generate support bundle config
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_generate_clusterconfig.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_generate_clusterconfig.md
@@ -1,0 +1,34 @@
+---
+title: "anywhere generate clusterconfig"
+linkTitle: "anywhere generate clusterconfig"
+---
+
+## anywhere generate clusterconfig
+
+Generate cluster config
+
+### Synopsis
+
+This command is used to generate a cluster config yaml for the create cluster command
+
+```
+anywhere generate clusterconfig <cluster-name> (max 80 chars) [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for clusterconfig
+  -p, --provider string   Provider to use (vsphere or tinkerbell or docker)
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere generate](../anywhere_generate/)	 - Generate resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_generate_hardware.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_generate_hardware.md
@@ -1,0 +1,37 @@
+---
+title: "anywhere generate hardware"
+linkTitle: "anywhere generate hardware"
+---
+
+## anywhere generate hardware
+
+Generate hardware files
+
+### Synopsis
+
+
+Generate Kubernetes hardware YAML manifests for each Hardware entry in the source.
+
+
+```
+anywhere generate hardware [flags]
+```
+
+### Options
+
+```
+  -z, --hardware-csv string   Path to a CSV file containing hardware data.
+  -h, --help                  help for hardware
+  -o, --output string         Path to output hardware YAML.
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere generate](../anywhere_generate/)	 - Generate resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_generate_packages.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_generate_packages.md
@@ -1,0 +1,37 @@
+---
+title: "anywhere generate packages"
+linkTitle: "anywhere generate packages"
+---
+
+## anywhere generate packages
+
+Generate package(s) configuration
+
+### Synopsis
+
+Generates Kubernetes configuration files for curated packages
+
+```
+anywhere generate packages [flags] package
+```
+
+### Options
+
+```
+      --cluster string        Name of cluster for package generation
+  -h, --help                  help for packages
+      --kube-version string   Kubernetes Version of the cluster to be used. Format <major>.<minor>
+      --kubeconfig string     Path to an optional kubeconfig file to use.
+      --registry string       Used to specify an alternative registry for package generation
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere generate](../anywhere_generate/)	 - Generate resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_generate_support-bundle-config.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_generate_support-bundle-config.md
@@ -1,0 +1,34 @@
+---
+title: "anywhere generate support-bundle-config"
+linkTitle: "anywhere generate support-bundle-config"
+---
+
+## anywhere generate support-bundle-config
+
+Generate support bundle config
+
+### Synopsis
+
+This command is used to generate a default support bundle config yaml
+
+```
+anywhere generate support-bundle-config [flags]
+```
+
+### Options
+
+```
+  -f, --filename string   Filename that contains EKS-A cluster configuration
+  -h, --help              help for support-bundle-config
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere generate](../anywhere_generate/)	 - Generate resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_generate_support-bundle.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_generate_support-bundle.md
@@ -1,0 +1,38 @@
+---
+title: "anywhere generate support-bundle"
+linkTitle: "anywhere generate support-bundle"
+---
+
+## anywhere generate support-bundle
+
+Generate a support bundle
+
+### Synopsis
+
+This command is used to create a support bundle to troubleshoot a cluster
+
+```
+anywhere generate support-bundle -f my-cluster.yaml [flags]
+```
+
+### Options
+
+```
+      --bundle-config string   Bundle Config file to use when generating support bundle
+  -f, --filename string        Filename that contains EKS-A cluster configuration
+  -h, --help                   help for support-bundle
+      --since string           Collect pod logs in the latest duration like 5s, 2m, or 3h.
+      --since-time string      Collect pod logs after a specific datetime(RFC3339) like 2021-06-28T15:04:05Z
+  -w, --w-config string        Kubeconfig file to use when creating support bundle for a workload cluster
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere generate](../anywhere_generate/)	 - Generate resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_get.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_get.md
@@ -1,0 +1,32 @@
+---
+title: "anywhere get"
+linkTitle: "anywhere get"
+---
+
+## anywhere get
+
+Get resources
+
+### Synopsis
+
+Use eksctl anywhere get to display one or many resources
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+* [anywhere get package(s)](../anywhere_get_packages/)	 - Get package(s)
+* [anywhere get packagebundle(s)](../anywhere_get_packagebundles/)	 - Get packagebundle(s)
+* [anywhere get packagebundlecontroller(s)](../anywhere_get_packagebundlecontrollers/)	 - Get packagebundlecontroller(s)
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_get_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_get_package(s).md
@@ -1,0 +1,36 @@
+---
+title: "anywhere get package(s)"
+linkTitle: "anywhere get package(s)"
+---
+
+## anywhere get package(s)
+
+Get package(s)
+
+### Synopsis
+
+This command is used to display the curated packages installed in the cluster
+
+```
+anywhere get package(s) [flags]
+```
+
+### Options
+
+```
+      --cluster string      Cluster to get list of packages.
+  -h, --help                help for package(s)
+      --kubeconfig string   Path to an optional kubeconfig file.
+  -o, --output string       Specifies the output format (valid option: json, yaml)
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere get](../anywhere_get/)	 - Get resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_get_packagebundle(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_get_packagebundle(s).md
@@ -1,0 +1,35 @@
+---
+title: "anywhere get packagebundle(s)"
+linkTitle: "anywhere get packagebundle(s)"
+---
+
+## anywhere get packagebundle(s)
+
+Get packagebundle(s)
+
+### Synopsis
+
+This command is used to display the currently supported packagebundles
+
+```
+anywhere get packagebundle(s) [flags]
+```
+
+### Options
+
+```
+  -h, --help                help for packagebundle(s)
+      --kubeconfig string   Path to an optional kubeconfig file.
+  -o, --output string       Specifies the output format (valid option: json, yaml)
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere get](../anywhere_get/)	 - Get resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_get_packagebundlecontroller(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_get_packagebundlecontroller(s).md
@@ -1,0 +1,35 @@
+---
+title: "anywhere get packagebundlecontroller(s)"
+linkTitle: "anywhere get packagebundlecontroller(s)"
+---
+
+## anywhere get packagebundlecontroller(s)
+
+Get packagebundlecontroller(s)
+
+### Synopsis
+
+This command is used to display the current packagebundlecontrollers
+
+```
+anywhere get packagebundlecontroller(s) [flags]
+```
+
+### Options
+
+```
+  -h, --help                help for packagebundlecontroller(s)
+      --kubeconfig string   Path to an optional kubeconfig file.
+  -o, --output string       Specifies the output format (valid option: json, yaml)
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere get](../anywhere_get/)	 - Get resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_import.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_import.md
@@ -1,0 +1,30 @@
+---
+title: "anywhere import"
+linkTitle: "anywhere import"
+---
+
+## anywhere import
+
+Import resources
+
+### Synopsis
+
+Use eksctl anywhere import to import resources, such as images and helm charts
+
+### Options
+
+```
+  -h, --help   help for import
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+* [anywhere import images](../anywhere_import_images/)	 - Import images and charts to a registry from a tarball
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_import_images.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_import_images.md
@@ -1,0 +1,39 @@
+---
+title: "anywhere import images"
+linkTitle: "anywhere import images"
+---
+
+## anywhere import images
+
+Import images and charts to a registry from a tarball
+
+### Synopsis
+
+Import all the images and helm charts necessary for EKS Anywhere clusters into a registry.
+Use this command in conjunction with download images, passing it output tarball as input to this command.
+
+```
+anywhere import images [flags]
+```
+
+### Options
+
+```
+  -b, --bundles string     Bundles file to read artifact dependencies from
+  -h, --help               help for images
+      --include-packages   Flag to indicate inclusion of curated packages in imported images (DEPRECATED: use copy packages command)
+  -i, --input string       Input tarball containing all images and charts to import
+      --insecure           Flag to indicate skipping TLS verification while pushing helm charts
+  -r, --registry string    Registry where to import images and charts
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere import](../anywhere_import/)	 - Import resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_install.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_install.md
@@ -1,0 +1,31 @@
+---
+title: "anywhere install"
+linkTitle: "anywhere install"
+---
+
+## anywhere install
+
+Install resources to the cluster
+
+### Synopsis
+
+Use eksctl anywhere install to install resources into a cluster
+
+### Options
+
+```
+  -h, --help   help for install
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+* [anywhere install package](../anywhere_install_package/)	 - Install package
+* [anywhere install packagecontroller](../anywhere_install_packagecontroller/)	 - Install packagecontroller on the cluster
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_install_package.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_install_package.md
@@ -1,0 +1,39 @@
+---
+title: "anywhere install package"
+linkTitle: "anywhere install package"
+---
+
+## anywhere install package
+
+Install package
+
+### Synopsis
+
+This command is used to Install a curated package. Use list to discover curated packages
+
+```
+anywhere install package [flags] package
+```
+
+### Options
+
+```
+      --cluster string        Target cluster for installation.
+  -h, --help                  help for package
+      --kube-version string   Kubernetes Version of the cluster to be used. Format <major>.<minor>
+      --kubeconfig string     Path to an optional kubeconfig file to use.
+  -n, --package-name string   Custom name of the curated package to install
+      --registry string       Used to specify an alternative registry for discovery
+      --set stringArray       Provide custom configurations for curated packages. Format key:value
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere install](../anywhere_install/)	 - Install resources to the cluster
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_install_packagecontroller.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_install_packagecontroller.md
@@ -1,0 +1,35 @@
+---
+title: "anywhere install packagecontroller"
+linkTitle: "anywhere install packagecontroller"
+---
+
+## anywhere install packagecontroller
+
+Install packagecontroller on the cluster
+
+### Synopsis
+
+This command is used to Install the packagecontroller on to an existing cluster
+
+```
+anywhere install packagecontroller [flags]
+```
+
+### Options
+
+```
+  -f, --filename string     Filename that contains EKS-A cluster configuration
+  -h, --help                help for packagecontroller
+      --kubeConfig string   Management cluster kubeconfig file
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere install](../anywhere_install/)	 - Install resources to the cluster
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_list.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_list.md
@@ -1,0 +1,32 @@
+---
+title: "anywhere list"
+linkTitle: "anywhere list"
+---
+
+## anywhere list
+
+List resources
+
+### Synopsis
+
+Use eksctl anywhere list to list images and artifacts used by EKS Anywhere
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+* [anywhere list images](../anywhere_list_images/)	 - Generate a list of images used by EKS Anywhere
+* [anywhere list ovas](../anywhere_list_ovas/)	 - List the OVAs that are supported by current version of EKS Anywhere
+* [anywhere list packages](../anywhere_list_packages/)	 - Lists curated packages available to install
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_list_images.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_list_images.md
@@ -1,0 +1,35 @@
+---
+title: "anywhere list images"
+linkTitle: "anywhere list images"
+---
+
+## anywhere list images
+
+Generate a list of images used by EKS Anywhere
+
+### Synopsis
+
+This command is used to generate a list of images used by EKS-Anywhere for cluster provisioning
+
+```
+anywhere list images [flags]
+```
+
+### Options
+
+```
+      --bundles-override string   Override default Bundles manifest (not recommended)
+  -f, --filename string           Filename that contains EKS-A cluster configuration
+  -h, --help                      help for images
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere list](../anywhere_list/)	 - List resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_list_ovas.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_list_ovas.md
@@ -1,0 +1,35 @@
+---
+title: "anywhere list ovas"
+linkTitle: "anywhere list ovas"
+---
+
+## anywhere list ovas
+
+List the OVAs that are supported by current version of EKS Anywhere
+
+### Synopsis
+
+This command is used to list the vSphere OVAs from the EKS Anywhere bundle manifest for the current version of the EKS Anywhere CLI
+
+```
+anywhere list ovas [flags]
+```
+
+### Options
+
+```
+      --bundles-override string   Override default Bundles manifest (not recommended)
+  -f, --filename string           Filename that contains EKS-A cluster configuration
+  -h, --help                      help for ovas
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere list](../anywhere_list/)	 - List resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_list_packages.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_list_packages.md
@@ -1,0 +1,33 @@
+---
+title: "anywhere list packages"
+linkTitle: "anywhere list packages"
+---
+
+## anywhere list packages
+
+Lists curated packages available to install
+
+```
+anywhere list packages [flags]
+```
+
+### Options
+
+```
+      --cluster string        Name of cluster for package list.
+  -h, --help                  help for packages
+      --kube-version string   Kubernetes version <major>.<minor> of the packages to list, for example: "1.23".
+      --kubeconfig string     Path to a kubeconfig file to use when source is a cluster.
+      --registry string       Specifies an alternative registry for packages discovery.
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere list](../anywhere_list/)	 - List resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_upgrade.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_upgrade.md
@@ -1,0 +1,32 @@
+---
+title: "anywhere upgrade"
+linkTitle: "anywhere upgrade"
+---
+
+## anywhere upgrade
+
+Upgrade resources
+
+### Synopsis
+
+Use eksctl anywhere upgrade to upgrade resources, such as clusters
+
+### Options
+
+```
+  -h, --help   help for upgrade
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+* [anywhere upgrade cluster](../anywhere_upgrade_cluster/)	 - Upgrade workload cluster
+* [anywhere upgrade packages](../anywhere_upgrade_packages/)	 - Upgrade all curated packages to the latest version
+* [anywhere upgrade plan](../anywhere_upgrade_plan/)	 - Provides information for a resource upgrade
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_upgrade_cluster.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_upgrade_cluster.md
@@ -1,0 +1,40 @@
+---
+title: "anywhere upgrade cluster"
+linkTitle: "anywhere upgrade cluster"
+---
+
+## anywhere upgrade cluster
+
+Upgrade workload cluster
+
+### Synopsis
+
+This command is used to upgrade workload clusters
+
+```
+anywhere upgrade cluster [flags]
+```
+
+### Options
+
+```
+      --bundles-override string   Override default Bundles manifest (not recommended)
+  -f, --filename string           Filename that contains EKS-A cluster configuration
+      --force-cleanup             Force deletion of previously created bootstrap cluster
+  -z, --hardware-csv string       Path to a CSV file containing hardware data.
+  -h, --help                      help for cluster
+      --kubeconfig string         Management cluster kubeconfig file
+      --no-timeouts               Disable timeout for all wait operations
+  -w, --w-config string           Kubeconfig file to use when upgrading a workload cluster
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere upgrade](../anywhere_upgrade/)	 - Upgrade resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_upgrade_packages.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_upgrade_packages.md
@@ -1,0 +1,32 @@
+---
+title: "anywhere upgrade packages"
+linkTitle: "anywhere upgrade packages"
+---
+
+## anywhere upgrade packages
+
+Upgrade all curated packages to the latest version
+
+```
+anywhere upgrade packages [flags]
+```
+
+### Options
+
+```
+      --bundle-version string   Bundle version to use
+      --cluster string          Cluster to upgrade.
+  -h, --help                    help for packages
+      --kubeconfig string       Path to an optional kubeconfig file to use.
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere upgrade](../anywhere_upgrade/)	 - Upgrade resources
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_upgrade_plan.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_upgrade_plan.md
@@ -1,0 +1,30 @@
+---
+title: "anywhere upgrade plan"
+linkTitle: "anywhere upgrade plan"
+---
+
+## anywhere upgrade plan
+
+Provides information for a resource upgrade
+
+### Synopsis
+
+Use eksctl anywhere upgrade plan to get information for a resource upgrade
+
+### Options
+
+```
+  -h, --help   help for plan
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere upgrade](../anywhere_upgrade/)	 - Upgrade resources
+* [anywhere upgrade plan cluster](../anywhere_upgrade_plan_cluster/)	 - Provides new release versions for the next cluster upgrade
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_upgrade_plan_cluster.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_upgrade_plan_cluster.md
@@ -1,0 +1,37 @@
+---
+title: "anywhere upgrade plan cluster"
+linkTitle: "anywhere upgrade plan cluster"
+---
+
+## anywhere upgrade plan cluster
+
+Provides new release versions for the next cluster upgrade
+
+### Synopsis
+
+Provides a list of target versions for upgrading the core components in the workload cluster
+
+```
+anywhere upgrade plan cluster [flags]
+```
+
+### Options
+
+```
+      --bundles-override string   Override default Bundles manifest (not recommended)
+  -f, --filename string           Filename that contains EKS-A cluster configuration
+  -h, --help                      help for cluster
+      --kubeconfig string         Management cluster kubeconfig file
+  -o, --output string             Output format: text|json (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere upgrade plan](../anywhere_upgrade_plan/)	 - Provides information for a resource upgrade
+

--- a/docs/content/en/docs/reference/eksctl/anywhere_version.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_version.md
@@ -1,0 +1,33 @@
+---
+title: "anywhere version"
+linkTitle: "anywhere version"
+---
+
+## anywhere version
+
+Get the eksctl anywhere version
+
+### Synopsis
+
+This command prints the version of eksctl anywhere
+
+```
+anywhere version [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for version
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbosity int   Set the log level verbosity
+```
+
+### SEE ALSO
+
+* [anywhere](../anywhere/)	 - Amazon EKS Anywhere
+

--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,7 @@ require (
 	github.com/containerd/containerd v1.6.19 // indirect
 	github.com/coredns/caddy v1.1.0 // indirect
 	github.com/coredns/corefile-migration v1.0.20 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v20.10.21+incompatible // indirect
@@ -170,6 +171,7 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -393,6 +393,7 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -1172,6 +1173,7 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=


### PR DESCRIPTION
*Issue #, if available:*

Resolves #5281
Resolves #5116 

*Description of changes:*

Introduce command: `eks-a-tool docgen` to auto generate eksctl commands doc from code with Cobra.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

