### PR TITLE
Update API e2e test timeouts

### DIFF
--- a/test/framework/clustervalidator.go
+++ b/test/framework/clustervalidator.go
@@ -18,8 +18,8 @@ import (
 )
 
 func validationsForExpectedObjects() []clusterf.StateValidation {
-	mediumRetier := retrier.NewWithMaxRetries(60, 5*time.Second)
-	longRetier := retrier.NewWithMaxRetries(120, 5*time.Second)
+	mediumRetier := retrier.NewWithMaxRetries(120, 5*time.Second)
+	longRetier := retrier.NewWithMaxRetries(120, 10*time.Second)
 	return []clusterf.StateValidation{
 		clusterf.RetriableStateValidation(mediumRetier, validations.ValidateClusterReady),
 		clusterf.RetriableStateValidation(mediumRetier, validations.ValidateEKSAObjects),
@@ -31,7 +31,7 @@ func validationsForExpectedObjects() []clusterf.StateValidation {
 
 func validationsForClusterDoesNotExist() []clusterf.StateValidation {
 	return []clusterf.StateValidation{
-		clusterf.RetriableStateValidation(retrier.NewWithMaxRetries(60, 5*time.Second), validations.ValidateClusterDoesNotExist),
+		clusterf.RetriableStateValidation(retrier.NewWithMaxRetries(120, 5*time.Second), validations.ValidateClusterDoesNotExist),
 	}
 }
 

--- a/test/framework/workload.go
+++ b/test/framework/workload.go
@@ -71,7 +71,7 @@ func (w *WorkloadCluster) WaitForAvailableHardware() {
 func (w *WorkloadCluster) WaitForKubeconfig() {
 	ctx := context.Background()
 	w.T.Logf("Waiting for workload cluster %s kubeconfig to be available", w.ClusterName)
-	err := retrier.Retry(60, 5*time.Second, func() error {
+	err := retrier.Retry(120, 5*time.Second, func() error {
 		return w.writeKubeconfigToDisk(ctx)
 	})
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
TestVSphereUpgradeKubernetesCiliumDisableCSIUbuntuAPI has been failing with a timeout waiting for kubeconfig. Also observed that it sometimes fails waiting for the cluster to be ready when running it locally. So, here we're increasing both of those timeout values.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

