### PR TITLE
Kubernetes version skew check for cluster webhook

### DIFF
--- a/pkg/api/v1alpha1/versionskew.go
+++ b/pkg/api/v1alpha1/versionskew.go
@@ -1,0 +1,28 @@
+package v1alpha1
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/version"
+)
+
+// SupportedMinorVersionIncrement represents the minor version skew for kubernetes version upgrades.
+const SupportedMinorVersionIncrement = 1
+
+// ValidateVersionSkew validates Kubernetes version skew between valid non-nil versions.
+func ValidateVersionSkew(oldVersion, newVersion *version.Version) error {
+	if newVersion.LessThan(oldVersion) {
+		return fmt.Errorf("kubernetes version downgrade is not supported (%s) -> (%s)", oldVersion, newVersion)
+	}
+
+	newVersionMinor := newVersion.Minor()
+	oldVersionMinor := oldVersion.Minor()
+
+	minorVersionDifference := int(newVersionMinor) - int(oldVersionMinor)
+
+	if minorVersionDifference < 0 || minorVersionDifference > SupportedMinorVersionIncrement {
+		return fmt.Errorf("only +%d minor version skew is supported, minor version skew detected %v", SupportedMinorVersionIncrement, minorVersionDifference)
+	}
+
+	return nil
+}

