### PR TITLE
Added Cloudstack IPValidator for lifecycle api

### DIFF
--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -415,7 +415,10 @@ func (f *Factory) withCloudStackClusterReconciler() *Factory {
 			return nil
 		}
 
-		f.cloudstackClusterReconciler = cloudstackreconciler.New()
+		f.cloudstackClusterReconciler = cloudstackreconciler.New(
+			f.manager.GetClient(),
+			f.ipValidator,
+		)
 		f.registryBuilder.Add(anywherev1.CloudStackDatacenterKind, f.cloudstackClusterReconciler)
 
 		return nil

--- a/pkg/providers/cloudstack/reconciler/mocks/reconciler.go
+++ b/pkg/providers/cloudstack/reconciler/mocks/reconciler.go
@@ -3,3 +3,51 @@
 
 // Package mocks is a generated GoMock package.
 package mocks
+
+import (
+	context "context"
+	reflect "reflect"
+
+	cluster "github.com/aws/eks-anywhere/pkg/cluster"
+	controller "github.com/aws/eks-anywhere/pkg/controller"
+	logr "github.com/go-logr/logr"
+	gomock "github.com/golang/mock/gomock"
+)
+
+// MockIPValidator is a mock of IPValidator interface.
+type MockIPValidator struct {
+	ctrl     *gomock.Controller
+	recorder *MockIPValidatorMockRecorder
+}
+
+// MockIPValidatorMockRecorder is the mock recorder for MockIPValidator.
+type MockIPValidatorMockRecorder struct {
+	mock *MockIPValidator
+}
+
+// NewMockIPValidator creates a new mock instance.
+func NewMockIPValidator(ctrl *gomock.Controller) *MockIPValidator {
+	mock := &MockIPValidator{ctrl: ctrl}
+	mock.recorder = &MockIPValidatorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockIPValidator) EXPECT() *MockIPValidatorMockRecorder {
+	return m.recorder
+}
+
+// ValidateControlPlaneIP mocks base method.
+func (m *MockIPValidator) ValidateControlPlaneIP(ctx context.Context, log logr.Logger, spec *cluster.Spec) (controller.Result, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateControlPlaneIP", ctx, log, spec)
+	ret0, _ := ret[0].(controller.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidateControlPlaneIP indicates an expected call of ValidateControlPlaneIP.
+func (mr *MockIPValidatorMockRecorder) ValidateControlPlaneIP(ctx, log, spec interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateControlPlaneIP", reflect.TypeOf((*MockIPValidator)(nil).ValidateControlPlaneIP), ctx, log, spec)
+}

--- a/pkg/providers/cloudstack/reconciler/reconciler_test.go
+++ b/pkg/providers/cloudstack/reconciler/reconciler_test.go
@@ -1,0 +1,246 @@
+package reconciler_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	clusterspec "github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/controller"
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
+	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/reconciler"
+	cloudstackreconcilermocks "github.com/aws/eks-anywhere/pkg/providers/cloudstack/reconciler/mocks"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
+)
+
+const (
+	clusterNamespace = "test-namespace"
+)
+
+func TestReconcilerReconcileSuccess(t *testing.T) {
+	tt := newReconcilerTest(t)
+
+	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
+		c.Name = tt.cluster.Name
+	})
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, capiCluster)
+	tt.withFakeClient()
+
+	logger := test.NewNullLogger()
+
+	tt.ipValidator.EXPECT().ValidateControlPlaneIP(tt.ctx, logger, tt.buildSpec()).Return(controller.Result{}, nil)
+
+	result, err := tt.reconciler().Reconcile(tt.ctx, logger, tt.cluster)
+
+	tt.Expect(err).NotTo(HaveOccurred())
+	tt.Expect(result).To(Equal(controller.Result{}))
+}
+
+func (tt *reconcilerTest) withFakeClient() {
+	tt.client = fake.NewClientBuilder().WithObjects(clientutil.ObjectsToClientObjects(tt.allObjs())...).Build()
+}
+
+func (tt *reconcilerTest) allObjs() []client.Object {
+	objs := make([]client.Object, 0, len(tt.eksaSupportObjs)+3)
+	objs = append(objs, tt.eksaSupportObjs...)
+	objs = append(objs, tt.cluster, tt.machineConfigControlPlane, tt.machineConfigWorker)
+
+	return objs
+}
+
+func (tt *reconcilerTest) reconciler() *reconciler.Reconciler {
+	return reconciler.New(tt.client, tt.ipValidator)
+}
+
+func (tt *reconcilerTest) buildSpec() *clusterspec.Spec {
+	tt.t.Helper()
+	spec, err := clusterspec.BuildSpec(tt.ctx, clientutil.NewKubeClient(tt.client), tt.cluster)
+	tt.Expect(err).NotTo(HaveOccurred())
+
+	return spec
+}
+
+type reconcilerTest struct {
+	t testing.TB
+	*WithT
+	ctx                       context.Context
+	cluster                   *anywherev1.Cluster
+	client                    client.Client
+	eksaSupportObjs           []client.Object
+	datacenterConfig          *anywherev1.CloudStackDatacenterConfig
+	machineConfigControlPlane *anywherev1.CloudStackMachineConfig
+	machineConfigWorker       *anywherev1.CloudStackMachineConfig
+	ipValidator               *cloudstackreconcilermocks.MockIPValidator
+}
+
+func newReconcilerTest(t testing.TB) *reconcilerTest {
+	ctrl := gomock.NewController(t)
+	c := env.Client()
+
+	ipValidator := cloudstackreconcilermocks.NewMockIPValidator(ctrl)
+
+	bundle := test.Bundle()
+
+	managementCluster := cloudstackCluster(func(c *anywherev1.Cluster) {
+		c.Name = "management-cluster"
+		c.Spec.ManagementCluster = anywherev1.ManagementCluster{
+			Name: c.Name,
+		}
+		c.Spec.BundlesRef = &anywherev1.BundlesRef{
+			Name:       bundle.Name,
+			Namespace:  bundle.Namespace,
+			APIVersion: bundle.APIVersion,
+		}
+	})
+
+	machineConfigCP := machineConfig(func(m *anywherev1.CloudStackMachineConfig) {
+		m.Name = "cp-machine-config"
+	})
+	machineConfigWN := machineConfig(func(m *anywherev1.CloudStackMachineConfig) {
+		m.Name = "worker-machine-config"
+	})
+
+	workloadClusterDatacenter := dataCenter(func(d *anywherev1.CloudStackDatacenterConfig) {})
+
+	cluster := cloudstackCluster(func(c *anywherev1.Cluster) {
+		c.Name = "workload-cluster"
+		c.Spec.ManagementCluster = anywherev1.ManagementCluster{
+			Name: managementCluster.Name,
+		}
+		c.Spec.BundlesRef = &anywherev1.BundlesRef{
+			Name:       bundle.Name,
+			Namespace:  bundle.Namespace,
+			APIVersion: bundle.APIVersion,
+		}
+		c.Spec.ControlPlaneConfiguration = anywherev1.ControlPlaneConfiguration{
+			Count: 1,
+			Endpoint: &anywherev1.Endpoint{
+				Host: "1.1.1.1",
+			},
+			MachineGroupRef: &anywherev1.Ref{
+				Kind: anywherev1.CloudStackMachineConfigKind,
+				Name: machineConfigCP.Name,
+			},
+		}
+		c.Spec.DatacenterRef = anywherev1.Ref{
+			Kind: anywherev1.CloudStackDatacenterKind,
+			Name: workloadClusterDatacenter.Name,
+		}
+
+		c.Spec.WorkerNodeGroupConfigurations = append(c.Spec.WorkerNodeGroupConfigurations,
+			anywherev1.WorkerNodeGroupConfiguration{
+				Count: ptr.Int(1),
+				MachineGroupRef: &anywherev1.Ref{
+					Kind: anywherev1.CloudStackMachineConfigKind,
+					Name: machineConfigWN.Name,
+				},
+				Name:   "md-0",
+				Labels: nil,
+			},
+		)
+	})
+
+	tt := &reconcilerTest{
+		t:           t,
+		WithT:       NewWithT(t),
+		ctx:         context.Background(),
+		ipValidator: ipValidator,
+		client:      c,
+		eksaSupportObjs: []client.Object{
+			test.Namespace(clusterNamespace),
+			test.Namespace(constants.EksaSystemNamespace),
+			managementCluster,
+			workloadClusterDatacenter,
+			bundle,
+			test.EksdRelease(),
+		},
+		cluster:                   cluster,
+		datacenterConfig:          workloadClusterDatacenter,
+		machineConfigControlPlane: machineConfigCP,
+		machineConfigWorker:       machineConfigWN,
+	}
+
+	return tt
+}
+
+type clusterOpt func(*anywherev1.Cluster)
+
+func cloudstackCluster(opts ...clusterOpt) *anywherev1.Cluster {
+	c := &anywherev1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       anywherev1.ClusterKind,
+			APIVersion: anywherev1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: clusterNamespace,
+		},
+		Spec: anywherev1.ClusterSpec{
+			KubernetesVersion: "1.22",
+			ClusterNetwork: anywherev1.ClusterNetwork{
+				Pods: anywherev1.Pods{
+					CidrBlocks: []string{"0.0.0.0"},
+				},
+				Services: anywherev1.Services{
+					CidrBlocks: []string{"0.0.0.0"},
+				},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+type datacenterOpt func(config *anywherev1.CloudStackDatacenterConfig)
+
+func dataCenter(opts ...datacenterOpt) *anywherev1.CloudStackDatacenterConfig {
+	d := &anywherev1.CloudStackDatacenterConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       anywherev1.CloudStackDatacenterKind,
+			APIVersion: anywherev1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datacenter",
+			Namespace: clusterNamespace,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	return d
+}
+
+type cloudstackMachineOpt func(config *anywherev1.CloudStackMachineConfig)
+
+func machineConfig(opts ...cloudstackMachineOpt) *anywherev1.CloudStackMachineConfig {
+	m := &anywherev1.CloudStackMachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       anywherev1.CloudStackMachineConfigKind,
+			APIVersion: anywherev1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: clusterNamespace,
+		},
+		Spec: anywherev1.CloudStackMachineConfigSpec{},
+	}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	return m
+}


### PR DESCRIPTION
*Issue #, if available:*
[976](https://github.com/aws/eks-anywhere-internal/issues/976)

*Description of changes:*
Adding IPValidator interface for full lifecycle api reconciler

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

