### PR TITLE
wait for package bundle controller to exist

### DIFF
--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -339,12 +339,12 @@ func (pc *PackageControllerClient) waitForActiveBundle(ctx context.Context) erro
 			readyCnt := 0
 			err := pc.kubectl.GetObject(timeoutCtx, packageBundleControllerResource, pc.clusterName,
 				packagesv1.PackageNamespace, pc.kubeConfig, pbc)
-			if err != nil {
+			if err != nil && !apierrors.IsNotFound(err) {
 				done <- fmt.Errorf("getting package bundle controller: %w", err)
 				return
 			}
 
-			if pbc.Spec.ActiveBundle != "" {
+			if pbc != nil && pbc.Spec.ActiveBundle != "" {
 				logger.V(6).Info("found packages bundle controller active bundle",
 					"name", pbc.Spec.ActiveBundle)
 				readyCnt++


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

When waiting for the package bundle controller to activate a bundle, if the package bundle controller itself isn't found, then continue to wait, just as if a bundle hadn't been activated yet.

This happens sometimes with workload clusters, as the packages controller client will be looking for a package bundle controller for the workload cluster that simply hasn't been created yet.

*Testing (if applicable):*

Unit test, and will perform manual validation.

