### PR TITLE
Expand all kubectl calls to fully qualified names

### DIFF
--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -97,6 +97,64 @@ func newKubectlTest(t *testing.T) *kubectlTest {
 	}
 }
 
+func TestKubectlGetCAPIMachines(t *testing.T) {
+	g := NewWithT(t)
+	k, ctx, cluster, e := newKubectl(t)
+
+	machinesResponseBuffer := bytes.Buffer{}
+	machinesResponseBuffer.WriteString(test.ReadFile(t, "testdata/kubectl_machines_no_conditions.json"))
+
+	tests := []struct {
+		name          string
+		buffer        bytes.Buffer
+		machineLength int
+		execErr       error
+		expectedErr   error
+	}{
+		{
+			name:          "GetCAPIMachines_Success",
+			buffer:        machinesResponseBuffer,
+			machineLength: 2,
+			execErr:       nil,
+			expectedErr:   nil,
+		},
+		{
+			name:          "GetCAPIMachines_Success",
+			buffer:        bytes.Buffer{},
+			machineLength: 0,
+			execErr:       nil,
+			expectedErr:   errors.New("parsing get machines response: unexpected end of JSON input"),
+		},
+		{
+			name:          "GetCAPIMachines_Success",
+			buffer:        bytes.Buffer{},
+			machineLength: 0,
+			execErr:       errors.New("exec error"),
+			expectedErr:   errors.New("getting machines: exec error"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			e.EXPECT().Execute(ctx,
+				"get", "machines.cluster.x-k8s.io",
+				"-o", "json",
+				"--kubeconfig", cluster.KubeconfigFile,
+				"--selector=cluster.x-k8s.io/cluster-name="+cluster.Name,
+				"--namespace", constants.EksaSystemNamespace,
+			).Return(test.buffer, test.execErr)
+
+			machines, err := k.GetCAPIMachines(ctx, cluster, cluster.Name)
+			if test.expectedErr != nil {
+				g.Expect(err).To(MatchError(test.expectedErr))
+			} else {
+				g.Expect(err).To(Not(HaveOccurred()))
+			}
+			g.Expect(len(machines)).To(Equal(test.machineLength))
+		})
+	}
+}
+
 func TestKubectlApplyManifestSuccess(t *testing.T) {
 	spec := "specfile"
 

--- a/pkg/validations/createvalidations/cluster_test.go
+++ b/pkg/validations/createvalidations/cluster_test.go
@@ -96,8 +96,8 @@ func TestValidateManagementClusterCRDs(t *testing.T) {
 	cluster.Name = testclustername
 	for _, tc := range tests {
 		t.Run(tc.name, func(tt *testing.T) {
-			e.EXPECT().Execute(ctx, []string{"get", "crd", capiClustersResourceType, "--kubeconfig", cluster.KubeconfigFile}).Return(bytes.Buffer{}, tc.errGetClusterCRD).Times(tc.errGetClusterCRDCount)
-			e.EXPECT().Execute(ctx, []string{"get", "crd", eksaClusterResourceType, "--kubeconfig", cluster.KubeconfigFile}).Return(bytes.Buffer{}, tc.errGetEKSAClusterCRD).Times(tc.errGetEKSAClusterCRDCount)
+			e.EXPECT().Execute(ctx, []string{"get", "customresourcedefinition", capiClustersResourceType, "--kubeconfig", cluster.KubeconfigFile}).Return(bytes.Buffer{}, tc.errGetClusterCRD).Times(tc.errGetClusterCRDCount)
+			e.EXPECT().Execute(ctx, []string{"get", "customresourcedefinition", eksaClusterResourceType, "--kubeconfig", cluster.KubeconfigFile}).Return(bytes.Buffer{}, tc.errGetEKSAClusterCRD).Times(tc.errGetEKSAClusterCRDCount)
 			err := createvalidations.ValidateManagementCluster(ctx, k, cluster)
 			if tc.wantErr {
 				assert.Error(tt, err, "expected ValidateManagementCluster to return an error", "test", tc.name)


### PR DESCRIPTION
*Description of changes:*
Expanding all kubectl calls to have their full qualified API names to avoid conflicts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

