### PR TITLE
Adding a case for no substring match

### DIFF
--- a/test/e2e/tools/eks-anywhere-test-tool/pkg/filewriter/writer.go
+++ b/test/e2e/tools/eks-anywhere-test-tool/pkg/filewriter/writer.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
 )
 
 type writer struct {
@@ -60,6 +62,11 @@ func (t *writer) Dir() string {
 // This method writes the e2e test artifacts from S3 to files in a directory named after the e2e test name.
 func (t *writer) WriteTestArtifactsS3ToFile(key string, data []byte) error {
 	i := strings.LastIndex(key, "/Test")
+	if i == -1 {
+		logger.Info("Failed writing object to file", "key", key)
+		return nil
+	}
+
 	p := path.Join(t.dir, key[i:])
 
 	err := os.MkdirAll(path.Dir(p), os.ModePerm)


### PR DESCRIPTION
*Description of changes:*
`eksa-test-tool` panics when fetching tinkerbell artifacts for use cases where `/Test` is not found in the object key. This happens when tests have a SSM time out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

