### PR TITLE
Skippackageinstallation

### DIFF
--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -46,6 +46,10 @@ func NewInstaller(runner KubectlRunner, pc PackageHandler, pcc PackageController
 
 // InstallCuratedPackages installs curated packages as part of the cluster creation.
 func (pi *Installer) InstallCuratedPackages(ctx context.Context) {
+	if IsPackageControllerDisabled(pi.spec.Cluster) {
+		logger.Info("  Package controller disabled")
+		return
+	}
 	PrintLicense()
 	err := pi.installPackagesController(ctx)
 	// There is an ask from customers to avoid considering the failure of installing curated packages
@@ -65,10 +69,6 @@ func (pi *Installer) InstallCuratedPackages(ctx context.Context) {
 
 func (pi *Installer) installPackagesController(ctx context.Context) error {
 	logger.Info("Enabling curated packages on the cluster")
-	if IsPackageControllerDisabled(pi.spec.Cluster) {
-		logger.Info("  Package controller disabled")
-		return nil
-	}
 	err := pi.packageController.Enable(ctx)
 	if err != nil {
 		return err

--- a/pkg/curatedpackages/packageinstaller_test.go
+++ b/pkg/curatedpackages/packageinstaller_test.go
@@ -100,8 +100,6 @@ func TestPackageInstallerDisabled(t *testing.T) {
 		Disable: true,
 	}
 
-	tt.packageClient.EXPECT().CreatePackages(tt.ctx, tt.packagePath, tt.kubeConfigPath).Return(nil)
-
 	tt.command.InstallCuratedPackages(tt.ctx)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Skip package installation when controller is disabled in cluster spec.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

