### PR TITLE
Remove apt commands and iscsid initiation from Nutanix control plane kubeadmconfig

### DIFF
--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -237,10 +237,6 @@ spec:
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >> /etc/hosts
-      # This section should be removed once these packages are added to the image builder process
-      - apt update
-      - apt install -y nfs-common open-iscsi
-      - systemctl enable --now iscsid
     postKubeadmCommands:
       - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
     useExperimentalRetryJoin: true

--- a/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
@@ -170,10 +170,6 @@ spec:
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
-      # This section should be removed once these packages are added to the image builder process
-      - apt update
-      - apt install -y nfs-common open-iscsi
-      - systemctl enable --now iscsid
     postKubeadmCommands:
       - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
     useExperimentalRetryJoin: true

--- a/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
@@ -163,10 +163,6 @@ spec:
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
-      # This section should be removed once these packages are added to the image builder process
-      - apt update
-      - apt install -y nfs-common open-iscsi
-      - systemctl enable --now iscsid
     postKubeadmCommands:
       - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
     useExperimentalRetryJoin: true

--- a/pkg/providers/nutanix/testdata/expected_results_project.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_project.yaml
@@ -160,10 +160,6 @@ spec:
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
-      # This section should be removed once these packages are added to the image builder process
-      - apt update
-      - apt install -y nfs-common open-iscsi
-      - systemctl enable --now iscsid
     postKubeadmCommands:
       - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
     useExperimentalRetryJoin: true

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
@@ -199,10 +199,6 @@ spec:
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
-      # This section should be removed once these packages are added to the image builder process
-      - apt update
-      - apt install -y nfs-common open-iscsi
-      - systemctl enable --now iscsid
     postKubeadmCommands:
       - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
     useExperimentalRetryJoin: true


### PR DESCRIPTION
These were initially introduced through [eks-anywhere#4111](https://github.com/aws/eks-anywhere/pull/4111) and were intended to be a temporary fix until the nutanix imagebuilder changes were merged upstream in [image-builder#1046](https://github.com/kubernetes-sigs/image-builder/pull/1046).

