### PR TITLE
Fix default EKS-A release manifest URL in Makefile

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -144,7 +144,7 @@ eks-a-release: build ## Perform EKS-A CLI release
 github-bundle-release:
 	scripts/github-bundle-release.sh $(REPO_ROOT)/release/downloaded-artifacts $(WEEKLY_RELEASES_URL_PREFIX)
 
-announce-eks-a-release: EKSA_RELEASE_MANIFEST_URL?=https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml"
+announce-eks-a-release: EKSA_RELEASE_MANIFEST_URL?=https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml
 announce-eks-a-release:
 	scripts/announce_eksa_release.sh $(EKSA_RELEASE_MANIFEST_URL)
 


### PR DESCRIPTION
Removing rogue double quote.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

