### PR TITLE
Fix regauth FLC

### DIFF
--- a/pkg/config/registry.go
+++ b/pkg/config/registry.go
@@ -1,11 +1,19 @@
 package config
 
 import (
-	"errors"
+	"context"
+	"fmt"
 	"os"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/eks-anywhere/pkg/constants"
 )
+
+const registryAuthSecretName = "registry-credentials"
 
 func ReadCredentials() (username, password string, err error) {
 	username, ok := os.LookupEnv(constants.RegistryUsername)
@@ -19,4 +27,32 @@ func ReadCredentials() (username, password string, err error) {
 	}
 
 	return username, password, nil
+}
+
+// ReadCredentialsFromSecret reads from Kubernetes secret registry-credentials.
+// Returns the username and password, or error.
+func ReadCredentialsFromSecret(ctx context.Context, client client.Client) (username, password string, err error) {
+	registryAuthSecret := &corev1.Secret{}
+	key := types.NamespacedName{Name: registryAuthSecretName, Namespace: constants.EksaSystemNamespace}
+	if err := client.Get(ctx, key, registryAuthSecret); err != nil {
+		return "", "", errors.Wrap(err, "fetching registry auth secret")
+	}
+
+	rUsername := registryAuthSecret.Data["username"]
+	rPassword := registryAuthSecret.Data["password"]
+
+	return string(rUsername), string(rPassword), nil
+}
+
+// SetCredentialsEnv sets the registry username and password env variables.
+func SetCredentialsEnv(username, password string) error {
+	if err := os.Setenv(constants.RegistryUsername, username); err != nil {
+		return fmt.Errorf("failed setting env %s: %v", constants.RegistryUsername, err)
+	}
+
+	if err := os.Setenv(constants.RegistryPassword, password); err != nil {
+		return fmt.Errorf("failed setting env %s: %v", constants.RegistryPassword, err)
+	}
+
+	return nil
 }

--- a/pkg/config/registry_test.go
+++ b/pkg/config/registry_test.go
@@ -61,3 +61,13 @@ func TestReadCredentialsFromSecret(t *testing.T) {
 	assert.Equal(t, expectedUser, u)
 	assert.Equal(t, expectedPassword, p)
 }
+
+func TestReadCredentialsFromSecretNotFound(t *testing.T) {
+	ctx := context.Background()
+	cb := fake.NewClientBuilder()
+	cl := cb.Build()
+	u, p, err := ReadCredentialsFromSecret(ctx, cl)
+	assert.ErrorContains(t, err, "fetching registry auth secret")
+	assert.Empty(t, u)
+	assert.Empty(t, p)
+}

--- a/pkg/config/registry_test.go
+++ b/pkg/config/registry_test.go
@@ -1,10 +1,15 @@
 package config
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/aws/eks-anywhere/pkg/constants"
 )
@@ -24,4 +29,35 @@ func TestReadConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedUser, username)
 	assert.Equal(t, expectedPassword, password)
+}
+
+func TestSetCredentialsEnv(t *testing.T) {
+	uName := ""
+	uPass := ""
+	err := SetCredentialsEnv(uName, uPass)
+	assert.NoError(t, err)
+}
+
+func TestReadCredentialsFromSecret(t *testing.T) {
+	ctx := context.Background()
+	expectedUser := "testuser"
+	expectedPassword := "testpass"
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      registryAuthSecretName,
+			Namespace: constants.EksaSystemNamespace,
+		},
+		Data: map[string][]byte{
+			"username": []byte(expectedUser),
+			"password": []byte(expectedPassword),
+		},
+	}
+
+	objs := []runtime.Object{sec}
+	cb := fake.NewClientBuilder()
+	cl := cb.WithRuntimeObjects(objs...).Build()
+	u, p, err := ReadCredentialsFromSecret(ctx, cl)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedUser, u)
+	assert.Equal(t, expectedPassword, p)
 }

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -298,3 +298,17 @@ spec:
           hostPath: /var/run/docker.sock
       customImage: {{.kindNodeImage}}
 {{- end }}
