### PR TITLE
Add missing domains to prerequisites list

### DIFF
--- a/docs/content/en/docs/reference/artifacts.md
+++ b/docs/content/en/docs/reference/artifacts.md
@@ -174,6 +174,8 @@ To use `image-builder`, you must meet the following prerequisites:
 * api.ecr.us-west-2.amazonaws.com (for EKS Anywhere package authentication matching your region)
 * d5l0dvt14r5h8.cloudfront.net (for EKS Anywhere package ECR container)
 * github.com (to download binaries and tools required for image builds from GitHub releases)
+* objects.githubusercontent.com (to download binaries and tools required for image builds from GitHub releases)
+* raw.githubusercontent.com (to download binaries and tools required for image builds from GitHub releases)
 * releases.hashicorp.com (to download Packer binary for image builds)
 * galaxy.ansible.com (to download Ansible packages from Ansible Galaxy)
 * **vSphere only:** VMware vCenter endpoint


### PR DESCRIPTION
*Issue #, if available:*
fixes #5273 

*Description of changes:*
Adds raw.githubusercontent.com and objects.githubusercontent.com to image-builder prerequisites lists

*Testing (if applicable):*
Doc preview

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

