### PR TITLE
Validate Mgmt Cluster Bundles Version on Workload Cluster Create

### DIFF
--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -84,6 +84,13 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 					Err: validations.ValidateManagementClusterName(ctx, k, v.Opts.ManagementCluster, v.Opts.Spec.Cluster.Spec.ManagementCluster.Name),
 				}
 			},
+			func() *validations.ValidationResult {
+				return &validations.ValidationResult{
+					Name:        "validate management cluster bundle version compatibility",
+					Remediation: fmt.Sprintf("upgrade management cluster %s before creating workload cluster %s", v.Opts.Spec.Cluster.ManagedBy(), v.Opts.WorkloadCluster.Name),
+					Err:         validations.ValidateManagementClusterBundlesVersion(ctx, k, v.Opts.ManagementCluster, v.Opts.Spec),
+				}
+			},
 		)
 	}
 


### PR DESCRIPTION
Validates that the management cluster's bundle is the same version or newer than the bundle version used to create a workload cluster.


*Issue #, if available:*
Follow up to https://github.com/aws/eks-anywhere/pull/5263#issuecomment-1476999424 for ticket https://github.com/aws/eks-anywhere/issues/5105.

*Description of changes:*
Validates management/CLI bundles versions on workload cluster creation.

*Testing (if applicable):*
Ran create workload cluster commands with valid and invalid bundles, validations succeeded/failed as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.