### PR TITLE
Fix check for conditional CLI tarball upload path

### DIFF
--- a/cmd/integration_test/build/script/upload_artifacts.sh
+++ b/cmd/integration_test/build/script/upload_artifacts.sh
@@ -97,7 +97,7 @@ function build::cli::upload() {
   upload_path="$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts
   latest_upload_path="$artifactsbucket"/"$projectpath"/"$latesttag"
   if [ "$CODEBUILD_CI" = "true" ]; then
-    if [[ "$CODEBUILD_BUILD_ID" =~ "aws-staging-eks-a-test" ]]; then
+    if [[ "$CODEBUILD_BUILD_ID" =~ "aws-staging-eks-a-build" ]]; then
       upload_path="$upload_path"/staging
       latest_upload_path="$artifactsbucket"/"$projectpath"/staging/"$latesttag"
     fi


### PR DESCRIPTION
After the provider-specific e2e test split, it is the build stage that uploads artifacts and not the test stage, to avoid duplicate artifacts upload. So this check needs to test for the build stage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

