### PR TITLE
Cloudstack reconciler cni

### DIFF
--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -418,6 +418,8 @@ func (f *Factory) withCloudStackClusterReconciler() *Factory {
 		f.cloudstackClusterReconciler = cloudstackreconciler.New(
 			f.manager.GetClient(),
 			f.ipValidator,
+			f.cniReconciler,
+			f.tracker,
 		)
 		f.registryBuilder.Add(anywherev1.CloudStackDatacenterKind, f.cloudstackClusterReconciler)
 

--- a/pkg/providers/cloudstack/reconciler/mocks/reconciler.go
+++ b/pkg/providers/cloudstack/reconciler/mocks/reconciler.go
@@ -12,6 +12,7 @@ import (
 	controller "github.com/aws/eks-anywhere/pkg/controller"
 	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // MockIPValidator is a mock of IPValidator interface.
@@ -50,4 +51,80 @@ func (m *MockIPValidator) ValidateControlPlaneIP(ctx context.Context, log logr.L
 func (mr *MockIPValidatorMockRecorder) ValidateControlPlaneIP(ctx, log, spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateControlPlaneIP", reflect.TypeOf((*MockIPValidator)(nil).ValidateControlPlaneIP), ctx, log, spec)
+}
+
+// MockCNIReconciler is a mock of CNIReconciler interface.
+type MockCNIReconciler struct {
+	ctrl     *gomock.Controller
+	recorder *MockCNIReconcilerMockRecorder
+}
+
+// MockCNIReconcilerMockRecorder is the mock recorder for MockCNIReconciler.
+type MockCNIReconcilerMockRecorder struct {
+	mock *MockCNIReconciler
+}
+
+// NewMockCNIReconciler creates a new mock instance.
+func NewMockCNIReconciler(ctrl *gomock.Controller) *MockCNIReconciler {
+	mock := &MockCNIReconciler{ctrl: ctrl}
+	mock.recorder = &MockCNIReconcilerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockCNIReconciler) EXPECT() *MockCNIReconcilerMockRecorder {
+	return m.recorder
+}
+
+// Reconcile mocks base method.
+func (m *MockCNIReconciler) Reconcile(ctx context.Context, logger logr.Logger, client client.Client, spec *cluster.Spec) (controller.Result, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Reconcile", ctx, logger, client, spec)
+	ret0, _ := ret[0].(controller.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Reconcile indicates an expected call of Reconcile.
+func (mr *MockCNIReconcilerMockRecorder) Reconcile(ctx, logger, client, spec interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockCNIReconciler)(nil).Reconcile), ctx, logger, client, spec)
+}
+
+// MockRemoteClientRegistry is a mock of RemoteClientRegistry interface.
+type MockRemoteClientRegistry struct {
+	ctrl     *gomock.Controller
+	recorder *MockRemoteClientRegistryMockRecorder
+}
+
+// MockRemoteClientRegistryMockRecorder is the mock recorder for MockRemoteClientRegistry.
+type MockRemoteClientRegistryMockRecorder struct {
+	mock *MockRemoteClientRegistry
+}
+
+// NewMockRemoteClientRegistry creates a new mock instance.
+func NewMockRemoteClientRegistry(ctrl *gomock.Controller) *MockRemoteClientRegistry {
+	mock := &MockRemoteClientRegistry{ctrl: ctrl}
+	mock.recorder = &MockRemoteClientRegistryMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRemoteClientRegistry) EXPECT() *MockRemoteClientRegistryMockRecorder {
+	return m.recorder
+}
+
+// GetClient mocks base method.
+func (m *MockRemoteClientRegistry) GetClient(ctx context.Context, cluster client.ObjectKey) (client.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClient", ctx, cluster)
+	ret0, _ := ret[0].(client.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClient indicates an expected call of GetClient.
+func (mr *MockRemoteClientRegistryMockRecorder) GetClient(ctx, cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClient", reflect.TypeOf((*MockRemoteClientRegistry)(nil).GetClient), ctx, cluster)
 }

--- a/pkg/providers/cloudstack/reconciler/reconciler.go
+++ b/pkg/providers/cloudstack/reconciler/reconciler.go
@@ -17,17 +17,31 @@ type IPValidator interface {
 	ValidateControlPlaneIP(ctx context.Context, log logr.Logger, spec *c.Spec) (controller.Result, error)
 }
 
+// CNIReconciler is an interface for reconciling CNI in the CloudStack cluster reconciler.
+type CNIReconciler interface {
+	Reconcile(ctx context.Context, logger logr.Logger, client client.Client, spec *c.Spec) (controller.Result, error)
+}
+
+// RemoteClientRegistry is an interface that defines methods for remote clients.
+type RemoteClientRegistry interface {
+	GetClient(ctx context.Context, cluster client.ObjectKey) (client.Client, error)
+}
+
 // Reconciler for CloudStack.
 type Reconciler struct {
-	client      client.Client
-	ipValidator IPValidator
+	client               client.Client
+	ipValidator          IPValidator
+	cniReconciler        CNIReconciler
+	remoteClientRegistry RemoteClientRegistry
 }
 
 // New defines a new CloudStack reconciler.
-func New(client client.Client, ipValidator IPValidator) *Reconciler {
+func New(client client.Client, ipValidator IPValidator, cniReconciler CNIReconciler, remoteClientRegistry RemoteClientRegistry) *Reconciler {
 	return &Reconciler{
-		client:      client,
-		ipValidator: ipValidator,
+		client:               client,
+		ipValidator:          ipValidator,
+		cniReconciler:        cniReconciler,
+		remoteClientRegistry: remoteClientRegistry,
 	}
 }
 
@@ -41,6 +55,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, log logr.Logger, cluster *an
 
 	return controller.NewPhaseRunner[*c.Spec]().Register(
 		r.ipValidator.ValidateControlPlaneIP,
+		r.ReconcileCNI,
 	).Run(ctx, log, clusterSpec)
 }
 
@@ -61,7 +76,11 @@ func (r *Reconciler) ReconcileWorkerNodes(ctx context.Context, log logr.Logger, 
 
 // ReconcileCNI reconciles the CNI to the desired state.
 func (r *Reconciler) ReconcileCNI(ctx context.Context, log logr.Logger, clusterSpec *c.Spec) (controller.Result, error) {
-	// Implement reconcile CNI here
+	log = log.WithValues("phase", "reconcileCNI")
+	client, err := r.remoteClientRegistry.GetClient(ctx, controller.CapiClusterObjectKey(clusterSpec.Cluster))
+	if err != nil {
+		return controller.Result{}, err
+	}
 
-	return controller.Result{}, nil
+	return r.cniReconciler.Reconcile(ctx, log, client, clusterSpec)
 }

--- a/pkg/providers/cloudstack/reconciler/reconciler_test.go
+++ b/pkg/providers/cloudstack/reconciler/reconciler_test.go
@@ -2,11 +2,11 @@ package reconciler_test
 
 import (
 	"context"
-	"github.com/pkg/errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
*Issue #, if available:*
[Implement the ProviderClusterReconciler interface: CNI#977](https://github.com/aws/eks-anywhere-internal/issues/977)

*Description of changes:*

*Testing (if applicable):*
unit-test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

