### PR TITLE
Skip Tinkerbell airgapped 1.26 e2e test

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -50,7 +50,7 @@ skipped_tests:
 - TestTinkerbellKubernetes122BottleRocketSimpleFlow
 - TestTinkerbellKubernetes122UbuntuTo123Upgrade
 - TestTinkerbellKubernetes123UbuntuTo124Upgrade
-- TestTinkerbellAirgappedKubernetes125BottleRocketRegistryMirror
+- TestTinkerbellAirgappedKubernetes126BottleRocketRegistryMirror
 - TestTinkerbellKubernetes123UbuntuSimpleFlow
 - TestTinkerbellKubernetes124UbuntuSimpleFlow
 - TestTinkerbellKubernetes125UbuntuSimpleFlow


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change was supposed to have been made in another PR, but there was a conflict with 1.26 e2e test changes that overrided it.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

