### PR TITLE
Use separate Helm drivers for source and destination registries

### DIFF
--- a/release/pkg/bundles/package-controller.go
+++ b/release/pkg/bundles/package-controller.go
@@ -137,19 +137,19 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]st
 					if strings.HasSuffix(imageArtifact.AssetName, "helm") {
 						trimmedAsset := strings.TrimSuffix(artifact.Image.AssetName, "-helm")
 						fmt.Printf("trimmedAsset=%v\n\n", trimmedAsset)
-						helmDriver, err := helm.NewHelm()
+						_, destHelmDriver, err := helm.NewHelm()
 						if err != nil {
 							return anywherev1alpha1.PackageBundle{}, errors.Wrap(err, "creating helm client")
 						}
 						fmt.Printf("Modifying helm chart for %s\n", trimmedAsset)
-						helmDest, err := helm.GetHelmDest(helmDriver, r, imageArtifact.ReleaseImageURI, trimmedAsset)
+						helmDest, err := helm.GetHelmDest(destHelmDriver, r, imageArtifact.ReleaseImageURI, trimmedAsset)
 						if err != nil {
 							return anywherev1alpha1.PackageBundle{}, errors.Wrap(err, "getting Helm destination:")
 						}
 						fmt.Printf("helmDest=%v\n", helmDest)
 						fmt.Printf("Pulled helm chart locally to %s\n", helmDest)
 						fmt.Printf("r.sourceClients")
-						err = helm.ModifyAndPushChartYaml(*imageArtifact, r, helmDriver, helmDest, artifacts, bundleImageArtifacts)
+						err = helm.ModifyAndPushChartYaml(*imageArtifact, r, destHelmDriver, helmDest, artifacts, bundleImageArtifacts)
 						if err != nil {
 							return anywherev1alpha1.PackageBundle{}, errors.Wrap(err, "modifying Chart.yaml and pushing Helm chart to destination:")
 						}

--- a/release/pkg/operations/upload.go
+++ b/release/pkg/operations/upload.go
@@ -88,19 +88,19 @@ func UploadArtifacts(r *releasetypes.ReleaseConfig, eksArtifacts map[string][]re
 					// Trim -helm on the packages helm chart, but don't need to trim tinkerbell chart since the AssetName is the same as the repoName
 					trimmedAsset := strings.TrimSuffix(artifact.Image.AssetName, "-helm")
 
-					helmDriver, err := helm.NewHelm()
+					sourceHelmDriver, destHelmDriver, err := helm.NewHelm()
 					if err != nil {
 						return fmt.Errorf("creating helm client: %v", err)
 					}
 
 					fmt.Printf("Modifying helm chart for %s\n", trimmedAsset)
-					helmDest, err := helm.GetHelmDest(helmDriver, r, artifact.Image.SourceImageURI, trimmedAsset)
+					helmDest, err := helm.GetHelmDest(sourceHelmDriver, r, artifact.Image.SourceImageURI, trimmedAsset)
 					if err != nil {
 						return fmt.Errorf("getting Helm destination: %v", err)
 					}
 
 					fmt.Printf("Pulled helm chart locally to %s\n", helmDest)
-					err = helm.ModifyAndPushChartYaml(*artifact.Image, r, helmDriver, helmDest, eksArtifacts, nil)
+					err = helm.ModifyAndPushChartYaml(*artifact.Image, r, destHelmDriver, helmDest, eksArtifacts, nil)
 					if err != nil {
 						return fmt.Errorf("modifying Chart.yaml and pushing Helm chart to destination: %v", err)
 					}
@@ -118,7 +118,7 @@ func UploadArtifacts(r *releasetypes.ReleaseConfig, eksArtifacts map[string][]re
 			}
 		}
 	}
-	fmt.Printf("%s Successsfully uploaded artifacts\n", constants.SuccessIcon)
+	fmt.Printf("%s Successfully uploaded artifacts\n", constants.SuccessIcon)
 
 	return nil
 }


### PR DESCRIPTION
Use separate Helm drivers for source and destination registries. To avoid credential conflicts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

