### PR TITLE
Retry client building in kube-proxy upgrader

### DIFF
--- a/pkg/clustermanager/kube_proxy.go
+++ b/pkg/clustermanager/kube_proxy.go
@@ -124,14 +124,18 @@ func (u KubeProxyCLIUpgrader) buildClients(
 	managementClusterKubeconfigPath, workloadClusterKubeconfigPath string,
 ) (managementClusterClient, workloadClusterClient client.Client, err error) {
 	u.log.V(4).Info("Building client for management cluster", "kubeconfig", managementClusterKubeconfigPath)
-	managementClusterClient, err = u.clientFactory.BuildClientFromKubeconfig(managementClusterKubeconfigPath)
-	if err != nil {
+	if err = u.retrier.Retry(func() error {
+		managementClusterClient, err = u.clientFactory.BuildClientFromKubeconfig(managementClusterKubeconfigPath)
+		return err
+	}); err != nil {
 		return nil, nil, err
 	}
 
 	u.log.V(4).Info("Building client for workload cluster", "kubeconfig", workloadClusterKubeconfigPath)
-	workloadClusterClient, err = u.clientFactory.BuildClientFromKubeconfig(workloadClusterKubeconfigPath)
-	if err != nil {
+	if err = u.retrier.Retry(func() error {
+		workloadClusterClient, err = u.clientFactory.BuildClientFromKubeconfig(workloadClusterKubeconfigPath)
+		return err
+	}); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/clustermanager/kube_proxy_test.go
+++ b/pkg/clustermanager/kube_proxy_test.go
@@ -527,9 +527,13 @@ func TestKubeProxyCLIUpgraderPrepareUpgradeErrorManagementClusterClient(t *testi
 	workloadKubeConfig := "workload.yaml"
 	ctrl := gomock.NewController(t)
 	factory := mocks.NewMockClientFactory(ctrl)
-	factory.EXPECT().BuildClientFromKubeconfig(managementKubeConfig).Return(nil, errors.New("building management client"))
+	factory.EXPECT().BuildClientFromKubeconfig(managementKubeConfig).Return(nil, errors.New("building management client")).Times(2)
 
-	u := clustermanager.NewKubeProxyCLIUpgrader(test.NewNullLogger(), factory)
+	u := clustermanager.NewKubeProxyCLIUpgrader(
+		test.NewNullLogger(),
+		factory,
+		clustermanager.KubeProxyCLIUpgraderRetrier(*retrier.NewWithMaxRetries(2, 0)),
+	)
 
 	g.Expect(
 		u.PrepareUpgrade(tt.ctx, tt.spec, managementKubeConfig, workloadKubeConfig),
@@ -545,9 +549,13 @@ func TestKubeProxyCLIUpgraderPrepareUpgradeErrorWorkloadClusterClient(t *testing
 	ctrl := gomock.NewController(t)
 	factory := mocks.NewMockClientFactory(ctrl)
 	factory.EXPECT().BuildClientFromKubeconfig(managementKubeConfig).Return(tt.managementClient, nil)
-	factory.EXPECT().BuildClientFromKubeconfig(workloadKubeConfig).Return(nil, errors.New("building workload client"))
+	factory.EXPECT().BuildClientFromKubeconfig(workloadKubeConfig).Return(nil, errors.New("building workload client")).Times(2)
 
-	u := clustermanager.NewKubeProxyCLIUpgrader(test.NewNullLogger(), factory)
+	u := clustermanager.NewKubeProxyCLIUpgrader(
+		test.NewNullLogger(),
+		factory,
+		clustermanager.KubeProxyCLIUpgraderRetrier(*retrier.NewWithMaxRetries(2, 0)),
+	)
 
 	g.Expect(
 		u.PrepareUpgrade(tt.ctx, tt.spec, managementKubeConfig, workloadKubeConfig),
@@ -622,9 +630,13 @@ func TestKubeProxyCLICleanupAfterUpgradeErrorWorkloadClusterClient(t *testing.T)
 	ctrl := gomock.NewController(t)
 	factory := mocks.NewMockClientFactory(ctrl)
 	factory.EXPECT().BuildClientFromKubeconfig(managementKubeConfig).Return(tt.managementClient, nil)
-	factory.EXPECT().BuildClientFromKubeconfig(workloadKubeConfig).Return(nil, errors.New("building workload client"))
+	factory.EXPECT().BuildClientFromKubeconfig(workloadKubeConfig).Return(nil, errors.New("building workload client")).Times(2)
 
-	u := clustermanager.NewKubeProxyCLIUpgrader(test.NewNullLogger(), factory)
+	u := clustermanager.NewKubeProxyCLIUpgrader(
+		test.NewNullLogger(),
+		factory,
+		clustermanager.KubeProxyCLIUpgraderRetrier(*retrier.NewWithMaxRetries(2, 0)),
+	)
 
 	g.Expect(
 		u.CleanupAfterUpgrade(tt.ctx, tt.spec, managementKubeConfig, workloadKubeConfig),


### PR DESCRIPTION
*Description of changes:*
Depending on the implementation, building a client might make API calls to the kube-api server. Retrying this operation protects the CLI flow against transient errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

