### PR TITLE
Feature: Implement unmanaged CNI for CLI based clusters

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -658,12 +658,24 @@ func validateCNIConfig(cniConfig *CNIConfig) error {
 }
 
 func validateCiliumConfig(cilium *CiliumConfig) error {
+	if cilium == nil {
+		return nil
+	}
+
+	if !cilium.IsManaged() {
+		if cilium.PolicyEnforcementMode != "" {
+			return errors.New("when using skipUpgrades for cilium all other fields must be empty")
+		}
+	}
+
 	if cilium.PolicyEnforcementMode == "" {
 		return nil
 	}
+
 	if !validCiliumPolicyEnforcementModes[cilium.PolicyEnforcementMode] {
 		return fmt.Errorf("cilium policyEnforcementMode \"%s\" not supported", cilium.PolicyEnforcementMode)
 	}
+
 	return nil
 }
 

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -2464,6 +2464,41 @@ func TestValidateCNIConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "CiliumSkipUpgradeWithoutOtherFields",
+			wantErr: nil,
+			clusterNetwork: &ClusterNetwork{
+				CNIConfig: &CNIConfig{
+					Cilium: &CiliumConfig{
+						SkipUpgrade: ptr.Bool(true),
+					},
+				},
+			},
+		},
+		{
+			name: "CiliumSkipUpgradeWithOtherFields",
+			wantErr: fmt.Errorf("validating cniConfig: when using skipUpgrades for cilium all " +
+				"other fields must be empty"),
+			clusterNetwork: &ClusterNetwork{
+				CNIConfig: &CNIConfig{
+					Cilium: &CiliumConfig{
+						SkipUpgrade:           ptr.Bool(true),
+						PolicyEnforcementMode: "never",
+					},
+				},
+			},
+		},
+		{
+			name: "CiliumSkipUpgradeExplicitFalseWithOtherFields",
+			clusterNetwork: &ClusterNetwork{
+				CNIConfig: &CNIConfig{
+					Cilium: &CiliumConfig{
+						SkipUpgrade:           ptr.Bool(false),
+						PolicyEnforcementMode: "never",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -489,7 +489,22 @@ func (n *CiliumConfig) Equal(o *CiliumConfig) bool {
 	if n == nil || o == nil {
 		return false
 	}
-	return n.PolicyEnforcementMode == o.PolicyEnforcementMode
+
+	if n.PolicyEnforcementMode != o.PolicyEnforcementMode {
+		return false
+	}
+
+	oSkipUpgradeIsFalse := o.SkipUpgrade == nil || !*o.SkipUpgrade
+	nSkipUpgradeIsFalse := n.SkipUpgrade == nil || !*n.SkipUpgrade
+
+	// We consider nil to be false in equality checks. Here we're checking if o is false then
+	// n must be false and vice-versa. If neither of these are true, then both o and n must be
+	// true so we don't need an explicit check.
+	if oSkipUpgradeIsFalse && !nSkipUpgradeIsFalse || !oSkipUpgradeIsFalse && nSkipUpgradeIsFalse {
+		return false
+	}
+
+	return true
 }
 
 func (n *KindnetdConfig) Equal(o *KindnetdConfig) bool {
@@ -684,6 +699,12 @@ type CiliumConfig struct {
 	// +kubebuilder:default=false
 	// +optional
 	SkipUpgrade *bool `json:"skipUpgrade,omitempty"`
+}
+
+// IsManaged returns true if SkipUpgrade is nil or false indicating EKS-A is responsible for
+// the Cilium installation.
+func (n *CiliumConfig) IsManaged() bool {
+	return n.SkipUpgrade == nil || !*n.SkipUpgrade
 }
 
 type KindnetdConfig struct{}

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -2471,3 +2471,136 @@ func TestPackageControllerCronJob_Equal(t *testing.T) {
 		})
 	}
 }
+
+func TestCiliumConfigEquality(t *testing.T) {
+	tests := []struct {
+		Name  string
+		A     *v1alpha1.CiliumConfig
+		B     *v1alpha1.CiliumConfig
+		Equal bool
+	}{
+		{
+			Name:  "Nils",
+			A:     nil,
+			B:     nil,
+			Equal: true,
+		},
+		{
+			Name:  "NilA",
+			A:     nil,
+			B:     &v1alpha1.CiliumConfig{},
+			Equal: false,
+		},
+		{
+			Name:  "NilB",
+			A:     &v1alpha1.CiliumConfig{},
+			B:     nil,
+			Equal: false,
+		},
+		{
+			Name:  "ZeroValues",
+			A:     &v1alpha1.CiliumConfig{},
+			B:     &v1alpha1.CiliumConfig{},
+			Equal: true,
+		},
+		{
+			Name: "EqualPolicyEnforcement",
+			A: &v1alpha1.CiliumConfig{
+				PolicyEnforcementMode: "always",
+			},
+			B: &v1alpha1.CiliumConfig{
+				PolicyEnforcementMode: "always",
+			},
+			Equal: true,
+		},
+		{
+			Name: "DiffPolicyEnforcement",
+			A: &v1alpha1.CiliumConfig{
+				PolicyEnforcementMode: "always",
+			},
+			B: &v1alpha1.CiliumConfig{
+				PolicyEnforcementMode: "default",
+			},
+			Equal: false,
+		},
+		{
+			Name: "NilSkipUpgradeAFalse",
+			A: &v1alpha1.CiliumConfig{
+				SkipUpgrade: ptr.Bool(false),
+			},
+			B:     &v1alpha1.CiliumConfig{},
+			Equal: true,
+		},
+		{
+			Name: "NilSkipUpgradeBFalse",
+			A:    &v1alpha1.CiliumConfig{},
+			B: &v1alpha1.CiliumConfig{
+				SkipUpgrade: ptr.Bool(false),
+			},
+			Equal: true,
+		},
+		{
+			Name: "SkipUpgradeBothFalse",
+			A: &v1alpha1.CiliumConfig{
+				SkipUpgrade: ptr.Bool(false),
+			},
+			B: &v1alpha1.CiliumConfig{
+				SkipUpgrade: ptr.Bool(false),
+			},
+			Equal: true,
+		},
+		{
+			Name: "NilSkipUpgradeATrue",
+			A: &v1alpha1.CiliumConfig{
+				SkipUpgrade: ptr.Bool(true),
+			},
+			B:     &v1alpha1.CiliumConfig{},
+			Equal: false,
+		},
+		{
+			Name: "NilSkipUpgradeBTrue",
+			A:    &v1alpha1.CiliumConfig{},
+			B: &v1alpha1.CiliumConfig{
+				SkipUpgrade: ptr.Bool(true),
+			},
+			Equal: false,
+		},
+		{
+			Name: "SkipUpgradeBothTrue",
+			A: &v1alpha1.CiliumConfig{
+				SkipUpgrade: ptr.Bool(true),
+			},
+			B: &v1alpha1.CiliumConfig{
+				SkipUpgrade: ptr.Bool(true),
+			},
+			Equal: true,
+		},
+		{
+			Name: "SkipUpgradeAFalseBTrue",
+			A: &v1alpha1.CiliumConfig{
+				SkipUpgrade: ptr.Bool(false),
+			},
+			B: &v1alpha1.CiliumConfig{
+				SkipUpgrade: ptr.Bool(true),
+			},
+			Equal: false,
+		},
+		{
+			Name: "SkipUpgradeATrueBFalse",
+			A: &v1alpha1.CiliumConfig{
+				SkipUpgrade: ptr.Bool(true),
+			},
+			B: &v1alpha1.CiliumConfig{
+				SkipUpgrade: ptr.Bool(false),
+			},
+			Equal: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tc.A.Equal(tc.B)).To(Equal(tc.Equal))
+		})
+	}
+}

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -707,10 +707,12 @@ func (f *Factory) WithNetworking(clusterConfig *v1alpha1.Cluster) *Factory {
 	} else {
 		f.WithKubectl().WithCiliumTemplater()
 		networkingBuilder = func() clustermanager.Networking {
-			return cilium.NewCilium(
+			c := cilium.NewCilium(
 				cilium.NewRetrier(f.dependencies.Kubectl),
 				f.dependencies.CiliumTemplater,
 			)
+			c.SetSkipUpgrade(!clusterConfig.Spec.ClusterNetwork.CNIConfig.Cilium.IsManaged())
+			return c
 		}
 	}
 

--- a/pkg/validations/upgradevalidations/immutableFields.go
+++ b/pkg/validations/upgradevalidations/immutableFields.go
@@ -57,6 +57,15 @@ func ValidateImmutableFields(ctx context.Context, k validations.KubectlClient, c
 		return fmt.Errorf("spec.clusterNetwork.CNI/CNIConfig is immutable")
 	}
 
+	// We don't want users to be able to toggle  off SkipUpgrade until we've understood the
+	// implications so we are temporarily disallowing it.
+
+	oCNI := prevSpec.Spec.ClusterNetwork.CNIConfig
+	nCNI := spec.Cluster.Spec.ClusterNetwork.CNIConfig
+	if oCNI != nil && oCNI.Cilium != nil && !oCNI.Cilium.IsManaged() && nCNI.Cilium.IsManaged() {
+		return fmt.Errorf("spec.clusterNetwork.cniConfig.cilium.skipUpgrade cannot be toggled off")
+	}
+
 	if !nSpec.ProxyConfiguration.Equal(oSpec.ProxyConfiguration) {
 		return fmt.Errorf("spec.proxyConfiguration is immutable")
 	}

--- a/pkg/validations/upgradevalidations/immutableFields_test.go
+++ b/pkg/validations/upgradevalidations/immutableFields_test.go
@@ -11,9 +11,12 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	pmock "github.com/aws/eks-anywhere/pkg/providers/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 	"github.com/aws/eks-anywhere/pkg/validations/mocks"
 	"github.com/aws/eks-anywhere/pkg/validations/upgradevalidations"
+	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 func TestValidateGitOpsImmutableFieldsRef(t *testing.T) {
@@ -238,6 +241,121 @@ func TestValidateGitOpsImmutableFieldsFluxConfig(t *testing.T) {
 				g.Expect(err).To(Succeed())
 			} else {
 				g.Expect(err).To(MatchError(ContainSubstring(tc.wantErr)))
+			}
+		})
+	}
+}
+
+func TestValidateImmutableFields(t *testing.T) {
+	tests := []struct {
+		Name             string
+		ConfigureCurrent func(current *v1alpha1.Cluster)
+		ConfigureDesired func(desired *v1alpha1.Cluster)
+		ExpectedError    string
+	}{
+		{
+			Name: "Toggle Spec.ClusterNetwork.CNIConfig.Cilium.SkipUpgrade on",
+			ConfigureCurrent: func(current *v1alpha1.Cluster) {
+				current.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{
+					Cilium: &v1alpha1.CiliumConfig{
+						SkipUpgrade: ptr.Bool(false),
+					},
+				}
+			},
+			ConfigureDesired: func(desired *v1alpha1.Cluster) {
+				desired.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{
+					Cilium: &v1alpha1.CiliumConfig{
+						SkipUpgrade: ptr.Bool(true),
+					},
+				}
+			},
+		},
+		{
+			Name: "Spec.ClusterNetwork.CNIConfig.Cilium.SkipUpgrade unset",
+			ConfigureCurrent: func(current *v1alpha1.Cluster) {
+				current.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{
+					Cilium: &v1alpha1.CiliumConfig{},
+				}
+			},
+			ConfigureDesired: func(desired *v1alpha1.Cluster) {
+				desired.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{
+					Cilium: &v1alpha1.CiliumConfig{},
+				}
+			},
+		},
+		{
+			Name: "Toggle Spec.ClusterNetwork.CNIConfig.Cilium.SkipUpgrade off",
+			ConfigureCurrent: func(current *v1alpha1.Cluster) {
+				current.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{
+					Cilium: &v1alpha1.CiliumConfig{
+						SkipUpgrade: ptr.Bool(true),
+					},
+				}
+			},
+			ConfigureDesired: func(desired *v1alpha1.Cluster) {
+				desired.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{
+					Cilium: &v1alpha1.CiliumConfig{
+						SkipUpgrade: ptr.Bool(false),
+					},
+				}
+			},
+			ExpectedError: "spec.clusterNetwork.cniConfig.cilium.skipUpgrade cannot be toggled off",
+		},
+	}
+
+	clstr := &types.Cluster{}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctrl := gomock.NewController(t)
+
+			current := &cluster.Spec{
+				Config: &cluster.Config{
+					Cluster: &v1alpha1.Cluster{
+						Spec: v1alpha1.ClusterSpec{
+							WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{}},
+						},
+					},
+				},
+				VersionsBundle: &cluster.VersionsBundle{
+					VersionsBundle: &releasev1alpha1.VersionsBundle{},
+					KubeDistro:     &cluster.KubeDistro{},
+				},
+				Bundles: &releasev1alpha1.Bundles{},
+			}
+			desired := current.DeepCopy()
+
+			tc.ConfigureCurrent(current.Config.Cluster)
+			tc.ConfigureDesired(desired.Config.Cluster)
+
+			client := mocks.NewMockKubectlClient(ctrl)
+			client.EXPECT().
+				GetEksaCluster(gomock.Any(), clstr, current.Cluster.Name).
+				Return(current.Cluster, nil)
+
+			provider := pmock.NewMockProvider(ctrl)
+
+			// The algorithm calls out to the provider to validate the new spec only if it finds
+			// no errors in the generic validation first.
+			if tc.ExpectedError == "" {
+				provider.EXPECT().
+					ValidateNewSpec(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+			}
+
+			err := upgradevalidations.ValidateImmutableFields(
+				context.Background(),
+				client,
+				clstr,
+				desired,
+				provider,
+			)
+
+			if tc.ExpectedError == "" {
+				g.Expect(err).To(Succeed())
+			} else {
+				g.Expect(err).To(MatchError(ContainSubstring(tc.ExpectedError)))
 			}
 		})
 	}


### PR DESCRIPTION
Implement the behavior for the `SkipUpgrade` Cilium flag on CLI based clusters (i.e. not FLC).

When creating a cluster without specifying `SkipUpgrade` the cluster should continue updating the embedded Cilium. When `SkipUpgrade` is true on create the system should install embedded Cilium but not upgrade it. If a user toggles on `SkipUpgrade` after creating the cluster we should no longer attempt to upgrade it.

Toggling off `SkipUpgrade` is disabled until we've explored the implications.