### PR TITLE
Fix e2e test names

### DIFF
--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -236,7 +236,7 @@ func TestTinkerbellKubernetes126BottlerocketWorkloadClusterSimpleFlow(t *testing
 	runTinkerbellWorkloadClusterFlow(test)
 }
 
-func TestTinkerbellKubernetes125BottlerocketWorkloadClusterWithAPI(t *testing.T) {
+func TestTinkerbellKubernetes126BottlerocketWorkloadClusterWithAPI(t *testing.T) {
 	provider := framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell())
 	managementCluster := framework.NewClusterE2ETest(
 		t,
@@ -352,7 +352,7 @@ func TestTinkerbellKubernetes126BottlerocketSingleNodeWorkloadCluster(t *testing
 	runTinkerbellWorkloadClusterFlow(test)
 }
 
-func TestTinkerbellKubernetes125BottlerocketSingleNodeWorkloadClusterWithAPI(t *testing.T) {
+func TestTinkerbellKubernetes126BottlerocketSingleNodeWorkloadClusterWithAPI(t *testing.T) {
 	provider := framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell())
 	managementCluster := framework.NewClusterE2ETest(
 		t,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix e2e test names for 126 e2e tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

