### PR TITLE
Add retries around clusterctl move --to-directory command

### DIFF
--- a/pkg/clustermanager/cluster_manager_wb_test.go
+++ b/pkg/clustermanager/cluster_manager_wb_test.go
@@ -8,6 +8,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var ClusterctlMoveRetryPolicy = clusterctlMoveRetryPolicy
+
 func TestClusterManager_totalTimeoutForMachinesReadyWait(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/executables/export_test.go
+++ b/pkg/executables/export_test.go
@@ -5,8 +5,6 @@ import (
 	"time"
 )
 
-var ClusterctlMoveRetryPolicy = clusterctlMoveRetryPolicy
-
 func KubectlWaitRetryPolicy(k *Kubectl, totalRetries int, err error) (retry bool, wait time.Duration) {
 	return k.kubectlWaitRetryPolicy(totalRetries, err)
 }


### PR DESCRIPTION
*Issue #, if available:*
#5576 

*Description of changes:*
During upgrade of a management cluster. we take the back of management cluster resources before moving it to the kind cluster. This PR adds retries around `clusterctl move --to-directory` command so if the command fails intermittently due to network error, timeout or any other similar error, it doesn't fail and retries to take the backup.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

