### PR TITLE
Referencing the right pointer for Tink validations

### DIFF
--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -140,8 +140,8 @@ func validateUpgradeRequestTinkerbell(new, old *Cluster) field.ErrorList {
 				field.Invalid(path, new.Spec.WorkerNodeGroupConfigurations, "cannot perform scale up or down during rolling upgrades. Please revert to the previous worker node groups."))
 		}
 		workerNodeGroupMap := make(map[string]*WorkerNodeGroupConfiguration)
-		for _, workerNodeGroupConfiguration := range old.Spec.WorkerNodeGroupConfigurations {
-			workerNodeGroupMap[workerNodeGroupConfiguration.Name] = &workerNodeGroupConfiguration
+		for i := range old.Spec.WorkerNodeGroupConfigurations {
+			workerNodeGroupMap[old.Spec.WorkerNodeGroupConfigurations[i].Name] = &old.Spec.WorkerNodeGroupConfigurations[i]
 		}
 		for _, nodeGroupNewSpec := range new.Spec.WorkerNodeGroupConfigurations {
 			workerNodeGrpOldSpec, ok := workerNodeGroupMap[nodeGroupNewSpec.Name]
@@ -267,8 +267,8 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 		}
 
 		workerNodeGroupMap := make(map[string]*WorkerNodeGroupConfiguration)
-		for _, workerNodeGroupConfiguration := range old.Spec.WorkerNodeGroupConfigurations {
-			workerNodeGroupMap[workerNodeGroupConfiguration.Name] = &workerNodeGroupConfiguration
+		for i := range old.Spec.WorkerNodeGroupConfigurations {
+			workerNodeGroupMap[old.Spec.WorkerNodeGroupConfigurations[i].Name] = &old.Spec.WorkerNodeGroupConfigurations[i]
 		}
 		for _, nodeGroupNewSpec := range new.Spec.WorkerNodeGroupConfigurations {
 			if workerNodeGrpOldSpec, ok := workerNodeGroupMap[nodeGroupNewSpec.Name]; ok {

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -283,8 +283,8 @@ func (p *Provider) isScaleUpDown(oldCluster *v1alpha1.Cluster, newCluster *v1alp
 	}
 
 	workerNodeGroupMap := make(map[string]*v1alpha1.WorkerNodeGroupConfiguration)
-	for _, workerNodeGroupConfiguration := range oldCluster.Spec.WorkerNodeGroupConfigurations {
-		workerNodeGroupMap[workerNodeGroupConfiguration.Name] = &workerNodeGroupConfiguration
+	for i := range oldCluster.Spec.WorkerNodeGroupConfigurations {
+		workerNodeGroupMap[oldCluster.Spec.WorkerNodeGroupConfigurations[i].Name] = &oldCluster.Spec.WorkerNodeGroupConfigurations[i]
 	}
 
 	for _, nodeGroupNewSpec := range newCluster.Spec.WorkerNodeGroupConfigurations {


### PR DESCRIPTION
*Description of changes:*
Cluster webhooks and preflights were failing for multiple worker node groups due to a pointer referencing error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

