### PR TITLE
Fix nil pointer panic during upgrade of machineConfigName

### DIFF
--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -1301,7 +1301,6 @@ func (p *cloudstackProvider) validateMachineConfigsNameUniqueness(ctx context.Co
 	}
 
 	cpMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
-	fmt.Println(cpMachineConfigName)
 	if prevSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name != cpMachineConfigName {
 		err := p.validateMachineConfigNameUniqueness(ctx, cpMachineConfigName, cluster, clusterSpec)
 		if err != nil {

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -1301,8 +1301,9 @@ func (p *cloudstackProvider) validateMachineConfigsNameUniqueness(ctx context.Co
 	}
 
 	cpMachineConfigName := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	fmt.Println(cpMachineConfigName)
 	if prevSpec.Spec.ControlPlaneConfiguration.MachineGroupRef.Name != cpMachineConfigName {
-		err := p.validateMachineConfigNameUniqueness(ctx, cpMachineConfigName, clusterSpec)
+		err := p.validateMachineConfigNameUniqueness(ctx, cpMachineConfigName, cluster, clusterSpec)
 		if err != nil {
 			return err
 		}
@@ -1311,7 +1312,7 @@ func (p *cloudstackProvider) validateMachineConfigsNameUniqueness(ctx context.Co
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil && prevSpec.Spec.ExternalEtcdConfiguration != nil {
 		etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 		if prevSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name != etcdMachineConfigName {
-			err := p.validateMachineConfigNameUniqueness(ctx, etcdMachineConfigName, clusterSpec)
+			err := p.validateMachineConfigNameUniqueness(ctx, etcdMachineConfigName, cluster, clusterSpec)
 			if err != nil {
 				return err
 			}
@@ -1321,8 +1322,8 @@ func (p *cloudstackProvider) validateMachineConfigsNameUniqueness(ctx context.Co
 	return nil
 }
 
-func (p *cloudstackProvider) validateMachineConfigNameUniqueness(ctx context.Context, machineConfigName string, clusterSpec *cluster.Spec) error {
-	em, err := p.providerKubectlClient.SearchCloudStackMachineConfig(ctx, machineConfigName, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Cluster.GetNamespace())
+func (p *cloudstackProvider) validateMachineConfigNameUniqueness(ctx context.Context, machineConfigName string, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
+	em, err := p.providerKubectlClient.SearchCloudStackMachineConfig(ctx, machineConfigName, cluster.KubeconfigFile, clusterSpec.Cluster.GetNamespace())
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -1656,6 +1656,66 @@ func TestSetupAndValidateForUpgradeSSHAuthorizedKeyInvalidEtcd(t *testing.T) {
 	thenErrorExpected(t, "setting up SSH keys: ssh: no key found", err)
 }
 
+func TestValidateMachineConfigsNameUniquenessSuccess(t *testing.T) {
+	ctx := context.Background()
+	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
+	provider := givenProvider(t)
+	prevSpec := clusterSpec.DeepCopy()
+	prevSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "prev-test-cp"
+	prevSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name = "prev-test-etcd"
+	setupContext(t)
+
+	mockCtrl := gomock.NewController(t)
+	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	provider.providerKubectlClient = kubectl
+	cluster := &types.Cluster{}
+	machineConfigs := clusterSpec.CloudStackMachineConfigs
+
+	kubectl.EXPECT().GetEksaCluster(ctx, cluster, prevSpec.Cluster.Name).Return(prevSpec.Cluster, nil)
+
+	for _, config := range machineConfigs {
+		kubectl.EXPECT().SearchCloudStackMachineConfig(context.TODO(), config.Name, cluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.CloudStackMachineConfig{}, nil).AnyTimes()
+	}
+
+	err := provider.validateMachineConfigsNameUniqueness(ctx, cluster, clusterSpec)
+	if err != nil {
+		t.Fatalf("unexpected failure %v", err)
+	}
+}
+
+func TestValidateMachineConfigsNameUniquenessError(t *testing.T) {
+	ctx := context.Background()
+	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
+	provider := givenProvider(t)
+	prevSpec := clusterSpec.DeepCopy()
+	prevSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "prev-test-cp"
+	prevSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name = "prev-test-etcd"
+	setupContext(t)
+
+	mockCtrl := gomock.NewController(t)
+	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	provider.providerKubectlClient = kubectl
+	cluster := &types.Cluster{}
+	machineConfigs := clusterSpec.CloudStackMachineConfigs
+
+	dummyMachineConfig := &v1alpha1.CloudStackMachineConfig{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec:       v1alpha1.CloudStackMachineConfigSpec{Users: []v1alpha1.UserConfiguration{{Name: "capc"}}},
+		Status:     v1alpha1.CloudStackMachineConfigStatus{},
+	}
+
+	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.Name).Return(prevSpec.Cluster, nil)
+
+	for _, config := range machineConfigs {
+		kubectl.EXPECT().SearchCloudStackMachineConfig(context.TODO(), config.Name, cluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.CloudStackMachineConfig{dummyMachineConfig}, nil).AnyTimes()
+	}
+	mc := []*v1alpha1.CloudStackMachineConfig{dummyMachineConfig}
+	fmt.Println(len(mc))
+	err := provider.validateMachineConfigsNameUniqueness(ctx, cluster, clusterSpec)
+	thenErrorExpected(t, fmt.Sprintf("machineconfig %s already exists", clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name), err)
+}
+
 func TestClusterUpgradeNeededNoChanges(t *testing.T) {
 	ctx := context.Background()
 	mockCtrl := gomock.NewController(t)

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -170,6 +170,59 @@ func setupContext(t *testing.T) {
 	saveContext(t, defaultCloudStackCloudConfigPath)
 }
 
+type providerTest struct {
+	*WithT
+	t                                  *testing.T
+	ctx                                context.Context
+	managementCluster, workloadCluster *types.Cluster
+	provider                           *cloudstackProvider
+	cluster                            *v1alpha1.Cluster
+	clusterSpec                        *cluster.Spec
+	datacenterConfig                   *v1alpha1.CloudStackDatacenterConfig
+	machineConfigs                     map[string]*v1alpha1.CloudStackMachineConfig
+	kubectl                            *mocks.MockProviderKubectlClient
+	validator                          *MockProviderValidator
+}
+
+func newProviderTest(t *testing.T) *providerTest {
+	setupContext(t)
+	ctrl := gomock.NewController(t)
+	kubectl := mocks.NewMockProviderKubectlClient(ctrl)
+	spec := givenClusterSpec(t, testClusterConfigMainFilename)
+	p := &providerTest{
+		t:     t,
+		WithT: NewWithT(t),
+		ctx:   context.Background(),
+		managementCluster: &types.Cluster{
+			Name:           "m-cluster",
+			KubeconfigFile: "kubeconfig-m.kubeconfig",
+		},
+		workloadCluster: &types.Cluster{
+			Name:           "test",
+			KubeconfigFile: "kubeconfig-w.kubeconfig",
+		},
+		cluster:          spec.Cluster,
+		clusterSpec:      spec,
+		datacenterConfig: spec.CloudStackDatacenter,
+		machineConfigs:   spec.CloudStackMachineConfigs,
+		kubectl:          kubectl,
+		validator:        givenWildcardValidator(ctrl, spec),
+	}
+	p.buildNewProvider()
+	return p
+}
+
+func (tt *providerTest) buildNewProvider() {
+	tt.provider = newProvider(
+		tt.t,
+		tt.clusterSpec.CloudStackDatacenter,
+		tt.clusterSpec.CloudStackMachineConfigs,
+		tt.clusterSpec.Cluster,
+		tt.kubectl,
+		tt.validator,
+	)
+}
+
 func TestNewProvider(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
@@ -1657,63 +1710,44 @@ func TestSetupAndValidateForUpgradeSSHAuthorizedKeyInvalidEtcd(t *testing.T) {
 }
 
 func TestValidateMachineConfigsNameUniquenessSuccess(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
-	provider := givenProvider(t)
-	prevSpec := clusterSpec.DeepCopy()
+	tt := newProviderTest(t)
+	cluster := &types.Cluster{
+		Name: "test",
+	}
+	prevSpec := tt.clusterSpec.DeepCopy()
 	prevSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "prev-test-cp"
 	prevSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name = "prev-test-etcd"
-	setupContext(t)
-
-	mockCtrl := gomock.NewController(t)
-	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
-	provider.providerKubectlClient = kubectl
-	cluster := &types.Cluster{}
-	machineConfigs := clusterSpec.CloudStackMachineConfigs
-
-	kubectl.EXPECT().GetEksaCluster(ctx, cluster, prevSpec.Cluster.Name).Return(prevSpec.Cluster, nil)
-
+	machineConfigs := tt.clusterSpec.CloudStackMachineConfigs
+	tt.kubectl.EXPECT().GetEksaCluster(tt.ctx, cluster, tt.clusterSpec.Cluster.Name).Return(prevSpec.Cluster, nil)
 	for _, config := range machineConfigs {
-		kubectl.EXPECT().SearchCloudStackMachineConfig(context.TODO(), config.Name, cluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.CloudStackMachineConfig{}, nil).AnyTimes()
+		tt.kubectl.EXPECT().SearchCloudStackMachineConfig(tt.ctx, config.Name, cluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.CloudStackMachineConfig{}, nil).AnyTimes()
 	}
 
-	err := provider.validateMachineConfigsNameUniqueness(ctx, cluster, clusterSpec)
+	err := tt.provider.validateMachineConfigsNameUniqueness(tt.ctx, cluster, tt.clusterSpec)
 	if err != nil {
 		t.Fatalf("unexpected failure %v", err)
 	}
 }
 
 func TestValidateMachineConfigsNameUniquenessError(t *testing.T) {
-	ctx := context.Background()
-	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
-	provider := givenProvider(t)
-	prevSpec := clusterSpec.DeepCopy()
+	tt := newProviderTest(t)
+	cluster := &types.Cluster{
+		Name: "test",
+	}
+	prevSpec := tt.clusterSpec.DeepCopy()
 	prevSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "prev-test-cp"
 	prevSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name = "prev-test-etcd"
-	setupContext(t)
-
-	mockCtrl := gomock.NewController(t)
-	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
-	provider.providerKubectlClient = kubectl
-	cluster := &types.Cluster{}
-	machineConfigs := clusterSpec.CloudStackMachineConfigs
-
+	machineConfigs := tt.clusterSpec.CloudStackMachineConfigs
 	dummyMachineConfig := &v1alpha1.CloudStackMachineConfig{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{},
-		Spec:       v1alpha1.CloudStackMachineConfigSpec{Users: []v1alpha1.UserConfiguration{{Name: "capc"}}},
-		Status:     v1alpha1.CloudStackMachineConfigStatus{},
+		Spec: v1alpha1.CloudStackMachineConfigSpec{Users: []v1alpha1.UserConfiguration{{Name: "capc"}}},
 	}
 
-	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.Name).Return(prevSpec.Cluster, nil)
-
+	tt.kubectl.EXPECT().GetEksaCluster(tt.ctx, cluster, tt.clusterSpec.Cluster.Name).Return(prevSpec.Cluster, nil)
 	for _, config := range machineConfigs {
-		kubectl.EXPECT().SearchCloudStackMachineConfig(context.TODO(), config.Name, cluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.CloudStackMachineConfig{dummyMachineConfig}, nil).AnyTimes()
+		tt.kubectl.EXPECT().SearchCloudStackMachineConfig(tt.ctx, config.Name, cluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.CloudStackMachineConfig{dummyMachineConfig}, nil).AnyTimes()
 	}
-	mc := []*v1alpha1.CloudStackMachineConfig{dummyMachineConfig}
-	fmt.Println(len(mc))
-	err := provider.validateMachineConfigsNameUniqueness(ctx, cluster, clusterSpec)
-	thenErrorExpected(t, fmt.Sprintf("machineconfig %s already exists", clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name), err)
+	err := tt.provider.validateMachineConfigsNameUniqueness(tt.ctx, cluster, tt.clusterSpec)
+	thenErrorExpected(t, fmt.Sprintf("machineconfig %s already exists", tt.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name), err)
 }
 
 func TestClusterUpgradeNeededNoChanges(t *testing.T) {

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -430,7 +430,7 @@ func (p *vsphereProvider) validateMachineConfigsNameUniqueness(ctx context.Conte
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil && prevSpec.Spec.ExternalEtcdConfiguration != nil {
 		etcdMachineConfigName := clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name
 		if prevSpec.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name != etcdMachineConfigName {
-			em, err := p.providerKubectlClient.SearchVsphereMachineConfig(ctx, etcdMachineConfigName, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Cluster.GetNamespace())
+			em, err := p.providerKubectlClient.SearchVsphereMachineConfig(ctx, etcdMachineConfigName, cluster.KubeconfigFile, clusterSpec.Cluster.GetNamespace())
 			if err != nil {
 				return err
 			}

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -3246,65 +3246,45 @@ func TestClusterSpecChangedMachineConfigsChanged(t *testing.T) {
 }
 
 func TestValidateMachineConfigsNameUniquenessSuccess(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	setupContext(t)
-	ctx := context.Background()
-	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
-	ipValidator := mocks.NewMockIPValidator(mockCtrl)
+	tt := newProviderTest(t)
 	cluster := &types.Cluster{
 		Name: "test",
 	}
-	dcConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
-	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
-	provider := newProviderWithKubectl(t, dcConfig, clusterSpec.Cluster, kubectl, ipValidator)
-
-	prevSpec := clusterSpec.DeepCopy()
+	prevSpec := tt.clusterSpec.DeepCopy()
 	prevSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "prev-test-cp"
 	prevSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name = "prev-test-etcd"
-	kubectl.EXPECT().GetEksaCluster(ctx, cluster, prevSpec.Cluster.Name).Return(prevSpec.Cluster, nil)
-	machineConfigs := clusterSpec.VSphereMachineConfigs
+	tt.kubectl.EXPECT().GetEksaCluster(tt.ctx, cluster, tt.clusterSpec.Cluster.Name).Return(prevSpec.Cluster, nil)
+	machineConfigs := tt.clusterSpec.VSphereMachineConfigs
 	for _, config := range machineConfigs {
-		kubectl.EXPECT().SearchVsphereMachineConfig(context.TODO(), config.Name, cluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.VSphereMachineConfig{}, nil).AnyTimes()
+		tt.kubectl.EXPECT().SearchVsphereMachineConfig(tt.ctx, config.Name, cluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.VSphereMachineConfig{}, nil).AnyTimes()
 	}
 
-	err := provider.validateMachineConfigsNameUniqueness(ctx, cluster, clusterSpec)
+	err := tt.provider.validateMachineConfigsNameUniqueness(tt.ctx, cluster, tt.clusterSpec)
 	if err != nil {
 		t.Fatalf("unexpected failure %v", err)
 	}
 }
 
 func TestValidateMachineConfigsNameUniquenessError(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	setupContext(t)
-	ctx := context.Background()
-	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
-	ipValidator := mocks.NewMockIPValidator(mockCtrl)
+	tt := newProviderTest(t)
 	cluster := &types.Cluster{
 		Name: "test",
 	}
-	dcConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
-	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
-	provider := newProviderWithKubectl(t, dcConfig, clusterSpec.Cluster, kubectl, ipValidator)
-
-	prevSpec := clusterSpec.DeepCopy()
+	prevSpec := tt.clusterSpec.DeepCopy()
 	prevSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "prev-test-cp"
 	prevSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name = "prev-test-etcd"
 	dummyVsphereMachineConfig := &v1alpha1.VSphereMachineConfig{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{},
 		Spec: v1alpha1.VSphereMachineConfigSpec{
 			Users: []v1alpha1.UserConfiguration{{Name: "ec2-user"}},
 		},
-		Status: v1alpha1.VSphereMachineConfigStatus{},
 	}
-	kubectl.EXPECT().GetEksaCluster(ctx, cluster, prevSpec.Cluster.Name).Return(prevSpec.Cluster, nil)
-	machineConfigs := clusterSpec.VSphereMachineConfigs
+	tt.kubectl.EXPECT().GetEksaCluster(tt.ctx, cluster, tt.clusterSpec.Cluster.Name).Return(prevSpec.Cluster, nil)
+	machineConfigs := tt.clusterSpec.VSphereMachineConfigs
 	for _, config := range machineConfigs {
-		kubectl.EXPECT().SearchVsphereMachineConfig(context.TODO(), config.Name, cluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.VSphereMachineConfig{dummyVsphereMachineConfig}, nil).AnyTimes()
+		tt.kubectl.EXPECT().SearchVsphereMachineConfig(tt.ctx, config.Name, cluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.VSphereMachineConfig{dummyVsphereMachineConfig}, nil).AnyTimes()
 	}
-
-	err := provider.validateMachineConfigsNameUniqueness(ctx, cluster, clusterSpec)
-	thenErrorExpected(t, fmt.Sprintf("control plane VSphereMachineConfig %s already exists", clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name), err)
+	err := tt.provider.validateMachineConfigsNameUniqueness(tt.ctx, cluster, tt.clusterSpec)
+	thenErrorExpected(t, fmt.Sprintf("control plane VSphereMachineConfig %s already exists", tt.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name), err)
 }
 
 func TestProviderGenerateCAPISpecForCreateMultipleCredentials(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
#5313 
*Description of changes:*
As the management cluster field is not set, until later in the flow, the `validateMachineConfigNameUniqueness` panics when there is a change in MachineGroupRef.name during the upgrade. 
*Testing (if applicable):*
Tested manually for both management and workload clusters for Vsphere and Cloudstack provider and the CLI does not panic. The upgrade still fails while changing `machineGroupRef.name` during the upgrade. This change just fixes the panic caused during the upgrade while changing `machineGroupRef.name` field. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

