### PR TITLE
Add notimeouts to eksd installer and upgrader

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -976,11 +976,17 @@ func (f *Factory) WithEksdInstaller() *Factory {
 			return nil
 		}
 
+		var opts []eksd.InstallerOpt
+		if f.config.noTimeouts {
+			opts = append(opts, eksd.WithRetrier(retrier.NewWithNoTimeout()))
+		}
+
 		f.dependencies.EksdInstaller = eksd.NewEksdInstaller(
 			&eksdInstallerClient{
 				f.dependencies.Kubectl,
 			},
 			f.dependencies.FileReader,
+			opts...,
 		)
 		return nil
 	})
@@ -996,11 +1002,17 @@ func (f *Factory) WithEksdUpgrader() *Factory {
 			return nil
 		}
 
+		var opts []eksd.InstallerOpt
+		if f.config.noTimeouts {
+			opts = append(opts, eksd.WithRetrier(retrier.NewWithNoTimeout()))
+		}
+
 		f.dependencies.EksdUpgrader = eksd.NewUpgrader(
 			&eksdInstallerClient{
 				f.dependencies.Kubectl,
 			},
 			f.dependencies.FileReader,
+			opts...,
 		)
 		return nil
 	})

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -519,6 +519,30 @@ func TestFactoryBuildWithBootstrapperNoTimeout(t *testing.T) {
 	tt.Expect(deps.Bootstrapper).NotTo(BeNil())
 }
 
+func TestFactoryBuildWithEksdUpgraderNoTimeout(t *testing.T) {
+	tt := newTest(t, vsphere)
+	deps, err := dependencies.NewFactory().
+		WithLocalExecutables().
+		WithNoTimeouts().
+		WithEksdUpgrader().
+		Build(context.Background())
+
+	tt.Expect(err).To(BeNil())
+	tt.Expect(deps.EksdUpgrader).NotTo(BeNil())
+}
+
+func TestFactoryBuildWithEksdInstallerNoTimeout(t *testing.T) {
+	tt := newTest(t, vsphere)
+	deps, err := dependencies.NewFactory().
+		WithLocalExecutables().
+		WithNoTimeouts().
+		WithEksdInstaller().
+		Build(context.Background())
+
+	tt.Expect(err).To(BeNil())
+	tt.Expect(deps.EksdInstaller).NotTo(BeNil())
+}
+
 type dummyDockerClient struct{}
 
 func (b dummyDockerClient) PullImage(ctx context.Context, image string) error {

--- a/pkg/eksd/installer.go
+++ b/pkg/eksd/installer.go
@@ -25,17 +25,35 @@ type Reader interface {
 	ReadFile(url string) ([]byte, error)
 }
 
+// InstallerOpt allows to customize an eksd installer
+// on construction.
+type InstallerOpt func(*Installer)
+
 type Installer struct {
 	client  EksdInstallerClient
 	retrier *retrier.Retrier
 	reader  Reader
 }
 
-func NewEksdInstaller(client EksdInstallerClient, reader Reader) *Installer {
-	return &Installer{
+// NewEksdInstaller constructs a new eks-d installer.
+func NewEksdInstaller(client EksdInstallerClient, reader Reader, opts ...InstallerOpt) *Installer {
+	i := &Installer{
 		client:  client,
 		retrier: retrier.NewWithMaxRetries(maxRetries, backOffPeriod),
 		reader:  reader,
+	}
+
+	for _, opt := range opts {
+		opt(i)
+	}
+
+	return i
+}
+
+// WithRetrier allows to use a custom retrier.
+func WithRetrier(retrier *retrier.Retrier) InstallerOpt {
+	return func(i *Installer) {
+		i.retrier = retrier
 	}
 }
 

--- a/pkg/eksd/upgrader.go
+++ b/pkg/eksd/upgrader.go
@@ -13,9 +13,13 @@ type Upgrader struct {
 	*Installer
 }
 
-func NewUpgrader(client EksdInstallerClient, reader Reader) *Upgrader {
+// UpgraderOpt allows to customize an eksd upgrader on construction.
+type UpgraderOpt = InstallerOpt
+
+// NewUpgrader constructs a new eks-d upgrader.
+func NewUpgrader(client EksdInstallerClient, reader Reader, opts ...UpgraderOpt) *Upgrader {
 	return &Upgrader{
-		NewEksdInstaller(client, reader),
+		NewEksdInstaller(client, reader, opts...),
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

Part of #5565 

*Description of changes:*

Respect `--no-timeouts` in eksd installer and upgrader.

*Testing (if applicable):*

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

