### PR TITLE
[release-0.14] Fix clustermanager no-timeouts option

### DIFF
--- a/pkg/clustermanager/cluster_manager_wb_test.go
+++ b/pkg/clustermanager/cluster_manager_wb_test.go
@@ -1,0 +1,65 @@
+package clustermanager
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestClusterManager_totalTimeoutForMachinesReadyWait(t *testing.T) {
+	tests := []struct {
+		name     string
+		replicas int
+		opts     []ClusterManagerOpt
+		want     time.Duration
+	}{
+		{
+			name:     "default timeouts with 1 replica",
+			replicas: 1,
+			want:     30 * time.Minute,
+		},
+		{
+			name:     "default timeouts with 2 replicas",
+			replicas: 2,
+			want:     30 * time.Minute,
+		},
+		{
+			name:     "default timeouts with 4 replicas",
+			replicas: 4,
+			want:     40 * time.Minute,
+		},
+		{
+			name:     "no timeouts with 1 replica",
+			replicas: 1,
+			opts:     []ClusterManagerOpt{WithNoTimeouts()},
+			want:     math.MaxInt64,
+		},
+		{
+			name:     "no timeouts with 2 replicas",
+			replicas: 2,
+			opts:     []ClusterManagerOpt{WithNoTimeouts()},
+			want:     math.MaxInt64,
+		},
+		{
+			name:     "no timeouts with 1 replica",
+			replicas: 1,
+			opts:     []ClusterManagerOpt{WithNoTimeouts()},
+			want:     math.MaxInt64,
+		},
+		{
+			name:     "no timeouts with 0 replicas",
+			replicas: 1,
+			opts:     []ClusterManagerOpt{WithNoTimeouts()},
+			want:     math.MaxInt64,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New(nil, nil, nil, nil, nil, nil, tt.opts...)
+			g := NewWithT(t)
+			g.Expect(c.totalTimeoutForMachinesReadyWait(tt.replicas)).To(Equal(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/aws/eks-anywhere/pull/5441

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

