### PR TITLE
Make image-builder OS support and prerequisites section more clear

### DIFF
--- a/docs/content/en/docs/reference/artifacts.md
+++ b/docs/content/en/docs/reference/artifacts.md
@@ -124,73 +124,95 @@ export KUBEVERSION="1.25"
 ## Building node images
 
 The `image-builder` CLI lets you build your own Ubuntu-based vSphere OVAs, Nutanix qcow2 images, RHEL-based qcow2 images, or Bare Metal gzip images to use in EKS Anywhere clusters.
-When you run `image-builder` it will pull in all components needed to create images to use for nodes in an EKS Anywhere cluster, including the lastest operating system, Kubernetes, and EKS Distro security updates, bug fixes, and patches.
-With this tool, when you build an image you get to choose:
+When you run `image-builder`, it will pull in all components needed to build images to be used as Kubernetes nodes in an EKS Anywhere cluster, including the latest operating system, Kubernetes control plane components, and EKS Distro security updates, bug fixes, and patches.
+When building an image using this tool, you get to choose:
 
-* Operating system type (for example, ubuntu)
-* Provider (vsphere, cloudstack, baremetal, ami, nutanix, snow)
+* Operating system type (for example, ubuntu, redhat)
+* Provider (vsphere, cloudstack, baremetal, ami, nutanix)
 * Release channel for EKS Distro (generally aligning with Kubernetes releases)
-* vSphere only: configuration file providing information needed to access your vSphere setup
-* CloudStack only: configuration file providing information needed to access your Cloudstack setup
-* AMI only: configuration file providing information needed to customize your AMI build parameters
-* Nutanix only: configuration file providing information needed to access Prism Central
+* **vSphere only:** configuration file providing information needed to access your vSphere setup
+* **CloudStack only:** configuration file providing information needed to access your CloudStack setup
+* **Snow AMI only:** configuration file providing information needed to customize your Snow AMI build parameters
+* **Nutanix only:** configuration file providing information needed to access Nutanix Prism Central
 
 Because `image-builder` creates images in the same way that the EKS Anywhere project does for their own testing, images built with that tool are supported.
-The following procedure describes how to use `image-builder` to build images for EKS Anywhere on a vSphere, Bare Metal, Nutanix, or Snow provider.
+
+The table below shows the support matrix for the hypervisor and OS combinations that `image-builder` supports.
+
+|            | vSphere | Baremetal | CloudStack | Nutanix | Snow |
+|:----------:|:-------:|:---------:|:----------:|:-------:|:----:|
+| **Ubuntu** |    ✓    |     ✓     |            |    ✓    |   ✓  |
+|  **RHEL**  |    ✓    |     ✓     |     ✓      |         |      |
+
 
 ### Prerequisites
 
-To use `image-builder` you must meet the following prerequisites:
+To use `image-builder`, you must meet the following prerequisites:
 
