### PR TITLE
Fix panic on Tinkerbell custom resource conversion

### DIFF
--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -444,7 +444,9 @@ func (p *Provider) handleRufioUnreleasedCRDs(ctx context.Context, cluster *types
 	}
 
 	for _, h := range hardware {
-		h.Spec.BMCRef.Kind = "Machine"
+		if h.Spec.BMCRef != nil {
+			h.Spec.BMCRef.Kind = "Machine"
+		}
 	}
 
 	serialized, err = yaml.Serialize(hardware...)


### PR DESCRIPTION
When Hardware are submitted to the cluster without baseboard management data they won't have a baseboard management controller reference. The upgrade procedure from pre v0.15 clusters to v0.15+ will panic if the reference is missing on Hardware objects. This change ensures a reference exists before trying to update it. 