### PR TITLE
Fix kernel sysctl for vsphere external etcd nodes

### DIFF
--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -520,7 +520,7 @@ spec:
 {{- range $key, $value := .etcdBootParameters }}
           {{ $key }}:
 {{- range $val := $value }}
-          - {{ $val }}
+          - "{{ $val }}"
 {{- end }}
 {{- end }}
 {{- end }}
@@ -528,7 +528,7 @@ spec:
       kernel:
         sysctlSettings:
 {{- range $key, $value := .etcdKernelSettings }}
-          {{ $key }}: {{ $value }}
+          {{ $key }}: "{{ $value }}"
 {{- end }}
 {{- end }}
 {{- else}}

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_boot_settings_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_boot_settings_config_cp.yaml
@@ -479,14 +479,14 @@ spec:
       boot:
         bootKernelParameters:
           setting1:
-          - foo
-          - bar
+          - "foo"
+          - "bar"
           setting2:
-          - abc
+          - "abc"
       kernel:
         sysctlSettings:
-          setting1: foo
-          setting2: bar
+          setting1: "foo"
+          setting2: "bar"
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
       - name: ec2-user

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_kernel_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_kernel_config_cp.yaml
@@ -464,8 +464,8 @@ spec:
       pauseImage: public.ecr.aws/eks-distro/kubernetes/pause:v1.21.2-eks-1-21-4
       kernel:
         sysctlSettings:
-          setting1: foo
-          setting2: bar
+          setting1: "foo"
+          setting2: "bar"
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     users:
       - name: ec2-user


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed BR settings.kernel.sysctl date type conversion issue with vSphere provider for etcd nodes

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

