### PR TITLE
Add cluster lifecycle information to docs

### DIFF
--- a/docs/content/en/docs/concepts/cluster-topologies.md
+++ b/docs/content/en/docs/concepts/cluster-topologies.md
@@ -35,7 +35,7 @@ This shows examples of a management cluster that deploys and manages multiple wo
 
 With the management cluster in place, you have a choice of tools for creating, upgrading, and deleting workload clusters.
 Check each provider to see which tools it currently supports.
-Supported workload cluster creation tools include:
+Supported workload cluster creation, upgrade and deletion tools include:
 
 * `eksctl` CLI
 * Terraform

--- a/docs/content/en/docs/concepts/cluster-topologies.md
+++ b/docs/content/en/docs/concepts/cluster-topologies.md
@@ -33,6 +33,15 @@ This shows examples of a management cluster that deploys and manages multiple wo
 
 ![Management clusters can create and manage multiple workload clusters](/images/eks-a_cluster_management.png)
 
+With the management cluster in place, you have a choice of tools for creating, upgrading, and deleting workload clusters.
+Check each provider to see which tools it currently supports.
+Supported workload cluster creation tools include:
+
+* `eksctl` CLI
+* Terraform
+* GitOps
+* `kubectl` CLI or similar tools that can communicate with the Kubernetes API
+
 ## What’s the difference between a management cluster and a bootstrap cluster for EKS Anywhere?
 
 A management cluster is a long-lived entity you have to actively operate.

--- a/docs/content/en/docs/concepts/cluster-topologies.md
+++ b/docs/content/en/docs/concepts/cluster-topologies.md
@@ -40,7 +40,7 @@ Supported workload cluster creation tools include:
 * `eksctl` CLI
 * Terraform
 * GitOps
-* `kubectl` CLI or similar tools that can communicate with the Kubernetes API
+* `kubectl` CLI to communicate with the Kubernetes API
 
 ## What’s the difference between a management cluster and a bootstrap cluster for EKS Anywhere?
 

--- a/docs/content/en/docs/concepts/clusterworkflow.md
+++ b/docs/content/en/docs/concepts/clusterworkflow.md
@@ -8,8 +8,9 @@ description: >
 ---
 
 Each EKS Anywhere cluster is built from a cluster specification file, with the structure of the configuration file based on the target provider for the cluster.
-Currently, Bare Metal, CloudStack, and VMware vSphere are the recommended providers for supported EKS Anywhere clusters.
-We step through the cluster creation workflow for those providers here.
+Currently, Bare Metal, CloudStack, Nutanix, Snow, and VMware vSphere are the recommended providers for supported EKS Anywhere clusters.
+Docker is available as an unsupported provider.
+We step through the cluster creation workflow for Bare Metal and vSphere providers here.
 
 
 ## Management and workload clusters

--- a/docs/content/en/docs/getting-started/local-environment/_index.md
+++ b/docs/content/en/docs/getting-started/local-environment/_index.md
@@ -323,6 +323,11 @@ Follow these steps to have your management cluster create and manage separate wo
    * **GitOps**: See [Manage separate workload clusters with GitOps]({{< relref "../../tasks/cluster/cluster-flux.md#manage-separate-workload-clusters-using-gitops" >}})
 
    * **Terraform**: See [Manage separate workload clusters with Terraform]({{< relref "../../tasks/cluster/cluster-terraform.md#manage-separate-workload-clusters-using-terraform" >}})
+
+   * **kubectl CLI**: The cluster lifecycle feature lets you use `kubectl`, or other tools that that can talk to the Kubernetes API, to create a workload cluster. To use `kubectl`, run:
+      ```bash
+      kubectl apply -f eksa-w01-cluster.yaml 
+      ```
      
    * **eksctl CLI**: Useful for temporary cluster configurations. To create a workload cluster with `eksctl`, do one of the following.
      For a regular cluster create (with internet access), type the following:

--- a/docs/content/en/docs/getting-started/local-environment/_index.md
+++ b/docs/content/en/docs/getting-started/local-environment/_index.md
@@ -324,7 +324,7 @@ Follow these steps to have your management cluster create and manage separate wo
 
    * **Terraform**: See [Manage separate workload clusters with Terraform]({{< relref "../../tasks/cluster/cluster-terraform.md#manage-separate-workload-clusters-using-terraform" >}})
 
-   * **kubectl CLI**: The cluster lifecycle feature lets you use `kubectl`, or other tools that that can talk to the Kubernetes API, to create a workload cluster. To use `kubectl`, run:
+   * **Kubernetes CLI**: The cluster lifecycle feature lets you use `kubectl` to manage a workload cluster. For example:
       ```bash
       kubectl apply -f eksa-w01-cluster.yaml 
       ```

--- a/docs/content/en/docs/getting-started/production-environment/snow-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/snow-getstarted.md
@@ -204,6 +204,10 @@ Follow these steps if you want to use your initial cluster to create and manage 
       ```
       As noted earlier, adding the `--kubeconfig` option tells `eksctl` to use the management cluster identified by that kubeconfig file to create a different workload cluster.
 
+   * **kubectl CLI**: The cluster lifecycle feature lets you use `kubectl`, or other tools that that can talk to the Kubernetes API, to create a workload cluster. To use `kubectl`, run:
+      ```bash
+      kubectl apply -f eksa-w01-cluster.yaml
+      ```
 1. Check the workload cluster:
 
    You can now use the workload cluster as you would any Kubernetes cluster.

--- a/docs/content/en/docs/getting-started/production-environment/vsphere-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/vsphere-getstarted.md
@@ -211,6 +211,11 @@ Follow these steps if you want to use your initial cluster to create and manage 
       ```
       As noted earlier, adding the `--kubeconfig` option tells `eksctl` to use the management cluster identified by that kubeconfig file to create a different workload cluster.
 
+   * **kubectl CLI**: The cluster lifecycle feature lets you use `kubectl`, or other tools that that can talk to the Kubernetes API, to create a workload cluster. To use `kubectl`, run:
+      ```bash
+      kubectl apply -f eksa-w01-cluster.yaml 
+      ```
+
 1. To check the workload cluster, get the workload cluster credentials and run a [test workload:]({{< relref "../../tasks/workload/test-app" >}})
 
    * If your workload cluster was created with `eksctl`, 


### PR DESCRIPTION
*Issue:* [#5119](https://github.com/aws/eks-anywhere/issues/5119)
*Description of changes:* This PR starts the documentation process for adding cluster lifecycle features to EKS Anywhere docs. In particular, it notes the ability to use kubectl to create workload clusters for vSphere, Docker, and Snow. It also describes this feature in the cluster workflow and cluster topology docs.

I still have some questions, so I have not yet added cluster lifecycle content for Nutanix, Bare Metal, or Cloudstack. I also need more information on how cluster lifecycle should be described in relation to workload cluster upgrades and deletions. I will either add that information here or create new PRs after this one merges.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


