### PR TITLE
Redact authenticated registry mirror creds

### DIFF
--- a/pkg/executables/executables.go
+++ b/pkg/executables/executables.go
@@ -35,6 +35,8 @@ var redactedEnvKeys = []string{
 	constants.SnowCertsKey,
 	constants.NutanixUsernameKey,
 	constants.NutanixPasswordKey,
+	constants.RegistryUsername,
+	constants.RegistryPassword,
 }
 
 type executable struct {
@@ -86,7 +88,9 @@ func (e *executable) Close(ctx context.Context) error {
 func RedactCreds(cmd string, envMap map[string]string) string {
 	redactedEnvs := []string{}
 	for _, redactedEnvKey := range redactedEnvKeys {
-		if env, found := envMap[redactedEnvKey]; found {
+		if env, found := os.LookupEnv(redactedEnvKey); found {
+			redactedEnvs = append(redactedEnvs, env)
+		} else if env, found := envMap[redactedEnvKey]; found {
 			redactedEnvs = append(redactedEnvs, env)
 		}
 	}

--- a/pkg/executables/executables_test.go
+++ b/pkg/executables/executables_test.go
@@ -9,7 +9,9 @@ import (
 
 func TestRedactCreds(t *testing.T) {
 	str := "My username is username123. My password is password456"
-	envMap := map[string]string{"var": "value", constants.VSphereUsernameKey: "username123", constants.VSpherePasswordKey: "password456"}
+	t.Setenv(constants.VSphereUsernameKey, "username123")
+	envMap := map[string]string{"var": "value", constants.VSpherePasswordKey: "password456"}
+
 	expected := "My username is *****. My password is *****"
 
 	redactedStr := executables.RedactCreds(str, envMap)


### PR DESCRIPTION
*Issue #, if available:*
#5143 
Redact authenticated registry mirror username and password from CLI logs and support bundle

*Description of changes:*
With this PR, when we use authenticated registry mirror, username and password will not be displayed on eksa-cli log and support bundle. 

*Testing (if applicable):*
`{"L":"V6","T":"2023-04-05T18:50:10.254Z","M":"Executing command","cmd":"/usr/bin/docker login x.x.x.x:443 --username ***** --password-stdin"}`

`2023-04-05T18:34:32.005Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i -e HELM_EXPERIMENTAL_OCI=1 -e HTTPS_PROXY= -e HTTP_PROXY= -e NO_PROXY= eksa_1680719601281607613 helm registry login x.x.x.x:443 --username ***** --password ***** --insecure"}`

`2023-04-05T18:35:17.183Z	V6	Executing command	{"cmd": "/usr/bin/docker run -d -i -v /home/test.kubeconfig:/kubeconfig --network host -e PUBLIC_IP=x.x.x.x -e PUBLIC_SYSLOG_IP=x.x.x.x -e BOOTS_KUBE_NAMESPACE=eksa-system -e REGISTRY_USERNAME=***** -e REGISTRY_PASSWORD=***** -e BOOTS_EXTRA_KERNEL_ARGS=tink_worker_image=x.x.x.x:443/l0g8r8j6/tinkerbell/tink/tink-worker:v0.8.0-eks-a-v0.0.0-dev-build.5819 insecure_registries=x.x.x.x:443 -e DATA_MODEL_VERSION=kubernetes -e TINKERBELL_TLS=false -e TINKERBELL_GRPC_AUTHORITY=x.x.x.x:42113 --name boots x.x.x.x:443/l0g8r8j6/tinkerbell/boots:v0.8.1-eks-a-v0.0.0-dev-build.5732 -kubeconfig /kubeconfig -dhcp-addr 0.0.0.0:67 -osie-path-override http://x.x.x.x:8000"}`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

