### PR TITLE
Update actions/labeler Githb Action version

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -17,6 +17,6 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Update the `actions/labeler` action to migrate away from the deprecated Node JS 12 Github Action base.