### PR TITLE
set management cluster name helm value

### DIFF
--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -214,7 +214,7 @@ func (pc *PackageControllerClient) Enable(ctx context.Context) error {
 	chartName := pc.chart.Name
 	if pc.managementClusterName != pc.clusterName {
 		values = append(values, "workloadPackageOnly=true")
-		values = append(values, "workloadOnly=true")
+		values = append(values, "managementClusterName="+pc.managementClusterName)
 		chartName = chartName + "-" + pc.clusterName
 		skipCRDs = true
 	}
@@ -470,7 +470,8 @@ func (pc *PackageControllerClient) Reconcile(ctx context.Context, logger logr.Lo
 
 	// No Kubeconfig is passed. This is intentional. The helm executable will
 	// get that configuration from its environment.
-	if err := pc.EnableFullLifecycle(ctx, logger, cluster.Name, "", image, registry); err != nil {
+	if err := pc.EnableFullLifecycle(ctx, logger, cluster.Name, "", image, registry,
+		WithManagementClusterName(cluster.ManagedBy())); err != nil {
 		return fmt.Errorf("packages client error: %w", err)
 	}
 

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -327,7 +327,7 @@ func TestEnableSucceedInWorkloadCluster(t *testing.T) {
 		if (tt.eksaAccessID == "" || tt.eksaAccessKey == "") && tt.registryMirror == nil {
 			values = append(values, "cronjob.suspend=true")
 		}
-		values = append(values, "workloadOnly=true")
+		values = append(values, "managementClusterName=mgmt")
 		values = append(values, "workloadPackageOnly=true")
 		tt.chartManager.EXPECT().InstallChart(tt.ctx, tt.chart.Name+"-billy", ociURI, tt.chart.Tag(), tt.kubeConfig, constants.EksaPackagesName, valueFilePath, true, gomock.InAnyOrder(values)).Return(nil)
 		tt.kubectl.EXPECT().
@@ -1091,7 +1091,7 @@ func TestEnableFullLifecyclePath(t *testing.T) {
 	// determined its chart.
 	values := []string{
 		"clusterName=" + clusterName,
-		"workloadOnly=true",
+		"managementClusterName=mgmt",
 		"workloadPackageOnly=true",
 		"sourceRegistry=public.ecr.aws/eks-anywhere",
 		"defaultRegistry=public.ecr.aws/eks-anywhere",
@@ -1113,7 +1113,9 @@ func TestEnableFullLifecyclePath(t *testing.T) {
 		URI:  "test_registry/eks-anywhere/eks-anywhere-packages:v1",
 	}
 
-	err := tt.command.EnableFullLifecycle(tt.ctx, log, clusterName, kubeConfig, chartImage, tt.registryMirror, curatedpackages.WithEksaRegion("us-west-2"))
+	err := tt.command.EnableFullLifecycle(tt.ctx, log, clusterName, kubeConfig, chartImage, tt.registryMirror,
+		curatedpackages.WithEksaRegion("us-west-2"),
+		curatedpackages.WithManagementClusterName("mgmt"))
 	if err != nil {
 		t.Errorf("Install Controller Should succeed when installation passes")
 	}


### PR DESCRIPTION
Passes the management cluster's name when installing curated packages on a workload cluster. Removes the workloadOnly flag, as it's no longer needed in this case, as the FCL/CLI curated packages installation for workload clusters is now triggered from the workloadPackageOnly flag.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

