### PR TITLE
Fix regex for BR settings e2e test

### DIFF
--- a/docs/content/en/docs/workshops/packages/prometheus/prometheus_grafana.md
+++ b/docs/content/en/docs/workshops/packages/prometheus/prometheus_grafana.md
@@ -21,10 +21,10 @@ The Prometheus package creates two components by default:
 - [Node-exporter,](https://github.com/prometheus/node_exporter) which exposes a wide variety of hardware- and kernel-related metrics for prometheus-server (or an equivalent metrics collector, i.e. ADOT collector) to scrape.
 
 The `prometheus-server` is pre-configured to scrape the following targets at `1m` interval:
-- Kuberenetes API servers
-- Kuberenetes nodes
-- Kuberenetes nodes cadvisor
-- Kuberenetes service endpoints
+- Kubernetes API servers
+- Kubernetes nodes
+- Kubernetes nodes cadvisor
+- Kubernetes service endpoints
 - Kubernetes services
 - Kubernetes pods
 - Prometheus-server itself

--- a/internal/test/e2e/hostOSConfig.go
+++ b/internal/test/e2e/hostOSConfig.go
@@ -22,7 +22,7 @@ func (e *E2ESession) setupNTPEnv(testRegex string) error {
 }
 
 func (e *E2ESession) setupBottlerocketKubernetesSettingsEnv(testRegex string) error {
-	re := regexp.MustCompile(`^.*BottlerocketKuberentesSettings.*$`)
+	re := regexp.MustCompile(`^.*BottlerocketKubernetesSettings.*$`)
 	if !re.MatchString(testRegex) {
 		return nil
 	}

--- a/pkg/api/v1alpha1/hostosconfig_test.go
+++ b/pkg/api/v1alpha1/hostosconfig_test.go
@@ -75,7 +75,7 @@ func TestValidateHostOSConfig(t *testing.T) {
 			wantErr:  "",
 		},
 		{
-			name: "empty Bottlerocket.Kuberentes config",
+			name: "empty Bottlerocket.Kubernetes config",
 			hostOSConfig: &HostOSConfiguration{
 				BottlerocketConfiguration: &BottlerocketConfiguration{
 					Kubernetes: &v1beta1.BottlerocketKubernetesSettings{},
@@ -85,7 +85,7 @@ func TestValidateHostOSConfig(t *testing.T) {
 			wantErr:  "",
 		},
 		{
-			name: "empty Bottlerocket.Kuberentes full valid config",
+			name: "empty Bottlerocket.Kubernetes full valid config",
 			hostOSConfig: &HostOSConfiguration{
 				BottlerocketConfiguration: &BottlerocketConfiguration{
 					Kubernetes: &v1beta1.BottlerocketKubernetesSettings{
@@ -105,7 +105,7 @@ func TestValidateHostOSConfig(t *testing.T) {
 			wantErr:  "",
 		},
 		{
-			name: "invalid Bottlerocket.Kuberentes.AllowedUnsafeSysctls",
+			name: "invalid Bottlerocket.Kubernetes.AllowedUnsafeSysctls",
 			hostOSConfig: &HostOSConfiguration{
 				BottlerocketConfiguration: &BottlerocketConfiguration{
 					Kubernetes: &v1beta1.BottlerocketKubernetesSettings{
@@ -120,7 +120,7 @@ func TestValidateHostOSConfig(t *testing.T) {
 			wantErr:  "BottlerocketConfiguration.Kubernetes.AllowedUnsafeSysctls can not have an empty string (\"\")",
 		},
 		{
-			name: "invalid Bottlerocket.Kuberentes.ClusterDNSIPs",
+			name: "invalid Bottlerocket.Kubernetes.ClusterDNSIPs",
 			hostOSConfig: &HostOSConfiguration{
 				BottlerocketConfiguration: &BottlerocketConfiguration{
 					Kubernetes: &v1beta1.BottlerocketKubernetesSettings{
@@ -135,7 +135,7 @@ func TestValidateHostOSConfig(t *testing.T) {
 			wantErr:  "IP address [not a valid IP] in BottlerocketConfiguration.Kubernetes.ClusterDNSIPs is not a valid IP",
 		},
 		{
-			name: "invalid Bottlerocket.Kuberentes.MaxPods",
+			name: "invalid Bottlerocket.Kubernetes.MaxPods",
 			hostOSConfig: &HostOSConfiguration{
 				BottlerocketConfiguration: &BottlerocketConfiguration{
 					Kubernetes: &v1beta1.BottlerocketKubernetesSettings{

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -206,7 +206,7 @@ func TestVSphereKubernetes125To126AWSIamAuthUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube126,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube126)),
-		provider.WithProviderUpgrade(provider.Ubuntu125Template()),
+		provider.WithProviderUpgrade(provider.Ubuntu126Template()),
 	)
 }
 
@@ -1366,7 +1366,7 @@ func TestVSphereKubernetes126BottlerocketWithBottlerocketKubernetesSettings(t *t
 		t,
 		framework.NewVSphere(
 			t, framework.WithBottleRocket126(),
-			framework.WithBottlerocketKuberentesSettingsForAllMachines(),
+			framework.WithBottlerocketKubernetesSettingsForAllMachines(),
 			framework.WithSSHAuthorizedKeyForAllMachines(""), // set SSH key to empty
 		),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),

--- a/test/framework/hostOSConfig.go
+++ b/test/framework/hostOSConfig.go
@@ -26,7 +26,7 @@ const (
 
 var (
 	ntpServersRequiredVar   = []string{ntpServersVar}
-	brKuberentesRequiredVar = []string{maxPodsVar, clusterDNSIPSVar, allowedUnsafeSysctlsVar}
+	brKubernetesRequiredVar = []string{maxPodsVar, clusterDNSIPSVar, allowedUnsafeSysctlsVar}
 )
 
 // RequiredNTPServersEnvVars returns a slice of environment variables required for NTP tests.
@@ -36,7 +36,7 @@ func RequiredNTPServersEnvVars() []string {
 
 // RequiredBottlerocketKubernetesSettingsEnvVars returns a slice of environment variables required for Bottlerocket Kubernetes tests.
 func RequiredBottlerocketKubernetesSettingsEnvVars() []string {
-	return brKuberentesRequiredVar
+	return brKubernetesRequiredVar
 }
 
 // GetNTPServersFromEnv returns a slice of NTP servers read from the NTP environment veriables.

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -397,8 +397,8 @@ func WithNTPServersForAllMachines() VSphereOpt {
 	}
 }
 
-// WithBottlerocketKuberentesSettingsForAllMachines sets Bottlerocket Kubernetes settings for all the machines.
-func WithBottlerocketKuberentesSettingsForAllMachines() VSphereOpt {
+// WithBottlerocketKubernetesSettingsForAllMachines sets Bottlerocket Kubernetes settings for all the machines.
+func WithBottlerocketKubernetesSettingsForAllMachines() VSphereOpt {
 	return func(v *VSphere) {
 		checkRequiredEnvVars(v.t, RequiredBottlerocketKubernetesSettingsEnvVars())
 		unsafeSysctls, clusterDNSIPS, maxPods, err := GetBottlerocketKubernetesSettingsFromEnv()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix regex for BR settings e2e test
Set correct template in 125To126 aws iam e2e test

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

