### PR TITLE
Clone default transport to honor http proxy config

### DIFF
--- a/internal/test/http.go
+++ b/internal/test/http.go
@@ -20,3 +20,19 @@ func NewHTTPServerForFile(t *testing.T, filePath string) *httptest.Server {
 	t.Cleanup(func() { ts.Close() })
 	return ts
 }
+
+// NewHTTPSServerForFile creates an HTTPS server that always serves the content of the
+// given file.
+func NewHTTPSServerForFile(t *testing.T, filePath string) *httptest.Server {
+	fileContent, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed reading file [%s] to serve from http: %s", filePath, err)
+	}
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write(fileContent); err != nil {
+			t.Errorf("Failed writing response to http request: %s", err)
+		}
+	}))
+	t.Cleanup(func() { ts.Close() })
+	return ts
+}

--- a/pkg/files/reader_test.go
+++ b/pkg/files/reader_test.go
@@ -1,8 +1,16 @@
 package files_test
 
 import (
+	"crypto/x509"
 	"embed"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -69,5 +77,183 @@ func TestReaderReadFileSuccess(t *testing.T) {
 			g.Expect(err).To(BeNil())
 			test.AssertContentToFile(t, string(got), tt.filePath)
 		})
+	}
+}
+
+func TestReaderReadFileHTTPSSuccess(t *testing.T) {
+	g := NewWithT(t)
+	filePath := "testdata/file.yaml"
+
+	server := test.NewHTTPSServerForFile(t, filePath)
+	uri := server.URL + "/" + filePath
+
+	r := files.NewReader(files.WithRootCACerts(serverCerts(g, server)))
+	got, err := r.ReadFile(uri)
+	g.Expect(err).To(BeNil())
+	test.AssertContentToFile(t, string(got), filePath)
+}
+
+func TestReaderReadFileHTTPSProxySuccess(t *testing.T) {
+	t.Run("prepapre", func(t *testing.T) {
+		g := NewWithT(t)
+		filePath := "testdata/file.yaml"
+
+		server := test.NewHTTPSServerForFile(t, filePath)
+		uri := server.URL + "/" + filePath
+
+		r := files.NewReader(files.WithRootCACerts(serverCerts(g, server)))
+		got, err := r.ReadFile(uri)
+		g.Expect(err).To(BeNil())
+		test.AssertContentToFile(t, string(got), filePath)
+	})
+
+	g := NewWithT(t)
+	filePath := "testdata/file.yaml"
+	// It's important to use example.com because the certificate created for
+	// the TLS server is only valid for this domain and 127.0.0.1.
+	fakeServerHost := "example.com:443"
+	fileURL := "https://" + fakeServerHost + "/" + filePath
+
+	server := test.NewHTTPSServerForFile(t, filePath)
+	serverHost := serverHost(g, server)
+	// We need to use the proxy server to do a host "swapping".
+	// The test server created by NewHTTPSServerForFile will be listening in
+	// 127.0.0.1. However, the Go documentation for the transport.Proxy states that:
+	// > if req.URL.Host is "localhost" or a loopback address (with or without
+	// > a port number), then a nil URL and nil error will be returned.
+	// https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config.ProxyFunc
+	// Which means that it will never honor the HTTPS_PROXY env var since our
+	// request will be pointing to a loopback address.
+	// In order to make it work, we pass example.com in our request and use the
+	// roxy to map this domain to 127.0.0.1, where our file server is listening.
+	hostMappings := map[string]string{fakeServerHost: serverHost}
+	proxy := newProxyServer(t, hostMappings)
+
+	t.Setenv("HTTPS_PROXY", proxy.URL)
+
+	r := files.NewReader(
+		files.WithRootCACerts(serverCerts(g, server)),
+		files.WithNonCachedProxyConfig(),
+	)
+
+	got, err := r.ReadFile(fileURL)
+	g.Expect(err).To(BeNil())
+	test.AssertContentToFile(t, string(got), filePath)
+
+	g.Expect(proxy.countForHost(serverHost)).To(
+		Equal(1), "Host %s should have been proxied exactly once", serverHost,
+	)
+}
+
+func serverCerts(g Gomega, server *httptest.Server) []*x509.Certificate {
+	certs := []*x509.Certificate{}
+	for _, c := range server.TLS.Certificates {
+		roots, err := x509.ParseCertificates(c.Certificate[len(c.Certificate)-1])
+		g.Expect(err).NotTo(HaveOccurred())
+		certs = append(certs, roots...)
+	}
+
+	return certs
+}
+
+func serverHost(g Gomega, server *httptest.Server) string {
+	u, err := url.Parse(server.URL)
+	g.Expect(err).NotTo(HaveOccurred())
+	return u.Host
+}
+
+type proxyServer struct {
+	*httptest.Server
+	*proxy
+}
+
+func newProxyServer(tb testing.TB, hostMappings map[string]string) *proxyServer {
+	proxyServer := &proxyServer{
+		proxy: newProxy(hostMappings),
+	}
+	proxyServer.Server = httptest.NewServer(http.HandlerFunc(proxyServer.handleProxy))
+
+	tb.Cleanup(func() {
+		proxyServer.Close()
+	})
+
+	return proxyServer
+}
+
+type proxy struct {
+	sync.Mutex
+	// proxied maitains a count of how many proxied requests\
+	// have been completed per host.
+	proxied map[string]int
+	// hostMappings allows to map the dst host in the CONNECT
+	// request to a different host.
+	hostMappings map[string]string
+}
+
+func newProxy(hostMappings map[string]string) *proxy {
+	return &proxy{
+		proxied:      map[string]int{},
+		hostMappings: hostMappings,
+	}
+}
+
+func (p *proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodConnect {
+		p.tunnelConnection(w, r)
+	} else {
+		http.Error(w, "Only supports CONNECT", http.StatusMethodNotAllowed)
+	}
+}
+
+func (p *proxy) tunnelConnection(w http.ResponseWriter, r *http.Request) {
+	host := r.Host
+	if mappedDstHost, ok := p.hostMappings[host]; ok {
+		host = mappedDstHost
+	}
+	destConn, err := net.DialTimeout("tcp", host, 2*time.Second)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+
+	h, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "Hijacking is not supported", http.StatusInternalServerError)
+		return
+	}
+
+	clientConn, _, err := h.Hijack()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+	}
+
+	p.countRequest(host)
+
+	go pipe(w, destConn, clientConn)
+	go pipe(w, clientConn, destConn)
+}
+
+// countRequest increases the proxied counter for the given host.
+func (p *proxy) countRequest(host string) {
+	p.Lock()
+	defer p.Unlock()
+
+	p.proxied[host] = p.proxied[host] + 1
+}
+
+// countForHost returns the number of time a particular host has been proxied.
+func (p *proxy) countForHost(host string) int {
+	p.Lock()
+	defer p.Unlock()
+
+	return p.proxied[host]
+}
+
+func pipe(w http.ResponseWriter, destination io.WriteCloser, source io.ReadCloser) {
+	defer destination.Close()
+	defer source.Close()
+	if _, err := io.Copy(destination, source); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }


### PR DESCRIPTION
*Description of changes:*
We need to preserve some of the defaults in the default transport. In particular Proxy, which is set to http.ProxyFromEnvironment. This will make the client honor the HTTP_PROXY, HTTPS_PROXY and NO_PROXY env variables.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

