### PR TITLE
Encode ca secret data value

### DIFF
--- a/pkg/awsiamauth/client.go
+++ b/pkg/awsiamauth/client.go
@@ -2,6 +2,7 @@ package awsiamauth
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -91,7 +92,9 @@ func (c RetrierClient) GetClusterCACert(ctx context.Context, cluster *types.Clus
 	}
 
 	if crt, ok := secret.Data["tls.crt"]; ok {
-		return crt, nil
+		b64EncodedCrt := make([]byte, base64.StdEncoding.EncodedLen(len(crt)))
+		base64.StdEncoding.Encode(b64EncodedCrt, crt)
+		return b64EncodedCrt, nil
 	}
 
 	return nil, fmt.Errorf("tls.crt not found in secret [%s]", secretName)

--- a/pkg/awsiamauth/client_test.go
+++ b/pkg/awsiamauth/client_test.go
@@ -88,7 +88,7 @@ func TestRetrierClientGetClusterCACertSuccess(t *testing.T) {
 		}).Times(1)
 
 	cert, err := tt.r.GetClusterCACert(tt.ctx, tt.cluster, "test-cluster")
-	tt.Expect(cert).To(Equal([]byte("cert")))
+	tt.Expect(cert).To(Equal([]byte("Y2VydA==")))
 	tt.Expect(err).To(Succeed(), "retrierClient.GetObject() should succeed after 5 tries")
 }
 


### PR DESCRIPTION
*Issue #, if available:*

Fix awsiam auth ca cert error

```
awsiam.go:57: Downloading aws-iam-authenticator client
    awsiam.go:62: Setting aws-iam-authenticator client in env PATH
    awsiam.go:68: Waiting for aws-iam-authenticator daemonset rollout status
    awsiam.go:79: Getting pods with aws-iam-authenticator kubeconfig
    awsiam.go:85: Error getting pods: getting pods: error: error loading config file "main-i-0ff4b-44dbdd0/main-i-0ff4b-44dbdd0-aws.kubeconfig": yaml: line 6: could not find expected ':'
```

introduced in https://github.com/aws/eks-anywhere/pull/5584/files#diff-c19a477c346a9ff0f5ca2043f9cf852a688246917596debc8243d54bd8ec1764R81

Where we update the way we get the cert from `kubectl get secret -o jsonpath` to use `kubectl get secret` then parses the secret as object and the data value is decoded vs the raw json output contains the base64 encoded value. 

*Description of changes:*

Base64 encode the secret data value.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

