### PR TITLE
Fix etcd certs backup instruction

### DIFF
--- a/docs/content/en/docs/tasks/cluster/manually-renew-certs.md
+++ b/docs/content/en/docs/tasks/cluster/manually-renew-certs.md
@@ -40,9 +40,9 @@ kubectl get etcdadmcluster -A
 {{< tab header="Ubuntu or RHEL" lang="bash" >}}
 # backup certs
 cd /etc/etcd
-sudo mv pki pki.bak
-sudo mkdir pki
-sudo mv pki.bak/ca.* pki
+sudo cp -r pki pki.bak
+sudo rm pki/*
+sudo cp pki.bak/ca.* pki
 
 # run certificates join phase to regenerate the deleted certificates
 sudo etcdadm join phase certificates http://eks-a-etcd-dumb-url
@@ -61,9 +61,9 @@ ctr image pull ${IMAGE_ID}
 
 # backup certs
 cd /var/lib/etcd
-mv pki pki.bak
-mkdir pki
-mv pki.bak/ca.* pki
+cp -r pki pki.bak
+rm pki/*
+cp pki.bak/ca.* pki
 
 # recreate certificates
 ctr run \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* In bottlerocket, the pki directory is mount to the container. Changing directory name would not take effect in container.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

