### PR TITLE
Add validation for OS when using registry mirror InsecureSkipVerify

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -346,8 +346,7 @@ spec:
                   insecureSkipVerify:
                     description: InsecureSkipVerify skips the registry certificate
                       verification. Only use this solution for isolated testing or
-                      in a tightly controlled, air-gapped environment. Currently only
-                      supported for snow provider
+                      in a tightly controlled, air-gapped environment.
                     type: boolean
                   ociNamespaces:
                     description: OCINamespaces defines the mapping from an upstream

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -3917,8 +3917,7 @@ spec:
                   insecureSkipVerify:
                     description: InsecureSkipVerify skips the registry certificate
                       verification. Only use this solution for isolated testing or
-                      in a tightly controlled, air-gapped environment. Currently only
-                      supported for snow provider
+                      in a tightly controlled, air-gapped environment.
                     type: boolean
                   ociNamespaces:
                     description: OCINamespaces defines the mapping from an upstream

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -723,15 +723,6 @@ func validateMirrorConfig(clusterConfig *Cluster) error {
 		return fmt.Errorf("registry mirror port %s is invalid, please provide a valid port", clusterConfig.Spec.RegistryMirrorConfiguration.Port)
 	}
 
-	if clusterConfig.Spec.RegistryMirrorConfiguration.InsecureSkipVerify {
-		switch clusterConfig.Spec.DatacenterRef.Kind {
-		case DockerDatacenterKind, NutanixDatacenterKind, VSphereDatacenterKind, TinkerbellDatacenterKind, CloudStackDatacenterKind, SnowDatacenterKind:
-			break
-		default:
-			return fmt.Errorf("insecureSkipVerify is only supported for docker, nutanix, snow, tinkerbell, cloudstack and vsphere providers")
-		}
-	}
-
 	mirrorCount := 0
 	ociNamespaces := clusterConfig.Spec.RegistryMirrorConfiguration.OCINamespaces
 	for _, ociNamespace := range ociNamespaces {

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -2572,22 +2572,6 @@ func TestValidateMirrorConfig(t *testing.T) {
 			},
 		},
 		{
-			name:    "insecureSkipVerify on an unsupported provider",
-			wantErr: "insecureSkipVerify is only supported for docker, nutanix, snow, tinkerbell, cloudstack and vsphere providers",
-			cluster: &Cluster{
-				Spec: ClusterSpec{
-					RegistryMirrorConfiguration: &RegistryMirrorConfiguration{
-						Endpoint:           "1.2.3.4",
-						Port:               "443",
-						InsecureSkipVerify: true,
-					},
-					DatacenterRef: Ref{
-						Kind: "nonsnow",
-					},
-				},
-			},
-		},
-		{
 			name:    "insecureSkipVerify on snow provider",
 			wantErr: "",
 			cluster: &Cluster{

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -174,7 +174,6 @@ type RegistryMirrorConfiguration struct {
 
 	// InsecureSkipVerify skips the registry certificate verification.
 	// Only use this solution for isolated testing or in a tightly controlled, air-gapped environment.
-	// Currently only supported for snow provider
 	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
 }
 

--- a/pkg/registrymirror/registrymirror.go
+++ b/pkg/registrymirror/registrymirror.go
@@ -23,7 +23,6 @@ type RegistryMirror struct {
 	CACertContent string
 	// InsecureSkipVerify skips the registry certificate verification.
 	// Only use this solution for isolated testing or in a tightly controlled, air-gapped environment.
-	// Currently only supported for snow provider
 	InsecureSkipVerify bool
 }
 

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -23,6 +23,13 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 	createValidations := []validations.Validation{
 		func() *validations.ValidationResult {
 			return &validations.ValidationResult{
+				Name:        "validate OS is compatible with registry mirror configuration",
+				Remediation: "please use a valid OS for your registry mirror configuration",
+				Err:         validations.ValidateOSForRegistryMirror(v.Opts.Spec, v.Opts.Provider),
+			}
+		},
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
 				Name:        "validate certificate for registry mirror",
 				Remediation: fmt.Sprintf("provide a valid certificate for you registry endpoint using %s env var", anywherev1.RegistryMirrorCAKey),
 				Err:         validations.ValidateCertForRegistryMirror(v.Opts.Spec, v.Opts.TlsValidator),

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -24,6 +24,13 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 	upgradeValidations := []validations.Validation{
 		func() *validations.ValidationResult {
 			return &validations.ValidationResult{
+				Name:        "validate OS is compatible with registry mirror configuration",
+				Remediation: "please use a valid OS for your registry mirror configuration",
+				Err:         validations.ValidateOSForRegistryMirror(u.Opts.Spec, u.Opts.Provider),
+			}
+		},
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
 				Name:        "validate certificate for registry mirror",
 				Remediation: fmt.Sprintf("provide a valid certificate for you registry endpoint using %s env var", anywherev1.RegistryMirrorCAKey),
 				Err:         validations.ValidateCertForRegistryMirror(u.Opts.Spec, u.Opts.TlsValidator),


### PR DESCRIPTION
*Issue #, if available:*
#647 following up on the introduction of InsecureSkipVerify flag, and introducing it to the other providers. However, bottlerocket is not supported

*Description of changes:*
Adds a preflight validation that checks if the OS is valid for the provided registry mirror configuration with insecure skip verify enabled.

*Testing (if applicable):*
Unit tests
Manual testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

