### PR TITLE
Use default credential names if credential names are not set

### DIFF
--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -116,7 +116,10 @@ func (ntb *TemplateBuilder) GenerateEKSASpecSecret(clusterSpec *cluster.Spec, bu
 // EKSASecretName returns the name of the secret containing the credentials for the nutanix prism central and is used by the
 // EKS-Anywhere controller.
 func EKSASecretName(spec *cluster.Spec) string {
-	return spec.NutanixDatacenter.Spec.CredentialRef.Name
+	if spec.NutanixDatacenter.Spec.CredentialRef != nil {
+		return spec.NutanixDatacenter.Spec.CredentialRef.Name
+	}
+	return constants.NutanixCredentialsName
 }
 
 func (ntb *TemplateBuilder) generateSpecSecret(secretName string, creds credentials.BasicAuthCredential, buildOptions ...providers.BuildMapOption) ([]byte, error) {

--- a/pkg/providers/nutanix/template_test.go
+++ b/pkg/providers/nutanix/template_test.go
@@ -98,6 +98,25 @@ func TestNewNutanixTemplateBuilderGenerateSpecSecretFailure(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestNewNutanixTemplateBuilderGenerateSpecSecretDefaultCreds(t *testing.T) {
+	dcConf, machineConf, workerConfs := minimalNutanixConfigSpec(t)
+	t.Setenv(constants.NutanixUsernameKey, "admin")
+	t.Setenv(constants.NutanixPasswordKey, "password")
+	creds := GetCredsFromEnv()
+	builder := NewNutanixTemplateBuilder(&dcConf.Spec, &machineConf.Spec, &machineConf.Spec, workerConfs, creds, time.Now)
+	assert.NotNil(t, builder)
+
+	buildSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster-no-credentialref.yaml")
+
+	secretSpec, err := builder.GenerateCAPISpecSecret(buildSpec)
+	assert.NoError(t, err)
+	assert.NotNil(t, secretSpec)
+
+	secretSpec, err = builder.GenerateEKSASpecSecret(buildSpec)
+	assert.NoError(t, err)
+	assert.NotNil(t, secretSpec)
+}
+
 func TestNutanixTemplateBuilderGenerateCAPISpecForCreateWithAutoscalingConfiguration(t *testing.T) {
 	dcConf, machineConf, workerConfs := minimalNutanixConfigSpec(t)
 

--- a/pkg/providers/nutanix/testdata/eksa-cluster-no-credentialref.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-no-credentialref.yaml
@@ -1,0 +1,72 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  kubernetesVersion: "1.19"
+  controlPlaneConfiguration:
+    name: eksa-unit-test
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  workerNodeGroupConfigurations:
+    - count: 4
+      name: eksa-unit-test
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: NutanixMachineConfig
+  externalEtcdConfiguration:
+    name: eksa-unit-test
+    count: 3
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  datacenterRef:
+    kind: NutanixDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"


### PR DESCRIPTION
Use `nutanix-credentials` as NutanixDatacenterConfig credentialRef name if it is not present. This ensures we don't get a nil-pointer dereference during upgrade and upgrade can happen smoothly.

**How has this been tested?**
* Created a cluster using a EKS-A CLI build before FCL changes were merged (NutanixDatacenterConfig spec had no credentialRef)
* Upgraded the cluster successfully using an EKS-A CLI build with these changes included and using the same cluster spec as above (no credentialRef set on NutanixDatacenterConfig). 

Full upgrade logs: https://app.warp.dev/block/w7d8Ic3TrSign6eYTeRv55