+{{- if .registryAuth }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-credentials
+  namespace: {{.eksaSystemNamespace}}
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+stringData:
+  username: "{{.registryUsername}}"
+  password: "{{.registryPassword}}"
+---
+{{- end }}

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -296,7 +296,10 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 	values["auditPolicy"] = auditPolicy
 
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {
-		values = populateRegistryMirrorValues(clusterSpec, values)
+		values, err := populateRegistryMirrorValues(clusterSpec, values)
+		if err != nil {
+			return values, err
+		}
 	}
 
 	return values, nil
@@ -328,7 +331,10 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration 
 	}
 
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {
-		values = populateRegistryMirrorValues(clusterSpec, values)
+		values, err := populateRegistryMirrorValues(clusterSpec, values)
+		if err != nil {
+			return values, err
+		}
 	}
 
 	return values, nil
@@ -624,7 +630,7 @@ func (p *provider) PreCoreComponentsUpgrade(
 	return nil
 }
 
-func populateRegistryMirrorValues(clusterSpec *cluster.Spec, values map[string]interface{}) map[string]interface{} {
+func populateRegistryMirrorValues(clusterSpec *cluster.Spec, values map[string]interface{}) (map[string]interface{}, error) {
 	registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 	values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 	values["mirrorBase"] = registryMirror.BaseRegistry
@@ -638,10 +644,10 @@ func populateRegistryMirrorValues(clusterSpec *cluster.Spec, values map[string]i
 		values["registryAuth"] = registryMirror.Auth
 		username, password, err := config.ReadCredentials()
 		if err != nil {
-			return values
+			return values, err
 		}
 		values["registryUsername"] = username
 		values["registryPassword"] = password
 	}
-	return values
+	return values, nil
 }

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -368,3 +368,15 @@ spec:
         - containerPath: /var/run/docker.sock
           hostPath: /var/run/docker.sock
       customImage: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind/node:v1.21.2-eks-d-1-21-4-eks-a-v0.0.0-dev-build.158
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-credentials
+  namespace: eksa-system
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+stringData:
+  username: "username"
+  password: "password"
+---

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -407,7 +407,11 @@ func buildTemplateMapCP(
 	}
 
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {
-		values = populateRegistryMirrorValues(clusterSpec, values)
+		values, err := populateRegistryMirrorValues(clusterSpec, values)
+		if err != nil {
+			return values, err
+		}
+
 		// Replace public.ecr.aws endpoint with the endpoint given in the cluster config file
 		localRegistry := values["publicMirror"].(string)
 		cpTemplateOverride = strings.ReplaceAll(cpTemplateOverride, defaultRegistry, localRegistry)
@@ -495,7 +499,11 @@ func buildTemplateMapMD(
 	}
 
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {
-		values = populateRegistryMirrorValues(clusterSpec, values)
+		values, err := populateRegistryMirrorValues(clusterSpec, values)
+		if err != nil {
+			return values, err
+		}
+
 		// Replace public.ecr.aws endpoint with the endpoint given in the cluster config file
 		localRegistry := values["publicMirror"].(string)
 		workerTemplateOverride = strings.ReplaceAll(workerTemplateOverride, defaultRegistry, localRegistry)
@@ -549,7 +557,7 @@ func omitTinkerbellMachineTemplate(inputSpec []byte) ([]byte, error) {
 	return unstructuredutil.UnstructuredToYaml(outSpec)
 }
 
-func populateRegistryMirrorValues(clusterSpec *cluster.Spec, values map[string]interface{}) map[string]interface{} {
+func populateRegistryMirrorValues(clusterSpec *cluster.Spec, values map[string]interface{}) (map[string]interface{}, error) {
 	registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 	values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 	values["mirrorBase"] = registryMirror.BaseRegistry
@@ -563,12 +571,12 @@ func populateRegistryMirrorValues(clusterSpec *cluster.Spec, values map[string]i
 		values["registryAuth"] = registryMirror.Auth
 		username, password, err := config.ReadCredentials()
 		if err != nil {
-			return values
+			return values, err
 		}
 		values["registryUsername"] = username
 		values["registryPassword"] = password
 	}
-	return values
+	return values, nil
 }
 
 func getControlPlaneMachineSpec(clusterSpec *cluster.Spec) (*v1alpha1.TinkerbellMachineConfigSpec, error) {


### PR DESCRIPTION
*Description of changes:*
When customers set up authenticated registry mirrors, the eks-a controller does not have access to the required env variables. Hence adding logic to read from registry-auth secret and setting Env on the controller pod.

*Testing:*
Built the eks-a controller and pushed to private registry. Tested changes on vsphere.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

