### PR TITLE
adding cloudstack disk offering validation

### DIFF
--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -478,6 +478,10 @@ func (p *cloudstackProvider) SetupAndValidateUpgradeCluster(ctx context.Context,
 		return fmt.Errorf("validating secrets unchanged: %v", err)
 	}
 
+	if err := p.validator.ValidateControlPlaneDiskOfferingUnchanged(ctx, cluster, clusterSpec, p.providerKubectlClient); err != nil {
+		return fmt.Errorf("failed validating control plane disk offering: %v", err)
+	}
+
 	return nil
 }
 

--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -262,7 +262,7 @@ func (v *Validator) ValidateControlPlaneDiskOfferingUnchanged(ctx context.Contex
 		return nil
 	}
 
-	kubeadmControlPlane, err := client.GetKubeadmControlPlane(ctx, cluster, clusterSpec.Cluster.Name, executables.WithCluster(cluster))
+	kubeadmControlPlane, err := client.GetKubeadmControlPlane(ctx, cluster, clusterSpec.Cluster.Name, executables.WithCluster(cluster), executables.WithAllNamespaces())
 	if err != nil {
 		return fmt.Errorf("getting kubeadmControlPlane for cluster %s: %v", clusterSpec.Cluster.Name, err)
 	}

--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -262,7 +262,7 @@ func (v *Validator) ValidateControlPlaneDiskOfferingUnchanged(ctx context.Contex
 		return nil
 	}
 
-	kubeadmControlPlane, err := client.GetKubeadmControlPlane(ctx, cluster, clusterSpec.Cluster.Name, executables.WithCluster(cluster), executables.WithAllNamespaces())
+	kubeadmControlPlane, err := client.GetKubeadmControlPlane(ctx, cluster, clusterSpec.Cluster.Name, executables.WithCluster(cluster), executables.WithNamespace(constants.EksaSystemNamespace))
 	if err != nil {
 		return fmt.Errorf("getting kubeadmControlPlane for cluster %s: %v", clusterSpec.Cluster.Name, err)
 	}

--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -14,6 +14,7 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
@@ -261,7 +262,7 @@ func (v *Validator) ValidateControlPlaneDiskOfferingUnchanged(ctx context.Contex
 		return nil
 	}
 
-	kubeadmControlPlane, err := client.GetKubeadmControlPlane(ctx, cluster, clusterSpec.Cluster.Name)
+	kubeadmControlPlane, err := client.GetKubeadmControlPlane(ctx, cluster, clusterSpec.Cluster.Name, executables.WithCluster(cluster))
 	if err != nil {
 		return fmt.Errorf("getting kubeadmControlPlane for cluster %s: %v", clusterSpec.Cluster.Name, err)
 	}

--- a/pkg/providers/cloudstack/validator_mocks.go
+++ b/pkg/providers/cloudstack/validator_mocks.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	cluster "github.com/aws/eks-anywhere/pkg/cluster"
 	decoder "github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 	types "github.com/aws/eks-anywhere/pkg/types"
 	gomock "github.com/golang/mock/gomock"
@@ -63,6 +64,20 @@ func (m *MockProviderValidator) ValidateClusterMachineConfigs(arg0 context.Conte
 func (mr *MockProviderValidatorMockRecorder) ValidateClusterMachineConfigs(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateClusterMachineConfigs", reflect.TypeOf((*MockProviderValidator)(nil).ValidateClusterMachineConfigs), arg0, arg1)
+}
+
+// ValidateControlPlaneDiskOfferingUnchanged mocks base method.
+func (m *MockProviderValidator) ValidateControlPlaneDiskOfferingUnchanged(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec, arg3 ProviderKubectlClient) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateControlPlaneDiskOfferingUnchanged", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateControlPlaneDiskOfferingUnchanged indicates an expected call of ValidateControlPlaneDiskOfferingUnchanged.
+func (mr *MockProviderValidatorMockRecorder) ValidateControlPlaneDiskOfferingUnchanged(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateControlPlaneDiskOfferingUnchanged", reflect.TypeOf((*MockProviderValidator)(nil).ValidateControlPlaneDiskOfferingUnchanged), arg0, arg1, arg2, arg3)
 }
 
 // ValidateControlPlaneEndpointUniqueness mocks base method.

--- a/pkg/providers/cloudstack/validator_registry.go
+++ b/pkg/providers/cloudstack/validator_registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
@@ -34,6 +35,7 @@ type ProviderValidator interface {
 	ValidateClusterMachineConfigs(ctx context.Context, cloudStackClusterSpec *Spec) error
 	ValidateControlPlaneEndpointUniqueness(endpoint string) error
 	ValidateSecretsUnchanged(ctx context.Context, cluster *types.Cluster, execConfig *decoder.CloudStackExecConfig, client ProviderKubectlClient) error
+	ValidateControlPlaneDiskOfferingUnchanged(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, client ProviderKubectlClient) error
 }
 
 // NewValidatorFactory initializes a factory for the CloudStack provider validator.


### PR DESCRIPTION
*Issue #, if available:*
[5319](https://github.com/aws/eks-anywhere/issues/5319)

*Description of changes:*
Modifying the diskOffering of the control plane cloudstack machine config will cause eksa cluster upgrades to fail because the `kubeadmcontrolplane` disk setup field is immutable. This occurs after bootstrap/kind cluster creation and setup. We would like this to be caught earlier via a preflight validation.

This validation should address the issue in the CLI `eksctl anywhere upgrade cluster` command and be able to be used for cloudstack full lifecycle API. 

Comparing the old and new clusterSpec would only be relevant to CLI and not the lifecycle API. I also do not think we can depend on the relevant machine config being available in the currentClusterSpec.

Comparing the new machine config diskOffering with the current `kubeadmControlPlane` fields can be done in both CLI and lifecycle API. This will tie the comparison to our machineConfig to kubeadmControlPlane template/mapping though.

Implementing a validation webhook to reject diskOffering changes for cloudstackMachineConfig would prevent this issue in lifecycleAPI, but also prevent worker node machine config updates which are allowed currently, unless the validation was context aware.

Currently using the machine config to `kubeadmControlPlane` comparison.

*Testing (if applicable):*
need to add/fix unit tests and test e2e flow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

