### PR TITLE
Run Helm push command using CLI instead of library

### DIFF
--- a/release/pkg/operations/upload.go
+++ b/release/pkg/operations/upload.go
@@ -118,7 +118,7 @@ func UploadArtifacts(r *releasetypes.ReleaseConfig, eksArtifacts map[string][]re
 			}
 		}
 	}
-	fmt.Printf("%s Successsfully uploaded artifacts\n", constants.SuccessIcon)
+	fmt.Printf("%s Successfully uploaded artifacts\n", constants.SuccessIcon)
 
 	return nil
 }


### PR DESCRIPTION
Running Helm push command using CLI instead of library to make it more robust when working credentials from the env. This will unblock the bundle release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

