### PR TITLE
Make EKS-A release manifest URL overrideable

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -144,9 +144,9 @@ eks-a-release: build ## Perform EKS-A CLI release
 github-bundle-release:
 	scripts/github-bundle-release.sh $(REPO_ROOT)/release/downloaded-artifacts $(WEEKLY_RELEASES_URL_PREFIX)
 
-announce-eks-a-release: CDN=https://anywhere-assets.eks.amazonaws.com
+announce-eks-a-release: EKSA_RELEASE_MANIFEST_URL?=https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml"
 announce-eks-a-release:
-	scripts/announce_eksa_release.sh $(CDN)
+	scripts/announce_eksa_release.sh $(EKSA_RELEASE_MANIFEST_URL)
 
 ##@ Deployment
 

--- a/release/scripts/announce_eksa_release.sh
+++ b/release/scripts/announce_eksa_release.sh
@@ -22,13 +22,12 @@ SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source ${SCRIPT_ROOT}/setup-aws-config.sh
 set_aws_config "production"
 
-EKSA_RELEASE_CDN="${1?Specify first argument - EKS-A release assets CDN}"
+EKSA_RELEASE_MANIFEST_URL="${1?Specify first argument - EKS-A release manifest URL}"
 
-EKSA_RELEASE_MANIFEST_URL="${EKSA_RELEASE_CDN}/releases/eks-a/manifest.yaml"
 LATEST_EKSA_VERSION=$(curl $EKSA_RELEASE_MANIFEST_URL | yq e '.spec.latestVersion')
 LATEST_EKSA_RELEASE_NUMBER=$(curl $EKSA_RELEASE_MANIFEST_URL | yq e '.spec.releases[] | select(.version == '\"$LATEST_EKSA_VERSION\"') | .number')
 LATEST_BUNDLE_RELEASE_MANIFEST_URI=$(curl $EKSA_RELEASE_MANIFEST_URL | yq e '.spec.releases[] | select(.version == '\"$LATEST_EKSA_VERSION\"') | .bundleManifestUrl')
-LATEST_EKSA_ADMIN_AMI_URI="$EKSA_RELEASE_CDN/releases/eks-a/$LATEST_EKSA_RELEASE_NUMBER/artifacts/eks-a-admin-ami/$LATEST_EKSA_VERSION/eks-anywhere-admin-ami-$LATEST_EKSA_VERSION-eks-a-$LATEST_EKSA_RELEASE_NUMBER.raw"
+LATEST_EKSA_ADMIN_AMI_URI="https://anywhere-assets.eks.amazonaws.com/releases/eks-a/$LATEST_EKSA_RELEASE_NUMBER/artifacts/eks-a-admin-ami/$LATEST_EKSA_VERSION/eks-anywhere-admin-ami-$LATEST_EKSA_VERSION-eks-a-$LATEST_EKSA_RELEASE_NUMBER.raw"
 
 NOTIFICATION_SUBJECT="New release of EKS Anywhere - version $LATEST_EKSA_VERSION"
 NOTIFICATION_BODY="Amazon EKS Anywhere version $LATEST_EKSA_VERSION has been released. You can get the latest EKS-A CLI tarballs from GitHub releases. The bundle release manifest corresponding to this version of EKS-A is $LATEST_BUNDLE_RELEASE_MANIFEST_URI. This release includes a new build of the EKS-A Admin AMI image which is available at $LATEST_EKSA_ADMIN_AMI_URI"


### PR DESCRIPTION
Make EKS-A release manifest URL overrideable to make out-of-band release announcements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