-* Run on Ubuntu 22.04 or later (for Ubuntu images) or RHEL 8.4 or later (for RHEL images)
-* Machine requirements:
-  * AMD 64-bit architecture
-  * 50 GB disk space
-  * 2 vCPUs
-  * 8 GB RAM
-  * Bare Metal only: Run on a bare metal machine with virtualization enabled
-* Network access to:
-  * vCenter endpoint (vSphere only)
-  * CloudStack endpoint (CloudStack only)
-  * Prism Central endpoint (Nutanix only)
-  * public.ecr.aws (to download container images from EKS Anywhere)
-  * anywhere-assets.eks.amazonaws.com (to download the EKS Anywhere binaries, manifests and OVAs)
-  * distro.eks.amazonaws.com (to download EKS Distro binaries and manifests)
-  * d2glxqk2uabbnd.cloudfront.net (for EKS Anywhere and EKS Distro ECR container images)
-  * api.ecr.us-west-2.amazonaws.com (for EKS Anywhere package authentication matching your region)
-  * d5l0dvt14r5h8.cloudfront.net (for EKS Anywhere package ECR container)
-* vSphere only:
-  * Required vSphere user permissions:
-    * Inventory:
-      * Create new
-    * Configuration:
-      * Change configuration
-      * Add new disk
-      * Add or remove device
-      * Change memory
-      * Change settings
-      * Set annotation
-    * Interaction:
-      * Power on
-      * Power off
-      * Console interaction
-      * Configure CD media
-      * Device connection
-    * Snapshot management:
-      * Create snapshot
-    * Provisioning
-      * Mark as template
-    * Resource Pool
-      * Assign vm to resource pool
-    * Datastore
-      * Allocate space
-      * Browse data
-      * Low level file operations
-    * Network
-      * Assign network to vm
-* CloudStack only: See [CloudStack Permissions for CAPC](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/blob/main/docs/book/src/topics/cloudstack-permissions.md) for required CloudStack user permissions.
-* AMI only: Packer will require prior authentication with your AWS account to launch EC2 instances for the AMI build. See [Authentication guide for Amazon EBS Packer builder](https://developer.hashicorp.com/packer/plugins/builders/amazon#authentication) for possible modes of authentication. We recommend that you run `image-builder` on a pre-existing Ubuntu EC2 instance and use an [IAM instance role with the required permissions](https://developer.hashicorp.com/packer/plugins/builders/amazon#iam-task-or-instance-role).
-* Nutanix only: Prism Admin permissions
+#### System requirements
+
+`image-builder` has been tested on Ubuntu, RHEL and Amazon Linux 2 machines. The following system requirements should be met for the machine on which `image-builder` is run:
+* AMD 64-bit architecture
+* 50 GB disk space
+* 2 vCPUs
+* 8 GB RAM
+* **Baremetal only:** Run on a bare metal machine with virtualization enabled
+
+#### Network connectivity requirements
+* public.ecr.aws (to download container images from EKS Anywhere)
+* anywhere-assets.eks.amazonaws.com (to download the EKS Anywhere artifacts such as binaries, manifests and OS images)
+* distro.eks.amazonaws.com (to download EKS Distro binaries and manifests)
+* d2glxqk2uabbnd.cloudfront.net (to pull the EKS Anywhere and EKS Distro ECR container images)
+* api.ecr.us-west-2.amazonaws.com (for EKS Anywhere package authentication matching your region)
+* d5l0dvt14r5h8.cloudfront.net (for EKS Anywhere package ECR container)
+* github.com (to download binaries and tools required for image builds from GitHub releases)
+* releases.hashicorp.com (to download Packer binary for image builds)
+* galaxy.ansible.com (to download Ansible packages from Ansible Galaxy)
+* **vSphere only:** VMware vCenter endpoint
+* **CloudStack only:** Apache CloudStack endpoint
+* **Nutanix only:** Nutanix Prism Central endpoint
+* **Red Hat only:** dl.fedoraproject.org (to download RPMs and GPG keys for RHEL image builds)
+* **Ubuntu only:** cdimage.ubuntu.com (to download Ubuntu server ISOs for Ubuntu image builds)
+
+#### vSphere requirements
+The following vSphere permissions are required to build  OVA images using `image-builder`:
+* Inventory:
+   * Create new
+* Configuration:
+   * Change configuration
+   * Add new disk
+   * Add or remove device
+   * Change memory
+   * Change settings
+   * Set annotation
+* Interaction:
+   * Power on
+   * Power off
+   * Console interaction
+   * Configure CD media
+   * Device connection
+* Snapshot management:
+   * Create snapshot
+* Provisioning
+   * Mark as template
+* Resource Pool
+   * Assign VM to resource pool
+* Datastore
+   * Allocate space
+   * Browse data
+   * Low level file operations
+* Network
+   * Assign network to VM
+
+#### CloudStack requirements
+Refer to the [CloudStack Permissions for CAPC](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/blob/main/docs/book/src/topics/cloudstack-permissions.md) doc for required CloudStack user permissions.
+
+#### Snow AMI requirements
+Packer will require prior authentication with your AWS account to launch EC2 instances for the Snow AMI build. Refer to the [Authentication guide for Amazon EBS Packer builder](https://developer.hashicorp.com/packer/plugins/builders/amazon#authentication) for possible modes of authentication. We recommend that you run `image-builder` on a pre-existing Ubuntu EC2 instance and use an [IAM instance role with the required permissions](https://developer.hashicorp.com/packer/plugins/builders/amazon#iam-task-or-instance-role).
+
+#### Nutanix permissions
+
+Prism Central Administrator permissions are required to build a Nutanix image using `image-builder`.
 
 ### Optional Proxy configuration
 You can use a proxy server to route outbound requests to the internet. To configure `image-builder` tool to use a proxy server, export these proxy environment variables:
@@ -202,7 +224,7 @@ You can use a proxy server to route outbound requests to the internet. To config
 
 ### Build vSphere OVA node images
 
-These steps use `image-builder` to create an Ubuntu-based or RHEL-based image for vSphere.
+These steps use `image-builder` to create an Ubuntu-based or RHEL-based image for vSphere. Before proceeding, ensure that the above system-level, network-level and vSphere-specific [prerequisites]({{< relref "#prerequisites">}}) have been met.
 
 1. Create a linux user for running image-builder.
    ```bash
@@ -248,12 +270,12 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
      "create_snapshot": "<creates a snapshot on base OVA after building if set to true>",
      "datacenter": "<vsphere datacenter used for image building>",
      "datastore": "<datastore used to store template/for image building>",
-     "folder": "<folder on vsphere to create temporary vm>",
+     "folder": "<folder on vsphere to create temporary VM>",
      "insecure_connection": "true",
      "linked_clone": "false",
      "network": "<vsphere network used for image building>",
      "password": "<vcenter password>",
-     "resource_pool": "<resource pool used for image building vm>",
+     "resource_pool": "<resource pool used for image building VM>",
      "username": "<vcenter username>",
      "vcenter_server": "<vcenter fqdn>",
      "vsphere_library_name": "<vsphere content library name>"
@@ -293,7 +315,7 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
       image-builder build --os redhat --hypervisor vsphere --release-channel 1-25 --vsphere-config vsphere-connection.json
       ```
 ### Build Bare Metal node images
-These steps use `image-builder` to create an Ubuntu-based or RHEL-based image for Bare Metal.
+These steps use `image-builder` to create an Ubuntu-based or RHEL-based image for Bare Metal. Before proceeding, ensure that the above system-level, network-level and baremetal-specific [prerequisites]({{< relref "#prerequisites">}}) have been met.
 
 1. Create a linux user for running image-builder.
    ```bash
@@ -381,7 +403,7 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
 
 ### Build CloudStack node images
 
-These steps use `image-builder` to create a RHEL-based image for CloudStack.
+These steps use `image-builder` to create a RHEL-based image for CloudStack. Before proceeding, ensure that the above system-level, network-level and CloudStack-specific [prerequisites]({{< relref "#prerequisites">}}) have been met.
 
 1. Create a linux user for running image-builder.
    ```bash
@@ -437,11 +459,11 @@ These steps use `image-builder` to create a RHEL-based image for CloudStack.
       image-builder build --os redhat --hypervisor cloudstack --release-channel 1-25 --cloudstack-config cloudstack.json
       ```
 
-1. To consume the resulting RHEL-based image, add it as a template to your CloudStack setup as described in [Preparing Cloudstack]({{< relref "./cloudstack/cloudstack-preparation.md" >}}).
+1. To consume the resulting RHEL-based image, add it as a template to your CloudStack setup as described in [Preparing CloudStack]({{< relref "./cloudstack/cloudstack-preparation.md" >}}).
 
 ### Build Snow node images
 
-These steps use `image-builder` to create an Ubuntu-based Amazon Machine Image (AMI) that is backed by EBS volumes for Snow.
+These steps use `image-builder` to create an Ubuntu-based Amazon Machine Image (AMI) that is backed by EBS volumes for Snow. Before proceeding, ensure that the above system-level, network-level and AMI-specific [prerequisites]({{< relref "#prerequisites">}}) have been met
 
 1. Create a linux user for running image-builder.
    ```bash
@@ -494,11 +516,11 @@ These steps use `image-builder` to create an Ubuntu-based Amazon Machine Image (
 
    * `--os`: `ubuntu`
    * `--hypervisor`: For AMI, use `ami`
-   * `--release-channel`: Supported EKS Distro releases include 1-21, 1-22, 1-23, 1-24 and 1-25.
+   * `--release-channel`: Supported EKS Distro releases include 1-21, 1-22, 1-23 and 1-24.
    * `--ami-config`: AMI configuration file (`ami.json` in this example)
 
    ```bash
-   image-builder build --os ubuntu --hypervisor ami --release-channel 1-25 --ami-config ami.json
+   image-builder build --os ubuntu --hypervisor ami --release-channel 1-24 --ami-config ami.json
    ```
 1. After the build, the Ubuntu AMI will be available in your AWS account in the AWS region specified in your AMI configuration file. If you wish to export it as a Raw image, you can achieve this using the AWS CLI.
    ```
@@ -514,7 +536,7 @@ These steps use `image-builder` to create an Ubuntu-based Amazon Machine Image (
 
 ### Build Nutanix node images
 
-These steps use `image-builder` to create a Ubuntu-based image for Nutanix AHV and import it into the AOS Image Service.
+These steps use `image-builder` to create a Ubuntu-based image for Nutanix AHV and import it into the AOS Image Service. Before proceeding, ensure that the above system-level, network-level and Nutanix-specific [prerequisites]({{< relref "#prerequisites">}}) have been met.
 
 1. Download an [Ubuntu cloud image](https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.img) for the build and upload it to the AOS Image Service using Prism. You will need to specify this image name as the `source_image_name` in the `nutanix-connection.json` config file specified below.
 

--- a/docs/content/en/docs/reference/nutanix/domains.md
+++ b/docs/content/en/docs/reference/nutanix/domains.md
@@ -8,4 +8,3 @@
 * api.ecr.us-west-2.amazonaws.com (for EKS Anywhere package authentication matching your region)
 * d5l0dvt14r5h8.cloudfront.net (for EKS Anywhere package ECR container images)
 * api.github.com (only if GitOps is enabled)
-


### PR DESCRIPTION
* Call out attention to prerequisites in all sections.
* Add image-builder OS/hypervisor combination support matrix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

