### PR TITLE
Fix kubectl get call to point to full API name

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -76,7 +76,7 @@ var (
 	kubeadmControlPlaneResourceType      = fmt.Sprintf("kubeadmcontrolplanes.controlplane.%s", clusterv1.GroupVersion.Group)
 	eksdReleaseType                      = fmt.Sprintf("releases.%s", eksdv1alpha1.GroupVersion.Group)
 	eksaPackagesType                     = fmt.Sprintf("packages.%s", packagesv1.GroupVersion.Group)
-	capiProvidersResourceType            = fmt.Sprintf("providers.%s", clusterv1.GroupVersion.Group)
+	capiProvidersResourceType            = fmt.Sprintf("providers.clusterctl.%s", clusterv1.GroupVersion.Group)
 	kubectlConnectionRefusedRegex        = regexp.MustCompile("The connection to the server .* was refused")
 	kubectlIoTimeoutRegex                = regexp.MustCompile("Unable to connect to the server.*i/o timeout.*")
 )

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -76,6 +76,7 @@ var (
 	kubeadmControlPlaneResourceType      = fmt.Sprintf("kubeadmcontrolplanes.controlplane.%s", clusterv1.GroupVersion.Group)
 	eksdReleaseType                      = fmt.Sprintf("releases.%s", eksdv1alpha1.GroupVersion.Group)
 	eksaPackagesType                     = fmt.Sprintf("packages.%s", packagesv1.GroupVersion.Group)
+	capiProvidersResourceType            = fmt.Sprintf("providers.%s", clusterv1.GroupVersion.Group)
 	kubectlConnectionRefusedRegex        = regexp.MustCompile("The connection to the server .* was refused")
 	kubectlIoTimeoutRegex                = regexp.MustCompile("Unable to connect to the server.*i/o timeout.*")
 )
@@ -1893,7 +1894,7 @@ func (k *Kubectl) CheckProviderExists(ctx context.Context, kubeconfigFile, name,
 		return false, nil
 	}
 
-	params = []string{"get", "providers.clusterctl.cluster.x-k8s.io", "--namespace", namespace, fmt.Sprintf("--field-selector=metadata.name=%s", name), "--kubeconfig", kubeconfigFile}
+	params = []string{"get", capiProvidersResourceType, "--namespace", namespace, fmt.Sprintf("--field-selector=metadata.name=%s", name), "--kubeconfig", kubeconfigFile}
 	stdOut, err = k.Execute(ctx, params...)
 	if err != nil {
 		return false, fmt.Errorf("checking whether provider exists: %v", err)

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -1893,7 +1893,7 @@ func (k *Kubectl) CheckProviderExists(ctx context.Context, kubeconfigFile, name,
 		return false, nil
 	}
 
-	params = []string{"get", "provider", "--namespace", namespace, fmt.Sprintf("--field-selector=metadata.name=%s", name), "--kubeconfig", kubeconfigFile}
+	params = []string{"get", "providers.clusterctl.cluster.x-k8s.io", "--namespace", namespace, fmt.Sprintf("--field-selector=metadata.name=%s", name), "--kubeconfig", kubeconfigFile}
 	stdOut, err = k.Execute(ctx, params...)
 	if err != nil {
 		return false, fmt.Errorf("checking whether provider exists: %v", err)

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -2182,7 +2182,7 @@ func TestKubectlCheckCAPIProviderExistsInstalled(t *testing.T) {
 		[]string{"get", "namespace", fmt.Sprintf("--field-selector=metadata.name=%s", providerNs), "--kubeconfig", tt.cluster.KubeconfigFile}).Return(*bytes.NewBufferString("namespace"), nil)
 
 	tt.e.EXPECT().Execute(tt.ctx,
-		[]string{"get", "provider", "--namespace", providerNs, fmt.Sprintf("--field-selector=metadata.name=%s", providerName), "--kubeconfig", tt.cluster.KubeconfigFile})
+		[]string{"get", "providers.clusterctl.cluster.x-k8s.io", "--namespace", providerNs, fmt.Sprintf("--field-selector=metadata.name=%s", providerName), "--kubeconfig", tt.cluster.KubeconfigFile})
 
 	tt.Expect(tt.k.CheckProviderExists(tt.ctx, tt.cluster.KubeconfigFile, providerName, providerNs))
 }


### PR DESCRIPTION

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