--- a/pkg/api/v1alpha1/versionskew_test.go
+++ b/pkg/api/v1alpha1/versionskew_test.go
@@ -1,0 +1,57 @@
+package v1alpha1_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/version"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+func TestValidateVersionSkew(t *testing.T) {
+	v122, _ := version.ParseGeneric(string(v1alpha1.Kube122))
+	v123, _ := version.ParseGeneric(string(v1alpha1.Kube123))
+	v124, _ := version.ParseGeneric(string(v1alpha1.Kube124))
+
+	tests := []struct {
+		name       string
+		oldVersion *version.Version
+		newVersion *version.Version
+		wantErr    error
+	}{
+		{
+			name:       "No upgrade",
+			oldVersion: v122,
+			newVersion: v122,
+			wantErr:    nil,
+		},
+		{
+			name:       "Minor version increment success",
+			oldVersion: v122,
+			newVersion: v123,
+			wantErr:    nil,
+		},
+		{
+			name:       "Minor version invalid, failure",
+			oldVersion: v122,
+			newVersion: v124,
+			wantErr:    fmt.Errorf("only +%d minor version skew is supported, minor version skew detected 2", v1alpha1.SupportedMinorVersionIncrement),
+		},
+		{
+			name:       "Minor version downgrade, failure",
+			oldVersion: v124,
+			newVersion: v123,
+			wantErr:    fmt.Errorf("kubernetes version downgrade is not supported (%s) -> (%s)", v124, v123),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v1alpha1.ValidateVersionSkew(tt.oldVersion, tt.newVersion)
+			if err != nil && !reflect.DeepEqual(err.Error(), tt.wantErr.Error()) {
+				t.Errorf("ValidateVersionSkew() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/validations/upgradevalidations/cluster_test.go
+++ b/pkg/validations/upgradevalidations/cluster_test.go
@@ -13,11 +13,17 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/upgradevalidations"
 )
 
 const testclustername string = "testcluster"
+
+type UnAuthKubectlClient struct {
+	*executables.Kubectl
+	*kubernetes.UnAuthClient
+}
 
 func TestValidateClusterPresent(t *testing.T) {
 	tests := []struct {

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -74,7 +74,7 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 			return &validations.ValidationResult{
 				Name:        "upgrade cluster kubernetes version increment",
 				Remediation: "ensure that the cluster kubernetes version is incremented by one minor version exactly (e.g. 1.18 -> 1.19)",
-				Err:         ValidateServerVersionSkew(ctx, u.Opts.Spec.Cluster.Spec.KubernetesVersion, u.Opts.WorkloadCluster, k),
+				Err:         ValidateServerVersionSkew(ctx, u.Opts.Spec.Cluster, u.Opts.WorkloadCluster, u.Opts.ManagementCluster, k),
 			}
 		},
 		func() *validations.ValidationResult {

--- a/pkg/validations/upgradevalidations/versions_test.go
+++ b/pkg/validations/upgradevalidations/versions_test.go
@@ -1,68 +1,128 @@
 package upgradevalidations_test
 
 import (
-	"bytes"
-	"errors"
-	"reflect"
+	"context"
+	"fmt"
+	"strings"
 	"testing"
 
-	"github.com/aws/eks-anywhere/internal/test"
-	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
-	"github.com/aws/eks-anywhere/pkg/executables"
-	"github.com/aws/eks-anywhere/pkg/validations"
+	"github.com/golang/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
+	"github.com/aws/eks-anywhere/pkg/validations/mocks"
 	"github.com/aws/eks-anywhere/pkg/validations/upgradevalidations"
 )
 
-type UnAuthKubectlClient struct {
-	*executables.Kubectl
-	*kubernetes.UnAuthClient
-}
-
 func TestValidateVersionSkew(t *testing.T) {
 	tests := []struct {
-		name                  string
-		wantErr               error
-		upgradeVersion        v1alpha1.KubernetesVersion
-		serverVersionResponse string
+		name           string
+		wantErr        error
+		upgradeVersion anywherev1.KubernetesVersion
+		oldVersion     anywherev1.KubernetesVersion
 	}{
 		{
-			name:                  "FailureTwoMinorVersions",
-			wantErr:               errors.New("WARNING: version difference between upgrade version (1.20) and server version (1.18) do not meet the supported version increment of +1"),
-			upgradeVersion:        v1alpha1.Kube120,
-			serverVersionResponse: "testdata/kubectl_version_server_118.json",
+			name:           "FailureTwoMinorVersions",
+			wantErr:        fmt.Errorf("only +1 minor version skew is supported"),
+			upgradeVersion: anywherev1.Kube120,
+			oldVersion:     anywherev1.Kube118,
 		},
 		{
-			name:                  "FailureMinusOneMinorVersion",
-			wantErr:               errors.New("WARNING: version difference between upgrade version (1.19) and server version (1.20) do not meet the supported version increment of +1"),
-			upgradeVersion:        v1alpha1.Kube119,
-			serverVersionResponse: "testdata/kubectl_version_server_120.json",
+			name:           "FailureMinusOneMinorVersion",
+			wantErr:        fmt.Errorf("kubernetes version downgrade is not supported (%s) -> (%s)", anywherev1.Kube120, anywherev1.Kube119),
+			upgradeVersion: anywherev1.Kube119,
+			oldVersion:     anywherev1.Kube120,
 		},
 		{
-			name:                  "SuccessSameVersion",
-			wantErr:               nil,
-			upgradeVersion:        v1alpha1.Kube119,
-			serverVersionResponse: "testdata/kubectl_version_server_119.json",
+			name:           "SuccessSameVersion",
+			wantErr:        nil,
+			upgradeVersion: anywherev1.Kube119,
+			oldVersion:     anywherev1.Kube119,
 		},
 		{
-			name:                  "SuccessOneMinorVersion",
-			wantErr:               nil,
-			upgradeVersion:        v1alpha1.Kube120,
-			serverVersionResponse: "testdata/kubectl_version_server_119.json",
+			name:           "SuccessOneMinorVersion",
+			wantErr:        nil,
+			upgradeVersion: anywherev1.Kube120,
+			oldVersion:     anywherev1.Kube119,
 		},
 	}
 
-	k, ctx, cluster, e := validations.NewKubectl(t)
-	uk := kubernetes.NewUnAuthClient(k)
+	mockCtrl := gomock.NewController(t)
+	k := mocks.NewMockKubectlClient(mockCtrl)
+	ctx := context.Background()
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(tt *testing.T) {
-			fileContent := test.ReadFile(t, tc.serverVersionResponse)
-			e.EXPECT().Execute(ctx, []string{"version", "-o", "json", "--kubeconfig", cluster.KubeconfigFile}).Return(*bytes.NewBufferString(fileContent), nil)
-			err := upgradevalidations.ValidateServerVersionSkew(ctx, tc.upgradeVersion, cluster, UnAuthKubectlClient{k, uk})
-			if !reflect.DeepEqual(err, tc.wantErr) {
+			newCluster := baseCluster()
+			newCluster.Spec.KubernetesVersion = tc.upgradeVersion
+
+			oldCluster := baseCluster()
+			oldCluster.Spec.KubernetesVersion = tc.oldVersion
+
+			cluster := &types.Cluster{KubeconfigFile: "test.kubeconfig"}
+
+			k.EXPECT().GetEksaCluster(ctx, cluster, newCluster.Name).Return(oldCluster, nil)
+
+			err := upgradevalidations.ValidateServerVersionSkew(ctx, newCluster, cluster, cluster, k)
+			if err != nil && !strings.Contains(err.Error(), tc.wantErr.Error()) {
 				t.Errorf("%v got = %v, \nwant %v", tc.name, err, tc.wantErr)
 			}
 		})
 	}
+}
+
+func baseCluster() *anywherev1.Cluster {
+	c := &anywherev1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       anywherev1.ClusterKind,
+			APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mgmt",
+		},
+		Spec: anywherev1.ClusterSpec{
+			KubernetesVersion: anywherev1.Kube121,
+			ControlPlaneConfiguration: anywherev1.ControlPlaneConfiguration{
+				Count: 3,
+				Endpoint: &anywherev1.Endpoint{
+					Host: "1.1.1.1",
+				},
+				MachineGroupRef: &anywherev1.Ref{
+					Kind: anywherev1.VSphereMachineConfigKind,
+					Name: "eksa-unit-test",
+				},
+			},
+			BundlesRef: &anywherev1.BundlesRef{
+				Name:       "bundles-1",
+				Namespace:  constants.EksaSystemNamespace,
+				APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+			},
+			WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{{
+				Name:  "md-0",
+				Count: ptr.Int(1),
+				MachineGroupRef: &anywherev1.Ref{
+					Kind: anywherev1.VSphereMachineConfigKind,
+					Name: "eksa-unit-test",
+				},
+			}},
+			ClusterNetwork: anywherev1.ClusterNetwork{
+				CNIConfig: &anywherev1.CNIConfig{Cilium: &anywherev1.CiliumConfig{}},
+				Pods: anywherev1.Pods{
+					CidrBlocks: []string{"192.168.0.0/16"},
+				},
+				Services: anywherev1.Services{
+					CidrBlocks: []string{"10.96.0.0/12"},
+				},
+			},
+			DatacenterRef: anywherev1.Ref{
+				Kind: anywherev1.VSphereDatacenterKind,
+				Name: "eksa-unit-test",
+			},
+		},
+	}
+
+	return c
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/1252

*Description of changes:*
Kubernetes version skew check for cluster webhook. This validation is a part of our cli validations, including it for the controller as well.

*Testing (if applicable):*
- unit tests
- Controller validations for docker
```
mpaygude@bcd0746652e3 eks-anywhere-1 % k apply -f docker-w1.yaml
dockerdatacenterconfig.anywhere.eks.amazonaws.com/docker124-w1 unchanged
The Cluster "docker124-w1" is invalid: spec: Invalid value: "1.26": only 1 minor version skew is supported
mpaygude@bcd0746652e3 eks-anywhere-1 % k apply -f docker-w1.yaml
dockerdatacenterconfig.anywhere.eks.amazonaws.com/docker124-w1 unchanged
The Cluster "docker124-w1" is invalid: spec: Invalid value: "2.26": major version upgrades are not supported
mpaygude@bcd0746652e3 eks-anywhere-1 % k apply -f docker-w1.yaml
dockerdatacenterconfig.anywhere.eks.amazonaws.com/docker124-w1 unchanged
The Cluster "docker124-w1" is invalid: spec: Invalid value: "1.23": minor version downgrade is not supported. Upgrades should meet the supported version increment of +1
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

