### PR TITLE
Removing default value for skipUpgrade to fix flux errors

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -72,7 +72,6 @@ spec:
                               never.
                             type: string
                           skipUpgrade:
-                            default: false
                             description: SkipUpgrade indicicates that Cilium maintenance
                               should be skipped during upgrades. This can be used
                               when operators wish to self manage the Cilium installation.

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -3643,7 +3643,6 @@ spec:
                               never.
                             type: string
                           skipUpgrade:
-                            default: false
                             description: SkipUpgrade indicicates that Cilium maintenance
                               should be skipped during upgrades. This can be used
                               when operators wish to self manage the Cilium installation.

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -695,7 +695,6 @@ type CiliumConfig struct {
 
 	// SkipUpgrade indicicates that Cilium maintenance should be skipped during upgrades. This can
 	// be used when operators wish to self manage the Cilium installation.
-	// +kubebuilder:default=false
 	// +optional
 	SkipUpgrade *bool `json:"skipUpgrade,omitempty"`
 }


### PR DESCRIPTION
*Description of changes:*
Removing defaults for `skipUpgrade` to handle unpredictable behavior from Flux controller.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

