### PR TITLE
Add cloudstack validator to controller

### DIFF
--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -2,6 +2,9 @@ package controllers
 
 import (
 	"context"
+	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/executables/cmk"
+	"github.com/aws/eks-anywhere/pkg/providers/cloudstack"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -48,6 +51,7 @@ type Factory struct {
 	logger                      logr.Logger
 	deps                        *dependencies.Dependencies
 	packageControllerClient     *curatedpackages.PackageControllerClient
+	cloudStackValidatorRegistry cloudstack.ValidatorRegistry
 }
 
 type Reconcilers struct {
@@ -189,6 +193,8 @@ func (f *Factory) WithTinkerbellDatacenterReconciler() *Factory {
 
 // WithCloudStackDatacenterReconciler adds the CloudStackDatacenterReconciler to the controller factory.
 func (f *Factory) WithCloudStackDatacenterReconciler() *Factory {
+	f.withCloudStackValidatorRegistry()
+
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.reconcilers.CloudStackDatacenterReconciler != nil {
 			return nil
@@ -196,6 +202,7 @@ func (f *Factory) WithCloudStackDatacenterReconciler() *Factory {
 
 		f.reconcilers.CloudStackDatacenterReconciler = NewCloudStackDatacenterReconciler(
 			f.manager.GetClient(),
+			f.cloudStackValidatorRegistry,
 		)
 
 		return nil
@@ -417,6 +424,23 @@ func (f *Factory) withCloudStackClusterReconciler() *Factory {
 
 		f.cloudstackClusterReconciler = cloudstackreconciler.New()
 		f.registryBuilder.Add(anywherev1.CloudStackDatacenterKind, f.cloudstackClusterReconciler)
+
+		return nil
+	})
+
+	return f
+}
+
+func (f *Factory) withCloudStackValidatorRegistry() *Factory {
+	f.dependencyFactory.WithWriter()
+
+	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
+		if f.cloudStackValidatorRegistry != nil {
+			return nil
+		}
+
+		cmkBuilder := cmk.NewCmkBuilder(executables.NewLocalExecutablesBuilder())
+		f.cloudStackValidatorRegistry = cloudstack.NewValidatorFactory(cmkBuilder, f.deps.Writer, false)
 
 		return nil
 	})

--- a/internal/test/cleanup/cleanup.go
+++ b/internal/test/cleanup/cleanup.go
@@ -109,10 +109,7 @@ func CleanUpCloudstackTestResources(ctx context.Context, clusterName string, dry
 	if err != nil {
 		return fmt.Errorf("parsing cloudstack credentials from environment: %v", err)
 	}
-	cmk, err := executableBuilder.BuildCmkExecutable(tmpWriter, execConfig)
-	if err != nil {
-		return fmt.Errorf("building cmk executable: %v", err)
-	}
+	cmk := executableBuilder.BuildCmkExecutable(tmpWriter, execConfig)
 	defer cmk.Close(ctx)
 	cleanupRetrier := retrier.NewWithMaxRetries(cleanupRetries, retryBackoff)
 

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -387,10 +387,7 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 			if err != nil {
 				return fmt.Errorf("parsing CloudStack credentials: %v", err)
 			}
-			validator, err := f.dependencies.CloudStackValidatorRegistry.Get(execConfig)
-			if err != nil {
-				return fmt.Errorf("building validator from exec config: %v", err)
-			}
+			validator := f.dependencies.CloudStackValidatorRegistry.Get(execConfig)
 			f.dependencies.Provider = cloudstack.NewProvider(datacenterConfig, machineConfigs, clusterConfig, f.dependencies.Kubectl, validator, f.dependencies.Writer, time.Now, logger.Get())
 
 		case v1alpha1.SnowDatacenterKind:

--- a/pkg/executables/builder.go
+++ b/pkg/executables/builder.go
@@ -51,7 +51,7 @@ func (b *ExecutablesBuilder) BuildGovcExecutable(writer filewriter.FileWriter, o
 }
 
 // BuildCmkExecutable initializes a Cmk object and returns it.
-func (b *ExecutablesBuilder) BuildCmkExecutable(writer filewriter.FileWriter, config *decoder.CloudStackExecConfig) (*Cmk, error) {
+func (b *ExecutablesBuilder) BuildCmkExecutable(writer filewriter.FileWriter, config *decoder.CloudStackExecConfig) *Cmk {
 	return NewCmk(b.executableBuilder.Build(cmkPath), writer, config)
 }
 

--- a/pkg/executables/cmk.go
+++ b/pkg/executables/cmk.go
@@ -338,10 +338,7 @@ func (c *Cmk) ValidateAccountPresent(ctx context.Context, profile string, accoun
 }
 
 // NewCmk initializes CloudMonkey executable to query CloudStack via CLI.
-func NewCmk(executable Executable, writer filewriter.FileWriter, config *decoder.CloudStackExecConfig) (*Cmk, error) {
-	if config == nil {
-		return nil, fmt.Errorf("nil exec config for CloudMonkey, unable to proceed")
-	}
+func NewCmk(executable Executable, writer filewriter.FileWriter, config *decoder.CloudStackExecConfig) *Cmk {
 	configMap := make(map[string]decoder.CloudStackProfileConfig, len(config.Profiles))
 	for _, profile := range config.Profiles {
 		configMap[profile.Name] = profile
@@ -351,7 +348,7 @@ func NewCmk(executable Executable, writer filewriter.FileWriter, config *decoder
 		writer:     writer,
 		executable: executable,
 		configMap:  configMap,
-	}, nil
+	}
 }
 
 func (c *Cmk) GetManagementApiEndpoint(profile string) (string, error) {

--- a/pkg/executables/cmk/builder.go
+++ b/pkg/executables/cmk/builder.go
@@ -18,6 +18,6 @@ func NewCmkBuilder(builder *executables.ExecutablesBuilder) *Builder {
 }
 
 // BuildCloudstackClient exposes a single method to consumers to abstract away executableBuilder's other operations and business logic.
-func (b *Builder) BuildCloudstackClient(writer filewriter.FileWriter, config *decoder.CloudStackExecConfig) (cloudstack.ProviderCmkClient, error) {
+func (b *Builder) BuildCloudstackClient(writer filewriter.FileWriter, config *decoder.CloudStackExecConfig) cloudstack.ProviderCmkClient {
 	return b.builder.BuildCmkExecutable(writer, config)
 }

--- a/pkg/providers/cloudstack/reconciler/credentials.go
+++ b/pkg/providers/cloudstack/reconciler/credentials.go
@@ -1,0 +1,41 @@
+package reconciler
+
+import (
+	"context"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/collection"
+	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
+	apiv1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
+)
+
+func GetCloudstackExecConfig(ctx context.Context, cli client.Client, datacenterConfig *v1alpha1.CloudStackDatacenterConfig) (*decoder.CloudStackExecConfig, error) {
+	var profiles []decoder.CloudStackProfileConfig
+	credRefs := collection.NewSet[string]()
+	for _, zone := range datacenterConfig.Spec.AvailabilityZones {
+		credRefs.Add(zone.CredentialsRef)
+	}
+	for _, profileName := range credRefs.ToSlice() {
+		secret := &apiv1.Secret{}
+		secretKey := client.ObjectKey{
+			Namespace: constants.EksaSystemNamespace,
+			Name:      profileName,
+		}
+		if err := cli.Get(ctx, secretKey, secret); err != nil {
+			return nil, err
+		}
+		profiles = append(profiles, decoder.CloudStackProfileConfig{
+			Name:          profileName,
+			ApiKey:        string(secret.Data[decoder.APIKeyKey]),
+			SecretKey:     string(secret.Data[decoder.SecretKeyKey]),
+			ManagementUrl: string(secret.Data[decoder.APIUrlKey]),
+			VerifySsl:     string(secret.Data[decoder.VerifySslKey]),
+		})
+	}
+
+	return &decoder.CloudStackExecConfig{
+		Profiles: profiles,
+	}, nil
+}

--- a/pkg/providers/cloudstack/validator_registry.go
+++ b/pkg/providers/cloudstack/validator_registry.go
@@ -2,7 +2,6 @@ package cloudstack
 
 import (
 	"context"
-	"fmt"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
@@ -13,12 +12,12 @@ import (
 
 // ValidatorRegistry exposes a single method for retrieving the CloudStack validator, and abstracts away how they are injected.
 type ValidatorRegistry interface {
-	Get(execConfig *decoder.CloudStackExecConfig) (ProviderValidator, error)
+	Get(execConfig *decoder.CloudStackExecConfig) ProviderValidator
 }
 
 // CmkBuilder defines the interface to be consumed by the ValidatorFactory which enables it to build a new CloudStackClient.
 type CmkBuilder interface {
-	BuildCloudstackClient(writer filewriter.FileWriter, config *decoder.CloudStackExecConfig) (ProviderCmkClient, error)
+	BuildCloudstackClient(writer filewriter.FileWriter, config *decoder.CloudStackExecConfig) ProviderCmkClient
 }
 
 // ValidatorFactory implements the ValidatorRegistry interface and holds the necessary structs for building fresh Validator objects.
@@ -46,11 +45,8 @@ func NewValidatorFactory(builder CmkBuilder, writer filewriter.FileWriter, skipI
 }
 
 // Get returns a validator for a particular cloudstack exec config.
-func (r ValidatorFactory) Get(execConfig *decoder.CloudStackExecConfig) (ProviderValidator, error) {
-	cmk, err := r.builder.BuildCloudstackClient(r.writer, execConfig)
-	if err != nil {
-		return nil, fmt.Errorf("building cmk executable: %v", err)
-	}
+func (r ValidatorFactory) Get(execConfig *decoder.CloudStackExecConfig) ProviderValidator {
+	cmk := r.builder.BuildCloudstackClient(r.writer, execConfig)
 
-	return NewValidator(cmk, &networkutils.DefaultNetClient{}, r.skipIPCheck), nil
+	return NewValidator(cmk, &networkutils.DefaultNetClient{}, r.skipIPCheck)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Building validator in controller to use cmk to run validations against Cloudstack. 

Currently in progress, better approach is to build client each time we call a validate function similar to how we do for Snow, but that requires a bigger refactor (https://github.com/aws/eks-anywhere/pull/2859, https://github.com/aws/eks-anywhere/pull/2887). I reused the validator factory that is defined in the provider package. I also removed the error check when building the cmk executable because we are already checking for the validity of execConfig (at least from what I understand) whenever we get it, so it's better to not have errors thrown in the constructor. But we need to make sure that there is enough validation for whether the profile exists or not in the cmk methods. The validator may also need to be built in the ClusterProviderReconciler as there are certain validations that are not isolated to just datacenter config, so that would be the best place to contain all the objects associated with the cluster.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

