### PR TITLE
change signaling method for FCL curated packages support

### DIFF
--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -6030,7 +6030,7 @@ rules:
 - apiGroups:
   - packages.eks.amazonaws.com
   resources:
-  - packagebundlecontrollers
+  - packages
   verbs:
   - create
   - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -213,7 +213,7 @@ rules:
 - apiGroups:
   - packages.eks.amazonaws.com
   resources:
-  - packagebundlecontrollers
+  - packages
   verbs:
   - create
   - delete

--- a/controllers/cluster_controller_legacy.go
+++ b/controllers/cluster_controller_legacy.go
@@ -62,11 +62,10 @@ func NewClusterReconcilerLegacy(client client.Client, log logr.Logger, scheme *r
 // +kubebuilder:rbac:groups=bmc.tinkerbell.org,resources=machines;machines/status,verbs=get;list;watch
 //
 // For the full cluster lifecycle to support Curated Packages, the controller
-// must be able to create, delete, update, and patch package bundle controller
-// resources, which will trigger the curated packages controller to do the
-// rest.
+// must be able to create, delete, update, and patch package resources, which
+// will trigger the curated packages controller to do the rest.
 //
-// +kubebuilder:rbac:groups=packages.eks.amazonaws.com,resources=packagebundlecontrollers,verbs=create;delete;get;list;patch;update;watch;
+// +kubebuilder:rbac:groups=packages.eks.amazonaws.com,resources=packages,verbs=create;delete;get;list;patch;update;watch;
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -213,6 +213,7 @@ func (pc *PackageControllerClient) Enable(ctx context.Context) error {
 	skipCRDs := false
 	chartName := pc.chart.Name
 	if pc.managementClusterName != pc.clusterName {
+		values = append(values, "workloadPackageOnly=true")
 		values = append(values, "workloadOnly=true")
 		chartName = chartName + "-" + pc.clusterName
 		skipCRDs = true

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -328,7 +328,8 @@ func TestEnableSucceedInWorkloadCluster(t *testing.T) {
 			values = append(values, "cronjob.suspend=true")
 		}
 		values = append(values, "workloadOnly=true")
-		tt.chartManager.EXPECT().InstallChart(tt.ctx, tt.chart.Name+"-billy", ociURI, tt.chart.Tag(), tt.kubeConfig, constants.EksaPackagesName, valueFilePath, true, values).Return(nil)
+		values = append(values, "workloadPackageOnly=true")
+		tt.chartManager.EXPECT().InstallChart(tt.ctx, tt.chart.Name+"-billy", ociURI, tt.chart.Tag(), tt.kubeConfig, constants.EksaPackagesName, valueFilePath, true, gomock.InAnyOrder(values)).Return(nil)
 		tt.kubectl.EXPECT().
 			GetObject(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			DoAndReturn(getPBCSuccess(t)).
@@ -1091,6 +1092,7 @@ func TestEnableFullLifecyclePath(t *testing.T) {
 	values := []string{
 		"clusterName=" + clusterName,
 		"workloadOnly=true",
+		"workloadPackageOnly=true",
 		"sourceRegistry=public.ecr.aws/eks-anywhere",
 		"defaultRegistry=public.ecr.aws/eks-anywhere",
 		"defaultImageRegistry=783794618700.dkr.ecr.us-west-2.amazonaws.com",


### PR DESCRIPTION
Previously, the creation a of package bundle controller was executed via a helm chart release. Now that helm chart will create a package instead. The end result being the same, that the packages controller will notice the newly created resource and do what it needs to support curated packages on the new workload cluster.

One additional value is passed to the helm invocation to help the packages controller take the appropriate actions.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

