### PR TITLE
Reduce Autoscaler HPA Busybox Test Resources

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -431,6 +431,20 @@ func TestVSphereKubernetes125UbuntuCuratedPackagesClusterAutoscalerSimpleFlow(t 
 	runAutoscalerWitMetricsServerSimpleFlow(test)
 }
 
+func TestVSphereKubernetes124UbuntuCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
+	minNodes := 1
+	maxNodes := 2
+	framework.CheckCuratedPackagesCredentials(t)
+	test := framework.NewClusterE2ETest(t,
+		framework.NewVSphere(t, framework.WithUbuntu124()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube124), api.WithWorkerNodeAutoScalingConfig(minNodes, maxNodes)),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube124),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+	)
+	runAutoscalerWitMetricsServerSimpleFlow(test)
+}
+
 func TestVSphereKubernetes125BottleRocketCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
 	minNodes := 1
 	maxNodes := 2

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1889,7 +1889,7 @@ func (e *ClusterE2ETest) CombinedAutoScalerMetricServerTest(autoscalerName strin
 	}
 
 	e.T.Log("Waiting for machinedeployment to finish scaling up")
-	err = e.KubectlClient.WaitJSONPathLoop(ctx, mgmtCluster.KubeconfigFile, "10m", "status.phase", "Running",
+	err = e.KubectlClient.WaitJSONPathLoop(ctx, mgmtCluster.KubeconfigFile, "15m", "status.phase", "Running",
 		fmt.Sprintf("machinedeployments.cluster.x-k8s.io/%s", machineDeploymentName), constants.EksaSystemNamespace)
 	if err != nil {
 		e.T.Fatalf("Failed to get Running phase for machinedeployment: %s", err)

--- a/test/framework/testdata/hpa_busybox.yaml
+++ b/test/framework/testdata/hpa_busybox.yaml
@@ -17,9 +17,9 @@ spec:
           image: busybox:1.34
           resources:
             limits:
-              cpu: 500m
+              cpu: 50m
             requests:
-              cpu: 20m
+              cpu: 10m
               memory: 500Mi
           command: ["sh", "-c"]
           args:


### PR DESCRIPTION
Also adds a 1.24 Ubuntu test.

*Issue #, if available:*

*Description of changes:*
Seeing some unusual behavior in the Ubuntu Cluster Autoscaler tests. Something about Ubuntu + 1.25 kubernetes + vSphere and Nutanix CI environments seem to result in no Scale Up action. @junshun and I think the issue is the HPA failing to trigger new pods to scale out.
